### PR TITLE
[core] Replace deprecated String.prototype.substr()

### DIFF
--- a/docs/data/material/components/avatars/BackgroundLetterAvatars.js
+++ b/docs/data/material/components/avatars/BackgroundLetterAvatars.js
@@ -15,7 +15,7 @@ function stringToColor(string) {
 
   for (i = 0; i < 3; i += 1) {
     const value = (hash >> (i * 8)) & 0xff;
-    color += `00${value.toString(16)}`.substr(-2);
+    color += `00${value.toString(16)}`.slice(-2);
   }
   /* eslint-enable no-bitwise */
 

--- a/docs/data/material/components/avatars/BackgroundLetterAvatars.tsx
+++ b/docs/data/material/components/avatars/BackgroundLetterAvatars.tsx
@@ -15,7 +15,7 @@ function stringToColor(string: string) {
 
   for (i = 0; i < 3; i += 1) {
     const value = (hash >> (i * 8)) & 0xff;
-    color += `00${value.toString(16)}`.substr(-2);
+    color += `00${value.toString(16)}`.slice(-2);
   }
   /* eslint-enable no-bitwise */
 

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -23,7 +23,7 @@ function clamp(value, min = 0, max = 1) {
  * @returns {string} A CSS rgb color string
  */
 export function hexToRgb(color) {
-  color = color.substr(1);
+  color = color.slice(1);
 
   const re = new RegExp(`.{1,${color.length >= 6 ? 2 : 1}}`, 'g');
   let colors = color.match(re);
@@ -81,7 +81,7 @@ export function decomposeColor(color) {
     values = values.split(' ');
     colorSpace = values.shift();
     if (values.length === 4 && values[3].charAt(0) === '/') {
-      values[3] = values[3].substr(1);
+      values[3] = values[3].slice(1);
     }
     if (['srgb', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec-2020'].indexOf(colorSpace) === -1) {
       throw new MuiError(


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

<img width="568" alt="Screenshot 2022-03-15 at 01 37 10" src="https://user-images.githubusercontent.com/3165635/158283410-4c00eaad-a68c-45a2-a82d-155251f0c8df.png">

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
