### PR TITLE
[system] Fix `CssVarsProvider` theme mutation

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -9,7 +9,9 @@ export interface ColorSchemeContextValue<SupportedColorScheme extends string>
 
 export interface CssVarsProviderConfig<ColorScheme extends string> {
   /**
-   * Design system default color scheme
+   * Design system default color scheme.
+   * - provides string if the design system has one default color scheme (either light or dark)
+   * - provides object if the design system has default light & dark color schemes
    */
   defaultColorScheme: ColorScheme | { light: ColorScheme; dark: ColorScheme };
   /**

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -43,6 +43,28 @@ export default function createCssVarsProvider<
   options: CssVarsProviderConfig<ColorScheme> & {
     /**
      * Design system default theme
+     *
+     * The structure inside `theme.colorSchemes[colorScheme]` should be exactly the same in all color schemes because
+     * those object of the color scheme will be used when the color scheme is active.
+     *
+     *  {
+     *    colorSchemes: {
+     *      light: { ...lightColorSchemeValues },
+     *      dark: { ...darkColorSchemeValues }
+     *    }
+     *  }
+     *
+     *  If colorScheme is 'light', the `lightColorSchemeValues` will be merged to theme as `{ ...theme, ...lightColorSchemeValues }`
+     *  likewise, if colorScheme is 'dark', the `darkColorSchemeValues` will be merged to theme as `{ ...theme, ...darkColorSchemeValues }`
+     *
+     *  !!! Don't provided the same keys as in colorSchemes to theme because they will be replaced internally when the selected colorScheme is calculated.
+     *  Ex. {
+     *    colorSchemes: {
+     *      light: { palette: { ... } },
+     *      dark: { palette: { ... } }
+     *    },
+     *    palette: { ... }, // This values will be replaced by the `palette` from the light | dark color scheme at runtime.
+     *  }
      */
     theme: any;
     /**

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -22,8 +22,8 @@ export default function createCssVarsProvider(options) {
     theme: baseTheme = {},
     defaultMode: desisgnSystemMode = 'light',
     defaultColorScheme: designSystemColorScheme,
-    disableTransitionOnChange = false,
-    enableColorScheme = true,
+    disableTransitionOnChange: designSystemTransitionOnChange = false,
+    enableColorScheme: designSystemEnableColorScheme = true,
     prefix: designSystemPrefix = '',
     shouldSkipGeneratingVar,
     resolveTheme,
@@ -61,6 +61,8 @@ export default function createCssVarsProvider(options) {
     attribute = DEFAULT_ATTRIBUTE,
     defaultMode = desisgnSystemMode,
     defaultColorScheme = designSystemColorScheme,
+    disableTransitionOnChange = designSystemTransitionOnChange,
+    enableColorScheme = designSystemEnableColorScheme,
   }) {
     const { colorSchemes: baseColorSchemes = {}, ...restBaseTheme } = baseTheme;
     const { colorSchemes: colorSchemesProp = {}, ...restThemeProp } = themeProp;
@@ -183,7 +185,7 @@ export default function createCssVarsProvider(options) {
       return () => {
         document.documentElement.style.setProperty('color-scheme', priorColorScheme);
       };
-    }, [mode, systemMode]);
+    }, [mode, systemMode, enableColorScheme]);
 
     React.useEffect(() => {
       let timer;
@@ -203,7 +205,7 @@ export default function createCssVarsProvider(options) {
       return () => {
         clearTimeout(timer);
       };
-    }, [colorScheme]);
+    }, [colorScheme, disableTransitionOnChange]);
 
     React.useEffect(() => {
       hasMounted.current = true;
@@ -250,6 +252,14 @@ export default function createCssVarsProvider(options) {
      * The initial mode used.
      */
     defaultMode: PropTypes.string,
+    /**
+     * Disable CSS transitions when switching between modes or color schemes
+     */
+    disableTransitionOnChange: PropTypes.bool,
+    /**
+     * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
+     */
+    enableColorScheme: PropTypes.bool,
     /**
      * The key in the local storage used to store current color scheme.
      */

--- a/packages/mui-system/src/cssVars/cssVarsParser.test.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.test.ts
@@ -141,6 +141,75 @@ describe('cssVarsParser', () => {
       });
     });
 
