### PR TITLE
[WIP] Fluent button and switch light theme

### DIFF
--- a/docs/pages/experiments/joy/fluent-ui.tsx
+++ b/docs/pages/experiments/joy/fluent-ui.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CssVarsProvider, PaletteRange } from '@mui/joy/styles';
+import { CssVarsProvider } from '@mui/joy/styles';
 import { Box } from '@mui/system';
 import JoyButton, { ButtonProps } from '@mui/joy/Button';
 import Switch from '@mui/joy/Switch';
@@ -8,26 +8,30 @@ interface FluentButtonProps extends Omit<ButtonProps, 'variant' | 'color'> {
   variant?: 'primary' | 'secondary' | 'text' | 'action';
 }
 
-const FluentButton = React.forwardRef<HTMLButtonElement, FluentButtonProps>(function Button(props, ref) {
+const FluentButton = React.forwardRef<HTMLButtonElement, FluentButtonProps>(function Button(
+  props,
+  ref,
+) {
   const { variant = 'primary', ...other } = props;
 
   const variantMap = {
     primary: 'contained',
     secondary: 'outlined',
     text: 'text',
-    action: 'light'
+    action: 'light',
   };
 
-  return <JoyButton 
-    color={variant === 'primary' ? 'primary' : 'neutral'}
-    variant={variantMap[variant] as ButtonProps['variant']}
-    ref={ref}
-    {...other}
-  />
+  return (
+    <JoyButton
+      color={variant === 'primary' ? 'primary' : 'neutral'}
+      variant={variantMap[variant] as ButtonProps['variant']}
+      ref={ref}
+      {...other}
+    />
+  );
 });
 
 export default function App() {
-
   return (
     <CssVarsProvider
       theme={{
@@ -36,18 +40,18 @@ export default function App() {
             palette: {
               primary: {
                 lighterAlt: '#EFF6FC',
-                lighter: "#DEECF9",
+                lighter: '#DEECF9',
                 light: '#C7E0F4',
                 tertiary: '#2B88D8',
                 main: '#0078D4',
                 darkAlt: '#106EBE',
                 dark: '#005A9E',
                 darker: '#004578',
-                containedBg: "var(--joy-palette-primary-main)",
-                containedHoverBg: "var(--joy-palette-primary-darkAlt)",
-                containedActiveBg: "var(--joy-palette-primary-dark)",
-                containedDisabledBg: "var(--joy-palette-neutral-grey20)",
-                containedDisabledColor: "var(--joy-palette-neutral-grey90)"
+                containedBg: 'var(--joy-palette-primary-main)',
+                containedHoverBg: 'var(--joy-palette-primary-darkAlt)',
+                containedActiveBg: 'var(--joy-palette-primary-dark)',
+                containedDisabledBg: 'var(--joy-palette-neutral-grey20)',
+                containedDisabledColor: 'var(--joy-palette-neutral-grey90)',
               },
               neutral: {
                 white: '#FFF',
@@ -60,37 +64,37 @@ export default function App() {
                 grey90: '#A19F9D',
                 grey130: '#605E5C',
                 grey150: '#3B3A39',
-                grey160: "#323130",
+                grey160: '#323130',
                 grey190: '#201F1E',
                 containedBg: 'var(--joy-palette-neutral-white)',
                 containedBorder: 'var(--joy-palette-neutral-white)',
 
                 outlinedBorder: 'rgb(138, 136, 134)',
                 outlinedColor: 'var(--joy-palette-neutral-grey190)',
-                outlinedHoverBg: "var(--joy-palette-neutral-grey20)",
+                outlinedHoverBg: 'var(--joy-palette-neutral-grey20)',
                 outlinedHoverColor: 'var(--joy-palette-neutral-grey190)',
                 outlinedHoverBorder: 'rgb(138, 136, 134)',
                 outlinedActiveBg: 'rgb(237, 235, 233)',
-                outlinedDisabledBorder: "var(--joy-palette-neutral-grey20)",
-                outlinedDisabledBg: "var(--joy-palette-neutral-grey20)",
-                outlinedDisabledColor: "var(--joy-palette-neutral-grey90)",
+                outlinedDisabledBorder: 'var(--joy-palette-neutral-grey20)',
+                outlinedDisabledBg: 'var(--joy-palette-neutral-grey20)',
+                outlinedDisabledColor: 'var(--joy-palette-neutral-grey90)',
 
-                textHoverBg: "var(--joy-palette-neutral-grey20)",
-                textActiveBg: "var(--joy-palette-neutral-grey30)",
+                textHoverBg: 'var(--joy-palette-neutral-grey20)',
+                textActiveBg: 'var(--joy-palette-neutral-grey30)',
                 // TODO: The tokens available for each variable are very opinionated
                 // this again resontates that not all design system would implement
                 // the different variants the same way
                 // @ts-ignore
-                textDisabledBg: "var(--joy-palette-neutral-grey20)",
-                textDisabledColor: "var(--joy-palette-neutral-grey90)",
+                textDisabledBg: 'var(--joy-palette-neutral-grey20)',
+                textDisabledColor: 'var(--joy-palette-neutral-grey90)',
 
                 lightBg: 'transparent',
                 lightHoverBr: 'transparent',
-                lightHoverColor: "var(--joy-palette-primary-main)",
+                lightHoverColor: 'var(--joy-palette-primary-main)',
                 lightActiveColor: '#000',
-              }
-            }
-          }
+              },
+            },
+          },
         },
         radius: {
           sm: '2px',
@@ -106,53 +110,53 @@ export default function App() {
                 '&.Mui-disabled': {
                   '& .MuiSwitch-track': {
                     ...(ownerState.checked && {
-                      backgroundColor: "var(--joy-palette-neutral-grey60)",
-                    })
+                      backgroundColor: 'var(--joy-palette-neutral-grey60)',
+                    }),
                   },
                 },
                 ':hover': {
                   '& .MuiSwitch-thumb': {
                     ...(!ownerState.checked && {
-                        backgroundColor: 'black'
-                    })
+                      backgroundColor: 'black',
+                    }),
                   },
                   '& .MuiSwitch-track': {
                     ...(!ownerState.checked && {
                       ':hover': {
-                        border: '1px solid black'
-                      }
-                    })
-                  }
+                        border: '1px solid black',
+                      },
+                    }),
+                  },
                 },
                 '& .MuiSwitch-thumb': {
                   boxSizing: 'border-box',
                   ...(!ownerState.checked && {
-                    backgroundColor: "var(--joy-palette-neutral-grey130)",
-                  })
+                    backgroundColor: 'var(--joy-palette-neutral-grey130)',
+                  }),
                 },
                 '& .MuiSwitch-track': {
                   boxSizing: 'border-box',
                   ...(!ownerState.checked && {
                     border: '1px solid var(--joy-palette-neutral-grey130)',
-                  })
+                  }),
                 },
                 '&.Mui-focusVisible': {
                   outline: 'none',
-                  ":after": {
+                  ':after': {
                     content: '""',
                     position: 'absolute',
                     inset: '0px',
                     border: '1px solid transparent',
                     outline: 'rgb(96, 94, 92) solid 1px',
                     zIndex: 1,
-                  }
-                }
+                  },
+                },
               }),
             },
           },
           MuiButton: {
             styleOverrides: {
-              root: ({ ownerState, theme}) => ({
+              root: ({ ownerState, theme }) => ({
                 '--Button-gutter': '16px',
                 '--Button-minHeight': '30px',
                 // there is no CSS variables for overriding these
@@ -161,20 +165,25 @@ export default function App() {
                 lineHeight: '1rem',
                 fontSize: '14px',
                 fontWeight: 500,
-                "&.Mui-focusVisible": {
+                ...(ownerState.color === 'primary' &&
+                  ownerState.variant === 'contained' &&
+                  !ownerState.disabled && {
+                    boxShadow: 'var(--joy-shadow-md)',
+                  }),
+                '&.Mui-focusVisible': {
                   outline: 'none',
                   ...(ownerState.color !== 'primary' && {
-                    ":after": {
+                    ':after': {
                       content: '""',
                       position: 'absolute',
                       inset: '2px',
                       border: '1px solid transparent',
                       outline: 'rgb(96, 94, 92) solid 1px',
                       zIndex: 1,
-                    }
+                    },
                   }),
                   ...(ownerState.color === 'primary' && {
-                    ":after": {
+                    ':after': {
                       content: '""',
                       position: 'absolute',
                       inset: '2px',
@@ -182,19 +191,19 @@ export default function App() {
                       // primary
                       border: 'none',
                       outline: 'rgb(255, 255, 255) solid 1px',
-                    }
-                  })
-                }
-              })
-            }
-          }
-        }
+                    },
+                  }),
+                },
+              }),
+            },
+          },
+        },
       }}
     >
       <Box sx={{ '& > * + *': { ml: 3 }, display: 'flex' }}>
         <div>
           <h4>Primary buttons</h4>
