### PR TITLE
[docs] Document that `@emotion/react` is not fully supported in the System

### DIFF
--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -588,6 +588,11 @@ export default function CssModulesSliderDeep2() {
 ![stars](https://img.shields.io/github/stars/emotion-js/emotion.svg?style=social&label=Star)
 ![npm](https://img.shields.io/npm/dm/@emotion/react.svg)
 
+> ⚠️ Even if it is used internally by MUI, `@emotion/react` is not
+> fully supported as a solution for writing custom style.  
+> It is not possible to use the `classes` property of MUI components,
+> the internal styles will always take precedence over yours. [See sandbox](https://stackblitz.com/edit/tss-react-t9hqtn?file=index.tsx).
+
 ### The `css` prop
 
 Emotion's **css()** method works seamlessly with MUI.


### PR DESCRIPTION
Hello!  

Currently it's not really possible to use`@emotion/react` to write custom styles for MUI.  
More precisely it is possible to use `className` and the `css` property but not the `classes` prop that the MUI component provides.  
The reason for that is that the internal styles will always take precedence over the custom styles unless users explicitly increase specificity using `!important` or `&&` which is not an acceptable solution.  
As detailed [here](https://github.com/mui/material-ui/issues/28045#issuecomment-913150807) there is no way for the user to configure it's project to change this state of things.  
I have opened [an issue](https://github.com/mui/material-ui/issues/28045) about it some time ago but for reasons that I perfectly understand you decided not to address it.  

Considering this, I think it is best, to save users frustration, to let them know that `@emotion/react` is not really supported.  