### PR TITLE
[examples] fix(remix): remove dev NODE_ENV guard for LiveReload

### DIFF
--- a/examples/remix-with-typescript/app/root.tsx
+++ b/examples/remix-with-typescript/app/root.tsx
@@ -49,7 +49,7 @@ const Document = withEmotionCache(({ children, title }: DocumentProps, emotionCa
         {children}
         <ScrollRestoration />
         <Scripts />
-        {process.env.NODE_ENV === 'development' && <LiveReload />}
+        <LiveReload />
       </body>
     </html>
   );


### PR DESCRIPTION
Based on https://github.com/remix-run/remix/pull/1352, it is no longer required to wrap <LiveReload /> in NODE_ENV === 'development' guard. From the PR:

> Another thing this PR does is it makes it so devs won't have to put the process.env.NODE_ENV guard around their usage of the component anymore. 

Modified examples/remix-with-typescript accordingly.