### PR TITLE
[DatePicker] Fix passing clearable prop

### DIFF
--- a/docs/pages/api-docs/desktop-date-picker.json
+++ b/docs/pages/api-docs/desktop-date-picker.json
@@ -8,6 +8,8 @@
     },
     "allowSameDateSelection": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/api-docs/desktop-date-range-picker.json
+++ b/docs/pages/api-docs/desktop-date-range-picker.json
@@ -19,6 +19,8 @@
       "default": "2"
     },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/api-docs/desktop-date-time-picker.json
+++ b/docs/pages/api-docs/desktop-date-time-picker.json
@@ -10,6 +10,8 @@
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/api-docs/desktop-time-picker.json
+++ b/docs/pages/api-docs/desktop-time-picker.json
@@ -9,6 +9,8 @@
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": { "name": "shape", "description": "{ OpenPickerIcon?: elementType }" }
     },

--- a/docs/pages/material/api/desktop-date-picker.json
+++ b/docs/pages/material/api/desktop-date-picker.json
@@ -8,6 +8,8 @@
     },
     "allowSameDateSelection": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/material/api/desktop-date-range-picker.json
+++ b/docs/pages/material/api/desktop-date-range-picker.json
@@ -19,6 +19,8 @@
       "default": "2"
     },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/material/api/desktop-date-time-picker.json
+++ b/docs/pages/material/api/desktop-date-time-picker.json
@@ -10,6 +10,8 @@
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/material/api/desktop-time-picker.json
+++ b/docs/pages/material/api/desktop-time-picker.json
@@ -9,6 +9,8 @@
     "ampm": { "type": { "name": "bool" } },
     "ampmInClock": { "type": { "name": "bool" } },
     "className": { "type": { "name": "string" } },
+    "clearable": { "type": { "name": "bool" } },
+    "clearText": { "type": { "name": "node" }, "default": "'Clear'" },
     "components": {
       "type": { "name": "shape", "description": "{ OpenPickerIcon?: elementType }" }
     },

--- a/docs/translations/api-docs/desktop-date-picker/desktop-date-picker.json
+++ b/docs/translations/api-docs/desktop-date-picker/desktop-date-picker.json
@@ -4,6 +4,8 @@
     "acceptRegex": "Regular expression to detect &quot;accepted&quot; symbols.",
     "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "className": "className applied to the root component.",
+    "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
+    "clearText": "Clear text message.",
     "components": "The components used for each slot. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "defaultCalendarMonth": "Default calendar month displayed when <code>value={null}</code>.",

--- a/docs/translations/api-docs/desktop-date-range-picker/desktop-date-range-picker.json
+++ b/docs/translations/api-docs/desktop-date-range-picker/desktop-date-range-picker.json
@@ -5,6 +5,8 @@
     "allowSameDateSelection": "If <code>true</code>, <code>onChange</code> is fired on click even if the same date is selected.",
     "calendars": "The number of calendars that render on <strong>desktop</strong>.",
     "className": "className applied to the root component.",
+    "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
+    "clearText": "Clear text message.",
     "components": "The components used for each slot. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "defaultCalendarMonth": "Default calendar month displayed when <code>value={null}</code>.",

--- a/docs/translations/api-docs/desktop-date-time-picker/desktop-date-time-picker.json
+++ b/docs/translations/api-docs/desktop-date-time-picker/desktop-date-time-picker.json
@@ -6,6 +6,8 @@
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",
+    "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
+    "clearText": "Clear text message.",
     "components": "The components used for each slot. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside.",
     "dateRangeIcon": "Date tab icon.",

--- a/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
+++ b/docs/translations/api-docs/desktop-time-picker/desktop-time-picker.json
@@ -5,6 +5,8 @@
     "ampm": "12h/24h view for hour selection clock.",
     "ampmInClock": "Display ampm controls under the clock (instead of in the toolbar).",
     "className": "className applied to the root component.",
