### PR TITLE
[DatePicker][TimePicker] Fix lab theme augmentation

### DIFF
--- a/packages/mui-lab/src/themeAugmentation/components.d.ts
+++ b/packages/mui-lab/src/themeAugmentation/components.d.ts
@@ -18,7 +18,6 @@ export interface LabComponents {
   };
   MuiDatePicker?: {
     defaultProps?: ComponentsProps['MuiDatePicker'];
-    styleOverrides?: ComponentsOverrides['MuiDatePicker'];
     variants?: ComponentsVariants['MuiDatePicker'];
   };
   MuiDateRangePickerDay?: {
@@ -28,7 +27,6 @@ export interface LabComponents {
   };
   MuiDateTimePicker?: {
     defaultProps?: ComponentsProps['MuiDateTimePicker'];
-    styleOverrides?: ComponentsOverrides['MuiDateTimePicker'];
     variants?: ComponentsVariants['MuiDateTimePicker'];
   };
   MuiLoadingButton?: {

--- a/packages/mui-lab/src/themeAugmentation/overrides.d.ts
+++ b/packages/mui-lab/src/themeAugmentation/overrides.d.ts
@@ -28,6 +28,7 @@ export interface LabComponentNameToClassKey {
   MuiLoadingButton: LoadingButtonClassKey;
   MuiMonthPicker: MonthPickerClassKey;
   MuiPickersDay: PickersDayClassKey;
+  MuiPickerStaticWrapper: PickerStaticWrapperClassKey;
   MuiTabList: TabListClassKey;
   MuiTabPanel: TabPanelClassKey;
   MuiTimeline: TimelineClassKey;
@@ -40,7 +41,6 @@ export interface LabComponentNameToClassKey {
   MuiTreeItem: TreeItemClassKey;
   MuiTreeView: TreeViewClassKey;
   MuiYearPicker: YearPickerClassKey;
-  MuiPickerStaticWrapper: PickerStaticWrapperClassKey;
 }
 
 declare module '@mui/material/styles' {

--- a/packages/mui-lab/src/themeAugmentation/props.d.ts
+++ b/packages/mui-lab/src/themeAugmentation/props.d.ts
@@ -29,6 +29,7 @@ import { TimePickerProps } from '../TimePicker';
 import { TreeItemProps } from '../TreeItem';
 import { TreeViewProps } from '../TreeView';
 import { YearPickerProps } from '../YearPicker';
+import { PickerStaticWrapperProps } from '../internal/pickers/wrappers/PickerStaticWrapper';
 
 export interface LabComponentsPropsList {
   MuiAvatarGroup: AvatarGroupProps;
@@ -46,6 +47,7 @@ export interface LabComponentsPropsList {
   MuiMobileTimePicker: MobileTimePickerProps;
   MuiMonthPicker: MonthPickerProps<unknown>;
   MuiPickersDay: PickersDayProps<unknown>;
+  MuiPickerStaticWrapper: PickerStaticWrapperProps;
   MuiStaticDatePicker: StaticDatePickerProps;
   MuiStaticDateTimePicker: StaticDateTimePickerProps;
   MuiStaticTimePicker: StaticTimePickerProps;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hi there,

While migrating a few older projects to V5, we ran into a Typescript issue where `@mui/lab`'s `themeAugmentation` for some of the Picker components was misconfigured. Existing issue from someone else: https://github.com/mui-org/material-ui/issues/29907

The issue appears as a build error like `Property 'MuiDatePicker' does not exist on type 'ComponentsOverrides'. ts(2339)` or `Property 'MuiPickerStaticWrapper' does not exist on type 'ComponentsVariants'. ts(2339)`

There are actually two separate but similar issues:

1. In `src/themeAugmentation/components.d.ts`, the MuiDatePicker and MuiDateTimePicker declared `stylesOverrides: ComponentsOverrides['MuiDatePicker']`. However, ComponentsOverrides does not have a key for those components because those Pickers are not style-able. From my digging, they do not expose a `classes` prop or have any `xxxClassMap` type available so I believe they actually don't have any `styleOverrides` available.  My fix here was to remove the `styleOverrides` key in this type, similar to what is done with the [Stack component here](https://github.com/mui-org/material-ui/blob/65803d75a81711c0a8b0237a14199dd159ae6e25/packages/mui-material/src/styles/components.d.ts#L431)
2. In `src/themeAugmentation/props.d.ts`, `MuiPickerStaticWrapper` hadn't been added to the ComponentsPropsList types,  so the use of that key in the themeAugmentation/components.d.ts file was invalid. Adding it to the list seemed like what was missing.

There have been 2 PRs (https://github.com/mui-org/material-ui/pull/29517, https://github.com/mui-org/material-ui/pull/29517) over the past month that have touched/attempted to fix this exact code, so it may be worth a deeper look by maintainers.

<details>
  <summary>Actual errors</summary>
  ```sh
  ../../node_modules/@mui/lab/themeAugmentation/components.d.ts:21:42 - error TS2339: Property 'MuiDatePicker' does not exist on type 'ComponentsOverrides'.

  21     styleOverrides?: ComponentsOverrides['MuiDatePicker'];
                                              ~~~~~~~~~~~~~~~

  ../../node_modules/@mui/lab/themeAugmentation/components.d.ts:31:42 - error TS2339: Property 'MuiDateTimePicker' does not exist on type 'ComponentsOverrides'.

  31     styleOverrides?: ComponentsOverrides['MuiDateTimePicker'];
                                              ~~~~~~~~~~~~~~~~~~~

  ../../node_modules/@mui/lab/themeAugmentation/components.d.ts:110:36 - error TS2339: Property 'MuiPickerStaticWrapper' does not exist on type 'ComponentsProps'.

  110     defaultProps?: ComponentsProps['MuiPickerStaticWrapper'];
  ```

</details>

