### PR TITLE
[Joy] Make Icon `fontSize` adaptable to its parent

### DIFF
--- a/docs/pages/experiments/joy/button.tsx
+++ b/docs/pages/experiments/joy/button.tsx
@@ -46,29 +46,7 @@ export default function JoyButton() {
     size: ['sm', 'md', 'lg'],
   } as const;
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3, pb: 4 }}>
           <ColorSchemePicker />

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -477,29 +477,7 @@ export default function JoyComponents() {
   }, []);
 
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <GlobalStyles styles={{ body: { margin: 0 } }} />
       {mounted && <Playground initialName={router.query.name as string} />}
     </CssVarsProvider>

--- a/docs/pages/experiments/joy/input.tsx
+++ b/docs/pages/experiments/joy/input.tsx
@@ -43,29 +43,7 @@ const ColorSchemePicker = () => {
 
 export default function JoyTypography() {
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <GlobalStyles styles={{ body: { margin: 0 } }} />
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 2 }}>

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -726,25 +726,6 @@ export default function JoyTypography() {
             },
           },
         },
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
       }}
     >
       <GlobalStyles

--- a/docs/pages/experiments/joy/sheet.tsx
+++ b/docs/pages/experiments/joy/sheet.tsx
@@ -44,29 +44,7 @@ export default function JoySheet() {
   } as const;
 
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <GlobalStyles
         styles={{ body: { backgroundColor: 'var(--joy-palette-background-level2)' } }}
       />

--- a/docs/pages/experiments/joy/switch.tsx
+++ b/docs/pages/experiments/joy/switch.tsx
@@ -42,29 +42,7 @@ const props = {
 
 export default function JoySwitch() {
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3 }}>
           <ColorSchemePicker />

--- a/docs/pages/experiments/joy/typography.tsx
+++ b/docs/pages/experiments/joy/typography.tsx
@@ -35,29 +35,7 @@ const ColorSchemePicker = () => {
 
 export default function JoyTypography() {
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3, pb: 4 }}>
           <ColorSchemePicker />

--- a/docs/pages/experiments/joy/variant-overrides.tsx
+++ b/docs/pages/experiments/joy/variant-overrides.tsx
@@ -114,29 +114,7 @@ export default function JoyVariant() {
     </React.Fragment>
   );
   return (
-    <CssVarsProvider
-      theme={{
-        components: {
-          MuiSvgIcon: {
-            defaultProps: {
-              fontSize: 'xl',
-            },
-            styleOverrides: {
-              root: ({ ownerState, theme }) => ({
-                ...(ownerState.fontSize &&
-                  ownerState.fontSize !== 'inherit' && {
-                    fontSize: theme.vars.fontSize[ownerState.fontSize],
-                  }),
-                ...(ownerState.color &&
-                  ownerState.color !== 'inherit' && {
-                    color: theme.vars.palette[ownerState.color].textColor,
-                  }),
-              }),
-            },
-          },
-        },
-      }}
-    >
+    <CssVarsProvider>
       <GlobalStyles styles={{ body: { margin: 0 } }} />
       <Box sx={{ px: 3, pb: 4 }}>
         <ColorSchemePicker />

--- a/docs/pages/experiments/joy/variant.tsx
+++ b/docs/pages/experiments/joy/variant.tsx
@@ -81,29 +81,7 @@ export default function JoyVariant() {
       }}
     >
       <GlobalStyles styles={{ body: { margin: 0 } }} />
