### PR TITLE
[docs] Update href for 'TypeScript guide on theme customization' 

### DIFF
--- a/packages/mui-private-theming/src/defaultTheme/index.d.ts
+++ b/packages/mui-private-theming/src/defaultTheme/index.d.ts
@@ -1,5 +1,5 @@
 /**
  * The default theme interface, augment this to avoid having to set the theme type everywhere.
- * Our [TypeScript guide on theme customization](https://mui.com/guides/typescript/#customization-of-theme) explains in detail how you would add custom properties.
+ * Our [TypeScript guide on theme customization](https://mui.com/customization/theming/#custom-variables) explains in detail how you would add custom properties.
  */
 export interface DefaultTheme {}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
- section on customizing themes has moved from "https://mui.com/guides/typescript/#customization-of-theme" to "https://mui.com/customization/theming/#custom-variables"
- update href to point to new location

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
