### PR TITLE
[BackdropUnstyled] Remove presentation attributes

### DIFF
--- a/docs/pages/api-docs/backdrop-unstyled.json
+++ b/docs/pages/api-docs/backdrop-unstyled.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
@@ -10,15 +9,10 @@
     "componentsProps": {
       "type": { "name": "shape", "description": "{ root?: object }" },
       "default": "{}"
-    },
-    "invisible": { "type": { "name": "bool" } }
+    }
   },
   "name": "BackdropUnstyled",
-  "styles": {
-    "classes": ["root", "invisible"],
-    "globalClasses": { "root": "MuiBackdrop-root", "invisible": "MuiBackdrop-invisible" },
-    "name": null
-  },
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
   "spread": true,
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.js",

--- a/docs/pages/api-docs/backdrop.json
+++ b/docs/pages/api-docs/backdrop.json
@@ -3,6 +3,7 @@
     "open": { "type": { "name": "bool" }, "required": true },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
+    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"

--- a/docs/pages/api-docs/backdrop.json
+++ b/docs/pages/api-docs/backdrop.json
@@ -3,7 +3,6 @@
     "open": { "type": { "name": "bool" }, "required": true },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"

--- a/docs/pages/api-docs/slider.json
+++ b/docs/pages/api-docs/slider.json
@@ -11,6 +11,7 @@
       },
       "default": "'primary'"
     },
+    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/pages/base/api/backdrop-unstyled.json
+++ b/docs/pages/base/api/backdrop-unstyled.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
@@ -10,15 +9,10 @@
     "componentsProps": {
       "type": { "name": "shape", "description": "{ root?: object }" },
       "default": "{}"
-    },
-    "invisible": { "type": { "name": "bool" } }
+    }
   },
   "name": "BackdropUnstyled",
-  "styles": {
-    "classes": ["root", "invisible"],
-    "globalClasses": { "root": "MuiBackdrop-root", "invisible": "MuiBackdrop-invisible" },
-    "name": null
-  },
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
   "spread": true,
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.js",

--- a/docs/pages/material-ui/api/backdrop.json
+++ b/docs/pages/material-ui/api/backdrop.json
@@ -3,6 +3,7 @@
     "open": { "type": { "name": "bool" }, "required": true },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
+    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"

--- a/docs/pages/material-ui/api/backdrop.json
+++ b/docs/pages/material-ui/api/backdrop.json
@@ -3,7 +3,6 @@
     "open": { "type": { "name": "bool" }, "required": true },
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
-    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"

--- a/docs/pages/material-ui/api/slider.json
+++ b/docs/pages/material-ui/api/slider.json
@@ -11,6 +11,7 @@
       },
       "default": "'primary'"
     },
+    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": {
         "name": "shape",

--- a/docs/translations/api-docs/backdrop-unstyled/backdrop-unstyled.json
+++ b/docs/translations/api-docs/backdrop-unstyled/backdrop-unstyled.json
@@ -2,18 +2,9 @@
   "componentDescription": "",
   "propDescriptions": {
     "children": "The content of the component.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "components": "The components used for each slot inside the Backdrop. Either a string to use a HTML element or a component.",
-    "componentsProps": "The props used for each slot inside the Backdrop.",
-    "invisible": "If <code>true</code>, the backdrop is invisible. It can be used when rendering a popover or a custom select component."
+    "componentsProps": "The props used for each slot inside the Backdrop."
   },
-  "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
-    "invisible": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>invisible={true}</code>"
-    }
-  }
+  "classDescriptions": {}
 }

--- a/docs/translations/api-docs/backdrop/backdrop.json
+++ b/docs/translations/api-docs/backdrop/backdrop.json
@@ -8,8 +8,7 @@
     "invisible": "If <code>true</code>, the backdrop is invisible. It can be used when rendering a popover or a custom select component.",
     "open": "If <code>true</code>, the component is shown.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
-    "transitionDuration": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.",
-    "component": "The component used for the root node. Either a string to use a HTML element or a component."
+    "transitionDuration": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/backdrop/backdrop.json
+++ b/docs/translations/api-docs/backdrop/backdrop.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "components": "The components used for each slot inside the Backdrop. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside the Backdrop.",
     "invisible": "If <code>true</code>, the backdrop is invisible. It can be used when rendering a popover or a custom select component.",

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -6,6 +6,7 @@
     "aria-valuetext": "A string value that provides a user-friendly name for the current value of the slider.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "color": "The color of the component. It supports those theme colors that make sense for this component.",
