### PR TITLE
[core] Remove github org identifier from CodeSandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -36,9 +36,9 @@
   },
   "sandboxes": [
     "material-ui-issue-latest-s2dsx",
-    "/examples/create-react-app",
-    "/examples/create-react-app-with-typescript",
-    "/examples/joy-cra-typescript"
+    "github/mui-org/material-ui/tree/HEAD/examples/create-react-app",
+    "github/mui-org/material-ui/tree/HEAD/examples/create-react-app-with-typescript",
+    "github/mui-org/material-ui/tree/HEAD/examples/joy-cra-typescript"
   ],
   "silent": true
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -36,9 +36,9 @@
   },
   "sandboxes": [
     "material-ui-issue-latest-s2dsx",
-    "github/mui/material-ui/tree/HEAD/examples/create-react-app",
-    "github/mui/material-ui/tree/HEAD/examples/create-react-app-with-typescript",
-    "github/mui/material-ui/tree/HEAD/examples/joy-cra-typescript"
+    "/examples/create-react-app",
+    "/examples/create-react-app-with-typescript",
+    "/examples/joy-cra-typescript"
   ],
   "silent": true
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The CodeSandbox CI disappears in some PRs. I guess it is because of the mui org name changes. From their documentation, the github org is unnecessary to reference sanboxes in our repo.

<img width="807" alt="Screen Shot 2565-02-08 at 13 35 56" src="https://user-images.githubusercontent.com/18292247/152931677-4ffb193d-0bc1-4d53-947a-736b275a55cb.png">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
