### PR TITLE
[docs] Improve description of the `disableRestoreFocus` prop of the `TrapFocus`

### DIFF
--- a/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
+++ b/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
@@ -14,7 +14,7 @@
     "disableEnforceFocus": "If <code>true</code>, the modal will not prevent focus from leaving the modal while open.<br>Generally this should never be set to <code>true</code> as it makes the modal less accessible to assistive technologies, like screen readers.",
     "disableEscapeKeyDown": "If <code>true</code>, hitting escape will not fire the <code>onClose</code> callback.",
     "disablePortal": "The <code>children</code> will be under the DOM hierarchy of the parent component.",
-    "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden.",
+    "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden or unmounted.",
     "disableScrollLock": "Disable the scroll lock behavior.",
     "hideBackdrop": "If <code>true</code>, the backdrop is not rendered.",
     "keepMounted": "Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Modal.",

--- a/docs/translations/api-docs/modal/modal.json
+++ b/docs/translations/api-docs/modal/modal.json
@@ -13,7 +13,7 @@
     "disableEnforceFocus": "If <code>true</code>, the modal will not prevent focus from leaving the modal while open.<br>Generally this should never be set to <code>true</code> as it makes the modal less accessible to assistive technologies, like screen readers.",
     "disableEscapeKeyDown": "If <code>true</code>, hitting escape will not fire the <code>onClose</code> callback.",
     "disablePortal": "The <code>children</code> will be under the DOM hierarchy of the parent component.",
-    "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden.",
+    "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden or unmounted.",
     "disableScrollLock": "Disable the scroll lock behavior.",
     "hideBackdrop": "If <code>true</code>, the backdrop is not rendered.",
     "keepMounted": "Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Modal.",

--- a/docs/translations/api-docs/unstable-trap-focus/unstable-trap-focus.json
+++ b/docs/translations/api-docs/unstable-trap-focus/unstable-trap-focus.json
@@ -4,7 +4,7 @@
     "children": "A single child content element.<br>⚠️ <a href=\"/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
     "disableAutoFocus": "If <code>true</code>, the trap focus will not automatically shift focus to itself when it opens, and replace it to the last focused element when it closes. This also works correctly with any trap focus children that have the <code>disableAutoFocus</code> prop.<br>Generally this should never be set to <code>true</code> as it makes the trap focus less accessible to assistive technologies, like screen readers.",
     "disableEnforceFocus": "If <code>true</code>, the trap focus will not prevent focus from leaving the trap focus while open.<br>Generally this should never be set to <code>true</code> as it makes the trap focus less accessible to assistive technologies, like screen readers.",
-    "disableRestoreFocus": "If <code>true</code>, the trap focus will not restore focus to previously focused element once trap focus is hidden.",
+    "disableRestoreFocus": "If <code>true</code>, the trap focus will not restore focus to previously focused element once trap focus is hidden or unmounted.",
     "getTabbable": "Returns an array of ordered tabbable nodes (i.e. in tab order) within the root. For instance, you can provide the &quot;tabbable&quot; npm dependency.<br><br><strong>Signature:</strong><br><code>function(root: HTMLElement) =&gt; void</code><br>",
     "isEnabled": "This prop extends the <code>open</code> prop. It allows to toggle the open state without having to wait for a rerender when changing the <code>open</code> prop. This prop should be memoized. It can be used to support multiple trap focus mounted at the same time.",
     "open": "If <code>true</code>, focus is locked."

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.d.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.d.ts
@@ -82,7 +82,7 @@ export interface ModalUnstyledTypeMap<P = {}, D extends React.ElementType = 'div
     disablePortal?: PortalProps['disablePortal'];
     /**
      * If `true`, the modal will not restore focus to previously focused element once
-     * modal is hidden.
+     * modal is hidden or unmounted.
      * @default false
      */
     disableRestoreFocus?: boolean;

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
@@ -374,7 +374,7 @@ ModalUnstyled.propTypes /* remove-proptypes */ = {
   disablePortal: PropTypes.bool,
   /**
    * If `true`, the modal will not restore focus to previously focused element once
-   * modal is hidden.
+   * modal is hidden or unmounted.
    * @default false
    */
   disableRestoreFocus: PropTypes.bool,

--- a/packages/mui-base/src/Unstable_TrapFocus/Unstable_TrapFocus.d.ts
+++ b/packages/mui-base/src/Unstable_TrapFocus/Unstable_TrapFocus.d.ts
@@ -46,7 +46,7 @@ export interface TrapFocusProps {
   disableEnforceFocus?: boolean;
   /**
    * If `true`, the trap focus will not restore focus to previously focused element once
-   * trap focus is hidden.
+   * trap focus is hidden or unmounted.
    * @default false
    */
   disableRestoreFocus?: boolean;

--- a/packages/mui-base/src/Unstable_TrapFocus/Unstable_TrapFocus.js
+++ b/packages/mui-base/src/Unstable_TrapFocus/Unstable_TrapFocus.js
@@ -365,7 +365,7 @@ Unstable_TrapFocus.propTypes /* remove-proptypes */ = {
   disableEnforceFocus: PropTypes.bool,
   /**
    * If `true`, the trap focus will not restore focus to previously focused element once
-   * trap focus is hidden.
+   * trap focus is hidden or unmounted.
    * @default false
    */
   disableRestoreFocus: PropTypes.bool,

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -216,7 +216,7 @@ Modal.propTypes /* remove-proptypes */ = {
   disablePortal: PropTypes.bool,
   /**
    * If `true`, the modal will not restore focus to previously focused element once
-   * modal is hidden.
+   * modal is hidden or unmounted.
    * @default false
    */
   disableRestoreFocus: PropTypes.bool,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


This behavior also runs on unmount (it is in the return function of an effect).