### PR TITLE
[snackbar] Fix TransitionProps override inner exited state

### DIFF
--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -109,11 +109,11 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
     disableWindowBlurListener = false,
     message,
     onClose,
-    onEnter,
+    onEnter: onEnterProp,
     onEntered,
     onEntering,
     onExit,
-    onExited,
+    onExited: onExitedProp,
     onExiting,
     onMouseEnter,
     onMouseLeave,
@@ -124,7 +124,7 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
     },
-    TransitionProps,
+    TransitionProps: { onEnter, onExited, ...TransitionProps } = {},
     ...other
   } = props;
 
@@ -192,11 +192,19 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
     }
   };
 
-  const handleExited = () => {
+  const handleExited = (element) => {
+    if (onExitedProp) {
+      onExitedProp(element);
+    }
+
     setExited(true);
   };
 
-  const handleEnter = () => {
+  const handleEnter = (element, isAppearing) => {
+    if (onEnterProp) {
+      onEnterProp(element, isAppearing);
+    }
+
     setExited(false);
   };
 


### PR DESCRIPTION
Hi team, when I try to migrate my existing project to `v4.12.3` prepare to upgrade API to v5 better, 

but I found that broke that `Snackbar` inner `exited` state, fix that by following the coding style in `packages/material-ui/src/Menu/Menu.js:71`


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
