### PR TITLE
[Autocomplete] Clicking anywhere on Input should open listbox

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -545,8 +545,6 @@ export default function useAutocomplete(props) {
   }, [syncHighlightedIndex]);
 
   const handleOpen = (event) => {
-    // Prevent blur (which happens after onMouseDown event on Input fires)
-    event.preventDefault();
     if (open || disabledProp) {
       return;
     }
@@ -560,8 +558,6 @@ export default function useAutocomplete(props) {
   };
 
   const handleClose = (event, reason) => {
-    // Prevent blur (which happens after onMouseDown event on Input fires)
-    event.preventDefault();
     if (!open) {
       return;
     }
@@ -697,8 +693,6 @@ export default function useAutocomplete(props) {
   };
 
   const handleClear = (event) => {
-    // Prevent blur (which happens after onMouseDown event on Input fires)
-    event.preventDefault();
     event.stopPropagation();
     ignoreFocus.current = true;
     setInputValueState('');
@@ -921,6 +915,21 @@ export default function useAutocomplete(props) {
     });
   };
 
+  // Focus the input when interacting with the combobox
+  const handleClick = () => {
+    inputRef.current.focus();
+
+    if (
+      selectOnFocus &&
+      firstFocus.current &&
+      inputRef.current.selectionEnd - inputRef.current.selectionStart === 0
+    ) {
+      inputRef.current.select();
+    }
+
+    firstFocus.current = false;
+  };
+
   const handlePopupIndicator = (event) => {
     event.stopPropagation();
     if (open) {
@@ -937,22 +946,7 @@ export default function useAutocomplete(props) {
     }
   };
 
-  // Focus the input when interacting with the combobox
-  const handleClick = () => {
-    inputRef.current.focus();
-
-    if (
-      selectOnFocus &&
-      firstFocus.current &&
-      inputRef.current.selectionEnd - inputRef.current.selectionStart === 0
-    ) {
-      inputRef.current.select();
-    }
-
-    firstFocus.current = false;
-  };
-
-  const handleInputMouseDown = (event) => {
+  const handleInputClick = (event) => {
     if (inputValue === '' || !open) {
       handlePopupIndicator(event);
     }
@@ -1008,7 +1002,6 @@ export default function useAutocomplete(props) {
       ...other,
       onKeyDown: handleKeyDown(other),
       onMouseDown: handleMouseDown,
-      onClick: handleClick,
     }),
     getInputLabelProps: () => ({
       id: `${id}-label`,
@@ -1020,7 +1013,10 @@ export default function useAutocomplete(props) {
       onBlur: handleBlur,
       onFocus: handleFocus,
       onChange: handleInputChange,
-      onMouseDown: handleInputMouseDown,
+      onClick: (event) => {
+        handleInputClick(event);
+        handleClick(event);
+      },
       // if open then this is handled imperativeley so don't let react override
       // only have an opinion about this when closed
       'aria-activedescendant': popupOpen ? '' : null,
@@ -1035,11 +1031,17 @@ export default function useAutocomplete(props) {
     }),
     getClearProps: () => ({
       tabIndex: -1,
-      onMouseDown: handleClear,
+      onClick: (event) => {
+        handleClear(event);
+        handleClick(event);
+      },
     }),
     getPopupIndicatorProps: () => ({
       tabIndex: -1,
-      onMouseDown: handlePopupIndicator,
+      onClick: (event) => {
+        handlePopupIndicator(event);
+        handleClick(event);
+      },
     }),
     getTagProps: ({ index }) => ({
       key: index,

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -1013,10 +1013,6 @@ export default function useAutocomplete(props) {
       onBlur: handleBlur,
       onFocus: handleFocus,
       onChange: handleInputChange,
-      onClick: (event) => {
-        handleInputClick(event);
-        handleClick(event);
-      },
       // if open then this is handled imperativeley so don't let react override
       // only have an opinion about this when closed
       'aria-activedescendant': popupOpen ? '' : null,
@@ -1088,5 +1084,9 @@ export default function useAutocomplete(props) {
     setAnchorEl,
     focusedTag,
     groupedOptions,
+    onInputClick: (event) => {
+      handleInputClick(event);
+      handleClick(event);
+    },
   };
 }

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -547,7 +547,7 @@ export default function useAutocomplete(props) {
   const handleOpen = (event) => {
     // Prevent blur (which happens after onMouseDown event on Input fires)
     event.preventDefault();
-    if (open) {
+    if (open || disabledProp) {
       return;
     }
 

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -545,6 +545,8 @@ export default function useAutocomplete(props) {
   }, [syncHighlightedIndex]);
 
   const handleOpen = (event) => {
+    // Prevent blur (which happens after onMouseDown event on Input fires)
+    event.preventDefault();
     if (open) {
       return;
     }
@@ -558,6 +560,8 @@ export default function useAutocomplete(props) {
   };
 
   const handleClose = (event, reason) => {
+    // Prevent blur (which happens after onMouseDown event on Input fires)
+    event.preventDefault();
     if (!open) {
       return;
     }
@@ -693,6 +697,9 @@ export default function useAutocomplete(props) {
   };
 
   const handleClear = (event) => {
+    // Prevent blur (which happens after onMouseDown event on Input fires)
+    event.preventDefault();
+    event.stopPropagation();
     ignoreFocus.current = true;
     setInputValueState('');
 
@@ -915,6 +922,7 @@ export default function useAutocomplete(props) {
   };
 
   const handlePopupIndicator = (event) => {
+    event.stopPropagation();
     if (open) {
       handleClose(event, 'toggleInput');
     } else {
@@ -1027,11 +1035,11 @@ export default function useAutocomplete(props) {
     }),
     getClearProps: () => ({
       tabIndex: -1,
-      onClick: handleClear,
+      onMouseDown: handleClear,
     }),
     getPopupIndicatorProps: () => ({
       tabIndex: -1,
-      onClick: handlePopupIndicator,
+      onMouseDown: handlePopupIndicator,
     }),
     getTagProps: ({ index }) => ({
       key: index,

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -519,6 +519,8 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     });
   };
 
+  const { onMouseDown: onInputMouseDown, ...inputProps } = getInputProps();
+
   return (
     <React.Fragment>
       <AutocompleteRoot
@@ -536,6 +538,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
           InputProps: {
             ref: setAnchorEl,
             className: classes.inputRoot,
+            onMouseDown: onInputMouseDown,
             startAdornment,
             endAdornment: (
               <AutocompleteEndAdornment className={classes.endAdornment} ownerState={ownerState}>
@@ -573,7 +576,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
           inputProps: {
             className: clsx(classes.input),
             disabled,
-            ...getInputProps(),
+            ...inputProps,
           },
         })}
       </AutocompleteRoot>

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -437,6 +437,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     setAnchorEl,
     inputValue,
     groupedOptions,
+    onInputClick,
   } = useAutocomplete({ ...props, componentName: 'Autocomplete' });
 
   const hasClearIcon = !disableClearable && !disabled && dirty;
@@ -519,8 +520,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     });
   };
 
-  const { onClick: onInputClick, ...inputProps } = getInputProps();
-
   return (
     <React.Fragment>
       <AutocompleteRoot
@@ -576,7 +575,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
           inputProps: {
             className: clsx(classes.input),
             disabled,
-            ...inputProps,
+            ...getInputProps(),
           },
         })}
       </AutocompleteRoot>

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -519,7 +519,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     });
   };
 
-  const { onMouseDown: onInputMouseDown, ...inputProps } = getInputProps();
+  const { onClick: onInputClick, ...inputProps } = getInputProps();
 
   return (
     <React.Fragment>
@@ -538,7 +538,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
           InputProps: {
             ref: setAnchorEl,
             className: classes.inputRoot,
-            onMouseDown: onInputMouseDown,
+            onClick: onInputClick,
             startAdornment,
             endAdornment: (
               <AutocompleteEndAdornment className={classes.endAdornment} ownerState={ownerState}>

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1591,9 +1591,9 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('textbox');
       const combobox = getByRole('combobox');
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
     });
 
@@ -1640,14 +1640,14 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('textbox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.click(textbox); // Open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       const options = getAllByRole('option');
       fireEvent.click(options[0]);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.click(textbox); // Open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox); // Remain open listbox
+      fireEvent.click(textbox); // Remain open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
 
@@ -1663,9 +1663,9 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('textbox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/29381

Problem:
- Only clicking `<input>` inside `InputBase` div opens the list box. It is generally expected that clicking anywhere on the `InputBase` div should open the listbox.
- preview: https://mui.com/components/autocomplete/

https://user-images.githubusercontent.com/758437/139541585-cdbf5b6b-f021-48bb-ab9c-0c75f2837f71.mp4

Solution:
- Remove `onMouseDown` event from  the nested `<input>` element 
- Attach `onClick` event to `InputBase` div
- make some small changes and use `event.stopPropagation()` properly on handlers to keep all other behaviours the same.
- preview: https://deploy-preview-29500--material-ui.netlify.app/components/autocomplete

https://user-images.githubusercontent.com/32841130/141288000-b681cfa6-fb7e-437e-a1fd-ddb28acd12e7.mov