### PR TITLE
[Autocomplete] extend renderOption prop type to allow key and ref

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -210,7 +210,7 @@ export interface AutocompleteProps<
    * @returns {ReactNode}
    */
   renderOption?: (
-    props: React.HTMLAttributes<HTMLLIElement>,
+    props: React.DetailedHTMLProps<React.HTMLAttributes<HTMLLIElement>, HTMLLIElement>,
     option: T,
     state: AutocompleteRenderOptionState,
   ) => React.ReactNode;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I would like to be able to override the key property for renderOption. Like so
```tsx
renderOption={(props, option, state) => renderOption({ ...props, key: option[optionValueField] }, option, state)}
```

Unfortunatyle this throws the following error
`Object literal may only specify known properties, and 'key' does not exist in type 'HTMLAttributes<HTMLLIElement>'.`
