### PR TITLE
[AvatarGroup] Fix misalignment with non-default spacing

### DIFF
--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -134,11 +134,13 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
       {children
         .slice(0, maxAvatars)
         .reverse()
-        .map((child) => {
+        .map((child, index) => {
           return React.cloneElement(child, {
             className: clsx(child.props.className, classes.avatar),
             style: {
-              marginLeft,
+              // Consistent with "&:last-child" styling for the default spacing,
+              // we do not apply custom marginLeft spacing on the last child
+              marginLeft: index === maxAvatars - 1 ? undefined : marginLeft,
               ...child.props.style,
             },
             variant: child.props.variant || variant,


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/29641

The `marginLeft` style (applied only for custom `spacing`) should be applied on all but the last element of the group, in order to avoid misalignment of the Avatar children. This makes the non-default spacing (such as `spacing="small"` or `spacing={10}`) consistent with the behavior of the default `spacing="medium"` CSS, which leaves the margin-left as-is for the `:last-child`.

### Before
<img width="171" alt="Screen Shot 2022-02-21 at 10 57 07 AM" src="https://user-images.githubusercontent.com/1647130/155013384-6b6dd73a-e271-433e-8d36-3e87b2f2e41b.png">


### After

<img width="159" alt="Screen Shot 2022-02-21 at 10 59 03 AM" src="https://user-images.githubusercontent.com/1647130/155013378-952e060b-fefa-47bb-a601-e017631696a3.png">

(This demo uses default spacing, then `spacing={10}`, then `spacing={-10}`, then `spacing="small"`.)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
