### PR TITLE
[docs] Fix link-underline-hover chapter of migration guides v4

### DIFF
--- a/docs/data/material/guides/migration-v4/migration-v4.md
+++ b/docs/data/material/guides/migration-v4/migration-v4.md
@@ -201,7 +201,7 @@ createMuiTheme({
 });
 ```
 
-If, however, you want to keep `variant="hover"`, run this codemod or configure theme default props.
+If, however, you want to keep `underline="hover"`, run this codemod or configure theme default props.
 
 ```sh
 npx @mui/codemod v5.0.0/link-underline-hover <path>


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I fixed a mistake I found during the migration.