-          <Box sx={{ '& > * + *': { ml: 1 }}}>
+          <Box sx={{ '& > * + *': { ml: 1 } }}>
             <FluentButton>Text</FluentButton>
             <FluentButton disabled>Text</FluentButton>
           </Box>
@@ -202,40 +211,44 @@ export default function App() {
 
         <div>
           <h4>Secondary buttons</h4>
-          <Box sx={{ '& > * + *': { ml: 1 }}}>
+          <Box sx={{ '& > * + *': { ml: 1 } }}>
             <FluentButton variant="secondary">Text</FluentButton>
-            <FluentButton variant="secondary" disabled>Text</FluentButton>
+            <FluentButton variant="secondary" disabled>
+              Text
+            </FluentButton>
           </Box>
         </div>
 
         <div>
           <h4>Text buttons</h4>
-          <Box sx={{ '& > * + *': { ml: 1 }}}>
+          <Box sx={{ '& > * + *': { ml: 1 } }}>
             <FluentButton variant="text">Text</FluentButton>
-            <FluentButton variant="text" disabled>Text</FluentButton>
+            <FluentButton variant="text" disabled>
+              Text
+            </FluentButton>
           </Box>
         </div>
-
 
         <div>
           <h4>Action buttons</h4>
-          <Box sx={{ '& > * + *': { ml: 1 }}}>
+          <Box sx={{ '& > * + *': { ml: 1 } }}>
             <FluentButton variant="action">Text</FluentButton>
-            <FluentButton variant="action" disabled>Text</FluentButton>
+            <FluentButton variant="action" disabled>
+              Text
+            </FluentButton>
           </Box>
         </div>
 
-        
         <div>
           <h4>Switch</h4>
-          <Box sx={{ '& > * + *': { ml: 1 }}}>
+          <Box sx={{ '& > * + *': { ml: 1 } }}>
             <Switch defaultChecked />
             <Switch defaultChecked={false} />
             <Switch defaultChecked disabled />
-            <Switch defaultChecked={false} disabled/>
+            <Switch defaultChecked={false} disabled />
           </Box>
         </div>
       </Box>
     </CssVarsProvider>
-  )
+  );
 }

