### PR TITLE
[Joy] `List` second iteration

### DIFF
--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -221,12 +221,21 @@ const components = [
             <ListItemContent>Inbox</ListItemContent>
             <KeyboardArrowUp />
           </ListItemButton>
-          <ListItemButton>
-            <ListItemDecorator>
-              <Star />
-            </ListItemDecorator>
-            <ListItemContent>Starred</ListItemContent>
-          </ListItemButton>
+          <ListItem
+            component="div"
+            secondaryAction={
+              <IconButton variant="text" color="danger">
+                <DeleteForever />
+              </IconButton>
+            }
+          >
+            <ListItemButton>
+              <ListItemDecorator>
+                <Star />
+              </ListItemDecorator>
+              <ListItemContent>Starred</ListItemContent>
+            </ListItemButton>
+          </ListItem>
           <ListDivider component="hr" />
           <ListItemButton>
             <ListItemDecorator>

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -173,7 +173,7 @@ export default function JoyTypography() {
           </List>
 
           {/* ex5 */}
-          <List>
+          <List sx={{ '--List-decorator-width': '3rem' }}>
             <ListItem>
               <ListItemDecorator>
                 <Circle>
@@ -444,6 +444,55 @@ export default function JoyTypography() {
               </li>
             ))}
           </List>
+
+          <Box>
+            <List size="sm">
+              <ListItem>
+                <Typography level="body2">Small size</Typography>
+              </ListItem>
+              <ListItem>
+                <ListItemDecorator>
+                  <Star fontSize="lg" />
+                </ListItemDecorator>
+                <ListItemButton>This is a small list</ListItemButton>
+              </ListItem>
+              <ListItem>
+                <ListItemDecorator>
+                  <Star fontSize="lg" />
+                </ListItemDecorator>
+                <ListItemButton>This is a small list</ListItemButton>
+              </ListItem>
+              <ListItem>
+                <ListItemDecorator>
+                  <Star fontSize="lg" />
+                </ListItemDecorator>
+                <ListItemButton>This is a small list</ListItemButton>
+              </ListItem>
+            </List>
+            <List size="lg">
+              <ListItem>
+                <Typography color="text.secondary">Large size</Typography>
+              </ListItem>
+              <ListItem>
+                <ListItemDecorator>
+                  <Star />
+                </ListItemDecorator>
+                <ListItemButton>This is a large list</ListItemButton>
+              </ListItem>
+              <ListItem>
+                <ListItemDecorator>
+                  <Star />
+                </ListItemDecorator>
+                <ListItemButton>This is a large list</ListItemButton>
+              </ListItem>
+              <ListItem>
+                <ListItemDecorator>
+                  <Star />
+                </ListItemDecorator>
+                <ListItemButton>This is a large list</ListItemButton>
+              </ListItem>
+            </List>
+          </Box>
         </Box>
       </Box>
     </CssVarsProvider>

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -113,7 +113,6 @@ export default function JoyTypography() {
             gap: 2,
             gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
             alignItems: 'flex-start',
-            '& > *': { bgcolor: 'background.body' },
           }}
         >
           {/* ex1 */}
