### PR TITLE
[Joy] Add `Link` component

### DIFF
--- a/docs/pages/experiments/joy/link.tsx
+++ b/docs/pages/experiments/joy/link.tsx
@@ -1,0 +1,103 @@
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import Link from '@mui/joy/Link';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import Typography from '@mui/joy/Typography';
+import * as React from 'react';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+      sx={{ '--Button-gutter': '0.25rem', minWidth: 'var(--Button-minHeight)' }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+export default function JoyButton() {
+  const buttonProps = {
+    variant: ['text', 'outlined', 'light', 'contained'],
+    color: ['primary', 'neutral', 'danger', 'info', 'success', 'warning'],
+    level: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body1', 'body2', 'body3'],
+    underline: ['hover', 'always', 'none'],
+  } as const;
+  return (
+    <CssVarsProvider
+      theme={{
+        components: {
+          MuiSvgIcon: {
+            defaultProps: {
+              fontSize: 'xl',
+            },
+            styleOverrides: {
+              root: ({ ownerState, theme }) => ({
+                ...(ownerState.fontSize &&
+                  ownerState.fontSize !== 'inherit' && {
+                    fontSize: theme.vars.fontSize[ownerState.fontSize],
+                  }),
+                ...(ownerState.color &&
+                  ownerState.color !== 'inherit' && {
+                    color: theme.vars.palette[ownerState.color].textColor,
+                  }),
+              }),
+            },
+          },
+        },
+      }}
+    >
+      <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
+        <Box sx={{ px: 3, pb: 4 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+          {Object.entries(buttonProps).map(([propName, propValue]) => (
+            <Box
+              key={propName}
+              sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+            >
+              <Typography level="body2" sx={{ fontWeight: 'bold' }}>
+                {propName}
+              </Typography>
+              {propValue.map((value) => (
+                <Box
+                  key={value}
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Link {...{ [propName]: value }}>Link</Link>
+                  <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                    {value || 'default'}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </CssVarsProvider>
+  );
+}

--- a/packages/mui-joy/src/Link/Link.spec.tsx
+++ b/packages/mui-joy/src/Link/Link.spec.tsx
@@ -1,0 +1,51 @@
+import Link from '@mui/joy/Link';
+import * as React from 'react';
+
+<Link />;
+<Link component="div" />;
+
+// `variant`
+<Link variant="text" />;
+<Link variant="light" />;
+<Link variant="outlined" />;
+<Link variant="contained" />;
+
+// `color`
+<Link color="primary" />;
+<Link color="danger" />;
+<Link color="info" />;
+<Link color="success" />;
+<Link color="warning" />;
+<Link color="neutral" />;
+
+// `level`
+<Link level="h1" />;
+<Link level="h2" />;
+<Link level="h3" />;
+<Link level="h4" />;
+<Link level="h5" />;
+<Link level="h6" />;
+<Link level="body1" />;
+<Link level="body2" />;
+<Link level="body3" />;
+<Link level="inherit" />;
+
+// `underline`
+<Link underline="always" />;
+<Link underline="none" />;
+<Link underline="hover" />;
+
+// @ts-expect-error there is no variant `filled`
+<Link variant="filled" />;
+
+// @ts-expect-error there is no color `secondary`
+<Link color="secondary" />;
+
+// @ts-expect-error there is no level `h7`
+<Link level="h7" />;
+
+// @ts-expect-error there is no level `body4`
+<Link level="body4" />;
+
+// @ts-expect-error there is no underline `never`
+<Link underline="never" />;

--- a/packages/mui-joy/src/Link/Link.spec.tsx
+++ b/packages/mui-joy/src/Link/Link.spec.tsx
@@ -19,7 +19,6 @@ import * as React from 'react';
 <Link color="neutral" />;
 
 // `level`
-<Link level="h1" />;
 <Link level="h2" />;
 <Link level="h3" />;
 <Link level="h4" />;

--- a/packages/mui-joy/src/Link/Link.test.js
+++ b/packages/mui-joy/src/Link/Link.test.js
@@ -27,7 +27,13 @@ describe('<Link />', () => {
     refInstanceof: window.HTMLAnchorElement,
     testVariantProps: { color: 'primary', variant: 'text' },
     testStateOverrides: { prop: 'underline', value: 'always', styleKey: 'underlineAlways' },
-    skip: ['classesRoot', 'componentsProp', 'themeDefaultProps', 'propsSpread'],
+    skip: [
+      'classesRoot',
+      'componentsProp',
+      'themeDefaultProps',
+      'propsSpread',
+      'themeStyleOverrides',
+    ],
   }));
 
   it('should render children', () => {

--- a/packages/mui-joy/src/Link/Link.test.js
+++ b/packages/mui-joy/src/Link/Link.test.js
@@ -4,6 +4,7 @@ import { spy } from 'sinon';
 import { act, createRenderer, fireEvent, describeConformance } from 'test/utils';
 import Typography from '@mui/joy/Typography';
 import Link, { linkClasses as classes } from '@mui/joy/Link';
+import { ThemeProvider } from '@mui/joy/styles';
 
 function focusVisible(element) {
   act(() => {
@@ -20,6 +21,7 @@ describe('<Link />', () => {
     classes,
     inheritComponent: Typography,
     render,
+    ThemeProvider,
     muiName: 'MuiLink',
     refInstanceof: window.HTMLAnchorElement,
     testVariantProps: { color: 'primary', variant: 'text' },
@@ -77,14 +79,17 @@ describe('<Link />', () => {
   });
 
   describe('prop: variant', () => {
-    it('text by default', () => {
+    it('undefined by default', () => {
       const { getByTestId } = render(
         <Link href="/" data-testid="root">
           Hello World
         </Link>,
       );
 
-      expect(getByTestId('root')).to.have.class(classes.variantText);
+      expect(getByTestId('root')).not.to.have.class(classes.variantText);
+      expect(getByTestId('root')).not.to.have.class(classes.variantOutlined);
+      expect(getByTestId('root')).not.to.have.class(classes.variantLight);
+      expect(getByTestId('root')).not.to.have.class(classes.variantContained);
     });
 
     it('adds a text class', () => {

--- a/packages/mui-joy/src/Link/Link.test.js
+++ b/packages/mui-joy/src/Link/Link.test.js
@@ -5,6 +5,7 @@ import { act, createRenderer, fireEvent, describeConformance } from 'test/utils'
 import Typography from '@mui/joy/Typography';
 import Link, { linkClasses as classes } from '@mui/joy/Link';
 import { ThemeProvider } from '@mui/joy/styles';
+import { unstable_capitalize as capitalize } from '@mui/utils';
 
 function focusVisible(element) {
   act(() => {
@@ -92,44 +93,16 @@ describe('<Link />', () => {
       expect(getByTestId('root')).not.to.have.class(classes.variantContained);
     });
 
-    it('adds a text class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" variant="text">
-          Hello World
-        </Link>,
-      );
+    ['text', 'outlined', 'light', 'contained'].forEach((variant) => {
+      it(`should render ${variant}`, () => {
+        const { getByTestId } = render(
+          <Link href="/" data-testid="root" variant={variant}>
+            Hello World
+          </Link>,
+        );
 
-      expect(getByTestId('root')).to.have.class(classes.variantText);
-    });
-
-    it('adds a outlined class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" variant="outlined">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.variantOutlined);
-    });
-
-    it('adds a light class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" variant="light">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.variantLight);
-    });
-
-    it('adds a contained class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" variant="contained">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.variantContained);
+        expect(getByTestId('root')).to.have.class(classes[`variant${capitalize(variant)}`]);
+      });
     });
   });
 
@@ -144,64 +117,16 @@ describe('<Link />', () => {
       expect(getByTestId('root')).to.have.class(classes.colorPrimary);
     });
 
-    it('adds a primary class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" color="primary">
-          Hello World
-        </Link>,
-      );
+    ['primary', 'success', 'info', 'danger', 'neutral', 'warning'].forEach((color) => {
+      it(`should render ${color}`, () => {
+        const { getByTestId } = render(
+          <Link href="/" data-testid="root" color={color}>
+            Hello World
+          </Link>,
+        );
 
-      expect(getByTestId('root')).to.have.class(classes.colorPrimary);
-    });
-
-    it('adds a neutral class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" color="neutral">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.colorNeutral);
-    });
-
-    it('adds a info class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" color="info">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.colorInfo);
-    });
-
-    it('adds a success class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" color="success">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.colorSuccess);
-    });
-
-    it('adds a warning class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" color="warning">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.colorWarning);
-    });
-
-    it('adds a danger class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" color="danger">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.colorDanger);
+        expect(getByTestId('root')).to.have.class(classes[`color${capitalize(color)}`]);
+      });
     });
   });
 
@@ -216,84 +141,16 @@ describe('<Link />', () => {
       expect(getByTestId('root')).have.class(classes.body1);
     });
 
-    it('adds a body2 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="body2">
-          Hello World
-        </Link>,
-      );
+    ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body1', 'body2', 'body3'].forEach((level) => {
+      it(`should render ${level}`, () => {
+        const { getByTestId } = render(
+          <Link href="/" data-testid="root" level={level}>
+            Hello World
+          </Link>,
+        );
 
-      expect(getByTestId('root')).to.have.class(classes.body2);
-    });
-
-    it('adds a body3 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="body3">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.body3);
-    });
-
-    it('adds a h1 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="h1">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.h1);
-    });
-
-    it('adds a h2 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="h2">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.h2);
-    });
-
-    it('adds a h3 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="h3">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.h3);
-    });
-
-    it('adds a h4 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="h4">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.h4);
-    });
-
-    it('adds a h5 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="h5">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.h5);
-    });
-
-    it('adds a h6 class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" level="h6">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).to.have.class(classes.h6);
+        expect(getByTestId('root')).to.have.class(classes[level]);
+      });
     });
   });
 
@@ -308,24 +165,16 @@ describe('<Link />', () => {
       expect(getByTestId('root')).have.class(classes.underlineHover);
     });
 
-    it('adds a none class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" underline="none">
-          Hello World
-        </Link>,
-      );
+    ['none', 'always', 'hover'].forEach((underline) => {
+      it(`should render ${underline}`, () => {
+        const { getByTestId } = render(
+          <Link href="/" data-testid="root" underline={underline}>
+            Hello World
+          </Link>,
+        );
 
-      expect(getByTestId('root')).have.class(classes.underlineNone);
-    });
-
-    it('adds a hover class', () => {
-      const { getByTestId } = render(
-        <Link href="/" data-testid="root" underline="hover">
-          Hello World
-        </Link>,
-      );
-
-      expect(getByTestId('root')).have.class(classes.underlineHover);
+        expect(getByTestId('root')).to.have.class(classes[`underline${capitalize(underline)}`]);
+      });
     });
   });
 });

