### PR TITLE
[website] Minor security improvements

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -17,4 +17,4 @@
   # Disable it (default) as it can cause security issues.
   X-XSS-Protection: 0
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy-Report-Only: default-src * data: 'unsafe-inline' 'unsafe-eval'; report-uri https://o210809.ingest.sentry.io/api/6201480/security/?sentry_key=e4a6f58c6cd9470fa2600a8ff6cde99f
+  Content-Security-Policy: default-src * data: 'unsafe-inline' 'unsafe-eval'; report-uri https://o210809.ingest.sentry.io/api/6201480/security/?sentry_key=e4a6f58c6cd9470fa2600a8ff6cde99f

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -9,3 +9,12 @@
 
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  # Block usage in iframes.
+  X-Frame-Options: DENY
+  # Force the browser to trust the Content-Type header
+  # https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
+  X-Content-Type-Options: nosniff
+  # Disable it (default) as it can cause security issues.
+  X-XSS-Protection: 0
+  Referrer-Policy: strict-origin-when-cross-origin
+  Content-Security-Policy-Report-Only: default-src * data: 'unsafe-inline' 'unsafe-eval'; report-uri https://o210809.ingest.sentry.io/api/6201480/security/?sentry_key=e4a6f58c6cd9470fa2600a8ff6cde99f


### PR DESCRIPTION
It's not really important but it doesn't harm either to **signal** that we care about security. It's already deployed in production and seems to work:

- https://snyk.io/test/website-scanner/?test=220213_AiDcC7_7YF

<img width="257" alt="Screenshot 2022-02-13 at 15 59 03" src="https://user-images.githubusercontent.com/3165635/153759176-489433bf-d87c-43af-bf24-8ed202188100.png">

- https://securityheaders.com/?q=https%3A%2F%2Fmui.com%2F

<img width="1073" alt="Screenshot 2022-02-13 at 15 58 28" src="https://user-images.githubusercontent.com/3165635/153759155-42e62659-4120-4876-82e6-cda5c403dd29.png">

I have tested the CSP policy using https://sentry.io/organizations/mui-org/issues/?project=6201480 in report-only mode beforehand.