### PR TITLE
[Autocomplete] Have the screen reader announce when autocomplete is open and closed

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -999,8 +999,6 @@ export default function useAutocomplete(props) {
   return {
     getRootProps: (other = {}) => ({
       'aria-owns': listboxAvailable ? `${id}-listbox` : null,
-      role: 'combobox',
-      'aria-expanded': listboxAvailable,
       ...other,
       onKeyDown: handleKeyDown(other),
       onMouseDown: handleMouseDown,
@@ -1022,12 +1020,14 @@ export default function useAutocomplete(props) {
       'aria-activedescendant': popupOpen ? '' : null,
       'aria-autocomplete': autoComplete ? 'both' : 'list',
       'aria-controls': listboxAvailable ? `${id}-listbox` : undefined,
+      'aria-expanded': listboxAvailable,
       // Disable browser's suggestion that might overlap with the popup.
       // Handle autocomplete but not autofill.
       autoComplete: 'off',
       ref: inputRef,
       autoCapitalize: 'none',
       spellCheck: 'false',
+      role: 'combobox',
     }),
     getClearProps: () => ({
       tabIndex: -1,

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
@@ -288,7 +288,7 @@ describe('useAutocomplete', () => {
         return <input {...getInputProps()} />;
       };
       render(<Test options={['foo', 'bar']} />);
-      const input = screen.getByRole('textbox');
+      const input = screen.getByRole('combobox');
 
       act(() => {
         fireEvent.change(input, { target: { value: 'free' } });

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -81,7 +81,7 @@ describe('<Autocomplete />', () => {
       const { getByRole } = render(
         <Autocomplete options={[]} renderInput={(params) => <TextField {...params} />} />,
       );
-      const input = getByRole('textbox');
+      const input = getByRole('combobox');
 
       act(() => {
         input.focus();
@@ -119,7 +119,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
       expect(document.querySelector(`.${classes.paper}`).textContent).to.equal('Loading…');
     });
   });
@@ -171,7 +171,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       expect(textbox).not.to.have.attribute('aria-activedescendant');
 
       setProps({ options, loading: false });
@@ -207,7 +207,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
 
       checkHighlightIs(getByRole('listbox'), 'one');
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -228,7 +228,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       checkHighlightIs(getByRole('listbox'), 'Bar');
@@ -277,7 +277,7 @@ describe('<Autocomplete />', () => {
       expect(getAllByRole('button', { hidden: true })).to.have.lengthOf(4);
 
       act(() => {
-        getByRole('textbox').focus();
+        getByRole('combobox').focus();
       });
       expect(container.textContent).to.equal('onetwothree');
       // Depending on the subset of components used in this test run the computed `visibility` changes in JSDOM.
@@ -302,7 +302,7 @@ describe('<Autocomplete />', () => {
       expect(getAllByRole('button', { hidden: true })).to.have.lengthOf(2);
 
       act(() => {
-        getByRole('textbox').focus();
+        getByRole('combobox').focus();
       });
       expect(container.textContent).to.equal('onetwothree');
       // Depending on the subset of components used in this test run the computed `visibility` changes in JSDOM.
@@ -322,12 +322,12 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowUp' });
       checkHighlightIs(getByRole('listbox'), 'three');
       fireEvent.keyDown(textbox, { key: 'Enter' }); // selects the last option (three)
-      const input = getByRole('textbox');
+      const input = getByRole('combobox');
       act(() => {
         input.blur();
         input.focus(); // opens the listbox again
@@ -349,7 +349,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.change(textbox, { target: { value: 'o' } });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -376,7 +376,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       act(() => {
         fireEvent.change(textbox, { target: { value: 't' } });
@@ -421,7 +421,7 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      const input = getByRole('textbox');
+      const input = getByRole('combobox');
 
       act(() => {
         input.focus();
@@ -459,7 +459,7 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       const [firstSelectedValue, secondSelectedValue] = screen.getAllByRole('button');
 
       fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
@@ -492,7 +492,7 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       const [firstSelectedValue] = screen.getAllByRole('button');
 
       fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
@@ -516,7 +516,7 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.change(textbox, { target: { value: 'two' } });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -537,7 +537,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      expect(screen.getByRole('textbox')).to.have.property('value', '');
+      expect(screen.getByRole('combobox')).to.have.property('value', '');
     });
 
     it('should fail validation if a required field has no value', function test() {
@@ -609,7 +609,7 @@ describe('<Autocomplete />', () => {
       </div>
     );
     const { setProps } = render(<Test />);
-    let textbox = screen.getByRole('textbox');
+    let textbox = screen.getByRole('combobox');
 
     fireEvent.keyDown(textbox, { key: 'Enter' });
     expect(handleSubmit.callCount).to.equal(1);
@@ -623,7 +623,7 @@ describe('<Autocomplete />', () => {
     expect(handleSubmit.callCount).to.equal(2);
 
     setProps({ key: 'test-2', multiple: true, freeSolo: true });
-    textbox = screen.getByRole('textbox');
+    textbox = screen.getByRole('combobox');
 
     fireEvent.change(textbox, { target: { value: 'o' } });
     fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -633,7 +633,7 @@ describe('<Autocomplete />', () => {
     expect(handleSubmit.callCount).to.equal(3);
 
     setProps({ key: 'test-3', freeSolo: true });
-    textbox = screen.getByRole('textbox');
+    textbox = screen.getByRole('combobox');
 
     fireEvent.change(textbox, { target: { value: 'o' } });
     fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -664,7 +664,7 @@ describe('<Autocomplete />', () => {
       );
 
       let options;
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -698,7 +698,7 @@ describe('<Autocomplete />', () => {
       // this assertion can fail if the value is `listbox`
       expect(combobox).not.to.have.attribute('aria-haspopup');
 
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       expect(combobox).to.contain(textbox);
       // reflected aria-multiline has to be false i.e. not present or false
       expect(textbox).not.to.have.attribute('aria-multiline');
@@ -731,13 +731,9 @@ describe('<Autocomplete />', () => {
       const combobox = getByRole('combobox');
       expect(combobox).to.have.attribute('aria-expanded', 'true');
 
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
 
       const listbox = getByRole('listbox');
-      expect(combobox, 'combobox owns listbox').to.have.attribute(
-        'aria-owns',
-        listbox.getAttribute('id'),
-      );
       expect(textbox).to.have.attribute('aria-controls', listbox.getAttribute('id'));
       expect(textbox, 'no option is focused when openened').not.to.have.attribute(
         'aria-activedescendant',
@@ -764,7 +760,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       expect(textbox, 'no option is focused when openened').not.to.have.attribute(
         'aria-activedescendant',
       );
@@ -827,7 +823,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        const textbox = screen.getByRole('textbox');
+        const textbox = screen.getByRole('combobox');
 
         fireEvent.keyDown(textbox, { key });
 
@@ -849,7 +845,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
 
       expect(handleChange.callCount).to.equal(0);
     });
@@ -869,7 +865,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.deep.equal([]);
     });
@@ -884,7 +880,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       fireEvent.change(textbox, { target: { value: 'test' } });
       expect(document.activeElement.value).to.equal('test');
       act(() => {
@@ -901,7 +897,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       fireEvent.change(textbox, { target: { value: 'test' } });
       expect(document.activeElement.value).to.equal('test');
       act(() => {
@@ -920,7 +916,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       fireEvent.change(textbox, { target: { value: 'test' } });
       expect(document.activeElement.value).to.equal('test');
       act(() => {
@@ -942,7 +938,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
       expect(handleClose.callCount).to.equal(1);
     });
 
@@ -987,8 +983,8 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowDown' });
-      expect(getByRole('textbox')).to.have.attribute(
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' });
+      expect(getByRole('combobox')).to.have.attribute(
         'aria-activedescendant',
         getAllByRole('option')[0].getAttribute('id'),
       );
@@ -1003,9 +999,9 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
+      fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowUp' });
       const options = getAllByRole('option');
-      expect(getByRole('textbox')).to.have.attribute(
+      expect(getByRole('combobox')).to.have.attribute(
         'aria-activedescendant',
         options[options.length - 1].getAttribute('id'),
       );
@@ -1023,7 +1019,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       const listbox = getByRole('listbox');
       // Actual Behavior when "가" (Korean) is entered and press the arrow down key once on macOS/Chrome
       fireEvent.change(textbox, { target: { value: '가' } });
@@ -1043,7 +1039,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       const combobox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'true');
@@ -1079,7 +1075,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowUp' });
@@ -1099,7 +1095,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowUp' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -1119,7 +1115,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        const textbox = screen.getByRole('textbox');
+        const textbox = screen.getByRole('combobox');
 
         fireEvent.keyDown(textbox, { key: 'ArrowDown' });
         fireEvent.keyDown(textbox, { key: 'ArrowUp' });
@@ -1137,7 +1133,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        const textbox = screen.getByRole('textbox');
+        const textbox = screen.getByRole('combobox');
 
         fireEvent.keyDown(textbox, { key: 'ArrowUp' });
         fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -1157,7 +1153,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        const textbox = screen.getByRole('textbox');
+        const textbox = screen.getByRole('combobox');
 
         fireEvent.keyDown(textbox, { key: 'ArrowDown' });
         fireEvent.keyDown(textbox, { key: 'ArrowUp' });
@@ -1178,7 +1174,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        const textbox = screen.getByRole('textbox');
+        const textbox = screen.getByRole('combobox');
 
         fireEvent.keyDown(textbox, { key: 'ArrowUp' });
 
@@ -1199,7 +1195,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} autoFocus />}
           />,
         );
-        const textbox = screen.getByRole('textbox');
+        const textbox = screen.getByRole('combobox');
 
         fireEvent.keyDown(textbox, { key: 'ArrowDown' });
         fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -1224,7 +1220,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} />}
         />,
       );
-      const input = getByRole('textbox');
+      const input = getByRole('combobox');
       expect(input).to.have.property('disabled', true);
     });
 
@@ -1269,7 +1265,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       act(() => {
         textbox.focus();
       });
@@ -1311,7 +1307,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       expect(() => {
         fireEvent.change(textbox, { target: { value: 'a' } });
@@ -1351,7 +1347,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       expect(() => {
         fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -1456,7 +1452,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       const listbox = screen.getByRole('listbox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // goes to 'one'
@@ -1479,7 +1475,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} />}
         />,
       );
-      const input = getByRole('textbox');
+      const input = getByRole('combobox');
       fireEvent.click(input);
 
       const listbox = getByRole('listbox');
@@ -1505,7 +1501,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      const input = getByRole('textbox');
+      const input = getByRole('combobox');
       fireEvent.click(input);
 
       const listbox = getByRole('listbox');
@@ -1520,7 +1516,7 @@ describe('<Autocomplete />', () => {
       );
 
       const combobox = getByRole('combobox');
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       expect(combobox).not.to.have.attribute('aria-owns');
       expect(textbox).not.to.have.attribute('aria-controls');
@@ -1539,7 +1535,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -1562,7 +1558,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -1584,7 +1580,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.change(document.activeElement, { target: { value: 'O' } });
 
@@ -1613,7 +1609,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       const combobox = getByRole('combobox');
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       fireEvent.mouseDown(textbox);
@@ -1630,7 +1626,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} />}
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       fireEvent.click(textbox);
       expect(textbox.selectionStart).to.equal(0);
       expect(textbox.selectionEnd).to.equal(3);
@@ -1645,7 +1641,7 @@ describe('<Autocomplete />', () => {
         />,
       );
 
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       fireEvent.click(textbox);
       expect(textbox).toHaveFocus();
 
@@ -1662,7 +1658,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete options={['one']} renderInput={(params) => <TextField {...params} />} />,
       );
       const combobox = getByRole('combobox');
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       fireEvent.mouseDown(textbox); // Open listbox
@@ -1685,7 +1681,7 @@ describe('<Autocomplete />', () => {
         />,
       );
       const combobox = getByRole('combobox');
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       fireEvent.mouseDown(textbox);
@@ -1735,7 +1731,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -1817,7 +1813,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -1843,7 +1839,7 @@ describe('<Autocomplete />', () => {
           multiple
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.change(textbox, { target: { value: 'three' } });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -1866,7 +1862,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       // Actual behavior when "あ" (Japanese) is entered on macOS/Safari with IME
       fireEvent.change(textbox, { target: { value: 'あ' } });
@@ -1893,7 +1889,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.change(textbox, { target: { value: options[2] } });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -1914,7 +1910,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -1938,7 +1934,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'Backspace' });
 
@@ -1959,7 +1955,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
@@ -2025,7 +2021,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'Enter' });
@@ -2048,7 +2044,7 @@ describe('<Autocomplete />', () => {
           blurOnSelect
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       let firstOption = getByRole('option');
       expect(textbox).toHaveFocus();
       fireEvent.click(firstOption);
@@ -2073,7 +2069,7 @@ describe('<Autocomplete />', () => {
           blurOnSelect="touch"
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       let firstOption = getByRole('option');
       fireEvent.click(firstOption);
       expect(textbox).toHaveFocus();
@@ -2096,7 +2092,7 @@ describe('<Autocomplete />', () => {
           blurOnSelect="mouse"
         />,
       );
-      const textbox = getByRole('textbox');
+      const textbox = getByRole('combobox');
       let firstOption = getByRole('option');
       fireEvent.touchStart(firstOption);
       fireEvent.click(firstOption);
@@ -2150,7 +2146,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       expect(textbox).to.have.property('value', 'one');
       setProps({
         getOptionLabel: (option) => option.toUpperCase(),
@@ -2168,7 +2164,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       expect(textbox).to.have.property('value', 'one');
       fireEvent.change(textbox, { target: { value: 'a' } });
       setProps({
@@ -2227,7 +2223,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
 
@@ -2291,7 +2287,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
 
       fireEvent.change(document.activeElement, { target: { value: 'one' } });
       expect(screen.getAllByRole('option').length).to.equal(2);
@@ -2334,7 +2330,7 @@ describe('<Autocomplete />', () => {
         renderInput={(params) => <TextField autoFocus {...params} />}
       />,
     );
-    const textbox = getByRole('textbox');
+    const textbox = getByRole('combobox');
     const combobox = getByRole('combobox');
 
     fireEvent.change(textbox, { target: { value: 'one' } });
@@ -2379,7 +2375,7 @@ describe('<Autocomplete />', () => {
       </div>
     );
     render(<Test />);
-    const textbox = screen.getByRole('textbox');
+    const textbox = screen.getByRole('combobox');
     fireEvent.keyDown(textbox, { key: 'ArrowDown' });
     fireEvent.keyDown(textbox, { key: 'ArrowDown' });
     fireEvent.keyDown(textbox, { key: 'Enter' });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes: https://github.com/mui-org/material-ui/issues/30369

Problem:
1. Start your the NVDA or JAWS screen reader
2. Tab to the Autocomplete component and open the dropdown by pressing down arrow
3. The screen reader should announce that the combobox is open ❌ 
4. Close the dropdown by pressing escape
5. The screen reader should announce that the combobox is closed ❌ 

Solution:
- Move `role="combobox"` to input
- Move `aria-expanded` to input