### PR TITLE
[docs] Use TypeScript demos by default

### DIFF
--- a/docs/src/modules/utils/codeVariant.js
+++ b/docs/src/modules/utils/codeVariant.js
@@ -23,7 +23,7 @@ function useFirstRender() {
 export function CodeVariantProvider(props) {
   const { children } = props;
 
-  const [codeVariant, setCodeVariant] = React.useState('JS');
+  const [codeVariant, setCodeVariant] = React.useState(CODE_VARIANTS.TS);
 
   const navigatedCodeVariant = React.useMemo(() => {
     const navigatedCodeVariantMatch =

--- a/docs/src/modules/utils/codeVariant.js
+++ b/docs/src/modules/utils/codeVariant.js
@@ -4,7 +4,7 @@ import { getCookie } from 'docs/src/modules/utils/helpers';
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
 
 const CodeVariantContext = React.createContext({
-  codeVariant: CODE_VARIANTS.JS,
+  codeVariant: CODE_VARIANTS.TS,
   setCodeVariant: () => {},
 });
 if (process.env.NODE_ENV !== 'production') {

--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -4,6 +4,7 @@ import { getDependencies } from 'docs/src/modules/utils/helpers';
 function jsDemo(demoData, options) {
   return {
     dependencies: getDependencies(demoData.raw, {
+      codeLanguage: CODE_VARIANTS.JS,
       muiCommitRef:
         process.env.PULL_REQUEST && options.previewPackage ? process.env.COMMIT_REF : undefined,
     }),

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -44,7 +44,7 @@ const styles = theme => ({
 `;
 
   it('should handle @ dependencies', () => {
-    expect(getDependencies(s1)).to.deep.equal({
+    expect(getDependencies(s1, { codeLanguage: 'JS' })).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
       '@emotion/react': 'latest',
@@ -71,7 +71,7 @@ import { withStyles } from '@mui/material/styles';
 const suggestions = [
 `;
 
-    expect(getDependencies(source)).to.deep.equal({
+    expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
       '@emotion/react': 'latest',
@@ -94,7 +94,7 @@ import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePicker, KeyboardDatePicker } from '@mui/lab';
 `;
 
-    expect(getDependencies(source)).to.deep.equal({
+    expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
       'prop-types': 'latest',
@@ -135,7 +135,7 @@ import {
 } from '@mui/lab';
     `;
 
-    expect(getDependencies(source)).to.deep.equal({
+    expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
       '@emotion/react': 'latest',
@@ -151,7 +151,7 @@ import {
 import lab from '@mui/lab';
     `;
 
-    expect(getDependencies(source)).to.deep.equal({
+    expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
       '@emotion/react': 'latest',
@@ -173,7 +173,10 @@ import * as Utils from '@mui/utils';
     `;
 
     expect(
-      getDependencies(source, { muiCommitRef: '2d0e8b4daf20b7494c818b6f8c4cc8423bc99d6f' }),
+      getDependencies(source, {
+        codeLanguage: 'JS',
+        muiCommitRef: '2d0e8b4daf20b7494c818b6f8c4cc8423bc99d6f',
+      }),
     ).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
@@ -199,7 +202,7 @@ import AdapterLuxon from '@mui/lab/AdapterLuxon';
 import AdapterMoment from '@mui/lab/AdapterMoment';
     `;
 
-    expect(getDependencies(source)).to.deep.equal({
+    expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
       react: 'latest',
       'react-dom': 'latest',
       '@emotion/react': 'latest',

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -147,7 +147,7 @@ export function getDependencies(
     muiCommitRef?: string;
   } = {},
 ) {
-  const { codeLanguage = CODE_VARIANTS.TS, muiCommitRef } = options;
+  const { codeLanguage, muiCommitRef } = options;
 
   let deps: Record<string, string> = {};
   let versions: Record<string, string> = {

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -147,7 +147,7 @@ export function getDependencies(
     muiCommitRef?: string;
   } = {},
 ) {
-  const { codeLanguage = CODE_VARIANTS.JS, muiCommitRef } = options;
+  const { codeLanguage = CODE_VARIANTS.TS, muiCommitRef } = options;
 
   let deps: Record<string, string> = {};
   let versions: Record<string, string> = {


### PR DESCRIPTION
Motivation: https://github.com/mui/material-ui/pull/30999#discussion_r815464531 and [the most upvoted issues](https://github.com/mui/material-ui/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc)

- 2020: https://mui.com/blog/2020-developer-survey-results/#21-what-type-system-are-you-using, TypeScript: 45%
- 2021: https://mui.com/blog/2021-developer-survey-results/#what-type-system-are-you-using, TypeScript: 63%

https://deploy-preview-31808--material-ui.netlify.app/components/switches/#controlled