### PR TITLE
[examples] Ignore tsbuildinfo with Next.js

### DIFF
--- a/examples/nextjs-with-typescript/.gitignore
+++ b/examples/nextjs-with-typescript/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# typescript
+*.tsbuildinfo


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Same as https://github.com/mui/mui-x/pull/3068, to match https://github.com/vercel/next.js/blob/5a16b1a26f6c213776deed9ac465e2bc81cdf5f3/packages/create-next-app/templates/typescript/gitignore#L35