### PR TITLE
[POC][docs] Investigate React 18 compatibility

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -27,6 +27,7 @@ import {
 } from 'docs/src/modules/utils/i18n';
 import DocsStyledEngineProvider from 'docs/src/modules/utils/StyledEngineProvider';
 import createEmotionCache from 'docs/src/createEmotionCache';
+import InteractiveIsland from 'docs/src/modules/components/InteractiveIsland';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -208,7 +209,7 @@ function AppWrapper(props) {
   }
 
   return (
-    <React.Fragment>
+    <InteractiveIsland>
       <NextHead>
         {fonts.map((font) => (
           <link rel="stylesheet" href={font} key={font} />
@@ -227,7 +228,8 @@ function AppWrapper(props) {
           <LanguageNegotiation />
         </CodeVariantProvider>
       </UserLanguageProvider>
-    </React.Fragment>
+      <GoogleAnalytics key={router.route} />
+    </InteractiveIsland>
   );
 }
 

--- a/docs/src/modules/components/AdGuest.js
+++ b/docs/src/modules/components/AdGuest.js
@@ -1,32 +1,29 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import Portal from '@mui/material/Portal';
 import { AdContext } from 'docs/src/modules/components/AdManager';
+import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 
 export default function AdGuest(props) {
-  const ad = React.useContext(AdContext);
+  const { element } = React.useContext(AdContext);
 
-  if (!ad.element) {
+  useEnhancedEffect(() => {
+    if (element != null) {
+      const description = document.querySelector('.description');
+
+      if (element === description) {
+        description.classList.add('ad');
+      } else {
+        description.classList.remove('ad');
+      }
+    }
+  }, [element]);
+
+  if (!element) {
     return null;
   }
 
-  return (
-    <Portal
-      container={() => {
-        const description = document.querySelector('.description');
-
-        if (ad.element === description) {
-          description.classList.add('ad');
-        } else {
-          description.classList.remove('ad');
-        }
-
-        return ad.element;
-      }}
-    >
-      {props.children}
-    </Portal>
-  );
+  return ReactDOM.createPortal(props.children, element);
 }
 
 AdGuest.propTypes = {

--- a/docs/src/modules/components/AdManager.js
+++ b/docs/src/modules/components/AdManager.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/material/utils';
 
 export const AdContext = React.createContext();
 
@@ -16,7 +15,7 @@ export const adShape = randomSession < 0.2 ? 'inline' : 'image';
 export default function AdManager(props) {
   const [portal, setPortal] = React.useState({});
 
-  useEnhancedEffect(() => {
+  React.useEffect(() => {
     const description = document.querySelector('.description');
     setPortal({ placement: 'body-top', element: description });
   }, []);

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -308,7 +308,7 @@ function AppFrame(props) {
         onOpen={handleNavDrawerOpen}
         mobileOpen={mobileOpen}
       />
-      {children}
+      <React.Suspense fallback={null}>{children}</React.Suspense>
       <AppSettingsDrawer onClose={handleSettingsDrawerClose} open={settingsOpen} />
     </RootDiv>
   );

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -53,20 +53,10 @@ export function NextNProgressBar() {
 
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
 export function DeferredAppSearch() {
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-
   return (
-    <React.Fragment>
-      {/* Suspense isn't supported for SSR yet */}
-      {mounted ? (
-        <React.Suspense fallback={null}>
-          <AppSearch />
-        </React.Suspense>
-      ) : null}
-    </React.Fragment>
+    <React.Suspense fallback={null}>
+      <AppSearch />
+    </React.Suspense>
   );
 }
 

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -21,6 +21,7 @@ import NProgressBar from '@mui/docs/NProgressBar';
 import AppNavDrawer from 'docs/src/modules/components/AppNavDrawer';
 import AppSettingsDrawer from 'docs/src/modules/components/AppSettingsDrawer';
 import Notifications from 'docs/src/modules/components/Notifications';
+import InteractiveIsland from 'docs/src/modules/components/InteractiveIsland';
 import MarkdownLinks from 'docs/src/modules/components/MarkdownLinks';
 import { LANGUAGES_LABEL } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
@@ -53,9 +54,9 @@ export function NextNProgressBar() {
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
 export function DeferredAppSearch() {
   return (
-    <React.Suspense fallback={null}>
+    <InteractiveIsland>
       <AppSearch />
-    </React.Suspense>
+    </InteractiveIsland>
   );
 }
 
@@ -214,8 +215,17 @@ function AppFrame(props) {
         {t('appFrame.skipToContent')}
       </SkipLink>
       <MarkdownLinks />
-      <React.Suspense>
-        <StyledAppBar disablePermanent={disablePermanent}>
+      <React.Suspense fallback={null}>
+        <StyledAppBar
+          disablePermanent={disablePermanent}
+          ref={(instance) => {
+            if (instance !== null) {
+              instance.style.filter = '';
+              instance.style.outline = '';
+            }
+          }}
+          style={{ filter: 'blur(5px)', outline: '3px solid red' }}
+        >
           <Toolbar>
             <NavIconButton
               edge="start"
@@ -257,7 +267,7 @@ function AppFrame(props) {
                   <SettingsIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
-              <React.Suspense fallback={null}>
+              <InteractiveIsland>
                 <Menu
                   id="language-menu"
                   anchorEl={languageMenu}
@@ -300,19 +310,19 @@ function AppFrame(props) {
                     {t('appFrame.helpToTranslate')}
                   </MenuItem>
                 </Menu>
-              </React.Suspense>
+              </InteractiveIsland>
             </Stack>
           </Toolbar>
         </StyledAppBar>
       </React.Suspense>
-      <React.Suspense>
+      <InteractiveIsland>
         <StyledAppNavDrawer
           disablePermanent={disablePermanent}
           onClose={handleNavDrawerClose}
           onOpen={handleNavDrawerOpen}
           mobileOpen={mobileOpen}
         />
-      </React.Suspense>
+      </InteractiveIsland>
       {children}
       <AppSettingsDrawer onClose={handleSettingsDrawerClose} open={settingsOpen} />
     </RootDiv>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -12,7 +12,6 @@ import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
-import NoSsr from '@mui/material/NoSsr';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Divider from '@mui/material/Divider';
@@ -215,100 +214,106 @@ function AppFrame(props) {
         {t('appFrame.skipToContent')}
       </SkipLink>
       <MarkdownLinks />
-      <StyledAppBar disablePermanent={disablePermanent}>
-        <Toolbar>
-          <NavIconButton
-            edge="start"
-            color="inherit"
-            aria-label={t('appFrame.openDrawer')}
-            disablePermanent={disablePermanent}
-            onClick={handleNavDrawerOpen}
-          >
-            <MenuIcon />
-          </NavIconButton>
-          <GrowingDiv />
-          <Stack direction="row" spacing={2} sx={{ '& > button': { width: 42 } }}>
-            <DeferredAppSearch />
-            <Tooltip title={t('appFrame.github')} enterDelay={300}>
-              <IconButton
-                component="a"
-                color="inherit"
-                href={process.env.SOURCE_CODE_REPO}
-                data-ga-event-category="header"
-                data-ga-event-action="github"
-                sx={{ px: '10px' }}
-              >
-                <GitHubIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Notifications />
-            <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
-              <IconButton
-                {...languageButtonProps}
-                sx={{
-                  px: '10px',
-                }}
-              >
-                <LanguageIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
-              <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
-                <SettingsIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <NoSsr defer>
-              <Menu
-                id="language-menu"
-                anchorEl={languageMenu}
-                open={Boolean(languageMenu)}
-                onClose={handleLanguageMenuClose}
-              >
-                {LANGUAGES_LABEL.map((language) => (
+      <React.Suspense>
+        <StyledAppBar disablePermanent={disablePermanent}>
+          <Toolbar>
+            <NavIconButton
+              edge="start"
+              color="inherit"
+              aria-label={t('appFrame.openDrawer')}
+              disablePermanent={disablePermanent}
+              onClick={handleNavDrawerOpen}
+            >
+              <MenuIcon />
+            </NavIconButton>
+            <GrowingDiv />
+            <Stack direction="row" spacing={2} sx={{ '& > button': { width: 42 } }}>
+              <DeferredAppSearch />
+              <Tooltip title={t('appFrame.github')} enterDelay={300}>
+                <IconButton
+                  component="a"
+                  color="inherit"
+                  href={process.env.SOURCE_CODE_REPO}
+                  data-ga-event-category="header"
+                  data-ga-event-action="github"
+                  sx={{ px: '10px' }}
+                >
+                  <GitHubIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Notifications />
+              <Tooltip title={t('appFrame.changeLanguage')} enterDelay={300}>
+                <IconButton
+                  {...languageButtonProps}
+                  sx={{
+                    px: '10px',
+                  }}
+                >
+                  <LanguageIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={t('appFrame.toggleSettings')} enterDelay={300}>
+                <IconButton color="inherit" onClick={handleSettingsDrawerOpen} sx={{ px: '10px' }}>
+                  <SettingsIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <React.Suspense fallback={null}>
+                <Menu
+                  id="language-menu"
+                  anchorEl={languageMenu}
+                  open={Boolean(languageMenu)}
+                  onClose={handleLanguageMenuClose}
+                >
+                  {LANGUAGES_LABEL.map((language) => (
+                    <MenuItem
+                      component="a"
+                      data-no-markdown-link="true"
+                      href={
+                        language.code === 'en' ? canonicalAs : `/${language.code}${canonicalAs}`
+                      }
+                      key={language.code}
+                      selected={userLanguage === language.code}
+                      onClick={handleLanguageMenuClose}
+                      lang={language.code}
+                      hrefLang={language.code}
+                    >
+                      {language.text}
+                    </MenuItem>
+                  ))}
+                  <Box sx={{ my: 1 }}>
+                    <Divider />
+                  </Box>
                   <MenuItem
                     component="a"
-                    data-no-markdown-link="true"
-                    href={language.code === 'en' ? canonicalAs : `/${language.code}${canonicalAs}`}
-                    key={language.code}
-                    selected={userLanguage === language.code}
+                    href={
+                      userLanguage === 'en'
+                        ? `${CROWDIN_ROOT_URL}`
+                        : `${CROWDIN_ROOT_URL}${crowdInLocale}#/staging`
+                    }
+                    rel="noopener nofollow"
+                    target="_blank"
+                    key={userLanguage}
+                    lang={userLanguage}
+                    hrefLang="en"
                     onClick={handleLanguageMenuClose}
-                    lang={language.code}
-                    hrefLang={language.code}
                   >
-                    {language.text}
+                    {t('appFrame.helpToTranslate')}
                   </MenuItem>
-                ))}
-                <Box sx={{ my: 1 }}>
-                  <Divider />
-                </Box>
-                <MenuItem
-                  component="a"
-                  href={
-                    userLanguage === 'en'
-                      ? `${CROWDIN_ROOT_URL}`
-                      : `${CROWDIN_ROOT_URL}${crowdInLocale}#/staging`
-                  }
-                  rel="noopener nofollow"
-                  target="_blank"
-                  key={userLanguage}
-                  lang={userLanguage}
-                  hrefLang="en"
-                  onClick={handleLanguageMenuClose}
-                >
-                  {t('appFrame.helpToTranslate')}
-                </MenuItem>
-              </Menu>
-            </NoSsr>
-          </Stack>
-        </Toolbar>
-      </StyledAppBar>
-      <StyledAppNavDrawer
-        disablePermanent={disablePermanent}
-        onClose={handleNavDrawerClose}
-        onOpen={handleNavDrawerOpen}
-        mobileOpen={mobileOpen}
-      />
-      <React.Suspense fallback={null}>{children}</React.Suspense>
+                </Menu>
+              </React.Suspense>
+            </Stack>
+          </Toolbar>
+        </StyledAppBar>
+      </React.Suspense>
+      <React.Suspense>
+        <StyledAppNavDrawer
+          disablePermanent={disablePermanent}
+          onClose={handleNavDrawerClose}
+          onOpen={handleNavDrawerOpen}
+          mobileOpen={mobileOpen}
+        />
+      </React.Suspense>
+      {children}
       <AppSettingsDrawer onClose={handleSettingsDrawerClose} open={settingsOpen} />
     </RootDiv>
   );

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { exactProp } from '@mui/utils';
-import NoSsr from '@mui/material/NoSsr';
 import Head from 'docs/src/modules/components/Head';
 import AppFrame from 'docs/src/modules/components/AppFrame';
 import EditPage from 'docs/src/modules/components/EditPage';
@@ -11,7 +10,10 @@ import AppTableOfContents from 'docs/src/modules/components/AppTableOfContents';
 import Ad from 'docs/src/modules/components/Ad';
 import AdManager from 'docs/src/modules/components/AdManager';
 import AdGuest from 'docs/src/modules/components/AdGuest';
-import AppLayoutDocsFooter from 'docs/src/modules/components/AppLayoutDocsFooter';
+
+const DeferredAppLayoutDocsFooter = React.lazy(() =>
+  import('docs/src/modules/components/AppLayoutDocsFooter'),
+);
 
 const TOC_WIDTH = 210;
 const NAV_WIDTH = 240;
@@ -97,11 +99,13 @@ function AppLayoutDocs(props) {
           <StyledAppContainer disableAd={disableAd} disableToc={disableToc}>
             <ActionsDiv>{location && <EditPage markdownLocation={location} />}</ActionsDiv>
             {children}
-            <NoSsr>
-              <AppLayoutDocsFooter />
-            </NoSsr>
+            <React.Suspense fallback={null}>
+              <DeferredAppLayoutDocsFooter />
+            </React.Suspense>
           </StyledAppContainer>
-          {disableToc ? null : <AppTableOfContents toc={toc} />}
+          <React.Suspense fallback={null}>
+            {disableToc ? null : <AppTableOfContents toc={toc} />}
+          </React.Suspense>
         </Main>
       </AdManager>
     </AppFrame>

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -98,14 +98,12 @@ function AppLayoutDocs(props) {
         <Main disableToc={disableToc}>
           <StyledAppContainer disableAd={disableAd} disableToc={disableToc}>
             <ActionsDiv>{location && <EditPage markdownLocation={location} />}</ActionsDiv>
-            {children}
+            <React.Suspense fallback={null}>{children}</React.Suspense>
             <React.Suspense fallback={null}>
               <DeferredAppLayoutDocsFooter />
             </React.Suspense>
           </StyledAppContainer>
-          <React.Suspense fallback={null}>
-            {disableToc ? null : <AppTableOfContents toc={toc} />}
-          </React.Suspense>
+          {disableToc ? null : <AppTableOfContents toc={toc} />}
         </Main>
       </AdManager>
     </AppFrame>

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -10,6 +10,7 @@ import AppTableOfContents from 'docs/src/modules/components/AppTableOfContents';
 import Ad from 'docs/src/modules/components/Ad';
 import AdManager from 'docs/src/modules/components/AdManager';
 import AdGuest from 'docs/src/modules/components/AdGuest';
+import InteractiveIsland from 'docs/src/modules/components/InteractiveIsland';
 
 const DeferredAppLayoutDocsFooter = React.lazy(() =>
   import('docs/src/modules/components/AppLayoutDocsFooter'),
@@ -98,10 +99,10 @@ function AppLayoutDocs(props) {
         <Main disableToc={disableToc}>
           <StyledAppContainer disableAd={disableAd} disableToc={disableToc}>
             <ActionsDiv>{location && <EditPage markdownLocation={location} />}</ActionsDiv>
-            <React.Suspense fallback={null}>{children}</React.Suspense>
-            <React.Suspense fallback={null}>
+            <InteractiveIsland>{children}</InteractiveIsland>
+            <InteractiveIsland>
               <DeferredAppLayoutDocsFooter />
-            </React.Suspense>
+            </InteractiveIsland>
           </StyledAppContainer>
           {disableToc ? null : <AppTableOfContents toc={toc} />}
         </Main>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -297,6 +297,13 @@ function AppNavDrawer(props) {
           variant="permanent"
           PaperProps={{
             component: SwipeableDrawerPaperComponent,
+            ref: (instance) => {
+              if (instance !== null) {
+                instance.style.filter = '';
+                instance.style.outline = '';
+              }
+            },
+            style: { filter: 'blur(5px)', outline: '3px solid red' },
             sx: {
               background: (theme) =>
                 theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : '#fff',

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { alpha, styled } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';
 import Collapse from '@mui/material/Collapse';
-import NoSsr from '@mui/material/NoSsr';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import DemoSandboxed from 'docs/src/modules/components/DemoSandboxed';
 import { AdCarbonInline } from 'docs/src/modules/components/AdCarbon';
@@ -225,29 +224,27 @@ export default function Demo(props) {
       <AnchorLink id={`${demoName}.js`} />
       <AnchorLink id={`${demoName}.tsx`} />
       {demoOptions.hideToolbar ? null : (
-        <NoSsr defer fallback={<DemoToolbarFallback />}>
-          <React.Suspense fallback={<DemoToolbarFallback />}>
-            <DemoToolbar
-              codeOpen={codeOpen}
-              codeVariant={codeVariant}
-              demo={demo}
-              demoData={demoData}
-              demoHovered={demoHovered}
-              demoId={demoId}
-              demoName={demoName}
-              demoOptions={demoOptions}
-              demoSourceId={demoSourceId}
-              initialFocusRef={initialFocusRef}
-              onCodeOpenChange={() => {
-                setCodeOpen((open) => !open);
-                setShowAd(true);
-              }}
-              onResetDemoClick={resetDemo}
-              openDemoSource={openDemoSource}
-              showPreview={showPreview}
-            />
-          </React.Suspense>
-        </NoSsr>
+        <React.Suspense fallback={<DemoToolbarFallback />}>
+          <DemoToolbar
+            codeOpen={codeOpen}
+            codeVariant={codeVariant}
+            demo={demo}
+            demoData={demoData}
+            demoHovered={demoHovered}
+            demoId={demoId}
+            demoName={demoName}
+            demoOptions={demoOptions}
+            demoSourceId={demoSourceId}
+            initialFocusRef={initialFocusRef}
+            onCodeOpenChange={() => {
+              setCodeOpen((open) => !open);
+              setShowAd(true);
+            }}
+            onResetDemoClick={resetDemo}
+            openDemoSource={openDemoSource}
+            showPreview={showPreview}
+          />
+        </React.Suspense>
       )}
       <Collapse in={openDemoSource} unmountOnExit>
         <div>

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -161,16 +161,18 @@ function DemoSandboxed(props) {
   const t = useTranslate();
 
   return (
-    <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
-      <StylesProvider jss={jss}>
-        <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
-          <Sandbox {...sandboxProps}>
-            {/* WARNING: `<Component />` needs to be a child of `Sandbox` since certain implementations rely on `cloneElement` */}
-            <Component />
-          </Sandbox>
-        </ThemeProvider>
-      </StylesProvider>
-    </DemoErrorBoundary>
+    <React.Suspense fallback={null}>
+      <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
+        <StylesProvider jss={jss}>
+          <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
+            <Sandbox {...sandboxProps}>
+              {/* WARNING: `<Component />` needs to be a child of `Sandbox` since certain implementations rely on `cloneElement` */}
+              <Component />
+            </Sandbox>
+          </ThemeProvider>
+        </StylesProvider>
+      </DemoErrorBoundary>
+    </React.Suspense>
   );
 }
 

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -11,6 +11,7 @@ import { jssPreset, StylesProvider } from '@mui/styles';
 import { useTheme, styled, createTheme, ThemeProvider } from '@mui/material/styles';
 import rtl from 'jss-rtl';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
+import InteractiveIsland from 'docs/src/modules/components/InteractiveIsland';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import { getDesignTokens } from 'docs/src/modules/brandingTheme';
 import { highDensity } from 'docs/src/modules/components/ThemeContext';
@@ -161,7 +162,7 @@ function DemoSandboxed(props) {
   const t = useTranslate();
 
   return (
-    <React.Suspense fallback={null}>
+    <InteractiveIsland>
       <DemoErrorBoundary name={name} onResetDemoClick={onResetDemoClick} t={t}>
         <StylesProvider jss={jss}>
           <ThemeProvider theme={(outerTheme) => getTheme(outerTheme)}>
@@ -172,7 +173,7 @@ function DemoSandboxed(props) {
           </ThemeProvider>
         </StylesProvider>
       </DemoErrorBoundary>
-    </React.Suspense>
+    </InteractiveIsland>
   );
 }
 

--- a/docs/src/modules/components/InteractiveIsland.tsx
+++ b/docs/src/modules/components/InteractiveIsland.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+/**
+ * We assume that this component is inside a suspense boundary whose fallback isn't triggered on the server.
+ * On the server, we render with the inline styles from props.
+ * On the client, we adjust the inline styles via ref callback (don't want to schedule any React work)
+ * @param props
+ * @returns
+ */
+function VisibleHydrationProgress({ children }: { children?: React.ReactNode }) {
+  return (
+    <div
+      ref={(instance) => {
+        if (instance !== null) {
+          instance.style.filter = '';
+          instance.style.outline = '';
+        }
+      }}
+      style={{ filter: 'blur(5px)', outline: '3px solid red' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const HydrationProgress =
+  // @ts-ignore
+  process.env.STAGING === true ? VisibleHydrationProgress : React.Fragment;
+
+export default function InteractiveIsland({ children }: { children?: React.ReactNode }) {
+  return (
+    <React.Suspense fallback={null}>
+      <HydrationProgress>{children}</HydrationProgress>
+    </React.Suspense>
+  );
+}

--- a/docs/src/pages/components/autocomplete/Asynchronous.js
+++ b/docs/src/pages/components/autocomplete/Asynchronous.js
@@ -42,7 +42,6 @@ export default function Asynchronous() {
 
   return (
     <Autocomplete
-      id="asynchronous-demo"
       sx={{ width: 300 }}
       open={open}
       onOpen={() => {

--- a/docs/src/pages/components/autocomplete/Asynchronous.tsx
+++ b/docs/src/pages/components/autocomplete/Asynchronous.tsx
@@ -47,7 +47,6 @@ export default function Asynchronous() {
 
   return (
     <Autocomplete
-      id="asynchronous-demo"
       sx={{ width: 300 }}
       open={open}
       onOpen={() => {

--- a/docs/src/pages/components/autocomplete/CheckboxesTags.js
+++ b/docs/src/pages/components/autocomplete/CheckboxesTags.js
@@ -12,7 +12,6 @@ export default function CheckboxesTags() {
   return (
     <Autocomplete
       multiple
-      id="checkboxes-tags-demo"
       options={top100Films}
       disableCloseOnSelect
       getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/CheckboxesTags.tsx
+++ b/docs/src/pages/components/autocomplete/CheckboxesTags.tsx
@@ -12,7 +12,6 @@ export default function CheckboxesTags() {
   return (
     <Autocomplete
       multiple
-      id="checkboxes-tags-demo"
       options={top100Films}
       disableCloseOnSelect
       getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/ComboBox.js
+++ b/docs/src/pages/components/autocomplete/ComboBox.js
@@ -6,7 +6,6 @@ export default function ComboBox() {
   return (
     <Autocomplete
       disablePortal
-      id="combo-box-demo"
       options={top100Films}
       sx={{ width: 300 }}
       renderInput={(params) => <TextField {...params} label="Movie" />}

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx
@@ -6,7 +6,6 @@ export default function ComboBox() {
   return (
     <Autocomplete
       disablePortal
-      id="combo-box-demo"
       options={top100Films}
       sx={{ width: 300 }}
       renderInput={(params) => <TextField {...params} label="Movie" />}

--- a/docs/src/pages/components/autocomplete/ComboBox.tsx.preview
+++ b/docs/src/pages/components/autocomplete/ComboBox.tsx.preview
@@ -1,6 +1,5 @@
 <Autocomplete
   disablePortal
-  id="combo-box-demo"
   options={top100Films}
   sx={{ width: 300 }}
   renderInput={(params) => <TextField {...params} label="Movie" />}

--- a/docs/src/pages/components/autocomplete/ControllableStates.js
+++ b/docs/src/pages/components/autocomplete/ControllableStates.js
@@ -22,7 +22,6 @@ export default function ControllableStates() {
         onInputChange={(event, newInputValue) => {
           setInputValue(newInputValue);
         }}
-        id="controllable-states-demo"
         options={options}
         sx={{ width: 300 }}
         renderInput={(params) => <TextField {...params} label="Controllable" />}

--- a/docs/src/pages/components/autocomplete/ControllableStates.tsx
+++ b/docs/src/pages/components/autocomplete/ControllableStates.tsx
@@ -22,7 +22,6 @@ export default function ControllableStates() {
         onInputChange={(event, newInputValue) => {
           setInputValue(newInputValue);
         }}
-        id="controllable-states-demo"
         options={options}
         sx={{ width: 300 }}
         renderInput={(params) => <TextField {...params} label="Controllable" />}

--- a/docs/src/pages/components/autocomplete/ControllableStates.tsx.preview
+++ b/docs/src/pages/components/autocomplete/ControllableStates.tsx.preview
@@ -1,0 +1,16 @@
+<div>{`value: ${value !== null ? `'${value}'` : 'null'}`}</div>
+<div>{`inputValue: '${inputValue}'`}</div>
+<br />
+<Autocomplete
+  value={value}
+  onChange={(event: any, newValue: string | null) => {
+    setValue(newValue);
+  }}
+  inputValue={inputValue}
+  onInputChange={(event, newInputValue) => {
+    setInputValue(newInputValue);
+  }}
+  options={options}
+  sx={{ width: 300 }}
+  renderInput={(params) => <TextField {...params} label="Controllable" />}
+/>

--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -6,7 +6,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 export default function CountrySelect() {
   return (
     <Autocomplete
-      id="country-select-demo"
       sx={{ width: 300 }}
       options={countries}
       autoHighlight

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -6,7 +6,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 export default function CountrySelect() {
   return (
     <Autocomplete
-      id="country-select-demo"
       sx={{ width: 300 }}
       options={countries}
       autoHighlight

--- a/docs/src/pages/components/autocomplete/CustomInputAutocomplete.js
+++ b/docs/src/pages/components/autocomplete/CustomInputAutocomplete.js
@@ -17,7 +17,6 @@ export default function CustomInputAutocomplete() {
               theme.palette.getContrastText(theme.palette.background.paper),
           },
         }}
-        id="custom-input-demo"
         options={options}
         renderInput={(params) => (
           <div ref={params.InputProps.ref}>

--- a/docs/src/pages/components/autocomplete/CustomInputAutocomplete.tsx
+++ b/docs/src/pages/components/autocomplete/CustomInputAutocomplete.tsx
@@ -17,7 +17,6 @@ export default function CustomInputAutocomplete() {
               theme.palette.getContrastText(theme.palette.background.paper),
           },
         }}
-        id="custom-input-demo"
         options={options}
         renderInput={(params) => (
           <div ref={params.InputProps.ref}>

--- a/docs/src/pages/components/autocomplete/DisabledOptions.js
+++ b/docs/src/pages/components/autocomplete/DisabledOptions.js
@@ -5,7 +5,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 export default function DisabledOptions() {
   return (
     <Autocomplete
-      id="disabled-options-demo"
       options={timeSlots}
       getOptionDisabled={(option) =>
         option === timeSlots[0] || option === timeSlots[2]

--- a/docs/src/pages/components/autocomplete/DisabledOptions.tsx
+++ b/docs/src/pages/components/autocomplete/DisabledOptions.tsx
@@ -5,7 +5,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 export default function DisabledOptions() {
   return (
     <Autocomplete
-      id="disabled-options-demo"
       options={timeSlots}
       getOptionDisabled={(option) =>
         option === timeSlots[0] || option === timeSlots[2]

--- a/docs/src/pages/components/autocomplete/DisabledOptions.tsx.preview
+++ b/docs/src/pages/components/autocomplete/DisabledOptions.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="disabled-options-demo"
   options={timeSlots}
   getOptionDisabled={(option) =>
     option === timeSlots[0] || option === timeSlots[2]

--- a/docs/src/pages/components/autocomplete/Filter.js
+++ b/docs/src/pages/components/autocomplete/Filter.js
@@ -10,7 +10,6 @@ const filterOptions = createFilterOptions({
 export default function Filter() {
   return (
     <Autocomplete
-      id="filter-demo"
       options={top100Films}
       getOptionLabel={(option) => option.title}
       filterOptions={filterOptions}

--- a/docs/src/pages/components/autocomplete/Filter.tsx
+++ b/docs/src/pages/components/autocomplete/Filter.tsx
@@ -10,7 +10,6 @@ const filterOptions = createFilterOptions({
 export default function Filter() {
   return (
     <Autocomplete
-      id="filter-demo"
       options={top100Films}
       getOptionLabel={(option) => option.title}
       filterOptions={filterOptions}

--- a/docs/src/pages/components/autocomplete/Filter.tsx.preview
+++ b/docs/src/pages/components/autocomplete/Filter.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="filter-demo"
   options={top100Films}
   getOptionLabel={(option) => option.title}
   filterOptions={filterOptions}

--- a/docs/src/pages/components/autocomplete/FixedTags.js
+++ b/docs/src/pages/components/autocomplete/FixedTags.js
@@ -10,7 +10,6 @@ export default function FixedTags() {
   return (
     <Autocomplete
       multiple
-      id="fixed-tags-demo"
       value={value}
       onChange={(event, newValue) => {
         setValue([

--- a/docs/src/pages/components/autocomplete/FixedTags.tsx
+++ b/docs/src/pages/components/autocomplete/FixedTags.tsx
@@ -10,7 +10,6 @@ export default function FixedTags() {
   return (
     <Autocomplete
       multiple
-      id="fixed-tags-demo"
       value={value}
       onChange={(event, newValue) => {
         setValue([

--- a/docs/src/pages/components/autocomplete/FreeSolo.js
+++ b/docs/src/pages/components/autocomplete/FreeSolo.js
@@ -7,14 +7,12 @@ export default function FreeSolo() {
   return (
     <Stack spacing={2} sx={{ width: 300 }}>
       <Autocomplete
-        id="free-solo-demo"
         freeSolo
         options={top100Films.map((option) => option.title)}
         renderInput={(params) => <TextField {...params} label="freeSolo" />}
       />
       <Autocomplete
         freeSolo
-        id="free-solo-2-demo"
         disableClearable
         options={top100Films.map((option) => option.title)}
         renderInput={(params) => (

--- a/docs/src/pages/components/autocomplete/FreeSolo.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSolo.tsx
@@ -7,14 +7,12 @@ export default function FreeSolo() {
   return (
     <Stack spacing={2} sx={{ width: 300 }}>
       <Autocomplete
-        id="free-solo-demo"
         freeSolo
         options={top100Films.map((option) => option.title)}
         renderInput={(params) => <TextField {...params} label="freeSolo" />}
       />
       <Autocomplete
         freeSolo
-        id="free-solo-2-demo"
         disableClearable
         options={top100Films.map((option) => option.title)}
         renderInput={(params) => (

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.js
@@ -42,7 +42,6 @@ export default function FreeSoloCreateOption() {
       selectOnFocus
       clearOnBlur
       handleHomeEndKeys
-      id="free-solo-with-text-demo"
       options={top100Films}
       getOptionLabel={(option) => {
         // Value selected with enter, right from the input

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOption.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOption.tsx
@@ -42,7 +42,6 @@ export default function FreeSoloCreateOption() {
       selectOnFocus
       clearOnBlur
       handleHomeEndKeys
-      id="free-solo-with-text-demo"
       options={top100Films}
       getOptionLabel={(option) => {
         // Value selected with enter, right from the input

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.js
@@ -74,7 +74,6 @@ export default function FreeSoloCreateOptionDialog() {
 
           return filtered;
         }}
-        id="free-solo-dialog-demo"
         options={top100Films}
         getOptionLabel={(option) => {
           // e.g value selected with enter, right from the input
@@ -104,7 +103,6 @@ export default function FreeSoloCreateOptionDialog() {
             <TextField
               autoFocus
               margin="dense"
-              id="name"
               value={dialogValue.title}
               onChange={(event) =>
                 setDialogValue({
@@ -118,7 +116,6 @@ export default function FreeSoloCreateOptionDialog() {
             />
             <TextField
               margin="dense"
-              id="name"
               value={dialogValue.year}
               onChange={(event) =>
                 setDialogValue({

--- a/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSoloCreateOptionDialog.tsx
@@ -72,7 +72,6 @@ export default function FreeSoloCreateOptionDialog() {
 
           return filtered;
         }}
-        id="free-solo-dialog-demo"
         options={top100Films}
         getOptionLabel={(option) => {
           // e.g value selected with enter, right from the input
@@ -102,7 +101,6 @@ export default function FreeSoloCreateOptionDialog() {
             <TextField
               autoFocus
               margin="dense"
-              id="name"
               value={dialogValue.title}
               onChange={(event) =>
                 setDialogValue({
@@ -116,7 +114,6 @@ export default function FreeSoloCreateOptionDialog() {
             />
             <TextField
               margin="dense"
-              id="name"
               value={dialogValue.year}
               onChange={(event) =>
                 setDialogValue({

--- a/docs/src/pages/components/autocomplete/GoogleMaps.js
+++ b/docs/src/pages/components/autocomplete/GoogleMaps.js
@@ -87,7 +87,6 @@ export default function GoogleMaps() {
 
   return (
     <Autocomplete
-      id="google-map-demo"
       sx={{ width: 300 }}
       getOptionLabel={(option) =>
         typeof option === 'string' ? option : option.description

--- a/docs/src/pages/components/autocomplete/GoogleMaps.tsx
+++ b/docs/src/pages/components/autocomplete/GoogleMaps.tsx
@@ -111,7 +111,6 @@ export default function GoogleMaps() {
 
   return (
     <Autocomplete
-      id="google-map-demo"
       sx={{ width: 300 }}
       getOptionLabel={(option) =>
         typeof option === 'string' ? option : option.description

--- a/docs/src/pages/components/autocomplete/Grouped.js
+++ b/docs/src/pages/components/autocomplete/Grouped.js
@@ -13,7 +13,6 @@ export default function Grouped() {
 
   return (
     <Autocomplete
-      id="grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/Grouped.tsx
+++ b/docs/src/pages/components/autocomplete/Grouped.tsx
@@ -13,7 +13,6 @@ export default function Grouped() {
 
   return (
     <Autocomplete
-      id="grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/Grouped.tsx.preview
+++ b/docs/src/pages/components/autocomplete/Grouped.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="grouped-demo"
   options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
   groupBy={(option) => option.firstLetter}
   getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/Highlights.js
+++ b/docs/src/pages/components/autocomplete/Highlights.js
@@ -7,7 +7,6 @@ import match from 'autosuggest-highlight/match';
 export default function Highlights() {
   return (
     <Autocomplete
-      id="highlights-demo"
       sx={{ width: 300 }}
       options={top100Films}
       getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/Highlights.tsx
+++ b/docs/src/pages/components/autocomplete/Highlights.tsx
@@ -7,7 +7,6 @@ import match from 'autosuggest-highlight/match';
 export default function Highlights() {
   return (
     <Autocomplete
-      id="highlights-demo"
       sx={{ width: 300 }}
       options={top100Films}
       getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/LimitTags.js
+++ b/docs/src/pages/components/autocomplete/LimitTags.js
@@ -7,7 +7,6 @@ export default function LimitTags() {
     <Autocomplete
       multiple
       limitTags={2}
-      id="multiple-limit-tags"
       options={top100Films}
       getOptionLabel={(option) => option.title}
       defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}

--- a/docs/src/pages/components/autocomplete/LimitTags.tsx
+++ b/docs/src/pages/components/autocomplete/LimitTags.tsx
@@ -7,7 +7,6 @@ export default function LimitTags() {
     <Autocomplete
       multiple
       limitTags={2}
-      id="multiple-limit-tags"
       options={top100Films}
       getOptionLabel={(option) => option.title}
       defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}

--- a/docs/src/pages/components/autocomplete/LimitTags.tsx.preview
+++ b/docs/src/pages/components/autocomplete/LimitTags.tsx.preview
@@ -1,7 +1,6 @@
 <Autocomplete
   multiple
   limitTags={2}
-  id="multiple-limit-tags"
   options={top100Films}
   getOptionLabel={(option) => option.title}
   defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}

--- a/docs/src/pages/components/autocomplete/Playground.js
+++ b/docs/src/pages/components/autocomplete/Playground.js
@@ -19,7 +19,6 @@ export default function Playground() {
     <Stack spacing={1} sx={{ width: 300 }}>
       <Autocomplete
         {...defaultProps}
-        id="disable-close-on-select"
         disableCloseOnSelect
         renderInput={(params) => (
           <TextField {...params} label="disableCloseOnSelect" variant="standard" />
@@ -27,7 +26,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="clear-on-escape"
         clearOnEscape
         renderInput={(params) => (
           <TextField {...params} label="clearOnEscape" variant="standard" />
@@ -35,7 +33,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disable-clearable"
         disableClearable
         renderInput={(params) => (
           <TextField {...params} label="disableClearable" variant="standard" />
@@ -43,7 +40,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="include-input-in-list"
         includeInputInList
         renderInput={(params) => (
           <TextField {...params} label="includeInputInList" variant="standard" />
@@ -51,14 +47,12 @@ export default function Playground() {
       />
       <Autocomplete
         {...flatProps}
-        id="flat-demo"
         renderInput={(params) => (
           <TextField {...params} label="flat" variant="standard" />
         )}
       />
       <Autocomplete
         {...defaultProps}
-        id="controlled-demo"
         value={value}
         onChange={(event, newValue) => {
           setValue(newValue);
@@ -69,7 +63,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="auto-complete"
         autoComplete
         includeInputInList
         renderInput={(params) => (
@@ -78,7 +71,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disable-list-wrap"
         disableListWrap
         renderInput={(params) => (
           <TextField {...params} label="disableListWrap" variant="standard" />
@@ -86,7 +78,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="open-on-focus"
         openOnFocus
         renderInput={(params) => (
           <TextField {...params} label="openOnFocus" variant="standard" />
@@ -94,7 +85,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="auto-highlight"
         autoHighlight
         renderInput={(params) => (
           <TextField {...params} label="autoHighlight" variant="standard" />
@@ -102,7 +92,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="auto-select"
         autoSelect
         renderInput={(params) => (
           <TextField {...params} label="autoSelect" variant="standard" />
@@ -110,7 +99,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disabled"
         disabled
         renderInput={(params) => (
           <TextField {...params} label="disabled" variant="standard" />
@@ -118,7 +106,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disable-portal"
         disablePortal
         renderInput={(params) => (
           <TextField {...params} label="disablePortal" variant="standard" />
@@ -126,7 +113,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="blur-on-select"
         blurOnSelect
         renderInput={(params) => (
           <TextField {...params} label="blurOnSelect" variant="standard" />
@@ -134,7 +120,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="clear-on-blur"
         clearOnBlur
         renderInput={(params) => (
           <TextField {...params} label="clearOnBlur" variant="standard" />
@@ -142,7 +127,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="select-on-focus"
         selectOnFocus
         renderInput={(params) => (
           <TextField {...params} label="selectOnFocus" variant="standard" />

--- a/docs/src/pages/components/autocomplete/Playground.tsx
+++ b/docs/src/pages/components/autocomplete/Playground.tsx
@@ -17,7 +17,6 @@ export default function Playground() {
     <Stack spacing={1} sx={{ width: 300 }}>
       <Autocomplete
         {...defaultProps}
-        id="disable-close-on-select"
         disableCloseOnSelect
         renderInput={(params) => (
           <TextField {...params} label="disableCloseOnSelect" variant="standard" />
@@ -25,7 +24,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="clear-on-escape"
         clearOnEscape
         renderInput={(params) => (
           <TextField {...params} label="clearOnEscape" variant="standard" />
@@ -33,7 +31,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disable-clearable"
         disableClearable
         renderInput={(params) => (
           <TextField {...params} label="disableClearable" variant="standard" />
@@ -41,7 +38,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="include-input-in-list"
         includeInputInList
         renderInput={(params) => (
           <TextField {...params} label="includeInputInList" variant="standard" />
@@ -49,14 +45,12 @@ export default function Playground() {
       />
       <Autocomplete
         {...flatProps}
-        id="flat-demo"
         renderInput={(params) => (
           <TextField {...params} label="flat" variant="standard" />
         )}
       />
       <Autocomplete
         {...defaultProps}
-        id="controlled-demo"
         value={value}
         onChange={(event: any, newValue: FilmOptionType | null) => {
           setValue(newValue);
@@ -67,7 +61,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="auto-complete"
         autoComplete
         includeInputInList
         renderInput={(params) => (
@@ -76,7 +69,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disable-list-wrap"
         disableListWrap
         renderInput={(params) => (
           <TextField {...params} label="disableListWrap" variant="standard" />
@@ -84,7 +76,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="open-on-focus"
         openOnFocus
         renderInput={(params) => (
           <TextField {...params} label="openOnFocus" variant="standard" />
@@ -92,7 +83,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="auto-highlight"
         autoHighlight
         renderInput={(params) => (
           <TextField {...params} label="autoHighlight" variant="standard" />
@@ -100,7 +90,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="auto-select"
         autoSelect
         renderInput={(params) => (
           <TextField {...params} label="autoSelect" variant="standard" />
@@ -108,7 +97,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disabled"
         disabled
         renderInput={(params) => (
           <TextField {...params} label="disabled" variant="standard" />
@@ -116,7 +104,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="disable-portal"
         disablePortal
         renderInput={(params) => (
           <TextField {...params} label="disablePortal" variant="standard" />
@@ -124,7 +111,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="blur-on-select"
         blurOnSelect
         renderInput={(params) => (
           <TextField {...params} label="blurOnSelect" variant="standard" />
@@ -132,7 +118,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="clear-on-blur"
         clearOnBlur
         renderInput={(params) => (
           <TextField {...params} label="clearOnBlur" variant="standard" />
@@ -140,7 +125,6 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        id="select-on-focus"
         selectOnFocus
         renderInput={(params) => (
           <TextField {...params} label="selectOnFocus" variant="standard" />

--- a/docs/src/pages/components/autocomplete/Sizes.js
+++ b/docs/src/pages/components/autocomplete/Sizes.js
@@ -8,7 +8,6 @@ export default function Sizes() {
   return (
     <Stack spacing={2} sx={{ width: 500 }}>
       <Autocomplete
-        id="size-small-standard"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -24,7 +23,6 @@ export default function Sizes() {
       />
       <Autocomplete
         multiple
-        id="size-small-standard-multi"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -39,7 +37,6 @@ export default function Sizes() {
         )}
       />
       <Autocomplete
-        id="size-small-outlined"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -50,7 +47,6 @@ export default function Sizes() {
       />
       <Autocomplete
         multiple
-        id="size-small-outlined-multi"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -60,7 +56,6 @@ export default function Sizes() {
         )}
       />
       <Autocomplete
-        id="size-small-filled"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -86,7 +81,6 @@ export default function Sizes() {
       />
       <Autocomplete
         multiple
-        id="size-small-filled-multi"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/Sizes.tsx
+++ b/docs/src/pages/components/autocomplete/Sizes.tsx
@@ -8,7 +8,6 @@ export default function Sizes() {
   return (
     <Stack spacing={2} sx={{ width: 500 }}>
       <Autocomplete
-        id="size-small-standard"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -24,7 +23,6 @@ export default function Sizes() {
       />
       <Autocomplete
         multiple
-        id="size-small-standard-multi"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -39,7 +37,6 @@ export default function Sizes() {
         )}
       />
       <Autocomplete
-        id="size-small-outlined"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -50,7 +47,6 @@ export default function Sizes() {
       />
       <Autocomplete
         multiple
-        id="size-small-outlined-multi"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -60,7 +56,6 @@ export default function Sizes() {
         )}
       />
       <Autocomplete
-        id="size-small-filled"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}
@@ -86,7 +81,6 @@ export default function Sizes() {
       />
       <Autocomplete
         multiple
-        id="size-small-filled-multi"
         size="small"
         options={top100Films}
         getOptionLabel={(option) => option.title}

--- a/docs/src/pages/components/autocomplete/Tags.js
+++ b/docs/src/pages/components/autocomplete/Tags.js
@@ -9,7 +9,6 @@ export default function Tags() {
     <Stack spacing={3} sx={{ width: 500 }}>
       <Autocomplete
         multiple
-        id="tags-standard"
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
@@ -24,7 +23,6 @@ export default function Tags() {
       />
       <Autocomplete
         multiple
-        id="tags-outlined"
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
@@ -39,7 +37,6 @@ export default function Tags() {
       />
       <Autocomplete
         multiple
-        id="tags-filled"
         options={top100Films.map((option) => option.title)}
         defaultValue={[top100Films[13].title]}
         freeSolo

--- a/docs/src/pages/components/autocomplete/Tags.tsx
+++ b/docs/src/pages/components/autocomplete/Tags.tsx
@@ -9,7 +9,6 @@ export default function Tags() {
     <Stack spacing={3} sx={{ width: 500 }}>
       <Autocomplete
         multiple
-        id="tags-standard"
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
@@ -24,7 +23,6 @@ export default function Tags() {
       />
       <Autocomplete
         multiple
-        id="tags-outlined"
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
@@ -39,7 +37,6 @@ export default function Tags() {
       />
       <Autocomplete
         multiple
-        id="tags-filled"
         options={top100Films.map((option) => option.title)}
         defaultValue={[top100Films[13].title]}
         freeSolo

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -139,7 +139,6 @@ const OPTIONS = Array.from(new Array(10000))
 export default function Virtualize() {
   return (
     <Autocomplete
-      id="virtualize-demo"
       sx={{ width: 300 }}
       disableListWrap
       PopperComponent={StyledPopper}

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -138,7 +138,6 @@ const OPTIONS = Array.from(new Array(10000))
 export default function Virtualize() {
   return (
     <Autocomplete
-      id="virtualize-demo"
       sx={{ width: 300 }}
       disableListWrap
       PopperComponent={StyledPopper}

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx.preview
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="virtualize-demo"
   sx={{ width: 300 }}
   disableListWrap
   PopperComponent={StyledPopper}

--- a/docs/src/pages/components/material-icons/SearchIcons.js
+++ b/docs/src/pages/components/material-icons/SearchIcons.js
@@ -6,6 +6,7 @@ import copy from 'clipboard-copy';
 import InputBase from '@mui/material/InputBase';
 import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
+import debounce from 'lodash/debounce';
 import Grid from '@mui/material/Grid';
 import Dialog from '@mui/material/Dialog';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
@@ -124,34 +125,7 @@ const StyledSvgIcon = styled(SvgIcon)(({ theme }) => ({
 }));
 
 const Icons = React.memo(function Icons(props) {
-  const { theme, value, handleOpenClick } = props;
-
-  const keys = React.useMemo(() => {
-    if (value === '') {
-      return null;
-    }
-    return searchIndex.search(value);
-  }, [value]);
-  React.useEffect(() => {
-    if (value.length >= 4 && keys !== null && keys.length === 0) {
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: 'material-icons',
-        eventAction: 'no-results',
-        eventLabel: value,
-      });
-    }
-  }, [keys, value]);
-
-  const searchedIcons = React.useMemo(() => {
-    if (keys === null) {
-      return allIcons;
-    }
-    return keys.map((key) => allIconsMap[key]);
-  }, [keys]);
-  const icons = React.useMemo(() => {
-    return searchedIcons.filter((icon) => theme === icon.theme);
-  }, [searchedIcons, theme]);
+  const { icons, handleOpenClick } = props;
 
   const handleIconClick = (icon) => () => {
     if (Math.random() < 0.1) {
@@ -175,8 +149,7 @@ const Icons = React.memo(function Icons(props) {
   };
 
   return (
-    <React.Fragment>
-      <Typography sx={{ mb: 1 }}>{`${icons.length} matching results`}</Typography>
+    <div>
       {icons.map((icon) => {
         /* eslint-disable jsx-a11y/click-events-have-key-events */
         return (
@@ -196,14 +169,13 @@ const Icons = React.memo(function Icons(props) {
           </StyledIcon>
         );
       })}
-    </React.Fragment>
+    </div>
   );
 });
 
 Icons.propTypes = {
   handleOpenClick: PropTypes.func.isRequired,
-  theme: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  icons: PropTypes.array.isRequired,
 };
 
 const ImportLink = styled(Link)(({ theme }) => ({
@@ -474,8 +446,7 @@ const allIcons = Object.keys(mui)
 
 export default function SearchIcons() {
   const [theme, setTheme] = React.useState('Filled');
-  const [value, setValue] = React.useState('');
-  const deferredValue = React.useDeferredValue(value);
+  const [keys, setKeys] = React.useState(null);
   const [open, setOpen] = React.useState(false);
   const [selectedIcon, setSelectedIcon] = React.useState(null);
 
@@ -487,6 +458,44 @@ export default function SearchIcons() {
   const handleClose = React.useCallback(() => {
     setOpen(false);
   }, []);
+
+  const handleChange = React.useMemo(
+    () =>
+      debounce((value) => {
+        if (value === '') {
+          setKeys(null);
+        } else {
+          searchIndex.searchAsync(value).then((results) => {
+            setKeys(results);
+
+            // Keep track of the no results so we can add synonyms in the future.
+            if (value.length >= 4 && results.length === 0) {
+              window.ga('send', {
+                hitType: 'event',
+                eventCategory: 'material-icons',
+                eventAction: 'no-results',
+                eventLabel: value,
+              });
+            }
+          });
+        }
+      }, 220),
+    [],
+  );
+
+  React.useEffect(() => {
+    return () => {
+      handleChange.cancel();
+    };
+  }, [handleChange]);
+
+  const icons = React.useMemo(
+    () =>
+      (keys === null ? allIcons : keys.map((key) => allIconsMap[key])).filter(
+        (icon) => theme === icon.theme,
+      ),
+    [theme, keys],
+  );
 
   return (
     <Grid container sx={{ minHeight: 500 }}>
@@ -521,18 +530,14 @@ export default function SearchIcons() {
           <Input
             autoFocus
             onChange={(event) => {
-              setValue(event.target.value);
+              handleChange(event.target.value);
             }}
             placeholder="Search icons…"
             inputProps={{ 'aria-label': 'search icons' }}
-            value={value}
           />
         </Paper>
-        <Icons
-          theme={theme}
-          value={deferredValue}
-          handleOpenClick={handleOpenClick}
-        />
+        <Typography sx={{ mb: 1 }}>{`${icons.length} matching results`}</Typography>
+        <Icons icons={icons} handleOpenClick={handleOpenClick} />
       </Grid>
       <DialogDetails
         open={open}

--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -285,7 +285,8 @@ In order for the text field to be accessible, **the input should be linked to th
 </div>
 ```
 
-- If you are using the `TextField` component, you just have to provide a unique `id`.
+- If you are using the `TextField` component, you just have to provide a unique `id` unless you're using the `TextField` only client side.
+  Until the UI is hydrated `TextField` without an explicit `id` will not have associated labels.
 - If you are composing the component:
 
 ```jsx

--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
     "@babel/register": "^7.16.0",
     "@emotion/react": "^11.6.0",
     "@emotion/styled": "^11.6.0",
-    "@eps1lon/enzyme-adapter-react-17": "^0.1.0",
+    "@eps1lon/enzyme-adapter-react-17": "npm:@eps1lon/enzyme-adapter-react-next",
     "@octokit/rest": "^18.12.0",
     "@rollup/plugin-replace": "^3.0.0",
     "@testing-library/dom": "^8.11.1",
-    "@testing-library/react": "^12.1.2",
+    "@testing-library/react": "alpha",
     "@types/chai": "^4.2.22",
     "@types/chai-dom": "^0.0.11",
     "@types/enzyme": "^3.10.10",
@@ -197,7 +197,13 @@
     "**/@types/react-dom": "^17.0.11",
     "**/@mui/core": "link:./packages/mui-base",
     "**/cross-fetch": "^3.1.4",
-    "**/react-is": "^17.0.2"
+    "**/react-is": "^17.0.2",
+    "scheduler": "0.21.0-beta-fdc1d617a-20211118",
+    "react": "18.0.0-beta-fdc1d617a-20211118",
+    "react-test-renderer": "18.0.0-beta-fdc1d617a-20211118",
+    "react-dom": "18.0.0-beta-fdc1d617a-20211118",
+    "react-is": "18.0.0-beta-fdc1d617a-20211118",
+    "use-sync-external-store": "1.0.0-beta-fdc1d617a-20211118"
   },
   "nyc": {
     "include": [

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { refType } from '@mui/utils';
+import { refType, unstable_useId as useId } from '@mui/utils';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import Input from '../Input';
@@ -82,7 +82,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     FormHelperTextProps,
     fullWidth = false,
     helperText,
-    id,
+    id: idOverride,
     InputLabelProps,
     inputProps,
     InputProps,
@@ -153,6 +153,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     InputMore['aria-describedby'] = undefined;
   }
 
+  const id = useId(idOverride);
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
   const inputLabelId = label && id ? `${id}-label` : undefined;
   const InputComponent = variantComponent[variant];

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -50,19 +50,14 @@ describe('<TextField />', () => {
 
   describe('with a label', () => {
     it('label the input', () => {
-      const { getByRole } = render(<TextField id="labelled" label="Foo bar" variant="standard" />);
+      const { getByRole } = render(<TextField label="Foo bar" variant="standard" />);
 
-      expect(getByRole('textbox', { name: 'Foo bar' })).not.to.equal(null);
+      expect(getByRole('textbox')).toHaveAccessibleName('Foo bar');
     });
 
     it('should apply the className to the label', () => {
       const { container } = render(
-        <TextField
-          id="labelled"
-          label="Foo bar"
-          InputLabelProps={{ className: 'foo' }}
-          variant="standard"
-        />,
+        <TextField label="Foo bar" InputLabelProps={{ className: 'foo' }} variant="standard" />,
       );
 
       expect(container.querySelector('label')).to.have.class('foo');
@@ -70,7 +65,7 @@ describe('<TextField />', () => {
 
     ['', undefined].forEach((label) => {
       it(`should not render empty (${label}) label element`, () => {
-        const { container } = render(<TextField id="labelled" label={label} variant="standard" />);
+        const { container } = render(<TextField label={label} variant="standard" />);
 
         expect(container.querySelector('label')).to.equal(null);
       });
@@ -81,7 +76,6 @@ describe('<TextField />', () => {
     it('should apply the className to the FormHelperText', () => {
       const { getDescriptionOf, getByRole } = render(
         <TextField
-          id="aria-test"
           helperText="Foo bar"
           FormHelperTextProps={{ className: 'foo' }}
           variant="standard"
@@ -91,17 +85,16 @@ describe('<TextField />', () => {
       expect(getDescriptionOf(getByRole('textbox'))).to.have.class('foo');
     });
 
-    it('should add accessibility labels to the input', () => {
-      const { getDescriptionOf, getByRole } = render(
+    it('has an accessible description', () => {
+      const { getByRole } = render(
         <TextField
-          id="aria-test"
           helperText="Foo bar"
           FormHelperTextProps={{ className: 'foo' }}
           variant="standard"
         />,
       );
 
-      expect(getDescriptionOf(getByRole('textbox'))).to.have.text('Foo bar');
+      expect(getByRole('textbox')).toHaveAccessibleDescription('Foo bar');
     });
   });
 
@@ -162,11 +155,10 @@ describe('<TextField />', () => {
       expect(select.options).to.have.lengthOf(2);
     });
 
-    it('associates the label with the <select /> when `native={true}` and `id`', () => {
+    it('associates the label with the <select /> when `native={true}`', () => {
       const { getByRole } = render(
         <TextField
           label="Currency:"
-          id="labelled-select"
           select
           SelectProps={{ native: true }}
           value="$"
@@ -181,7 +173,7 @@ describe('<TextField />', () => {
 
     it('renders a combobox with the appropriate accessible name', () => {
       const { getByRole } = render(
-        <TextField select id="my-select" label="Release: " value="stable" variant="standard">
+        <TextField select label="Release: " value="stable" variant="standard">
           <MenuItem value="alpha">Alpha</MenuItem>
           <MenuItem value="beta">Beta</MenuItem>
           <MenuItem value="stable">Stable</MenuItem>
@@ -193,7 +185,7 @@ describe('<TextField />', () => {
 
     it('creates an input[hidden] that has no accessible properties', () => {
       const { container } = render(
-        <TextField select id="my-select" label="Release: " value="stable" variant="standard">
+        <TextField select label="Release: " value="stable" variant="standard">
           <MenuItem value="stable">Stable</MenuItem>
         </TextField>,
       );
@@ -205,7 +197,7 @@ describe('<TextField />', () => {
 
     it('renders a combobox with the appropriate accessible description', () => {
       const { getByRole } = render(
-        <TextField select id="aria-test" helperText="Foo bar" value="10">
+        <TextField select helperText="Foo bar" value="10">
           <MenuItem value={10}>Ten</MenuItem>
         </TextField>,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,20 +1499,19 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@eps1lon/enzyme-adapter-react-17@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@eps1lon/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.1.0.tgz#68e8db7fe231d29f86ce3c4b0331b6d04ee14dd3"
-  integrity sha512-NiiEG6rfeE7NuZc1oNr8CBb6zNpDO4gpVt4JiVCYnaLOEMEE9Kj3I+vFjawEYLxnMfptTdawHgYVvSeTenZSVw==
+"@eps1lon/enzyme-adapter-react-17@npm:@eps1lon/enzyme-adapter-react-next":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@eps1lon/enzyme-adapter-react-next/-/enzyme-adapter-react-next-0.0.1.tgz#e44d436323a00d8065788e3ab4493efed216edce"
+  integrity sha512-oGecpGf84lE3jpsI48HZhT4TtuVeHpKDXYvrsGVYBvLJS7LT3mCB1R4Etrcg5SnCVwxrNLRKiquHo5hXBsKJjg==
   dependencies:
-    enzyme-adapter-utils "^1.13.1"
-    enzyme-shallow-equal "^1.0.4"
+    enzyme-adapter-utils "^1.13.0"
+    enzyme-shallow-equal "^1.0.1"
     has "^1.0.3"
     object.assign "^4.1.0"
     object.values "^1.1.1"
     prop-types "^15.7.2"
-    react-is "^17.0.0"
-    react-reconciler "^0.26.1"
-    react-test-renderer "^17.0.0"
+    react-is "^16.12.0"
+    react-test-renderer "^16.0.0-0"
     semver "^5.7.0"
 
 "@eslint/eslintrc@^0.4.3":
@@ -2899,7 +2898,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.11.1":
+"@testing-library/dom@^8.11.1", "@testing-library/dom@^8.5.0":
   version "8.11.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.1.tgz#03fa2684aa09ade589b460db46b4c7be9fc69753"
   integrity sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==
@@ -2913,13 +2912,13 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
-"@testing-library/react@^12.1.2":
-  version "12.1.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
-  integrity sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==
+"@testing-library/react@alpha":
+  version "13.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.0.0-alpha.4.tgz#00cf104f3a9b90d07691497abc50ade74e534d98"
+  integrity sha512-SY+sz4juZDcMlAaEI8kYpdi4qv+fGjvqLHETVAcL13Q+N9PFtsdmNJnVu3Ez4V1dJuR59y4vZlSJa/U69YyYBg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.0.0"
+    "@testing-library/dom" "^8.5.0"
 
 "@theme-ui/color-modes@0.12.0":
   version "0.12.0"
@@ -7249,7 +7248,7 @@ envinfo@^7.7.3, envinfo@^7.7.4, envinfo@^7.8.1:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
 
-enzyme-adapter-utils@^1.13.1:
+enzyme-adapter-utils@^1.13.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz#afbb0485e8033aa50c744efb5f5711e64fbf1ad0"
   integrity sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==
@@ -7262,7 +7261,7 @@ enzyme-adapter-utils@^1.13.1:
     prop-types "^15.7.2"
     semver "^5.7.1"
 
-enzyme-shallow-equal@^1.0.1, enzyme-shallow-equal@^1.0.4:
+enzyme-shallow-equal@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.4.tgz#b9256cb25a5f430f9bfe073a84808c1d74fced2e"
   integrity sha512-MttIwB8kKxypwHvRynuC3ahyNc+cFbR8mjVIltnmzQ0uKGqmsfO4bfBuLxb0beLNPhjblUEYvEbsg+VSygvF1Q==
@@ -13472,14 +13471,14 @@ react-docgen@^5.4.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@18.0.0-beta-fdc1d617a-20211118, react-dom@^17.0.2:
+  version "18.0.0-beta-fdc1d617a-20211118"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-beta-fdc1d617a-20211118.tgz#0d2ddaa962fae1bbcf17c0eac5e3879d30793753"
+  integrity sha512-BlA0NdAKE+Ibe5orAfHphf76ltL9+PiWsexrjVjtRcumrra3WH3rDYT+evXfLFBzxpbZDjhkL1oQ1/zCjKyWBA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "0.21.0-beta-fdc1d617a-20211118"
 
 react-draggable@^4.4.4:
   version "4.4.4"
@@ -13523,7 +13522,7 @@ react-intersection-observer@^8.32.2:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.32.2.tgz#527eeecf569309d64ed96330636d90aac336c957"
   integrity sha512-QTcea+n28AvOHbTku+jErfQqknbc4Nuh7EUNik8p/JMN56W2Jhjs+qcYZzQhAoyLX8pZD0QXpYX0lW87faackQ==
 
-react-is@17.0.2, react-is@^16.10.2, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
+react-is@17.0.2, react-is@18.0.0-beta-fdc1d617a-20211118, react-is@^16.10.2, react-is@^16.12.0, "react-is@^16.12.0 || ^17.0.0", react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -13556,15 +13555,6 @@ react-number-format@^4.8.0:
   integrity sha512-oGGiQpqzvKTR5PD2/AJbyUsci8jyupaoKxpuSPevjpWHMhFkUtmo390t+EIpJOgnuAHZogLu6PHiXgb/OXETKA==
   dependencies:
     prop-types "^15.7.2"
-
-react-reconciler@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.1.tgz#860952dd359fd870f94895c254271e3a9de3b2d6"
-  integrity sha512-6E/CvH9zcDmHjhiNJlP0qJ8+3ufnY2b5RWs774Uy8XKWN0l6qfnlkz0XnDacxqj2rbJdq76w9dlFXjPPOQrmqA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.1"
 
 react-redux@^7.2.6:
   version "7.2.6"
@@ -13678,15 +13668,15 @@ react-swipeable-views@^0.14.0:
     react-swipeable-views-utils "^0.14.0"
     warning "^4.0.1"
 
-react-test-renderer@^17.0.0, react-test-renderer@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
-  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+react-test-renderer@18.0.0-beta-fdc1d617a-20211118, react-test-renderer@^16.0.0-0, react-test-renderer@^17.0.2:
+  version "18.0.0-beta-fdc1d617a-20211118"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.0.0-beta-fdc1d617a-20211118.tgz#0c749540d1d67e975936027db8a8d8df0eb83a40"
+  integrity sha512-7bPLHLWd3Pgy/O6WF5DsoWsLrWLuJ8i8wydEM/mEy7m0n6YP8LIbwVLpJ7qIj/OahijQmIseJQsOKJbI9JT9Dw==
   dependencies:
     object-assign "^4.1.1"
-    react-is "^17.0.2"
+    react-is "18.0.0-beta-fdc1d617a-20211118"
     react-shallow-renderer "^16.13.1"
-    scheduler "^0.20.2"
+    scheduler "0.21.0-beta-fdc1d617a-20211118"
 
 react-transition-group@2.9.0:
   version "2.9.0"
@@ -13728,10 +13718,10 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@18.0.0-beta-fdc1d617a-20211118, react@^17.0.2:
+  version "18.0.0-beta-fdc1d617a-20211118"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-beta-fdc1d617a-20211118.tgz#ed8dd1674ddcab02bfff88ba368ad4d44db79fa7"
+  integrity sha512-+02tXs7Wc5az4Aw+dWp7Vwmd68POpiJF0pD20dVCwS+W8xxQ9GFEJrd5VE4Nal+HWDkGzSb6dApxoahULK/8ZA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -14484,10 +14474,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.1, scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@0.21.0-beta-fdc1d617a-20211118, scheduler@^0.20.2:
+  version "0.21.0-beta-fdc1d617a-20211118"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-beta-fdc1d617a-20211118.tgz#1f5e075e81b48af4a50d8f602a7a636731f0b8d4"
+  integrity sha512-fagjljhO7tVIGdT3rtYjjbHve/XfMubdY3Yna799WMK/rfYZtsGvX3GPu3IsjwOIs3IrcGjlxVRm6u3PFO+lwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -16388,6 +16378,11 @@ use-subscription@1.5.1:
   integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
   dependencies:
     object-assign "^4.1.1"
+
+use-sync-external-store@1.0.0-beta-fdc1d617a-20211118:
+  version "1.0.0-beta-fdc1d617a-20211118"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.0.0-beta-fdc1d617a-20211118.tgz#3b4a4b704c71a207442e0ce668318a5bd8945bfd"
+  integrity sha512-y61IkqITq6jkikjAU6e0sIyOFal8UCmpSg08lBEwqgdir1t11V+22WK+1eHrRwKD3494yt0PtST8hsMn3aFC2g==
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,26 +2307,12 @@
     glob-to-regexp "^0.3.0"
 
 "@mui/core@^5.0.0-alpha.54":
-  version "5.0.0-alpha.55"
-  dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@emotion/is-prop-valid" "^1.1.1"
-    "@mui/utils" "^5.1.1"
-    "@popperjs/core" "^2.4.4"
-    clsx "^1.1.1"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
+  version "0.0.0"
+  uid ""
 
 "@mui/core@link:./packages/mui-base":
-  version "5.0.0-alpha.55"
-  dependencies:
-    "@babel/runtime" "^7.16.3"
-    "@emotion/is-prop-valid" "^1.1.1"
-    "@mui/utils" "^5.1.1"
-    "@popperjs/core" "^2.4.4"
-    clsx "^1.1.1"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
+  version "0.0.0"
+  uid ""
 
 "@mui/x-data-grid-generator@^5.0.1":
   version "5.0.1"


### PR DESCRIPTION
Continuing https://github.com/mui-org/material-ui/pull/26766

Preview: https://deploy-preview-29171--material-ui.netlify.app/

Investigate some items for https://github.com/mui-org/material-ui/issues/26763

For the AppSearch we actually want to render the input outside and just the algolia logic inside the Suspense boundary. That way the user can orient themselve when landing on the page and hydration gets prioritized once they want to start typing. This would require some more boundaries though because right now hydration couldn't be priorized for the AppSearch since its parent is just one big Suspense boundary.

features usingReact 18:
- [ ] `Demo` will have their own `Suspense` boundary while the the demos itself will be wrapped in `lazy`. Then we can wrap `main` in a `SuspenseList` (Update: Not so sure about this one. If the 3rd demo is interacted with, will React wait for hydration of 1 and 2? If so then we don't want a SuspenseList). This means we can prioritize hydration of demos that the user wants to interact with and deprioritize hydration of offscreen demos (not planned for React 18 I believe. Should be part of the Offscreen API).
- [x] ~icon search uses `useDeferredValue`: https://deploy-preview-29171--material-ui.netlify.app/components/material-icons~ See description of https://github.com/mui-org/material-ui/pull/29171/commits/445eb99c2a9fd89e0715fe806424697c92e930fe for explainer