### PR TITLE
[core] Fix propTypes generation for optional `any` props

### DIFF
--- a/docs/pages/api-docs/popper-unstyled.json
+++ b/docs/pages/api-docs/popper-unstyled.json
@@ -18,7 +18,7 @@
     "modifiers": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
+        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name?: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
       }
     },
     "placement": {

--- a/docs/pages/api-docs/popper.json
+++ b/docs/pages/api-docs/popper.json
@@ -18,7 +18,7 @@
     "modifiers": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
+        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name?: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
       }
     },
     "placement": {

--- a/docs/pages/base/api/popper-unstyled.json
+++ b/docs/pages/base/api/popper-unstyled.json
@@ -18,7 +18,7 @@
     "modifiers": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
+        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name?: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
       }
     },
     "placement": {

--- a/docs/pages/material/api/popper.json
+++ b/docs/pages/material/api/popper.json
@@ -18,7 +18,7 @@
     "modifiers": {
       "type": {
         "name": "arrayOf",
-        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
+        "description": "Array&lt;{ data?: object, effect?: func, enabled?: bool, fn?: func, name?: any, options?: object, phase?: 'afterMain'<br>&#124;&nbsp;'afterRead'<br>&#124;&nbsp;'afterWrite'<br>&#124;&nbsp;'beforeMain'<br>&#124;&nbsp;'beforeRead'<br>&#124;&nbsp;'beforeWrite'<br>&#124;&nbsp;'main'<br>&#124;&nbsp;'read'<br>&#124;&nbsp;'write', requires?: Array&lt;string&gt;, requiresIfExists?: Array&lt;string&gt; }&gt;"
       }
     },
     "placement": {

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
@@ -351,7 +351,7 @@ PopperUnstyled.propTypes /* remove-proptypes */ = {
       effect: PropTypes.func,
       enabled: PropTypes.bool,
       fn: PropTypes.func,
-      name: PropTypes.any.isRequired,
+      name: PropTypes.any,
       options: PropTypes.object,
       phase: PropTypes.oneOf([
         'afterMain',

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -87,7 +87,7 @@ Popper.propTypes /* remove-proptypes */ = {
       effect: PropTypes.func,
       enabled: PropTypes.bool,
       fn: PropTypes.func,
-      name: PropTypes.any.isRequired,
+      name: PropTypes.any,
       options: PropTypes.object,
       phase: PropTypes.oneOf([
         'afterMain',

--- a/packages/typescript-to-proptypes/src/parser.ts
+++ b/packages/typescript-to-proptypes/src/parser.ts
@@ -437,15 +437,16 @@ export function parseFromProgram(
       declaration &&
       ts.isPropertySignature(declaration)
     ) {
-      parsedType = declaration.questionToken
-        ? t.createUnionType({
-            jsDoc: getDocumentation(symbol),
-            types: [
-              t.createUndefinedType({ jsDoc: undefined }),
-              t.createAnyType({ jsDoc: undefined }),
-            ],
-          })
-        : t.createAnyType({ jsDoc: getDocumentation(symbol) });
+      parsedType =
+        symbol.flags & ts.SymbolFlags.Optional
+          ? t.createUnionType({
+              jsDoc: getDocumentation(symbol),
+              types: [
+                t.createUndefinedType({ jsDoc: undefined }),
+                t.createAnyType({ jsDoc: undefined }),
+              ],
+            })
+          : t.createAnyType({ jsDoc: getDocumentation(symbol) });
     } else {
       parsedType = checkType(type, location, typeStack, symbol.getName());
     }

--- a/packages/typescript-to-proptypes/test/partial-any-props/input.d.ts
+++ b/packages/typescript-to-proptypes/test/partial-any-props/input.d.ts
@@ -1,0 +1,5 @@
+type Props = {
+  foo: any;
+};
+
+export default function Foo(props: Partial<Props>): JSX.Element;

--- a/packages/typescript-to-proptypes/test/partial-any-props/output.js
+++ b/packages/typescript-to-proptypes/test/partial-any-props/output.js
@@ -1,0 +1,3 @@
+Foo.propTypes = {
+  foo: PropTypes.any,
+};


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following change will generate incorrect propTypes:

```diff
diff --git a/packages/mui-material/src/Popper/Popper.tsx b/packages/mui-material/src/Popper/Popper.tsx
index cb0bf4de5d..5bf0957724 100644
--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -19,7 +19,7 @@ export type PopperProps = Omit<PopperUnstyledProps, 'direction'>;
  * - [Popper API](https://mui.com/api/popper/)
  */
 const Popper = React.forwardRef(function Popper(
-  props: PopperProps,
+  props: PopperProps & Partial<{ fooBar: any }>,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const theme = useTheme<{ direction?: Direction }>();
@@ -65,6 +65,10 @@ Popper.propTypes /* remove-proptypes */ = {
    * @default false
    */
   disablePortal: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  fooBar: PropTypes.any.isRequired,
   /**
    * Always keep the children in the DOM.
    * This prop can be useful in SEO situation or
```

It happens because we check `declaration.questionToken`, but this approach only works if the property was declared as `fooBar?: any`, not when `Partial` makes it optional.

https://github.com/mui/material-ui/blob/9cd3b9907f881c9ae82ba0af1fbb7904e1f96c4b/packages/typescript-to-proptypes/src/parser.ts#L440-L441

This PR fixes it by using the solution from https://github.com/microsoft/TypeScript/issues/39629#issuecomment-1044892208.

To give context of where this change will be used, in the DataGrid we have a component whose props come from a interface where all properties are required. Until now we used `Pick` to accept only a few props, but now we want to accept all props and forward the rest of them to the root element. It turns out that two of the props we want to make optional, but prop-types makes them required.

In https://github.com/mui/mui-x/blob/master/packages/grid/x-data-grid/src/internals/components/cell/GridActionsCell.tsx we want to be able to do:

```diff
diff --git a/packages/grid/x-data-grid/src/internals/components/cell/GridActionsCell.tsx b/packages/grid/x-data-grid/src/internals/components/cell/GridActionsCell.tsx
index c31207a7a..11d37a60d 100644
--- a/packages/grid/x-data-grid/src/internals/components/cell/GridActionsCell.tsx
+++ b/packages/grid/x-data-grid/src/internals/components/cell/GridActionsCell.tsx
@@ -16,7 +16,8 @@ interface TouchRippleActions {
   stop: (event: any, callback?: () => void) => void;
 }

-type GridActionsCellProps = Pick<GridRenderCellParams, 'colDef' | 'id' | 'api' | 'hasFocus'> &
+type GridActionsCellProps = Omit<GridRenderCellParams, 'value' | 'formattedValue'> &
+  Partial<Pick<GridRenderCellParams, 'value' | 'formattedValue'>> &
   Pick<GridMenuProps, 'position'>;
```

Note that the same problem might still occur with props of type `React.ElementType`. There's still one usage of `declaration.questionToken` left. I didn't touch it because I don't see false required propTypes of this type, but the solution is the same.

https://github.com/mui/material-ui/blob/9cd3b9907f881c9ae82ba0af1fbb7904e1f96c4b/packages/typescript-to-proptypes/src/parser.ts#L393