### PR TITLE
[useInput] Fix focused context and improve usability

### DIFF
--- a/packages/mui-base/src/FormControlUnstyled/FormControlContext.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlContext.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type FormControlUnstyledState = {
+export interface FormControlUnstyledState {
   disabled?: boolean;
   error?: boolean;
   filled?: boolean;
@@ -11,7 +11,7 @@ export type FormControlUnstyledState = {
   onFocus?: () => void;
   onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
   registerEffect?: () => void;
-};
+}
 
 /**
  * @ignore - internal component.

--- a/packages/mui-base/src/FormControlUnstyled/FormControlContext.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlContext.ts
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import FormControlUnstyledProps from './FormControlUnstyledProps';
 
-type ContextFromPropsKey = 'disabled' | 'error' | 'onChange' | 'required' | 'value';
-
-export interface FormControlUnstyledState
-  extends Pick<FormControlUnstyledProps, ContextFromPropsKey> {
-  filled: boolean;
-  focused: boolean;
-  onBlur: () => void;
-  onFocus: () => void;
-  registerEffect: () => void;
-}
+export type FormControlUnstyledState = {
+  disabled?: boolean;
+  error?: boolean;
+  filled?: boolean;
+  focused?: boolean;
+  required?: boolean;
+  value?: unknown;
+  onBlur?: () => void;
+  onFocus?: () => void;
+  onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
+  registerEffect?: () => void;
+};
 
 /**
  * @ignore - internal component.

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
@@ -252,14 +252,14 @@ describe('<FormControlUnstyled />', () => {
     });
   });
 
-  describe('prop: extraContextProperties', () => {
+  describe('prop: extraContextProps', () => {
     it('should be able to receive extra context properies inside the child', () => {
       function TestComponent() {
         const context = useFormControlUnstyled<{ text: string }>();
         return <div>{context?.text}</div>;
       }
       const { getByText } = render(
-        <FormControlUnstyled extraContextProperties={{ text: 'foo' }}>
+        <FormControlUnstyled extraContextProps={{ text: 'foo' }}>
           <TestComponent />
         </FormControlUnstyled>,
       );

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
@@ -255,19 +255,4 @@ describe('<FormControlUnstyled />', () => {
       expect(handleChange.args[0][0].target).to.have.property('value', 'test');
     });
   });
-
-  describe('prop: extraContextProps', () => {
-    it('should be able to receive extra context properies inside the child', () => {
-      function TestComponent() {
-        const context = useFormControlUnstyled<{ text: string }>();
-        return <div>{context?.text}</div>;
-      }
-      const { getByText } = render(
-        <FormControlUnstyled extraContextProps={{ text: 'foo' }}>
-          <TestComponent />
-        </FormControlUnstyled>,
-      );
-      expect(getByText('foo')).toBeVisible();
-    });
-  });
 });

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
@@ -251,4 +251,19 @@ describe('<FormControlUnstyled />', () => {
       expect(handleChange.args[0][0].target).to.have.property('value', 'test');
     });
   });
+
+  describe('prop: extraContextProperties', () => {
+    it('should be able to receive extra context properies inside the child', () => {
+      function TestComponent() {
+        const context = useFormControlUnstyled<{ text: string }>();
+        return <div>{context?.text}</div>;
+      }
+      const { getByText } = render(
+        <FormControlUnstyled extraContextProperties={{ text: 'foo' }}>
+          <TestComponent />
+        </FormControlUnstyled>,
+      );
+      expect(getByText('foo')).toBeVisible();
+    });
+  });
 });

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.test.tsx
@@ -202,6 +202,10 @@ describe('<FormControlUnstyled />', () => {
       );
 
       expect(getByRole('textbox').dataset).to.have.property('filled', 'true');
+
+      fireEvent.change(getByRole('textbox'), { target: { value: 'a' } });
+
+      expect(getByRole('textbox')).to.have.value('a');
     });
 
     it('should be set if a controlled inner input sets its value', () => {

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -58,9 +58,7 @@ export type FormControlUnstyledOwnerState = Omit<
  *
  * - [FormControlUnstyled API](https://mui.com/api/form-control-unstyled/)
  */
-const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
-  D extends React.ElementType = FormControlUnstyledTypeMap['defaultComponent'],
->(props: FormControlUnstyledProps<D>, ref: React.ForwardedRef<any>) {
+const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props, ref) {
   const {
     defaultValue,
     children,
@@ -75,7 +73,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
     required = false,
     value: incomingValue,
     ...other
-  } = props;
+  } = props as typeof props & { component?: React.ElementType };
 
   const [value, setValue] = useControlled({
     controlled: incomingValue,

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -72,6 +72,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props,
     onChange,
     required = false,
     value: incomingValue,
+    extraContextProperties,
     ...other
   } = props as typeof props & { component?: React.ElementType };
 
@@ -127,6 +128,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props,
   };
 
   const childContext: FormControlUnstyledState = {
+    ...extraContextProperties,
     disabled,
     error,
     filled,

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -72,7 +72,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props,
     onChange,
     required = false,
     value: incomingValue,
-    extraContextProperties,
+    extraContextProps,
     ...other
   } = props as typeof props & { component?: React.ElementType };
 
@@ -128,7 +128,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props,
   };
 
   const childContext: FormControlUnstyledState = {
-    ...extraContextProperties,
+    ...extraContextProps,
     disabled,
     error,
     filled,

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -74,7 +74,6 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
     onChange,
     required = false,
     value: incomingValue,
-    extraContextProps,
     ...other
   } = props;
 
