### PR TITLE
[Autocomplete] Make the scrollbar stay in current position on mouse expand

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -366,11 +366,6 @@ export default function useAutocomplete(props) {
       const elementBottom = element.offsetTop + element.offsetHeight;
       if (elementBottom > scrollBottom) {
         listboxNode.scrollTop = elementBottom - listboxNode.clientHeight;
-      } else if (
-        element.offsetTop - element.offsetHeight * (groupBy ? 1.3 : 0) <
-        listboxNode.scrollTop
-      ) {
-        listboxNode.scrollTop = element.offsetTop - element.offsetHeight * (groupBy ? 1.3 : 0);
       }
     }
   });


### PR DESCRIPTION
As shown in this CSB, the scrollbar returns to top on scrolling down the list with mouse.

https://codesandbox.io/s/confident-kare-5n6i6

removing the else-if condition in the following if statement removes the reason for this scrollbar adjustment, the scrollbar will now stay in its current position.

if (listboxNode.scrollHeight > listboxNode.clientHeight && reason !== 'mouse') 