### PR TITLE
[test] Allow to pass options to `createDOM`

### DIFF
--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -19,10 +19,11 @@ const whitelist = [
 ];
 const blacklist = ['sessionStorage', 'localStorage'];
 
-function createDOM() {
+function createDOM(options) {
   const dom = new JSDOM('', {
     pretendToBeVisual: true,
     url: 'http://localhost', // https://github.com/jsdom/jsdom/issues/2383
+    ...options,
   });
   global.window = dom.window;
   // Not yet supported: https://github.com/jsdom/jsdom/issues/2152


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

After upgrading monorepo in https://github.com/mui/mui-x/pull/4149 few unit tests started to fail.
This change allows us to override JSDOM options and fix failing tests.