### PR TITLE
[Button Base] Fix typo

### DIFF
--- a/docs/translations/api-docs/button-base/button-base.json
+++ b/docs/translations/api-docs/button-base/button-base.json
@@ -15,7 +15,7 @@
     "onFocusVisible": "Callback fired when the component is focused with a keyboard. We trigger a <code>onFocus</code> callback too.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "TouchRippleProps": "Props applied to the <code>TouchRipple</code> element.",
-    "touchRippleRef": "A ref that points to the <code>TouchRippple</code> element."
+    "touchRippleRef": "A ref that points to the <code>TouchRipple</code> element."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -81,7 +81,7 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
      */
     TouchRippleProps?: Partial<TouchRippleProps>;
     /**
-     * A ref that points to the `TouchRippple` element.
+     * A ref that points to the `TouchRipple` element.
      */
     touchRippleRef?: React.Ref<TouchRippleActions>;
   };

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -519,7 +519,7 @@ ButtonBase.propTypes /* remove-proptypes */ = {
    */
   TouchRippleProps: PropTypes.object,
   /**
-   * A ref that points to the `TouchRippple` element.
+   * A ref that points to the `TouchRipple` element.
    */
   touchRippleRef: PropTypes.oneOfType([
     PropTypes.func,


### PR DESCRIPTION
Change `TouchRippple` to `TouchRipple`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
