### PR TITLE
[docs] Update TextField multiline description

### DIFF
--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -40,7 +40,7 @@ The `helperText` prop can then be used to provide feedback to the user about the
 
 ## Multiline
 
-The `multiline` prop transforms the text field into a [`<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) element.
+The `multiline` prop transforms the text field into a [TextareaAutosize](/components/textarea-autosize/) element.
 Unless the `rows` prop is set, the height of the text field dynamically matches its content (using [TextareaAutosize](/components/textarea-autosize/)).
 You can use the `minRows` and `maxRows` props to bound it.
 

--- a/docs/translations/api-docs/filled-input/filled-input.json
+++ b/docs/translations/api-docs/filled-input/filled-input.json
@@ -21,7 +21,7 @@
     "margin": "If <code>dense</code>, will adjust vertical spacing. This is normally obtained via context from FormControl. The prop defaults to the value (<code>&#39;none&#39;</code>) inherited from the parent FormControl component.",
     "maxRows": "Maximum number of rows to display when multiline option is set to true.",
     "minRows": "Minimum number of rows to display when multiline option is set to true.",
-    "multiline": "If <code>true</code>, a <code>textarea</code> element is rendered.",
+    "multiline": "If <code>true</code>, a <a href=\"/components/textarea-autosize/\">TextareaAutosize</a> element is rendered.",
     "name": "Name attribute of the <code>input</code> element.",
     "onChange": "Callback fired when the value is changed.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLTextAreaElement | HTMLInputElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",
     "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",

--- a/docs/translations/api-docs/input-base/input-base.json
+++ b/docs/translations/api-docs/input-base/input-base.json
@@ -20,7 +20,7 @@
     "margin": "If <code>dense</code>, will adjust vertical spacing. This is normally obtained via context from FormControl. The prop defaults to the value (<code>&#39;none&#39;</code>) inherited from the parent FormControl component.",
     "maxRows": "Maximum number of rows to display when multiline option is set to true.",
     "minRows": "Minimum number of rows to display when multiline option is set to true.",
-    "multiline": "If <code>true</code>, a <code>textarea</code> element is rendered.",
+    "multiline": "If <code>true</code>, a <a href=\"/components/textarea-autosize/\">TextareaAutosize</a> element is rendered.",
     "name": "Name attribute of the <code>input</code> element.",
     "onBlur": "Callback fired when the <code>input</code> is blurred.<br>Notice that the first argument (event) might be undefined.",
     "onChange": "Callback fired when the value is changed.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLTextAreaElement | HTMLInputElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",

--- a/docs/translations/api-docs/input/input.json
+++ b/docs/translations/api-docs/input/input.json
@@ -20,7 +20,7 @@
     "margin": "If <code>dense</code>, will adjust vertical spacing. This is normally obtained via context from FormControl. The prop defaults to the value (<code>&#39;none&#39;</code>) inherited from the parent FormControl component.",
     "maxRows": "Maximum number of rows to display when multiline option is set to true.",
     "minRows": "Minimum number of rows to display when multiline option is set to true.",
-    "multiline": "If <code>true</code>, a <code>textarea</code> element is rendered.",
+    "multiline": "If <code>true</code>, a <a href=\"/components/textarea-autosize/\">TextareaAutosize</a> element is rendered.",
     "name": "Name attribute of the <code>input</code> element.",
     "onChange": "Callback fired when the value is changed.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLTextAreaElement | HTMLInputElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",
     "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",

--- a/docs/translations/api-docs/outlined-input/outlined-input.json
+++ b/docs/translations/api-docs/outlined-input/outlined-input.json
@@ -19,7 +19,7 @@
     "margin": "If <code>dense</code>, will adjust vertical spacing. This is normally obtained via context from FormControl. The prop defaults to the value (<code>&#39;none&#39;</code>) inherited from the parent FormControl component.",
     "maxRows": "Maximum number of rows to display when multiline option is set to true.",
     "minRows": "Minimum number of rows to display when multiline option is set to true.",
-    "multiline": "If <code>true</code>, a <code>textarea</code> element is rendered.",
+    "multiline": "If <code>true</code>, a <a href=\"/components/textarea-autosize/\">TextareaAutosize</a> element is rendered.",
     "name": "Name attribute of the <code>input</code> element.",
     "notched": "If <code>true</code>, the outline is notched to accommodate the label.",
     "onChange": "Callback fired when the value is changed.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLTextAreaElement | HTMLInputElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -329,7 +329,7 @@ FilledInput.propTypes /* remove-proptypes */ = {
    */
   minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
-   * If `true`, a `textarea` element is rendered.
+   * If `true`, a [TextareaAutosize](/components/textarea-autosize/) element is rendered.
    * @default false
    */
   multiline: PropTypes.bool,

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -249,7 +249,7 @@ Input.propTypes /* remove-proptypes */ = {
    */
   minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
-   * If `true`, a `textarea` element is rendered.
+   * If `true`, a [TextareaAutosize](/components/textarea-autosize/) element is rendered.
    * @default false
    */
   multiline: PropTypes.bool,

--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -116,7 +116,7 @@ export interface InputBaseProps
    */
   margin?: 'dense' | 'none';
   /**
-   * If `true`, a `textarea` element is rendered.
+   * If `true`, a [TextareaAutosize](/components/textarea-autosize/) element is rendered.
    * @default false
    */
   multiline?: boolean;

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -663,7 +663,7 @@ InputBase.propTypes /* remove-proptypes */ = {
    */
   minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
-   * If `true`, a `textarea` element is rendered.
+   * If `true`, a [TextareaAutosize](/components/textarea-autosize/) element is rendered.
    * @default false
    */
   multiline: PropTypes.bool,

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -268,7 +268,7 @@ OutlinedInput.propTypes /* remove-proptypes */ = {
    */
   minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
-   * If `true`, a `textarea` element is rendered.
+   * If `true`, a [TextareaAutosize](/components/textarea-autosize/) element is rendered.
    * @default false
    */
   multiline: PropTypes.bool,


### PR DESCRIPTION
The documentation here read to me that if you set `multiline` and use the `rows` prop, you'd get a textarea component that was not a `TextareaAutosize` component. Looking into the code it looks like that used to be the case but was changed in this PR: git@github.com:jontewks/material-ui.git to always be a `TextareaAutosize` no matter what props are passed. Updated the documentation wording here to be more clear that using the `multiline` prop will always result in a `TextareaAutosize` component, and then any additional props just bound how that `TextareaAutosize` adjusts.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
