### PR TITLE
Prevent SwipeableDrawer crash when parent update while swiping

### DIFF
--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -227,7 +227,8 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
   );
 
   const handleBodyTouchEnd = useEventCallback((nativeEvent) => {
-    if (!touchDetected.current) {
+    // the ref may be null when a parent component updates while swiping
+    if (!paperRef.current || !touchDetected.current) {
       return;
     }
     claimedSwipeInstance = null;


### PR DESCRIPTION
Hey hey ! 👋 

We noticed a lot of sentries in getMaxTranslate because this crashes when the parent updates while the user is swiping the drawer.

This is already handled in `handleBodyTouchMove` here
https://github.com/mui-org/material-ui/blob/98c9aad08696f44976f55aa1e254d013df6c38e1/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js#L296-L300

but not in `handleBodyTouchEnd` yet

Tested locally in multiple cases and it works fine 👌 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Cheers from Doctolib ✌️ 
