### PR TITLE
[Input] Export InputBase's classes from the classes const

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -42,7 +42,13 @@ describe('<FilledInput />', () => {
   });
 
   it('should respect the classes coming from InputBase', () => {
-    render(<FilledInput data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />);
+    render(
+      <FilledInput
+        data-test="test"
+        multiline
+        sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }}
+      />,
+    );
     expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
   });
 });

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -40,4 +40,9 @@ describe('<FilledInput />', () => {
     render(<FilledInput componentsProps={{ root: { 'data-test': 'test' } }} />);
     expect(document.querySelector('[data-test=test]')).not.to.equal(null);
   });
+
+  it('should respect the classes coming from InputBase', () => {
+    render(<FilledInput data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />);
+    expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
+  });
 });

--- a/packages/mui-material/src/FilledInput/filledInputClasses.ts
+++ b/packages/mui-material/src/FilledInput/filledInputClasses.ts
@@ -1,4 +1,5 @@
 import { generateUtilityClasses, generateUtilityClass } from '@mui/base';
+import { inputBaseClasses } from '../InputBase';
 
 export interface FilledInputClasses {
   /** Styles applied to the root element. */
@@ -43,24 +44,13 @@ export function getFilledInputUtilityClass(slot: string): string {
   return generateUtilityClass('MuiFilledInput', slot);
 }
 
-const filledInputClasses: FilledInputClasses = generateUtilityClasses('MuiFilledInput', [
-  'root',
-  'colorSecondary',
-  'underline',
-  'focused',
-  'disabled',
-  'adornedStart',
-  'adornedEnd',
-  'error',
-  'sizeSmall',
-  'multiline',
-  'hiddenLabel',
-  'input',
-  'inputSizeSmall',
-  'inputHiddenLabel',
-  'inputMultiline',
-  'inputAdornedStart',
-  'inputAdornedEnd',
-]);
+const filledInputClasses: FilledInputClasses = {
+  ...inputBaseClasses, 
+  ...generateUtilityClasses('MuiFilledInput', [
+    'root',
+    'underline',
+    'input',
+  ]),
+};
 
 export default filledInputClasses;

--- a/packages/mui-material/src/FilledInput/filledInputClasses.ts
+++ b/packages/mui-material/src/FilledInput/filledInputClasses.ts
@@ -45,12 +45,8 @@ export function getFilledInputUtilityClass(slot: string): string {
 }
 
 const filledInputClasses: FilledInputClasses = {
-  ...inputBaseClasses, 
-  ...generateUtilityClasses('MuiFilledInput', [
-    'root',
-    'underline',
-    'input',
-  ]),
+  ...inputBaseClasses,
+  ...generateUtilityClasses('MuiFilledInput', ['root', 'underline', 'input']),
 };
 
 export default filledInputClasses;

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -30,7 +30,9 @@ describe('<Input />', () => {
   });
 
   it('should respect the classes coming from InputBase', () => {
-    render(<Input data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />);
+    render(
+      <Input data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />,
+    );
     expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
   });
 });

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -28,4 +28,9 @@ describe('<Input />', () => {
     render(<Input componentsProps={{ root: { 'data-test': 'test' } }} />);
     expect(document.querySelector('[data-test=test]')).not.to.equal(null);
   });
