### PR TITLE
[docs] Fix JS files overloading

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -247,6 +247,7 @@ export default function AppNavDrawerItem(props) {
     return (
       <React.Fragment>
         <StyledLi {...other} depth={depth}>
+          {/* Fix overloading with prefetch={false}, only prefetch on hover */}
           <ItemLink
             component={Link}
             activeClassName="app-drawer-active"
@@ -255,6 +256,7 @@ export default function AppNavDrawerItem(props) {
             onClick={onClick}
             depth={depth}
             hasIcon={hasIcon}
+            prefetch={false}
             {...linkProps}
           >
             {iconElement}


### PR DESCRIPTION
In February 2022, we have used 5.2 TB of data for https://mui.com/. Netlify doesn't provide much analytics, so we can only guess why. Now, I did notice behavior that looks completely wrong. The Next's Link component prefetches all the pages for the page that are in the viewport https://nextjs.org/docs/api-reference/next/link. So this means, loading many pages (100?) when only consuming on. This only happens in production:

https://user-images.githubusercontent.com/3165635/156935100-b3617f14-e9bf-4761-9199-748f3c909c02.mp4

https://mui.com/components/alert/

I would expect (hope) this fix to reduce the bandwidth usage by a good 3 TB, saving $600/month. https://deploy-preview-31341--material-ui.netlify.app/components/alert/

Why did I work on this? Because Netlify started to bill $1,000/month for the bandwidth of Material UI last month. We have discovered this a few days ago. Why did it change? It's not clear to me. @mbrookes Do you remember what was the bandwidth guaranteed by Netlify when we moved from Cloudfront in 2018? I thought it was a couple of TB, not 400 GB.
As side historical data, we were using 357 GB of data 3 years ago. I have sent the support of Netlify a new email.