### PR TITLE
Added targets for adding @emotion/react and @emotion/styled as externals

### DIFF
--- a/packages/mui-material/scripts/rollup.config.js
+++ b/packages/mui-material/scripts/rollup.config.js
@@ -123,7 +123,7 @@ const globals = {
 const globalsWithoutEmotion = {
   ...globals,
   '@emotion/react': 'emotionReact',
-  '@emotion/styled': 'emotionStyled'
+  '@emotion/styled': 'emotionStyled',
 };
 
 const babelOptions = {
@@ -205,7 +205,7 @@ const rollupConfig = [
       file: 'build/umd/material-ui.emotionless.development.js',
       format: 'umd',
       name: 'MaterialUI',
-      globals : globalsWithoutEmotion,
+      globals: globalsWithoutEmotion,
     },
     external: Object.keys(globalsWithoutEmotion),
     plugins: [
@@ -245,7 +245,7 @@ const rollupConfig = [
       file: 'build/umd/material-ui.emotionless.production.min.js',
       format: 'umd',
       name: 'MaterialUI',
-      globals : globalsWithoutEmotion,
+      globals: globalsWithoutEmotion,
     },
     external: Object.keys(globalsWithoutEmotion),
     plugins: [
@@ -258,7 +258,7 @@ const rollupConfig = [
       terser(),
       sizeSnapshot({ snapshotPath: 'size-snapshot.json' }),
     ],
-  }
+  },
 ];
 
 export default rollupConfig;

--- a/packages/mui-material/scripts/rollup.config.js
+++ b/packages/mui-material/scripts/rollup.config.js
@@ -119,6 +119,13 @@ const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
 };
+
+const globalsWithoutEmotion = {
+  ...globals,
+  '@emotion/react': 'emotionReact',
+  '@emotion/styled': 'emotionStyled'
+};
+
 const babelOptions = {
   exclude: /node_modules/,
   // We are using @babel/plugin-transform-runtime
@@ -171,7 +178,7 @@ function onwarn(warning) {
   }
 }
 
-export default [
+const rollupConfig = [
   {
     input,
     onwarn,
@@ -182,6 +189,25 @@ export default [
       globals,
     },
     external: Object.keys(globals),
+    plugins: [
+      nodeResolve(nodeOptions),
+      nestedFolder,
+      babel(babelOptions),
+      commonjs(commonjsOptions),
+      nodeGlobals(), // Wait for https://github.com/cssinjs/jss/pull/893
+      replace({ preventAssignment: true, 'process.env.NODE_ENV': JSON.stringify('development') }),
+    ],
+  },
+  {
+    input,
+    onwarn,
+    output: {
+      file: 'build/umd/material-ui.emotionless.development.js',
+      format: 'umd',
+      name: 'MaterialUI',
+      globals : globalsWithoutEmotion,
+    },
+    external: Object.keys(globalsWithoutEmotion),
     plugins: [
       nodeResolve(nodeOptions),
       nestedFolder,
@@ -212,4 +238,27 @@ export default [
       sizeSnapshot({ snapshotPath: 'size-snapshot.json' }),
     ],
   },
+  {
+    input,
+    onwarn,
+    output: {
+      file: 'build/umd/material-ui.emotionless.production.min.js',
+      format: 'umd',
+      name: 'MaterialUI',
+      globals : globalsWithoutEmotion,
+    },
+    external: Object.keys(globalsWithoutEmotion),
+    plugins: [
+      nodeResolve(nodeOptions),
+      nestedFolder,
+      babel(babelOptions),
+      commonjs(commonjsOptions),
+      nodeGlobals(), // Wait for https://github.com/cssinjs/jss/pull/893
+      replace({ preventAssignment: true, 'process.env.NODE_ENV': JSON.stringify('production') }),
+      terser(),
+      sizeSnapshot({ snapshotPath: 'size-snapshot.json' }),
+    ],
+  }
 ];
+
+export default rollupConfig;


### PR DESCRIPTION
 Added @emotion/react and @emotion/styled as externals so @mui can be used as an external itself when the client-code external to the page.

Fixes https://github.com/mui-org/material-ui/issues/29840