### PR TITLE
[docs] Fix y-axis unit used in the responsive font sizes chart

### DIFF
--- a/docs/data/material/customization/typography/ResponsiveFontSizesChart.js
+++ b/docs/data/material/customization/typography/ResponsiveFontSizesChart.js
@@ -88,7 +88,7 @@ export default function ResponsiveFontSizes() {
           </XAxis>
           <YAxis dataKey="fontSize" type="number">
             <Label position="top" offset={20}>
-              font-size (rem)
+              font-size (px)
             </Label>
           </YAxis>
           <Tooltip />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Changes
- update unit from `rem` to `px` in displayed responsive font-sizes chart

**before:**
Values shown in the chart are in `px` same as y-axis scale. But y-axis says `rem` instead of `px`
![Bildschirmfoto 2022-03-11 um 20 16 55](https://user-images.githubusercontent.com/2707029/157936979-74f08ad8-b422-423f-bc71-c31c47280fb4.png)

**after:**
![Bildschirmfoto 2022-03-11 um 20 25 44](https://user-images.githubusercontent.com/2707029/157937508-e2a35a1f-df1d-48c2-ac8e-c4baffa81e5f.png)