+    it('use prefix if provided', () => {
+      const theme = {
+        bg: 'var(--palette-neutral-50)',
+        text: {
+          heading: 'var(--palette-primary-500, var(--palette-neutral-500))',
+        },
+      };
+      const { css } = cssVarsParser(theme, {
+        prefix: 'foo-bar',
+      });
+      expect(css).to.deep.equal({
+        '--foo-bar-bg': 'var(--foo-bar-palette-neutral-50)',
+        '--foo-bar-text-heading':
+          'var(--foo-bar-palette-primary-500, var(--foo-bar-palette-neutral-500))',
+      });
+    });
+
+    it('replace default prefix if provided', () => {
+      const theme = {
+        fontFamily: {
+          body: '"Public Sans", var( --joy-fontFamily-fallback)',
+          display: '"Public Sans", var(    --joy-fontFamily-fallback)',
+        },
+      };
+      const { css } = cssVarsParser(theme, {
+        prefix: 'foo-bar',
+        basePrefix: 'joy',
+      });
+      expect(css).to.deep.equal({
+        '--foo-bar-fontFamily-body': '"Public Sans", var(--foo-bar-fontFamily-fallback)',
+        '--foo-bar-fontFamily-display': '"Public Sans", var(--foo-bar-fontFamily-fallback)',
+      });
+    });
+
+    it('replace value starts with `var` if basePrefix, prefix are different', () => {
+      const theme = {
+        bg: 'var(--joy-palette-neutral-50)',
+        text: {
+          heading: 'var(--joy-palette-primary-500, var(--joy-palette-neutral-500))',
+        },
+      };
+      const { css } = cssVarsParser(theme, {
+        basePrefix: 'joy',
+        prefix: 'custom',
+      });
+      expect(css).to.deep.equal({
+        '--custom-bg': 'var(--custom-palette-neutral-50)',
+        '--custom-text-heading':
+          'var(--custom-palette-primary-500, var(--custom-palette-neutral-500))',
+      });
+    });
+
+    it('basePrefix in the value is removed if prefix is ""', () => {
+      const theme = {
+        bg: 'var(--joy-palette-neutral-50, var(--joy-colors-white))',
+        text: {
+          heading: 'var(--joy-palette-primary-500)',
+        },
+      };
+      const { css } = cssVarsParser(theme, {
+        basePrefix: 'joy',
+        prefix: '',
+      });
+      expect(css).to.deep.equal({
+        '--bg': 'var(--palette-neutral-50, var(--colors-white))',
+        '--text-heading': 'var(--palette-primary-500)',
+      });
+    });
+
     it('attach px to number value', () => {
       const { css } = cssVarsParser({
         fontSize: {
@@ -203,101 +272,6 @@ describe('cssVarsParser', () => {
       );
       expect(css).to.deep.equal({
         '--palette-primary-100': '#ffffff',
-      });
-    });
-
-    describe('variable reference with `var()`', () => {
-      it('use prefix if provided', () => {
-        const theme = {
-          bg: 'var(--palette-neutral-50)',
-          text: {
-            heading: 'var(--palette-primary-500, var(--palette-neutral-500))',
-          },
-        };
-        const { css } = cssVarsParser(theme, {
-          prefix: 'foo-bar',
-        });
-        expect(theme).to.deep.equal({
-          bg: 'var(--foo-bar-palette-neutral-50)',
-          text: {
-            heading: 'var(--foo-bar-palette-primary-500, var(--foo-bar-palette-neutral-500))',
-          },
-        });
-        expect(css).to.deep.equal({
-          '--foo-bar-bg': 'var(--foo-bar-palette-neutral-50)',
-          '--foo-bar-text-heading':
-            'var(--foo-bar-palette-primary-500, var(--foo-bar-palette-neutral-500))',
-        });
-      });
-
-      it('replace default prefix if provided', () => {
-        const theme = {
-          fontFamily: {
-            body: '"Public Sans", var( --joy-fontFamily-fallback)',
-            display: '"Public Sans", var(    --joy-fontFamily-fallback)',
-          },
-        };
-        const { css } = cssVarsParser(theme, {
-          prefix: 'foo-bar',
-          basePrefix: 'joy',
-        });
-        expect(theme).to.deep.equal({
-          fontFamily: {
-            body: '"Public Sans", var(--foo-bar-fontFamily-fallback)',
-            display: '"Public Sans", var(--foo-bar-fontFamily-fallback)',
-          },
-        });
-        expect(css).to.deep.equal({
-          '--foo-bar-fontFamily-body': '"Public Sans", var(--foo-bar-fontFamily-fallback)',
-          '--foo-bar-fontFamily-display': '"Public Sans", var(--foo-bar-fontFamily-fallback)',
-        });
-      });
-
-      it('replace value starts with `var` if basePrefix, prefix are different', () => {
-        const theme = {
-          bg: 'var(--joy-palette-neutral-50)',
-          text: {
-            heading: 'var(--joy-palette-primary-500, var(--joy-palette-neutral-500))',
-          },
-        };
-        const { css } = cssVarsParser(theme, {
-          basePrefix: 'joy',
-          prefix: 'custom',
-        });
-        expect(theme).to.deep.equal({
-          bg: 'var(--custom-palette-neutral-50)',
-          text: {
-            heading: 'var(--custom-palette-primary-500, var(--custom-palette-neutral-500))',
-          },
-        });
-        expect(css).to.deep.equal({
-          '--custom-bg': 'var(--custom-palette-neutral-50)',
-          '--custom-text-heading':
-            'var(--custom-palette-primary-500, var(--custom-palette-neutral-500))',
-        });
-      });
-
-      it('basePrefix in the value is removed if prefix is ""', () => {
-        const theme = {
-          bg: 'var(--joy-palette-neutral-50, var(--joy-colors-white))',
-          text: {
-            heading: 'var(--joy-palette-primary-500)',
-          },
-        };
-        const { css } = cssVarsParser(theme, {
-          basePrefix: 'joy',
-          prefix: '',
-        });
-        expect(theme).to.deep.equal({
-          bg: 'var(--palette-neutral-50, var(--colors-white))',
-          text: {
-            heading: 'var(--palette-primary-500)',
-          },
-        });
-        expect(css).to.deep.equal({
-          '--bg': 'var(--palette-neutral-50, var(--colors-white))',
-          '--text-heading': 'var(--palette-primary-500)',
-        });
       });
     });
   });
@@ -373,6 +347,119 @@ describe('cssVarsParser', () => {
           primary: {
             100: 'var(--palette-primary-100)',
           },
+        },
+      });
+    });
+  });
+
+  describe('parsedObject', () => {
+    it('creates a new object on every call', () => {
+      const theme = {
+        primary: {
+          500: '#ffffff',
+          main: 'var(--palette-500)',
+        },
+      };
+      const { parsedTheme } = cssVarsParser(theme, { prefix: 'foo' });
+      const { parsedTheme: parsedTheme2 } = cssVarsParser(theme, { prefix: 'bar' });
+      expect(theme).not.to.equal(parsedTheme);
+      expect(parsedTheme).to.deep.equal({
+        primary: {
+          500: '#ffffff',
+          main: 'var(--foo-palette-500)',
+        },
+      });
+      expect(parsedTheme2).to.deep.equal({
+        primary: {
+          500: '#ffffff',
+          main: 'var(--bar-palette-500)',
+        },
+      });
+      expect(parsedTheme).not.to.deep.equal(parsedTheme2);
+    });
+
+    it('preserve function value', () => {
+      const theme = {
+        palette: {
+          getContrastText: () => 'foo',
+        },
+        pxToRem: (px: number) => `${px / 16}rem`,
+      };
+      const { parsedTheme } = cssVarsParser(theme);
+      expect(parsedTheme.palette.getContrastText()).to.equal('foo');
+      expect(parsedTheme.pxToRem(16)).to.equal('1rem');
+    });
+
+    it('apply prefix to CSS variable value', () => {
+      const { parsedTheme } = cssVarsParser(
+        {
+          palette: {
+            primary: {
+              main: 'var(--palette-token)',
+            },
+            secondary: {
+              main: 'var(--palette-token, var(--palette-token))',
+            },
+          },
+        },
+        { prefix: 'foo' },
+      );
+      expect(parsedTheme).to.deep.equal({
+        palette: {
+          primary: {
+            main: 'var(--foo-palette-token)',
+          },
+          secondary: {
+            main: 'var(--foo-palette-token, var(--foo-palette-token))',
+          },
+        },
+      });
+    });
+
+    it('replace basePrefix with prefix', () => {
+      const { parsedTheme } = cssVarsParser(
+        {
+          palette: {
+            primary: {
+              main: 'var(--foo-palette-token)',
+            },
+            secondary: {
+              main: 'var(--foo-palette-token, var(--foo-palette-token))',
+            },
+          },
+        },
+        { prefix: 'joy', basePrefix: 'foo' },
+      );
+      expect(parsedTheme).to.deep.equal({
+        palette: {
+          primary: {
+            main: 'var(--joy-palette-token)',
+          },
+          secondary: {
+            main: 'var(--joy-palette-token, var(--joy-palette-token))',
+          },
+        },
+      });
+    });
+
+    it('all key,values remains in parsedTheme even shouldSkipGeneratingVar is provided', () => {
+      const { parsedTheme } = cssVarsParser(
+        {
+          pxToRem: (px: number) => `${px / 16}rem`,
+          typography: {
+            body: {
+              fontSize: 'var(--fontSize-md)',
+              fontFamily: 'Roboto, var(--fontFamily-fallback)',
+            },
+          },
+        },
+        { prefix: 'foo', shouldSkipGeneratingVar: (keys) => keys[0] === 'typgoraphy' },
+      );
+      expect(parsedTheme.pxToRem(14)).to.equal('0.875rem');
+      expect(parsedTheme.typography).to.deep.equal({
+        body: {
+          fontSize: 'var(--foo-fontSize-md)',
+          fontFamily: 'Roboto, var(--foo-fontFamily-fallback)',
         },
       });
     });

--- a/test/regressions/fixtures/CssVarsProvider/CssVarsProviderJoy.js
+++ b/test/regressions/fixtures/CssVarsProvider/CssVarsProviderJoy.js
@@ -3,6 +3,7 @@ import { CssVarsProvider } from '@mui/joy/styles';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 
+// All buttons should look the same, otherwise, it means that multiple instances with different prefixes do not work.
 export default function VariantColorJoy() {
   return (
     <Box sx={{ display: 'flex', gap: 2 }}>

--- a/test/regressions/fixtures/CssVarsProvider/CssVarsProviderJoy.js
+++ b/test/regressions/fixtures/CssVarsProvider/CssVarsProviderJoy.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { CssVarsProvider } from '@mui/joy/styles';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+
+export default function VariantColorJoy() {
+  return (
+    <Box sx={{ display: 'flex', gap: 2 }}>
+      <CssVarsProvider>
+        <Button>Button</Button>
+      </CssVarsProvider>
+      <CssVarsProvider prefix="foo">
+        <Button>Button</Button>
+      </CssVarsProvider>
+      <CssVarsProvider prefix="bar">
+        <Button>Button</Button>
+      </CssVarsProvider>
+    </Box>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Based no #31138, there is a problem when `baseTheme` provided to `createCssVarsProvider` contains functions. Those functions are removed because of JSON.stringify to make the object fresh on every render (the logic inside `CssVarsProvider` mutate the object, so we need to make sure that the object is new on every call, otherwise the multiple `CssVarsProvider` on a single page would not work).

There are 2 possible ways to fix this:

1. receive `basedTheme` as a function that returns a new object 
2. fix the logic inside `CssVarsProvider` to not mutate the object

In this PR, I chose the 2nd option because it is safer. It guarantees that the object is new on every renders and developers do not need to be concerned about the theme they are passing.

> Note: the first option seems not a good idea because if the function returns the same object, we will face the same problem.

### **Performance**

From what I collect, there is no performance difference between **before** and **after**. Collected by capturing the time (in millisecond) that the logic used in each render (sample sizes are 5).

> Note: 4x & 6x is the CPU slowdown from devtool setting

**Before**
1x | 4x | 6x
-- | -- | --
2.39892578125 | 8.531982421875 | 11.440185546875
4.144775390625 | 9.327880859375 | 12.02197265625
2.445068359375 | 10.386962890625 | 12.864013671875
2.839111328125 | 8.4951171875 | 13.427001953125
2.4599609375 | 7.711669921875 | 12.79296875
  |   |  


**After**

1x | 4x | 6x
-- | -- | --
3.626220703125 | 8.1669921875 | 11.341064453125
2.31201171875 | 10.117919921875 | 12.72119140625
2.280029296875 | 9.003173828125 | 12.02099609375
2.296875 | 8.082763671875 | 12.14306640625
2.466064453125 | 7.845947265625 | 12.010009765625

### Test

Added regression test to make sure that multiple instances of `<CssVarsProvider>` with different prefix works.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