@@ -130,7 +129,6 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
   };
 
   const childContext: FormControlUnstyledState = {
-    ...extraContextProps,
     disabled,
     error,
     filled,
@@ -214,11 +212,6 @@ FormControlUnstyled.propTypes /* remove-proptypes */ = {
    * @default false
    */
   error: PropTypes.bool,
-  /**
-   * Extra properties to be placed on the FormControlContext.
-   * @default {}
-   */
-  extraContextProps: PropTypes.object,
   /**
    * If `true`, the component is displayed in focused state.
    * @default false

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -58,7 +58,9 @@ export type FormControlUnstyledOwnerState = Omit<
  *
  * - [FormControlUnstyled API](https://mui.com/api/form-control-unstyled/)
  */
-const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props, ref) {
+const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
+  D extends React.ElementType = FormControlUnstyledTypeMap['defaultComponent'],
+>(props: FormControlUnstyledProps<D>, ref: React.ForwardedRef<any>) {
   const {
     defaultValue,
     children,
@@ -74,7 +76,7 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled(props,
     value: incomingValue,
     extraContextProps,
     ...other
-  } = props as typeof props & { component?: React.ElementType };
+  } = props;
 
   const [value, setValue] = useControlled({
     controlled: incomingValue,
@@ -212,6 +214,11 @@ FormControlUnstyled.propTypes /* remove-proptypes */ = {
    * @default false
    */
   error: PropTypes.bool,
+  /**
+   * Extra properties to be placed on the FormControlContext.
+   * @default {}
+   */
+  extraContextProps: PropTypes.object,
   /**
    * If `true`, the component is displayed in focused state.
    * @default false

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyledProps.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyledProps.ts
@@ -40,7 +40,7 @@ export interface FormControlUnstyledOwnProps {
    * Extra properties to be placed on the FormControlContext.
    * @default {}
    */
-  extraContextProperties?: object;
+  extraContextProps?: object;
   /**
    * If `true`, the component is displayed in focused state.
    * @default false

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyledProps.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyledProps.ts
@@ -37,11 +37,6 @@ export interface FormControlUnstyledOwnProps {
    */
   error?: boolean;
   /**
-   * Extra properties to be placed on the FormControlContext.
-   * @default {}
-   */
-  extraContextProps?: object;
-  /**
    * If `true`, the component is displayed in focused state.
    * @default false
    */

--- a/packages/mui-base/src/FormControlUnstyled/useFormControl.ts
+++ b/packages/mui-base/src/FormControlUnstyled/useFormControl.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import FormControlUnstyledContext, { FormControlUnstyledState } from './FormControlContext';
 
-export default function useFormControlUnstyled<ExtraContextProps = any>() {
+export default function useFormControlUnstyled<ExtraContextProps = {}>() {
   return React.useContext(FormControlUnstyledContext) as
     | (FormControlUnstyledState & ExtraContextProps)
     | undefined;

--- a/packages/mui-base/src/FormControlUnstyled/useFormControl.ts
+++ b/packages/mui-base/src/FormControlUnstyled/useFormControl.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import FormControlUnstyledContext from './FormControlContext';
+import FormControlUnstyledContext, { FormControlUnstyledState } from './FormControlContext';
 
-export default function useFormControlUnstyled() {
-  return React.useContext(FormControlUnstyledContext);
+export default function useFormControlUnstyled<ExtraContextProps = any>() {
+  return React.useContext(FormControlUnstyledContext) as
+    | (FormControlUnstyledState & ExtraContextProps)
+    | undefined;
 }

--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.test.tsx
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { createMount, createRenderer, describeConformanceUnstyled } from 'test/utils';
 import InputUnstyled, { inputUnstyledClasses } from '@mui/base/InputUnstyled';
+import FormControlUnstyled from '@mui/base/FormControlUnstyled';
 
 describe('<InputUnstyled />', () => {
   const mount = createMount();
@@ -23,4 +25,13 @@ describe('<InputUnstyled />', () => {
       },
     },
   }));
+
+  it('inherit focused from FormControl', () => {
+    const { container } = render(
+      <FormControlUnstyled focused>
+        <InputUnstyled />
+      </FormControlUnstyled>,
+    );
+    expect(container.firstChild?.firstChild).to.have.class(inputUnstyledClasses.focused);
+  });
 });

--- a/packages/mui-base/src/InputUnstyled/useInput.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.ts
@@ -173,7 +173,7 @@ export default function useInput(props: UseInputProps, inputRef?: React.Ref<HTML
   return {
     disabled,
     error,
-    focused,
+    focused: formControlContext ? formControlContext.focused : focused,
     formControlContext,
     getInputProps,
     getRootProps,

--- a/packages/mui-base/src/InputUnstyled/useInput.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.ts
@@ -19,22 +19,10 @@ export default function useInput(props: UseInputProps, inputRef?: React.Ref<HTML
 
   const formControlContext = useFormControl();
 
-  let value: unknown;
-  let required: boolean;
-  let disabled: boolean;
-  let error: boolean;
-
-  if (formControlContext) {
-    value = formControlContext.value;
-    disabled = formControlContext.disabled ?? false;
-    required = formControlContext.required ?? false;
-    error = formControlContext.error ?? false;
-  } else {
-    value = valueProp;
-    disabled = disabledProp;
-    required = requiredProp;
-    error = errorProp;
-  }
+  const value = formControlContext?.value ?? valueProp;
+  const disabled = formControlContext?.disabled ?? disabledProp;
+  const error = formControlContext?.error ?? errorProp;
+  const required = formControlContext?.required ?? requiredProp;
 
   const { current: isControlled } = React.useRef(value != null);
 
@@ -81,11 +69,8 @@ export default function useInput(props: UseInputProps, inputRef?: React.Ref<HTML
 
       otherHandlers.onFocus?.(event);
 
-      if (formControlContext && formControlContext.onFocus) {
-        formControlContext?.onFocus?.();
-      } else {
-        setFocused(true);
-      }
+      formControlContext?.onFocus?.();
+      setFocused(true);
     };
 
   const handleBlur =
@@ -93,11 +78,8 @@ export default function useInput(props: UseInputProps, inputRef?: React.Ref<HTML
     (event: React.FocusEvent<HTMLInputElement>) => {
       otherHandlers.onBlur?.(event);
 
-      if (formControlContext && formControlContext.onBlur) {
-        formControlContext.onBlur();
-      } else {
-        setFocused(false);
-      }
+      formControlContext?.onBlur?.();
+      setFocused(false);
     };
 
   const handleChange =
@@ -173,7 +155,7 @@ export default function useInput(props: UseInputProps, inputRef?: React.Ref<HTML
   return {
     disabled,
     error,
-    focused: formControlContext ? formControlContext.focused : focused,
+    focused: formControlContext?.focused ?? focused,
     formControlContext,
     getInputProps,
     getRootProps,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

After trying to use the base to build a TextField in Joy, I came across multiple improvements that I think the base should have so I created this PR to discuss the changes.

### Bug
- ~fix `extraContextProps` to be able to send via context in `FormControlUnstyled`~
- fix `focused` from `useInput` to use context if exists.

### Typings

- Simplify typings on the `FormControlContext`.
- allow `useFormControl` to receive a generic for extra context props

### Improvements

- shorten `extraContextProperties` to just `extraContextProps` (I think `props` are more familiar than `properties` in react and it is more consistent. Since we don't have documentation on this hook yet, I think it is safe to rename and no components are using it at this point)
- make all fields optional for `FormControlUnstyledState`. I think this is useful so that the consumer (eg Joy) can use it to build custom components that can communicate with `useInput`. In Joy, I am thinking about creating a new component called `FormField` that handle the styles for `required, error, disabled, focused, ...extraContextProps` but not dealing with the `value` so developers can use it like:
  
  ```js
  <FormField error disabled variant="..." color="...">
    <FormLabel>...</FormLabel>
    <Input value="..." onChange={() => {}} />
    <FormHelperText>...</FormHelperText>
  </FormField>
  ```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
