### PR TITLE
[docs] Fix layout shift on loading

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -19,20 +19,18 @@ const NAV_WIDTH = 280;
 
 const Main = styled('main', {
   shouldForwardProp: (prop) => prop !== 'disableToc',
-})(({ disableToc, theme }) => {
-  return {
-    display: 'flex',
-    width: '100%',
-    ...(disableToc && {
-      [theme.breakpoints.up('lg')]: {
-        marginRight: '5%',
-      },
-    }),
+})(({ disableToc, theme }) => ({
+  display: 'flex',
+  width: '100%',
+  ...(disableToc && {
     [theme.breakpoints.up('lg')]: {
-      width: `calc(100% - ${NAV_WIDTH}px)`,
+      marginRight: '5%',
     },
-  };
-});
+  }),
+  [theme.breakpoints.up('lg')]: {
+    width: `calc(100% - ${NAV_WIDTH}px)`,
+  },
+}));
 
 const StyledAppContainer = styled(AppContainer, {
   shouldForwardProp: (prop) => prop !== 'disableAd' && prop !== 'disableToc',

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -106,6 +106,7 @@ function AppLayoutDocs(props) {
           </AdGuest>
         )}
         <Main disableToc={disableToc}>
+          {disableToc ? null : <AppTableOfContents toc={toc} />}
           <StyledAppContainer disableAd={disableAd} disableToc={disableToc}>
             <ActionsDiv>{location && <EditPage markdownLocation={location} />}</ActionsDiv>
             {children}
@@ -113,7 +114,6 @@ function AppLayoutDocs(props) {
               <AppLayoutDocsFooter />
             </NoSsr>
           </StyledAppContainer>
-          {disableToc ? null : <AppTableOfContents toc={toc} />}
         </Main>
       </AdManager>
     </AppFrame>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -12,6 +12,7 @@ import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBan
 
 const Nav = styled('nav')(({ theme }) => ({
   top: 60,
+  order: 1,
   // Fix IE11 position sticky issue.
   marginTop: 60,
   width: 240,

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -10,36 +10,32 @@ import PageContext from 'docs/src/modules/components/PageContext';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBanner';
 
-const Nav = styled('nav')(({ theme }) => {
-  return {
-    top: 60,
-    // Fix IE11 position sticky issue.
-    marginTop: 60,
-    width: 240,
-    flexShrink: 0,
-    position: 'sticky',
-    height: 'calc(100vh - 70px)',
-    overflowY: 'auto',
-    padding: theme.spacing(2, 4, 2, 0),
-    display: 'none',
-    [theme.breakpoints.up('sm')]: {
-      display: 'block',
-    },
-  };
-});
+const Nav = styled('nav')(({ theme }) => ({
+  top: 60,
+  // Fix IE11 position sticky issue.
+  marginTop: 60,
+  width: 240,
+  flexShrink: 0,
+  position: 'sticky',
+  height: 'calc(100vh - 70px)',
+  overflowY: 'auto',
+  padding: theme.spacing(2, 4, 2, 0),
+  display: 'none',
+  [theme.breakpoints.up('sm')]: {
+    display: 'block',
+  },
+}));
 
-const NavLabel = styled(Typography)(({ theme }) => {
-  return {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(1),
-    paddingLeft: theme.spacing(1.4),
-    fontSize: theme.typography.pxToRem(11),
-    fontWeight: theme.typography.fontWeightBold,
-    textTransform: 'uppercase',
-    letterSpacing: '.08rem',
-    color: theme.palette.grey[600],
-  };
-});
+const NavLabel = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(1),
+  paddingLeft: theme.spacing(1.4),
+  fontSize: theme.typography.pxToRem(11),
+  fontWeight: theme.typography.fontWeightBold,
+  textTransform: 'uppercase',
+  letterSpacing: '.08rem',
+  color: theme.palette.grey[600],
+}));
 
 const NavList = styled(Typography)({
   padding: 0,


### PR DESCRIPTION
This one has been driving me crazy for months. The problem is well explained in https://jakearchibald.com/2014/dont-use-flexbox-for-page-layout/. An illustration of the problem. I press <kbd>Ctrl</kbd> + <kbd>R</kbd> to reload the page on the follow:

https://user-images.githubusercontent.com/3165635/153504226-b347195f-8bfd-499b-804d-56ad36baf428.mp4

It's a 🎄🎄🎄

The fix is the second commit. I reverse the DOM order to have the TOCs streamed first.