### PR TITLE
add export Portal in @mui/material index.d.ts

### DIFF
--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -464,6 +464,9 @@ export * from './useMediaQuery';
 export { default as useScrollTrigger } from './useScrollTrigger';
 export * from './useScrollTrigger';
 
+export { default as Portal} from "./Portal";
+export * from './Portal'
+
 export { default as Zoom } from './Zoom';
 export * from './Zoom';
 


### PR DESCRIPTION
## background

when I use @mui/material library, find Portal doesn't export in index.d.ts

so I propose adding some code in @mui/material types file.

## work desc

add Portal export code in @mui/material index.d.ts for convenience when import the module

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
