### PR TITLE
Improve type check performance

### DIFF
--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -1,4 +1,4 @@
-import { StyleRules } from '@material-ui/styles/withStyles';
+import { StaticStyleRules, StyleRules } from '@material-ui/styles/withStyles';
 
 /**
  * This function doesn't really "do anything" at runtime, it's just the identity
@@ -10,6 +10,9 @@ import { StyleRules } from '@material-ui/styles/withStyles';
 // For TypeScript v3.5 Props has to extend {} instead of object
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
+export default function createStyles<ClassKey extends string>(
+  styles: StaticStyleRules<ClassKey>,
+): StaticStyleRules<ClassKey>;
 export default function createStyles<ClassKey extends string, Props extends {}>(
   styles: StyleRules<Props, ClassKey>,
 ): StyleRules<Props, ClassKey>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -1,6 +1,15 @@
-import { ClassNameMap, Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
+import {
+  ClassNameMap,
+  StaticStyles,
+  Styles,
+  WithStylesOptions,
+} from '@material-ui/styles/withStyles';
 import { DefaultTheme } from '../defaultTheme';
 
+export default function makeStyles<Theme = DefaultTheme, ClassKey extends string = string>(
+  styles: StaticStyles<Theme, ClassKey>,
+  options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
+): (props?: any) => ClassNameMap<ClassKey>; // `makeStyles` where the passed `styles` do not have callbacks on properties
 export default function makeStyles<
   Theme = DefaultTheme,
   Props extends object = {},

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -62,15 +62,31 @@ export type StyleRules<Props extends object = {}, ClassKey extends string = stri
 >;
 
 /**
+ * By removing parameterized type references, this type brings better type check performance.
+ */
+export type StaticStyleRules<ClassKey extends string = string> = Record<ClassKey, CSSProperties>;
+
+/**
  * @internal
  */
 export type StyleRulesCallback<Theme, Props extends object, ClassKey extends string = string> = (
   theme: Theme,
 ) => StyleRules<Props, ClassKey>;
 
+/**
+ * @internal
+ */
+export type StaticStyleRulesCallback<Theme, ClassKey extends string = string> = (
+  theme: Theme,
+) => StaticStyleRules<ClassKey>;
+
 export type Styles<Theme, Props extends object, ClassKey extends string = string> =
   | StyleRules<Props, ClassKey>
   | StyleRulesCallback<Theme, Props, ClassKey>;
+
+export type StaticStyles<Theme, ClassKey extends string = string> =
+  | StaticStyleRules<ClassKey>
+  | StaticStyleRulesCallback<Theme, ClassKey>;
 
 export interface WithStylesOptions<Theme = DefaultTheme> extends JSS.StyleSheetFactoryOptions {
   defaultTheme?: Theme;

--- a/packages/material-ui-system/src/createStyled.d.ts
+++ b/packages/material-ui-system/src/createStyled.d.ts
@@ -59,6 +59,13 @@ export interface FunctionInterpolation<Props> {
   (props: Props): Interpolation<Props>;
 }
 
+/**
+ * By removing parameterized type references, this type brings better type check performance.
+ */
+interface StaticFunctionInterpolation {
+  (props: { theme: DefaultTheme }): CSSInterpolation;
+}
+
 export interface ArrayInterpolation<Props> extends Array<Interpolation<Props>> {}
 
 export type Interpolation<Props> =
@@ -119,6 +126,12 @@ export interface CreateStyledComponent<
   SpecificComponentProps extends {} = {},
   JSXProps extends {} = {},
 > {
+  (...styles: Array<InterpolationPrimitive | StaticFunctionInterpolation>): StyledComponent<
+    ComponentProps,
+    SpecificComponentProps,
+    JSXProps
+  >;
+
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Implements performance improvement for:
- [x] makeStyles/createStyles: https://github.com/mui-org/material-ui/issues/19113#issuecomment-878819650
- [x] styled(): https://github.com/mui-org/material-ui/issues/19113#issuecomment-879431287
- [ ] OverridableComponent: TBD

TODO: "`< 10` includes to primitives" issue should be sent to TypeScript.