### PR TITLE
[docs] Include JSS in styling solution interoperability guide

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -22,5 +22,7 @@
   // MD029/ol-prefix. Buggy
   "MD029": false,
   // MD004/ul-style. Buggy
-  "MD004": false
+  "MD004": false,
+  // MD028/no-blanks-blockquote prevent double blockquote
+  "MD028": false
 }

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -824,9 +824,9 @@ const useStyles = makeStyles<{ color: 'red' | 'blue' }>()((theme, { color }) => 
 
 For info on how to setup SSR or anything else, please refer to [the TSS documentation](https://github.com/garronej/tss-react).
 
-> WARNING: **Keep `@emotion/styled` as a dependency of your project**. Even if you never use it explicitly,
+> ⚠️ **Keep `@emotion/styled` as a dependency of your project**. Even if you never use it explicitly,
 > it's a peer dependency of `@mui/material`.
 
-> WARNING for [Storybook](https://storybook.js.org): As of writing this lines storybook still uses by default emotion 10.  
+> ⚠️ For [Storybook](https://storybook.js.org): As of writing this lines storybook still uses by default emotion 10.  
 > Material-ui and TSS runs emotion 11 so there is [some changes](https://github.com/garronej/onyxia-ui/blob/324de62248074582b227e584c53fb2e123f5325f/.storybook/main.js#L31-L32)
 > to be made to your `.storybook/main.js` to make it uses emotion 11.

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -740,10 +740,10 @@ export default function SliderThumbOverrides() {
 ## ~~JSS~~ TSS
 
 [JSS](https://cssinjs.org/) itself is no longer supported in MUI however,
-if you like the hook-based API (`makeStyles` → `useStyles`) that [`react-jss`](https://codesandbox.io/s/j3l06yyqpw) was offering you can opt for [`tss-react`](https://github.com/garronej/tss-react).  
+if you like the hook-based API (`makeStyles` → `useStyles`) that [`react-jss`](https://codesandbox.io/s/j3l06yyqpw) was offering you can opt for [`tss-react`](https://github.com/garronej/tss-react).
 
 [TSS](https://docs.tss-react.dev) integrates well with MUI and provide a better
-TypeScript support than JSS.  
+TypeScript support than JSS.
 
 > If you are updating from `@material-ui/core` (v4) to `@mui/material` (v5) checkout
 > [migration guide](https://mui.com/guides/migration-v4/#2-use-tss-react).
@@ -755,18 +755,18 @@ import createCache from '@emotion/cache';
 import { ThemeProvider } from '@mui/material/styles';
 
 export const muiCache = createCache({
-    key: 'mui',
-    prepend: true,
+  key: 'mui',
+  prepend: true,
 });
 
 //NOTE: Don't use <StyledEngineProvider injectFirst/>
 render(
-    <CacheProvider value={muiCache}>
-        <ThemeProvider theme={myTheme}>
-            <Root />
-        </ThemeProvider>
-    </CacheProvider>,
-    document.getElementById('root')
+  <CacheProvider value={muiCache}>
+    <ThemeProvider theme={myTheme}>
+      <Root />
+    </ThemeProvider>
+  </CacheProvider>,
+  document.getElementById('root'),
 );
 ```
 
@@ -786,46 +786,43 @@ import { useTheme } from '@mui/material/styles';
 import { createMakeAndWithStyles } from 'tss-react';
 
 export const { makeStyles, withStyles } = createMakeAndWithStyles({
-    useTheme
-    /*
+  useTheme,
+  /*
     OR, if you have extended the default mui theme adding your own custom properties: 
     Let's assume the myTheme object that you provide to the <ThemeProvider /> is of 
     type MyTheme then you'll write:
     */
-    //"useTheme": useTheme as (()=> MyTheme)
+  //"useTheme": useTheme as (()=> MyTheme)
 });
 ```
 
-Then, the library is used like this:  
+Then, the library is used like this:
 
 ```tsx
 import { makeStyles } from 'tss-react/mui';
 
 export function MyComponent(props: Props) {
+  const { className } = props;
 
-    const { className } = props;
+  const [color, setColor] = useState<'red' | 'blue'>('red');
 
-    const [color, setColor] = useState<'red' | 'blue'>('red');
+  const { classes, cx } = useStyles({ color });
 
-    const { classes, cx } = useStyles({ color });
-
-    //Thanks to cx, className will take priority over classes.root
-    return <span className={cx(classes.root, className)}>hello world</span>;
+  //Thanks to cx, className will take priority over classes.root
+  return <span className={cx(classes.root, className)}>hello world</span>;
 }
 
-const useStyles = makeStyles<{ color: 'red' | 'blue' }>()(
-    (theme, { color }) => ({
-        root: {
-            color,
-            '&:hover': {
-                backgroundColor: theme.palette.primary.main
-            },
-        },
-    }),
-);
+const useStyles = makeStyles<{ color: 'red' | 'blue' }>()((theme, { color }) => ({
+  root: {
+    color,
+    '&:hover': {
+      backgroundColor: theme.palette.primary.main,
+    },
+  },
+}));
 ```
 
-For info on how to setup SSR or anything else, please refer to [the TSS documentation](https://github.com/garronej/tss-react).  
+For info on how to setup SSR or anything else, please refer to [the TSS documentation](https://github.com/garronej/tss-react).
 
 > WARNING: **Keep `@emotion/styled` as a dependency of your project**. Even if you never use it explicitly,
 > it's a peer dependency of `@mui/material`.

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -779,7 +779,7 @@ get with
 If you want to take controls over what the `theme` object should be,
 you can re-export `makeStyles` and `withStyles` from a file called, for example, `makesStyles.ts`:
 
-```typescript
+```ts
 import { useTheme } from '@mui/material/styles';
 //WARNING: tss-react require TypeScript v4.4 or newer. If you can't update use:
 //import { createMakeAndWithStyles } from "tss-react/compat";

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -12,6 +12,7 @@ There are examples for the following styling solutions:
 - [CSS Modules](#css-modules)
 - [Emotion](#emotion)
 - [Tailwind CSS](#tailwind-css)
+- [~~JSS~~ TSS](#jss-tss)
 
 ## Plain CSS
 
@@ -735,3 +736,100 @@ export default function SliderThumbOverrides() {
   return <Slider className="p-4" classes={{ active: 'shadow-none' }} />;
 }
 ```
+
+## ~~JSS~~ TSS
+
+[JSS](https://cssinjs.org/) itself is no longer supported in MUI however,
+if you like the hook-based API (`makeStyles` → `useStyles`) that [`react-jss`](https://codesandbox.io/s/j3l06yyqpw) was offering you can opt for [`tss-react`](https://github.com/garronej/tss-react).  
+
+[TSS](https://docs.tss-react.dev) integrates well with MUI and provide a better
+TypeScript support than JSS.  
+
+> If you are updating from `@material-ui/core` (v4) to `@mui/material` (v5) checkout
+> [migration guide](https://mui.com/guides/migration-v4/#2-use-tss-react).
+
+```tsx
+import { render } from 'react-dom';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import { ThemeProvider } from '@mui/material/styles';
+
+export const muiCache = createCache({
+    key: 'mui',
+    prepend: true,
+});
+
+//NOTE: Don't use <StyledEngineProvider injectFirst/>
+render(
+    <CacheProvider value={muiCache}>
+        <ThemeProvider theme={myTheme}>
+            <Root />
+        </ThemeProvider>
+    </CacheProvider>,
+    document.getElementById('root')
+);
+```
+
+Now you can simply  
+`import { makeStyles, withStyles } from 'tss-react/mui'`.  
+The theme object that will be passed to your callbacks functions will be the one you
+get with  
+`import { useTheme } from '@mui/material/styles'`.
+
+If you want to take controls over what the `theme` object should be,
+you can re-export `makeStyles` and `withStyles` from a file called, for example, `makesStyles.ts`:
+
+```typescript
+import { useTheme } from '@mui/material/styles';
+//WARNING: tss-react require TypeScript v4.4 or newer. If you can't update use:
+//import { createMakeAndWithStyles } from "tss-react/compat";
+import { createMakeAndWithStyles } from 'tss-react';
+
+export const { makeStyles, withStyles } = createMakeAndWithStyles({
+    useTheme
+    /*
+    OR, if you have extended the default mui theme adding your own custom properties: 
+    Let's assume the myTheme object that you provide to the <ThemeProvider /> is of 
+    type MyTheme then you'll write:
+    */
+    //"useTheme": useTheme as (()=> MyTheme)
+});
+```
+
+Then, the library is used like this:  
+
+```tsx
+import { makeStyles } from 'tss-react/mui';
+
+export function MyComponent(props: Props) {
+
+    const { className } = props;
+
+    const [color, setColor] = useState<'red' | 'blue'>('red');
+
+    const { classes, cx } = useStyles({ color });
+
+    //Thanks to cx, className will take priority over classes.root
+    return <span className={cx(classes.root, className)}>hello world</span>;
+}
+
+const useStyles = makeStyles<{ color: 'red' | 'blue' }>()(
+    (theme, { color }) => ({
+        root: {
+            color,
+            '&:hover': {
+                backgroundColor: theme.palette.primary.main
+            },
+        },
+    }),
+);
+```
+
+For info on how to setup SSR or anything else, please refer to [the TSS documentation](https://github.com/garronej/tss-react).  
+
+> WARNING: **Keep `@emotion/styled` as a dependency of your project**. Even if you never use it explicitly,
+> it's a peer dependency of `@mui/material`.
+
+> WARNING for [Storybook](https://storybook.js.org): As of writing this lines storybook still uses by default emotion 10.  
+> Material-ui and TSS runs emotion 11 so there is [some changes](https://github.com/garronej/onyxia-ui/blob/324de62248074582b227e584c53fb2e123f5325f/.storybook/main.js#L31-L32)
+> to be made to your `.storybook/main.js` to make it uses emotion 11.


### PR DESCRIPTION
Good day,  

I think the JSS hook-based API (`makeStyles` ->  `useStyles`) has still a solid fanbase.  
If you think that this is pushing TSS too hard, feel free to close, I won't take offense.  

Best regads,