### PR TITLE
[DesktopTimePicker] show mask with ampm

### DIFF
--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.test.tsx
@@ -297,4 +297,68 @@ describe('<DesktopTimePicker />', () => {
       expect(handleTouchStart.callCount).to.equal(1);
     });
   });
+  describe('prop: mask', () => {
+    it('renders mask properly with ampm option', () => {
+      const onChangeMock = spy();
+      render(
+        <DesktopTimePicker
+          renderInput={(props) => <TextField placeholder="09:41 PM" {...props} />}
+          value={adapterToUse.date('2018-01-01T01:00:00.000Z')}
+          onChange={onChangeMock}
+          ampm
+          inputFormat="hh:mm a"
+          mask="__:__ _M"
+        />,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: '09:43 P',
+        },
+      });
+      const input = screen.getByRole('textbox');
+      expect(input).to.have.value('09:43 PM');
+    });
+    it('should not render mask when not passing the mask value', () => {
+      const onChangeMock = spy();
+      render(
+        <DesktopTimePicker
+          renderInput={(props) => <TextField placeholder="09:41 PM" {...props} />}
+          value={adapterToUse.date('2018-01-01T01:00:00.000Z')}
+          onChange={onChangeMock}
+          ampm
+        />,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: '09:43 P',
+        },
+      });
+      const input = screen.getByRole('textbox');
+      expect(input).to.have.value('09:43 P');
+    });
+    it('should not render mask when disableMaskedInput is true', () => {
+      const onChangeMock = spy();
+      render(
+        <DesktopTimePicker
+          renderInput={(props) => <TextField placeholder="09:41 PM" {...props} />}
+          value={adapterToUse.date('2018-01-01T01:00:00.000Z')}
+          onChange={onChangeMock}
+          ampm
+          inputFormat="hh:mm a"
+          mask="__:__ _M"
+          disableMaskedInput
+        />,
+      );
+
+      fireEvent.change(screen.getByRole('textbox'), {
+        target: {
+          value: '09:43 P',
+        },
+      });
+      const input = screen.getByRole('textbox');
+      expect(input).to.have.value('09:43 P');
+    });
+  });
 });

--- a/packages/mui-lab/src/TimePicker/shared.tsx
+++ b/packages/mui-lab/src/TimePicker/shared.tsx
@@ -54,6 +54,8 @@ export function useTimePickerDefaultizedProps<Props extends BaseTimePickerProps<
     inputFormat,
     openTo = 'hours',
     views = ['hours', 'minutes'],
+    disableMaskedInput,
+    mask,
     ...other
   }: Props,
   name: string,
@@ -67,8 +69,8 @@ export function useTimePickerDefaultizedProps<Props extends BaseTimePickerProps<
       openTo,
       ampm: willUseAmPm,
       acceptRegex: willUseAmPm ? /[\dapAP]/gi : /\d/gi,
-      mask: '__:__',
-      disableMaskedInput: willUseAmPm,
+      mask,
+      disableMaskedInput: disableMaskedInput ?? false,
       getOpenDialogAriaText: getTextFieldAriaText,
       components: {
         OpenPickerIcon: ClockIcon,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
Fixes: #29061
[demo](https://codesandbox.io/s/basictimepicker-material-demo-forked-2r4ex?file=/demo.js)

Problem:
- `mask` is not working with `ampm` prop in `DesktopTimePicker` component
- `disableMaskedInput` value was based on the `willUseAmPm` variable(which means it ignored the `disableMaskedInput` prop passed to the component)


Solution:
- changing mask and disableMaskedInput values from hardcoded ones to their prop values

