### PR TITLE
[docs] Fix wrong documentation on the `styled`'s slot option

### DIFF
--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -34,7 +34,7 @@ It aims to solve the same problem, but also provides the following benefits:
    - `options.shouldForwardProp` (_`(prop: string) => bool`_ [optional]): Indicates whether the `prop` should be forwarded to the `Component`.
    - `options.label` (_string_ [optional]): The suffix of the style sheet. Useful for debugging.
    - `options.name` (_string_ [optional]): The key used under `theme.components` for specifying `styleOverrides` and `variants`. Also used for generating the `label`.
-   - `options.slot` (_string_ [optional]): If `Root`, it automatically applies the theme's `styleOverrides` & `variants`.
+   - `options.slot` (_string_ [optional]): If `Root`, it automatically applies the theme's `variants`.
    - `options.overridesResolver` (_(props: object, styles: Record<string, styles>) => styles_ [optional]): Function that returns styles based on the props and the `theme.components[name].styleOverrides` object.
    - `options.skipVariantsResolver` (_bool_): Disables the automatic resolver for the `theme.components[name].variants`.
    - `options.skipSx` (_bool_ [optional]): Disables the `sx` prop on the component.


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/31252