### PR TITLE
[deepmerge] Remove ts-expect-error

### DIFF
--- a/packages/material-ui-utils/src/deepmerge.ts
+++ b/packages/material-ui-utils/src/deepmerge.ts
@@ -1,11 +1,5 @@
 export function isPlainObject(item: unknown): item is Record<keyof any, unknown> {
-  return (
-    item !== null &&
-    typeof item === 'object' &&
-    // TS thinks `item is possibly null` even though this was our first guard.
-    // @ts-expect-error
-    item.constructor === Object
-  );
+  return typeof item === 'object' && item !== null && item.constructor === Object;
 }
 
 export interface DeepmergeOptions {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Typescript seems to have trouble keeping track of the first check `item !== null` when reaching the third one `item.constructor === Object`. But putting those two checks just next one another solves this issue.

This should not change the behavior at all