### PR TITLE
[SelectUnstyled] Prevent window scrolling after opening

### DIFF
--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -83,6 +83,7 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
 
   const [buttonDefined, setButtonDefined] = React.useState(false);
   const buttonRef = React.useRef<HTMLElement | null>(null);
+  const listboxRef = React.useRef<HTMLElement>(null);
 
   const Button = component ?? components.Root ?? 'button';
   const ListboxRoot = components.Listbox ?? 'ul';
@@ -97,6 +98,7 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
   };
 
   const handleButtonRef = useForkRef(ref, handleButtonRefChange);
+  const handleListboxRef = useForkRef(listboxRef, componentsProps.listbox?.ref);
 
   React.useEffect(() => {
     if (autoFocus) {
@@ -124,7 +126,7 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
     defaultValue,
     disabled: disabledProp,
     listboxId: componentsProps.listbox?.id,
-    listboxRef: componentsProps.listbox?.ref,
+    listboxRef: handleListboxRef,
     multiple: true,
     onChange,
     onOpenChange: handleOpenChange,
@@ -191,6 +193,7 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
   const context: SelectUnstyledContextType = {
     getOptionProps,
     getOptionState,
+    listboxRef,
   };
 
   return (

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
@@ -7,7 +7,6 @@ const dummyGetOptionState = () => ({
   disabled: false,
   highlighted: false,
   selected: false,
-  index: 0,
 });
 
 const dummyGetOptionProps = () => ({});
@@ -21,7 +20,11 @@ describe('OptionUnstyled', () => {
     render: (node) => {
       return render(
         <SelectUnstyledContext.Provider
-          value={{ getOptionState: dummyGetOptionState, getOptionProps: dummyGetOptionProps }}
+          value={{
+            getOptionState: dummyGetOptionState,
+            getOptionProps: dummyGetOptionProps,
+            listboxRef: React.createRef(),
+          }}
         >
           {node}
         </SelectUnstyledContext.Provider>,
@@ -30,7 +33,11 @@ describe('OptionUnstyled', () => {
     mount: (node: React.ReactNode) => {
       const wrapper = mount(
         <SelectUnstyledContext.Provider
-          value={{ getOptionState: dummyGetOptionState, getOptionProps: dummyGetOptionProps }}
+          value={{
+            getOptionState: dummyGetOptionState,
+            getOptionProps: dummyGetOptionProps,
+            listboxRef: React.createRef(),
+          }}
         >
           {node}
         </SelectUnstyledContext.Provider>,

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
@@ -52,6 +52,7 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
 
   const optionState = selectContext.getOptionState(selectOption);
   const optionProps = selectContext.getOptionProps(selectOption);
+  const listboxRef = selectContext.listboxRef;
 
   const ownerState: OptionUnstyledOwnerState<TValue> = {
     ...props,
@@ -62,10 +63,21 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
   const handleRef = useForkRef(ref, optionRef);
 
   React.useEffect(() => {
+    // Scroll to the currently highlighted option
     if (optionState.highlighted) {
-      optionRef.current?.scrollIntoView?.({ block: 'nearest' });
+      if (!listboxRef.current || !optionRef.current) {
+        return;
+      }
+      const listboxClientRect = listboxRef.current.getBoundingClientRect();
+      const optionClientRect = optionRef.current.getBoundingClientRect();
+
+      if (optionClientRect.top < listboxClientRect.top) {
+        listboxRef.current.scrollTop -= listboxClientRect.top - optionClientRect.top;
+      } else if (optionClientRect.bottom > listboxClientRect.bottom) {
+        listboxRef.current.scrollTop += optionClientRect.bottom - listboxClientRect.bottom;
+      }
     }
-  }, [optionState.highlighted]);
+  }, [optionState.highlighted, listboxRef]);
 
   const classes = useUtilityClasses(ownerState);
 
@@ -73,9 +85,9 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
     Root,
     {
       ...other,
-      ref: handleRef,
       ...optionProps,
       ...componentsProps.root,
+      ref: handleRef,
       className: clsx(classes.root, className, componentsProps.root?.className),
     },
     ownerState,

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -79,6 +79,7 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue>(
 
   const [buttonDefined, setButtonDefined] = React.useState(false);
   const buttonRef = React.useRef<HTMLElement | null>(null);
+  const listboxRef = React.useRef<HTMLElement>(null);
 
   const Button = component ?? components.Root ?? 'button';
   const ListboxRoot = components.Listbox ?? 'ul';
@@ -93,6 +94,7 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue>(
   };
 
   const handleButtonRef = useForkRef(ref, handleButtonRefChange);
+  const handleListboxRef = useForkRef(listboxRef, componentsProps.listbox?.ref);
 
   React.useEffect(() => {
     if (autoFocus) {
@@ -120,7 +122,7 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue>(
     defaultValue,
     disabled: disabledProp,
     listboxId: componentsProps.listbox?.id,
-    listboxRef: componentsProps.listbox?.ref,
+    listboxRef: handleListboxRef,
     multiple: false,
     onChange,
     onOpenChange: handleOpenChange,
@@ -184,6 +186,7 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue>(
   const context: SelectUnstyledContextType = {
     getOptionProps,
     getOptionState,
+    listboxRef,
   };
 
   return (

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
@@ -1,10 +1,11 @@
-import React from 'react';
+import * as React from 'react';
 import { OptionState } from '../ListboxUnstyled';
 import { SelectOption } from './useSelectProps';
 
 export interface SelectUnstyledContextType {
   getOptionState: (value: SelectOption<any>) => OptionState;
   getOptionProps: (option: SelectOption<any>) => Record<string, any>;
+  listboxRef: React.RefObject<HTMLElement>;
 }
 
 export const SelectUnstyledContext = React.createContext<SelectUnstyledContextType | undefined>(

--- a/packages/mui-base/test/integration/SelectUnstyled.test.tsx
+++ b/packages/mui-base/test/integration/SelectUnstyled.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { act, createRenderer, fireEvent } from 'test/utils';
+import OptionUnstyled from '@mui/base/OptionUnstyled';
+import SelectUnstyled from '@mui/base/SelectUnstyled';
+import { styled } from '@mui/system';
+
+describe('<SelectUnstyled> integration', () => {
+  const { render } = createRenderer();
+
+  it('should scroll to highlighted option so it is visible', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const SelectListbox = styled('ul')({
+      maxHeight: '100px',
+      overflow: 'auto',
+    });
+
+    const Option = styled(OptionUnstyled)({
+      height: '50px',
+    });
+
+    const { getByRole } = render(
+      <SelectUnstyled components={{ Listbox: SelectListbox }}>
+        <Option value="1">1</Option>
+        <Option value="2">2</Option>
+        <Option value="3">3</Option>
+        <Option value="4">4</Option>
+        <Option value="5">5</Option>
+        <Option value="6">6</Option>
+      </SelectUnstyled>,
+    );
+
+    const select = getByRole('button');
+
+    act(() => {
+      select.focus();
+    });
+
+    fireEvent.keyDown(select, { key: 'ArrowDown' });
+
+    const listbox = getByRole('listbox');
+
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+
+    expect(listbox.scrollTop).to.equal(100);
+
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+
+    expect(listbox.scrollTop).to.equal(50);
+  });
+});

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,19 +1,26 @@
 import './utils/init';
 import './utils/setupKarma';
 
-const integrationContext = require.context(
+const materialIntegrationContext = require.context(
   '../packages/mui-material/test/integration',
   true,
   /\.test\.(js|ts|tsx)$/,
 );
-integrationContext.keys().forEach(integrationContext);
+materialIntegrationContext.keys().forEach(materialIntegrationContext);
 
-const coreUnitContext = require.context(
+const baseIntegrationContext = require.context(
+  '../packages/mui-base/test/integration',
+  true,
+  /\.test\.(js|ts|tsx)$/,
+);
+baseIntegrationContext.keys().forEach(baseIntegrationContext);
+
+const materialUnitContext = require.context(
   '../packages/mui-material/src/',
   true,
   /\.test\.(js|ts|tsx)$/,
 );
-coreUnitContext.keys().forEach(coreUnitContext);
+materialUnitContext.keys().forEach(materialUnitContext);
 
 const labUnitContext = require.context('../packages/mui-lab/src/', true, /\.test\.(js|ts|tsx)$/);
 labUnitContext.keys().forEach(labUnitContext);
@@ -35,8 +42,8 @@ styledEngineSCContext.keys().forEach(styledEngineSCContext);
 const systemContext = require.context('../packages/mui-system/src/', true, /\.test\.(js|ts|tsx)$/);
 systemContext.keys().forEach(systemContext);
 
-const coreContext = require.context('../packages/mui-base/src/', true, /\.test\.(js|ts|tsx)$/);
-coreContext.keys().forEach(coreContext);
+const baseUnitContext = require.context('../packages/mui-base/src/', true, /\.test\.(js|ts|tsx)$/);
+baseUnitContext.keys().forEach(baseUnitContext);
 
 const utilsContext = require.context('../packages/mui-utils/src/', true, /\.test\.(js|ts|tsx)$/);
 utilsContext.keys().forEach(utilsContext);


### PR DESCRIPTION
Changes the implementation of scrolling to the highlighted option. Instead of using `scrollIntoView`, the listbox `scrollTop` is calculated and applied if necessary. This ensures only the listbox content is scrolled, not the entire window (or other external scroll container).

Fixes #31010