+    "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "components": "The components used for each slot inside the Slider. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside the Slider.",
     "defaultValue": "The default value. Use when the component is not controlled.",

--- a/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.d.ts
+++ b/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.d.ts
@@ -32,7 +32,7 @@ export interface BackdropUnstyledTypeMap<P = {}, D extends React.ElementType = '
  * Utility to create component types that inherit props from BackdropUnstyled.
  */
 export interface ExtendBackdropUnstyledTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & BackdropUnstyledTypeMap['props'];
+  props: M['props'] & BackdropUnstyledTypeMap['props'] & { component?: React.ElementType };
   defaultComponent: M['defaultComponent'];
 }
 

--- a/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.d.ts
+++ b/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { OverridableComponent, OverridableTypeMap, OverrideProps } from '@mui/types';
-import { BackdropUnstyledClasses } from './backdropUnstyledClasses';
 
 export interface BackdropUnstyledComponentsPropsOverrides {}
 
@@ -25,16 +24,6 @@ export interface BackdropUnstyledTypeMap<P = {}, D extends React.ElementType = '
     componentsProps?: {
       root?: React.HTMLAttributes<HTMLDivElement> & BackdropUnstyledComponentsPropsOverrides;
     };
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<BackdropUnstyledClasses>;
-    /**
-     * If `true`, the backdrop is invisible.
-     * It can be used when rendering a popover or a custom select component.
-     * @default false
-     */
-    invisible?: boolean;
   };
   defaultComponent: D;
 }

--- a/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.js
+++ b/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.js
@@ -2,57 +2,38 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '../composeClasses';
-import isHostComponent from '../utils/isHostComponent';
-import { getBackdropUtilityClass } from './backdropUnstyledClasses';
+import appendOwnerState from '../utils/appendOwnerState';
+import { getBackdropUnstyledUtilityClass } from './backdropUnstyledClasses';
 
