### PR TITLE
[examples] Fix Link leak of Next.js props

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -44,7 +44,7 @@ const Item = styled(function Item({ component: Component = 'div', ...props }) {
   paddingTop: 5,
   paddingBottom: 5,
   justifyContent: 'flex-start',
-  fontWeight: 500,
+  fontWeight: theme.typography.fontWeightMedium,
   transition: theme.transitions.create(['color', 'background-color'], {
     duration: theme.transitions.duration.shortest,
   }),
@@ -70,13 +70,13 @@ const ItemLink = styled(Item, {
   return {
     fontSize: theme.typography.pxToRem(14),
     color: theme.palette.text.secondary,
+    textDecoration: 'none',
     '&.app-drawer-active': {
       // color: theme.palette.primary.main,
       color:
         theme.palette.mode === 'dark' ? theme.palette.primary[300] : theme.palette.primary[600],
       backgroundColor:
         theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.primary[50],
-      fontWeight: 500,
       '&:hover': {
         backgroundColor: alpha(
           theme.palette.primary.main,
@@ -137,7 +137,7 @@ const ItemButton = styled(Item, {
     fontSize: theme.typography.pxToRem(depth === 0 ? 14 : 11),
     textTransform: depth === 0 ? 'none' : 'uppercase',
     letterSpacing: depth === 0 ? null : '.08rem',
-    fontWeight: depth === 0 ? 500 : 700,
+    fontWeight: depth === 0 ? theme.typography.fontWeightMedium : theme.typography.fontWeightBold,
     marginBottom: depth === 0 ? '5px' : null,
     marginTop,
     '&:hover': {
@@ -253,6 +253,7 @@ export default function AppNavDrawerItem(props) {
             activeClassName="app-drawer-active"
             href={href}
             underline="none"
+            noLinkStyle
             onClick={onClick}
             depth={depth}
             hasIcon={hasIcon}

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -22,12 +22,11 @@ interface NextLinkComposedProps
     Omit<NextLinkProps, 'href' | 'as' | 'passHref'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];
-  href?: NextLinkProps['href'];
 }
 
 const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, shallow, prefetch, locale, ...other } = props;
+    const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
     return (
       <NextLink
@@ -60,12 +59,17 @@ export type LinkProps = {
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
   const {
     activeClassName = 'active',
-    as: asProp,
+    as,
     className: classNameProps,
     href,
     linkAs: linkAsProp,
+    locale,
     noLinkStyle,
+    prefetch,
+    replace,
     role, // Link don't have roles.
+    scroll,
+    shallow,
     ...other
   } = props;
 
@@ -87,7 +91,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     return <MuiLink className={className} href={href} ref={ref} {...other} />;
   }
 
-  let linkAs = linkAsProp || asProp || (href as string);
+  let linkAs = linkAsProp || as || (href as string);
   if (
     userLanguage !== 'en' &&
     pathname &&
@@ -98,19 +102,18 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     linkAs = `/${userLanguage}${linkAs}`;
   }
 
+  const nextjsProps = { to: href, linkAs, replace, scroll, shallow, prefetch, locale };
+
   if (noLinkStyle) {
-    return (
-      <NextLinkComposed className={className} ref={ref} to={href} linkAs={linkAs} {...other} />
-    );
+    return <NextLinkComposed className={className} ref={ref} {...nextjsProps} {...other} />;
   }
 
   return (
     <MuiLink
       component={NextLinkComposed}
-      linkAs={linkAs}
       className={className}
       ref={ref}
-      to={href}
+      {...nextjsProps}
       {...other}
     />
   );

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -13,12 +13,11 @@ interface NextLinkComposedProps
     Omit<NextLinkProps, 'href' | 'as'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];
-  href?: NextLinkProps['href'];
 }
 
 export const NextLinkComposed = React.forwardRef<HTMLAnchorElement, NextLinkComposedProps>(
   function NextLinkComposed(props, ref) {
-    const { to, linkAs, href, replace, scroll, shallow, prefetch, locale, ...other } = props;
+    const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
     return (
       <NextLink
@@ -51,11 +50,17 @@ export type LinkProps = {
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props, ref) {
   const {
     activeClassName = 'active',
-    as: linkAs,
+    as,
     className: classNameProps,
     href,
+    linkAs: linkAsProp,
+    locale,
     noLinkStyle,
+    prefetch,
+    replace,
     role, // Link don't have roles.
+    scroll,
+    shallow,
     ...other
   } = props;
 
@@ -76,17 +81,19 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     return <MuiLink className={className} href={href} ref={ref} {...other} />;
   }
 
+  const linkAs = linkAsProp || as;
+  const nextjsProps = { to: href, linkAs, replace, scroll, shallow, prefetch, locale };
+
   if (noLinkStyle) {
-    return <NextLinkComposed className={className} ref={ref} to={href} {...other} />;
+    return <NextLinkComposed className={className} ref={ref} {...nextjsProps} {...other} />;
   }
 
   return (
     <MuiLink
       component={NextLinkComposed}
-      linkAs={linkAs}
       className={className}
       ref={ref}
-      to={href}
+      {...nextjsProps}
       {...other}
     />
   );

--- a/examples/nextjs/src/Link.js
+++ b/examples/nextjs/src/Link.js
@@ -10,7 +10,7 @@ import { styled } from '@mui/material/styles';
 const Anchor = styled('a')({});
 
 export const NextLinkComposed = React.forwardRef(function NextLinkComposed(props, ref) {
-  const { to, linkAs, href, replace, scroll, shallow, prefetch, locale, ...other } = props;
+  const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } = props;
 
   return (
     <NextLink
@@ -45,11 +45,17 @@ NextLinkComposed.propTypes = {
 const Link = React.forwardRef(function Link(props, ref) {
   const {
     activeClassName = 'active',
-    as: linkAs,
+    as,
     className: classNameProps,
     href,
+    linkAs: linkAsProp,
+    locale,
     noLinkStyle,
+    prefetch,
+    replace,
     role, // Link don't have roles.
+    scroll,
+    shallow,
     ...other
   } = props;
 
@@ -70,17 +76,19 @@ const Link = React.forwardRef(function Link(props, ref) {
     return <MuiLink className={className} href={href} ref={ref} {...other} />;
   }
 
+  const linkAs = linkAsProp || as;
+  const nextjsProps = { to: href, linkAs, replace, scroll, shallow, prefetch, locale };
+
   if (noLinkStyle) {
-    return <NextLinkComposed className={className} ref={ref} to={href} {...other} />;
+    return <NextLinkComposed className={className} ref={ref} {...nextjsProps} {...other} />;
   }
 
   return (
     <MuiLink
       component={NextLinkComposed}
-      linkAs={linkAs}
       className={className}
       ref={ref}
-      to={href}
+      {...nextjsProps}
       {...other}
     />
   );
@@ -92,8 +100,13 @@ Link.propTypes = {
   className: PropTypes.string,
   href: PropTypes.any,
   linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  locale: PropTypes.string,
   noLinkStyle: PropTypes.bool,
+  prefetch: PropTypes.bool,
+  replace: PropTypes.bool,
   role: PropTypes.string,
+  scroll: PropTypes.bool,
+  shallow: PropTypes.bool,
 };
 
 export default Link;


### PR DESCRIPTION
#31341 introduces a regression:

<img width="507" alt="Screenshot 2022-03-11 at 16 22 04" src="https://user-images.githubusercontent.com/3165635/157896198-1f5bff40-a9b4-410a-addf-454f51f56788.png">

This is because of the how `docs/src/modules/components/Link` is implemented. In some cases (external links), we don't land into Next.js's Link component that intercepts the `prefetch` prop.