### PR TITLE
[docs] Add note about pickers migration

### DIFF
--- a/docs/src/pages/guides/pickers-migration/pickers-migration.md
+++ b/docs/src/pages/guides/pickers-migration/pickers-migration.md
@@ -113,6 +113,11 @@ Mask is no longer required. Also, if your provided mask is not valid, pickers wi
 />
 ```
 
+## Clearable
+
+The `clearable` prop, which was previously supported on desktop and mobile date-pickers, is now only
+supported on the MobileDatePicker view.
+
 ## And many more
 
 - ```diff

--- a/docs/src/pages/guides/pickers-migration/pickers-migration.md
+++ b/docs/src/pages/guides/pickers-migration/pickers-migration.md
@@ -115,8 +115,7 @@ Mask is no longer required. Also, if your provided mask is not valid, pickers wi
 
 ## Clearable
 
-The `clearable` prop, which was previously supported on desktop and mobile date-pickers, is now only
-supported on the MobileDatePicker view.
+The `clearable` prop, which was previously supported on desktop and mobile date-pickers, is now only supported on the MobileDatePicker view.
 
 ## And many more
 


### PR DESCRIPTION
The [DatePicker API doc](https://mui.com/api/date-picker/) specifies that it supports the `clearable` prop. Previously, this would allow for a "clear" button in the dialog of the `@material-ui/pickers/KeyboardDatePicker`, like so:

![image](https://user-images.githubusercontent.com/15660097/139285036-811a9454-b9fc-4cb6-9325-26404a3ab7a5.png)

I expected that this would be supported in @mui/lab/DatePicker. I spent a couple of minutes while migrating trying to figure out why it wasn't working as expected, and ultimately looked into the code for `material-ui/packages/mui-lab/src/DatePicker/DatePicker.tsx`.

What I found is that the `clearable` prop is not passed to the Desktop variant of the DatePicker component, only Mobile.

I figured this line in the docs would help others during the migration.