### PR TITLE
[docs] Fix API page table styles in Safari

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import clsx from 'clsx';
 import { exactProp } from '@mui/utils';
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
@@ -19,13 +19,20 @@ const Wrapper = styled('div')({
   overflow: 'hidden',
 });
 const Table = styled('table')(({ theme }) => {
-  const contentColor = theme.palette.mode === 'dark' ? theme.palette.primaryDark[900] : '#fff';
+  const contentColor =
+    theme.palette.mode === 'dark'
+      ? alpha(theme.palette.primaryDark[900], 1)
+      : 'rgba(255, 255, 255, 1)';
+  const contentColorTransparent =
+    theme.palette.mode === 'dark'
+      ? alpha(theme.palette.primaryDark[900], 0)
+      : 'rgba(255, 255, 255, 0)';
   const shadowColor = theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.7)' : 'rgba(0,0,0,0.2)';
   return {
     borderRadius: 10,
     background: `
-  linear-gradient(to right, ${contentColor} 5%, rgba(0, 0, 0, 0)),
-  linear-gradient(to right, rgba(0, 0, 0, 0), ${contentColor} 100%) 100%,
+  linear-gradient(to right, ${contentColor} 5%, ${contentColorTransparent}),
+  linear-gradient(to right, ${contentColorTransparent}, ${contentColor} 100%) 100%,
   linear-gradient(to right, ${shadowColor}, rgba(0, 0, 0, 0) 5%),
   linear-gradient(to left, ${shadowColor}, rgba(0, 0, 0, 0) 5%)`,
     backgroundAttachment: 'local, local, scroll, scroll',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Issue
Safari 15 shows the API table with weird background. The cause here is the use of `hex` and `rgba` values, color transition between different colors ( "contentColor" vs black ) and maybe missing color stop on the transparent black color.

**before**
<img width="1349" alt="Bildschirmfoto 2022-03-13 um 17 22 05" src="https://user-images.githubusercontent.com/2707029/158070059-ed819cbc-5074-43b9-b077-884411e9b067.png">

**after:**
<img width="1046" alt="Bildschirmfoto 2022-03-14 um 08 05 10" src="https://user-images.githubusercontent.com/2707029/158121478-eff94c0c-bea2-4605-838e-f839250bef4e.png">

