### PR TITLE
[Transitions] Some components do not use transition duration/easing values from theme

### DIFF
--- a/docs/pages/api-docs/dialog.json
+++ b/docs/pages/api-docs/dialog.json
@@ -39,7 +39,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" } }
   },

--- a/docs/pages/api-docs/dialog.json
+++ b/docs/pages/api-docs/dialog.json
@@ -39,7 +39,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{ enter: duration.enteringScreen, exit: duration.leavingScreen }"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" } }
   },

--- a/docs/pages/api-docs/drawer.json
+++ b/docs/pages/api-docs/drawer.json
@@ -27,7 +27,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{ enter: duration.enteringScreen, exit: duration.leavingScreen }"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     },
     "variant": {
       "type": {

--- a/docs/pages/api-docs/drawer.json
+++ b/docs/pages/api-docs/drawer.json
@@ -27,7 +27,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "variant": {
       "type": {

--- a/docs/pages/api-docs/fade.json
+++ b/docs/pages/api-docs/fade.json
@@ -15,7 +15,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     }
   },
   "name": "Fade",

--- a/docs/pages/api-docs/fade.json
+++ b/docs/pages/api-docs/fade.json
@@ -15,7 +15,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "Fade",

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -26,7 +26,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     }
   },
   "name": "Slide",

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -26,7 +26,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "Slide",

--- a/docs/pages/api-docs/slide.json
+++ b/docs/pages/api-docs/slide.json
@@ -18,7 +18,7 @@
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
       },
-      "default": "{\n  enter: easing.easeOut,\n  exit: easing.sharp,\n}"
+      "default": "{\n  enter: theme.transitions.easing.easeOut,\n  exit: theme.transitions.easing.sharp,\n}"
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {

--- a/docs/pages/api-docs/snackbar.json
+++ b/docs/pages/api-docs/snackbar.json
@@ -31,7 +31,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/api-docs/snackbar.json
+++ b/docs/pages/api-docs/snackbar.json
@@ -31,7 +31,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/api-docs/speed-dial.json
+++ b/docs/pages/api-docs/speed-dial.json
@@ -29,7 +29,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" } }
   },

--- a/docs/pages/api-docs/speed-dial.json
+++ b/docs/pages/api-docs/speed-dial.json
@@ -29,7 +29,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" } }
   },

--- a/docs/pages/api-docs/swipeable-drawer.json
+++ b/docs/pages/api-docs/swipeable-drawer.json
@@ -19,7 +19,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "SwipeableDrawer",

--- a/docs/pages/api-docs/swipeable-drawer.json
+++ b/docs/pages/api-docs/swipeable-drawer.json
@@ -19,7 +19,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{ enter: duration.enteringScreen, exit: duration.leavingScreen }"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     }
   },
   "name": "SwipeableDrawer",

--- a/docs/pages/api-docs/zoom.json
+++ b/docs/pages/api-docs/zoom.json
@@ -15,7 +15,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
     }
   },
   "name": "Zoom",

--- a/docs/pages/api-docs/zoom.json
+++ b/docs/pages/api-docs/zoom.json
@@ -15,7 +15,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: theme.duration.enteringScreen,\n  exit: theme.duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "Zoom",

--- a/docs/pages/material/api/dialog.json
+++ b/docs/pages/material/api/dialog.json
@@ -39,7 +39,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{ enter: duration.enteringScreen, exit: duration.leavingScreen }"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" } }
   },

--- a/docs/pages/material/api/drawer.json
+++ b/docs/pages/material/api/drawer.json
@@ -27,7 +27,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{ enter: duration.enteringScreen, exit: duration.leavingScreen }"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "variant": {
       "type": {

--- a/docs/pages/material/api/fade.json
+++ b/docs/pages/material/api/fade.json
@@ -15,7 +15,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "Fade",

--- a/docs/pages/material/api/slide.json
+++ b/docs/pages/material/api/slide.json
@@ -18,7 +18,7 @@
         "name": "union",
         "description": "{ enter?: string, exit?: string }<br>&#124;&nbsp;string"
       },
-      "default": "{\n  enter: easing.easeOut,\n  exit: easing.sharp,\n}"
+      "default": "{\n  enter: theme.transitions.easing.easeOut,\n  exit: theme.transitions.easing.sharp,\n}"
     },
     "in": { "type": { "name": "bool" } },
     "timeout": {
@@ -26,7 +26,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "Slide",

--- a/docs/pages/material/api/snackbar.json
+++ b/docs/pages/material/api/snackbar.json
@@ -31,7 +31,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" }, "default": "{}" }
   },

--- a/docs/pages/material/api/speed-dial.json
+++ b/docs/pages/material/api/speed-dial.json
@@ -29,7 +29,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     },
     "TransitionProps": { "type": { "name": "object" } }
   },

--- a/docs/pages/material/api/swipeable-drawer.json
+++ b/docs/pages/material/api/swipeable-drawer.json
@@ -19,7 +19,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{ enter: duration.enteringScreen, exit: duration.leavingScreen }"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "SwipeableDrawer",

--- a/docs/pages/material/api/zoom.json
+++ b/docs/pages/material/api/zoom.json
@@ -15,7 +15,7 @@
         "name": "union",
         "description": "number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }"
       },