+    "clearable": "If <code>true</code>, it shows the clear action in the picker dialog.",
+    "clearText": "Clear text message.",
     "components": "The components used for each slot. Either a string to use a HTML element or a component.",
     "disableCloseOnSelect": "If <code>true</code> the popup or dialog will immediately close after submitting full date.",
     "disabled": "If <code>true</code>, the picker and text field are disabled.",

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -57,6 +57,8 @@ const DatePicker = React.forwardRef(function DatePicker<TDate>(
       ref={ref}
       PopperProps={PopperProps}
       TransitionComponent={TransitionComponent}
+      clearText={clearText}
+      clearable={clearable}
       {...other}
     />
   ) : (

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -267,6 +267,27 @@ describe('<DesktopDatePicker />', () => {
 
     expect(screen.getByMuiTest('picker-toolbar')).toBeVisible();
   });
+  it('prop `clearable` - renders clear button in Desktop mode', () => {
+    const onChangeMock = spy();
+    render(
+      <UncontrolledOpenDesktopDatePicker
+        // @ts-expect-error internal prop
+        defaultOpen
+        showToolbar
+        clearable
+        TransitionComponent={FakeTransitionComponent}
+        value={adapterToUse.date('2018-01-01T00:00:00.000')}
+        renderInput={(params) => <TextField {...params} />}
+        onChange={onChangeMock}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Clear'));
+
+    expect(onChangeMock.callCount).to.equal(1);
+    expect(onChangeMock.args[0][0]).to.equal(null);
+    expect(screen.queryByRole('dialog')).to.equal(null);
+  });
 
   it('switches between views uncontrolled', () => {
     const handleViewChange = spy();

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -268,24 +268,38 @@ describe('<DesktopDatePicker />', () => {
     expect(screen.getByMuiTest('picker-toolbar')).toBeVisible();
   });
   it('prop `clearable` - renders clear button in Desktop mode', () => {
-    const onChangeMock = spy();
-    render(
-      <UncontrolledOpenDesktopDatePicker
-        // @ts-expect-error internal prop
-        defaultOpen
-        showToolbar
-        clearable
-        TransitionComponent={FakeTransitionComponent}
-        value={adapterToUse.date('2018-01-01T00:00:00.000')}
-        renderInput={(params) => <TextField {...params} />}
-        onChange={onChangeMock}
-      />,
-    );
+    function DesktopDatePickerClearable() {
+      const [value, setValue] = React.useState<Date | null>(
+        adapterToUse.date('2018-01-01T00:00:00.000'),
+      );
+      const [open, setOpen] = React.useState<boolean | undefined>(true);
+      const handleChange = (newValue: Date | null) => {
+        setValue(newValue);
+      };
+      return (
+        <DesktopDatePicker
+          onChange={handleChange}
+          value={value}
+          clearable
+          renderInput={(params) => <TextField {...params} />}
+          TransitionComponent={FakeTransitionComponent}
+          open={open}
+          onClose={() => {
+            setOpen(false);
+          }}
+          onOpen={() => {
+            setOpen(true);
+          }}
+        />
+      );
+    }
+    render(<DesktopDatePickerClearable />);
+
+    expect(screen.getByRole('textbox')).to.have.value('01/01/2018');
 
     fireEvent.click(screen.getByText('Clear'));
 
-    expect(onChangeMock.callCount).to.equal(1);
-    expect(onChangeMock.args[0][0]).to.equal(null);
+    expect(screen.getByRole('textbox')).to.have.value('');
     expect(screen.queryByRole('dialog')).to.equal(null);
   });
 

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -267,6 +267,7 @@ describe('<DesktopDatePicker />', () => {
 
     expect(screen.getByMuiTest('picker-toolbar')).toBeVisible();
   });
+
   it('prop `clearable` - renders clear button in Desktop mode', () => {
     function DesktopDatePickerClearable() {
       const [value, setValue] = React.useState<Date | null>(

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -60,6 +60,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
 
   return (
     <DesktopWrapper
+      {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -54,19 +54,22 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
     ToolbarComponent = DatePickerToolbar,
     TransitionComponent,
     value,
+    clearText,
+    clearable,
     ...other
   } = props;
   const AllDateInputProps = { ...inputProps, ...other, ref, validationError };
 
   return (
     <DesktopWrapper
-      {...other}
       {...wrapperProps}
       DateInputProps={AllDateInputProps}
       KeyboardDateInputComponent={KeyboardDateInput}
       PopperProps={PopperProps}
       PaperProps={PaperProps}
       TransitionComponent={TransitionComponent}
+      clearText={clearText}
+      clearable={clearable}
     >
       <Picker
         {...pickerProps}

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -108,6 +108,16 @@ DesktopDatePicker.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
    * The components used for each slot.
    * Either a string to use a HTML element or a component.
    * @default {}

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -210,6 +210,16 @@ DesktopDateRangePicker.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
    * The components used for each slot.
    * Either a string to use a HTML element or a component.
    * @default {}

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -118,6 +118,16 @@ DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
    * The components used for each slot.
    * Either a string to use a HTML element or a component.
    * @default {}

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -107,6 +107,16 @@ DesktopTimePicker.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
    * The components used for each slot.
    * Either a string to use a HTML element or a component.
    */

--- a/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
@@ -66,12 +66,14 @@ const PickersPopperPaper = styled(Paper)<{
 const PickersPopperAction = styled(DialogActions, { skipSx: true })<{
   ownerState: PickerPopperProps;
 }>(({ ownerState }) => ({
-  ...(ownerState.clearable && {
-    justifyContent: 'flex-start',
-    '& > *:first-of-type': {
-      marginRight: 'auto',
-    },
-  }),
+  ...(ownerState.clearable
+    ? {
+        justifyContent: 'flex-start',
+        '& > *:first-of-type': {
+          marginRight: 'auto',
+        },
+      }
+    : { padding: 0 }),
 }));
 
 function clickedRootScrollbar(event: MouseEvent, doc: Document) {

--- a/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
@@ -63,7 +63,7 @@ const PickersPopperPaper = styled(Paper)<{
   }),
 }));
 
-const PickersPopperAction = styled(DialogActions, { skipSx: true })<{
+const PickersPopperAction = styled(DialogActions)<{
   ownerState: PickerPopperProps;
 }>(({ ownerState }) => ({
   ...(ownerState.clearable

--- a/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
+++ b/packages/mui-lab/src/internal/pickers/PickersPopper.tsx
@@ -6,8 +6,20 @@ import TrapFocus, { TrapFocusProps as MuiTrapFocusProps } from '@mui/material/Un
 import { useForkRef, useEventCallback, ownerDocument } from '@mui/material/utils';
 import { styled } from '@mui/material/styles';
 import { TransitionProps as MuiTransitionProps } from '@mui/material/transitions';
+import Button from '@mui/material/Button';
+import DialogActions from '@mui/material/DialogActions';
 
 export interface ExportedPickerPaperProps {
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable?: boolean;
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText?: React.ReactNode;
   /**
    * Paper props passed down to [Paper](https://mui.com/api/paper/) component.
    */
@@ -34,6 +46,7 @@ export interface PickerPopperProps extends ExportedPickerPopperProps, ExportedPi
   children?: React.ReactNode;
   onClose: () => void;
   onBlur?: () => void;
+  onClear?: () => void;
 }
 
 const PickersPopperRoot = styled(Popper)<{ ownerState: PickerPopperProps }>(({ theme }) => ({
@@ -47,6 +60,17 @@ const PickersPopperPaper = styled(Paper)<{
   outline: 0,
   ...(ownerState.placement === 'top' && {
     transformOrigin: 'bottom center',
+  }),
+}));
+
+const PickersPopperAction = styled(DialogActions, { skipSx: true })<{
+  ownerState: PickerPopperProps;
+}>(({ ownerState }) => ({
+  ...(ownerState.clearable && {
+    justifyContent: 'flex-start',
+    '& > *:first-of-type': {
+      marginRight: 'auto',
+    },
   }),
 }));
 
@@ -198,6 +222,9 @@ const PickersPopper = (props: PickerPopperProps) => {
     children,
     containerRef = null,
     onClose,
+    onClear,
+    clearable = false,
+    clearText = 'Clear',
     open,
     PopperProps,
     role,
@@ -287,6 +314,13 @@ const PickersPopper = (props: PickerPopperProps) => {
               {...otherPaperProps}
             >
               {children}
+              <PickersPopperAction ownerState={ownerState}>
+                {clearable && (
+                  <Button data-mui-test="clear-action-button" onClick={onClear}>
+                    {clearText}
+                  </Button>
+                )}
+              </PickersPopperAction>
             </PickersPopperPaper>
           </TransitionComponent>
         </TrapFocus>

--- a/packages/mui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
+++ b/packages/mui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
@@ -28,6 +28,9 @@ function DesktopWrapper(props: InternalDesktopWrapperProps) {
     PopperProps,
     PaperProps,
     TransitionComponent,
+    onClear,
+    clearText,
+    clearable,
   } = props;
   const ownInputRef = React.useRef<HTMLInputElement>(null);
   const inputRef = useForkRef(DateInputProps.inputRef, ownInputRef);
@@ -43,6 +46,9 @@ function DesktopWrapper(props: InternalDesktopWrapperProps) {
         PopperProps={PopperProps}
         PaperProps={PaperProps}
         onClose={onDismiss}
+        onClear={onClear}
+        clearText={clearText}
+        clearable={clearable}
       >
         {children}
       </PickersPopper>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
Fixes: #30676

[Demo](https://codesandbox.io/s/responsivedatepickers-material-demo-forked-p4z0y?file=/demo.js)

**Problems:**
- clearable prop did not render the clear button in DesktopDatePicker component and it was only passed to the MobileDatePicker component

**Solution:**
- passing clearable and clearText props and rendering clear button on PickersPopper whenever clearable is true
