### PR TITLE
[docs] Editable demos with CSB Sandpack

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
     "@babel/core": "^7.16.7",
     "@babel/plugin-transform-object-assign": "^7.16.7",
     "@babel/runtime-corejs2": "^7.16.7",
+    "@codesandbox/sandpack-react": "^0.13.1",
     "@date-io/core": "^2.11.0",
     "@date-io/date-fns-jalali": "^2.11.0",
     "@docsearch/react": "^3.0.0-alpha.42",

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
-import Demo from 'docs/src/modules/components/Demo';
+import { Sandpack } from '@codesandbox/sandpack-react';
+import '@codesandbox/sandpack-react/dist/index.css';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { exactProp } from '@mui/utils';
 import ComponentLinkHeader from 'docs/src/modules/components/ComponentLinkHeader';
@@ -14,15 +15,9 @@ const markdownComponents = {
   'modules/components/ComponentLinkHeader.js': ComponentLinkHeader,
 };
 
-function noComponent(moduleID) {
-  return function NoComponent() {
-    throw new Error(`No demo component provided for '${moduleID}'`);
-  };
-}
-
 function MarkdownDocs(props) {
   const router = useRouter();
-  const { disableAd = false, disableToc = false, demos = {}, docs, demoComponents } = props;
+  const { disableAd = false, disableToc = false, demos = {}, docs } = props;
 
   const userLanguage = useUserLanguage();
   const t = useTranslate();
@@ -83,18 +78,19 @@ function MarkdownDocs(props) {
         }
 
         return (
-          <Demo
-            key={index}
-            demo={{
-              raw: demo.raw,
-              js: demoComponents[demo.module] ?? noComponent(demo.module),
-              jsxPreview: demo.jsxPreview,
-              rawTS: demo.rawTS,
-              tsx: demo.moduleTS ? demoComponents[demo.moduleTS] : null,
+          <Sandpack
+            template="react"
+            theme="night-owl"
+            files={{ '/App.js': demo.raw }}
+            customSetup={{
+              dependencies: {
+                '@mui/material': '^5.2.8',
+                '@mui/icons-material': '^5.2.4',
+                '@mui/lab': '^5.0.0-alpha.64',
+                '@emotion/styled': '^11.6.0',
+                '@emotion/react': '^11.7.1',
+              },
             }}
-            disableAd={disableAd}
-            demoOptions={renderedMarkdownOrDemo}
-            githubLocation={`${process.env.SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}/docs/src/${name}`}
           />
         );
       })}
@@ -103,7 +99,7 @@ function MarkdownDocs(props) {
 }
 
 MarkdownDocs.propTypes = {
-  demoComponents: PropTypes.object,
+  // demoComponents: PropTypes.object,
   demos: PropTypes.object,
   disableAd: PropTypes.bool,
   disableToc: PropTypes.bool,


### PR DESCRIPTION
- Allows editing the demos on the documentation website, using [Sandpack](https://sandpack.codesandbox.io/)

- Proof of concept: We can leverage [the custom theming](https://sandpack.codesandbox.io/docs/getting-started/custom-ui#custom-styling) to make it match the earlier appearance

- Based off the discussion [here](https://github.com/mui-org/material-ui/pull/29885#issuecomment-998043157)

- An alternative to #29885 (which uses `Jarle` and `simple-react-code-editor` along with Next.js `dynamic`)

- Fixes #26476

- [Deploy preview](https://deploy-preview-30627--material-ui.netlify.app/)