### PR TITLE
[Joy] Support horizontal `List`

### DIFF
--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -713,7 +713,7 @@ const Gatsby = () => {
   );
 };
 
-export default function JoyTypography() {
+export default function JoyList() {
   return (
     <CssVarsProvider
       theme={{
@@ -1172,6 +1172,61 @@ export default function JoyTypography() {
           <Firebash />
 
           <Gatsby />
+        </Box>
+        <Box sx={{ height: 40 }} />
+        <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2 }}>
+          <List row>
+            <ListItem>Item 1</ListItem>
+            <ListItem>Item 2</ListItem>
+            <ListItem>Item 3</ListItem>
+          </List>
+          <List row>
+            <ListItem>Item 1</ListItem>
+            <ListDivider />
+            <ListItem>Item 2</ListItem>
+            <ListDivider />
+            <ListItem>Item 3</ListItem>
+          </List>
+          <List row component="nav">
+            <ListItemButton>Action 1</ListItemButton>
+            <ListItemButton>Action 2</ListItemButton>
+            <ListItemButton>Action 3</ListItemButton>
+          </List>
+          <List
+            row
+            sx={{
+              '--List-gap': '0px',
+              '--List-item-paddingLeft': '1rem',
+              '--List-item-paddingRight': '1rem',
+            }}
+          >
+            <ListItem>
+              <ListItemButton selected variant="light">
+                <ListItemDecorator>
+                  <InboxIcon />
+                </ListItemDecorator>{' '}
+                Inbox
+              </ListItemButton>
+            </ListItem>
+            <ListDivider />
+            <ListItem>
+              <ListItemButton>
+                <ListItemDecorator>
+                  <Label />
+                </ListItemDecorator>
+                Categories
+              </ListItemButton>
+            </ListItem>
+            <ListDivider />
+            <ListItem>
+              <ListItemButton>
+                <ListItemDecorator>
+                  <People />
+                </ListItemDecorator>
+                Social
+              </ListItemButton>
+            </ListItem>
+          </List>
         </Box>
       </Box>
     </CssVarsProvider>

--- a/packages/mui-joy/src/List/List.test.js
+++ b/packages/mui-joy/src/List/List.test.js
@@ -47,4 +47,9 @@ describe('Joy <List />', () => {
     );
     expect(getByRole('list')).to.have.class(classes.nested);
   });
+
+  it('should have row classes', () => {
+    const { getByRole } = render(<List row />);
+    expect(getByRole('list')).to.have.class(classes.row);
+  });
 });

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -8,6 +8,7 @@ import { styled, useThemeProps } from '../styles';
 import { ListProps, ListTypeMap } from './ListProps';
 import { getListUtilityClass } from './listClasses';
 import { useNestedList } from './NestedListContext';
+import RowListContext from './RowListContext';
 
 const useUtilityClasses = (ownerState: ListProps & { nested: boolean }) => {
   const { size, nested } = ownerState;
@@ -33,7 +34,7 @@ const ListRoot = styled('ul', {
           '--List-item-paddingLeft': '0.25rem',
           '--List-item-paddingRight': '0.25rem',
           '--List-item-fontSize': theme.vars.fontSize.sm,
-          '--List-decorator-width': '2rem',
+          '--List-decorator-width': ownerState.row ? '1.5rem' : '2rem',
           '--Icon-fontSize': '1.125rem',
         };
       }
@@ -45,7 +46,7 @@ const ListRoot = styled('ul', {
           '--List-item-paddingLeft': '0.75rem',
           '--List-item-paddingRight': '0.75rem',
           '--List-item-fontSize': theme.vars.fontSize.md,
-          '--List-decorator-width': '2.5rem',
+          '--List-decorator-width': ownerState.row ? '2rem' : '2.5rem',
           '--Icon-fontSize': '1.25rem',
         };
       }
@@ -57,7 +58,7 @@ const ListRoot = styled('ul', {
           '--List-item-paddingLeft': '0.5rem',
           '--List-item-paddingRight': '0.5rem',
           '--List-item-fontSize': theme.vars.fontSize.md,
-          '--List-decorator-width': '3rem',
+          '--List-decorator-width': ownerState.row ? '2.5rem' : '3rem',
           '--Icon-fontSize': '1.5rem',
         };
       }
@@ -97,7 +98,7 @@ const ListRoot = styled('ul', {
       {
         listStyle: 'none',
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: ownerState.row ? 'row' : 'column',
         flexGrow: 1,
         position: 'relative', // for sticky ListItem
       },
@@ -112,27 +113,30 @@ const List = React.forwardRef(function List(inProps, ref) {
     name: 'MuiList',
   });
 
-  const { component, className, children, size = 'md', ...other } = props;
+  const { component, className, children, size = 'md', row = false, ...other } = props;
 
   const ownerState = {
     instanceSize: inProps.size,
     size,
     nested,
+    row,
     ...props,
   };
 
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <ListRoot
-      ref={ref}
-      as={component}
-      className={clsx(classes.root, className)}
-      ownerState={ownerState}
-      {...other}
-    >
-      {children}
-    </ListRoot>
+    <RowListContext.Provider value={row}>
+      <ListRoot
+        ref={ref}
+        as={component}
+        className={clsx(classes.root, className)}
+        ownerState={ownerState}
+        {...other}
+      >
+        {children}
+      </ListRoot>
+    </RowListContext.Provider>
   );
 }) as OverridableComponent<ListTypeMap>;
 

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -11,9 +11,9 @@ import { useNestedList } from './NestedListContext';
 import RowListContext from './RowListContext';
 
 const useUtilityClasses = (ownerState: ListProps & { nested: boolean }) => {
-  const { size, nested } = ownerState;
+  const { size, nested, row } = ownerState;
   const slots = {
-    root: ['root', size && `size${capitalize(size)}`, nested && 'nested'],
+    root: ['root', size && `size${capitalize(size)}`, nested && 'nested', row && 'row'],
   };
 
   return composeClasses(slots, getListUtilityClass, {});

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -159,6 +159,10 @@ List.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
+   * If `true`, display the list in horizontal direction.
+   */
+  row: PropTypes.bool,
+  /**
    * The size of the component (affect other nested list* components).
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([

--- a/packages/mui-joy/src/List/ListProps.ts
+++ b/packages/mui-joy/src/List/ListProps.ts
@@ -18,6 +18,10 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      */
     classes?: Partial<ListClasses>;
     /**
+     * If `true`, display the list in horizontal direction.
+     */
+    row?: boolean;
+    /**
      * The size of the component (affect other nested list* components).
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', ListPropsSizeOverrides>;

--- a/packages/mui-joy/src/List/RowListContext.ts
+++ b/packages/mui-joy/src/List/RowListContext.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const RowListContext = React.createContext(false);
+
+export const useRowList = () => React.useContext(RowListContext);
+
+export default RowListContext;

--- a/packages/mui-joy/src/List/listClasses.ts
+++ b/packages/mui-joy/src/List/listClasses.ts
@@ -5,6 +5,8 @@ export interface ListClasses {
   root: string;
   /** Styles applied to the root element if wrapped with nested context. */
   nested: string;
+  /** Styles applied to the root element if `row` is true. */
+  row: string;
   /** Styles applied to the root element if `size="sm"`. */
   sizeSm: string;
   /** Styles applied to the root element if `size="md"`. */
@@ -22,6 +24,7 @@ export function getListUtilityClass(slot: string): string {
 const listClasses: ListClasses = generateUtilityClasses('MuiList', [
   'root',
   'nested',
+  'row',
   'sizeSm',
   'sizeMd',
   'sizeLg',

--- a/packages/mui-joy/src/ListDivider/ListDivider.test.js
+++ b/packages/mui-joy/src/ListDivider/ListDivider.test.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { describeConformance, createRenderer, screen } from 'test/utils';
 import { ThemeProvider } from '@mui/joy/styles';
+import List from '@mui/joy/List';
 import ListDivider, { listDividerClasses as classes } from '@mui/joy/ListDivider';
 
 describe('Joy <ListDivider />', () => {
@@ -26,5 +27,14 @@ describe('Joy <ListDivider />', () => {
   it('should accept className prop', () => {
     const { container } = render(<ListDivider className="foo-bar" />);
     expect(container.firstChild).to.have.class('foo-bar');
+  });
+
+  it('should have aria-orientation set to horizontal', () => {
+    render(
+      <List row>
+        <ListDivider />
+      </List>,
+    );
+    expect(screen.getByRole('separator')).to.have.attribute('aria-orientation', 'horizontal');
   });
 });

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -55,6 +55,7 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
     props: inProps,
     name: 'MuiListDivider',
   });
+
   const row = React.useContext(RowListContext);
 
   const { component, className, children, inset, ...other } = props;
@@ -102,6 +103,7 @@ ListDivider.propTypes /* remove-proptypes */ = {
   component: PropTypes.elementType,
   /**
    * The empty space on the side(s) of the divider.
+   * This prop has no effect on the divider if the nearest parent List has `row` prop set to `true`.
    */
   inset: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['gutter', 'startDecorator', 'startContent']),

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -7,6 +7,7 @@ import composeClasses from '@mui/base/composeClasses';
 import { styled, useThemeProps } from '../styles';
 import { ListDividerProps, ListDividerTypeMap } from './ListDividerProps';
 import { getListDividerUtilityClass } from './listDividerClasses';
+import RowListContext from '../List/RowListContext';
 
 const useUtilityClasses = (ownerState: ListDividerProps) => {
   const slots = {
@@ -20,26 +21,33 @@ const ListDividerRoot = styled('li', {
   name: 'MuiListDivider',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ListDividerProps }>(({ theme, ownerState }) => ({
-  '--List-divider-marginY': 'calc(var(--List-gap) + var(--List-divider-gap))',
+})<{ ownerState: ListDividerProps & { row: boolean } }>(({ theme, ownerState }) => ({
   border: 'none', // reset the border for `hr` tag
-  borderBottom: '1px solid',
+  ...(ownerState.row && {
+    '--List-divider-marginX': 'calc(var(--List-gap) + var(--List-divider-gap))',
+    borderRight: '1px solid',
+    margin: '0px var(--List-divider-marginX)',
+  }),
+  ...(!ownerState.row && {
+    '--List-divider-marginY': 'calc(var(--List-gap) + var(--List-divider-gap))',
+    // by default, the divider line is stretched from edge-to-edge of the List
+    // spacing between ListItem can be controlled by `--List-divider-gap` on the List
+    margin: 'var(--List-divider-marginY) calc(-1 * var(--List-padding))',
+    ...(ownerState.inset === 'gutter' && {
+      margin: 'var(--List-divider-marginY)',
+      marginRight: 'var(--List-item-paddingRight)',
+      marginLeft: 'var(--List-item-paddingLeft)',
+    }),
+    ...(ownerState.inset === 'startDecorator' && {
+      marginLeft: 'var(--List-item-paddingLeft)',
+    }),
+    ...(ownerState.inset === 'startContent' && {
+      marginLeft: 'calc(var(--List-item-paddingLeft) + var(--List-decorator-width))',
+    }),
+    borderBottom: '1px solid',
+  }),
   borderColor: theme.vars.palette.divider,
-  // by default, the divider line is stretched from edge-to-edge of the List
-  // spacing between ListItem can be controlled by `--List-divider-gap` on the List
-  margin: 'var(--List-divider-marginY) calc(-1 * var(--List-padding))',
   listStyle: 'none',
-  ...(ownerState.inset === 'gutter' && {
-    margin: 'var(--List-divider-marginY)',
-    marginRight: 'var(--List-item-paddingRight)',
-    marginLeft: 'var(--List-item-paddingLeft)',
-  }),
-  ...(ownerState.inset === 'startDecorator' && {
-    marginLeft: 'var(--List-item-paddingLeft)',
-  }),
-  ...(ownerState.inset === 'startContent' && {
-    marginLeft: 'calc(var(--List-item-paddingLeft) + var(--List-decorator-width))',
-  }),
 }));
 
 const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
@@ -47,11 +55,13 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
     props: inProps,
     name: 'MuiListDivider',
   });
+  const row = React.useContext(RowListContext);
 
   const { component, className, children, inset, ...other } = props;
 
   const ownerState = {
     inset,
+    row,
     ...props,
   };
 
@@ -64,6 +74,7 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
       className={clsx(classes.root, className)}
       ownerState={ownerState}
       role="separator"
+      aria-orientation={row ? 'horizontal' : 'vertical'}
       {...other}
     >
       {children}

--- a/packages/mui-joy/src/ListDivider/ListDividerProps.ts
+++ b/packages/mui-joy/src/ListDivider/ListDividerProps.ts
@@ -19,6 +19,7 @@ export interface ListDividerTypeMap<P = {}, D extends React.ElementType = 'li'> 
     classes?: Partial<ListDividerClasses>;
     /**
      * The empty space on the side(s) of the divider.
+     * This prop has no effect on the divider if the nearest parent List has `row` prop set to `true`.
      */
     inset?: OverridableStringUnion<
       'gutter' | 'startDecorator' | 'startContent',

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -115,6 +115,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     props: inProps,
     name: 'MuiListItem',
   });
+
   const row = React.useContext(RowListContext);
 
   const {

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -8,6 +8,7 @@ import { ListItemProps, ListItemTypeMap } from './ListItemProps';
 import listItemClasses, { getListItemUtilityClass } from './listItemClasses';
 import { listItemButtonClasses } from '../ListItemButton';
 import NestedListContext from '../List/NestedListContext';
+import RowListContext from '../List/RowListContext';
 
 const useUtilityClasses = (ownerState: ListItemProps) => {
   const { sticky, nested } = ownerState;
@@ -24,7 +25,7 @@ const ListItemRoot = styled('li', {
   name: 'MuiListItem',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ListItemProps }>(({ theme, ownerState }) => [
+})<{ ownerState: ListItemProps & { row: boolean } }>(({ theme, ownerState }) => [
   !ownerState.nested && {
     // add negative margin to ListItemButton equal to this ListItem padding
     '--List-itemButton-margin': `calc(-1 * var(--List-item-paddingY))
@@ -70,12 +71,18 @@ calc(-1 * var(--List-item-paddingLeft))`,
       background: 'var(--List-background)',
     }),
     // Using :last-child or :first-child selector would complicate ListDivider margin
-    [`& + .${listItemClasses.root}`]: {
-      marginTop: 'var(--List-gap)',
-    },
-    [`& + .${listItemButtonClasses.root}`]: {
-      marginTop: 'var(--List-gap)',
-    },
+    [`& + .${listItemClasses.root}`]: ownerState.row
+      ? {
+          marginLeft: 'var(--List-gap)',
+        }
+      : {
+          marginTop: 'var(--List-gap)',
+        },
+    [`& + .${listItemButtonClasses.root}`]: ownerState.row
+      ? { marginLeft: 'var(--List-gap)' }
+      : {
+          marginTop: 'var(--List-gap)',
+        },
   },
 ]);
 
@@ -108,6 +115,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     props: inProps,
     name: 'MuiListItem',
   });
+  const row = React.useContext(RowListContext);
 
   const {
     component,
@@ -124,6 +132,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     sticky,
     startAction,
     endAction,
+    row,
     ...props,
   };
 

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -116,6 +116,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     props: inProps,
     name: 'MuiListItemButton',
   });
+
   const row = React.useContext(RowListContext);
 
   const {

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -12,6 +12,7 @@ import {
 } from './ListItemButtonProps';
 import listItemButtonClasses, { getListItemButtonUtilityClass } from './listItemButtonClasses';
 import listItemClasses from '../ListItem/listItemClasses';
+import RowListContext from '../List/RowListContext';
 
 const useUtilityClasses = (ownerState: ListItemButtonProps & { focusVisible: boolean }) => {
   const { color, disabled, focusVisible, focusVisibleClassName, selected, variant } = ownerState;
@@ -40,7 +41,7 @@ const ListItemButtonRoot = styled('div', {
   name: 'MuiListItemButton',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ListItemButtonProps }>(({ theme, ownerState }) => [
+})<{ ownerState: ListItemButtonProps & { row: boolean } }>(({ theme, ownerState }) => [
   {
     ...(ownerState.color &&
       ownerState.color !== 'context' && {
@@ -62,7 +63,7 @@ const ListItemButtonRoot = styled('div', {
     minHeight: 'var(--List-item-minHeight)',
     border: 'none',
     borderRadius: 'var(--List-item-radius)',
-    flex: 1,
+    flex: ownerState.row ? 'none' : 1,
     minWidth: 0,
     // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
     transition:
@@ -75,12 +76,16 @@ const ListItemButtonRoot = styled('div', {
     '&.Mui-focusVisible': theme.focus.default,
     // Can't use :last-child or :first-child selector because ListItemButton can be inside ListItem with start/end action
     // We want to be specific on what siblings the gap should be added.
-    [`& + .${listItemButtonClasses.root}`]: {
-      marginTop: 'var(--List-gap)',
-    },
-    [`& + .${listItemClasses.root}`]: {
-      marginTop: 'var(--List-gap)',
-    },
+    [`& + .${listItemButtonClasses.root}`]: ownerState.row
+      ? { marginLeft: 'var(--List-gap)' }
+      : {
+          marginTop: 'var(--List-gap)',
+        },
+    [`& + .${listItemClasses.root}`]: ownerState.row
+      ? { marginLeft: 'var(--List-gap)' }
+      : {
+          marginTop: 'var(--List-gap)',
+        },
     // default color & background styles when `color` prop is not specified or set as default
     ...(!ownerState.color &&
       !ownerState.selected && {
@@ -111,6 +116,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     props: inProps,
     name: 'MuiListItemButton',
   });
+  const row = React.useContext(RowListContext);
 
   const {
     children,
@@ -150,6 +156,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     component,
     color,
     focusVisible,
+    row,
     selected,
     variant,
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## 🖥 [Preview](https://deploy-preview-31620--material-ui.netlify.app/experiments/joy/list/)

Prepare for the menu components (menubar).

## Changes

- add `row` prop to `List` component which passes to React context.
- `ListItem`, `ListItemButton`, and `ListDivider` listen to the context and adjust the styles according to the direction of the parent list.

Note: the context is not nestable which makes sense because the nested row is not common.

<img width="1206" alt="Screen Shot 2565-03-14 at 10 51 31" src="https://user-images.githubusercontent.com/18292247/158101908-cb4903d5-5c38-4a13-b2cf-81e0e8128627.png">

---

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