--- a/docs/pages/experiments/joy/fluent-ui.tsx
+++ b/docs/pages/experiments/joy/fluent-ui.tsx
@@ -1,0 +1,241 @@
+import * as React from 'react';
+import { CssVarsProvider, PaletteRange } from '@mui/joy/styles';
+import { Box } from '@mui/system';
+import JoyButton, { ButtonProps } from '@mui/joy/Button';
+import Switch from '@mui/joy/Switch';
+
+interface FluentButtonProps extends Omit<ButtonProps, 'variant' | 'color'> {
+  variant?: 'primary' | 'secondary' | 'text' | 'action';
+}
+
+const FluentButton = React.forwardRef<HTMLButtonElement, FluentButtonProps>(function Button(props, ref) {
+  const { variant = 'primary', ...other } = props;
+
+  const variantMap = {
+    primary: 'contained',
+    secondary: 'outlined',
+    text: 'text',
+    action: 'light'
+  };
+
+  return <JoyButton 
+    color={variant === 'primary' ? 'primary' : 'neutral'}
+    variant={variantMap[variant] as ButtonProps['variant']}
+    ref={ref}
+    {...other}
+  />
+});
+
+export default function App() {
+
+  return (
+    <CssVarsProvider
+      theme={{
+        colorSchemes: {
+          light: {
+            palette: {
+              primary: {
+                lighterAlt: '#EFF6FC',
+                lighter: "#DEECF9",
+                light: '#C7E0F4',
+                tertiary: '#2B88D8',
+                main: '#0078D4',
+                darkAlt: '#106EBE',
+                dark: '#005A9E',
+                darker: '#004578',
+                containedBg: "var(--joy-palette-primary-main)",
+                containedHoverBg: "var(--joy-palette-primary-darkAlt)",
+                containedActiveBg: "var(--joy-palette-primary-dark)",
+                containedDisabledBg: "var(--joy-palette-neutral-grey20)",
+                containedDisabledColor: "var(--joy-palette-neutral-grey90)"
+              },
+              neutral: {
+                white: '#FFF',
+                grey10: '#FAF9F8',
+                grey20: '#F3F2F1',
+                grey30: '#EDEBE9',
+                grey40: '#E1DFDD',
+                grey50: '#D2D0CE',
+                grey60: '#C8C6C4',
+                grey90: '#A19F9D',
+                grey130: '#605E5C',
+                grey150: '#3B3A39',
+                grey160: "#323130",
+                grey190: '#201F1E',
+                containedBg: 'var(--joy-palette-neutral-white)',
+                containedBorder: 'var(--joy-palette-neutral-white)',
+
+                outlinedBorder: 'rgb(138, 136, 134)',
+                outlinedColor: 'var(--joy-palette-neutral-grey190)',
+                outlinedHoverBg: "var(--joy-palette-neutral-grey20)",
+                outlinedHoverColor: 'var(--joy-palette-neutral-grey190)',
+                outlinedHoverBorder: 'rgb(138, 136, 134)',
+                outlinedActiveBg: 'rgb(237, 235, 233)',
+                outlinedDisabledBorder: "var(--joy-palette-neutral-grey20)",
+                outlinedDisabledBg: "var(--joy-palette-neutral-grey20)",
+                outlinedDisabledColor: "var(--joy-palette-neutral-grey90)",
+
+                textHoverBg: "var(--joy-palette-neutral-grey20)",
+                textActiveBg: "var(--joy-palette-neutral-grey30)",
+                // TODO: The tokens available for each variable are very opinionated
+                // this again resontates that not all design system would implement
+                // the different variants the same way
+                // @ts-ignore
+                textDisabledBg: "var(--joy-palette-neutral-grey20)",
+                textDisabledColor: "var(--joy-palette-neutral-grey90)",
+
+                lightBg: 'transparent',
+                lightHoverBr: 'transparent',
+                lightHoverColor: "var(--joy-palette-primary-main)",
+                lightActiveColor: '#000',
+              }
+            }
+          }
+        },
+        radius: {
+          sm: '2px',
+        },
+        components: {
+          MuiSwitch: {
+            styleOverrides: {
+              root: ({ ownerState, theme }) => ({
+                '--Switch-track-width': '40px',
+                '--Switch-track-height': '20px',
+                '--Switch-thumb-size': '12px',
+                boxSizing: 'border-box',
+                '&.Mui-disabled': {
+                  '& .MuiSwitch-track': {
+                    ...(ownerState.checked && {
+                      backgroundColor: "var(--joy-palette-neutral-grey60)",
+                    })
+                  },
+                },
+                ':hover': {
+                  '& .MuiSwitch-thumb': {
+                    ...(!ownerState.checked && {
+                        backgroundColor: 'black'
+                    })
+                  },
+                  '& .MuiSwitch-track': {
+                    ...(!ownerState.checked && {
+                      ':hover': {
+                        border: '1px solid black'
+                      }
+                    })
+                  }
+                },
+                '& .MuiSwitch-thumb': {
+                  boxSizing: 'border-box',
+                  ...(!ownerState.checked && {
+                    backgroundColor: "var(--joy-palette-neutral-grey130)",
+                  })
+                },
+                '& .MuiSwitch-track': {
+                  boxSizing: 'border-box',
+                  ...(!ownerState.checked && {
+                    border: '1px solid var(--joy-palette-neutral-grey130)',
+                  })
+                },
+                '&.Mui-focusVisible': {
+                  outline: 'none',
+                  ":after": {
+                    content: '""',
+                    position: 'absolute',
+                    inset: '0px',
+                    border: '1px solid transparent',
+                    outline: 'rgb(96, 94, 92) solid 1px',
+                    zIndex: 1,
+                  }
+                }
+              }),
+            },
+          },
+          MuiButton: {
+            styleOverrides: {
+              root: ({ ownerState, theme}) => ({
+                '--Button-gutter': '16px',
+                '--Button-minHeight': '30px',
+                // there is no CSS variables for overriding these
+                paddingTop: 0,
+                paddingBottom: 0,
+                lineHeight: '1rem',
+                fontSize: '14px',
+                fontWeight: 500,
+                "&.Mui-focusVisible": {
+                  outline: 'none',
+                  ...(ownerState.color !== 'primary' && {
+                    ":after": {
+                      content: '""',
+                      position: 'absolute',
+                      inset: '2px',
+                      border: '1px solid transparent',
+                      outline: 'rgb(96, 94, 92) solid 1px',
+                      zIndex: 1,
+                    }
+                  }),
+                  ...(ownerState.color === 'primary' && {
+                    ":after": {
+                      content: '""',
+                      position: 'absolute',
+                      inset: '2px',
+                      zIndex: 1,
+                      // primary
+                      border: 'none',
+                      outline: 'rgb(255, 255, 255) solid 1px',
+                    }
+                  })
+                }
+              })
+            }
+          }
+        }
+      }}
+    >
+      <Box sx={{ '& > * + *': { ml: 3 }, display: 'flex' }}>
+        <div>
+          <h4>Primary buttons</h4>
+          <Box sx={{ '& > * + *': { ml: 1 }}}>
+            <FluentButton>Text</FluentButton>
+            <FluentButton disabled>Text</FluentButton>
+          </Box>
+        </div>
+
+        <div>
+          <h4>Secondary buttons</h4>
+          <Box sx={{ '& > * + *': { ml: 1 }}}>
+            <FluentButton variant="secondary">Text</FluentButton>
+            <FluentButton variant="secondary" disabled>Text</FluentButton>
+          </Box>
+        </div>
+
+        <div>
+          <h4>Text buttons</h4>
+          <Box sx={{ '& > * + *': { ml: 1 }}}>
+            <FluentButton variant="text">Text</FluentButton>
+            <FluentButton variant="text" disabled>Text</FluentButton>
+          </Box>
+        </div>
+
+
+        <div>
+          <h4>Action buttons</h4>
+          <Box sx={{ '& > * + *': { ml: 1 }}}>
+            <FluentButton variant="action">Text</FluentButton>
+            <FluentButton variant="action" disabled>Text</FluentButton>
+          </Box>
+        </div>
+
+        
+        <div>
+          <h4>Switch</h4>
+          <Box sx={{ '& > * + *': { ml: 1 }}}>
+            <Switch defaultChecked />
+            <Switch defaultChecked={false} />
+            <Switch defaultChecked disabled />
+            <Switch defaultChecked={false} disabled/>
+          </Box>
+        </div>
+      </Box>
+    </CssVarsProvider>
+  )
+}

