### PR TITLE
[typescript] Simplify display of slot props types

### DIFF
--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
@@ -1,5 +1,5 @@
-import { OverrideProps } from '@mui/types';
 import React from 'react';
+import { OverrideProps, Simplify } from '@mui/types';
 import { UseButtonParameters, UseButtonRootSlotProps } from './useButton.types';
 
 export interface ButtonUnstyledActions {
@@ -54,8 +54,10 @@ export type ButtonUnstyledOwnerState = ButtonUnstyledOwnProps & {
   focusVisible: boolean;
 };
 
-export type ButtonUnstyledRootSlotProps = UseButtonRootSlotProps & {
-  ownerState: ButtonUnstyledOwnerState;
-  className: string;
-  children?: React.ReactNode;
-};
+export type ButtonUnstyledRootSlotProps = Simplify<
+  UseButtonRootSlotProps & {
+    ownerState: ButtonUnstyledOwnerState;
+    className: string;
+    children?: React.ReactNode;
+  }
+>;

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Simplify } from '@mui/types';
 import PopperUnstyled, { PopperUnstyledProps } from '../PopperUnstyled';
 import {
   SelectOption,
@@ -58,17 +59,21 @@ export interface MultiSelectUnstyledOwnerState<TValue> extends MultiSelectUnstyl
   focusVisible: boolean;
 }
 
-export type MultiSelectUnstyledRootSlotProps<TValue> = UseSelectButtonSlotProps & {
-  className: string;
-  children?: React.ReactNode;
-  ownerState: MultiSelectUnstyledOwnerState<TValue>;
-};
+export type MultiSelectUnstyledRootSlotProps<TValue> = Simplify<
+  UseSelectButtonSlotProps & {
+    className: string;
+    children?: React.ReactNode;
+    ownerState: MultiSelectUnstyledOwnerState<TValue>;
+  }
+>;
 
-export type MultiSelectUnstyledListboxSlotProps<TValue> = UseSelectListboxSlotProps & {
-  className: string;
-  children?: React.ReactNode;
-  ownerState: MultiSelectUnstyledOwnerState<TValue>;
-};
+export type MultiSelectUnstyledListboxSlotProps<TValue> = Simplify<
+  UseSelectListboxSlotProps & {
+    className: string;
+    children?: React.ReactNode;
+    ownerState: MultiSelectUnstyledOwnerState<TValue>;
+  }
+>;
 
 export type MultiSelectUnstyledPopperSlotProps<TValue> = {
   anchorEl: PopperUnstyledProps['anchorEl'];

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Simplify } from '@mui/types';
 import {
   SelectOption,
   UseSelectButtonSlotProps,
@@ -87,17 +88,21 @@ export interface SelectUnstyledOwnerState<TValue> extends SelectUnstyledProps<TV
   open: boolean;
 }
 
-export type SelectUnstyledRootSlotProps<TValue> = UseSelectButtonSlotProps & {
-  className: string;
-  children?: React.ReactNode;
-  ownerState: SelectUnstyledOwnerState<TValue>;
-};
+export type SelectUnstyledRootSlotProps<TValue> = Simplify<
+  UseSelectButtonSlotProps & {
+    className: string;
+    children?: React.ReactNode;
+    ownerState: SelectUnstyledOwnerState<TValue>;
+  }
+>;
 
-export type SelectUnstyledListboxSlotProps<TValue> = UseSelectListboxSlotProps & {
-  className: string;
-  children?: React.ReactNode;
-  ownerState: SelectUnstyledOwnerState<TValue>;
-};
+export type SelectUnstyledListboxSlotProps<TValue> = Simplify<
+  UseSelectListboxSlotProps & {
+    className: string;
+    children?: React.ReactNode;
+    ownerState: SelectUnstyledOwnerState<TValue>;
+  }
+>;
 
 export type SelectUnstyledPopperSlotProps<TValue> = {
   anchorEl: PopperUnstyledProps['anchorEl'];

--- a/packages/mui-types/index.d.ts
+++ b/packages/mui-types/index.d.ts
@@ -135,3 +135,10 @@ export interface OverridableTypeMap {
   props: {};
   defaultComponent: React.ElementType;
 }
+
+/**
+ * Simplifies the display of a type (without modifying it).
+ * Taken from https://effectivetypescript.com/2022/02/25/gentips-4-display/
+ */
+// tslint:disable-next-line: ban-types
+export type Simplify<T> = T extends Function ? T : { [K in keyof T]: T[K] };


### PR DESCRIPTION
This changes the display of slot props types from the quite cryptic

```ts
type ButtonUnstyledRootSlotProps = Omit<{}, keyof UseButtonRootSlotOwnProps> & UseButtonRootSlotOwnProps & {
    ownerState: ButtonUnstyledOwnerState;
    className: string;
    children?: React.ReactNode;
}
```

to more readable

```ts
type ButtonUnstyledRootSlotProps = {
    'aria-disabled'?: Booleanish | undefined;
    disabled?: boolean | undefined;
    tabIndex: number;
    // ...
}
```

The shape of the types remains unchanged. Just the display in the editor is affected.
The idea was taken from https://effectivetypescript.com/2022/02/25/gentips-4-display/
