### PR TITLE
[utils] Improve type inference of useForkRef

### DIFF
--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -72,7 +72,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     }
   }, [listboxFocusRequested]);
 
-  const updateListboxRef = (listboxElement: HTMLUListElement) => {
+  const updateListboxRef = (listboxElement: HTMLUListElement | null) => {
     listboxRef.current = listboxElement;
     focusListboxIfRequested();
   };

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -115,7 +115,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     ref: focusVisibleRef,
   } = useIsFocusVisible();
   const [focusVisible, setFocusVisible] = React.useState<boolean>(false);
-  const handlerRef = useForkRef(ref, focusVisibleRef) as React.RefObject<HTMLSpanElement>;
+  const handleRef = useForkRef(ref, focusVisibleRef) as React.Ref<HTMLSpanElement>;
   const handleBlur = (event: React.FocusEvent<HTMLAnchorElement>) => {
     handleBlurVisible(event);
     if (isFocusVisibleRef.current === false) {
@@ -154,7 +154,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
       as={component}
       onBlur={handleBlur}
       onFocus={handleFocus}
-      ref={handlerRef}
+      ref={handleRef}
       ownerState={ownerState}
       {...other}
     />

--- a/packages/mui-utils/src/useForkRef.ts
+++ b/packages/mui-utils/src/useForkRef.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import setRef from './setRef';
 
-export default function useForkRef<Instance>(
-  refA: React.Ref<Instance> | null | undefined,
-  refB: React.Ref<Instance> | null | undefined,
-): React.Ref<Instance> | null {
+export default function useForkRef<InstanceA, InstanceB>(
+  refA: React.Ref<InstanceA> | null | undefined,
+  refB: React.Ref<InstanceB> | null | undefined,
+): React.Ref<InstanceA & InstanceB> | null {
   /**
    * This will create a new function if the ref props change and are defined.
    * This means react will call the old forkRef with `null` and the new forkRef


### PR DESCRIPTION
Currently instances in [ref callbacks are allowed to be nullable due to our bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/78d7283e392c638452e7c1c29001d6cc57453f40/types/react/index.d.ts#L91). However, during runtime these instances can be null: https://codesandbox.io/s/refs-are-nullable-m44vxx

[We'll likely remove the bivariance hack](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58936) to catch these issues in the future. In the meantime, existing packages and tests should guard against nullable instances regardless.

The issue was first reported in https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/58464
