### PR TITLE
[List] List item accepts list of Icon Buttons

### DIFF
--- a/docs/data/material/components/lists/ActionsList.js
+++ b/docs/data/material/components/lists/ActionsList.js
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+import IconButton from '@mui/material/IconButton';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+
+export default function CheckboxList() {
+  return (
+    <List sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
+      <ListItem
+        secondaryAction={
+          <IconButton key="delete" aria-label="delete" edge="end">
+            <DeleteIcon />
+          </IconButton>
+        }
+        disablePadding
+      >
+        <ListItemButton role={undefined} dense>
+          <ListItemText primary={`Item with a single action`} />
+        </ListItemButton>
+      </ListItem>
+      <ListItem
+        secondaryAction={[
+          <IconButton key="edit" aria-label="edit">
+            <EditIcon />
+          </IconButton>,
+          <IconButton key="delete" aria-label="delete" edge="end">
+            <DeleteIcon />
+          </IconButton>,
+        ]}
+        disablePadding
+      >
+        <ListItemButton role={undefined} dense>
+          <ListItemText primary={`Items with a very long text will not overlapp`} />
+        </ListItemButton>
+      </ListItem>
+    </List>
+  );
+}

--- a/docs/data/material/components/lists/lists.md
+++ b/docs/data/material/components/lists/lists.md
@@ -73,6 +73,12 @@ The switch is the secondary action and a separate target.
 
 {{"demo": "SwitchListSecondary.js", "bg": true}}
 
+### Actions
+
+A list item can contain a single icon button or a list of icon buttons.
+
+{{"demo": "ActionsList.js", "bg": true}}
+
 ## Sticky subheader
 
 Upon scrolling, subheaders remain pinned to the top of the screen until pushed off screen by the next subheader.

--- a/docs/pages/api-docs/list-item.json
+++ b/docs/pages/api-docs/list-item.json
@@ -40,7 +40,12 @@
     "disableGutters": { "type": { "name": "bool" } },
     "disablePadding": { "type": { "name": "bool" } },
     "divider": { "type": { "name": "bool" } },
-    "secondaryAction": { "type": { "name": "node" } },
+    "secondaryAction": {
+      "type": {
+        "name": "union",
+        "description": "Array&lt;node&gt;<br>&#124;&nbsp;element<br>&#124;&nbsp;number<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@415: func }<br>&#124;&nbsp;string<br>&#124;&nbsp;bool"
+      }
+    },
     "selected": {
       "type": { "name": "bool" },
       "deprecated": true,

--- a/docs/pages/material-ui/api/list-item.json
+++ b/docs/pages/material-ui/api/list-item.json
@@ -40,7 +40,12 @@
     "disableGutters": { "type": { "name": "bool" } },
     "disablePadding": { "type": { "name": "bool" } },
     "divider": { "type": { "name": "bool" } },
-    "secondaryAction": { "type": { "name": "node" } },
+    "secondaryAction": {
+      "type": {
+        "name": "union",
+        "description": "Array&lt;node&gt;<br>&#124;&nbsp;element<br>&#124;&nbsp;number<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@415: func }<br>&#124;&nbsp;string<br>&#124;&nbsp;bool"
+      }
+    },
     "selected": {
       "type": { "name": "bool" },
       "deprecated": true,

--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -71,7 +71,7 @@ export interface ListItemBaseProps {
   /**
    * The element to display at the end of ListItem.
    */
-  secondaryAction?: React.ReactNode;
+  secondaryAction?: React.ReactNode | React.ReactNode[];
   /**
    * Use to apply selected styling.
    * @default false

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -63,6 +63,15 @@ const useUtilityClasses = (ownerState) => {
   return composeClasses(slots, getListItemUtilityClass, classes);
 };
 
+function getListItemPaddingRight(secondaryAction) {
+  if (!secondaryAction) {
+    return 0;
+  }
+
+  const actions = Array.isArray(secondaryAction) ? secondaryAction.length : 1;
+  return actions * 48;
+}
+
 export const ListItemRoot = styled('div', {
   name: 'MuiListItem',
   slot: 'Root',
@@ -90,12 +99,12 @@ export const ListItemRoot = styled('div', {
     ...(!!ownerState.secondaryAction && {
       // Add some space to avoid collision as `ListItemSecondaryAction`
       // is absolutely positioned.
-      paddingRight: 48,
+      paddingRight: getListItemPaddingRight(ownerState.secondaryAction),
     }),
   }),
   ...(!!ownerState.secondaryAction && {
     [`& > .${listItemButtonClasses.root}`]: {
-      paddingRight: 48,
+      paddingRight: getListItemPaddingRight(ownerState.secondaryAction),
     },
   }),
   [`&.${listItemClasses.focusVisible}`]: {
@@ -434,7 +443,17 @@ ListItem.propTypes /* remove-proptypes */ = {
   /**
    * The element to display at the end of ListItem.
    */
-  secondaryAction: PropTypes.node,
+  secondaryAction: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.element,
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@415': PropTypes.func.isRequired,
+    }),
+    PropTypes.string,
+    PropTypes.bool,
+  ]),
   /**
    * Use to apply selected styling.
    * @default false


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I created this PR to allow the adding of multiple IconButtons as a secondary action of a ListItem (see #31865 for more details).

I added a new section to the documentation which shows the new feature in action. The main change in the code is checking if the secondaryAction is an array and if it is adjusting the padding depending on the length of it (see [here](packages/mui-material/src/ListItem/ListItem.js)).

What do you think of the change? One downside of the use of an array is that each IconButton needs a key property.

It looks like the prop generation didn't work correctly on ListItem.propTypes. Is there a way to fix this issue?