### PR TITLE
(WIP) [DatePicker] Allow to change order of month and year in PickersCalendarHeader

### DIFF
--- a/packages/mui-lab/src/CalendarPicker/CalendarPicker.test.tsx
+++ b/packages/mui-lab/src/CalendarPicker/CalendarPicker.test.tsx
@@ -36,8 +36,7 @@ describe('<CalendarPicker />', () => {
       <CalendarPicker date={adapterToUse.date('2019-01-01T00:00:00.000')} onChange={() => {}} />,
     );
 
-    expect(screen.getByText('January')).toBeVisible();
-    expect(screen.getByText('2019')).toBeVisible();
+    expect(screen.getByText('January 2019')).toBeVisible();
     expect(screen.getAllByMuiTest('day')).to.have.length(31);
     // It should follow https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html
     expect(
@@ -95,7 +94,7 @@ describe('<CalendarPicker />', () => {
     fireEvent.click(screen.getByLabelText(/Jan 5, 2019/i));
     expect(onChangeMock.callCount).to.equal(0);
 
-    fireEvent.click(screen.getByText('January'));
+    fireEvent.click(screen.getByText('January 2019'));
     expect(screen.queryByLabelText('year view is open, switch to calendar view')).toBeVisible();
   });
 
@@ -111,8 +110,8 @@ describe('<CalendarPicker />', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('January'));
-    expect(screen.queryByText('January')).toBeVisible();
+    fireEvent.click(screen.getByText('January 2019'));
+    expect(screen.queryByText('January 2019')).toBeVisible();
     expect(screen.queryByLabelText('year view is open, switch to calendar view')).to.equal(null);
 
     fireEvent.click(screen.getByTitle('Previous month'));

--- a/packages/mui-lab/src/CalendarPicker/PickersCalendarHeader.tsx
+++ b/packages/mui-lab/src/CalendarPicker/PickersCalendarHeader.tsx
@@ -184,26 +184,14 @@ function PickersCalendarHeader<TDate>(props: PickersCalendarHeaderProps<TDate>) 
       >
         <FadeTransitionGroup
           reduceAnimations={reduceAnimations}
-          transKey={utils.format(month, 'month')}
+          transKey={utils.format(month, 'monthAndYear')}
         >
           <PickersCalendarHeaderLabelItem
             aria-live="polite"
-            data-mui-test="calendar-month-text"
+            data-mui-test="calendar-month-and-year-text"
             ownerState={ownerState}
           >
-            {utils.format(month, 'month')}
-          </PickersCalendarHeaderLabelItem>
-        </FadeTransitionGroup>
-        <FadeTransitionGroup
-          reduceAnimations={reduceAnimations}
-          transKey={utils.format(month, 'year')}
-        >
-          <PickersCalendarHeaderLabelItem
-            aria-live="polite"
-            data-mui-test="calendar-year-text"
-            ownerState={ownerState}
-          >
-            {utils.format(month, 'year')}
+            {utils.format(month, 'monthAndYear')}
           </PickersCalendarHeaderLabelItem>
         </FadeTransitionGroup>
         {views.length > 1 && !disabled && (

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.test.tsx
@@ -52,8 +52,7 @@ describe('<MobileDatePicker />', () => {
       />,
     );
 
-    expect(screen.getAllByMuiTest('calendar-year-text')[0]).to.have.text('2018');
-    expect(screen.getByMuiTest('calendar-month-text')).to.have.text('January');
+    expect(screen.getAllByMuiTest('calendar-month-and-year-text')[0]).to.have.text('January 2018');
 
     // onChange must be dispatched with newly selected date
     expect(onChangeMock.callCount).to.equal(
@@ -77,7 +76,7 @@ describe('<MobileDatePicker />', () => {
     fireEvent.click(screen.getByLabelText(/switch to year view/i));
     fireEvent.click(screen.getByText('2010', { selector: 'button' }));
 
-    expect(screen.getAllByMuiTest('calendar-year-text')[0]).to.have.text('2010');
+    expect(screen.getAllByMuiTest('calendar-month-and-year-text')[0]).to.have.text('January 2010');
     expect(onChangeMock.callCount).to.equal(1);
   });
 
@@ -265,7 +264,7 @@ describe('<MobileDatePicker />', () => {
       />,
     );
 
-    expect(screen.getByText('July')).toBeVisible();
+    expect(screen.getByText('July 2018')).toBeVisible();
   });
 
   it('prop `showTodayButton` – accept current date when "today" button is clicked', () => {

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.test.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.test.tsx
@@ -17,8 +17,7 @@ describe('<StaticDatePicker />', () => {
       />,
     );
 
-    expect(screen.getByText('January')).toBeVisible();
-    expect(screen.getByText('2019')).toBeVisible();
+    expect(screen.getByText('January 2019')).toBeVisible();
     expect(screen.getAllByMuiTest('day')).to.have.length(31);
   });
 
@@ -32,7 +31,7 @@ describe('<StaticDatePicker />', () => {
       />,
     );
 
-    expect(screen.getByMuiTest('calendar-month-text')).to.have.text('January');
+    expect(screen.getByMuiTest('calendar-month-and-year-text')).to.have.text('January 2019');
 
     const nextMonth = screen.getByLabelText('Next month');
     const previousMonth = screen.getByLabelText('Previous month');
@@ -43,7 +42,7 @@ describe('<StaticDatePicker />', () => {
     fireEvent.click(previousMonth);
     fireEvent.click(previousMonth);
 
-    expect(screen.getByMuiTest('calendar-month-text')).to.have.text('December');
+    expect(screen.getByMuiTest('calendar-month-and-year-text')).to.have.text('December 2018');
   });
 
   it('prop `shouldDisableYear` – disables years dynamically', () => {


### PR DESCRIPTION
Fixes #29456.

Allow changing the order of month and year in PickersCalendarHeader by using `monthAndYear` format instead of `month` and `year` format separately.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
