### PR TITLE
[docs] Update installation guide of the icons package

### DIFF
--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -36,7 +36,7 @@ yarn add @mui/icons-material
 
 These components use the MUI `SvgIcon` component to render the SVG path for each icon, and so have a peer-dependency on `@mui/material`.
 
-If you aren't already using MUI in your project, you can add it following the [installation guide](/getting-started/installation/).
+If you aren't already using Material UI in your project, you can add it following the [installation guide](/getting-started/installation/).
 
 ### Usage
 

--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -36,15 +36,7 @@ yarn add @mui/icons-material
 
 These components use the MUI `SvgIcon` component to render the SVG path for each icon, and so have a peer-dependency on `@mui/material`.
 
-If you aren't already using MUI in your project, you can add it with:
-
-```sh
-// with npm
-npm install @mui/material
-
-// with yarn
-yarn add @mui/material
-```
+If you aren't already using MUI in your project, you can add it following the [installation guide](https://mui.com/getting-started/installation/).
 
 ### Usage
 

--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -36,7 +36,7 @@ yarn add @mui/icons-material
 
 These components use the MUI `SvgIcon` component to render the SVG path for each icon, and so have a peer-dependency on `@mui/material`.
 
-If you aren't already using MUI in your project, you can add it following the [installation guide](https://mui.com/getting-started/installation/).
+If you aren't already using MUI in your project, you can add it following the [installation guide](/getting-started/installation/).
 
 ### Usage
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The documentation of the `icons` package mentions that we need to install MUI in order to use it. However, the MUI installation command is missing `@emotion/react` and `@emotion/styled`. Instead of adding them to the command, I replaced the command with the link to the MUI installation guide so that we won't have to keep the two guides in-sync.