### PR TITLE
[core] Remove parallel on `buildTypes`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ jobs:
             git add -f packages/mui-material/build || echo '/material declarations do not exist'
             git add -f packages/mui-lab/build || echo '/lab declarations do not exist'
             git add -f packages/mui-utils/build || echo '/utils declarations do not exist'
-            yarn lerna run --parallel build:types
+            yarn lerna run build:types
             git --no-pager diff
 
       - run:
@@ -323,7 +323,7 @@ jobs:
             git add -f packages/mui-material/build || echo '/core declarations do not exist'
             git add -f packages/mui-lab/build || echo '/lab declarations do not exist'
             git add -f packages/mui-utils/build || echo '/utils declarations do not exist'
-            yarn lerna run --parallel build:types
+            yarn lerna run build:types
             git --no-pager diff
 
       - run:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The error below occurs frequently, and triggering the failed pipeline again seems to work most of the time. I suspect that the error comes from the unfinished build of the dependency types.

It always happens with `base` because `material`, `material-next`, and `joy` rely on it. If the `base` part that Joy needs is not there (unfinished built), then there will be an error. It is likely because of the `--parallel` flag we specify (by default, lerna build based on topological sorting).

https://github.com/lerna/lerna/tree/main/commands/exec#--parallel


<img width="1440" alt="Screen Shot 2565-02-24 at 09 41 02" src="https://user-images.githubusercontent.com/18292247/155478234-388dc583-deea-42db-b4b0-28dfa292ccef.png">

<img width="1440" alt="Screen Shot 2565-02-24 at 09 41 10" src="https://user-images.githubusercontent.com/18292247/155478261-dfc10bc6-ac23-4e5f-82ba-4f66ad6841d8.png">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
