### PR TITLE
[Joy] Add Avatar component

### DIFF
--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -1,46 +1,11 @@
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import Avatar from '@mui/joy/Avatar';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
-import SvgIcon from '@mui/joy/SvgIcon';
-import Avatar from '@mui/joy/Avatar';
 import Typography from '@mui/joy/Typography';
 import * as React from 'react';
-// @ts-ignore
-import { jsx as _jsx } from 'react/jsx-runtime';
-
-function createSvgIcon(path: any, displayName: any, initialProps?: any) {
-  const Component = (props: any, ref: any) =>
-    (
-      <SvgIcon
-        data-testid={`${displayName}Icon`}
-        ref={ref}
-        viewBox="0 0 24 24"
-        fontSize="extraLarge"
-        {...initialProps}
-        {...props}
-        sx={{ ...initialProps?.sx, ...props.sx }}
-      >
-        {path}
-      </SvgIcon>
-    ) as unknown as typeof SvgIcon;
-
-  // @ts-ignore
-  return React.memo(React.forwardRef(Component));
-}
-
-export const Moon = createSvgIcon(
-  _jsx('path', {
-    d: 'M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1z',
-  }),
-  'DarkMode',
-);
-
-export const Sun = createSvgIcon(
-  _jsx('path', {
-    d: 'M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0 .39-.39.39-1.03 0-1.41l-1.06-1.06zm1.06-10.96c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z',
-  }),
-  'LightMode',
-);
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -78,7 +43,29 @@ const props = {
 
 export default function JoySvgIcon() {
   return (
-    <CssVarsProvider>
+    <CssVarsProvider
+      theme={{
+        components: {
+          MuiSvgIcon: {
+            defaultProps: {
+              fontSize: 'xl',
+            },
+            styleOverrides: {
+              root: ({ ownerState, theme }) => ({
+                ...(ownerState.fontSize &&
+                  ownerState.fontSize !== 'inherit' && {
+                    fontSize: theme.vars.fontSize[ownerState.fontSize],
+                  }),
+                ...(ownerState.color &&
+                  ownerState.color !== 'inherit' && {
+                    color: theme.vars.palette[ownerState.color].textColor,
+                  }),
+              }),
+            },
+          },
+        },
+      }}
+    >
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3 }}>
           <ColorSchemePicker />
@@ -91,7 +78,10 @@ export default function JoySvgIcon() {
             >
               <Typography sx={{ textDecoration: 'underline' }}>{propName}</Typography>
               {propValue.map((value) => (
-                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Box
+                  key={value}
+                  sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                >
                   <Avatar {...{ [propName]: value }} />
                   {value && (
                     <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>

--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -38,7 +38,6 @@ const props = {
   size: ['sm', 'md', 'lg'],
   color: ['primary', 'danger', 'info', 'success', 'warning', 'neutral'],
   variant: ['contained', 'outlined', 'light'],
-  shape: ['rounded', 'circular', 'square'],
 } as const;
 
 export default function JoySvgIcon() {

--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -1,0 +1,109 @@
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import SvgIcon from '@mui/joy/SvgIcon';
+import Avatar from '@mui/joy/Avatar';
+import Typography from '@mui/joy/Typography';
+import * as React from 'react';
+// @ts-ignore
+import { jsx as _jsx } from 'react/jsx-runtime';
+
+function createSvgIcon(path: any, displayName: any, initialProps?: any) {
+  const Component = (props: any, ref: any) =>
+    (
+      <SvgIcon
+        data-testid={`${displayName}Icon`}
+        ref={ref}
+        viewBox="0 0 24 24"
+        fontSize="extraLarge"
+        {...initialProps}
+        {...props}
+        sx={{ ...initialProps?.sx, ...props.sx }}
+      >
+        {path}
+      </SvgIcon>
+    ) as unknown as typeof SvgIcon;
+
+  // @ts-ignore
+  return React.memo(React.forwardRef(Component));
+}
+
+export const Moon = createSvgIcon(
+  _jsx('path', {
+    d: 'M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1z',
+  }),
+  'DarkMode',
+);
+
+export const Sun = createSvgIcon(
+  _jsx('path', {
+    d: 'M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0 .39-.39.39-1.03 0-1.41l-1.06-1.06zm1.06-10.96c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z',
+  }),
+  'LightMode',
+);
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+      sx={{ minWidth: 40, p: '0.25rem' }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+const props = {
+  size: ['sm', 'md', 'lg'],
+  color: ['primary', 'danger', 'info', 'success', 'warning', 'neutral'],
+  variant: ['contained', 'outlined', 'light'],
+  shape: ['rounded', 'circular', 'square'],
+} as const;
+
+export default function JoySvgIcon() {
+  return (
+    <CssVarsProvider>
+      <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
+        <Box sx={{ px: 3 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+          {Object.entries(props).map(([propName, propValue]) => (
+            <Box
+              key={propName}
+              sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+            >
+              <Typography sx={{ textDecoration: 'underline' }}>{propName}</Typography>
+              {propValue.map((value) => (
+                <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <Avatar {...{ [propName]: value }} />
+                  {value && (
+                    <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                      {value}
+                    </Typography>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </CssVarsProvider>
+  );
+}

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -11,7 +11,7 @@ import { getAvatarUtilityClass } from './avatarClasses';
 import { AvatarProps, AvatarTypeMap } from './AvatarProps';
 
 const useUtilityClasses = (ownerState: AvatarProps) => {
-  const { size, variant, color, shape, src, srcSet } = ownerState;
+  const { size, variant, color, src, srcSet } = ownerState;
 
   const slots = {
     root: [
@@ -19,7 +19,6 @@ const useUtilityClasses = (ownerState: AvatarProps) => {
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
-      shape && `shape${capitalize(shape)}`,
     ],
     img: [(src || srcSet) && 'img'],
     fallback: ['fallback'],
@@ -55,12 +54,6 @@ const AvatarRoot = styled('div', {
       borderRadius: '50%',
       overflow: 'hidden',
       userSelect: 'none',
-      ...(ownerState.shape === 'rounded' && {
-        borderRadius: theme.vars.radius[ownerState.size!],
-      }),
-      ...(ownerState.shape === 'square' && {
-        borderRadius: 0,
-      }),
     },
     theme.variants[ownerState.variant!]?.[ownerState.color!],
   ];
@@ -150,7 +143,6 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     color = 'neutral',
     component = 'div',
     size = 'md',
-    shape = 'circular',
     variant = 'contained',
     imgProps,
     src,
@@ -172,7 +164,6 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     component,
     size,
     variant,
-    shape,
   };
 
   const classes = useUtilityClasses(ownerState);
@@ -239,14 +230,6 @@ Avatar.propTypes /* remove-proptypes */ = {
    * It can be used to listen for the loading error event.
    */
   imgProps: PropTypes.object,
-  /**
-   * The shape of the component.
-   * @default 'circlular'
-   */
-  shape: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['circlular', 'rounded', 'square']),
-    PropTypes.string,
-  ]),
   /**
    * The size of the component.
    * It accepts theme values between 'xs' and 'xl'.

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import * as React from 'react';
 import Person from '../internal/svg-icons/Person';
 import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
 import { getAvatarUtilityClass } from './avatarClasses';
-import { AvatarProps, AvatarShapeProp, AvatarTypeMap } from './AvatarProps';
+import { AvatarProps, AvatarTypeMap } from './AvatarProps';
 
 const useUtilityClasses = (ownerState: AvatarProps) => {
   const { size, variant, color, shape, src, srcSet } = ownerState;
@@ -36,13 +36,13 @@ const AvatarRoot = styled('div', {
   return [
     {
       ...(ownerState.size === 'sm' && {
-        '--Avatar-size': '3rem',
+        '--Avatar-size': '2rem',
       }),
       ...(ownerState.size === 'md' && {
-        '--Avatar-size': '4rem',
+        '--Avatar-size': '2.5rem',
       }),
       ...(ownerState.size === 'lg' && {
-        '--Avatar-size': '5rem',
+        '--Avatar-size': '3rem',
       }),
       position: 'relative',
       display: 'flex',
@@ -63,9 +63,6 @@ const AvatarRoot = styled('div', {
       }),
     },
     theme.variants[ownerState.variant!]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
   ];
 });
 
@@ -153,7 +150,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     color = 'neutral',
     component = 'div',
     size = 'md',
-    shape = 'circular' as AvatarShapeProp,
+    shape = 'circular',
     variant = 'contained',
     imgProps,
     src,

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -1,0 +1,281 @@
+import * as React from 'react';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { OverridableComponent } from '@mui/types';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import Person from '../internal/svg-icons/Person';
+import { useThemeProps } from '../styles';
+import styled from '../styles/styled';
+import { getAvatarUtilityClass } from './avatarClasses';
+import { AvatarProps, AvatarShapeProp, AvatarTypeMap } from './AvatarProps';
+
+const useUtilityClasses = (ownerState: AvatarProps) => {
+  const { size, variant, color, shape, src, srcSet } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      variant && `variant${capitalize(variant)}`,
+      color && `color${capitalize(color)}`,
+      size && `size${capitalize(size)}`,
+      shape && `shape${capitalize(shape)}`,
+    ],
+    img: [(src || srcSet) && 'img'],
+    fallback: ['fallback'],
+  };
+
+  return composeClasses(slots, getAvatarUtilityClass, {});
+};
+
+const AvatarRoot = styled('div', {
+  name: 'MuiAvatar',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: AvatarProps }>(({ theme, ownerState }) => {
+  return [
+    {
+      ...(ownerState.size === 'sm' && {
+        '--Avatar-size': '3rem',
+      }),
+      ...(ownerState.size === 'md' && {
+        '--Avatar-size': '4rem',
+      }),
+      ...(ownerState.size === 'lg' && {
+        '--Avatar-size': '5rem',
+      }),
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+      width: 'var(--Avatar-size)',
+      height: 'var(--Avatar-size)',
+      lineHeight: 1,
+      borderRadius: '50%',
+      overflow: 'hidden',
+      userSelect: 'none',
+      ...(ownerState.shape === 'rounded' && {
+        borderRadius: theme.vars.radius[ownerState.size!],
+      }),
+      ...(ownerState.shape === 'square' && {
+        borderRadius: 0,
+      }),
+    },
+    theme.variants[ownerState.variant!]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
+    theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+  ];
+});
+
+const AvatarImg = styled('img', {
+  name: 'MuiAvatar',
+  slot: 'Img',
+  overridesResolver: (props, styles) => styles.img,
+})(() => {
+  return [
+    {
+      width: '100%',
+      height: '100%',
+      textAlign: 'center',
+      // Handle non-square image. The property isn't supported by IE11.
+      objectFit: 'cover',
+      // Hide alt text.
+      color: 'transparent',
+      // Hide the image broken icon, only works on Chrome.
+      textIndent: 10000,
+    },
+  ];
+});
+
+const AvatarFallback = styled(Person, {
+  name: 'MuiAvatar',
+  slot: 'Fallback',
+  overridesResolver: (props, styles) => styles.fallback,
+})({
+  width: '75%',
+  height: '75%',
+});
+
+type UseLoadedProps = { src?: string; srcSet?: string; crossOrigin?: any; referrerPolicy?: any };
+
+function useLoaded({ crossOrigin, referrerPolicy, src, srcSet }: UseLoadedProps) {
+  const [loaded, setLoaded] = React.useState<string | boolean>(false);
+
+  React.useEffect(() => {
+    if (!src && !srcSet) {
+      return undefined;
+    }
+
+    setLoaded(false);
+
+    let active = true;
+    const image = new Image();
+    image.onload = () => {
+      if (!active) {
+        return;
+      }
+      setLoaded('loaded');
+    };
+    image.onerror = () => {
+      if (!active) {
+        return;
+      }
+      setLoaded('error');
+    };
+    image.crossOrigin = crossOrigin;
+    image.referrerPolicy = referrerPolicy;
+    if (src) {
+      image.src = src;
+    }
+    if (srcSet) {
+      image.srcset = srcSet;
+    }
+
+    return () => {
+      active = false;
+    };
+  }, [crossOrigin, referrerPolicy, src, srcSet]);
+
+  return loaded;
+}
+
+const Avatar = React.forwardRef(function Avatar(inProps, ref) {
+  const props = useThemeProps<typeof inProps & AvatarProps>({
+    props: inProps,
+    name: 'MuiAvatar',
+  });
+
+  const {
+    alt,
+    className,
+    color = 'neutral',
+    component = 'div',
+    size = 'md',
+    shape = 'circular' as AvatarShapeProp,
+    variant = 'contained',
+    imgProps,
+    src,
+    srcSet,
+    children: childrenProp,
+    ...other
+  } = props;
+
+  let children = null;
+
+  // Use a hook instead of onError on the img element to support server-side rendering.
+  const loaded = useLoaded({ ...imgProps, src, srcSet });
+  const hasImg = src || srcSet;
+  const hasImgNotFailing = hasImg && loaded !== 'error';
+
+  const ownerState = {
+    ...props,
+    color,
+    component,
+    size,
+    variant,
+    shape,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  if (hasImgNotFailing) {
+    children = (
+      <AvatarImg alt={alt} src={src} srcSet={srcSet} className={classes.img} {...imgProps} />
+    );
+  } else if (childrenProp != null) {
+    children = childrenProp;
+  } else if (hasImg && alt) {
+    children = alt[0];
+  } else {
+    children = <AvatarFallback className={classes.fallback} />;
+  }
+
+  return (
+    <AvatarRoot
+      as={component}
+      ownerState={ownerState}
+      className={clsx(classes.root, className)}
+      ref={ref}
+      {...other}
+    >
+      {children}
+    </AvatarRoot>
+  );
+}) as OverridableComponent<AvatarTypeMap>;
+
+Avatar.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Used in combination with `src` or `srcSet` to
+   * provide an alt attribute for the rendered `img` element.
+   */
+  alt: PropTypes.string,
+  /**
+   * Used to render icon or text elements inside the Avatar if `src` is not set.
+   * This can be an element, or just a string.
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'neutral'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['danger', 'info', 'neutral', 'primary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes) applied to the `img` element if the component is used to display an image.
+   * It can be used to listen for the loading error event.
+   */
+  imgProps: PropTypes.object,
+  /**
+   * The shape of the component.
+   * @default 'circlular'
+   */
+  shape: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['circlular', 'rounded', 'square']),
+    PropTypes.string,
+  ]),
+  /**
+   * The size of the component.
+   * It accepts theme values between 'xs' and 'xl'.
+   * @default 'md'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['lg', 'md', 'sm']),
+    PropTypes.string,
+  ]),
+  /**
+   * The `src` attribute for the `img` element.
+   */
+  src: PropTypes.string,
+  /**
+   * The `srcSet` attribute for the `img` element.
+   * Use this attribute for responsive image display.
+   */
+  srcSet: PropTypes.string,
+  /**
+   * The variant to use.
+   * @default 'contained'
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['contained', 'light', 'outlined', 'text']),
+    PropTypes.string,
+  ]),
+} as any;
+
+export default Avatar;

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -1,0 +1,73 @@
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import * as React from 'react';
+import { SxProps } from '../styles/defaultTheme';
+import { ColorPaletteProp, VariantProp } from '../styles/types';
+
+export type AvatarSlot = 'root';
+
+export interface AvatarPropsColorOverrides {}
+export interface AvatarPropsVariantOverrides {}
+export type AvatarShapeProp = 'circlular' | 'rounded' | 'square';
+export type AvatarSizeProp = 'sm' | 'md' | 'lg';
+
+export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P & {
+    /**
+     * Used in combination with `src` or `srcSet` to
+     * provide an alt attribute for the rendered `img` element.
+     */
+    alt?: string;
+    /**
+     * Used to render icon or text elements inside the Avatar if `src` is not set.
+     * This can be an element, or just a string.
+     */
+    children?: React.ReactNode;
+    /**
+     * The color of the component. It supports those theme colors that make sense for this component.
+     * @default 'neutral'
+     */
+    color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, AvatarPropsColorOverrides>;
+    /**
+     * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attributes) applied to the `img` element if the component is used to display an image.
+     * It can be used to listen for the loading error event.
+     */
+    imgProps?: React.ImgHTMLAttributes<HTMLImageElement> & {
+      sx?: SxProps;
+    };
+    /**
+     * The shape of the component.
+     * @default 'circlular'
+     */
+    shape?: AvatarShapeProp;
+    /**
+     * The size of the component.
+     * It accepts theme values between 'xs' and 'xl'.
+     * @default 'md'
+     */
+    size?: AvatarSizeProp;
+    /**
+     * The `src` attribute for the `img` element.
+     */
+    src?: string;
+    /**
+     * The `srcSet` attribute for the `img` element.
+     * Use this attribute for responsive image display.
+     */
+    srcSet?: string;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps;
+    /**
+     * The variant to use.
+     * @default 'contained'
+     */
+    variant?: OverridableStringUnion<Exclude<VariantProp, 'text'>, AvatarPropsVariantOverrides>;
+  };
+  defaultComponent: D;
+}
+
+export type AvatarProps<
+  D extends React.ElementType = AvatarTypeMap['defaultComponent'],
+  P = { component?: React.ElementType },
+> = OverrideProps<AvatarTypeMap<P, D>, D>;

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -34,11 +34,6 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
       sx?: SxProps;
     };
     /**
-     * The shape of the component.
-     * @default 'circlular'
-     */
-    shape?: 'circlular' | 'rounded' | 'square';
-    /**
      * The size of the component.
      * It accepts theme values between 'xs' and 'xl'.
      * @default 'md'

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -7,8 +7,7 @@ export type AvatarSlot = 'root';
 
 export interface AvatarPropsColorOverrides {}
 export interface AvatarPropsVariantOverrides {}
-export type AvatarShapeProp = 'circlular' | 'rounded' | 'square';
-export type AvatarSizeProp = 'sm' | 'md' | 'lg';
+export interface AvatarPropsSizeOverrides {};
 
 export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
@@ -38,13 +37,13 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * The shape of the component.
      * @default 'circlular'
      */
-    shape?: AvatarShapeProp;
+    shape?: 'circlular' | 'rounded' | 'square';
     /**
      * The size of the component.
      * It accepts theme values between 'xs' and 'xl'.
      * @default 'md'
      */
-    size?: AvatarSizeProp;
+    size?: OverridableStringUnion<'sm' | 'md' | 'lg', AvatarPropsSizeOverrides>;
     /**
      * The `src` attribute for the `img` element.
      */

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -7,7 +7,7 @@ export type AvatarSlot = 'root';
 
 export interface AvatarPropsColorOverrides {}
 export interface AvatarPropsVariantOverrides {}
-export interface AvatarPropsSizeOverrides {};
+export interface AvatarPropsSizeOverrides {}
 
 export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {

--- a/packages/mui-joy/src/Avatar/avatarClasses.ts
+++ b/packages/mui-joy/src/Avatar/avatarClasses.ts
@@ -1,0 +1,72 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export interface AvatarClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="neutral"`. */
+  colorNeutral: string;
+  /** Styles applied to the root element if `color="danger"`. */
+  colorDanger: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** Styles applied to the fallback icon */
+  fallback: string;
+  /** Styles applied to the root element if `shape="circular"`. */
+  shapeCircular: string;
+  /** Styles applied to the root element if `shape="rounded"`. */
+  shapeRounded: string;
+  /** Styles applied to the root element if `shape="square"`. */
+  shapeSquare: string;
+  /** Styles applied to the root element if `size="sm"`. */
+  sizeSm: string;
+  /** Styles applied to the root element if `size="md"`. */
+  sizeMd: string;
+  /** Styles applied to the root element if `size="lg"`. */
+  sizeLg: string;
+  /** Styles applied to the img element if either `src` or `srcSet` is defined. */
+  img: string;
+  /** Styles applied to the root element if `variant="text"`. */
+  variantText: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  variantOutlined: string;
+  /** Styles applied to the root element if `variant="light"`. */
+  variantLight: string;
+  /** Styles applied to the root element if `variant="contained"`. */
+  variantContained: string;
+}
+
+export type AvatarClassKey = keyof AvatarClasses;
+
+export function getAvatarUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiAvatar', slot);
+}
+
+const avatarClasses: AvatarClasses = generateUtilityClasses('MuiAvatar', [
+  'root',
+  'colorPrimary',
+  'colorNeutral',
+  'colorDanger',
+  'colorInfo',
+  'colorSuccess',
+  'colorWarning',
+  'fallback',
+  'shapeCircular',
+  'shapeRounded',
+  'shapeSquare',
+  'sizeSm',
+  'sizeMd',
+  'sizeLg',
+  'img',
+  'variantText',
+  'variantOutlined',
+  'variantLight',
+  'variantContained',
+]);
+
+export default avatarClasses;

--- a/packages/mui-joy/src/Avatar/avatarClasses.ts
+++ b/packages/mui-joy/src/Avatar/avatarClasses.ts
@@ -17,12 +17,6 @@ export interface AvatarClasses {
   colorWarning: string;
   /** Styles applied to the fallback icon */
   fallback: string;
-  /** Styles applied to the root element if `shape="circular"`. */
-  shapeCircular: string;
-  /** Styles applied to the root element if `shape="rounded"`. */
-  shapeRounded: string;
-  /** Styles applied to the root element if `shape="square"`. */
-  shapeSquare: string;
   /** Styles applied to the root element if `size="sm"`. */
   sizeSm: string;
   /** Styles applied to the root element if `size="md"`. */
@@ -54,9 +48,6 @@ const avatarClasses: AvatarClasses = generateUtilityClasses('MuiAvatar', [
   'colorSuccess',
   'colorWarning',
   'fallback',
-  'shapeCircular',
-  'shapeRounded',
-  'shapeSquare',
   'sizeSm',
   'sizeMd',
   'sizeLg',

--- a/packages/mui-joy/src/Avatar/avatarClasses.ts
+++ b/packages/mui-joy/src/Avatar/avatarClasses.ts
@@ -31,8 +31,6 @@ export interface AvatarClasses {
   sizeLg: string;
   /** Styles applied to the img element if either `src` or `srcSet` is defined. */
   img: string;
-  /** Styles applied to the root element if `variant="text"`. */
-  variantText: string;
   /** Styles applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
   /** Styles applied to the root element if `variant="light"`. */
@@ -63,7 +61,6 @@ const avatarClasses: AvatarClasses = generateUtilityClasses('MuiAvatar', [
   'sizeMd',
   'sizeLg',
   'img',
-  'variantText',
   'variantOutlined',
   'variantLight',
   'variantContained',

--- a/packages/mui-joy/src/Avatar/index.ts
+++ b/packages/mui-joy/src/Avatar/index.ts
@@ -1,0 +1,4 @@
+export { default } from './Avatar';
+export * from './avatarClasses';
+export { default as avatarClasses } from './avatarClasses';
+export * from './AvatarProps';

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -1,6 +1,9 @@
 export { default as colors } from './colors';
 export * from './styles';
 
+export { default as Avatar } from './Avatar';
+export * from './Avatar';
+
 export { default as Button } from './Button';
 export * from './Button';
 

--- a/packages/mui-joy/src/internal/svg-icons/Person.tsx
+++ b/packages/mui-joy/src/internal/svg-icons/Person.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import createSvgIcon from '../../utils/createSvgIcon';
+
+/**
+ * @ignore - internal component.
+ */
+export default createSvgIcon(
+  <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />,
+  'Person',
+);

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -6,6 +6,7 @@ import { LinkProps, LinkSlot } from '../Link/LinkProps';
 import { ListProps, ListSlot } from '../List/ListProps';
 import { ListDividerProps, ListDividerSlot } from '../ListDivider/ListDividerProps';
 import { ListItemProps, ListItemSlot } from '../ListItem/ListItemProps';
+import { AvatarProps, AvatarSlot } from '../Avatar/AvatarProps';
 import { ListItemButtonProps, ListItemButtonSlot } from '../ListItemButton/ListItemButtonProps';
 import { ListItemContentProps, ListItemContentSlot } from '../ListItemContent/ListItemContentProps';
 import {
@@ -41,6 +42,10 @@ export type OverridesStyleRules<
 >;
 
 export interface Components<Theme = unknown> {
+  MuiAvatar?: {
+    defaultProps?: Partial<AvatarProps>;
+    styleOverrides?: OverridesStyleRules<AvatarSlot, AvatarProps, Theme>;
+  };
   MuiButton?: {
     defaultProps?: Partial<ButtonProps>;
     styleOverrides?: OverridesStyleRules<ButtonSlot, ButtonProps, Theme>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


- `variant`: `'outlined' | 'light' | 'contained'` (`contained` by default)
- `color`: `'danger' | 'info' | 'neutral' | 'primary' | 'success' | 'warning'` (`neutral` by default)
-  `size`: `'sm' | 'md' | 'lg'` (`md` by default)

Preview: https://deploy-preview-31303--material-ui.netlify.app/experiments/joy/avatar/