### PR TITLE
Fix running markdownlint on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint . --cache --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",
     "lint:ci": "eslint . --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",
     "stylelint": "stylelint --reportInvalidScopeDisables --reportNeedlessDisables docs/**/*.{js,ts,tsx}",
-    "markdownlint": "markdownlint '**/*.md' --config .markdownlint.jsonc",
+    "markdownlint": "markdownlint \"**/*.md\" --config .markdownlint.jsonc",
     "prettier": "node ./scripts/prettier.js",
     "prettier:all": "node ./scripts/prettier.js write",
     "size:snapshot": "node --max-old-space-size=4096 ./scripts/sizeSnapshot/create",


### PR DESCRIPTION
Changed `'` to `"` in markdownlint script to allow it to be run on Windows
