### PR TITLE
[docs] Fix product name capitalization

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -81,7 +81,6 @@ const ProductLabel = styled(Typography)(({ theme }) => ({
   marginBottom: theme.spacing(0.3),
   fontSize: theme.typography.pxToRem(12),
   fontWeight: theme.typography.fontWeightBold,
-  textTransform: 'uppercase',
   letterSpacing: '.05rem',
   color: theme.palette.mode === 'dark' ? theme.palette.primary[300] : theme.palette.primary[600],
 }));


### PR DESCRIPTION
AFAIK the product names are, e.g. "MUI Base", not "MUI BASE".

<img width="527" alt="Screenshot 2022-03-20 at 12 52 01" src="https://user-images.githubusercontent.com/3165635/159160883-5af8e615-b06d-412c-b20e-1a13658b1615.png">

---

Off-topic: interesting move from apollo, they move more toward a set of features:

<img width="508" alt="Screenshot 2022-03-20 at 12 54 01" src="https://user-images.githubusercontent.com/3165635/159160970-eac10cf3-54ea-4ae6-8a9f-895181bfbed5.png">

https://www.apollographql.com/docs/kotlin