### PR TITLE
[docs] Remove career pages from translation

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,7 @@ files:
       - /docs/src/pages/discover-more/backers/*
       - /docs/src/pages/discover-more/roadmap/*
       - /docs/src/pages/company/**/*
+      - /docs/src/pages/careers/**/*
     translation: /%original_path%/%file_name%-%two_letters_code%.%file_extension%
   - source: /docs/data/**/*.md
     ignore:
@@ -16,7 +17,6 @@ files:
       - /docs/data/material/discover-more/backers/*
       - /docs/data/material/discover-more/roadmap/*
       - /docs/data/material/premium-themes/*/**/*
-      - /docs/data/company/**/*
     translation: /%original_path%/%file_name%-%two_letters_code%.%file_extension%
   - source: /docs/translations/**/*.json
     ignore:


### PR DESCRIPTION
Our career page should be English only, we filter candidates based on this. I'm ignoring these files

<img width="1173" alt="Screenshot 2022-03-06 at 23 47 09" src="https://user-images.githubusercontent.com/3165635/156945481-38d7685c-07fb-4494-a941-5726401cbe8b.png">

https://translate.mui.com/project/material-ui-docs/zh-CN#/material-ui/master/docs

I would propose we start to actively translate the docs once the docs split is pushed enough.