+
+  it('should respect the classes coming from InputBase', () => {
+    render(<Input data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />);
+    expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
+  });
 });

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -40,11 +40,7 @@ export function getInputUtilityClass(slot: string): string {
 
 const inputClasses: InputClasses = {
   ...inputBaseClasses,
-  ...generateUtilityClasses('MuiInput', [
-    'root',
-    'underline',
-    'input',
-  ])
+  ...generateUtilityClasses('MuiInput', ['root', 'underline', 'input']),
 };
 
 export default inputClasses;

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -1,4 +1,5 @@
 import { generateUtilityClasses, generateUtilityClass } from '@mui/base';
+import { inputBaseClasses } from '../InputBase';
 
 export interface InputClasses {
   /** Styles applied to the root element. */
@@ -37,21 +38,13 @@ export function getInputUtilityClass(slot: string): string {
   return generateUtilityClass('MuiInput', slot);
 }
 
-const inputClasses: InputClasses = generateUtilityClasses('MuiInput', [
-  'root',
-  'formControl',
-  'focused',
-  'disabled',
-  'colorSecondary',
-  'underline',
-  'error',
-  'sizeSmall',
-  'multiline',
-  'fullWidth',
-  'input',
-  'inputSizeSmall',
-  'inputMultiline',
-  'inputTypeSearch',
-]);
+const inputClasses: InputClasses = {
+  ...inputBaseClasses,
+  ...generateUtilityClasses('MuiInput', [
+    'root',
+    'underline',
+    'input',
+  ])
+};
 
 export default inputClasses;

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -50,7 +50,13 @@ describe('<OutlinedInput />', () => {
   });
 
   it('should respect the classes coming from InputBase', () => {
-    render(<OutlinedInput data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />);
+    render(
+      <OutlinedInput
+        data-test="test"
+        multiline
+        sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }}
+      />,
+    );
     expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
   });
 });

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -48,4 +48,9 @@ describe('<OutlinedInput />', () => {
     render(<OutlinedInput componentsProps={{ root: { 'data-test': 'test' } }} />);
     expect(document.querySelector('[data-test=test]')).not.to.equal(null);
   });
+
+  it('should respect the classes coming from InputBase', () => {
+    render(<OutlinedInput data-test="test" multiline sx={{ [`&.${classes.multiline}`]: { mt: '10px' } }} />);
+    expect(document.querySelector('[data-test=test]')).toHaveComputedStyle({ marginTop: '10px' });
+  });
 });

--- a/packages/mui-material/src/OutlinedInput/outlinedInputClasses.ts
+++ b/packages/mui-material/src/OutlinedInput/outlinedInputClasses.ts
@@ -1,4 +1,5 @@
 import { generateUtilityClasses, generateUtilityClass } from '@mui/base';
+import { inputBaseClasses } from '../InputBase';
 
 export interface OutlinedInputClasses {
   /** Styles applied to the root element. */
@@ -39,22 +40,13 @@ export function getOutlinedInputUtilityClass(slot: string): string {
   return generateUtilityClass('MuiOutlinedInput', slot);
 }
 
-const outlinedInputClasses: OutlinedInputClasses = generateUtilityClasses('MuiOutlinedInput', [
-  'root',
-  'colorSecondary',
-  'focused',
-  'disabled',
-  'adornedStart',
-  'adornedEnd',
-  'error',
-  'sizeSmall',
-  'multiline',
-  'notchedOutline',
-  'input',
-  'inputSizeSmall',
-  'inputMultiline',
-  'inputAdornedStart',
-  'inputAdornedEnd',
-]);
+const outlinedInputClasses: OutlinedInputClasses = {
+  ...inputBaseClasses,
+  ...generateUtilityClasses('MuiOutlinedInput', [
+    'root',
+    'notchedOutline',
+    'input',
+  ]),
+};
 
 export default outlinedInputClasses;

--- a/packages/mui-material/src/OutlinedInput/outlinedInputClasses.ts
+++ b/packages/mui-material/src/OutlinedInput/outlinedInputClasses.ts
@@ -42,11 +42,7 @@ export function getOutlinedInputUtilityClass(slot: string): string {
 
 const outlinedInputClasses: OutlinedInputClasses = {
   ...inputBaseClasses,
-  ...generateUtilityClasses('MuiOutlinedInput', [
-    'root',
-    'notchedOutline',
-    'input',
-  ]),
+  ...generateUtilityClasses('MuiOutlinedInput', ['root', 'notchedOutline', 'input']),
 };
 
 export default outlinedInputClasses;


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/31080

The input components (Input, FilledInput, OutlinedInput) were exporting the wrong classes in the respected `inputClasses`, `filledInputClasses` and the `outliendInputClasses`. The classes exported now are the `inputBaseClasses` wih the additional classes added by the specific component.