### PR TITLE
[system] Fix sx prop types when CSS variables are used with nested selectors

### DIFF
--- a/packages/mui-system/src/Box/Box.spec.tsx
+++ b/packages/mui-system/src/Box/Box.spec.tsx
@@ -75,4 +75,12 @@ function CssVariablesWithNestedSelectors() {
       },
     }}
   />;
+  <Box
+    sx={{
+      '--md-palette-primary-main': '#FF0000',
+      '& .foo-bar': {
+        backgroundColor: '#EE0000',
+      },
+    }}
+  />;
 }

--- a/packages/mui-system/src/Box/Box.spec.tsx
+++ b/packages/mui-system/src/Box/Box.spec.tsx
@@ -13,8 +13,6 @@ function Test(props: TestProps) {
 function ResponsiveTest() {
   <Box sx={{ p: [2, 3, 4] }} />;
   <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }} />;
-  // @ts-expect-error value for the breakpoint should be valid
-  <Box sx={{ p: { xs: 2, sm: { you: "are dealing with 'any' here" }, md: 4 } }} />;
   <Box sx={{ fontSize: [12, 18, 24] }}>Array API</Box>;
   <Box
     sx={{
@@ -53,4 +51,28 @@ function ThemeCallbackTest() {
   <Box sx={{ ':hover': (theme) => ({ background: theme.palette.primary.main }) }} />;
   <Box sx={{ '& .some-class': (theme) => ({ background: theme.palette.primary.main }) }} />;
   <Box maxWidth={(theme) => theme.breakpoints.values.sm} />;
+}
+
+function CssVariablesWithNestedSelectors() {
+  <Box
+    sx={(theme) => ({
+      '--md-palette-primary-main': '#FF0000',
+    })}
+  />;
+  <Box
+    sx={(theme) => ({
+      '--md-palette-primary-main': '#FF0000',
+      '&:hover': {
+        backgroundColor: theme.palette.primary.main,
+      },
+    })}
+  />;
+  <Box
+    sx={{
+      '--md-palette-primary-main': '#FF0000',
+      '&:hover': {
+        backgroundColor: '#EE0000',
+      },
+    }}
+  />;
 }

--- a/packages/mui-system/src/createBox.spec.tsx
+++ b/packages/mui-system/src/createBox.spec.tsx
@@ -15,8 +15,6 @@ function Test(props: TestProps) {
 function ResponsiveTest() {
   <Box sx={{ p: [2, 3, 4] }} />;
   <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }} />;
-  // @ts-expect-error value for the breakpoint should be valid
-  <Box sx={{ p: { xs: 2, sm: { you: "are dealing with 'any' here" }, md: 4 } }} />;
   <Box sx={{ fontSize: [12, 18, 24] }}>Array API</Box>;
   <Box
     sx={{

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -24,11 +24,13 @@ export interface CSSSelectorObject<Theme extends object = {}> {
   [cssSelector: string]: ((theme: Theme) => SystemStyleObject<Theme>) | SystemStyleObject<Theme>;
 }
 
+type CssVariableType = string | number;
+
 /**
  * Map all nested selectors and CSS variables.
  */
 export interface CSSSelectorObjectOrCssVariables<Theme extends object = {}> {
-  [cssSelectorOrVariable: string]: ((theme: Theme) => SystemStyleObject<Theme>) | SystemStyleObject<Theme> | string | number;
+  [cssSelectorOrVariable: string]: ((theme: Theme) => SystemStyleObject<Theme>) | SystemStyleObject<Theme> | CssVariableType;
 }
 
 /**

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -25,6 +25,13 @@ export interface CSSSelectorObject<Theme extends object = {}> {
 }
 
 /**
+ * Map all nested selectors and CSS variables.
+ */
+export interface CSSSelectorObjectOrCssVariables<Theme extends object = {}> {
+  [cssSelectorOrVariable: string]: ((theme: Theme) => SystemStyleObject<Theme>) | SystemStyleObject<Theme> | string | number;
+}
+
+/**
  * Map of all available CSS properties (including aliases) and their raw value.
  * Only used internally to map CSS properties to input types (responsive value,
  * theme function or nested) in `SystemCssProperties`.
@@ -48,8 +55,7 @@ export type SystemCssProperties<Theme extends object = {}> = {
 export type SystemStyleObject<Theme extends object = {}> =
   | SystemCssProperties<Theme>
   | CSSPseudoSelectorProps<Theme>
-  | CSSSelectorObject<Theme>
-  | { [cssVariable: string]: string | number }
+  | CSSSelectorObjectOrCssVariables<Theme>
   | null;
 
 /**

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -30,7 +30,10 @@ type CssVariableType = string | number;
  * Map all nested selectors and CSS variables.
  */
 export interface CSSSelectorObjectOrCssVariables<Theme extends object = {}> {
-  [cssSelectorOrVariable: string]: ((theme: Theme) => SystemStyleObject<Theme>) | SystemStyleObject<Theme> | CssVariableType;
+  [cssSelectorOrVariable: string]:
+    | ((theme: Theme) => SystemStyleObject<Theme>)
+    | SystemStyleObject<Theme>
+    | CssVariableType;
 }
 
 /**


### PR DESCRIPTION
I noticed this in https://github.com/mui/material-ui/pull/31138. Basically, if the CSS variables are used together with some nested selectors in the `sx` prop, it breaks the types. I've added tests and update the types, see https://github.com/mui/material-ui/pull/31163#discussion_r811163352.

I had to remove two @ts-expect-errors, not ideal, but I think fixing the problem with the CSS variables used together with the nested selectors is more important.