### PR TITLE
[test] Test if certain Base members are exported from Material UI

### DIFF
--- a/packages/mui-material/src/index.test.js
+++ b/packages/mui-material/src/index.test.js
@@ -17,4 +17,21 @@ describe('material-ui', () => {
       expect(Boolean(MaterialUI[exportKey])).to.equal(true),
     );
   });
+
+  it('should reexport certain members from @mui/base', () => {
+    const expectedReexports = [
+      'ClickAwayListener',
+      'generateUtilityClass',
+      'generateUtilityClasses',
+      'NoSsr',
+      'Portal',
+      'TextareaAutosize',
+      'unstable_ClassNameGenerator',
+      'unstable_composeClasses',
+    ];
+
+    const exportedNames = Object.keys(MaterialUI);
+
+    expectedReexports.forEach((reexport) => expect(exportedNames).to.contain(reexport));
+  });
 });


### PR DESCRIPTION
Added a test to make sure @mui/material reexports certain members of @mui/base (to prevent issues like #31003 in the future).