### PR TITLE
[l10n] Add it-IT translation for labelDisplayedRows

### DIFF
--- a/packages/mui-material/src/locale/index.ts
+++ b/packages/mui-material/src/locale/index.ts
@@ -1699,8 +1699,8 @@ export const itIT: Localization = {
           return 'Vai alla pagina precedente';
         },
         labelRowsPerPage: 'Righe per pagina:',
-        // labelDisplayedRows: ({ from, to, count }) =>
-        //   `${from}–${to} di ${count !== -1 ? count : `more than ${to}`}`,
+        labelDisplayedRows: ({ from, to, count }) =>
+          `${from}–${to} di ${count !== -1 ? count : `più di ${to}`}`,
       },
     },
     MuiRating: {

--- a/packages/mui-material/src/locale/index.ts
+++ b/packages/mui-material/src/locale/index.ts
@@ -1,4 +1,3 @@
-import { LabelDisplayedRowsArgs } from '..';
 import { ComponentsPropsList } from '../styles/props';
 
 export interface Localization {
@@ -1700,7 +1699,7 @@ export const itIT: Localization = {
           return 'Vai alla pagina precedente';
         },
         labelRowsPerPage: 'Righe per pagina:',
-        labelDisplayedRows: ({ from, to, count }: LabelDisplayedRowsArgs) =>
+        labelDisplayedRows: ({ from, to, count }) =>
           `${from}–${to} di ${count !== -1 ? count : `più di ${to}`}`,
       },
     },

--- a/packages/mui-material/src/locale/index.ts
+++ b/packages/mui-material/src/locale/index.ts
@@ -1,3 +1,4 @@
+import { LabelDisplayedRowsArgs } from '..';
 import { ComponentsPropsList } from '../styles/props';
 
 export interface Localization {
@@ -1699,7 +1700,7 @@ export const itIT: Localization = {
           return 'Vai alla pagina precedente';
         },
         labelRowsPerPage: 'Righe per pagina:',
-        labelDisplayedRows: ({ from, to, count }) =>
+        labelDisplayedRows: ({ from, to, count }: LabelDisplayedRowsArgs) =>
           `${from}–${to} di ${count !== -1 ? count : `più di ${to}`}`,
       },
     },


### PR DESCRIPTION
The translation for `labelDisplayedRows` was missing so when using a component that required it (e.g, the the `DataGrid` component from the `mui-x` library), the default one (english) was used.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
