### PR TITLE
[Grid] Fix columns of nested container

### DIFF
--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -312,9 +312,8 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
 
   const columnsContext = React.useContext(GridContext);
 
-  // setting prop before context to accomodate nesting
   // colums set with default breakpoint unit of 12
-  const columns = columnsProp || columnsContext || 12;
+  const columns = container ? (columnsProp || 12) : columnsContext 
 
   const ownerState = {
     ...props,
@@ -336,11 +335,7 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   const wrapChild = (element) =>
-    columns !== 12 ? (
       <GridContext.Provider value={columns}>{element}</GridContext.Provider>
-    ) : (
-      element
-    );
 
   return wrapChild(
     <GridRoot

--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -312,7 +312,7 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
 
   const columnsContext = React.useContext(GridContext);
 
-  // colums set with default breakpoint unit of 12
+  // columns set with default breakpoint unit of 12
   const columns = container ? columnsProp || 12 : columnsContext;
 
   const ownerState = {
@@ -334,18 +334,16 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const wrapChild = (element) => (
-    <GridContext.Provider value={columns}>{element}</GridContext.Provider>
-  );
-
-  return wrapChild(
-    <GridRoot
-      ownerState={ownerState}
-      className={clsx(classes.root, className)}
-      as={component}
-      ref={ref}
-      {...other}
-    />,
+  return (
+    <GridContext.Provider value={columns}>
+      <GridRoot
+        ownerState={ownerState}
+        className={clsx(classes.root, className)}
+        as={component}
+        ref={ref}
+        {...other}
+      />
+    </GridContext.Provider>
   );
 });
 

--- a/packages/mui-material/src/Grid/Grid.js
+++ b/packages/mui-material/src/Grid/Grid.js
@@ -313,7 +313,7 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
   const columnsContext = React.useContext(GridContext);
 
   // colums set with default breakpoint unit of 12
-  const columns = container ? (columnsProp || 12) : columnsContext 
+  const columns = container ? columnsProp || 12 : columnsContext;
 
   const ownerState = {
     ...props,
@@ -334,8 +334,9 @@ const Grid = React.forwardRef(function Grid(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const wrapChild = (element) =>
-      <GridContext.Provider value={columns}>{element}</GridContext.Provider>
+  const wrapChild = (element) => (
+    <GridContext.Provider value={columns}>{element}</GridContext.Provider>
+  );
 
   return wrapChild(
     <GridRoot

--- a/packages/mui-material/src/Grid/Grid.test.js
+++ b/packages/mui-material/src/Grid/Grid.test.js
@@ -45,6 +45,24 @@ describe('<Grid />', () => {
       // otherwise, max-width would be 50% in this test
       expect(container.firstChild).toHaveComputedStyle({ maxWidth: '100%' });
     });
+
+    it('should apply the correct number of columns for nested containers with undefined prop columns', () => {
+      const { getByTestId } = render(
+        <Grid container columns={16}>
+          <Grid item xs={8}>
+            <Grid container  data-testid="nested-container-in-item">
+              <Grid item xs={12} />
+            </Grid>
+          </Grid>
+        </Grid>,
+      );
+      const container = getByTestId('nested-container-in-item');
+
+            // test whether the class of the child of the container is correct or not
+            expect(container.firstChild).to.have.class(classes.item);
+            
+      expect(container.firstChild).toHaveComputedStyle({ maxWidth: '100%' });
+    });
   });
 
   describe('prop: item', () => {
@@ -360,6 +378,32 @@ describe('<Grid />', () => {
         },
       });
     });
+
+    it('should generate responsive grid when grid item misses breakpoints of its container and breakpoint starts from the middle', () => {
+      const theme = createTheme();
+      expect(
+        generateGrid({
+          ownerState: {
+            columns: { sm: 8, md: 12 },
+            sm: 4,
+            item: true,
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${defaultTheme.breakpoints.values.sm}px)`]: {
+          flexBasis: '50%',
+          flexGrow: 0,
+          maxWidth: '50%',
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.md}px)`]: {
+          flexBasis: '33.333333%',
+          flexGrow: 0,
+          maxWidth: '33.333333%',
+        },
+      });
+    });
+
   });
 
   describe('spacing', () => {

--- a/packages/mui-material/src/Grid/Grid.test.js
+++ b/packages/mui-material/src/Grid/Grid.test.js
@@ -56,11 +56,23 @@ describe('<Grid />', () => {
           </Grid>
         </Grid>,
       );
+
       const container = getByTestId('nested-container-in-item');
+      expect(container.firstChild).toHaveComputedStyle({ maxWidth: '100%' });
+    });
 
-      // test whether the class of the child of the container is correct or not
-      expect(container.firstChild).to.have.class(classes.item);
+    it('should apply the correct number of columns for nested containers with columns=12 (default)', () => {
+      const { getByTestId } = render(
+        <Grid container columns={16}>
+          <Grid item xs={8}>
+            <Grid container columns={12} data-testid="nested-container-in-item">
+              <Grid item xs={12} />
+            </Grid>
+          </Grid>
+        </Grid>,
+      );
 
+      const container = getByTestId('nested-container-in-item');
       expect(container.firstChild).toHaveComputedStyle({ maxWidth: '100%' });
     });
   });

--- a/packages/mui-material/src/Grid/Grid.test.js
+++ b/packages/mui-material/src/Grid/Grid.test.js
@@ -50,7 +50,7 @@ describe('<Grid />', () => {
       const { getByTestId } = render(
         <Grid container columns={16}>
           <Grid item xs={8}>
-            <Grid container  data-testid="nested-container-in-item">
+            <Grid container data-testid="nested-container-in-item">
               <Grid item xs={12} />
             </Grid>
           </Grid>
@@ -58,9 +58,9 @@ describe('<Grid />', () => {
       );
       const container = getByTestId('nested-container-in-item');
 
-            // test whether the class of the child of the container is correct or not
-            expect(container.firstChild).to.have.class(classes.item);
-            
+      // test whether the class of the child of the container is correct or not
+      expect(container.firstChild).to.have.class(classes.item);
+
       expect(container.firstChild).toHaveComputedStyle({ maxWidth: '100%' });
     });
   });
@@ -378,32 +378,6 @@ describe('<Grid />', () => {
         },
       });
     });
-
-    it('should generate responsive grid when grid item misses breakpoints of its container and breakpoint starts from the middle', () => {
-      const theme = createTheme();
-      expect(
-        generateGrid({
-          ownerState: {
-            columns: { sm: 8, md: 12 },
-            sm: 4,
-            item: true,
-          },
-          theme,
-        }),
-      ).to.deep.equal({
-        [`@media (min-width:${defaultTheme.breakpoints.values.sm}px)`]: {
-          flexBasis: '50%',
-          flexGrow: 0,
-          maxWidth: '50%',
-        },
-        [`@media (min-width:${defaultTheme.breakpoints.values.md}px)`]: {
-          flexBasis: '33.333333%',
-          flexGrow: 0,
-          maxWidth: '33.333333%',
-        },
-      });
-    });
-
   });
 
   describe('spacing', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #30209.

This fixes the problem of giving a grid item within a nested grid container the wrong `width`. I think the source of the problem is the grid container inherits the `columns` of the root container and this happens only in the case when the prop `columns` value is 12. I tried to use the default `columns` value which’s 12.