### PR TITLE
[Portal] Re-export 'Portal' in material

### DIFF
--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -326,7 +326,7 @@ export * from './Popover';
 export { default as Popper } from './Popper';
 export * from './Popper';
 
-export { default as Portal } from './Popper';
+export { default as Portal } from './Portal';
 export * from './Portal';
 
 export { default as Radio } from './Radio';

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -326,6 +326,9 @@ export * from './Popover';
 export { default as Popper } from './Popper';
 export * from './Popper';
 
+export { default as Portal } from './Popper';
+export * from './Portal';
+
 export { default as Radio } from './Radio';
 export * from './Radio';
 

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -255,7 +255,7 @@ export * from './Popover';
 export { default as Popper } from './Popper';
 export * from './Popper';
 
-export { default as Portal } from './Popper';
+export { default as Portal } from './Portal';
 export * from './Portal';
 
 export { default as Radio } from './Radio';

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -255,6 +255,9 @@ export * from './Popover';
 export { default as Popper } from './Popper';
 export * from './Popper';
 
+export { default as Portal } from './Popper';
+export * from './Portal';
+
 export { default as Radio } from './Radio';
 export * from './Radio';
 


### PR DESCRIPTION
Recently #30853 is pushed and applied version 5.4.x.

However, **Portal Component is missing and can't access the component.**

In #30853 PR, 
> Note: utility components, such as ClickAwayListener, NoSsr, Portal, and TextareaAutosize continue to be exported from both @mui/material and @mui/base


This PR is a re-export Portal Component and can access the Component without **'@mui/base'** package.


```diff
// package/mui-material/src/index.js
...
export * from './Popper';

+ export { default as Portal } from './Portal';
+ export * from './Portal';
+
export { default as Radio } from './Radio';
...
```

```diff
// package/mui-material/src/index.d.ts
...
export * from './Popper';

+ export { default as Portal } from './Portal';
+ export * from './Portal';
+
export { default as Radio } from './Radio';
...
```
