### PR TITLE
[docs] The data grid is part of MUI X

### DIFF
--- a/docs/src/components/productX/XHero.tsx
+++ b/docs/src/components/productX/XHero.tsx
@@ -61,7 +61,7 @@ export default function XHero() {
           </Typography>
           <GetStartedButtons
             installation="npm install @mui/x-data-grid"
-            to={ROUTES.dataGridDocs}
+            to={ROUTES.muiXDocs}
             sx={{ justifyContent: { xs: 'center', md: 'flex-start' } }}
           />
         </Box>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -228,10 +228,10 @@ function ProductDrawerButton(props) {
           />
           <LinksWrapper>
             <Link
-              href={ROUTES.dataGridDocs}
+              href={ROUTES.muiXDocs}
               // eslint-disable-next-line material-ui/no-hardcoded-labels
             >
-              Data Grid <KeyboardArrowRight fontSize="small" />
+              MUI X <KeyboardArrowRight fontSize="small" />
             </Link>
           </LinksWrapper>
         </li>

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -52,9 +52,9 @@ const ROUTES = {
     ? '/material/discover-more/backers/#gold'
     : '/discover-more/backers/#gold/',
   store: 'https://mui.com/store/',
-  dataGridDocs: FEATURE_TOGGLE.enable_redirects
-    ? '/x/react-data-grid/getting-started/'
-    : '/components/data-grid/getting-started/',
+  muiXDocs: FEATURE_TOGGLE.enable_redirects
+    ? '/x/react-data-grid/'
+    : '/components/data-grid/',
   dataGridFeatures: FEATURE_TOGGLE.enable_redirects
     ? '/x/react-data-grid/#features'
     : '/components/data-grid/#features',

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -52,9 +52,7 @@ const ROUTES = {
     ? '/material/discover-more/backers/#gold'
     : '/discover-more/backers/#gold/',
   store: 'https://mui.com/store/',
-  muiXDocs: FEATURE_TOGGLE.enable_redirects
-    ? '/x/react-data-grid/'
-    : '/components/data-grid/',
+  muiXDocs: FEATURE_TOGGLE.enable_redirects ? '/x/react-data-grid/' : '/components/data-grid/',
   dataGridFeatures: FEATURE_TOGGLE.enable_redirects
     ? '/x/react-data-grid/#features'
     : '/components/data-grid/#features',


### PR DESCRIPTION
<img width="381" alt="Screenshot 2022-02-08 at 11 12 53" src="https://user-images.githubusercontent.com/3165635/152966296-e2f377ec-6075-44cc-9c10-e13c88b7610c.png">

Put the emphasis on MUI X, not the data grid to scale to a dozen of components. People that look for a data grid specifically can search it or find it on the Table page.