### PR TITLE
[material-next] Mark `@mui/material` as a dependency

### DIFF
--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@mui/base": "5.0.0-alpha.70",
+    "@mui/material": "^5.4.4",
     "@mui/system": "^5.4.4",
     "@mui/types": "^7.1.2",
     "@mui/utils": "^5.4.4",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Without `@mui/material` as a dependency in `@mui/material-next`, this error could happen in any PRs. The fix allows lerna to organize the build order for us.

<img width="1235" alt="Screen Shot 2565-03-02 at 09 24 48" src="https://user-images.githubusercontent.com/18292247/156282700-5535b580-ef7d-4df8-bdb4-b65296f5328b.png">

Source: https://app.circleci.com/pipelines/github/mui/material-ui/65801/workflows/aebea217-a369-486e-83e0-452db3ff7c20/jobs/355054

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
