### PR TITLE
[website] Sample GA to avoid hit limit

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -29,7 +29,10 @@ if (process.env.NODE_ENV === 'production') {
   cleanCSS = new CleanCSS();
 }
 
-const GOOGLE_ID = process.env.NODE_ENV === 'production' ? 'UA-106598593-2' : 'UA-106598593-3';
+const PRODUCTION_DEPLOYEMENT =
+  process.env.PULL_REQUEST !== 'true' && process.env.NODE_ENV === 'production';
+
+const GOOGLE_ANALYTICS_ID = PRODUCTION_DEPLOYEMENT ? 'UA-106598593-2' : 'UA-106598593-3';
 
 export default class MyDocument extends Document {
   render() {
@@ -140,7 +143,9 @@ export default class MyDocument extends Document {
             dangerouslySetInnerHTML={{
               __html: `
                 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-                window.ga('create','${GOOGLE_ID}','auto');
+                window.ga('create','${GOOGLE_ANALYTICS_ID}',{
+                  sampleRate: ${PRODUCTION_DEPLOYEMENT ? 80 : 100},
+                });
               `,
             }}
           />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -29,8 +29,7 @@ if (process.env.NODE_ENV === 'production') {
   cleanCSS = new CleanCSS();
 }
 
-const PRODUCTION_DEPLOYEMENT =
-  process.env.PULL_REQUEST !== 'true' && process.env.NODE_ENV === 'production';
+const PRODUCTION_DEPLOYEMENT = !process.env.PULL_REQUEST && process.env.NODE_ENV === 'production';
 
 const GOOGLE_ANALYTICS_ID = PRODUCTION_DEPLOYEMENT ? 'UA-106598593-2' : 'UA-106598593-3';
 


### PR DESCRIPTION
https://deploy-preview-30919--material-ui.netlify.app/getting-started/installation/

In GA, we had the following warning a few days ago:

<img width="420" alt="Screenshot 2022-02-05 at 12 58 35" src="https://user-images.githubusercontent.com/3165635/152641117-dbe2a647-0f7b-47ed-bac5-29c63c427096.png">

This is our current quote usage:

<img width="218" alt="Screenshot 2022-02-05 at 12 59 10" src="https://user-images.githubusercontent.com/3165635/152641145-755184e6-8851-4138-95e0-aa532bf5fa6f.png">

We are above the 10M/month limit: https://developers.google.com/analytics/devguides/collection/analyticsjs/limits-quotas.
While Google doesn't seem to penalize us so far, he might in the future. I'm adding a bit of sampling https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference in case.
