### PR TITLE
[docs] Mount Tooltip inside custom container instead of document.body

### DIFF
--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -9,6 +9,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { enUS, zhCN, faIR, ruRU, ptBR, esES, frFR, deDE, jaJP } from '@material-ui/core/locale';
 import darkScrollbar from '@material-ui/core/darkScrollbar';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@material-ui/core/utils';
+import Portal from '@material-ui/core/Portal';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
@@ -198,6 +199,11 @@ export function ThemeProvider(props) {
     document.body.dir = direction;
   }, [direction]);
 
+  const tooltipContainerRef = React.useRef(null);
+  const tooltipContainer = React.useCallback(() => {
+    return tooltipContainerRef.current;
+  }, []);
+
   const theme = React.useMemo(() => {
     const nextTheme = createTheme(
       {
@@ -219,13 +225,20 @@ export function ThemeProvider(props) {
               body: paletteMode === 'dark' ? darkScrollbar() : null,
             },
           },
+          MuiTooltip: {
+            defaultProps: {
+              PopperProps: {
+                container: tooltipContainer,
+              },
+            },
+          },
         },
       },
       languageMap[userLanguage],
     );
 
     return nextTheme;
-  }, [dense, direction, paletteColors, paletteMode, spacing, userLanguage]);
+  }, [dense, direction, paletteColors, paletteMode, spacing, tooltipContainer, userLanguage]);
 
   React.useEffect(() => {
     // Expose the theme as a global variable so people can play with it.
@@ -237,6 +250,9 @@ export function ThemeProvider(props) {
 
   return (
     <MuiThemeProvider theme={theme}>
+      <Portal>
+        <div data-testid="tooltip-container" ref={tooltipContainerRef} />
+      </Portal>
       <DispatchContext.Provider value={dispatch}>{children}</DispatchContext.Provider>
     </MuiThemeProvider>
   );


### PR DESCRIPTION
Investigating potential solutions for a reported performance problem with where we attach our `Tooltip` <sup>[afzal]</sup>.

Preview: https://deploy-preview-27699--material-ui.netlify.app/components/tooltips/

May not be trivial to do this by default (considering iframes and garbage collection) so first we'll check if we can reproduce the findings of [[afzal]].

For now let's focus on the fact that we attach to a separate `<div />` inside `document.body` instead of just `document.body`. How this `<div />` is provided is just thrown together (it has bugs).

[Afzal]: https://atfzl.com/don-t-attach-tooltips-to-document-body

/cc @atfzl

Update: We probably want to use `useInsertionEffect` for creating the custom container: 

> The use case is specifically for inserting global DOM nodes like <style> or SVG <defs>. (Maybe global Portals.) 

-- https://github.com/reactwg/react-18/discussions/110