### PR TITLE
[Badge] fix showzero and invisible condition

### DIFF
--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.js
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.js
@@ -140,6 +140,7 @@ BadgeUnstyled.propTypes /* remove-proptypes */ = {
   }),
   /**
    * If `true`, the badge is invisible.
+   * @default false
    */
   invisible: PropTypes.bool,
   /**

--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyledProps.ts
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyledProps.ts
@@ -50,6 +50,7 @@ export interface BadgeUnstyledTypeMap<P = {}, D extends React.ElementType = 'spa
     classes?: Partial<BadgeUnstyledClasses>;
     /**
      * If `true`, the badge is invisible.
+     * @default false
      */
     invisible?: boolean;
     /**

--- a/packages/mui-base/src/BadgeUnstyled/useBadge.ts
+++ b/packages/mui-base/src/BadgeUnstyled/useBadge.ts
@@ -34,7 +34,7 @@ export default function useBadge(props: UseBadgeProps) {
   let invisible = invisibleProp;
 
   if (
-    invisibleProp == null &&
+    invisibleProp !== true &&
     ((badgeContentProp === 0 && !showZero) || (badgeContentProp == null && variantProp !== 'dot'))
   ) {
     invisible = true;

--- a/packages/mui-base/src/BadgeUnstyled/useBadge.ts
+++ b/packages/mui-base/src/BadgeUnstyled/useBadge.ts
@@ -18,7 +18,7 @@ export default function useBadge(props: UseBadgeProps) {
       horizontal: 'right',
     },
     badgeContent: badgeContentProp,
-    invisible: invisibleProp,
+    invisible: invisibleProp = false,
     max: maxProp = 99,
     showZero = false,
     variant: variantProp = 'standard',
@@ -34,7 +34,7 @@ export default function useBadge(props: UseBadgeProps) {
   let invisible = invisibleProp;
 
   if (
-    invisibleProp !== true &&
+    invisibleProp === false &&
     ((badgeContentProp === 0 && !showZero) || (badgeContentProp == null && variantProp !== 'dot'))
   ) {
     invisible = true;

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -226,7 +226,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
     componentsProps = {},
     overlap: overlapProp = 'rectangular',
     color: colorProp = 'default',
-    invisible: invisibleProp,
+    invisible: invisibleProp = false,
     badgeContent: badgeContentProp,
     showZero = false,
     variant: variantProp = 'standard',
@@ -242,7 +242,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
   let invisible = invisibleProp;
 
   if (
-    invisibleProp !== true &&
+    invisibleProp === false &&
     ((badgeContentProp === 0 && !showZero) || (badgeContentProp == null && variantProp !== 'dot'))
   ) {
     invisible = true;
@@ -351,6 +351,7 @@ Badge.propTypes /* remove-proptypes */ = {
   }),
   /**
    * If `true`, the badge is invisible.
+   * @default false
    */
   invisible: PropTypes.bool,
   /**

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -242,7 +242,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
   let invisible = invisibleProp;
 
   if (
-    invisibleProp == null &&
+    invisibleProp !== true &&
     ((badgeContentProp === 0 && !showZero) || (badgeContentProp == null && variantProp !== 'dot'))
   ) {
     invisible = true;

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -99,6 +99,11 @@ describe('<Badge />', () => {
       ).container;
       expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
+    it('should render with invisible class when invisible and showZero are set to false and content is 0', () => {
+      const { container } = render(<Badge badgeContent={0} showZero={false} invisible={false} />);
+      expect(findBadge(container)).to.have.class(classes.invisible);
+      expect(findBadge(container)).to.have.text('');
+    });
   });
 
   describe('prop: showZero', () => {

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -104,6 +104,11 @@ describe('<Badge />', () => {
       expect(findBadge(container)).to.have.class(classes.invisible);
       expect(findBadge(container)).to.have.text('');
     });
+    it('should not render with invisible class when invisible and showZero are set to false and content is not 0', () => {
+      const { container } = render(<Badge badgeContent={1} showZero={false} invisible={false} />);
+      expect(findBadge(container)).not.to.have.class(classes.invisible);
+      expect(findBadge(container)).to.have.text('1');
+    });
   });
 
   describe('prop: showZero', () => {

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -99,11 +99,13 @@ describe('<Badge />', () => {
       ).container;
       expect(findBadge(container)).not.to.have.class(classes.invisible);
     });
+
     it('should render with invisible class when invisible and showZero are set to false and content is 0', () => {
       const { container } = render(<Badge badgeContent={0} showZero={false} invisible={false} />);
       expect(findBadge(container)).to.have.class(classes.invisible);
       expect(findBadge(container)).to.have.text('');
     });
+
     it('should not render with invisible class when invisible and showZero are set to false and content is not 0', () => {
       const { container } = render(<Badge badgeContent={1} showZero={false} invisible={false} />);
       expect(findBadge(container)).not.to.have.class(classes.invisible);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #30807 [codeSandBox demo](https://codesandbox.io/s/simplebadge-material-demo-forked-n1388?file=/demo.js)

**Problem:**
`Badge` component did not work correctly when the invisible prop was equal to false.

**Solution:**
In the Badge component, instead of checking if the invisible prop is not equal to null or undefined, we can check if it is not true. Then we can change the invisible value to true in certain circumstances, such as when the `badgeContent` is zero and `showZero` is false.

