### PR TITLE
[website] Revise the row grouping blog post

### DIFF
--- a/docs/pages/blog/introducing-the-row-grouping-feature.md
+++ b/docs/pages/blog/introducing-the-row-grouping-feature.md
@@ -1,6 +1,6 @@
 ---
-title: 'Customize your data grid with row grouping'
-description: Give your users the freedom to reorganize their data using our data grid's new row grouping feature.
+title: Give your users more freedom with data grid row grouping
+description: The new row grouping feature gives your users more customization options for organizing their data.
 date: 2022-01-20T00:00:00.000Z
 authors: ['alexfauquette']
 tags: ['MUI X', 'News']

--- a/docs/pages/blog/introducing-the-row-grouping-feature.md
+++ b/docs/pages/blog/introducing-the-row-grouping-feature.md
@@ -1,48 +1,50 @@
 ---
-title: 'Introducing the Row Grouping feature'
-description: After more than a year of development on the DataGrid, the first premium feature is live.
+title: 'Customize your data grid with row grouping'
+description: Give your users the freedom to reorganize their data using our data grid's new row grouping feature.
 date: 2022-01-20T00:00:00.000Z
 authors: ['alexfauquette']
 tags: ['MUI X', 'News']
 ---
 
-A lot of you were asking about it, and we are pleased to announce that the Premium plan is on the road.
-After an incredible year fully focused on improving the DataGrid, we are moving forward by launching the first feature of the Premium plan: the [row grouping](/components/data-grid/group-pivot/#row-grouping) which is released in [v5.3.0](https://github.com/mui/mui-x/releases/tag/v5.3.0).
+After an incredible year fully focused on improving our data grid component, we are moving forward by launching the first feature of our new Premium plan: [row grouping](/components/data-grid/group-pivot/#row-grouping), released in [v5.3.0](https://github.com/mui/mui-x/releases/tag/v5.3.0).
 
-Let me introduce this new feature.
+Let's take a closer look at this feature.
 
-## Start navigating the data 🚢
+## Navigate your data 🚢
 
-If you already use the pro plan, you may be familiar with the [tree data](/components/data-grid/group-pivot/#tree-data) which allows your users to navigate in the hierarchy by opening/closing children of a row.
-However, everything does not have a natural hierarchy, and users might like to modify it.
-Good news!
-It is now possible with row grouping.
+If you already use the Pro plan, you may be familiar with the [tree data](/components/data-grid/group-pivot/#tree-data) which allows your users to navigate in the hierarchy by opening and closing children of a row.
 
-Let's play with the top 250 movies according to IMDb.
-There is not a clear hierarchy to organize movies.
-Should you group them by director, box office results, or year of release?
-The answer depends on what the user wants to do.
-So let them be free to choose their own organization.
-With the row grouping, they can go to the column menu of the “director” column and click on “Group by director” to group all the rows with the same director.
-If they are not interested anymore in the director, they can simply click on “Stop grouping by director”.
+But not all data has a natural hierarchy, and your users might need to modify the order.
+
+Good news! This is now possible with row grouping.
+
+### Row grouping in action
+
+Consider this sample data of the top 250 movies according to IMDb. Would you group them by director, box office results, or year of release?
+
+The answer depends on what the user wants to do. So give them the freedom to choose!
+
+With the new row grouping feature, you can click on the **Director** column menu and select **Group by Director** to group all the rows with the same director.
+
+When you're ready to return to the default view, click on **Stop Grouping by Director** in the same column menu.
 
 <img src="/static/blog/introducing-the-row-grouping-feature/blog1.gif" alt="grouping and un-grouping by director" style="width: 100%; margin-bottom: 16px;" />
 
-## Unlock the feature 🔓🎁
+## How to unlock this feature 🔓🎁
 
-This feature will be part of the Premium plan when we will launch it. For now, you can access it on the Pro plan by enabling an experimental feature.
-The row grouping is stable in its current form.
-The experimental flag is here to make sure that the Pro plan will not have any regression when the feature will be moved to the Premium plan.
+The row grouping feature will be part of the Premium plan when it is launched. For now, you can access it on the Pro plan by enabling experimental features.
 
 ```js
 <DataGridPro experimentalFeatures={{ rowGrouping: true }} {...otherProps} />
 ```
 
-Congratulation! Your users are now able to use the row grouping 🎉.
+Note: Row grouping is stable in its current form. The _experimental_ flag is here to make sure that the Pro plan will not have any regression when the feature is eventually moved to the Premium plan.
 
-## Provide nice default grouping
+## How to set the default grouping ⚡️
 
-Save your user time by defining initial grouping. To do so, specify the row grouping model in the `initialState` prop. For a page about director's results, we could group by director, and box office as follows.
+Save your users time by defining the initial grouping. To do so, specify the row grouping model in the `initialState` prop.
+
+For a page with information about directors, we could group by director and box office as follows:
 
 ```js
 <DataGridPro
@@ -56,27 +58,39 @@ Save your user time by defining initial grouping. To do so, specify the row grou
 />
 ```
 
-Users are still free to modify this grouping configuration by going into the column menu.
-But in a few clicks, you can see that Hitchcock's box office results vary a lot.
+You can still modify this grouping configuration in the column menus.
+
+But as you can see in the example below, setting the default grouping allows us to hone in on the data we find most interesting, such as the box office results of Hitchcock's films:
 
 <img src="/static/blog/introducing-the-row-grouping-feature/defaultSettings.png" alt="remove groupable option" style="width: 100%; margin-bottom: 16px;" />
 
 ## Cherry-pick the groupable columns 🍒
 
 Before letting your users enjoy this new feature, let's adapt it to your use case.
-All the columns are not good candidates for grouping.
-In our movies example, grouping by title does not make sense since each movie has a different name.
-You can remove the ability to group this specific column by setting the property `groupable` to `false` in the column definition.
+
+Not all columns will be ideal candidates. Row grouping is most useful when information is repeated in a given column, such as the names of movie directors.
+
+In our example of the top 250 movies, grouping by title does not make sense—each movie has a different name, so there will be no row groups.
+
+You can remove the ability to group a specific column by setting the property `groupable` to `false` in the column definition.
+
+This removes the **Group by** option in the corresponding column menu.
 
 <img src="/static/blog/introducing-the-row-grouping-feature/groupable1.png" alt="remove groupable option" style="width: 100%; margin-bottom: 16px;" />
 
-## Customize the grouping behavior 🔧
+## Customize grouping behavior 🔧
 
-Some columns are interesting, but not that easy to group by.
-For example, the release date of a movie is interesting, but grouping by the exact date leads to one group per movie (except for “The Thing” and “Blade Runner” both released on June 25, 1982).
+Some columns are interesting, but don't lend themselves well to grouping.
+
+For example, the release date of a movie is interesting information, but grouping by the exact date leads to one group per movie (except for _The Thing_ and _Blade Runner_, which as we all know were both released on June 25th, 1982 😅).
+
 It is more interesting to group them by decade.
+
 For this purpose, the column definitions accept the property [`groupingValueGetter`](/components/data-grid/group-pivot/#using-groupingvaluegetter-for-complex-grouping-value).
-Its signature is similar to `valueGetter` and it returns the grouping value associated to the column. To group movies by decade, you can use for example
+
+Its signature is similar to `valueGetter` and it returns the grouping value associated with the column.
+
+To group our movies by decade, we could use the following:
 
 ```js
 groupingValueGetter: ({ value }) => `${Math.floor(value.getFullYear() / 10)}0's`;
@@ -84,9 +98,10 @@ groupingValueGetter: ({ value }) => `${Math.floor(value.getFullYear() / 10)}0's`
 
 <img src="/static/blog/introducing-the-row-grouping-feature/blog2.gif" alt="grouping by release decade" style="width: 100%; margin-bottom: 16px;" />
 
-## Thank you
+## Share your feedback 🗣
 
-More details about customization can be found in the [documentation](/components/data-grid/group-pivot/#disable-the-row-grouping)
+We hope you find this new feature useful. Please don't hesitate to open [issues](https://github.com/mui/mui-x/issues/new/choose) to share feedback, report bugs, or propose enhancements.
 
-Thanks for reading. To get more information about the v5.3.0 release, visit the [changelog](https://github.com/mui/mui-x/releases/tag/v5.3.0).
-We hope you will enjoy this new feature. Do not hesitate to open [issues](https://github.com/mui/mui-x/issues/new/choose) to share feedback, report bugs, or propose enhancements.
+More details about row grouping customization can be found in the [documentation](/components/data-grid/group-pivot/#disable-the-row-grouping).
+
+For more information about our v5.3.0 release, visit the [changelog](https://github.com/mui/mui-x/releases/tag/v5.3.0).


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR suggests various revisions for the row grouping announcement blog post.

- adds value proposition to headline and subheader
- removes unnecessary intro text
- adds more line breaks for readability and skim-ability
- fixes minor grammar and punctuation mistakes throughout
- simplifies and clarifies language and phrasing throughout to better match the norms of US English
- defines "share your feedback" as the primary call to action in the conclusion

@alexfauquette I hope this is helpful! Please let me know if you'd like any more detailed feedback. The main things I would point out would be adding the value proposition in the headline, getting straight to the point in the intro, and defining a clear call to action in the conclusion. These tweaks can make a big difference! 😁

https://deploy-preview-31101--material-ui.netlify.app/blog/introducing-the-row-grouping-feature/