### PR TITLE
[docs] Fix 404 link to the blog

### DIFF
--- a/docs/data/material/guides/migration-v4/migration-v4.md
+++ b/docs/data/material/guides/migration-v4/migration-v4.md
@@ -2724,7 +2724,7 @@ In some cases, you might want to create multiple styled components in a file ins
 
 ### 2. Use [tss-react](https://github.com/garronej/tss-react)
 
-> Note: This API will not work if you are [using `styled-components` as underlying styling engine in place of `@emotion`](https://mui.com/guides/interoperability/#styled-components).
+> Note: This API will not work if you are [using `styled-components` as underlying styling engine in place of `@emotion`](/guides/interoperability/#styled-components).
 
 The API is similar to JSS `makeStyles` but, under the hood, it uses `@emotion/react`.
 It is also features a much better TypeScript support than v4's `makeStyles`.

--- a/docs/data/material/guides/routing/routing.md
+++ b/docs/data/material/guides/routing/routing.md
@@ -123,7 +123,7 @@ The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextj
 
 - The second version of the adapter is the `Link` component.
   This component is styled.
-  It leverages the [link component of MUI](https://mui.com/components/links/) with `NextLinkComposed`.
+  It leverages the [link component of MUI](/components/links/) with `NextLinkComposed`.
 
   ```tsx
   import Link from '../src/Link';

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -211,8 +211,14 @@ function createRender(context) {
 
       let finalHref = href;
 
-      if (userLanguage !== 'en' && finalHref.indexOf('/') === 0 && finalHref !== '/size-snapshot') {
-        finalHref = `/${userLanguage}${finalHref}`;
+      if (
+        userLanguage !== 'en' &&
+        href.indexOf('/') === 0 &&
+        href !== '/size-snapshot' &&
+        // The blog is not translated
+        !href.startsWith('/blog/')
+      ) {
+        finalHref = `/${userLanguage}${href}`;
       }
 
       return `<a href="${finalHref}"${more}>${linkText}</a>`;

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -490,7 +490,7 @@ const emeriti = [
   {
     name: 'Dmitriy Kovalenko',
     github: 'dmtrKovalenko',
-    twitter: 'dmtrKovalenko',
+    twitter: 'goose_plus_plus',
     title: 'MUI X, date pickers',
     location: 'Kharkiv, Ukraine',
     locationCountry: 'ua',


### PR DESCRIPTION
In https://mui.com/zh/guides/migration-v4/#update-mui-core-version, the link to the blog is broken

<img width="129" alt="Screenshot 2022-02-27 at 22 21 22" src="https://user-images.githubusercontent.com/3165635/155900394-190bd560-5bb2-4bb6-a8f8-7faa57426894.png">
 
The error https://app.ahrefs.com/site-audit/2944028/34/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2Ccompliant%2CincomingAllLinks%2Corigin&filterCollapsed=true&filterId=ce299062c267aa6829f86c4c4966bd3c&issueId=c64dae3f-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating&udUrl=https%3A%2F%2Fmui.com%2Fzh%2Fblog%2Fmaterial-ui-is-now-mui%2F