### PR TITLE
[DialogContent] Changing `paddingTop` from 0 to 8

### DIFF
--- a/packages/mui-material/src/DialogContent/DialogContent.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.js
@@ -39,7 +39,7 @@ const DialogContentRoot = styled('div', {
       }
     : {
         [`.${dialogTitleClasses.root} + &`]: {
-          paddingTop: 0,
+          paddingTop: 8,
         },
       }),
 }));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/29892 
This PR is related to the `paddingTop` of the `DialogContent` component.

Preview: https://deploy-preview-31245--material-ui.netlify.app/components/dialogs/#main-content
Demo: https://codesandbox.io/s/alertdialog-material-demo-forked-nbjy7w?file=/demo.js