### PR TITLE
[docs] Add missing import into tss-react migration guide

### DIFF
--- a/docs/data/material/guides/migration-v4/migration-v4.md
+++ b/docs/data/material/guides/migration-v4/migration-v4.md
@@ -2744,7 +2744,7 @@ yarn add tss-react
  import { render } from 'react-dom';
 -import { StylesProvider } from '@material-ui/core/styles';
 +import createCache from '@emotion/cache';
-+import { ThemeProvider } from '@mui/material/styles';
++import { CacheProvider } from "@emotion/react";
 
 +export const muiCache = createCache({
 +  'key': 'mui',


### PR DESCRIPTION
For tss-react migration guide: add missing import CacheProvider and replace unused ThemProvider import



- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
