### PR TITLE
[examples] Use useDarkMode hook to introduce theme switching in NextJS example

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs",
-  "version": "5.0.0",
+  "version": "12.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -19,7 +19,8 @@
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "use-dark-mode": "^2.3.1"
   },
   "devDependencies": {
     "eslint": "latest",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -20,7 +20,7 @@
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "use-dark-mode": "^2.3.1"
+    "use-dark-mode": "latest"
   },
   "devDependencies": {
     "eslint": "latest",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs",
-  "version": "12.0.0",
+  "version": "5.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -4,15 +4,18 @@ import Head from 'next/head';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { CacheProvider } from '@emotion/react';
-import theme from '../src/theme';
+import useDarkMode from 'use-dark-mode';
 import createEmotionCache from '../src/createEmotionCache';
+import { darkTheme, lightTheme } from '../src/theme';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
 
 export default function MyApp(props) {
+  const { value: isDark } = useDarkMode(true);
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
 
+  const theme = isDark ? darkTheme : lightTheme;
   return (
     <CacheProvider value={emotionCache}>
       <Head>

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -12,7 +12,7 @@ import { darkTheme, lightTheme } from '../src/theme';
 const clientSideEmotionCache = createEmotionCache();
 
 export default function MyApp(props) {
-  const { value: isDark } = useDarkMode(true);
+  const { value: isDark } = useDarkMode(false);
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
 
   const theme = isDark ? darkTheme : lightTheme;

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
-import theme from '../src/theme';
+import { darkTheme }  from '../src/theme';
 import createEmotionCache from '../src/createEmotionCache';
 
 export default class MyDocument extends Document {
@@ -10,7 +10,7 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
           {/* PWA primary color */}
-          <meta name="theme-color" content={theme.palette.primary.main} />
+          <meta name="theme-color" content={darkTheme.palette.primary.main} />
           <link rel="shortcut icon" href="/static/favicon.ico" />
           <link
             rel="stylesheet"

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -2,11 +2,14 @@ import * as React from 'react';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import useDarkMode from 'use-dark-mode';
 import ProTip from '../src/ProTip';
 import Link from '../src/Link';
 import Copyright from '../src/Copyright';
 
 export default function Index() {
+  const { toggle } = useDarkMode();
   return (
     <Container maxWidth="sm">
       <Box sx={{ my: 4 }}>
@@ -16,6 +19,7 @@ export default function Index() {
         <Link href="/about" color="secondary">
           Go to the about page
         </Link>
+        <Button onClick={toggle}> Toggle Theme </Button>
         <ProTip />
         <Copyright />
       </Box>

--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -1,19 +1,26 @@
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
-// Create a theme instance.
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#556cd6',
-    },
-    secondary: {
-      main: '#19857b',
-    },
-    error: {
-      main: red.A400,
-    },
+export const LIGHT = 'light';
+export const DARK = 'dark';
+
+const palette = {
+  mode: LIGHT,
+  primary: {
+    main: '#556cd6',
   },
+  secondary: {
+    main: '#19857b',
+  },
+  error: {
+    main: red.A400,
+  },
+};
+
+export const lightTheme = createTheme({
+  palette: { ...palette, mode: LIGHT },
 });
 
-export default theme;
+export const darkTheme = createTheme({
+  palette: { ...palette, mode: DARK },
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

One amazing piece of using Material UI is the ability to "Theme" our apps. And the ability to switch themes is so integral to almost every app, I wanted to show the lowest friction way to introduce this to a Next JS App.

https://user-images.githubusercontent.com/10850753/159105767-09062f62-fa4b-4b1e-ad27-0405135d66b1.mov



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
