### PR TITLE
[TextField] fix disappearing border in Safari

### DIFF
--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -47,6 +47,8 @@ const NotchedOutlineLegend = styled('legend')(({ ownerState, theme }) => ({
       paddingLeft: 5,
       paddingRight: 5,
       display: 'inline-block',
+      opacity: 0,
+      visibility: 'visible'
     },
     ...(ownerState.notched && {
       maxWidth: '100%',

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -48,7 +48,7 @@ const NotchedOutlineLegend = styled('legend')(({ ownerState, theme }) => ({
       paddingRight: 5,
       display: 'inline-block',
       opacity: 0,
-      visibility: 'visible'
+      visibility: 'visible',
     },
     ...(ownerState.notched && {
       maxWidth: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/31367
Makes span in `NotchedOutline` visible so that border respects it and its' padding in Safari