### PR TITLE
[docs] Use full product names (Material UI, MUI System)

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -200,7 +200,7 @@ function ProductDrawerButton(props) {
               href={ROUTES.materialDocs}
               // eslint-disable-next-line material-ui/no-hardcoded-labels
             >
-              Material Design <KeyboardArrowRight fontSize="small" />
+              Material UI <KeyboardArrowRight fontSize="small" />
             </Link>
             <Link
               href={ROUTES.systemDocs}
@@ -585,7 +585,7 @@ function AppNavDrawer(props) {
               ])}
             {router.asPath.startsWith('/material/') && (
               <ProductIdentifier
-                name="Material"
+                name="Material UI"
                 metadata="MUI Core"
                 versionSelector={renderVersionSelector([
                   { text: `v${materialPkgJson.version}`, current: true },

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -206,7 +206,7 @@ function ProductDrawerButton(props) {
               href={ROUTES.systemDocs}
               // eslint-disable-next-line material-ui/no-hardcoded-labels
             >
-              System <KeyboardArrowRight fontSize="small" />
+              MUI System <KeyboardArrowRight fontSize="small" />
             </Link>
           </LinksWrapper>
         </li>
@@ -231,7 +231,7 @@ function ProductDrawerButton(props) {
               href={ROUTES.dataGridDocs}
               // eslint-disable-next-line material-ui/no-hardcoded-labels
             >
-              Data Grid <KeyboardArrowRight fontSize="small" />
+              Advanced components <KeyboardArrowRight fontSize="small" />
             </Link>
           </LinksWrapper>
         </li>
@@ -598,7 +598,7 @@ function AppNavDrawer(props) {
             )}
             {router.asPath.startsWith('/system/') && FEATURE_TOGGLE.enable_system_scope && (
               <ProductIdentifier
-                name="System"
+                name="MUI System"
                 metadata="MUI Core"
                 versionSelector={renderVersionSelector([
                   { text: `v${systemPkgJson.version}`, current: true },

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -231,7 +231,7 @@ function ProductDrawerButton(props) {
               href={ROUTES.dataGridDocs}
               // eslint-disable-next-line material-ui/no-hardcoded-labels
             >
-              Advanced components <KeyboardArrowRight fontSize="small" />
+              Data Grid <KeyboardArrowRight fontSize="small" />
             </Link>
           </LinksWrapper>
         </li>


### PR DESCRIPTION
<img width="439" alt="Screenshot 2022-02-08 at 11 00 25" src="https://user-images.githubusercontent.com/3165635/152964051-fb9b9e7f-3f8c-4cb2-8f25-f4d116eb2680.png">

- Rename "Material" to "Material UI" as the official name
- Rename "Material Design" to "Material UI"  as the official name
- Rename "System" to "MUI System" to match the pricing page: The name should be self-sustained, a great test is can you search it on Google?

<img width="317" alt="Screenshot 2022-02-07 at 14 29 32" src="https://user-images.githubusercontent.com/3165635/152797102-3b9f7fe6-c75b-41e3-94e0-0d4123f752a9.png">

- ~Rename "Data Grid" to "Advanced components" as it will include the date picker very soon.~ Moved to #30972