### PR TITLE
[docs] Prefer useEnhancedEffect to avoid server side warnings

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -12,6 +12,7 @@ import NextHead from 'next/head';
 import PropTypes from 'prop-types';
 import acceptLanguage from 'accept-language';
 import { useRouter } from 'next/router';
+import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 import pages from 'docs/src/pages';
 import basePages from 'docs/data/base/pages';
 import materialPages from 'docs/data/material/pages';
@@ -43,7 +44,7 @@ function LanguageNegotiation() {
   const router = useRouter();
   const userLanguage = useUserLanguage();
 
-  React.useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     const { userLanguage: userLanguageUrl, canonicalAs } = pathnameToLanguage(router.asPath);
     const preferedLanguage =
       LANGUAGES.find((lang) => lang === getCookie('userLanguage')) ||


### PR DESCRIPTION
Fixes the warning:

```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at LanguageNegotiation (webpack-internal:///./pages/_app.js:134:103)
    at UserLanguageProvider (webpack-internal:///./src/modules/utils/i18n.js:61:5)
    at AppWrapper (webpack-internal:///./pages/_app.js:225:5)
    at MyApp (webpack-internal:///./pages/_app.js:342:5)
    at StylesProvider (webpack-internal:///../packages/mui-styles/src/StylesProvider/StylesProvider.js:64:5)
    at ae (D:\workspace\mui\node_modules\styled-components\dist\styled-components.cjs.js:1:13296)
    at InnerApp
    at StyleRegistry (D:\workspace\mui\node_modules\styled-jsx\dist\stylesheet-registry.js:231:34)
    at AppContainer (D:\workspace\mui\node_modules\next\dist\server\render.js:340:29)
    at AppContainerWithIsomorphicFiberStructure (D:\workspace\mui\node_modules\next\dist\server\render.js:370:57)
    at div
    at Body (D:\workspace\mui\node_modules\next\dist\server\render.js:638:21)
```