### PR TITLE
[DateTimePicker] Fix onChange(null) of DesktopDateTimePicker on click away

### DIFF
--- a/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePicker.tsx
@@ -129,7 +129,7 @@ const DateRangePicker = React.forwardRef(function DateRangePicker<TDate>(
   const { pickerProps, inputProps, wrapperProps } = usePickerState<
     RangeInput<TDate>,
     DateRange<TDate>
-  >(pickerStateProps, rangePickerValueManager);
+  >(pickerStateProps, rangePickerValueManager, false);
 
   const validationError = useDateRangeValidation(props);
 

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.test.tsx
@@ -452,4 +452,41 @@ describe('<DesktopDatePicker />', () => {
       expect(window.scrollY, 'focus caused scroll').to.equal(scrollYBeforeOpen);
     });
   });
+
+  it('does not reset the input value when clicking outside after changing the date value', () => {
+    const initialDateValue = adapterToUse.date('2022-01-01T00:00:00.000');
+
+    function DemoDesktopDatePicker() {
+      const [value, setValue] = React.useState<Date | null>(initialDateValue);
+      const [open, setOpen] = React.useState<boolean | undefined>(true);
+      const handleChange = (newValue: Date | null) => {
+        setValue(newValue);
+      };
+      return (
+        <DesktopDatePicker
+          onChange={handleChange}
+          value={value}
+          renderInput={(params) => <TextField {...params} />}
+          TransitionComponent={FakeTransitionComponent}
+          open={open}
+          onClose={() => {
+            setOpen(false);
+          }}
+          onOpen={() => {
+            setOpen(true);
+          }}
+        />
+      );
+    }
+
+    render(<DemoDesktopDatePicker />);
+
+    fireEvent.click(screen.getByLabelText(/Choose date/));
+    expect(screen.getByRole('textbox')).to.have.value('01/01/2022');
+
+    fireEvent.click(screen.getByLabelText('Jan 30, 2022'));
+
+    fireEvent.click(document.body);
+    expect(screen.getByRole('textbox')).to.have.value('01/30/2022');
+  });
 });

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -45,7 +45,7 @@ const DesktopDatePicker = React.forwardRef(function DesktopDatePicker<TDate>(
   );
 
   const validationError = useDateValidation(props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, false);
 
   const {
     onChange,

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.tsx
@@ -137,7 +137,7 @@ const DesktopDateRangePicker = React.forwardRef(function DesktopDateRangePicker<
   const { pickerProps, inputProps, wrapperProps } = usePickerState<
     RangeInput<TDate>,
     DateRange<TDate>
-  >(pickerStateProps, rangePickerValueManager);
+  >(pickerStateProps, rangePickerValueManager, false);
 
   const validationError = useDateRangeValidation(props);
 

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -48,7 +48,7 @@ const DesktopDateTimePicker = React.forwardRef(function DesktopDateTimePicker<TD
   );
 
   const validationError = useDateTimeValidation(props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, false);
 
   const {
     onChange,

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -45,7 +45,7 @@ const DesktopTimePicker = React.forwardRef(function DesktopTimePicker<TDate>(
   );
 
   const validationError = useTimeValidation(props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, false);
 
   const {
     onChange,

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -45,7 +45,7 @@ const MobileDatePicker = React.forwardRef(function MobileDatePicker<TDate>(
   );
 
   const validationError = useDateValidation(props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, true);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
+++ b/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.tsx
@@ -134,7 +134,7 @@ const MobileDateRangePicker = React.forwardRef(function MobileDateRangePicker<TD
   const { pickerProps, inputProps, wrapperProps } = usePickerState<
     RangeInput<TDate>,
     DateRange<TDate>
-  >(pickerStateProps, rangePickerValueManager);
+  >(pickerStateProps, rangePickerValueManager, true);
 
   const validationError = useDateRangeValidation(props);
 

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -50,7 +50,6 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
   const validationError = useDateTimeValidation(props) !== null;
   const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, true);
 
-
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.
   const { ToolbarComponent = DateTimePickerToolbar, value, onChange, ...other } = props;

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -48,7 +48,8 @@ const MobileDateTimePicker = React.forwardRef(function MobileDateTimePicker<TDat
   );
 
   const validationError = useDateTimeValidation(props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, true);
+
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -45,7 +45,7 @@ const MobileTimePicker = React.forwardRef(function MobileTimePicker<TDate>(
   );
 
   const validationError = useTimeValidation(props) !== null;
-  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps, wrapperProps } = usePickerState(props, valueManager, true);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -50,7 +50,7 @@ const StaticDatePicker = React.forwardRef(function StaticDatePicker<TDate>(
   );
 
   const validationError = useDateValidation(props) !== null;
-  const { pickerProps, inputProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps } = usePickerState(props, valueManager, false);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
+++ b/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.tsx
@@ -135,7 +135,7 @@ const StaticDateRangePicker = React.forwardRef(function StaticDateRangePicker<TD
   const { pickerProps, inputProps, wrapperProps } = usePickerState<
     RangeInput<TDate>,
     DateRange<TDate>
-  >(pickerStateProps, rangePickerValueManager);
+  >(pickerStateProps, rangePickerValueManager, false);
 
   const validationError = useDateRangeValidation(props);
 

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -53,7 +53,7 @@ const StaticDateTimePicker = React.forwardRef(function StaticDateTimePicker<TDat
   );
 
   const validationError = useDateTimeValidation(props) !== null;
-  const { pickerProps, inputProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps } = usePickerState(props, valueManager, false);
 
   // Note that we are passing down all the value without spread.
   // It saves us >1kb gzip and make any prop available automatically on any level down.

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -50,7 +50,7 @@ const StaticTimePicker = React.forwardRef(function StaticTimePicker<TDate>(
   );
 
   const validationError = useTimeValidation(props) !== null;
-  const { pickerProps, inputProps } = usePickerState(props, valueManager);
+  const { pickerProps, inputProps } = usePickerState(props, valueManager, false);
 
   const {
     displayStaticWrapperAs = 'mobile',

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -38,6 +38,7 @@ export interface PickerStateProps<TInput, TDateValue> {
 export function usePickerState<TInput, TDateValue>(
   props: PickerStateProps<TInput, TDateValue>,
   valueManager: PickerStateValueManager<TInput, TDateValue>,
+  resetDateOnDismiss: boolean,
 ) {
   const { disableCloseOnSelect, onAccept, onChange, value } = props;
 
@@ -96,7 +97,7 @@ export function usePickerState<TInput, TDateValue>(
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
       onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(initialDate, true),
+      onDismiss: () => (resetDateOnDismiss ? acceptDate(initialDate, true) : setIsOpen(false)),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });
@@ -104,13 +105,15 @@ export function usePickerState<TInput, TDateValue>(
       },
     }),
     [
-      acceptDate,
-      disableCloseOnSelect,
       isOpen,
-      utils,
-      draftState.draft,
+      acceptDate,
       valueManager.emptyValue,
+      draftState.draft,
+      resetDateOnDismiss,
       initialDate,
+      setIsOpen,
+      utils,
+      disableCloseOnSelect,
     ],
   );
 


### PR DESCRIPTION
Related issue https://github.com/mui/material-ui/issues/31023 and the cause might from this [PR](https://github.com/mui/material-ui/pull/30768)



**Before**

https://user-images.githubusercontent.com/16300114/154071545-b9e9ff26-70cb-4b76-9746-0257868047ea.mp4

**After**

https://user-images.githubusercontent.com/16300114/154072404-c32899a7-3054-4ef9-9e5f-521b395a8292.mp4




I am not sure that is it good approach to add more arguments to `usePickerState` but feel free to comment 🙏🏼



<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
