### PR TITLE
[renovate] Add group for the @fortawesome dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,10 @@
       "matchPackagePatterns": "@emotion/*"
     },
     {
+      "groupName": "Font awesome SVG icons",
+      "matchPackagePatterns": "@fortawesome/*"
+    },
+    {
       "groupName": "core-js",
       "matchPackageNames": ["core-js"],
       "allowedVersions": "< 2.0.0"


### PR DESCRIPTION
Fixes issue that came across in https://github.com/mui/material-ui/pull/31056 where the core package was not being updated together with the icons package.