### PR TITLE
[TextField] Fix underlined input transition issue for safari

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -83,6 +83,7 @@ const FilledInputRoot = styled(InputBaseRoot, {
         pointerEvents: 'none', // Transparent to the hover style.
       },
       [`&.${filledInputClasses.focused}:after`]: {
+        willChange: 'transform',
         transform: 'scaleX(1)',
       },
       [`&.${filledInputClasses.error}:after`]: {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -68,6 +68,7 @@ const InputRoot = styled(InputBaseRoot, {
         pointerEvents: 'none', // Transparent to the hover style.
       },
       [`&.${inputClasses.focused}:after`]: {
+        willChange: 'transform',
         transform: 'scaleX(1)',
       },
       [`&.${inputClasses.error}:after`]: {


### PR DESCRIPTION
Fixes #31766 , fixes #31861 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixed this issues with add will-change property.
watch a video on troubleshooting in Safari.

Refernce : https://stackoverflow.com/questions/68298782/safari-css-transition-on-scale-with-border-radius


https://user-images.githubusercontent.com/59679962/159717055-d61c5c04-7723-4c08-b7ab-15eca356c144.mov


