### PR TITLE
[ClockNumber] add font for outer numbers

### DIFF
--- a/packages/mui-lab/src/ClockPicker/ClockNumber.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockNumber.tsx
@@ -30,6 +30,7 @@ const ClockNumberRoot = styled('span', { skipSx: true })<{ ownerState: ClockNumb
     alignItems: 'center',
     borderRadius: '50%',
     color: theme.palette.text.primary,
+    fontFamily: theme.typography.fontFamily,
     '&:focused': {
       backgroundColor: theme.palette.background.paper,
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
Fixes: #30228

**Problem**
- In `ClockNumber` component, `fontFamily` was not assigned to the outer numbers

**Solution**
- adding fontFamily based on the typography's font
