### PR TITLE
[docs] Solve duplication of content

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -63,6 +63,10 @@ export default class MyDocument extends Document {
             rel="canonical"
             href={`https://mui.com${userLanguage === 'en' ? '' : `/${userLanguage}`}${canonicalAs}`}
           />
+          {/* TODO remove post migration */}
+          {canonicalAs.startsWith('/material-ui/') ? (
+            <meta name="robots" content="noindex,nofollow" />
+          ) : null}
           <link rel="alternate" href={`https://mui.com${canonicalAs}`} hrefLang="x-default" />
           {/*
             Preconnect allows the browser to setup early connections before an HTTP request

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -7,6 +7,7 @@ import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import createEmotionCache from 'docs/src/createEmotionCache';
 import { getMetaThemeColor } from 'docs/src/modules/brandingTheme';
 import GlobalStyles from '@mui/material/GlobalStyles';
+import FEATURE_TOGGLE from 'docs/src/featureToggle';
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -64,7 +65,7 @@ export default class MyDocument extends Document {
             href={`https://mui.com${userLanguage === 'en' ? '' : `/${userLanguage}`}${canonicalAs}`}
           />
           {/* TODO remove post migration */}
-          {canonicalAs.startsWith('/material-ui/') ? (
+          {!FEATURE_TOGGLE.enable_redirects && canonicalAs.startsWith('/material-ui/') ? (
             <meta name="robots" content="noindex,nofollow" />
           ) : null}
           <link rel="alternate" href={`https://mui.com${canonicalAs}`} hrefLang="x-default" />


### PR DESCRIPTION
All of the https://mui.com/material-ui/ pages are indexed on Google, for instance: https://www.google.com/search?q=%22https%3A%2F%2Fmui.com%2Fmaterial-ui%2Freact-alert%2F%22. I could find one path that leads to this outcome

1. https://mui.com/components/menus/#unstyled
2. https://mui.com/base/react-menu/
3. https://mui.com/base/api/menu-unstyled/
4. https://mui.com/material-ui/guides/minimizing-bundle-size/ 
5. https://mui.com/material-ui/react-alert/ 🎰

This leads to duplication of content, which we shouldn't let fly.

I have noticed the problem in https://app.ahrefs.com/site-audit/2944028/37/issues. We reach the limit I set on the number of internal pages (2,000). Usually, we have ~1,352 internal pages that are crawlable.

<img width="1072" alt="Screenshot 2022-03-20 at 14 15 50" src="https://user-images.githubusercontent.com/3165635/159164147-11d6f4e4-1be4-4c48-9211-a8f887edb630.png">

