### PR TITLE
[website] Update Ukraine support link

### DIFF
--- a/docs/src/components/banner/TableOfContentsBanner.tsx
+++ b/docs/src/components/banner/TableOfContentsBanner.tsx
@@ -8,7 +8,7 @@ import { alpha } from '@mui/material/styles';
 export default function TableOfContentsBanner() {
   return FEATURE_TOGGLE.enable_toc_banner ? (
     <Link
-      href="https://ukraine.ua/news/stand-with-ukraine/" // Fix me!
+      href="https://war.ukraine.ua/support-ukraine/"
       target="_blank"
       sx={(theme) => ({
         mb: 2,
@@ -49,7 +49,7 @@ export default function TableOfContentsBanner() {
           MUI stands in solidarity with the Ukrainian people against the Russian invasion.
         </Typography>
         <Typography component="span" variant="caption" fontWeight="normal" color="text.secondary">
-          Find out here how you can help.
+          Find out how you can help.
         </Typography>
       </Box>
     </Link>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The current link in the Ukraine banner returns a 404. The support page appears to have been moved to a new subdomain. I have updated the link, and also removed the word "here" from the call to action so it reads better.