--- a/packages/mui-joy/src/Link/Link.test.js
+++ b/packages/mui-joy/src/Link/Link.test.js
@@ -298,14 +298,14 @@ describe('<Link />', () => {
   });
 
   describe('prop: underline', () => {
-    it('always by default', () => {
+    it('hover by default', () => {
       const { getByTestId } = render(
         <Link href="/" data-testid="root">
           Hello World
         </Link>,
       );
 
-      expect(getByTestId('root')).have.class(classes.underlineAlways);
+      expect(getByTestId('root')).have.class(classes.underlineHover);
     });
 
     it('adds a none class', () => {

--- a/packages/mui-joy/src/Link/Link.test.js
+++ b/packages/mui-joy/src/Link/Link.test.js
@@ -1,0 +1,326 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { act, createRenderer, fireEvent, describeConformance } from 'test/utils';
+import Typography from '@mui/joy/Typography';
+import Link, { linkClasses as classes } from '@mui/joy/Link';
+
+function focusVisible(element) {
+  act(() => {
+    element.blur();
+    document.dispatchEvent(new window.Event('keydown'));
+    element.focus();
+  });
+}
+
+describe('<Link />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Link href="/">Home</Link>, () => ({
+    classes,
+    inheritComponent: Typography,
+    render,
+    muiName: 'MuiLink',
+    refInstanceof: window.HTMLAnchorElement,
+    testVariantProps: { color: 'primary', variant: 'text' },
+    testStateOverrides: { prop: 'underline', value: 'always', styleKey: 'underlineAlways' },
+    skip: ['classesRoot', 'componentsProp', 'themeDefaultProps', 'propsSpread'],
+  }));
+
+  it('should render children', () => {
+    const { queryByText } = render(<Link href="/">Home</Link>);
+
+    expect(queryByText('Home')).not.to.equal(null);
+  });
+
+  describe('event callbacks', () => {
+    it('should fire event callbacks', () => {
+      const events = ['onBlur', 'onFocus'];
+
+      const handlers = events.reduce((result, n) => {
+        result[n] = spy();
+        return result;
+      }, {});
+
+      const { container } = render(
+        <Link href="/" {...handlers}>
+          Home
+        </Link>,
+      );
+      const anchor = container.querySelector('a');
+
+      events.forEach((n) => {
+        const event = n.charAt(2).toLowerCase() + n.slice(3);
+        fireEvent[event](anchor);
+        expect(handlers[n].callCount).to.equal(1);
+      });
+    });
+  });
+
+  describe('keyboard focus', () => {
+    it('should add the focusVisible class when focused', () => {
+      const { container } = render(<Link href="/">Home</Link>);
+      const anchor = container.querySelector('a');
+
+      expect(anchor).not.to.have.class(classes.focusVisible);
+
+      focusVisible(anchor);
+
+      expect(anchor).to.have.class(classes.focusVisible);
+
+      act(() => {
+        anchor.blur();
+      });
+
+      expect(anchor).not.to.have.class(classes.focusVisible);
+    });
+  });
+
+  describe('prop: variant', () => {
+    it('text by default', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.variantText);
+    });
+
+    it('adds a text class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" variant="text">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.variantText);
+    });
+
+    it('adds a outlined class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" variant="outlined">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.variantOutlined);
+    });
+
+    it('adds a light class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" variant="light">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.variantLight);
+    });
+
+    it('adds a contained class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" variant="contained">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.variantContained);
+    });
+  });
+
+  describe('prop: color', () => {
+    it('adds a primary class by default', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorPrimary);
+    });
+
+    it('adds a primary class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" color="primary">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorPrimary);
+    });
+
+    it('adds a neutral class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" color="neutral">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorNeutral);
+    });
+
+    it('adds a info class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" color="info">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorInfo);
+    });
+
+    it('adds a success class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" color="success">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorSuccess);
+    });
+
+    it('adds a warning class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" color="warning">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorWarning);
+    });
+
+    it('adds a danger class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" color="danger">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.colorDanger);
+    });
+  });
+
+  describe('prop: level', () => {
+    it('body1 by default', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).have.class(classes.body1);
+    });
+
+    it('adds a body2 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="body2">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.body2);
+    });
+
+    it('adds a body3 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="body3">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.body3);
+    });
+
+    it('adds a h1 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="h1">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.h1);
+    });
+
+    it('adds a h2 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="h2">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.h2);
+    });
+
+    it('adds a h3 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="h3">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.h3);
+    });
+
+    it('adds a h4 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="h4">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.h4);
+    });
+
+    it('adds a h5 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="h5">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.h5);
+    });
+
+    it('adds a h6 class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" level="h6">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.h6);
+    });
+  });
+
+  describe('prop: underline', () => {
+    it('always by default', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).have.class(classes.underlineAlways);
+    });
+
+    it('adds a none class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" underline="none">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).have.class(classes.underlineNone);
+    });
+
+    it('adds a hover class', () => {
+      const { getByTestId } = render(
+        <Link href="/" data-testid="root" underline="hover">
+          Hello World
+        </Link>,
+      );
+
+      expect(getByTestId('root')).have.class(classes.underlineHover);
+    });
+  });
+});

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -66,6 +66,10 @@ const LinkRoot = styled(Typography, {
         margin: 0, // Remove the margin in Safari
         borderRadius: 0,
         padding: 0, // Remove the padding in Firefox
+        ...(!!ownerState.variant && {
+          paddingInline: '0.25em', // better than left, right because it also works with writing mode.
+          marginInline: '-0.25em',
+        }),
         cursor: 'pointer',
         color: theme.vars.palette[ownerState.color!]?.textColor,
         userSelect: 'none',
@@ -100,7 +104,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     onBlur,
     onFocus,
     level = 'body1',
-    underline = 'always',
+    underline = 'hover',
     variant,
     ...other
   } = props;
@@ -215,7 +219,7 @@ Link.propTypes /* remove-proptypes */ = {
   onFocus: PropTypes.func,
   /**
    * Controls when the link should have an underline.
-   * @default 'always'
+   * @default 'hover'
    */
   underline: PropTypes.oneOf(['always', 'hover', 'none']),
   /**

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -1,0 +1,212 @@
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { OverridableComponent } from '@mui/types';
+import {
+  unstable_capitalize as capitalize,
+  unstable_useForkRef as useForkRef,
+  unstable_useIsFocusVisible as useIsFocusVisible,
+} from '@mui/utils';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import styled from '../styles/styled';
+import useThemeProps from '../styles/useThemeProps';
+import Typography from '../Typography';
+import linkClasses, { getLinkUtilityClass } from './linkClasses';
+import { LinkProps, LinkTypeMap } from './LinkProps';
+
+const useUtilityClasses = (ownerState: LinkProps) => {
+  const { component, level, color, variant, underline, focusVisible, disabled } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      color && `color${capitalize(color)}`,
+      disabled && 'disabled',
+      focusVisible && 'focusVisible',
+      level,
+      underline && `underline${capitalize(underline)}`,
+      variant && `variant${capitalize(variant)}`,
+      component === 'button' && 'button',
+    ],
+  };
+
+  return composeClasses(slots, getLinkUtilityClass, {});
+};
+
+const LinkRoot = styled(Typography, {
+  name: 'MuiLink',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: LinkProps }>(({ theme, ownerState }) => {
+  return [
+    {
+      ...(ownerState.underline === 'none' && {
+        textDecoration: 'none',
+      }),
+      ...(ownerState.underline === 'hover' && {
+        textDecoration: 'none',
+        '&:hover': {
+          textDecoration: 'underline',
+        },
+      }),
+      ...(ownerState.underline === 'always' && {
+        textDecoration: 'underline',
+        // textDecorationColor: color !== 'inherit' ? alpha(color, 0.4) : undefined,
+        '&:hover': {
+          textDecorationColor: 'inherit',
+        },
+      }),
+      // Same reset as ButtonBase.root
+      ...(ownerState.component === 'button' && {
+        position: 'relative',
+        WebkitTapHighlightColor: 'transparent',
+        backgroundColor: 'transparent', // Reset default value
+        // We disable the focus ring for mouse, touch and keyboard users.
+        outline: 0,
+        border: 0,
+        margin: 0, // Remove the margin in Safari
+        borderRadius: 0,
+        padding: 0, // Remove the padding in Firefox
+        cursor: 'pointer',
+        userSelect: 'none',
+        verticalAlign: 'middle',
+        MozAppearance: 'none', // Reset
+        WebkitAppearance: 'none', // Reset
+        '&::-moz-focus-inner': {
+          borderStyle: 'none', // Remove Firefox dotted outline.
+        },
+        [`&.${linkClasses.focusVisible}`]: {
+          outline: 'auto',
+        },
+      }),
+    },
+    ownerState.level && ownerState.level !== 'inherit' && theme.typography[ownerState.level],
+    theme.variants[ownerState.variant!]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+  ];
+});
+
+const Link = React.forwardRef(function Link(inProps, ref) {
+  const props = useThemeProps<typeof inProps & LinkProps>({
+    props: inProps,
+    name: 'MuiLink',
+  });
+
+  const {
+    className,
+    color = 'primary',
+    component = 'a',
+    disabled = false,
+    onBlur,
+    onFocus,
+    level = 'body1',
+    underline = 'always',
+    variant = 'text',
+    ...other
+  } = props;
+
+  const {
+    isFocusVisibleRef,
+    onBlur: handleBlurVisible,
+    onFocus: handleFocusVisible,
+    ref: focusVisibleRef,
+  } = useIsFocusVisible();
+  const [focusVisible, setFocusVisible] = React.useState<boolean>(false);
+  const handlerRef = useForkRef(ref, focusVisibleRef) as React.RefObject<HTMLSpanElement>;
+  const handleBlur = (event: React.FocusEvent<HTMLAnchorElement>) => {
+    handleBlurVisible(event);
+    if (isFocusVisibleRef.current === false) {
+      setFocusVisible(false);
+    }
+    if (onBlur) {
+      onBlur(event);
+    }
+  };
+  const handleFocus = (event: React.FocusEvent<HTMLAnchorElement>) => {
+    handleFocusVisible(event);
+    if (isFocusVisibleRef.current === true) {
+      setFocusVisible(true);
+    }
+    if (onFocus) {
+      onFocus(event);
+    }
+  };
+
+  const ownerState = {
+    ...props,
+    color,
+    component,
+    disabled,
+    focusVisible,
+    underline,
+    variant,
+    level,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <LinkRoot
+      className={clsx(classes.root, className)}
+      as={component}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      ref={handlerRef}
+      ownerState={ownerState}
+      {...other}
+    />
+  );
+}) as OverridableComponent<LinkTypeMap>;
+
+Link.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the link.
+   * @default 'primary'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['context', 'danger', 'info', 'neutral', 'primary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
+  /**
+   * Controls when the link should have an underline.
+   * @default 'always'
+   */
+  underline: PropTypes.oneOf(['always', 'hover', 'none']),
+  /**
+   * Applies the theme link styles.
+   * @default 'text'
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['contained', 'light', 'outlined', 'text']),
+    PropTypes.string,
+  ]),
+} as any;
+
+export default Link;

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -51,7 +51,6 @@ const LinkRoot = styled(Typography, {
       }),
       ...(ownerState.underline === 'always' && {
         textDecoration: 'underline',
-        // textDecorationColor: color !== 'inherit' ? alpha(color, 0.4) : undefined,
         '&:hover': {
           textDecorationColor: 'inherit',
         },
@@ -68,6 +67,7 @@ const LinkRoot = styled(Typography, {
         borderRadius: 0,
         padding: 0, // Remove the padding in Firefox
         cursor: 'pointer',
+        color: theme.vars.palette[ownerState.color!]?.textColor,
         userSelect: 'none',
         verticalAlign: 'middle',
         MozAppearance: 'none', // Reset
@@ -75,9 +75,7 @@ const LinkRoot = styled(Typography, {
         '&::-moz-focus-inner': {
           borderStyle: 'none', // Remove Firefox dotted outline.
         },
-        [`&.${linkClasses.focusVisible}`]: {
-          outline: 'auto',
-        },
+        [`&.${linkClasses.focusVisible}`]: theme.focus.default,
       }),
     },
     ownerState.level && ownerState.level !== 'inherit' && theme.typography[ownerState.level],
@@ -103,7 +101,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     onFocus,
     level = 'body1',
     underline = 'always',
-    variant = 'text',
+    variant,
     ...other
   } = props;
 

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -15,7 +15,7 @@ import linkClasses, { getLinkUtilityClass } from './linkClasses';
 import { LinkProps, LinkTypeMap } from './LinkProps';
 
 const useUtilityClasses = (ownerState: LinkProps) => {
-  const { component, level, color, variant, underline, focusVisible, disabled } = ownerState;
+  const { level, color, variant, underline, focusVisible, disabled } = ownerState;
 
   const slots = {
     root: [
@@ -26,7 +26,6 @@ const useUtilityClasses = (ownerState: LinkProps) => {
       level,
       underline && `underline${capitalize(underline)}`,
       variant && `variant${capitalize(variant)}`,
-      component === 'button' && 'button',
     ],
   };
 

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -187,6 +187,27 @@ Link.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Applies the theme typography styles.
+   * @default 'body1'
+   */
+  level: PropTypes.oneOf([
+    'body1',
+    'body2',
+    'body3',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'inherit',
+  ]),
+  /**
    * @ignore
    */
   onBlur: PropTypes.func,

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -56,30 +56,27 @@ const LinkRoot = styled(Typography, {
           textDecorationColor: 'inherit',
         },
       }),
-      // Same reset as ButtonBase.root
-      ...(ownerState.component === 'button' && {
-        position: 'relative',
-        WebkitTapHighlightColor: 'transparent',
-        backgroundColor: 'transparent', // Reset default value
-        // We disable the focus ring for mouse, touch and keyboard users.
-        outline: 0,
-        border: 0,
-        margin: 0, // Remove the margin in Safari
-        borderRadius: 0,
-        padding: 0, // Remove the padding in Firefox
-        ...(!!ownerState.variant && {
-          paddingInline: '0.25em', // better than left, right because it also works with writing mode.
-          marginInline: '-0.25em',
-        }),
-        userSelect: 'none',
-        verticalAlign: 'middle',
-        MozAppearance: 'none', // Reset
-        WebkitAppearance: 'none', // Reset
-        '&::-moz-focus-inner': {
-          borderStyle: 'none', // Remove Firefox dotted outline.
-        },
-        [`&.${linkClasses.focusVisible}`]: theme.focus.default,
+      position: 'relative',
+      WebkitTapHighlightColor: 'transparent',
+      backgroundColor: 'transparent', // Reset default value
+      // We disable the focus ring for mouse, touch and keyboard users.
+      outline: 0,
+      border: 0,
+      margin: 0, // Remove the margin in Safari
+      borderRadius: 0,
+      padding: 0, // Remove the padding in Firefox
+      ...(!!ownerState.variant && {
+        paddingInline: '0.25em', // better than left, right because it also works with writing mode.
+        marginInline: '-0.25em',
       }),
+      userSelect: 'none',
+      verticalAlign: 'middle',
+      MozAppearance: 'none', // Reset
+      WebkitAppearance: 'none', // Reset
+      '&::-moz-focus-inner': {
+        borderStyle: 'none', // Remove Firefox dotted outline.
+      },
+      [`&.${linkClasses.focusVisible}`]: theme.focus.default,
       color: theme.vars.palette[ownerState.color!]?.textColor,
       cursor: 'pointer',
     },

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -82,8 +82,7 @@ const LinkRoot = styled(Typography, {
     ownerState.variant && theme.variants[ownerState.variant]?.[ownerState.color!],
     ownerState.variant && theme.variants[`${ownerState.variant}Hover`]?.[ownerState.color!],
     ownerState.variant && theme.variants[`${ownerState.variant}Active`]?.[ownerState.color!],
-    ownerState.variant &&
-      theme.variants[`${ownerState.variant || 'text'}Disabled`]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant || 'text'}Disabled`]?.[ownerState.color!],
   ];
 });
 

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -40,6 +40,7 @@ const LinkRoot = styled(Typography, {
 })<{ ownerState: LinkProps }>(({ theme, ownerState }) => {
   return [
     {
+      ...(ownerState.level && ownerState.level !== 'inherit' && theme.typography[ownerState.level]),
       ...(ownerState.underline === 'none' && {
         textDecoration: 'none',
       }),
@@ -70,8 +71,6 @@ const LinkRoot = styled(Typography, {
           paddingInline: '0.25em', // better than left, right because it also works with writing mode.
           marginInline: '-0.25em',
         }),
-        cursor: 'pointer',
-        color: theme.vars.palette[ownerState.color!]?.textColor,
         userSelect: 'none',
         verticalAlign: 'middle',
         MozAppearance: 'none', // Reset
@@ -81,12 +80,14 @@ const LinkRoot = styled(Typography, {
         },
         [`&.${linkClasses.focusVisible}`]: theme.focus.default,
       }),
+      color: theme.vars.palette[ownerState.color!]?.textColor,
+      cursor: 'pointer',
     },
-    ownerState.level && ownerState.level !== 'inherit' && theme.typography[ownerState.level],
-    theme.variants[ownerState.variant!]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+    ownerState.variant && theme.variants[ownerState.variant]?.[ownerState.color!],
+    ownerState.variant && theme.variants[`${ownerState.variant}Hover`]?.[ownerState.color!],
+    ownerState.variant && theme.variants[`${ownerState.variant}Active`]?.[ownerState.color!],
+    ownerState.variant &&
+      theme.variants[`${ownerState.variant || 'text'}Disabled`]?.[ownerState.color!],
   ];
 });
 

--- a/packages/mui-joy/src/Link/LinkProps.ts
+++ b/packages/mui-joy/src/Link/LinkProps.ts
@@ -19,7 +19,7 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
      * The color of the link.
      * @default 'primary'
      */
-    color?: OverridableStringUnion<ColorPaletteProp, LinkPropsColorOverrides>;
+    color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, LinkPropsColorOverrides>;
     /**
      * If `true`, the component is disabled.
      * @default false

--- a/packages/mui-joy/src/Link/LinkProps.ts
+++ b/packages/mui-joy/src/Link/LinkProps.ts
@@ -36,7 +36,7 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
     sx?: SxProps;
     /**
      * Controls when the link should have an underline.
-     * @default 'always'
+     * @default 'hover'
      */
     underline?: 'none' | 'hover' | 'always';
     /**

--- a/packages/mui-joy/src/Link/LinkProps.ts
+++ b/packages/mui-joy/src/Link/LinkProps.ts
@@ -1,0 +1,57 @@
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import React from 'react';
+import { SxProps } from '../styles/defaultTheme';
+import { ColorPaletteProp, TypographySystem, VariantProp } from '../styles/types';
+
+export type LinkSlot = 'root';
+
+export interface LinkPropsVariantOverrides {}
+
+export interface LinkPropsColorOverrides {}
+
+export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
+  props: P & {
+    /**
+     * The content of the component.
+     */
+    children?: React.ReactNode;
+    /**
+     * The color of the link.
+     * @default 'primary'
+     */
+    color?: OverridableStringUnion<ColorPaletteProp, LinkPropsColorOverrides>;
+    /**
+     * If `true`, the component is disabled.
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * Applies the theme typography styles.
+     * @default 'body1'
+     */
+    level?: keyof TypographySystem | 'inherit';
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps;
+    /**
+     * Controls when the link should have an underline.
+     * @default 'always'
+     */
+    underline?: 'none' | 'hover' | 'always';
+    /**
+     * Applies the theme link styles.
+     * @default 'text'
+     */
+    variant?: OverridableStringUnion<VariantProp, LinkPropsVariantOverrides>;
+  };
+  defaultComponent: D;
+}
+
+export type LinkProps<
+  D extends React.ElementType = LinkTypeMap['defaultComponent'],
+  P = {
+    component?: React.ElementType;
+    focusVisible?: boolean;
+  },
+> = OverrideProps<LinkTypeMap<P, D>, D>;

--- a/packages/mui-joy/src/Link/index.ts
+++ b/packages/mui-joy/src/Link/index.ts
@@ -1,0 +1,4 @@
+export { default } from './Link';
+export * from './linkClasses';
+export { default as linkClasses } from './linkClasses';
+export * from './LinkProps';

--- a/packages/mui-joy/src/Link/linkClasses.ts
+++ b/packages/mui-joy/src/Link/linkClasses.ts
@@ -35,6 +35,24 @@ export interface LinkClasses {
   underlineHover: string;
   /** Styles applied to the root element if `underline="always"`. */
   underlineAlways: string;
+  /** Styles applied to the root element if `level="h1"`. */
+  h1: string;
+  /** Styles applied to the root element if `level="h2"`. */
+  h2: string;
+  /** Styles applied to the root element if `level="h3"`. */
+  h3: string;
+  /** Styles applied to the root element if `level="h4"`. */
+  h4: string;
+  /** Styles applied to the root element if `level="h5"`. */
+  h5: string;
+  /** Styles applied to the root element if `level="h6"`. */
+  h6: string;
+  /** Styles applied to the root element if `level="body1"`. */
+  body1: string;
+  /** Styles applied to the root element if `level="body2"`. */
+  body2: string;
+  /** Styles applied to the root element if `level="body3"`. */
+  body3: string;
 }
 
 export type LinkClassKey = keyof LinkClasses;
@@ -62,6 +80,15 @@ const linkClasses: LinkClasses = generateUtilityClasses('MuiLink', [
   'underlineNone',
   'underlineHover',
   'underlineAlways',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'body1',
+  'body2',
+  'body3',
 ]);
 
 export default linkClasses;

--- a/packages/mui-joy/src/Link/linkClasses.ts
+++ b/packages/mui-joy/src/Link/linkClasses.ts
@@ -3,8 +3,6 @@ import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 export interface LinkClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element if `component="button"`. */
-  button: string;
   /** Styles applied to the root element if `color="primary"`. */
   colorPrimary: string;
   /** Styles applied to the root element if `color="neutral"`. */
@@ -63,7 +61,6 @@ export function getLinkUtilityClass(slot: string): string {
 
 const linkClasses: LinkClasses = generateUtilityClasses('MuiLink', [
   'root',
-  'button',
   'disabled',
   'focusVisible',
   'colorPrimary',

--- a/packages/mui-joy/src/Link/linkClasses.ts
+++ b/packages/mui-joy/src/Link/linkClasses.ts
@@ -1,0 +1,67 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export interface LinkClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `component="button"`. */
+  button: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="neutral"`. */
+  colorNeutral: string;
+  /** Styles applied to the root element if `color="danger"`. */
+  colorDanger: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** State class applied to the root element if the link is keyboard focused. */
+  focusVisible: string;
+  /** Styles applied to the root element if `variant="text"`. */
+  variantText: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  variantOutlined: string;
+  /** Styles applied to the root element if `variant="light"`. */
+  variantLight: string;
+  /** Styles applied to the root element if `variant="contained"`. */
+  variantContained: string;
+  /** Styles applied to the root element if `underline="none"`. */
+  underlineNone: string;
+  /** Styles applied to the root element if `underline="hover"`. */
+  underlineHover: string;
+  /** Styles applied to the root element if `underline="always"`. */
+  underlineAlways: string;
+}
+
+export type LinkClassKey = keyof LinkClasses;
+
+export function getLinkUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiLink', slot);
+}
+
+const linkClasses: LinkClasses = generateUtilityClasses('MuiLink', [
+  'root',
+  'button',
+  'disabled',
+  'focusVisible',
+  'colorPrimary',
+  'colorNeutral',
+  'colorDanger',
+  'colorInfo',
+  'colorSuccess',
+  'colorWarning',
+  'focusVisible',
+  'variantText',
+  'variantOutlined',
+  'variantLight',
+  'variantContained',
+  'underlineNone',
+  'underlineHover',
+  'underlineAlways',
+]);
+
+export default linkClasses;

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -13,6 +13,9 @@ export * from './Switch';
 export { default as SvgIcon } from './SvgIcon';
 export * from './SvgIcon';
 
+export { default as Link } from './Link';
+export * from './Link';
+
 export { default as List } from './List';
 export * from './List';
 

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -10,7 +10,7 @@ import { ListItemButtonProps, ListItemButtonSlot } from '../ListItemButton/ListI
 import { ListItemContentProps, ListItemContentSlot } from '../ListItemContent/ListItemContentProps';
 import {
   ListItemDecoratorProps,
-  ListItemDecoratorSlot
+  ListItemDecoratorSlot,
 } from '../ListItemDecorator/ListItemDecoratorProps';
 import { SheetProps, SheetSlot } from '../Sheet/SheetProps';
 import { SvgIconProps, SvgIconSlot } from '../SvgIcon/SvgIconProps';
@@ -84,6 +84,7 @@ export interface Components<Theme = unknown> {
   MuiSheet?: {
     defaultProps?: Partial<SheetProps>;
     styleOverrides?: OverridesStyleRules<SheetSlot, SheetProps, Theme>;
+  };
   MuiLink?: {
     defaultProps?: Partial<LinkProps>;
     styleOverrides?: OverridesStyleRules<LinkSlot, LinkProps, Theme>;

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -1,20 +1,21 @@
 import { GlobalStateSlot } from '@mui/base';
 import { CSSInterpolation } from '@mui/system';
 import { ButtonProps, ButtonSlot } from '../Button/ButtonProps';
+import { InputProps, InputSlot } from '../Input/InputProps';
+import { LinkProps, LinkSlot } from '../Link/LinkProps';
+import { ListProps, ListSlot } from '../List/ListProps';
+import { ListDividerProps, ListDividerSlot } from '../ListDivider/ListDividerProps';
+import { ListItemProps, ListItemSlot } from '../ListItem/ListItemProps';
+import { ListItemButtonProps, ListItemButtonSlot } from '../ListItemButton/ListItemButtonProps';
+import { ListItemContentProps, ListItemContentSlot } from '../ListItemContent/ListItemContentProps';
+import {
+  ListItemDecoratorProps,
+  ListItemDecoratorSlot
+} from '../ListItemDecorator/ListItemDecoratorProps';
 import { SheetProps, SheetSlot } from '../Sheet/SheetProps';
 import { SvgIconProps, SvgIconSlot } from '../SvgIcon/SvgIconProps';
 import { SwitchProps, SwitchSlot } from '../Switch/SwitchProps';
 import { TypographyProps, TypographySlot } from '../Typography/TypographyProps';
-import { ListProps, ListSlot } from '../List/ListProps';
-import { ListDividerProps, ListDividerSlot } from '../ListDivider/ListDividerProps';
-import { ListItemProps, ListItemSlot } from '../ListItem/ListItemProps';
-import { ListItemContentProps, ListItemContentSlot } from '../ListItemContent/ListItemContentProps';
-import { ListItemButtonProps, ListItemButtonSlot } from '../ListItemButton/ListItemButtonProps';
-import {
-  ListItemDecoratorProps,
-  ListItemDecoratorSlot,
-} from '../ListItemDecorator/ListItemDecoratorProps';
-import { InputProps, InputSlot } from '../Input/InputProps';
 
 export type OverridesStyleRules<
   ClassKey extends string = string,
@@ -83,5 +84,8 @@ export interface Components<Theme = unknown> {
   MuiSheet?: {
     defaultProps?: Partial<SheetProps>;
     styleOverrides?: OverridesStyleRules<SheetSlot, SheetProps, Theme>;
+  MuiLink?: {
+    defaultProps?: Partial<LinkProps>;
+    styleOverrides?: OverridesStyleRules<LinkSlot, LinkProps, Theme>;
   };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- `variant`: `'text' | 'outlined' | 'light' | 'contained'` (`undefined` by default)
- `color`: `'danger' | 'info' | 'neutral' | 'primary' | 'success' | 'warning'` (`primary` by default)
- `level`: `'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'body1' | 'body2' | 'body3'` (`body1` by default)
-  `underline`: `'none' | 'hover' | 'always'` (`always` by default)

Preview: https://deploy-preview-31175--material-ui.netlify.app/experiments/joy/link/