### PR TITLE
[docs] Use new Algolia app for new structure

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -74,10 +74,12 @@ export function DeferredAppSearch() {
     <React.Fragment>
       {/* Suspense isn't supported for SSR yet */}
       {mounted ? (
-        <React.Suspense fallback={null}>
+        <React.Suspense fallback={<Box sx={{ minWidth: { sm: 200 } }} />}>
           <AppSearch />
         </React.Suspense>
-      ) : null}
+      ) : (
+        <Box sx={{ minWidth: { sm: 200 } }} />
+      )}
     </React.Fragment>
   );
 }

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -286,25 +286,6 @@ ProductIdentifier.propTypes = {
   versionSelector: PropTypes.element,
 };
 
-const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
-export function DeferredAppSearch() {
-  const [mounted, setMounted] = React.useState(false);
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  return (
-    <React.Fragment>
-      {/* Suspense isn't supported for SSR yet */}
-      {mounted ? (
-        <React.Suspense fallback={null}>
-          <AppSearch />
-        </React.Suspense>
-      ) : null}
-    </React.Fragment>
-  );
-}
-
 function PersistScroll(props) {
   const { slot, children, enabled } = props;
   const rootRef = React.useRef();

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -18,7 +18,7 @@ import Link from 'docs/src/modules/components/Link';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import { useRouter } from 'next/router';
-import replaceUrl from 'docs/src/modules/utils/replaceUrl';
+import replaceUrl, { isNewLocation } from 'docs/src/modules/utils/replaceUrl';
 
 const SearchButton = styled('button')(({ theme }) => {
   return {
@@ -192,6 +192,8 @@ export default function AppSearch() {
     setIsOpen(true);
   }, [setIsOpen]);
   const router = useRouter();
+  const isNewDocStructure = isNewLocation(router.asPath);
+
   const keyboardNavigator = {
     navigate({ item }) {
       const as = item.userLanguage !== 'en' ? `/${item.userLanguage}${item.as}` : item.as;
@@ -285,7 +287,12 @@ export default function AppSearch() {
         createPortal(
           <DocSearchModal
             initialQuery={initialQuery}
-            apiKey="1d8534f83b9b0cfea8f16498d19fbcab"
+            appId={isNewDocStructure ? 'TZGZ85B9TB' : 'BH4D9OD16A'}
+            apiKey={
+              isNewDocStructure
+                ? '8177dfb3e2be72b241ffb8c5abafa899'
+                : '1d8534f83b9b0cfea8f16498d19fbcab'
+            }
             indexName="material-ui"
             searchParameters={{
               facetFilters: ['version:master', facetFilterLanguage],

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -18,7 +18,7 @@ import Link from 'docs/src/modules/components/Link';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import useLazyCSS from 'docs/src/modules/utils/useLazyCSS';
 import { useRouter } from 'next/router';
-import replaceUrl, { isNewLocation } from 'docs/src/modules/utils/replaceUrl';
+import { isNewLocation } from 'docs/src/modules/utils/replaceUrl';
 
 const SearchButton = styled('button')(({ theme }) => {
   return {
@@ -306,7 +306,6 @@ export default function AppSearch() {
                 parseUrl.href = item.url;
 
                 let hash = parseUrl.hash;
-                let pathname = parseUrl.pathname;
 
                 if (['lvl2', 'lvl3'].includes(item.type)) {
                   // remove '#heading-' from `href` url so that the link targets <span class="anchor-link"> inside <h2> or <h3>
@@ -314,12 +313,9 @@ export default function AppSearch() {
                   hash = hash.replace('#heading-', '#');
                 }
 
-                // TODO: remove this logic once the migration to new structure is done.
-                // This logic covers us during the ~60 minutes that it takes Algolia to run a crawl and update its index.
-                // It also allows us to have a search bar that works in dev mode while the new structure is not pushed to production.
-                pathname = replaceUrl(pathname, router.asPath);
-
-                const { canonicalAs, canonicalPathname } = pathnameToLanguage(`${pathname}${hash}`);
+                const { canonicalAs, canonicalPathname } = pathnameToLanguage(
+                  `${parseUrl.pathname}${hash}`,
+                );
 
                 return {
                   ...item,

--- a/docs/src/modules/utils/replaceUrl.ts
+++ b/docs/src/modules/utils/replaceUrl.ts
@@ -1,6 +1,6 @@
 import FEATURE_TOGGLE from 'docs/src/featureToggle';
 
-function isNewLocation(url: string) {
+export function isNewLocation(url: string) {
   url = url.replace(/^\/[a-z]{2}\//, '/');
   if (url === '/x' || url === '/x/') {
     // skipped if it is the X marketing page


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Using the new app for only the new URLs will allow us to test the search experience without impacting the existing experience on the old URLs.

### **How to check that the new app is working**
I adjust the setting on the new app (in algolia console) to have `queryType: "prefixAll"` which is different from the old app setting.

**current URLs result**

The `queryType` is `prefixLast`. https://deploy-preview-31178--material-ui.netlify.app/getting-started/installation/

<img width="1292" alt="Screen Shot 2565-02-23 at 12 35 34" src="https://user-images.githubusercontent.com/18292247/155266696-5b51e541-e346-47be-a7ea-e1d322344903.png">

**New URLs result**

https://deploy-preview-31178--material-ui.netlify.app/material/getting-started/installation/

<img width="1303" alt="Screen Shot 2565-02-23 at 12 35 59" src="https://user-images.githubusercontent.com/18292247/155266736-277d42c3-1351-4b91-b043-782509dbc522.png">

This proves that the new algolia app is working on the new URLs.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