--- a/packages/mui-joy/src/Switch/Switch.tsx
+++ b/packages/mui-joy/src/Switch/Switch.tsx
@@ -119,6 +119,7 @@ const SwitchThumb = styled('span', {
   width: 'var(--Switch-thumb-width)',
   height: 'var(--Switch-thumb-size)',
   borderRadius: 'var(--Switch-thumb-radius)',
+  // This should be variable, we need for both checked and unchecked
   backgroundColor: '#fff',
   [`&.${switchClasses.checked}`]: {
     left: 'calc(50% + var(--Switch-track-width) / 2 - var(--Switch-thumb-width) / 2 - var(--Switch-thumb-offset))',


### PR DESCRIPTION
This PR experiments with implementing Fluent version of the `Button` and `Switch` components, based on the Joy design system.

Figma - https://www.figma.com/file/wPdi7ZY1w375vurlw3N0gY/Microsoft-Fluent-Web-(Community)?node-id=3194%3A10322
Preview - https://deploy-preview-31090--material-ui.netlify.app/experiments/joy/fluent-ui/

# Feedback

## Color schemas

### Palette

Some design systems have global palette, and each color schemes picks color from it for each variant/state (this is how it is defined in Fluent Design for example). We discussed with Jun, that maybe we could add a global key in the color schemes, that will allow us to have the palette be defined only once. With this it would improve the DX and bundle size, but let's wait to see if this is the case in more design systems. It may be a Fluent specific thing, not worth adding in this first iteration.

### Variants

The overall confusion I had with the variants was that I thought they are similar to the variants for the components where you can define basically any styles associated with the component when a certain variant is applied. In contrast, in Joy, they are related only to colors, namely defining how colors would be applied for each combination of color + variant + state. I am not sure that this would scale, but we should at least document this well, or even find a better name for it, so that it doesn't conflict with the idea around variants we have from MD.

Regarding naming, I am not sure that these are the best names we could have. Keeping in mind that they are related only to colors, I would say that maybe the `text` and `outlined` makes sense, maybe I would rename the `contained` to `fill`. Regarding the `light` I am not sure this is the best name, because in dark mode, the `light` variant is basically dark not light.

One problem I see with the tokens is that, some of the token are not avilable for some variants, for example `textDisabledBg`, doesn't exists in the typings, however it works as expected. I think we should have all tokens on all variants, as different design systems may implement them differently.

I think we will need to update the tokens regarding the borders. It is not enough to have one token for the border, as in some design systems for some components only some of the borders may be used, for example:

<img src="https://user-images.githubusercontent.com/4512430/154067531-17a7d786-f680-4da9-af78-cdc50f50542a.png" width="242px" />

Regarding the states, I think we will need to add the `focus` state, as some design systems do not have a one way for applying focus, again we can use the MD Standard input

<img src="https://user-images.githubusercontent.com/4512430/154067805-246284bd-f3ac-499a-8042-f31bf029b4b1.png" width ="242px" />

## Components

In general, I really liked that I can use the CSS variables override to customize the look and feel of the component. I was actually bumped when I couldn't use them and needed to add some style overrides. In my opinion we should expose as many design tokens as possible, even tough in Joy some components don't use all of them (the Switch was one example of this, there weren't really CSS variables for most of the styles).

At first I thought that we need to add variables for different sizes for the CSS proeprties like height, weight etc (something like `--Button-minHeight-sm`, `--Button-minHeight-md`, `--Button-minHeight-lg`), but after some thought I changed my mind, as this would just complicate things, it would be much easier for develoepers to swap the variables based on the `ownerState.size`.

----

I also left some comments in the code for things that were not intuitive/didn't work.