### PR TITLE
[core] Simplify anchor link

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -6,7 +6,6 @@ import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import NoSsr from '@mui/material/NoSsr';
 import Link from 'docs/src/modules/components/Link';
-import PageContext from 'docs/src/modules/components/PageContext';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBanner';
 
@@ -119,8 +118,6 @@ export default function AppTableOfContents(props) {
   const t = useTranslate();
 
   const items = React.useMemo(() => flatten(toc), [toc]);
-
-  const { activePage } = React.useContext(PageContext);
   const [activeState, setActiveState] = React.useState(null);
   const clickedRef = React.useRef(false);
   const unsetClickedRef = React.useRef(null);
@@ -199,7 +196,7 @@ export default function AppTableOfContents(props) {
   const itemLink = (item, secondary) => (
     <NavItem
       display="block"
-      href={`${activePage?.linkProps?.linkAs ?? activePage?.pathname}#${item.hash}`}
+      href={`#${item.hash}`}
       underline="none"
       onClick={handleClick(item.hash)}
       active={activeState === item.hash}


### PR DESCRIPTION
This is a follow-up on #18756 from @Janpot. I wanted to test that the bug was indeed fixed in Next.js: https://github.com/vercel/next.js/issues/9678. It's indeed fixed, proof: https://deploy-preview-31419--material-ui.netlify.app/components/alert/#basic-alerts.

In https://mui.com/api/data-grid/grid-row-spacing-params/ you can see how the page is missing the `activePage` which breaks the anchor: 

<img width="669" alt="Screenshot 2022-03-11 at 17 14 52" src="https://user-images.githubusercontent.com/3165635/157905582-8579a542-e7fa-4c45-acb9-3d646fcac0c3.png">