-const useUtilityClasses = (ownerState) => {
-  const { classes, invisible } = ownerState;
-
+const useUtilityClasses = () => {
   const slots = {
-    root: ['root', invisible && 'invisible'],
+    root: ['root'],
   };
 
-  return composeClasses(slots, getBackdropUtilityClass, classes);
+  return composeClasses(slots, getBackdropUnstyledUtilityClass, {});
 };
 
 const BackdropUnstyled = React.forwardRef(function BackdropUnstyled(props, ref) {
-  const {
-    classes: classesProp,
-    className,
-    invisible = false,
-    component = 'div',
-    components = {},
-    componentsProps = {},
-    /* eslint-disable react/prop-types */
-    theme,
-    ...other
-  } = props;
+  const { className, component, components = {}, componentsProps = {}, ...other } = props;
 
-  const ownerState = {
-    ...props,
-    classes: classesProp,
-    invisible,
-  };
+  const ownerState = props;
 
   const classes = useUtilityClasses(ownerState);
 
-  const Root = components.Root || component;
-  const rootProps = componentsProps.root || {};
-
-  return (
-    <Root
-      aria-hidden
-      {...rootProps}
-      {...(!isHostComponent(Root) && {
-        as: component,
-        ownerState: { ...ownerState, ...rootProps.ownerState },
-        theme,
-      })}
-      ref={ref}
-      {...other}
-      className={clsx(classes.root, rootProps.className, className)}
-    />
+  const Root = component ?? components.Root ?? 'div';
+  const rootProps = appendOwnerState(
+    Root,
+    {
+      'aria-hidden': true,
+      ...other,
+      ...componentsProps.root,
+      ref,
+      className: clsx(className, componentsProps.root?.className, classes.root),
+    },
+    ownerState,
   );
+
+  return <Root {...rootProps} />;
 });
 
 BackdropUnstyled.propTypes /* remove-proptypes */ = {
@@ -64,10 +45,6 @@ BackdropUnstyled.propTypes /* remove-proptypes */ = {
    * The content of the component.
    */
   children: PropTypes.node,
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -92,12 +69,6 @@ BackdropUnstyled.propTypes /* remove-proptypes */ = {
   componentsProps: PropTypes.shape({
     root: PropTypes.object,
   }),
-  /**
-   * If `true`, the backdrop is invisible.
-   * It can be used when rendering a popover or a custom select component.
-   * @default false
-   */
-  invisible: PropTypes.bool,
 };
 
 export default BackdropUnstyled;

--- a/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.test.js
+++ b/packages/mui-base/src/BackdropUnstyled/BackdropUnstyled.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from 'test/utils';
+import { createMount, createRenderer, describeConformanceUnstyled } from 'test/utils';
 import BackdropUnstyled, { backdropUnstyledClasses as classes } from '@mui/base/BackdropUnstyled';
 
 describe('<BackdropUnstyled />', () => {
+  const mount = createMount();
   const { render } = createRenderer();
 
-  describeConformance(
+  describeConformanceUnstyled(
     <BackdropUnstyled>
       <div />
     </BackdropUnstyled>,
@@ -14,13 +15,14 @@ describe('<BackdropUnstyled />', () => {
       classes,
       inheritComponent: 'div',
       render,
+      mount,
       refInstanceof: window.HTMLDivElement,
       testComponentPropWith: 'div',
-      skip: [
-        'themeDefaultProps', // unstyled
-        'themeStyleOverrides', // unstyled
-        'themeVariants', // unstyled
-      ],
+      slots: {
+        root: {
+          expectedClassName: classes.root,
+        },
+      },
     }),
   );
 

--- a/packages/mui-base/src/BackdropUnstyled/backdropUnstyledClasses.ts
+++ b/packages/mui-base/src/BackdropUnstyled/backdropUnstyledClasses.ts
@@ -4,19 +4,17 @@ import generateUtilityClass from '../generateUtilityClass';
 export interface BackdropUnstyledClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element if `invisible={true}`. */
-  invisible: string;
 }
 
 export type BackdropUnstyledClassKey = keyof BackdropUnstyledClasses;
 
-export function getBackdropUtilityClass(slot: string): string {
-  return generateUtilityClass('MuiBackdrop', slot);
+export function getBackdropUnstyledUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiBackdropUnstyled', slot);
 }
 
-const backdropUnstyledClasses: BackdropUnstyledClasses = generateUtilityClasses('MuiBackdrop', [
-  'root',
-  'invisible',
-]);
+const backdropUnstyledClasses: BackdropUnstyledClasses = generateUtilityClasses(
+  'MuiBackdropUnstyled',
+  ['root'],
+);
 
 export default backdropUnstyledClasses;

--- a/packages/mui-base/src/BackdropUnstyled/index.js
+++ b/packages/mui-base/src/BackdropUnstyled/index.js
@@ -2,5 +2,5 @@ export { default } from './BackdropUnstyled';
 
 export {
   default as backdropUnstyledClasses,
-  getBackdropUtilityClass,
+  getBackdropUnstyledUtilityClass,
 } from './backdropUnstyledClasses';

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { OverrideProps, Simplify } from '@mui/types';
 import { UseButtonParameters, UseButtonRootSlotProps } from './useButton.types';
 

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyledProps.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyledProps.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { OverridableComponent, OverridableTypeMap, OverrideProps } from '@mui/types';
 import { SliderUnstyledClasses } from './sliderUnstyledClasses';
 import SliderValueLabelUnstyled from './SliderValueLabelUnstyled';
@@ -204,7 +205,7 @@ export interface SliderUnstyledTypeMap<P = {}, D extends React.ElementType = 'sp
  * Utility to create component types that inherit props from SliderUnstyled.
  */
 export interface ExtendSliderUnstyledTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & SliderUnstyledTypeMap['props'];
+  props: M['props'] & SliderUnstyledTypeMap['props'] & { component?: React.ElementType };
   defaultComponent: M['defaultComponent'];
 }
 

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { ExtendBackdropUnstyledTypeMap, BackdropUnstyledTypeMap } from '@mui/base/BackdropUnstyled';
+import { ExtendBackdropUnstyledTypeMap } from '@mui/base/BackdropUnstyled';
 import { FadeProps } from '../Fade';
 import { TransitionProps } from '../transitions/transition';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { BackdropClasses } from './backdropClasses';
 
 export type BackdropTypeMap<
   D extends React.ElementType = 'span',
@@ -15,7 +16,13 @@ export type BackdropTypeMap<
       /**
        * Override or extend the styles applied to the component.
        */
-      classes?: BackdropUnstyledTypeMap['props']['classes'];
+      classes?: Partial<BackdropClasses>;
+      /**
+       * If `true`, the backdrop is invisible.
+       * It can be used when rendering a popover or a custom select component.
+       * @default false
+       */
+      invisible?: boolean;
       /**
        * If `true`, the component is shown.
        */
@@ -37,8 +44,6 @@ type BackdropRootProps = NonNullable<BackdropTypeMap['props']['componentsProps']
 
 export const BackdropRoot: React.FC<BackdropRootProps>;
 
-export type BackdropClassKey = keyof NonNullable<BackdropTypeMap['props']['classes']>;
-
 /**
  *
  * Demos:
@@ -52,10 +57,6 @@ export type BackdropClassKey = keyof NonNullable<BackdropTypeMap['props']['class
  */
 
 declare const Backdrop: OverridableComponent<BackdropTypeMap>;
-
-export type BackdropClasses = Record<BackdropClassKey, string>;
-
-export const backdropClasses: BackdropClasses;
 
 export type BackdropProps<
   D extends React.ElementType = BackdropTypeMap['defaultComponent'],

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -1,16 +1,20 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { isHostComponent } from '@mui/base';
-import BackdropUnstyled, { backdropUnstyledClasses } from '@mui/base/BackdropUnstyled';
+import clsx from 'clsx';
+import { isHostComponent, unstable_composeClasses as composeClasses } from '@mui/base';
+import BackdropUnstyled from '@mui/base/BackdropUnstyled';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import Fade from '../Fade';
+import { getBackdropUtilityClass } from './backdropClasses';
 
-export const backdropClasses = backdropUnstyledClasses;
+const useUtilityClasses = (ownerState) => {
+  const { classes, invisible } = ownerState;
+  const slots = {
+    root: ['root', invisible && 'invisible'],
+  };
 
-const extendUtilityClasses = (ownerState) => {
-  const { classes } = ownerState;
-  return classes;
+  return composeClasses(slots, getBackdropUtilityClass, classes);
 };
 
 const BackdropRoot = styled('div', {
@@ -57,13 +61,12 @@ const Backdrop = React.forwardRef(function Backdrop(inProps, ref) {
     invisible,
   };
 
-  const classes = extendUtilityClasses(ownerState);
+  const classes = useUtilityClasses(ownerState);
 
   return (
     <TransitionComponent in={open} timeout={transitionDuration} {...other}>
       <BackdropUnstyled
-        className={className}
-        invisible={invisible}
+        className={clsx(className, classes.root)}
         components={{
           Root: BackdropRoot,
           ...components,

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -75,7 +75,7 @@ const Backdrop = React.forwardRef(function Backdrop(inProps, ref) {
           root: {
             ...componentsProps.root,
             ...((!components.Root || !isHostComponent(components.Root)) && {
-              ownerState: { ...componentsProps.root?.ownerState },
+              ownerState: { ...ownerState, ...componentsProps.root?.ownerState },
             }),
           },
         }}

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -106,6 +106,11 @@ Backdrop.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
    * The components used for each slot inside the Backdrop.
    * Either a string to use a HTML element or a component.
    * @default {}

--- a/packages/mui-material/src/Backdrop/backdropClasses.ts
+++ b/packages/mui-material/src/Backdrop/backdropClasses.ts
@@ -1,0 +1,22 @@
+import generateUtilityClasses from '@mui/base/generateUtilityClasses';
+import generateUtilityClass from '@mui/base/generateUtilityClass';
+
+export interface BackdropClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `invisible={true}`. */
+  invisible: string;
+}
+
+export type BackdropClassKey = keyof BackdropClasses;
+
+export function getBackdropUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiBackdrop', slot);
+}
+
+const backdropClasses: BackdropClasses = generateUtilityClasses('MuiBackdrop', [
+  'root',
+  'invisible',
+]);
+
+export default backdropClasses;

--- a/packages/mui-material/src/Backdrop/index.d.ts
+++ b/packages/mui-material/src/Backdrop/index.d.ts
@@ -1,2 +1,5 @@
 export { default } from './Backdrop';
 export * from './Backdrop';
+
+export { default as backdropClasses } from './backdropClasses';
+export * from './backdropClasses';

--- a/packages/mui-material/src/Backdrop/index.js
+++ b/packages/mui-material/src/Backdrop/index.js
@@ -1,2 +1,4 @@
 export { default } from './Backdrop';
-export * from './Backdrop';
+
+export { default as backdropClasses } from './backdropClasses';
+export * from './backdropClasses';

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -584,6 +584,11 @@ Slider.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
    * The components used for each slot inside the Slider.
    * Either a string to use a HTML element or a component.
    * @default {}


### PR DESCRIPTION
Removed the `invisible` and `theme` props from BackdropUnstyled and made a few other adjustments to make it more in line with other unstyled components.

~~For some reason, the docs for the `component` prop are not being generated after the change (I saw this is also the case in SliderUnstyled). I'll continue investigating it, but in the meantime, the remaining code can be reviewed.~~ Fixed.


