### PR TITLE
[TextField] Fix to show `input[type=number]` spinner icons in Chrome

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -211,6 +211,11 @@ export const InputBaseComponent = styled('input', {
       // Improve type search style.
       MozAppearance: 'textfield',
     }),
+    ...(ownerState.type === 'number' && {
+      // Overwrite Chrome default settings
+      '&::-webkit-inner-spin-button': { opacity: 1 },
+      '&::-webkit-outer-spin-button': { opacity: 1 },
+    }),
   };
 });
 

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -213,8 +213,7 @@ export const InputBaseComponent = styled('input', {
     }),
     ...(ownerState.type === 'number' && {
       // Overwrite Chrome default settings
-      '&::-webkit-inner-spin-button': { opacity: 1 },
-      '&::-webkit-outer-spin-button': { opacity: 1 },
+      '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button': { opacity: 1 },
     }),
   };
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**before:**
In Chrome, the `input[type=number]` spinner are hidden by default. They will only show when the input receives focus
![Bildschirmfoto 2022-03-13 um 09 08 33](https://user-images.githubusercontent.com/2707029/158050941-52bb4c1c-1b53-467c-9460-a2a10193c8da.png)

**after:**
![Bildschirmfoto 2022-03-13 um 09 03 54](https://user-images.githubusercontent.com/2707029/158050918-f4663a83-d5e7-4f78-ac0b-5621cf2d7282.png)

based on https://davidwalsh.name/always-show-arrows-for-number-input to improve accessibility