-      <CssVarsProvider
-        theme={{
-          components: {
-            MuiSvgIcon: {
-              defaultProps: {
-                fontSize: 'xl',
-              },
-              styleOverrides: {
-                root: ({ ownerState, theme }) => ({
-                  ...(ownerState.fontSize &&
-                    ownerState.fontSize !== 'inherit' && {
-                      fontSize: theme.vars.fontSize[ownerState.fontSize],
-                    }),
-                  ...(ownerState.color &&
-                    ownerState.color !== 'inherit' && {
-                      color: theme.vars.palette[ownerState.color].textColor,
-                    }),
-                }),
-              },
-            },
-          },
-        }}
-      >
+      <CssVarsProvider>
         <Box sx={{ p: 2 }}>
           <Typography component="h1" level="h3" gutterBottom>
             Variant demonstration

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -64,16 +64,18 @@ const ButtonRoot = styled('button', {
     {
       '--Button-minHeight': '2.5rem', // use min-height instead of height to make the button resilient to its content
       '--Button-gutter': '1.5rem', // gutter is the padding-x
-      '--Button-iconOffsetStep': 2, // negative margin of the start/end icon
-      '--Button-gap': 'clamp(0.25rem, var(--Button-gutter) * 0.5, 0.5rem)', // gap between start/end icon and content [0.25rem, x, 0.5rem]
       ...(ownerState.size === 'sm' && {
         '--Button-minHeight': '2rem',
         '--Button-gutter': '1rem',
+        '--SvgIcon-fontSize': '1.25rem',
       }),
       ...(ownerState.size === 'lg' && {
         '--Button-minHeight': '3rem',
         '--Button-gutter': '2rem',
+        '--SvgIcon-fontSize': '1.75rem',
       }),
+      '--Button-iconOffsetStep': 2, // negative margin of the start/end icon
+      '--Button-gap': 'clamp(0.25rem, var(--Button-gutter) * 0.5, 0.5rem)', // gap between start/end icon and content [0.25rem, x, 0.5rem]
     },
     {
       padding: '0.25rem var(--Button-gutter)', // the padding-top, bottom act as a minimum spacing between content and root element

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -67,12 +67,12 @@ const ButtonRoot = styled('button', {
       ...(ownerState.size === 'sm' && {
         '--Button-minHeight': '2rem',
         '--Button-gutter': '1rem',
-        '--SvgIcon-fontSize': '1.25rem',
+        '--Icon-fontSize': '1.25rem',
       }),
       ...(ownerState.size === 'lg' && {
         '--Button-minHeight': '3rem',
         '--Button-gutter': '2rem',
-        '--SvgIcon-fontSize': '1.75rem',
+        '--Icon-fontSize': '1.75rem',
       }),
       '--Button-iconOffsetStep': 2, // negative margin of the start/end icon
       '--Button-gap': 'clamp(0.25rem, var(--Button-gutter) * 0.5, 0.5rem)', // gap between start/end icon and content [0.25rem, x, 0.5rem]

--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -41,10 +41,12 @@ const IconButtonRoot = styled('button', {
     '--IconButton-padding': '0.25rem',
     ...(ownerState.size === 'sm' && {
       '--IconButton-size': '2rem',
+      '--SvgIcon-fontSize': '1.25rem',
     }),
     ...(ownerState.size === 'lg' && {
       '--IconButton-size': '3rem',
       '--IconButton-padding': '0.5rem',
+      '--SvgIcon-fontSize': '1.75rem',
     }),
     padding: 'var(--IconButton-padding)',
     ...(ownerState.variant === 'outlined' && {

--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -41,12 +41,12 @@ const IconButtonRoot = styled('button', {
     '--IconButton-padding': '0.25rem',
     ...(ownerState.size === 'sm' && {
       '--IconButton-size': '2rem',
-      '--SvgIcon-fontSize': '1.25rem',
+      '--Icon-fontSize': '1.25rem',
     }),
     ...(ownerState.size === 'lg' && {
       '--IconButton-size': '3rem',
       '--IconButton-padding': '0.5rem',
-      '--SvgIcon-fontSize': '1.75rem',
+      '--Icon-fontSize': '1.75rem',
     }),
     padding: 'var(--IconButton-padding)',
     ...(ownerState.variant === 'outlined' && {

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -14,7 +14,7 @@ import defaultTheme, {
 import { DefaultColorScheme, ExtendedColorScheme } from './types/colorScheme';
 import { Variants } from './types/variants';
 import { ColorSystem } from './types/colorSystem';
-import { TypographySystem } from './types/typography';
+import { TypographySystem, FontSize } from './types/typography';
 import { Components } from './components';
 import { createVariant, createTextOverrides, createContainedOverrides } from './variantUtils';
 
@@ -64,22 +64,24 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
     components: {
       // TODO: find a way to abstract SvgIcon out of @mui/material
       MuiSvgIcon: {
-        // Note: do not specify default props here because it will break the adaptive component.
-        //       To fix this we need to know if developer pass fontSize through `inProps` or not which is impossible right not in theming
-        //       because `ownerState.fontSize` is the merged value by theme default props.
+        defaultProps: {
+          fontSize: 'xl',
+        },
         styleOverrides: {
           root: ({ ownerState, theme }) => {
+            const instanceFontSize = ownerState.instanceFontSize as 'inherit' | keyof FontSize;
             return {
-              fontSize: `var(--Icon-fontSize, ${theme.fontSize.xl})`,
+              ...(ownerState.fontSize &&
+                ownerState.fontSize !== 'inherit' && {
+                  fontSize: `var(--Icon-fontSize, ${theme.fontSize[ownerState.fontSize]})`,
+                }),
               ...(ownerState.color &&
                 ownerState.color !== 'inherit' && {
                   color: theme.vars.palette[ownerState.color].textColor,
                 }),
-              ...(ownerState.fontSize &&
-                // @ts-ignore
-                ownerState.fontSize !== 'medium' &&
-                ownerState.fontSize !== 'inherit' && {
-                  '--Icon-fontSize': theme.vars.fontSize[ownerState.fontSize],
+              ...(instanceFontSize &&
+                instanceFontSize !== 'inherit' && {
+                  '--Icon-fontSize': theme.vars.fontSize[instanceFontSize],
                 }),
             };
           },

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -70,7 +70,7 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
         styleOverrides: {
           root: ({ ownerState, theme }) => {
             return {
-              fontSize: `var(--SvgIcon-fontSize, ${theme.fontSize.xl})`,
+              fontSize: `var(--Icon-fontSize, ${theme.fontSize.xl})`,
               ...(ownerState.color &&
                 ownerState.color !== 'inherit' && {
                   color: theme.vars.palette[ownerState.color].textColor,
@@ -79,7 +79,7 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
                 // @ts-ignore
                 ownerState.fontSize !== 'medium' &&
                 ownerState.fontSize !== 'inherit' && {
-                  '--SvgIcon-fontSize': theme.vars.fontSize[ownerState.fontSize],
+                  '--Icon-fontSize': theme.vars.fontSize[ownerState.fontSize],
                 }),
             };
           },

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -64,20 +64,22 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
     components: {
       // TODO: find a way to abstract SvgIcon out of @mui/material
       MuiSvgIcon: {
-        defaultProps: {
-          fontSize: 'xl',
-        },
         styleOverrides: {
-          root: ({ ownerState, theme }) => ({
-            ...(ownerState.fontSize &&
-              ownerState.fontSize !== 'inherit' && {
-                fontSize: theme.vars.fontSize[ownerState.fontSize],
-              }),
-            ...(ownerState.color &&
-              ownerState.color !== 'inherit' && {
-                color: theme.vars.palette[ownerState.color].textColor,
-              }),
-          }),
+          root: ({ ownerState, theme }) => {
+            return {
+              ...(ownerState.fontSize &&
+                // @ts-ignore
+                ownerState.fontSize !== 'medium' &&
+                ownerState.fontSize !== 'inherit' && {
+                  '--SvgIcon-fontSize': theme.vars.fontSize[ownerState.fontSize],
+                }),
+              fontSize: `var(--SvgIcon-fontSize, ${theme.fontSize.xl})`,
+              ...(ownerState.color &&
+                ownerState.color !== 'inherit' && {
+                  color: theme.vars.palette[ownerState.color].textColor,
+                }),
+            };
+          },
         },
       },
     } as Components<JoyTheme>,

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -64,19 +64,22 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
     components: {
       // TODO: find a way to abstract SvgIcon out of @mui/material
       MuiSvgIcon: {
+        // Note: do not specify default props here because it will break the adaptive component.
+        //       To fix this we need to know if developer pass fontSize through `inProps` or not which is impossible right not in theming
+        //       because `ownerState.fontSize` is the merged value by theme default props.
         styleOverrides: {
           root: ({ ownerState, theme }) => {
             return {
+              fontSize: `var(--SvgIcon-fontSize, ${theme.fontSize.xl})`,
+              ...(ownerState.color &&
+                ownerState.color !== 'inherit' && {
+                  color: theme.vars.palette[ownerState.color].textColor,
+                }),
               ...(ownerState.fontSize &&
                 // @ts-ignore
                 ownerState.fontSize !== 'medium' &&
                 ownerState.fontSize !== 'inherit' && {
                   '--SvgIcon-fontSize': theme.vars.fontSize[ownerState.fontSize],
-                }),
-              fontSize: `var(--SvgIcon-fontSize, ${theme.fontSize.xl})`,
-              ...(ownerState.color &&
-                ownerState.color !== 'inherit' && {
-                  color: theme.vars.palette[ownerState.color].textColor,
                 }),
             };
           },

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -61,6 +61,25 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
       light: lightColorSystem,
       dark: darkColorSystem,
     },
+    components: {
+      MuiSvgIcon: {
+        defaultProps: {
+          fontSize: 'xl',
+        },
+        styleOverrides: {
+          root: ({ ownerState, theme }) => ({
+            ...(ownerState.fontSize &&
+              ownerState.fontSize !== 'inherit' && {
+                fontSize: theme.vars.fontSize[ownerState.fontSize],
+              }),
+            ...(ownerState.color &&
+              ownerState.color !== 'inherit' && {
+                color: theme.vars.palette[ownerState.color].textColor,
+              }),
+          }),
+        },
+      },
+    } as Components<JoyTheme>,
   },
   defaultColorScheme: {
     light: 'light',

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -62,6 +62,7 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
       dark: darkColorSystem,
     },
     components: {
+      // TODO: find a way to abstract SvgIcon out of @mui/material
       MuiSvgIcon: {
         defaultProps: {
           fontSize: 'xl',

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -79,6 +79,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
     color,
     component,
     fontSize,
+    instanceFontSize: inProps.fontSize,
     inheritViewBox,
     viewBox,
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This is an experimental feature called ["Adaptive component"](https://www.notion.so/mui-org/Adaptive-component-4cf81866231b4071ae25cb2eba1c64dd).

It gives the parent component the ability to control the children without hurting customization experience.

### The problem

In Material UI, it is using CSS selector to control the children which leads to bad customization experience. https://github.com/mui/material-ui/issues/28917

```js
<Button size="small" startIcon={<Icon />}>...</Button>
// some icon looks great by default, but for some icon needs customization

// here is what I expect to do with sx
<Button size="small" startIcon={<Icon sx={{ fontSize: '18px' }} />}>...</Button>
//❗️it does not work, and then I have to open a devtool and found that it is using CSS selector

// Finally, ends up with this
<Button size="small" startIcon={<Icon />}
  sx={{[`& .${buttonClasses.startIcon} > *:nth-of-type(1)`]: {
    fontSize: "30px"
  }}}
>...</Button>
// 🥲 too much thing to do just to change the size of the icon
```

### The solution

create CSS variable with a default value, so by default `<Icon />` renders this:

```js
<Icon /> // font-size: var(--Icon-fontSize, 1.5rem);
```

This allows any component to control this icon via `--Icon-fontSize`, for example a Button:

```js
// Button size "sm" create a variable `--Icon-fontSize: 20px`
<Button size="sm" startIcon={<Icon />}>
// it looks great by default
```

**Customization**

When developer defines a fontSize prop to the instance, it creates the variable at the icon, so the value has the highest priority.
```js
// `--Icon-fontSize: 1rem`
<Icon fontSize="md" />
```

Meaning, the variable from the parent has no effect 😲. I think this is the best experience so far.

A plus of using CSS variables is that developers do not need to use our theme (in js) to set the default props, they can use any CSS solution without any setup 😲

```css
// any CSS solution, ex. global.css
:root {
  --Icon-fontSize: 1.25rem; // apply to all default <Icon />
}
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
