### PR TITLE
[Select] Add extending `OutlinedInputProps` by SelectProps

### DIFF
--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -5,12 +5,14 @@ import { InputProps } from '../Input';
 import { MenuProps } from '../Menu';
 import { SelectChangeEvent, SelectInputProps } from './SelectInput';
 import { SelectClasses } from './selectClasses';
+import { OutlinedInputProps } from '../OutlinedInput';
 
 export { SelectChangeEvent };
 
 export interface SelectProps<T = unknown>
   extends StandardProps<InputProps, 'value' | 'onChange'>,
-    Pick<SelectInputProps<T>, 'onChange'> {
+    Pick<SelectInputProps<T>, 'onChange'>,
+    Omit<OutlinedInputProps, 'onChange'> {
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.

--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -11,8 +11,8 @@ export { SelectChangeEvent };
 
 export interface SelectProps<T = unknown>
   extends StandardProps<InputProps, 'value' | 'onChange'>,
-    Pick<SelectInputProps<T>, 'onChange'>,
-    Omit<OutlinedInputProps, 'onChange'> {
+    Omit<OutlinedInputProps, 'value' | 'onChange'>,
+    Pick<SelectInputProps<T>, 'onChange'> {
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.

--- a/packages/mui-material/src/Select/Select.spec.tsx
+++ b/packages/mui-material/src/Select/Select.spec.tsx
@@ -38,4 +38,10 @@ function genericValueTest() {
     {/* Whoops. The value in onChange won't be a string */}
     <MenuItem value={2} />
   </Select>;
+
+  // notched prop should be available (inherited from OutlinedInputProps) and NOT throw typescript error
+  <Select notched />;
+
+  // disabledUnderline prop should be available (inherited from InputProps) and NOT throw typescript error
+  <Select disableUnderline />;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/31208
According to [docs](https://mui.com/api/select/#props) Select should have OutlineInput props available. Functionality works, but typescript coverage was lacking.
