### PR TITLE
[system] Fix broken behavior when breakpoints input are not ordered

### DIFF
--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -2,6 +2,15 @@
 // It can't be configured as it's used statically for propTypes.
 export const breakpointKeys = ['xs', 'sm', 'md', 'lg', 'xl'];
 
+const sortBreakpointsValues = (values) => {
+  const breakpointsAsArray = Object.keys(values).map((key) => ({ key, val: values[key] })) || [];
+  // Sort in ascending order
+  breakpointsAsArray.sort((breakpoint1, breakpoint2) => breakpoint1.val - breakpoint2.val);
+  return breakpointsAsArray.reduce((acc, obj) => {
+    return { ...acc, [obj.key]: obj.val }
+  }, {});
+}
+
 // Keep in mind that @media is inclusive by the CSS specification.
 export default function createBreakpoints(breakpoints) {
   const {
@@ -19,7 +28,8 @@ export default function createBreakpoints(breakpoints) {
     ...other
   } = breakpoints;
 
-  const keys = Object.keys(values);
+  const sortedValues = sortBreakpointsValues(values);
+  const keys = Object.keys(sortedValues);
 
   function up(key) {
     const value = typeof values[key] === 'number' ? values[key] : key;
@@ -70,7 +80,7 @@ export default function createBreakpoints(breakpoints) {
 
   return {
     keys,
-    values,
+    values: sortedValues,
     up,
     down,
     between,

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -12,6 +12,29 @@ describe('createBreakpoints', () => {
     },
   });
 
+  it('should sort the values', () => {
+    const orderedValues = createBreakpoints({
+      values: {
+        mobile: 0,
+        tablet: 640,
+        laptop: 1024,
+        desktop: 1280,
+      },
+    });
+
+    const unorderedValues = createBreakpoints({
+      values: {
+        tablet: 640,
+        mobile: 0,
+        laptop: 1024,
+        desktop: 1280,
+      },
+    });
+
+    expect(unorderedValues.keys).to.deep.equal(orderedValues.keys);
+    expect(unorderedValues.values).to.deep.equal(orderedValues.values);
+  })
+
   describe('up', () => {
     it('should work for xs', () => {
       expect(breakpoints.up('xs')).to.equal('@media (min-width:0px)');


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/30982

We assume that breakpoints are ordered, but it may not be the case if custom breakpoints are used.