### PR TITLE
[data-grid] Fix print export feature

### DIFF
--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -10,7 +10,7 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   # Block usage in iframes.
-  X-Frame-Options: DENY
+  X-Frame-Options: SAMEORIGIN
   # Force the browser to trust the Content-Type header
   # https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
The reproduction:

1. open https://mui.com/components/data-grid/export/
2. click on the print button.

<img width="1127" alt="Screenshot 2022-03-15 at 01 24 52" src="https://user-images.githubusercontent.com/3165635/158282363-c1384cf5-56e9-4dc6-967c-f2640077e50f.png">

It was first raised by @alexfauquette in https://mui-org.slack.com/archives/G011VC970AW/p1646824105396129. I broke it in https://github.com/mui/material-ui/pull/31062.

@DanailH Should we document this limitation? Maybe this is a strong case for having a new intermediary API like AG Grid, one that only puts the grid in a print-ready mode to avoid the iframe.

---

@danilo-leal A side note on the screenshot. Did we recently work on the CSS of the `"bg": "inline"}}` option? It feels a bit broken. On https://mui.com/components/data-grid/export/#disabled-format

**Current**

<img width="519" alt="Screenshot 2022-03-15 at 01 30 13" src="https://user-images.githubusercontent.com/3165635/158282883-e28778cf-6929-4d19-9fa0-348606d4ea52.png">

**Expected?**

<img width="518" alt="Screenshot 2022-03-15 at 01 30 33" src="https://user-images.githubusercontent.com/3165635/158282880-7f0d10c6-ed8a-444b-b2ea-5c2139613b0a.png">