-      "default": "{\n  enter: duration.enteringScreen,\n  exit: duration.leavingScreen,\n}"
+      "default": "{\n  enter: theme.transitions.duration.enteringScreen,\n  exit: theme.transitions.duration.leavingScreen,\n}"
     }
   },
   "name": "Zoom",

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -92,7 +92,10 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
+   * @default {
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
+   * }
    */
   transitionDuration?: TransitionProps['timeout'];
   /**

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -93,8 +93,8 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -92,7 +92,7 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: duration.enteringScreen, exit: duration.leavingScreen }
+   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
    */
   transitionDuration?: TransitionProps['timeout'];
   /**

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -164,8 +164,8 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiDialog' });
   const theme = useTheme();
   const defaultTransitionDuration = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -397,8 +397,8 @@ Dialog.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -6,13 +6,13 @@ import { unstable_useId as useId } from '@mui/utils';
 import capitalize from '../utils/capitalize';
 import Modal from '../Modal';
 import Fade from '../Fade';
-import { duration } from '../styles/createTransitions';
 import Paper from '../Paper';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
 import dialogClasses, { getDialogUtilityClass } from './dialogClasses';
 import DialogContext from './DialogContext';
 import Backdrop from '../Backdrop';
+import useTheme from '../styles/useTheme';
 
 const DialogBackdrop = styled(Backdrop, {
   name: 'MuiDialog',
@@ -157,12 +157,17 @@ const DialogPaper = styled(Paper, {
   }),
 }));
 
-const defaultTransitionDuration = { enter: duration.enteringScreen, exit: duration.leavingScreen };
 /**
  * Dialogs are overlaid modal paper based components with a backdrop.
  */
 const Dialog = React.forwardRef(function Dialog(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiDialog' });
+  const theme = useTheme();
+  const defaultTransitionDuration = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     'aria-describedby': ariaDescribedby,
     'aria-labelledby': ariaLabelledbyProp,
@@ -391,7 +396,7 @@ Dialog.propTypes /* remove-proptypes */ = {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: duration.enteringScreen, exit: duration.leavingScreen }
+   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -396,7 +396,10 @@ Dialog.propTypes /* remove-proptypes */ = {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
+   * @default {
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
+   * }
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { describeConformance, act, createRenderer, fireEvent, screen } from 'test/utils';
 import Modal from '@mui/material/Modal';
 import Dialog, { dialogClasses as classes } from '@mui/material/Dialog';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 /**
  * more comprehensive simulation of a user click (mousedown + click)
@@ -274,6 +275,58 @@ describe('<Dialog />', () => {
       expect(dialog).to.have.attr('aria-labelledby', 'dialog-title');
       const label = document.getElementById(dialog.getAttribute('aria-labelledby'));
       expect(label).to.have.text('Choose either one');
+    });
+  });
+
+  describe('prop: transitionDuration', () => {
+    it('should render the default theme values by default', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme();
+      const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+      render(<Dialog open />);
+
+      const container = document.querySelector(`.${classes.container}`);
+      expect(container).toHaveComputedStyle({
+        transitionDuration: `${enteringScreenDurationInSeconds}s`,
+      });
+    });
+
+    it('should render the custom theme values', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+      render(
+        <ThemeProvider theme={theme}>
+          <Dialog open />
+        </ThemeProvider>,
+      );
+
+      const container = document.querySelector(`.${classes.container}`);
+      expect(container).toHaveComputedStyle({ transitionDuration: '0.001s' });
+    });
+
+    it('should render the values provided via prop', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      render(<Dialog open transitionDuration={{ enter: 1 }} />);
+
+      const container = document.querySelector(`.${classes.container}`);
+      expect(container).toHaveComputedStyle({
+        transitionDuration: '0.001s',
+      });
     });
   });
 });

--- a/packages/mui-material/src/Drawer/Drawer.d.ts
+++ b/packages/mui-material/src/Drawer/Drawer.d.ts
@@ -58,7 +58,10 @@ export interface DrawerProps extends StandardProps<ModalProps, 'open' | 'childre
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
+   * @default {
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
+   * }
    */
   transitionDuration?: TransitionProps['timeout'];
   /**

--- a/packages/mui-material/src/Drawer/Drawer.d.ts
+++ b/packages/mui-material/src/Drawer/Drawer.d.ts
@@ -59,8 +59,8 @@ export interface DrawerProps extends StandardProps<ModalProps, 'open' | 'childre
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Drawer/Drawer.d.ts
+++ b/packages/mui-material/src/Drawer/Drawer.d.ts
@@ -58,7 +58,7 @@ export interface DrawerProps extends StandardProps<ModalProps, 'open' | 'childre
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: duration.enteringScreen, exit: duration.leavingScreen }
+   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
    */
   transitionDuration?: TransitionProps['timeout'];
   /**

--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -7,7 +7,6 @@ import Modal from '../Modal';
 import Slide from '../Slide';
 import Paper from '../Paper';
 import capitalize from '../utils/capitalize';
-import { duration } from '../styles/createTransitions';
 import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import styled, { rootShouldForwardProp } from '../styles/styled';
@@ -141,13 +140,18 @@ export function getAnchor(theme, anchor) {
   return theme.direction === 'rtl' && isHorizontal(anchor) ? oppositeDirection[anchor] : anchor;
 }
 
-const defaultTransitionDuration = { enter: duration.enteringScreen, exit: duration.leavingScreen };
 /**
  * The props of the [Modal](/api/modal/) component are available
  * when `variant="temporary"` is set.
  */
 const Drawer = React.forwardRef(function Drawer(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiDrawer' });
+  const theme = useTheme();
+  const defaultTransitionDuration = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     anchor: anchorProp = 'left',
     BackdropProps,
@@ -166,7 +170,6 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
     variant = 'temporary',
     ...other
   } = props;
-  const theme = useTheme();
 
   // Let's assume that the Drawer will always be rendered on user space.
   // We use this state is order to skip the appear transition during the
@@ -334,7 +337,7 @@ Drawer.propTypes /* remove-proptypes */ = {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: duration.enteringScreen, exit: duration.leavingScreen }
+   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,

--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -337,7 +337,10 @@ Drawer.propTypes /* remove-proptypes */ = {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: theme.duration.enteringScreen, exit: theme.duration.leavingScreen }
+   * @default {
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
+   * }
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,

--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -148,8 +148,8 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiDrawer' });
   const theme = useTheme();
   const defaultTransitionDuration = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -338,8 +338,8 @@ Drawer.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/Drawer/Drawer.test.js
+++ b/packages/mui-material/src/Drawer/Drawer.test.js
@@ -38,7 +38,50 @@ describe('<Drawer />', () => {
         exit: 2967,
       };
 
-      it('delay the slide transition to complete', () => {
+      it('should delay the slide transition to complete using default theme values by default', function test() {
+        if (/jsdom/.test(window.navigator.userAgent)) {
+          this.skip();
+        }
+        const theme = createTheme();
+        const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+        render(
+          <Drawer open>
+            <div />
+          </Drawer>,
+        );
+
+        const container = document.querySelector(`.${classes.root}`);
+        const backdropRoot = container.firstChild;
+        expect(backdropRoot).toHaveComputedStyle({
+          transitionDuration: `${enteringScreenDurationInSeconds}s`,
+        });
+      });
+
+      it('should delay the slide transition to complete using custom theme values', function test() {
+        if (/jsdom/.test(window.navigator.userAgent)) {
+          this.skip();
+        }
+        const theme = createTheme({
+          transitions: {
+            duration: {
+              enteringScreen: 1,
+            },
+          },
+        });
+        render(
+          <ThemeProvider theme={theme}>
+            <Drawer open>
+              <div />
+            </Drawer>
+          </ThemeProvider>,
+        );
+
+        const container = document.querySelector(`.${classes.root}`);
+        const backdropRoot = container.firstChild;
+        expect(backdropRoot).toHaveComputedStyle({ transitionDuration: '0.001s' });
+      });
+
+      it('delay the slide transition to complete using values provided via prop', () => {
         const handleEntered = spy();
         const { setProps } = render(
           <Drawer

--- a/packages/mui-material/src/Fade/Fade.d.ts
+++ b/packages/mui-material/src/Fade/Fade.d.ts
@@ -26,8 +26,8 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   timeout?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Fade/Fade.d.ts
+++ b/packages/mui-material/src/Fade/Fade.d.ts
@@ -26,8 +26,8 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   timeout?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Fade/Fade.js
+++ b/packages/mui-material/src/Fade/Fade.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@mui/utils';
-import { duration } from '../styles/createTransitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
@@ -16,16 +15,17 @@ const styles = {
   },
 };
 
-const defaultTimeout = {
-  enter: duration.enteringScreen,
-  exit: duration.leavingScreen,
-};
-
 /**
  * The Fade transition is used by the [Modal](/components/modal/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 const Fade = React.forwardRef(function Fade(props, ref) {
+  const theme = useTheme();
+  const defaultTimeout = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     addEndListener,
     appear = true,
@@ -44,7 +44,6 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     TransitionComponent = Transition,
     ...other
   } = props;
-  const theme = useTheme();
 
   const enableStrictModeCompat = true;
   const nodeRef = React.useRef(null);
@@ -213,8 +212,8 @@ Fade.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   timeout: PropTypes.oneOfType([

--- a/packages/mui-material/src/Fade/Fade.js
+++ b/packages/mui-material/src/Fade/Fade.js
@@ -22,8 +22,8 @@ const styles = {
 const Fade = React.forwardRef(function Fade(props, ref) {
   const theme = useTheme();
   const defaultTimeout = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -212,8 +212,8 @@ Fade.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   timeout: PropTypes.oneOfType([

--- a/packages/mui-material/src/Fade/Fade.test.js
+++ b/packages/mui-material/src/Fade/Fade.test.js
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { createRenderer, describeConformance } from 'test/utils';
 import { Transition } from 'react-transition-group';
 import Fade from '@mui/material/Fade';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 describe('<Fade />', () => {
   const { clock, render } = createRenderer();
@@ -114,6 +115,66 @@ describe('<Fade />', () => {
 
       expect(element).toHaveInlineStyle({ opacity: '0' });
       expect(element).toHaveInlineStyle({ visibility: 'hidden' });
+    });
+  });
+
+  describe('prop: timeout', () => {
+    it('should render the default theme values by default', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme();
+      const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+      const { getByTestId } = render(
+        <Fade in appear>
+          <div data-testid="child">Foo</div>
+        </Fade>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({
+        transitionDuration: `${enteringScreenDurationInSeconds}s`,
+      });
+    });
+
+    it('should render the custom theme values', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Fade in appear>
+            <div data-testid="child">Foo</div>
+          </Fade>
+        </ThemeProvider>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s' });
+    });
+
+    it('should render the values provided via prop', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const { getByTestId } = render(
+        <Fade in appear timeout={{ enter: 1 }}>
+          <div data-testid="child">Foo</div>
+        </Fade>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s' });
     });
   });
 });

--- a/packages/mui-material/src/Slide/Slide.d.ts
+++ b/packages/mui-material/src/Slide/Slide.d.ts
@@ -40,8 +40,8 @@ export interface SlideProps extends TransitionProps {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   timeout?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Slide/Slide.d.ts
+++ b/packages/mui-material/src/Slide/Slide.d.ts
@@ -26,8 +26,8 @@ export interface SlideProps extends TransitionProps {
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
    * @default {
-   *   enter: easing.easeOut,
-   *   exit: easing.sharp,
+   *   enter: theme.transitions.easing.easeOut,
+   *   exit: theme.transitions.easing.sharp,
    * }
    */
   easing?: TransitionProps['easing'];

--- a/packages/mui-material/src/Slide/Slide.d.ts
+++ b/packages/mui-material/src/Slide/Slide.d.ts
@@ -40,8 +40,8 @@ export interface SlideProps extends TransitionProps {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   timeout?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Slide/Slide.js
+++ b/packages/mui-material/src/Slide/Slide.js
@@ -5,7 +5,6 @@ import { elementAcceptingRef, HTMLElementType, chainPropTypes } from '@mui/utils
 import debounce from '../utils/debounce';
 import useForkRef from '../utils/useForkRef';
 import useTheme from '../styles/useTheme';
-import { easing } from '../styles/createTransitions';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import { ownerWindow } from '../utils';
 
@@ -79,17 +78,17 @@ export function setTranslateValue(direction, node, containerProp) {
   }
 }
 
-const defaultEasing = {
-  enter: easing.easeOut,
-  exit: easing.sharp,
-};
-
 /**
  * The Slide transition is used by the [Drawer](/components/drawers/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 const Slide = React.forwardRef(function Slide(props, ref) {
   const theme = useTheme();
+  const defaultEasing = {
+    enter: theme.transitions.easing.easeOut,
+    exit: theme.transitions.easing.sharp,
+  };
+
   const defaultTimeout = {
     enter: theme.transitions.duration.enteringScreen,
     exit: theme.transitions.duration.leavingScreen,
@@ -338,8 +337,8 @@ Slide.propTypes /* remove-proptypes */ = {
    * The transition timing function.
    * You may specify a single easing or a object containing enter and exit values.
    * @default {
-   *   enter: easing.easeOut,
-   *   exit: easing.sharp,
+   *   enter: theme.transitions.easing.easeOut,
+   *   exit: theme.transitions.easing.sharp,
    * }
    */
   easing: PropTypes.oneOfType([

--- a/packages/mui-material/src/Slide/Slide.js
+++ b/packages/mui-material/src/Slide/Slide.js
@@ -91,8 +91,8 @@ const defaultEasing = {
 const Slide = React.forwardRef(function Slide(props, ref) {
   const theme = useTheme();
   const defaultTimeout = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -385,8 +385,8 @@ Slide.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   timeout: PropTypes.oneOfType([

--- a/packages/mui-material/src/Slide/Slide.js
+++ b/packages/mui-material/src/Slide/Slide.js
@@ -5,7 +5,7 @@ import { elementAcceptingRef, HTMLElementType, chainPropTypes } from '@mui/utils
 import debounce from '../utils/debounce';
 import useForkRef from '../utils/useForkRef';
 import useTheme from '../styles/useTheme';
-import { duration, easing } from '../styles/createTransitions';
+import { easing } from '../styles/createTransitions';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import { ownerWindow } from '../utils';
 
@@ -84,16 +84,17 @@ const defaultEasing = {
   exit: easing.sharp,
 };
 
-const defaultTimeout = {
-  enter: duration.enteringScreen,
-  exit: duration.leavingScreen,
-};
-
 /**
  * The Slide transition is used by the [Drawer](/components/drawers/) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 const Slide = React.forwardRef(function Slide(props, ref) {
+  const theme = useTheme();
+  const defaultTimeout = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     addEndListener,
     appear = true,
@@ -115,7 +116,6 @@ const Slide = React.forwardRef(function Slide(props, ref) {
     ...other
   } = props;
 
-  const theme = useTheme();
   const childrenRef = React.useRef(null);
   const handleRefIntermediary = useForkRef(children.ref, childrenRef);
   const handleRef = useForkRef(handleRefIntermediary, ref);
@@ -385,8 +385,8 @@ Slide.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   timeout: PropTypes.oneOfType([

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import { act, createRenderer, describeConformance } from 'test/utils';
-import { createTheme } from '@mui/material/styles';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Transition } from 'react-transition-group';
 import Slide from '@mui/material/Slide';
 import { setTranslateValue } from './Slide';
@@ -154,6 +154,43 @@ describe('<Slide />', () => {
         /transform 446ms cubic-bezier\(0.4, 0, 0.6, 1\)( 0ms)?/,
       );
     });
+
+    it('should render the default theme values by default', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const theme = createTheme();
+      const handleEntering = spy();
+      render(<Slide {...defaultProps} onEntering={handleEntering} />);
+
+      expect(handleEntering.args[0][0].style.transition).to.equal(
+        `transform ${theme.transitions.duration.enteringScreen}ms cubic-bezier(0.0, 0, 0.2, 1) 0ms`,
+      );
+    });
+
+    it('should render the custom theme values', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+
+      const handleEntering = spy();
+      render(
+        <ThemeProvider theme={theme}>
+          <Slide {...defaultProps} onEntering={handleEntering} />
+        </ThemeProvider>,
+      );
+
+      expect(handleEntering.args[0][0].style.transition).to.equal(
+        `transform ${theme.transitions.duration.enteringScreen}ms cubic-bezier(0.0, 0, 0.2, 1) 0ms`,
+      );
+    });
   });
 
   describe('prop: easing', () => {
@@ -191,6 +228,43 @@ describe('<Slide />', () => {
 
       expect(handleExit.args[0][0].style.transition).to.match(
         /transform 195ms cubic-bezier\(0, 0, 1, 1\)( 0ms)?/,
+      );
+    });
+
+    it('should render the default theme values by default', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const theme = createTheme();
+      const handleEntering = spy();
+      render(<Slide {...defaultProps} onEntering={handleEntering} />);
+
+      expect(handleEntering.args[0][0].style.transition).to.equal(
+        `transform 225ms ${theme.transitions.easing.easeOut} 0ms`,
+      );
+    });
+
+    it('should render the custom theme values', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const theme = createTheme({
+        transitions: {
+          easing: {
+            easeOut: 'cubic-bezier(1, 1, 1, 1)',
+          },
+        },
+      });
+
+      const handleEntering = spy();
+      render(
+        <ThemeProvider theme={theme}>
+          <Slide {...defaultProps} onEntering={handleEntering} />
+        </ThemeProvider>,
+      );
+
+      expect(handleEntering.args[0][0].style.transition).to.equal(
+        `transform 225ms ${theme.transitions.easing.easeOut} 0ms`,
       );
     });
   });

--- a/packages/mui-material/src/Snackbar/Snackbar.d.ts
+++ b/packages/mui-material/src/Snackbar/Snackbar.d.ts
@@ -104,8 +104,8 @@ export interface SnackbarProps extends StandardProps<React.HTMLAttributes<HTMLDi
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Snackbar/Snackbar.d.ts
+++ b/packages/mui-material/src/Snackbar/Snackbar.d.ts
@@ -104,8 +104,8 @@ export interface SnackbarProps extends StandardProps<React.HTMLAttributes<HTMLDi
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   transitionDuration?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Snackbar/Snackbar.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.js
@@ -6,7 +6,6 @@ import ClickAwayListener from '@mui/base/ClickAwayListener';
 import styled from '../styles/styled';
 import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
-import { duration } from '../styles/createTransitions';
 import useEventCallback from '../utils/useEventCallback';
 import capitalize from '../utils/capitalize';
 import Grow from '../Grow';
@@ -95,6 +94,12 @@ const SnackbarRoot = styled('div', {
 
 const Snackbar = React.forwardRef(function Snackbar(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiSnackbar' });
+  const theme = useTheme();
+  const defaultTransitionDuration = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     action,
     anchorOrigin: { vertical, horizontal } = { vertical: 'bottom', horizontal: 'left' },
@@ -113,15 +118,11 @@ const Snackbar = React.forwardRef(function Snackbar(inProps, ref) {
     open,
     resumeHideDuration,
     TransitionComponent = Grow,
-    transitionDuration = {
-      enter: duration.enteringScreen,
-      exit: duration.leavingScreen,
-    },
+    transitionDuration = defaultTransitionDuration,
     TransitionProps: { onEnter, onExited, ...TransitionProps } = {},
     ...other
   } = props;
 
-  const theme = useTheme();
   const isRtl = theme.direction === 'rtl';
 
   const ownerState = { ...props, anchorOrigin: { vertical, horizontal }, isRtl };
@@ -416,8 +417,8 @@ Snackbar.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/Snackbar/Snackbar.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.js
@@ -96,8 +96,8 @@ const Snackbar = React.forwardRef(function Snackbar(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiSnackbar' });
   const theme = useTheme();
   const defaultTransitionDuration = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -417,8 +417,8 @@ Snackbar.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { describeConformance, act, createRenderer, fireEvent } from 'test/utils';
 import Snackbar, { snackbarClasses as classes } from '@mui/material/Snackbar';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 describe('<Snackbar />', () => {
   const { clock, render: clientRender } = createRenderer({ clock: 'fake' });
@@ -532,6 +533,67 @@ describe('<Snackbar />', () => {
       const Transition = () => <div className="cloned-element-class" ref={transitionRef} />;
       const { container } = render(<Snackbar open TransitionComponent={Transition} />);
       expect(container).to.contain(transitionRef.current);
+    });
+  });
+
+  describe('prop: transitionDuration', () => {
+    it('should render the default theme values by default', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme();
+      const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+      const { getByTestId } = render(
+        <Snackbar open message="Hello, World!">
+          <div data-testid="child">Foo</div>
+        </Snackbar>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({
+        transitionDuration: `${enteringScreenDurationInSeconds}s, 0.15s`,
+      });
+    });
+
+    it('should render the custom theme values', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Snackbar open message="Hello, World!">
+            <div data-testid="child">Foo</div>
+          </Snackbar>
+        </ThemeProvider>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s, 0.001s' });
+    });
+
+    it('should render the values provided via prop', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const { getByTestId } = render(
+        <Snackbar open message="Hello, World!" transitionDuration={1}>
+          <div data-testid="child">Foo</div>
+        </Snackbar>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s, 0.001s' });
     });
   });
 });

--- a/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
@@ -80,8 +80,8 @@ export interface SpeedDialProps
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   transitionDuration?: TransitionProps['timeout'];

--- a/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
@@ -80,8 +80,8 @@ export interface SpeedDialProps
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration?: TransitionProps['timeout'];

--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -125,8 +125,8 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiSpeedDial' });
   const theme = useTheme();
   const defaultTransitionDuration = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -520,8 +520,8 @@ SpeedDial.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
-import { duration } from '../styles/createTransitions';
+import useTheme from '../styles/useTheme';
 import Zoom from '../Zoom';
 import Fab from '../Fab';
 import capitalize from '../utils/capitalize';
@@ -123,6 +123,12 @@ const SpeedDialActions = styled('div', {
 
 const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiSpeedDial' });
+  const theme = useTheme();
+  const defaultTransitionDuration = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     ariaLabel,
     FabProps: { ref: origDialButtonRef, ...FabProps } = {},
@@ -141,10 +147,7 @@ const SpeedDial = React.forwardRef(function SpeedDial(inProps, ref) {
     open: openProp,
     openIcon,
     TransitionComponent = Zoom,
-    transitionDuration = {
-      enter: duration.enteringScreen,
-      exit: duration.leavingScreen,
-    },
+    transitionDuration = defaultTransitionDuration,
     TransitionProps,
     ...other
   } = props;
@@ -517,8 +520,8 @@ SpeedDial.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -13,6 +13,7 @@ import Icon from '@mui/material/Icon';
 import SpeedDial, { speedDialClasses as classes } from '@mui/material/SpeedDial';
 import SpeedDialAction from '@mui/material/SpeedDialAction';
 import { tooltipClasses } from '@mui/material/Tooltip';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 describe('<SpeedDial />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });
@@ -408,6 +409,59 @@ describe('<SpeedDial />', () => {
           [0, -1, -1, 0],
         );
       });
+    });
+  });
+
+  describe('prop: transitionDuration', () => {
+    it('should render the default theme values by default', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme();
+      const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+      const { getByTestId } = render(<SpeedDial data-testid="speedDial" {...defaultProps} />);
+
+      const child = getByTestId('speedDial').firstChild;
+      expect(child).toHaveComputedStyle({
+        transitionDuration: `${enteringScreenDurationInSeconds}s`,
+      });
+    });
+
+    it('should render the custom theme values', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <SpeedDial data-testid="speedDial" {...defaultProps} />,
+        </ThemeProvider>,
+      );
+
+      const child = getByTestId('speedDial').firstChild;
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s' });
+    });
+
+    it('should render the values provided via prop', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const { getByTestId } = render(
+        <SpeedDial data-testid="speedDial" {...defaultProps} transitionDuration={1} />,
+      );
+
+      const child = getByTestId('speedDial').firstChild;
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s' });
     });
   });
 });

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -677,7 +677,10 @@ SwipeableDrawer.propTypes /* remove-proptypes */ = {
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
-   * @default { enter: duration.enteringScreen, exit: duration.leavingScreen }
+   * @default {
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
+   * }
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -135,8 +135,8 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
   const props = useThemeProps({ name: 'MuiSwipeableDrawer', props: inProps });
   const theme = useTheme();
   const transitionDurationDefault = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
   const {
     anchor = 'left',
@@ -678,8 +678,8 @@ SwipeableDrawer.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   transitionDuration: PropTypes.oneOfType([

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -8,7 +8,6 @@ import ownerDocument from '../utils/ownerDocument';
 import ownerWindow from '../utils/ownerWindow';
 import useEventCallback from '../utils/useEventCallback';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
-import { duration } from '../styles/createTransitions';
 import useTheme from '../styles/useTheme';
 import { getTransitionProps } from '../transitions/utils';
 import SwipeArea from './SwipeArea';
@@ -131,11 +130,14 @@ function computeHasNativeHandler({ domTreeShapes, start, current, anchor }) {
 }
 
 const iOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
-const transitionDurationDefault = { enter: duration.enteringScreen, exit: duration.leavingScreen };
 
 const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) {
   const props = useThemeProps({ name: 'MuiSwipeableDrawer', props: inProps });
   const theme = useTheme();
+  const transitionDurationDefault = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
   const {
     anchor = 'left',
     disableBackdropTransition = false,

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -6,6 +6,7 @@ import PropTypes, { checkPropTypes } from 'prop-types';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Drawer, { drawerClasses } from '@mui/material/Drawer';
 import { backdropClasses } from '@mui/material/Backdrop';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import useForkRef from '../utils/useForkRef';
 
 const FakePaper = React.forwardRef(function FakeWidthPaper(props, ref) {
@@ -737,5 +738,60 @@ describe('<SwipeableDrawer />', () => {
 
     expect(handleTouchMove.callCount).to.equal(1);
     expect(handleTouchMove.firstCall.args[0]).to.have.property('defaultPrevented', false);
+  });
+
+  describe('prop: transitionDuration', () => {
+    it('should render the default theme values by default', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme();
+      const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+      render(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />);
+
+      const backdropRoot = document.querySelector(`.${backdropClasses.root}`);
+      expect(backdropRoot).toHaveComputedStyle({
+        transitionDuration: `${enteringScreenDurationInSeconds}s`,
+      });
+    });
+
+    it('should render the custom theme values', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+
+      render(
+        <ThemeProvider theme={theme}>
+          <SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />
+        </ThemeProvider>,
+      );
+
+      const backdropRoot = document.querySelector(`.${backdropClasses.root}`);
+      expect(backdropRoot).toHaveComputedStyle({
+        transitionDuration: '0.001s',
+      });
+    });
+
+    it('should render the values provided via prop', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      render(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open transitionDuration={1} />);
+
+      const backdropRoot = document.querySelector(`.${backdropClasses.root}`);
+      expect(backdropRoot).toHaveComputedStyle({
+        transitionDuration: '0.001s',
+      });
+    });
   });
 });

--- a/packages/mui-material/src/Zoom/Zoom.d.ts
+++ b/packages/mui-material/src/Zoom/Zoom.d.ts
@@ -26,8 +26,8 @@ export interface ZoomProps extends TransitionProps {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   timeout?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Zoom/Zoom.d.ts
+++ b/packages/mui-material/src/Zoom/Zoom.d.ts
@@ -26,8 +26,8 @@ export interface ZoomProps extends TransitionProps {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   timeout?: TransitionProps['timeout'];

--- a/packages/mui-material/src/Zoom/Zoom.js
+++ b/packages/mui-material/src/Zoom/Zoom.js
@@ -23,8 +23,8 @@ const styles = {
 const Zoom = React.forwardRef(function Zoom(props, ref) {
   const theme = useTheme();
   const defaultTimeout = {
-    enter: theme.duration.enteringScreen,
-    exit: theme.duration.leavingScreen,
+    enter: theme.transitions.duration.enteringScreen,
+    exit: theme.transitions.duration.leavingScreen,
   };
 
   const {
@@ -212,8 +212,8 @@ Zoom.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: theme.duration.enteringScreen,
-   *   exit: theme.duration.leavingScreen,
+   *   enter: theme.transitions.duration.enteringScreen,
+   *   exit: theme.transitions.duration.leavingScreen,
    * }
    */
   timeout: PropTypes.oneOfType([

--- a/packages/mui-material/src/Zoom/Zoom.js
+++ b/packages/mui-material/src/Zoom/Zoom.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@mui/utils';
-import { duration } from '../styles/createTransitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
@@ -16,17 +15,18 @@ const styles = {
   },
 };
 
-const defaultTimeout = {
-  enter: duration.enteringScreen,
-  exit: duration.leavingScreen,
-};
-
 /**
  * The Zoom transition can be used for the floating variant of the
  * [Button](/components/buttons/#floating-action-buttons) component.
  * It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 const Zoom = React.forwardRef(function Zoom(props, ref) {
+  const theme = useTheme();
+  const defaultTimeout = {
+    enter: theme.duration.enteringScreen,
+    exit: theme.duration.leavingScreen,
+  };
+
   const {
     addEndListener,
     appear = true,
@@ -45,8 +45,6 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     TransitionComponent = Transition,
     ...other
   } = props;
-
-  const theme = useTheme();
 
   const nodeRef = React.useRef(null);
   const foreignRef = useForkRef(children.ref, ref);
@@ -214,8 +212,8 @@ Zoom.propTypes /* remove-proptypes */ = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    * @default {
-   *   enter: duration.enteringScreen,
-   *   exit: duration.leavingScreen,
+   *   enter: theme.duration.enteringScreen,
+   *   exit: theme.duration.leavingScreen,
    * }
    */
   timeout: PropTypes.oneOfType([

--- a/packages/mui-material/src/Zoom/Zoom.test.js
+++ b/packages/mui-material/src/Zoom/Zoom.test.js
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { describeConformance, createRenderer } from 'test/utils';
 import { Transition } from 'react-transition-group';
 import Zoom from '@mui/material/Zoom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 describe('<Zoom />', () => {
   const { clock, render } = createRenderer();
@@ -116,6 +117,66 @@ describe('<Zoom />', () => {
 
       expect(element.style).to.have.property('transform', 'scale(0)');
       expect(element.style).to.have.property('visibility', 'hidden');
+    });
+  });
+
+  describe('prop: timeout', () => {
+    it('should render the default theme values by default', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme();
+      const enteringScreenDurationInSeconds = theme.transitions.duration.enteringScreen / 1000;
+      const { getByTestId } = render(
+        <Zoom in appear>
+          <div data-testid="child">Foo</div>
+        </Zoom>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({
+        transitionDuration: `${enteringScreenDurationInSeconds}s`,
+      });
+    });
+
+    it('should render the custom theme values', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            enteringScreen: 1,
+          },
+        },
+      });
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Zoom in appear>
+            <div data-testid="child">Foo</div>
+          </Zoom>
+        </ThemeProvider>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s' });
+    });
+
+    it('should render the values provided via prop', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const { getByTestId } = render(
+        <Zoom in appear timeout={{ enter: 1 }}>
+          <div data-testid="child">Foo</div>
+        </Zoom>,
+      );
+
+      const child = getByTestId('child');
+      expect(child).toHaveComputedStyle({ transitionDuration: '0.001s' });
     });
   });
 });

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -22,9 +22,70 @@ describe('createTheme', () => {
     expect(theme.palette.secondary.main).to.equal(green.A400);
   });
 
-  it('should allow providing a partial structure', () => {
-    const theme = createTheme({ transitions: { duration: { shortest: 150 } } });
-    expect(theme.transitions.duration.shorter).not.to.equal(undefined);
+  describe('transitions', () => {
+    it('[`easing`]: should provide the default values', () => {
+      const theme = createTheme();
+      expect(theme.transitions.easing.easeInOut).to.equal('cubic-bezier(0.4, 0, 0.2, 1)');
+      expect(theme.transitions.easing.easeOut).to.equal('cubic-bezier(0.0, 0, 0.2, 1)');
+      expect(theme.transitions.easing.easeIn).to.equal('cubic-bezier(0.4, 0, 1, 1)');
+      expect(theme.transitions.easing.sharp).to.equal('cubic-bezier(0.4, 0, 0.6, 1)');
+    });
+
+    it('[`duration`]: should provide the default values', () => {
+      const theme = createTheme();
+      expect(theme.transitions.duration.shortest).to.equal(150);
+      expect(theme.transitions.duration.shorter).to.equal(200);
+      expect(theme.transitions.duration.short).to.equal(250);
+      expect(theme.transitions.duration.standard).to.equal(300);
+      expect(theme.transitions.duration.complex).to.equal(375);
+      expect(theme.transitions.duration.enteringScreen).to.equal(225);
+      expect(theme.transitions.duration.leavingScreen).to.equal(195);
+    });
+
+    it('[`easing`]: should provide the custom values', () => {
+      const theme = createTheme({
+        transitions: {
+          easing: {
+            easeInOut: 'cubic-bezier(1, 1, 1, 1)',
+            easeOut: 'cubic-bezier(1, 1, 1, 1)',
+            easeIn: 'cubic-bezier(1, 1, 1, 1)',
+            sharp: 'cubic-bezier(1, 1, 1, 1)',
+          },
+        },
+      });
+      expect(theme.transitions.easing.easeInOut).to.equal('cubic-bezier(1, 1, 1, 1)');
+      expect(theme.transitions.easing.easeOut).to.equal('cubic-bezier(1, 1, 1, 1)');
+      expect(theme.transitions.easing.easeIn).to.equal('cubic-bezier(1, 1, 1, 1)');
+      expect(theme.transitions.easing.sharp).to.equal('cubic-bezier(1, 1, 1, 1)');
+    });
+
+    it('[`duration`]: should provide the custom values', () => {
+      const theme = createTheme({
+        transitions: {
+          duration: {
+            shortest: 1,
+            shorter: 1,
+            short: 1,
+            standard: 1,
+            complex: 1,
+            enteringScreen: 1,
+            leavingScreen: 1,
+          },
+        },
+      });
+      expect(theme.transitions.duration.shortest).to.equal(1);
+      expect(theme.transitions.duration.shorter).to.equal(1);
+      expect(theme.transitions.duration.short).to.equal(1);
+      expect(theme.transitions.duration.standard).to.equal(1);
+      expect(theme.transitions.duration.complex).to.equal(1);
+      expect(theme.transitions.duration.enteringScreen).to.equal(1);
+      expect(theme.transitions.duration.leavingScreen).to.equal(1);
+    });
+
+    it('should allow providing a partial structure', () => {
+      const theme = createTheme({ transitions: { duration: { shortest: 150 } } });
+      expect(theme.transitions.duration.shorter).not.to.equal(undefined);
+    });
   });
 
   describe('shadows', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/30826

Problem:
- A few components don't reference the transition duration values from the theme, but instead reference the hard-coded values defined in [createTransitions.js](https://github.com/mui-org/material-ui/blob/ec5df5f94f472628103eb1cfbecccc6afc2658bd/packages/mui-material/src/styles/createTransitions.js#L17-L29).

Solution:
- Define default transition duration used in components using `theme.transitions.duration`.
- [Codesandbox BEFORE this PR](https://codesandbox.io/s/persistentdrawerleft-material-demo-forked-pslqy?file=/demo.js)
- [Codesandbox AFTER this PR](https://codesandbox.io/s/persistentdrawerleft-material-demo-forked-lzwlc?file=/demo.js)