### PR TITLE
[docs] Make LTS searchable

### DIFF
--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -74,7 +74,7 @@ The current status of each MUI version is as follows:
 
 For teams and organizations that require additional support for older versions, MUI has [options available](/getting-started/support/#professional-support-premium).
 
-### Long-term support
+### Long-term support (LTS)
 
 MUI will continue to give security updates and regressions support (for example, if there's any regression caused by Chrome, React, etc) to the version prior to the current major until the next one is released.
 


### PR DESCRIPTION
A quick follow-up on #31029. I believe that LTS is a common term developer might search for, but in the current form, there is no relevant matches:

<img width="737" alt="Screenshot 2022-03-14 at 22 08 18" src="https://user-images.githubusercontent.com/3165635/158261613-50a771ef-4080-4520-b9d7-dbe8771420e5.png">

(found this while I was looking at something unrelated on https://next.vuetifyjs.com/en/getting-started/installation/)