### PR TITLE
[test] Upgrade CircleCI convenience image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ defaults: &defaults
     AWS_REGION_ARTIFACTS: eu-central-1
   working_directory: /tmp/material-ui
   docker:
-    - image: circleci/node:12
+    - image: cimg/node:12.22
 
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes 

![image](https://user-images.githubusercontent.com/42154031/157551267-7e1d6267-8a44-4067-8e07-c71e6f67089a.png)

From https://app.circleci.com/pipelines/github/mui/material-ui/66259/workflows/a10e4a36-1fc8-4053-9cbf-405af395a630/jobs/357658

More information: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

I did the same for X in https://github.com/mui/mui-x/pull/4143

I changed `node:12` -> `node:12.22` because the `12` tag doesn't exist: 

![image](https://user-images.githubusercontent.com/42154031/157556301-5b57969f-7469-4c65-b675-b731a8e27f34.png)
