### PR TITLE
Default generic type for useMediaQuery

### DIFF
--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.ts
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getThemeProps, useThemeWithoutDefault as useTheme } from '@mui/system';
+import { getThemeProps, useThemeWithoutDefault as useTheme, Theme } from '@mui/system';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 
 /**
@@ -126,11 +126,11 @@ function useMediaQueryNew(
   return match;
 }
 
-export default function useMediaQuery<Theme = unknown>(
-  queryInput: string | ((theme: Theme) => string),
+export default function useMediaQuery<T = Theme>(
+  queryInput: string | ((theme: T) => string),
   options: Options = {},
 ): boolean {
-  const theme = useTheme<Theme>();
+  const theme = useTheme<T>();
   // Wait for jsdom to support the match media feature.
   // All the browsers MUI support have this built-in.
   // This defensive check is here for simplicity.


### PR DESCRIPTION
Currently the default generic type for `useMediaQuery` is `unknown` which forces users to pass in a type, e.g.

```ts
import { Theme, useMediaQuery } from '@mui/material'

...
useMediaQuery<Theme>(theme => ...)
// or
useMediaQuery((theme: Theme) => ...)
...
```

Omitting the theme type would cause type errors when trying to access `theme` since it is typed to `unknown`.

This feels strange to me since other parts in the eco-system seems to usually assume the theme to be of type `Theme` (e.g. in the prop for `sx`).

-----

This commit allow users to do the following directly without the need to specify `Theme` as the type for `theme`, i.e.

```ts
useMediaQuery(theme => ...) // `theme` will be of type `Theme`
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
