### PR TITLE
[Pickers] Fix `onDismiss` handler Mobile && Desktop

### DIFF
--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -71,6 +71,7 @@ export function usePickerState<TInput, TDateValue>(
   }
 
   const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
+  const [isWrapperVariant, setIsWrapperVariant] = React.useState<WrapperVariant>(null);
 
   // Mobile keyboard view is a special case.
   // When it's open picker should work like closed, cause we are just showing text field
@@ -96,7 +97,13 @@ export function usePickerState<TInput, TDateValue>(
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
       onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(initialDate, true),
+      onDismiss: () => {
+        if (isWrapperVariant === 'mobile') {
+          acceptDate(initialDate, true);
+        } else {
+          setIsOpen(false);
+        }
+      },
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });
@@ -109,8 +116,10 @@ export function usePickerState<TInput, TDateValue>(
       isOpen,
       utils,
       draftState.draft,
+      setIsOpen,
       valueManager.emptyValue,
       initialDate,
+      isWrapperVariant,
     ],
   );
 
@@ -124,6 +133,7 @@ export function usePickerState<TInput, TDateValue>(
         wrapperVariant: WrapperVariant,
         selectionState: PickerSelectionState = 'partial',
       ) => {
+        setIsWrapperVariant(wrapperVariant);
         dispatch({ type: 'update', payload: newDate });
         if (selectionState === 'partial') {
           acceptDate(newDate, false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: https://github.com/mui/material-ui/issues/31278
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Demo: https://deploy-preview-31793--material-ui.netlify.app/components/date-picker/