### PR TITLE
[website] Rework the `Support Engineer - X` position title and description

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -161,12 +161,6 @@ const openRolesData = [
     title: 'Developer Experience',
     roles: [
       {
-        title: 'Support Engineer - X',
-        description:
-          "You will provide support to users for the advanced components team. You will directly impact developers' satisfaction and success.",
-        url: '/company/support-engineer/',
-      },
-      {
         title: 'Developer Experience Engineer',
         description: 'You will focus on providing experiences that delight developers using MUI.',
         url: '/company/developer-experience-engineer/',
@@ -182,6 +176,12 @@ const openRolesData = [
         description:
           'You will strengthen the advanced components team, build new ambitious complex features, work on strategic problems, and help grow the adoption.',
         url: '/company/react-engineer/',
+      },
+      {
+        title: 'React Engineer - X - Community support',
+        description:
+          "You will provide support, remove blockers and unwrap potential features from reported issues for the advanced components team. You will directly impact developers' satisfaction and success.",
+        url: '/company/support-engineer/',
       },
       {
         title: 'Hustler Engineer - Store',

--- a/docs/src/pages/company/careers/support-engineer.md
+++ b/docs/src/pages/company/careers/support-engineer.md
@@ -1,6 +1,6 @@
-# Support Engineer - X
+# React Engineer - X - Community support
 
-<p class="description">You will provide support to users for the advanced components team. You will directly impact developers' satisfaction and success.</p>
+<p class="description">You will provide support, remove blockers and unwrap potential features from reported issues for the advanced components team. You will directly impact developers' satisfaction and success.</p>
 
 ## Details of the Role
 


### PR DESCRIPTION
### The problem:
We have almost no applicants for this position. I'm worried that because it says `Support Engineer` in the job title people are not applying to it, even tho we know it is still very much about engineering but with a different focus

### The solution:
I was thinking about how to make the `Support Engineer - X` position more interesting and this is one suggestion. I wanted to highlight that it is still about engineering but with a different focus. I chose `React Engineer - X - Community support` as a potential job title but I'm open to suggestions or improvements.