### PR TITLE
[MobileStepper] Add getPaginationLabel prop

### DIFF
--- a/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.js
+++ b/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.js
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import MobileStepper from '@mui/material/MobileStepper';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
+
+const steps = [
+  {
+    label: 'This my first step',
+    description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                  laboris nisi ut aliquip ex ea commodo consequat.`,
+  },
+  {
+    label: 'This, right here, is my second step',
+    description: `Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                  non proident, sunt in culpa qui officia deserunt mollit anim id
+                  est laborum.`,
+  },
+  {
+    label: 'Finally! The third step!',
+    description: `Nibh tortor id aliquet lectus proin nibh nisl condimentum id.
+                  Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus
+                  at augue eget.`,
+  },
+];
+
+export default function CustomPaginationLabelTextMobileStepper() {
+  const theme = useTheme();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const maxSteps = steps.length;
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400, flexGrow: 1 }}>
+      <Paper
+        square
+        elevation={0}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: 50,
+          pl: 2,
+          bgcolor: 'background.default',
+        }}
+      >
+        <Typography>{steps[activeStep].label}</Typography>
+      </Paper>
+      <Box sx={{ height: 255, maxWidth: 400, width: '100%', p: 2 }}>
+        {steps[activeStep].description}
+      </Box>
+      <MobileStepper
+        variant="text"
+        steps={maxSteps}
+        position="static"
+        activeStep={activeStep}
+        getPaginationLabel={({ activeStepIndex, totalSteps }) =>
+          `On step ${activeStepIndex + 1} of ${totalSteps}`
+        }
+        nextButton={
+          <Button
+            size="small"
+            onClick={handleNext}
+            disabled={activeStep === maxSteps - 1}
+          >
+            Next
+            {theme.direction === 'rtl' ? (
+              <KeyboardArrowLeft />
+            ) : (
+              <KeyboardArrowRight />
+            )}
+          </Button>
+        }
+        backButton={
+          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+            {theme.direction === 'rtl' ? (
+              <KeyboardArrowRight />
+            ) : (
+              <KeyboardArrowLeft />
+            )}
+            Back
+          </Button>
+        }
+      />
+    </Box>
+  );
+}

--- a/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.js
+++ b/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.js
@@ -67,7 +67,7 @@ export default function CustomPaginationLabelTextMobileStepper() {
         steps={maxSteps}
         position="static"
         activeStep={activeStep}
-        getPaginationLabel={({ activeStepIndex, totalSteps }) =>
+        getPaginationLabel={(activeStepIndex, totalSteps) =>
           `On step ${activeStepIndex + 1} of ${totalSteps}`
         }
         nextButton={

--- a/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.tsx
+++ b/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { useTheme } from '@mui/material/styles';
+import MobileStepper from '@mui/material/MobileStepper';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
+
+const steps = [
+  {
+    label: 'This my first step',
+    description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                  laboris nisi ut aliquip ex ea commodo consequat.`,
+  },
+  {
+    label: 'This, right here, is my second step',
+    description: `Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                  non proident, sunt in culpa qui officia deserunt mollit anim id
+                  est laborum.`,
+  },
+  {
+    label: 'Finally! The third step!',
+    description: `Nibh tortor id aliquet lectus proin nibh nisl condimentum id.
+                  Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus
+                  at augue eget.`,
+  },
+];
+
+export default function CustomPaginationLabelTextMobileStepper() {
+  const theme = useTheme();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const maxSteps = steps.length;
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400, flexGrow: 1 }}>
+      <Paper
+        square
+        elevation={0}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: 50,
+          pl: 2,
+          bgcolor: 'background.default',
+        }}
+      >
+        <Typography>{steps[activeStep].label}</Typography>
+      </Paper>
+      <Box sx={{ height: 255, maxWidth: 400, width: '100%', p: 2 }}>
+        {steps[activeStep].description}
+      </Box>
+      <MobileStepper
+        variant="text"
+        steps={maxSteps}
+        position="static"
+        activeStep={activeStep}
+        getPaginationLabel={({ activeStepIndex, totalSteps }) =>
+          `On step ${activeStepIndex + 1} of ${totalSteps}`
+        }
+        nextButton={
+          <Button
+            size="small"
+            onClick={handleNext}
+            disabled={activeStep === maxSteps - 1}
+          >
+            Next
+            {theme.direction === 'rtl' ? (
+              <KeyboardArrowLeft />
+            ) : (
+              <KeyboardArrowRight />
+            )}
+          </Button>
+        }
+        backButton={
+          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+            {theme.direction === 'rtl' ? (
+              <KeyboardArrowRight />
+            ) : (
+              <KeyboardArrowLeft />
+            )}
+            Back
+          </Button>
+        }
+      />
+    </Box>
+  );
+}

