### PR TITLE
[TextField] Fix Safari rendering issue with outlined variant and notched label

### DIFF
--- a/packages/mui-joy/src/FormLabel/FormLabel.tsx
+++ b/packages/mui-joy/src/FormLabel/FormLabel.tsx
@@ -87,7 +87,7 @@ FormLabel.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * The component used for the root node.
-   * Either a string to use a HTML element or a component.
+   * Either a string to use an HTML element or a component.
    */
   component: PropTypes.elementType,
   /**

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -38,11 +38,13 @@ const NotchedOutlineLegend = styled('legend')(({ ownerState, theme }) => ({
     fontSize: '0.75em',
     visibility: 'hidden',
     maxWidth: 0.01,
-    transition: theme.transitions.create('max-width', {
+    // by transitioning opacity, Safari correctly rerenders outer fieldset border after notched state
+    transition: theme.transitions.create(['max-width', 'opacity'], {
       duration: 50,
       easing: theme.transitions.easing.easeOut,
     }),
     whiteSpace: 'nowrap',
+    opacity: 0,
     '& > span': {
       paddingLeft: 5,
       paddingRight: 5,
@@ -50,7 +52,9 @@ const NotchedOutlineLegend = styled('legend')(({ ownerState, theme }) => ({
     },
     ...(ownerState.notched && {
       maxWidth: '100%',
-      transition: theme.transitions.create('max-width', {
+      opacity: 1,
+      // by transitioning opacity, Safari correctly rerenders outer fieldset border after notched state
+      transition: theme.transitions.create(['max-width', 'opacity'], {
         duration: 100,
         easing: theme.transitions.easing.easeOut,
         delay: 50,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Issue

In Safari 15 on macOS Monterey the outlined textfield and the label are broken when the field is focused. With this component used in other places like autocomplete, other components are affected as well.

When the input is focused and the label gets notched, the border bleeds through the label. 
<img width="302" alt="Bildschirmfoto 2022-03-12 um 23 27 42" src="https://user-images.githubusercontent.com/2707029/158037189-2638563e-5529-4d04-b0a6-455df425315d.png">
The label "background" will only show when the browser repaints, e.g if you update any css like in the dev tools.

When the input is blurred, a ghost background can still be seen. It will go away when on a browser paint event.
<img width="292" alt="Bildschirmfoto 2022-03-12 um 22 02 17" src="https://user-images.githubusercontent.com/2707029/158037008-8dd1c0a7-bd09-482c-8a5d-76fa42dbd6b7.png">

### Fix

The fix is actually an odd one. In order to trigger paint, 2/3 potential fixes require setting a css prop that will cause a browser paint. I chose `opacity` with different (random) values to both non-notched and notched state.

1. (done in this PR) After setting the different opacity values, both transitions properties need to  include `opacity`.
2. (could be done) set only `opacity` to the non-notched transition, and remove the notched state transition
3. remove the `transition` on both notched and non-notched state

### NOTE
- I didn't choose the second option because it isn't clear to me, why the notched state has a transition and what it's used for.
- For the 3rd option removing both transition fixed the problem, but made no different to rendered label, since the notched label component is actually visually hidden. Not sure whats up with that 🤷‍♂️ 

To me the 3rd option would be the best solution but it's unclear to me what will break when removing the transition css prop