@@ -394,6 +393,30 @@ export default function JoyTypography() {
                 Clear
               </Button>
             </ListItemButton>
+          </List>
+
+          <List
+            sx={{
+              maxWidth: 360,
+              maxHeight: 300,
+              overflow: 'auto',
+              '& ul': { p: 0 },
+              '--List-padding': 0,
+              '--List-item-paddingX': '1rem',
+            }}
+          >
+            {[0, 1, 2, 3, 4].map((sectionId) => (
+              <li key={`section-${sectionId}`}>
+                <ul>
+                  <ListItem sticky sx={{ pt: '1.5rem' }}>
+                    <Typography level="body2">{`I'm sticky ${sectionId}`}</Typography>
+                  </ListItem>
+                  {[0, 1, 2].map((item) => (
+                    <ListItem key={`item-${sectionId}-${item}`}>Item {item}</ListItem>
+                  ))}
+                </ul>
+              </li>
+            ))}
           </List>
         </Box>
       </Box>

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -511,7 +511,7 @@ export default function JoyTypography() {
                 <ListItemButton>This is a small list</ListItemButton>
               </ListItem>
             </List>
-            <List size="lg">
+            <List size="lg" sx={{ mt: 1 }}>
               <ListItem>
                 <Typography color="text.secondary">Large size</Typography>
               </ListItem>

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -21,6 +21,9 @@ import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
 import Star from '@mui/icons-material/StarBorder';
 import Favorite from '@mui/icons-material/FavoriteBorder';
 import DeleteForever from '@mui/icons-material/DeleteForever';
+import CommentIcon from '@mui/icons-material/Comment';
+import CheckBox from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlank from '@mui/icons-material/CheckBoxOutlineBlank';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -67,6 +70,45 @@ const Circle = ({
     ]}
   />
 );
+
+function CheckboxList() {
+  const [checked, setChecked] = React.useState([0]);
+
+  const handleToggle = (value: number) => () => {
+    const currentIndex = checked.indexOf(value);
+    const newChecked = [...checked];
+
+    if (currentIndex === -1) {
+      newChecked.push(value);
+    } else {
+      newChecked.splice(currentIndex, 1);
+    }
+
+    setChecked(newChecked);
+  };
+
+  return (
+    <List>
+      {[0, 1, 2, 3].map((value) => (
+        <ListItem
+          key={value}
+          secondaryAction={
+            <IconButton aria-label="comments" size="sm">
+              <CommentIcon />
+            </IconButton>
+          }
+        >
+          <ListItemButton role={undefined} onClick={handleToggle(value)}>
+            <ListItemDecorator>
+              {checked.indexOf(value) !== -1 ? <CheckBox /> : <CheckBoxOutlineBlank />}
+            </ListItemDecorator>
+            Line item {value + 1}
+          </ListItemButton>
+        </ListItem>
+      ))}
+    </List>
+  );
+}
 
 export default function JoyTypography() {
   return (
@@ -493,6 +535,8 @@ export default function JoyTypography() {
               </ListItem>
             </List>
           </Box>
+
+          <CheckboxList />
         </Box>
       </Box>
     </CssVarsProvider>

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -4,6 +4,7 @@ import { ColorPaletteProp, CssVarsProvider, useColorScheme } from '@mui/joy/styl
 import NextLink from 'next/link';
 import Box, { BoxProps } from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
+import IconButton from '@mui/joy/IconButton';
 import List from '@mui/joy/List';
 import ListItem from '@mui/joy/ListItem';
 import ListItemButton from '@mui/joy/ListItemButton';
@@ -19,6 +20,7 @@ import BeachAccess from '@mui/icons-material/BeachAccess';
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp';
 import Star from '@mui/icons-material/StarBorder';
 import Favorite from '@mui/icons-material/FavoriteBorder';
+import DeleteForever from '@mui/icons-material/DeleteForever';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -344,55 +346,79 @@ export default function JoyTypography() {
             component="nav"
             sx={{ '--List-decorator-width': '56px', '--List-divider-gap': '1rem' }}
           >
-            <ListItemButton selected selectedVariant="light">
-              <ListItemDecorator>
-                <Circle color="primary">
-                  <InboxIcon />
-                </Circle>
-              </ListItemDecorator>
-              <ListItemContent>
-                <Typography>Inbox</Typography>
-                <Typography level="body2">Jan 9, 2014</Typography>
-              </ListItemContent>
-              <Button variant="light" size="sm">
-                Clear
-              </Button>
-            </ListItemButton>
-            <ListDivider component="hr" />
-            <ListItemButton selected selectedVariant="outlined" color="danger">
-              <ListItemDecorator>
-                <Circle color="danger">
-                  <Star />
-                </Circle>
-              </ListItemDecorator>
-              <ListItemContent>
-                <Typography>Starred</Typography>
-                <Typography level="body2">Jan 9, 2014</Typography>
-              </ListItemContent>
-              <Button variant="light" color="danger" size="sm">
-                Clear
-              </Button>
-            </ListItemButton>
-            <ListDivider component="hr" />
-            <ListItemButton
-              selected
-              selectedVariant="contained"
-              color="success"
-              sx={(theme) => theme.variants.containedOverrides.success}
+            <ListItem
+              secondaryAction={
+                <Button variant="light" size="sm">
+                  Clear
+                </Button>
+              }
             >
-              <ListItemDecorator>
-                <Circle color="success">
-                  <Favorite />
-                </Circle>
-              </ListItemDecorator>
-              <ListItemContent>
-                <Typography>Favorite</Typography>
-                <Typography level="body2">Jan 9, 2014</Typography>
-              </ListItemContent>
-              <Button variant="outlined" color="context" size="sm">
-                Clear
-              </Button>
-            </ListItemButton>
+              <ListItemButton selected selectedVariant="light">
+                <ListItemDecorator>
+                  <Circle color="primary">
+                    <InboxIcon />
+                  </Circle>
+                </ListItemDecorator>
+                <ListItemContent>
+                  <Typography>Inbox</Typography>
+                  <Typography level="body2">Jan 9, 2014</Typography>
+                </ListItemContent>
+              </ListItemButton>
+            </ListItem>
+            <ListDivider component="hr" />
+            <ListItem
+              secondaryAction={
+                <Button variant="light" color="danger" size="sm">
+                  Clear
+                </Button>
+              }
+            >
+              <ListItemButton selected selectedVariant="outlined" color="danger">
+                <ListItemDecorator>
+                  <Circle color="danger">
+                    <Star />
+                  </Circle>
+                </ListItemDecorator>
+                <ListItemContent>
+                  <Typography>Starred</Typography>
+                  <Typography level="body2">Jan 9, 2014</Typography>
+                </ListItemContent>
+              </ListItemButton>
+            </ListItem>
+            <ListDivider component="hr" />
+            <ListItem
+              secondaryAction={
+                <IconButton
+                  variant="outlined"
+                  color="success"
+                  size="sm"
+                  sx={{
+                    borderColor: 'success.200',
+                    color: 'success.100',
+                    '&:hover': { bgcolor: 'success.700' },
+                  }}
+                >
+                  <DeleteForever />
+                </IconButton>
+              }
+            >
+              <ListItemButton
+                selected
+                selectedVariant="contained"
+                color="success"
+                sx={(theme) => theme.variants.containedOverrides.success}
+              >
+                <ListItemDecorator>
+                  <Circle color="success">
+                    <Favorite />
+                  </Circle>
+                </ListItemDecorator>
+                <ListItemContent>
+                  <Typography>Favorite</Typography>
+                  <Typography level="body2">Jan 9, 2014</Typography>
+                </ListItemContent>
+              </ListItemButton>
+            </ListItem>
           </List>
 
           <List

--- a/packages/mui-joy/src/List/List.test.js
+++ b/packages/mui-joy/src/List/List.test.js
@@ -20,10 +20,21 @@ describe('Joy <List />', () => {
   it('should have root className', () => {
     const { container } = render(<List />);
     expect(container.firstChild).to.have.class(classes.root);
+    expect(container.firstChild).to.have.class(classes.sizeMd);
   });
 
   it('should accept className prop', () => {
     const { container } = render(<List className="foo-bar" />);
     expect(container.firstChild).to.have.class('foo-bar');
+  });
+
+  it('should have sm classes', () => {
+    const { container } = render(<List size="sm" />);
+    expect(container.firstChild).to.have.class(classes.sizeSm);
+  });
+
+  it('should have lg classes', () => {
+    const { container } = render(<List size="lg" />);
+    expect(container.firstChild).to.have.class(classes.sizeLg);
   });
 });

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -19,16 +19,31 @@ const ListRoot = styled('ul', {
   name: 'MuiList',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ListProps }>(({ theme }) => ({
+})<{ ownerState: ListProps }>(({ theme, ownerState }) => ({
   '--List-padding': '0.375rem',
   '--List-gap': '0.375rem', // spacing between ListItem + ListItem or ListItemButton + ListItemButton
   '--List-radius': theme.vars.radius.sm,
-  '--List-background': theme.vars.palette.background.body,
   '--List-item-minHeight': '2.5rem',
   '--List-item-paddingX': '0.375rem',
-  '--List-decorator-width': '3rem',
+  '--List-decorator-width': '2.5rem',
+  ...(ownerState.size === 'sm' && {
+    '--List-padding': '0.25rem',
+    '--List-gap': '0.25rem',
+    '--List-radius': theme.vars.radius.xs,
+    '--List-item-minHeight': '2rem',
+    '--List-item-paddingX': '0.25rem',
+    '--List-decorator-width': '2rem',
+  }),
+  ...(ownerState.size === 'lg' && {
+    '--List-padding': '0.5rem',
+    '--List-gap': '0.5rem',
+    '--List-item-minHeight': '3rem',
+    '--List-item-paddingX': '0.5rem',
+    '--List-decorator-width': '3rem',
+  }),
   '--List-divider-gap': 'var(--List-gap)',
   '--List-insetStart': 'var(--List-item-paddingX)',
+  '--List-background': theme.vars.palette.background.body,
   // by default, The ListItem & ListItemButton use automatic radius adjustment based on the parent List.
   '--List-item-radius':
     'max(var(--List-radius) - var(--List-padding), min(var(--List-padding) / 2, var(--List-radius) / 2))',
@@ -49,9 +64,10 @@ const List = React.forwardRef(function List(inProps, ref) {
     name: 'MuiList',
   });
 
-  const { component, className, children, ...other } = props;
+  const { component, className, children, size = 'md', ...other } = props;
 
   const ownerState = {
+    size,
     ...props,
   };
 

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';
 import composeClasses from '@mui/base/composeClasses';
 import { styled, useThemeProps } from '../styles';
 import { ListProps, ListTypeMap } from './ListProps';
 import { getListUtilityClass } from './listClasses';
 
-const useUtilityClasses = () => {
+const useUtilityClasses = (ownerState: ListProps) => {
+  const { size } = ownerState;
   const slots = {
-    root: ['root'],
+    root: ['root', size && `size${capitalize(size)}`],
   };
 
   return composeClasses(slots, getListUtilityClass, {});
@@ -71,7 +73,7 @@ const List = React.forwardRef(function List(inProps, ref) {
     ...props,
   };
 
-  const classes = useUtilityClasses();
+  const classes = useUtilityClasses(ownerState);
 
   return (
     <ListRoot
@@ -105,9 +107,12 @@ List.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
-   * The size of the component.
+   * The size of the component (affect other nested list* components).
    */
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['sm', 'md', 'lg']),
+    PropTypes.string,
+  ]),
 } as any;
 
 export default List;

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -23,6 +23,7 @@ const ListRoot = styled('ul', {
   '--List-padding': '0.375rem',
   '--List-gap': '0.375rem', // spacing between ListItem + ListItem or ListItemButton + ListItemButton
   '--List-radius': theme.vars.radius.sm,
+  '--List-background': theme.vars.palette.background.body,
   '--List-item-minHeight': '2.5rem',
   '--List-item-paddingX': '0.375rem',
   '--List-decorator-width': '3rem',
@@ -31,6 +32,7 @@ const ListRoot = styled('ul', {
   // by default, The ListItem & ListItemButton use automatic radius adjustment based on the parent List.
   '--List-item-radius':
     'max(var(--List-radius) - var(--List-padding), min(var(--List-padding) / 2, var(--List-radius) / 2))',
+  background: 'var(--List-background)',
   borderRadius: 'var(--List-radius)',
   padding: 'var(--List-padding)',
   margin: 'initial',
@@ -38,6 +40,7 @@ const ListRoot = styled('ul', {
   display: 'flex',
   flexDirection: 'column',
   flexGrow: 1,
+  position: 'relative', // for sticky ListItem
 }));
 
 const List = React.forwardRef(function List(inProps, ref) {

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -104,6 +104,10 @@ List.propTypes /* remove-proptypes */ = {
    * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
+  /**
+   * The size of the component.
+   */
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
 } as any;
 
 export default List;

--- a/packages/mui-joy/src/List/ListProps.ts
+++ b/packages/mui-joy/src/List/ListProps.ts
@@ -16,7 +16,7 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      */
     classes?: Partial<ListClasses>;
     /**
-     * The size of the component.
+     * The size of the component (affect other nested list* components).
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', ListPropsSizeOverrides>;
     /**

--- a/packages/mui-joy/src/List/ListProps.ts
+++ b/packages/mui-joy/src/List/ListProps.ts
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { OverrideProps } from '@mui/types';
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/defaultTheme';
 import { ListClasses } from './listClasses';
+
+export interface ListPropsSizeOverrides {}
 
 export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
   props: P & {
@@ -13,6 +15,10 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      * Override or extend the styles applied to the component.
      */
     classes?: Partial<ListClasses>;
+    /**
+     * The size of the component.
+     */
+    size?: OverridableStringUnion<'sm' | 'md' | 'lg', ListPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/mui-joy/src/List/listClasses.ts
+++ b/packages/mui-joy/src/List/listClasses.ts
@@ -3,6 +3,12 @@ import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 export interface ListClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the root element if `size="sm"`. */
+  sizeSm: string;
+  /** Styles applied to the root element if `size="md"`. */
+  sizeMd: string;
+  /** Styles applied to the root element if `size="lg"`. */
+  sizeLg: string;
 }
 
 export type ListClassKey = keyof ListClasses;
@@ -11,6 +17,11 @@ export function getListUtilityClass(slot: string): string {
   return generateUtilityClass('MuiList', slot);
 }
 
-const listClasses: ListClasses = generateUtilityClasses('MuiList', ['root']);
+const listClasses: ListClasses = generateUtilityClasses('MuiList', [
+  'root',
+  'sizeSm',
+  'sizeMd',
+  'sizeLg',
+]);
 
 export default listClasses;

--- a/packages/mui-joy/src/ListItem/ListItem.test.js
+++ b/packages/mui-joy/src/ListItem/ListItem.test.js
@@ -35,5 +35,6 @@ describe('Joy <ListItem />', () => {
   it('should show action if provided', () => {
     const { getByText } = render(<ListItem secondaryAction="foo" />);
     expect(getByText('foo')).toBeVisible();
+    expect(getByText('foo')).to.have.class(classes.secondaryAction);
   });
 });

--- a/packages/mui-joy/src/ListItem/ListItem.test.js
+++ b/packages/mui-joy/src/ListItem/ListItem.test.js
@@ -26,4 +26,9 @@ describe('Joy <ListItem />', () => {
     const { container } = render(<ListItem className="foo-bar" />);
     expect(container.firstChild).to.have.class('foo-bar');
   });
+
+  it('should have sticky classes', () => {
+    const { container } = render(<ListItem sticky />);
+    expect(container.firstChild).to.have.class(classes.sticky);
+  });
 });

--- a/packages/mui-joy/src/ListItem/ListItem.test.js
+++ b/packages/mui-joy/src/ListItem/ListItem.test.js
@@ -31,4 +31,9 @@ describe('Joy <ListItem />', () => {
     const { container } = render(<ListItem sticky />);
     expect(container.firstChild).to.have.class(classes.sticky);
   });
+
+  it('should show action if provided', () => {
+    const { getByText } = render(<ListItem secondaryAction="foo" />);
+    expect(getByText('foo')).toBeVisible();
+  });
 });

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -6,6 +6,7 @@ import composeClasses from '@mui/base/composeClasses';
 import { styled, useThemeProps } from '../styles';
 import { ListItemProps, ListItemTypeMap } from './ListItemProps';
 import listItemClasses, { getListItemUtilityClass } from './listItemClasses';
+import listItemButtonClasses from '../ListItemButton/listItemButtonClasses';
 
 const useUtilityClasses = (ownerState: ListItemProps) => {
   const { sticky } = ownerState;
@@ -43,7 +44,7 @@ const ListItemRoot = styled('li', {
     zIndex: 1,
     background: 'var(--List-background)',
   }),
-  [`& + .${listItemClasses.root}`]: {
+  [`& + .${listItemClasses.root}, & + .${listItemButtonClasses.root}`]: {
     marginTop: 'var(--List-gap)',
   },
 }));

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -11,6 +11,7 @@ const useUtilityClasses = (ownerState: ListItemProps) => {
   const { sticky } = ownerState;
   const slots = {
     root: ['root', sticky && 'sticky'],
+    secondaryAction: ['secondaryAction'],
   };
 
   return composeClasses(slots, getListItemUtilityClass, {});
@@ -25,9 +26,13 @@ const ListItemRoot = styled('li', {
   '--List-itemButton-margin':
     'max(-0.375rem, -1 * var(--List-item-paddingX)) calc(-1 * var(--List-item-paddingX))',
   '--List-decorator-color': theme.vars.palette.text.tertiary, // for making icon color less obvious
+  ...(ownerState.secondaryAction && {
+    '--List-item-secondaryActionWidth': '3rem', // for ListItemButton
+  }),
   boxSizing: 'border-box',
   display: 'flex',
   alignItems: 'center',
+  position: 'relative',
   padding: 'min(0.375rem, var(--List-item-paddingX)) var(--List-item-paddingX)',
   paddingLeft: 'var(--List-insetStart)',
   minHeight: 'var(--List-item-minHeight)',
@@ -35,6 +40,7 @@ const ListItemRoot = styled('li', {
   ...(ownerState.sticky && {
     position: 'sticky',
     top: 0,
+    zIndex: 1,
     background: 'var(--List-background)',
   }),
   [`& + .${listItemClasses.root}`]: {
@@ -42,16 +48,29 @@ const ListItemRoot = styled('li', {
   },
 }));
 
+const ListItemSecondaryAction = styled('div', {
+  name: 'MuiListItem',
+  slot: 'SecondaryAction',
+  overridesResolver: (props, styles) => styles.secondaryAction,
+})<{ ownerState: ListItemProps }>({
+  display: 'inherit',
+  position: 'absolute',
+  top: '50%',
+  right: 'var(--List-item-paddingX)',
+  transform: 'translateY(-50%)',
+});
+
 const ListItem = React.forwardRef(function ListItem(inProps, ref) {
   const props = useThemeProps<typeof inProps & { component?: React.ElementType }>({
     props: inProps,
     name: 'MuiListItem',
   });
 
-  const { component, className, children, sticky = false, ...other } = props;
+  const { component, className, children, sticky = false, secondaryAction, ...other } = props;
 
   const ownerState = {
     sticky,
+    secondaryAction,
     ...props,
   };
 
@@ -66,6 +85,11 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
       {...other}
     >
       {children}
+      {secondaryAction && (
+        <ListItemSecondaryAction className={classes.secondaryAction} ownerState={ownerState}>
+          {secondaryAction}
+        </ListItemSecondaryAction>
+      )}
     </ListItemRoot>
   );
 }) as OverridableComponent<ListItemTypeMap>;

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -27,7 +27,7 @@ const ListItemRoot = styled('li', {
     'max(-0.375rem, -1 * var(--List-item-paddingX)) calc(-1 * var(--List-item-paddingX))',
   '--List-decorator-color': theme.vars.palette.text.tertiary, // for making icon color less obvious
   ...(ownerState.secondaryAction && {
-    '--List-item-secondaryActionWidth': '3rem', // for ListItemButton
+    '--List-item-secondaryActionWidth': '3rem', // to add sufficient padding-right on ListItemButton
   }),
   boxSizing: 'border-box',
   display: 'flex',

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -113,6 +113,10 @@ ListItem.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
+   * The element to display at the end of ListItem.
+   */
+  secondaryAction: PropTypes.node,
+  /**
    * If `true`, the component has sticky position (with top = 0).
    * @default false
    */

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -7,9 +7,10 @@ import { styled, useThemeProps } from '../styles';
 import { ListItemProps, ListItemTypeMap } from './ListItemProps';
 import listItemClasses, { getListItemUtilityClass } from './listItemClasses';
 
-const useUtilityClasses = () => {
+const useUtilityClasses = (ownerState: ListItemProps) => {
+  const { sticky } = ownerState;
   const slots = {
-    root: ['root'],
+    root: ['root', sticky && 'sticky'],
   };
 
   return composeClasses(slots, getListItemUtilityClass, {});
@@ -19,7 +20,7 @@ const ListItemRoot = styled('li', {
   name: 'MuiListItem',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ListItemProps }>(({ theme }) => ({
+})<{ ownerState: ListItemProps }>(({ theme, ownerState }) => ({
   // add negative margin to ListItemButton equal to this ListItem padding
   '--List-itemButton-margin':
     'max(-0.375rem, -1 * var(--List-item-paddingX)) calc(-1 * var(--List-item-paddingX))',
@@ -31,6 +32,11 @@ const ListItemRoot = styled('li', {
   paddingLeft: 'var(--List-insetStart)',
   minHeight: 'var(--List-item-minHeight)',
   ...theme.typography.body1,
+  ...(ownerState.sticky && {
+    position: 'sticky',
+    top: 0,
+    background: 'var(--List-background)',
+  }),
   [`& + .${listItemClasses.root}`]: {
     marginTop: 'var(--List-gap)',
   },
@@ -42,13 +48,14 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     name: 'MuiListItem',
   });
 
-  const { component, className, children, ...other } = props;
+  const { component, className, children, sticky = false, ...other } = props;
 
   const ownerState = {
+    sticky,
     ...props,
   };
 
-  const classes = useUtilityClasses();
+  const classes = useUtilityClasses(ownerState);
 
   return (
     <ListItemRoot
@@ -81,6 +88,11 @@ ListItem.propTypes /* remove-proptypes */ = {
    * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
+  /**
+   * If `true`, the component has sticky position (with top = 0).
+   * @default false
+   */
+  sticky: PropTypes.bool,
 } as any;
 
 export default ListItem;

--- a/packages/mui-joy/src/ListItem/ListItemProps.ts
+++ b/packages/mui-joy/src/ListItem/ListItemProps.ts
@@ -14,6 +14,11 @@ export interface ListItemTypeMap<P = {}, D extends React.ElementType = 'li'> {
      */
     classes?: Partial<ListItemClasses>;
     /**
+     * If `true`, the component has sticky position (with top = 0).
+     * @default false
+     */
+    sticky?: boolean;
+    /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */
     sx?: SxProps;

--- a/packages/mui-joy/src/ListItem/ListItemProps.ts
+++ b/packages/mui-joy/src/ListItem/ListItemProps.ts
@@ -14,6 +14,10 @@ export interface ListItemTypeMap<P = {}, D extends React.ElementType = 'li'> {
      */
     classes?: Partial<ListItemClasses>;
     /**
+     * The element to display at the end of ListItem.
+     */
+    secondaryAction?: React.ReactNode;
+    /**
      * If `true`, the component has sticky position (with top = 0).
      * @default false
      */

--- a/packages/mui-joy/src/ListItem/listItemClasses.ts
+++ b/packages/mui-joy/src/ListItem/listItemClasses.ts
@@ -3,6 +3,8 @@ import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 export interface ListItemClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the component element if `children` includes `ListItemSecondaryAction`. */
+  secondaryAction: string;
   /** Styles applied to the root element, if sticky={true}. */
   sticky: string;
 }
@@ -13,6 +15,10 @@ export function getListItemUtilityClass(slot: string): string {
   return generateUtilityClass('MuiListItem', slot);
 }
 
-const listItemClasses: ListItemClasses = generateUtilityClasses('MuiListItem', ['root', 'sticky']);
+const listItemClasses: ListItemClasses = generateUtilityClasses('MuiListItem', [
+  'root',
+  'secondaryAction',
+  'sticky',
+]);
 
 export default listItemClasses;

--- a/packages/mui-joy/src/ListItem/listItemClasses.ts
+++ b/packages/mui-joy/src/ListItem/listItemClasses.ts
@@ -3,6 +3,8 @@ import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 export interface ListItemClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the root element, if sticky={true}. */
+  sticky: string;
 }
 
 export type ListItemClassKey = keyof ListItemClasses;
@@ -11,6 +13,6 @@ export function getListItemUtilityClass(slot: string): string {
   return generateUtilityClass('MuiListItem', slot);
 }
 
-const listItemClasses: ListItemClasses = generateUtilityClasses('MuiListItem', ['root']);
+const listItemClasses: ListItemClasses = generateUtilityClasses('MuiListItem', ['root', 'sticky']);
 
 export default listItemClasses;

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -11,6 +11,7 @@ import {
   ListItemButtonTypeMap,
 } from './ListItemButtonProps';
 import listItemButtonClasses, { getListItemButtonUtilityClass } from './listItemButtonClasses';
+import listItemClasses from '../ListItem/listItemClasses';
 
 const useUtilityClasses = (ownerState: ListItemButtonProps & { focusVisible: boolean }) => {
   const { color, disabled, focusVisible, focusVisibleClassName, selectedVariant, selected } =
@@ -74,7 +75,7 @@ const ListItemButtonRoot = styled('div', {
       fontWeight: theme.vars.fontWeight.md,
     }),
     '&.Mui-focusVisible': theme.focus.default,
-    [`& + .${listItemButtonClasses.root}`]: {
+    [`& + .${listItemButtonClasses.root}, & + .${listItemClasses.root}`]: {
       marginTop: 'var(--List-gap)',
     },
   },

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -58,8 +58,9 @@ const ListItemButtonRoot = styled('div', {
     // In some cases, ListItemButton is a child of ListItem so the margin needs to be controlled by the ListItem.
     // The value is negative to account for the ListItem's padding
     margin: 'var(--List-itemButton-margin)',
-    padding: 'min(0.375rem, var(--List-item-paddingX)) var(--List-item-paddingX)',
+    padding: 'min(0.375rem, var(--List-item-paddingX))',
     paddingLeft: 'var(--List-insetStart, var(--List-item-paddingX))',
+    paddingRight: 'calc(var(--List-item-paddingX) + var(--List-item-secondaryActionWidth, 0px))',
     minHeight: 'var(--List-item-minHeight)',
     border: 'none',
     borderRadius: 'var(--List-item-radius)',

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -48,7 +48,8 @@ const ListItemButtonRoot = styled('div', {
     }),
     ...(ownerState.color &&
       ownerState.color !== 'context' && {
-        '--List-decorator-color': theme.vars.palette[ownerState.color]?.textColor,
+        '--List-decorator-color':
+          theme.vars.palette[ownerState.color]?.[`${ownerState.selectedVariant || 'text'}Color`],
       }),
     boxSizing: 'border-box',
     display: 'flex',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

2nd iteration for the List component. I am pushing `List` component to be the first complete component that can be compared with Material, so that we can measure how it is different & how much improvements we gain with the new approach.

### 🖥  [Preview](https://deploy-preview-31134--material-ui.netlify.app/experiments/joy/list/)

### 🎠  [Playground](https://deploy-preview-31134--material-ui.netlify.app/experiments/joy/components/?name=List)

### 📦  [CodeSandbox](https://codesandbox.io/s/joy-cra-typescript-forked-fbj8o5?file=/src/App.tsx)

## Scope of this PR

- support different sizes
- able to provide secondary action on the list item
- sticky subheader

## Changes

- add `size: 'sm' | 'md' | 'lg'` to `List` component (**take a look at the Preview**)
- add `secondaryAction` (same as Material) to `ListItem` (**take a look at the Preview**)
- add `sticky` prop to `ListItem`. I think this is a lot easier than in Material:
   - No need a new component (ListSubheader in Material)
   - background is handled automatically (controlled by the List)

### CSS Variables
**New**
- `--List-item-secondaryActionWidth`: this var is needed to communicate with secondary action & ListItemButton
- `--List-background`: for sticky list item 

## Report

Total lines of code comparison between Material & Joy. I think it is helpful to keep track of the change so we get the idea of how much it is improved (My assumption is that less code means less bundle size)

|                          | Material   | Joy        | % change   |
| ------------------------ | ---------- | ---------- | ---------- |
| ButtonBase               | 541        |            |            |
| List                     | 135        | 119        | -11.85     |
| ListDivider              |            | 100        |            |
| ListItem                 | 455        | 128        | -71.87     |
| ListItemButton           | 258        | 219        | -15.12     |
| ListItemText             | 183        |            |            |
| ListSubheader            | 156        |            |            |
| ListItemIcon             | 91         |            |            |
| ListItemContent          |            | 75         |            |
| ListItemDecorator        |            | 76         |            |
| total                    | 1819       | 717        | -60.58     |

---


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
