### PR TITLE
[DateTimePicker] Change showToolbar default value to false

### DIFF
--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import DateTimePicker from '@mui/lab/DateTimePicker';
+import { expect } from 'chai';
+import { screen } from 'test/utils';
 import { createPickerRenderer } from '../internal/pickers/test-utils';
 
 describe('<DateTimePicker />', () => {
@@ -15,5 +17,18 @@ describe('<DateTimePicker />', () => {
         value={null}
       />,
     );
+  });
+  it('prop `showToolbar` – renders toolbar in DateTimePicker', () => {
+    render(
+      <DateTimePicker
+        open
+        showToolbar
+        onChange={() => {}}
+        value={null}
+        renderInput={(params) => <TextField {...params} />}
+      />,
+    );
+
+    expect(screen.getByMuiTest('picker-toolbar')).toBeVisible();
   });
 });

--- a/packages/mui-lab/src/DateTimePicker/shared.ts
+++ b/packages/mui-lab/src/DateTimePicker/shared.ts
@@ -108,7 +108,7 @@ export function useDateTimePickerDefaultizedProps<Props extends BaseDateTimePick
       ampm: willUseAmPm,
       ampmInClock: true,
       orientation,
-      showToolbar: true,
+      showToolbar: false,
       allowSameDateSelection: true,
       minDate: minDateTime ?? minDate,
       minTime: minDateTime ?? minTime,

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.test.tsx
@@ -89,6 +89,7 @@ describe('<DesktopDateTimePicker />', () => {
         renderInput={(params) => <TextField {...params} />}
         value={null}
         open
+        showToolbar
         onClose={handleClose}
       />,
     );

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -141,6 +141,20 @@ describe('<MobileDateTimePicker />', () => {
     expect(screen.getByMuiTest('datetimepicker-toolbar-day')).to.have.text('Nov 20');
   });
 
+  it('prop `showToolbar` – renders toolbar in MobileDateTimePicker', () => {
+    render(
+      <MobileDateTimePicker
+        open
+        showToolbar
+        onChange={() => {}}
+        value={adapterToUse.date('2021-11-20T10:01:22.000')}
+        renderInput={(params) => <TextField {...params} />}
+      />,
+    );
+
+    expect(screen.getByMuiTest('picker-toolbar')).toBeVisible();
+  });
+
   it('can render seconds on view', () => {
     render(
       <MobileDateTimePicker

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.test.tsx
@@ -51,6 +51,7 @@ describe('<MobileDateTimePicker />', () => {
             setDate(newDate);
             onChangeMock(newDate);
           }}
+          showToolbar
           renderInput={(params) => <TextField autoFocus {...params} />}
         />
       );
@@ -128,6 +129,7 @@ describe('<MobileDateTimePicker />', () => {
         renderInput={(params) => <TextField {...params} />}
         onChange={() => {}}
         open
+        showToolbar
         value={adapterToUse.date('2021-11-20T10:01:22.000')}
       />,
     );
@@ -145,6 +147,7 @@ describe('<MobileDateTimePicker />', () => {
         renderInput={(params) => <TextField {...params} />}
         onChange={() => {}}
         open
+        showToolbar
         views={['seconds']}
         value={adapterToUse.date('2021-11-20T10:01:22.000')}
       />,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #30032

**Problem:**

The default value of the `showToolbar` prop was true while the according to the documentation suggestion, it should be false.

**Solution:**

- Changing the `showToolbar` value to false
- passing `showToolbar` as a prop to the previous tests that were failed by changing `showToolbar` to false.
- adding new tests to `DateTimePicker.test.tsx` and `MobileDateTimePicker.test.tsx` in order to check if the toolbar is rendered properly when `showToolbar` value is passed.
