### PR TITLE
[ClickAwayListener] Trigger in mouseup instead of click

### DIFF
--- a/docs/pages/api-docs/click-away-listener.json
+++ b/docs/pages/api-docs/click-away-listener.json
@@ -8,7 +8,7 @@
         "name": "enum",
         "description": "'onClick'<br>&#124;&nbsp;'onMouseDown'<br>&#124;&nbsp;'onMouseUp'<br>&#124;&nbsp;false"
       },
-      "default": "'onClick'"
+      "default": "'onMouseUp'"
     },
     "touchEvent": {
       "type": {

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
@@ -32,6 +32,33 @@ describe('<ClickAwayListener />', () => {
     expect(container.querySelectorAll('span').length).to.equal(1);
   });
 
+  it('should not be highlighted on tap', function test() {
+    if (
+      /jsdom/.test(window.navigator.userAgent) ||
+      !('webkitTapHighlightColor' in document.body.style)
+    ) {
+      this.skip();
+    }
+
+    const initialTapHighlightColor = window.getComputedStyle(document.body).webkitTapHighlightColor;
+    const transparentColor = 'rgba(0, 0, 0, 0)';
+    render(
+      <ClickAwayListener onClickAway={() => {}}>
+        <div data-testid="child">
+          Not tappable
+          <button data-testid="tappable">tappable</button>
+        </div>
+      </ClickAwayListener>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveComputedStyle({
+      webkitTapHighlightColor: transparentColor,
+    });
+    expect(screen.getByTestId('tappable')).toHaveComputedStyle({
+      webkitTapHighlightColor: initialTapHighlightColor,
+    });
+  });
+
   describe('prop: onClickAway', () => {
     it('should be called when clicking away', () => {
       const handleClickAway = spy();

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
@@ -70,7 +70,7 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
 
-      fireEvent.click(document.body);
+      fireEvent.mouseUp(document.body);
       expect(handleClickAway.callCount).to.equal(1);
       expect(handleClickAway.args[0].length).to.equal(1);
     });
@@ -83,7 +83,7 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
 
-      fireEvent.click(container.querySelector('span'));
+      fireEvent.mouseUp(container.querySelector('span'));
       expect(handleClickAway.callCount).to.equal(0);
     });
 
@@ -95,12 +95,12 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
       const preventDefault = (event) => event.preventDefault();
-      document.body.addEventListener('click', preventDefault);
+      document.body.addEventListener('mouseup', preventDefault);
 
-      fireEvent.click(document.body);
+      fireEvent.mouseUp(document.body);
       expect(handleClickAway.callCount).to.equal(1);
 
-      document.body.removeEventListener('click', preventDefault);
+      document.body.removeEventListener('mouseup', preventDefault);
     });
 
     it('should not be called when clicking inside a portaled element', () => {
@@ -115,7 +115,7 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
 
-      fireEvent.click(getByText('Inside a portal'));
+      fireEvent.mouseDown(getByText('Inside a portal'));
       expect(handleClickAway.callCount).to.equal(0);
     });
 
@@ -131,6 +131,7 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
 
+      fireEvent.mouseUp(getByText('Inside a portal'));
       fireEvent.click(getByText('Inside a portal'));
       expect(handleClickAway.callCount).to.equal(1);
     });
@@ -170,13 +171,13 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
 
-      fireEvent.click(getByText('Outside a portal'));
+      fireEvent.mouseDown(getByText('Outside a portal'));
       expect(handleClickAway.callCount).to.equal(0);
 
-      fireEvent.click(getByText('Stop all inside a portal'));
+      fireEvent.mouseDown(getByText('Stop all inside a portal'));
       expect(handleClickAway.callCount).to.equal(0);
 
-      fireEvent.click(getByText('Stop inside a portal'));
+      fireEvent.mouseDown(getByText('Stop inside a portal'));
       // undesired behavior in React 16
       expect(handleClickAway.callCount).to.equal(React.version.startsWith('16') ? 1 : 0);
     });
@@ -202,6 +203,7 @@ describe('<ClickAwayListener />', () => {
         }
         render(<Test />);
 
+        fireDiscreteEvent.mouseUp(screen.getByTestId('trigger'));
         fireDiscreteEvent.click(screen.getByTestId('trigger'));
 
         expect(screen.getByTestId('child')).not.to.equal(null);
@@ -273,7 +275,7 @@ describe('<ClickAwayListener />', () => {
       fireDiscreteEvent.mouseUp(mouseUpTarget);
       fireDiscreteEvent.click(clickTarget);
 
-      expect(onClickAway.callCount).to.equal(1);
+      expect(onClickAway.callCount).to.equal(0);
     });
   });
 
@@ -285,7 +287,7 @@ describe('<ClickAwayListener />', () => {
           <span />
         </ClickAwayListener>,
       );
-      fireEvent.click(document.body);
+      fireEvent.mouseUp(document.body);
       expect(handleClickAway.callCount).to.equal(0);
     });
 