--- a/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.tsx
+++ b/docs/data/material/components/steppers/CustomPaginationLabelTextMobileStepper.tsx
@@ -67,7 +67,7 @@ export default function CustomPaginationLabelTextMobileStepper() {
         steps={maxSteps}
         position="static"
         activeStep={activeStep}
-        getPaginationLabel={({ activeStepIndex, totalSteps }) =>
+        getPaginationLabel={(activeStepIndex, totalSteps) =>
           `On step ${activeStepIndex + 1} of ${totalSteps}`
         }
         nextButton={

--- a/docs/data/material/components/steppers/steppers.md
+++ b/docs/data/material/components/steppers/steppers.md
@@ -99,6 +99,12 @@ This demo uses
 
 {{"demo": "SwipeableTextMobileStepper.js", "bg": true}}
 
+### Text with custom pagination label
+
+This demo customizes the label of the current step and total number of steps
+
+{{"demo": "CustomPaginationLabelTextMobileStepper.js", "bg": true}}
+
 ### Dots
 
 Use dots when the number of steps is small.

--- a/docs/pages/api-docs/mobile-stepper.json
+++ b/docs/pages/api-docs/mobile-stepper.json
@@ -4,6 +4,10 @@
     "activeStep": { "type": { "name": "custom", "description": "integer" }, "default": "0" },
     "backButton": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
+    "getPaginationLabel": {
+      "type": { "name": "func" },
+      "default": "(activeStepIndex, totalSteps) => `${activeStepIndex + 1} / ${totalSteps}`"
+    },
     "LinearProgressProps": { "type": { "name": "object" } },
     "nextButton": { "type": { "name": "node" } },
     "position": {

--- a/docs/pages/material-ui/api/mobile-stepper.json
+++ b/docs/pages/material-ui/api/mobile-stepper.json
@@ -4,6 +4,10 @@
     "activeStep": { "type": { "name": "custom", "description": "integer" }, "default": "0" },
     "backButton": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
+    "getPaginationLabel": {
+      "type": { "name": "func" },
+      "default": "(activeStepIndex, totalSteps) => `${activeStepIndex + 1} / ${totalSteps}`"
+    },
     "LinearProgressProps": { "type": { "name": "object" } },
     "nextButton": { "type": { "name": "node" } },
     "position": {

--- a/docs/translations/api-docs/mobile-stepper/mobile-stepper.json
+++ b/docs/translations/api-docs/mobile-stepper/mobile-stepper.json
@@ -4,6 +4,7 @@
     "activeStep": "Set the active step (zero based index). Defines which dot is highlighted when the variant is &#39;dots&#39;.",
     "backButton": "A back button element. For instance, it can be a <code>Button</code> or an <code>IconButton</code>.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
+    "getPaginationLabel": "Customize the pagination label for the <code>text</code> variant.<br><br><strong>Signature:</strong><br><code>function(activeStepIndex: number, totalSteps: number) =&gt; string | ReactNode</code><br><em>activeStepIndex:</em> The current active step, zero-indexed.<br><em>totalSteps:</em> The total number of steps.",
     "LinearProgressProps": "Props applied to the <code>LinearProgress</code> element.",
     "nextButton": "A next button element. For instance, it can be a <code>Button</code> or an <code>IconButton</code>.",
     "position": "Set the positioning type.",

--- a/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
@@ -5,11 +5,6 @@ import { PaperProps } from '../Paper';
 import { LinearProgressProps } from '../LinearProgress';
 import { MobileStepperClasses } from './mobileStepperClasses';
 
-type PaginationLabelProps = {
-  activeStepIndex: number;
-  totalSteps: number;
-}
-
 export interface MobileStepperProps extends StandardProps<PaperProps, 'children' | 'variant'> {
   /**
    * Set the active step (zero based index).
@@ -27,10 +22,12 @@ export interface MobileStepperProps extends StandardProps<PaperProps, 'children'
   classes?: Partial<MobileStepperClasses>;
   /**
    * Customize the pagination label for the `text` variant.
-   * `activeStepIndex` is zero-based.
-   * @default (activeStepIndex, totalSteps) => `${activeStepIndex + 1} of ${totalSteps}`
+   * @param {number} activeStepIndex The current active step, zero-indexed.
+   * @param {number} totalSteps The total number of steps.
+   * @returns {(string|ReactNode)}
+   * @default (activeStepIndex, totalSteps) => `${activeStepIndex + 1} / ${totalSteps}`
    */
-  getPaginationLabel?: ((props: PaginationLabelProps) => string | React.ReactNode);
+  getPaginationLabel?: (activeStepIndex: number, totalSteps: number) => string | React.ReactNode;
   /**
    * Props applied to the `LinearProgress` element.
    */

--- a/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
@@ -6,8 +6,8 @@ import { LinearProgressProps } from '../LinearProgress';
 import { MobileStepperClasses } from './mobileStepperClasses';
 
 type PaginationLabelProps = {
-  activeStep: number;
-  steps: number;
+  activeStepIndex: number;
+  totalSteps: number;
 }
 
 export interface MobileStepperProps extends StandardProps<PaperProps, 'children' | 'variant'> {
@@ -27,6 +27,8 @@ export interface MobileStepperProps extends StandardProps<PaperProps, 'children'
   classes?: Partial<MobileStepperClasses>;
   /**
    * Customize the pagination label for the `text` variant.
+   * `activeStepIndex` is zero-based.
+   * @default (activeStepIndex, totalSteps) => `${activeStepIndex + 1} of ${totalSteps}`
    */
   getPaginationLabel?: ((props: PaginationLabelProps) => string | React.ReactNode);
   /**

--- a/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
@@ -5,6 +5,11 @@ import { PaperProps } from '../Paper';
 import { LinearProgressProps } from '../LinearProgress';
 import { MobileStepperClasses } from './mobileStepperClasses';
 
+type PaginationLabelProps = {
+  activeStep: number;
+  steps: number;
+}
+
 export interface MobileStepperProps extends StandardProps<PaperProps, 'children' | 'variant'> {
   /**
    * Set the active step (zero based index).
@@ -20,6 +25,10 @@ export interface MobileStepperProps extends StandardProps<PaperProps, 'children'
    * Override or extend the styles applied to the component.
    */
   classes?: Partial<MobileStepperClasses>;
+  /**
+   * Customize the pagination label for the `text` variant.
+   */
+  getPaginationLabel?: ((props: PaginationLabelProps) => string | React.ReactNode);
   /**
    * Props applied to the `LinearProgress` element.
    */

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -101,7 +101,8 @@ const MobileStepperProgress = styled(LinearProgress, {
   }),
 }));
 
-const defaultPaginationLabel = ({ activeStep, steps }) => `${activeStep + 1} / ${steps}`;
+const defaultPaginationLabel = ({ activeStepIndex, totalSteps }) =>
+  `${activeStepIndex + 1} / ${totalSteps}`;
 
 const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiMobileStepper' });
@@ -127,7 +128,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const paginationLabel = getPaginationLabel({ activeStep, steps });
+  const paginationLabel = getPaginationLabel({ activeStepIndex: activeStep, totalSteps: steps });
 
   return (
     <MobileStepperRoot
@@ -194,6 +195,8 @@ MobileStepper.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Customize the pagination label for the `text` variant.
+   * `activeStepIndex` is zero-based.
+   * @default (activeStepIndex, totalSteps) => `${activeStepIndex + 1} of ${totalSteps}`
    */
   getPaginationLabel: PropTypes.func,
   /**

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -101,16 +101,13 @@ const MobileStepperProgress = styled(LinearProgress, {
   }),
 }));
 
-const defaultPaginationLabel = ({ activeStepIndex, totalSteps }) =>
-  `${activeStepIndex + 1} / ${totalSteps}`;
-
 const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiMobileStepper' });
   const {
     activeStep = 0,
     backButton,
     className,
-    getPaginationLabel = defaultPaginationLabel,
+    getPaginationLabel = (activeStepIndex, totalSteps) => `${activeStepIndex + 1} / ${totalSteps}`,
     LinearProgressProps,
     nextButton,
     position = 'bottom',
@@ -128,7 +125,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const paginationLabel = getPaginationLabel({ activeStepIndex: activeStep, totalSteps: steps });
+  const paginationLabel = getPaginationLabel(activeStep, steps);
 
   return (
     <MobileStepperRoot
@@ -195,8 +192,10 @@ MobileStepper.propTypes /* remove-proptypes */ = {
   className: PropTypes.string,
   /**
    * Customize the pagination label for the `text` variant.
-   * `activeStepIndex` is zero-based.
-   * @default (activeStepIndex, totalSteps) => `${activeStepIndex + 1} of ${totalSteps}`
+   * @param {number} activeStepIndex The current active step, zero-indexed.
+   * @param {number} totalSteps The total number of steps.
+   * @returns {(string|ReactNode)}
+   * @default (activeStepIndex, totalSteps) => `${activeStepIndex + 1} / ${totalSteps}`
    */
   getPaginationLabel: PropTypes.func,
   /**

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -101,12 +101,15 @@ const MobileStepperProgress = styled(LinearProgress, {
   }),
 }));
 
+const defaultPaginationLabel = ({ activeStep, steps }) => `${activeStep + 1} / ${steps}`;
+
 const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiMobileStepper' });
   const {
     activeStep = 0,
     backButton,
     className,
+    getPaginationLabel = defaultPaginationLabel,
     LinearProgressProps,
     nextButton,
     position = 'bottom',
@@ -124,6 +127,8 @@ const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  const paginationLabel = getPaginationLabel({ activeStep, steps });
+
   return (
     <MobileStepperRoot
       square
@@ -134,11 +139,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(inProps, ref) {
       {...other}
     >
       {backButton}
-      {variant === 'text' && (
-        <React.Fragment>
-          {activeStep + 1} / {steps}
-        </React.Fragment>
-      )}
+      {variant === 'text' && <React.Fragment>{paginationLabel}</React.Fragment>}
 
       {variant === 'dots' && (
         <MobileStepperDots ownerState={ownerState} className={classes.dots}>
@@ -191,6 +192,10 @@ MobileStepper.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * Customize the pagination label for the `text` variant.
+   */
+  getPaginationLabel: PropTypes.func,
   /**
    * Props applied to the `LinearProgress` element.
    */

--- a/packages/mui-material/src/MobileStepper/MobileStepper.test.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.test.js
@@ -78,6 +78,50 @@ describe('<MobileStepper />', () => {
     expect(container.firstChild.textContent).to.equal('Back2 / 3Next');
   });
 
+  describe('paginationLabel', () => {
+    describe('when not supplied', () => {
+      it('should render the default string', () => {
+        const { container } = render(
+          <MobileStepper {...defaultProps} variant="text" activeStep={1} steps={3} />,
+        );
+        expect(container.firstChild.textContent).to.equal('Back2 / 3Next');
+      });
+    });
+    describe('when it returns a string', () => {
+      it('should render the label string', () => {
+        const { container } = render(
+          <MobileStepper
+            {...defaultProps}
+            variant="text"
+            activeStep={1}
+            steps={3}
+            getPaginationLabel={({ activeStep, steps }) => `Step ${activeStep + 1} of ${steps}`}
+          />,
+        );
+        expect(container.firstChild.textContent).to.equal('BackStep 2 of 3Next');
+      });
+    });
+    describe('when it returns a component', () => {
+      it('should render the component', () => {
+        const { container } = render(
+          <MobileStepper
+            {...defaultProps}
+            variant="text"
+            activeStep={1}
+            steps={3}
+            getPaginationLabel={({ activeStep, steps }) => (
+              <h3 data-testid="my-label-test">
+                It is currently step {activeStep + 1} of {steps}
+              </h3>
+            )}
+          />,
+        );
+        const label = container.querySelector('[data-testid="my-label-test"]');
+        expect(label.textContent).to.equal('It is currently step 2 of 3');
+      });
+    });
+  });
+
   it('should render dots when supplied with variant dots', () => {
     const { container } = render(<MobileStepper {...defaultProps} variant="dots" />);
     expect(container.querySelectorAll(`.${classes.dots}`)).to.have.lengthOf(1);

--- a/packages/mui-material/src/MobileStepper/MobileStepper.test.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.test.js
@@ -95,7 +95,9 @@ describe('<MobileStepper />', () => {
             variant="text"
             activeStep={1}
             steps={3}
-            getPaginationLabel={({ activeStep, steps }) => `Step ${activeStep + 1} of ${steps}`}
+            getPaginationLabel={({ activeStepIndex, totalSteps }) =>
+              `Step ${activeStepIndex + 1} of ${totalSteps}`
+            }
           />,
         );
         expect(container.firstChild.textContent).to.equal('BackStep 2 of 3Next');
@@ -109,9 +111,9 @@ describe('<MobileStepper />', () => {
             variant="text"
             activeStep={1}
             steps={3}
-            getPaginationLabel={({ activeStep, steps }) => (
+            getPaginationLabel={({ activeStepIndex, totalSteps }) => (
               <h3 data-testid="my-label-test">
-                It is currently step {activeStep + 1} of {steps}
+                It is currently step {activeStepIndex + 1} of {totalSteps}
               </h3>
             )}
           />,

--- a/packages/mui-material/src/MobileStepper/MobileStepper.test.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.test.js
@@ -95,7 +95,7 @@ describe('<MobileStepper />', () => {
             variant="text"
             activeStep={1}
             steps={3}
-            getPaginationLabel={({ activeStepIndex, totalSteps }) =>
+            getPaginationLabel={(activeStepIndex, totalSteps) =>
               `Step ${activeStepIndex + 1} of ${totalSteps}`
             }
           />,
@@ -111,7 +111,7 @@ describe('<MobileStepper />', () => {
             variant="text"
             activeStep={1}
             steps={3}
-            getPaginationLabel={({ activeStepIndex, totalSteps }) => (
+            getPaginationLabel={(activeStepIndex, totalSteps) => (
               <h3 data-testid="my-label-test">
                 It is currently step {activeStepIndex + 1} of {totalSteps}
               </h3>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Hi there, I added a prop to the `MobileStepper` to customize the pagination label. I needed to render `[x] of [y]` instead of `[x] / [y]`, but there wasn't an API to customize it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