@@ -357,7 +359,7 @@ describe('<ClickAwayListener />', () => {
         <Child />
       </ClickAwayListener>,
     );
-    fireEvent.click(document.body);
+    fireEvent.mouseUp(document.body);
     expect(handleClickAway.callCount).to.equal(0);
   });
 
@@ -388,7 +390,10 @@ describe('<ClickAwayListener />', () => {
       render(<Test />);
 
       act(() => {
-        screen.getByRole('button').click();
+        const target = screen.getByRole('button');
+        fireEvent.mouseDown(target);
+        fireEvent.mouseUp(target);
+        target.click();
       });
 
       expect(handleClickAway.callCount).to.equal(1);
@@ -413,7 +418,10 @@ describe('<ClickAwayListener />', () => {
       render(<Test />);
 
       act(() => {
-        screen.getByRole('button').click();
+        const target = screen.getByRole('button');
+        fireEvent.mouseDown(target);
+        fireEvent.mouseUp(target);
+        target.click();
       });
 
       expect(handleClickAway.callCount).to.equal(0);

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
@@ -51,9 +51,11 @@ describe('<ClickAwayListener />', () => {
       </ClickAwayListener>,
     );
 
-    expect(screen.getByTestId('child')).toHaveComputedStyle({
-      webkitTapHighlightColor: transparentColor,
-    });
+    if (typeof screen.getByTestId('child').onclick === 'function') {
+      expect(screen.getByTestId('child')).toHaveComputedStyle({
+        webkitTapHighlightColor: transparentColor,
+      });
+    }
     expect(screen.getByTestId('tappable')).toHaveComputedStyle({
       webkitTapHighlightColor: initialTapHighlightColor,
     });

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
@@ -38,7 +38,7 @@ export interface ClickAwayListenerProps {
   disableReactTree?: boolean;
   /**
    * The mouse event to listen to. You can disable the listener by providing `false`.
-   * @default 'onClick'
+   * @default 'onMouseUp'
    */
   mouseEvent?: ClickAwayMouseEventHandler | false;
   /**
@@ -227,7 +227,7 @@ ClickAwayListener.propTypes /* remove-proptypes */ = {
   disableReactTree: PropTypes.bool,
   /**
    * The mouse event to listen to. You can disable the listener by providing `false`.
-   * @default 'onClick'
+   * @default 'onMouseUp'
    */
   mouseEvent: PropTypes.oneOf(['onClick', 'onMouseDown', 'onMouseUp', false]),
   /**

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
@@ -69,7 +69,7 @@ function ClickAwayListener(props: ClickAwayListenerProps): JSX.Element {
   const {
     children,
     disableReactTree = false,
-    mouseEvent = 'onClick',
+    mouseEvent = 'onMouseUp',
     onClickAway,
     touchEvent = 'onTouchEnd',
   } = props;

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -42,11 +42,10 @@ describe('<Snackbar />', () => {
       const handleClose = spy();
       render(<Snackbar open onClose={handleClose} message="message" />);
 
-      const event = new window.Event('click', { view: window, bubbles: true, cancelable: true });
-      document.body.dispatchEvent(event);
+      fireEvent.mouseUp(document.body);
 
       expect(handleClose.callCount).to.equal(1);
-      expect(handleClose.args[0]).to.deep.equal([event, 'clickaway']);
+      expect(handleClose.args[0][1]).to.deep.equal('clickaway');
     });
 
     it('should be called when pressing Escape', () => {


### PR DESCRIPTION
- Closes https://github.com/mui-org/material-ui/issues/29080: https://codesandbox.io/s/snackbar-alert-nvda-issues-forked-te04o?file=/src/App.js
- Closes https://github.com/mui-org/material-ui/issues/25578: https://codesandbox.io/s/vigorous-albattani-8e2xv
- Fixes a tap highlight being applied on iOS to children of `ClickAwayListener` if the children took up a small amount on the screen: https://codesandbox.io/s/clickaway-material-ios-tap-highlight-3prkw
   For example clicking "Click me" in https://codesandbox.io/s/clickaway-material-ios-tap-highlight-y42nf?file=/demo.js would trigger a tap highlight even though the child is not actually interactive (notice the black transparent flash):

https://user-images.githubusercontent.com/12292047/144111983-0c320e24-5b1d-4a93-8991-4eed94c4f137.mp4

Note that this usually isn't an issue since iOS only applies the tap highlight if the element with an explicit `onclick` takes up a small portion of the screen (or parent?). As far as I can tell it's <30% (see https://trac.webkit.org/browser/webkit/trunk/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm?rev=286260#L2096. I don't actually know for sure if the linked value is responsible but looking at the code overall I'm fairly certain these are the iOS tap heuristics).

Basically we apply click-away heuristics while processing `mouseup` instead of `click`.

Note that this change needs extensive manual testing and has the potential of breaking existing applications that relied on `clickaway` firing after `mouseup` events finished bubbling.

Browser run: https://app.circleci.com/pipelines/github/mui-org/material-ui/57385/workflows/d26c82b1-22e6-41c7-87ec-13683dab9b0c