### PR TITLE
[DatePicker] Fix input value issues

### DIFF
--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -110,6 +110,7 @@ export function usePickerState<TInput, TDateValue>(
       isOpen,
       utils,
       draftState.draft,
+      draftState.committed,
       valueManager.emptyValue,
       initialDate,
     ],

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -82,7 +82,7 @@ export function usePickerState<TInput, TDateValue>(
 
       if (needClosePicker) {
         setIsOpen(false);
-        setInitialDate(acceptedDate);
+
         if (onAccept) {
           onAccept(acceptedDate);
         }
@@ -145,9 +145,12 @@ export function usePickerState<TInput, TDateValue>(
       onChange,
       open: isOpen,
       rawValue: value,
-      openPicker: () => setIsOpen(true),
+      openPicker: () => {
+        setInitialDate(parsedDateValue);
+        setIsOpen(true);
+      },
     }),
-    [onChange, isOpen, value, setIsOpen],
+    [onChange, isOpen, value, parsedDateValue, setIsOpen],
   );
 
   const pickerState = { pickerProps, inputProps, wrapperProps };

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -70,6 +70,7 @@ export function usePickerState<TInput, TDateValue>(
     dispatch({ type: 'reset', payload: parsedDateValue });
   }
 
+  // TODO need to reconsider whether initialDate variable is necessary.
   const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
 
   // Mobile keyboard view is a special case.
@@ -96,7 +97,7 @@ export function usePickerState<TInput, TDateValue>(
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
       onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(initialDate, true),
+      onDismiss: () => acceptDate(draftState.committed, true),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -70,8 +70,7 @@ export function usePickerState<TInput, TDateValue>(
     dispatch({ type: 'reset', payload: parsedDateValue });
   }
 
-  // TODO need to reconsider whether initialDate variable is necessary.
-  // const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
+  const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
 
   // Mobile keyboard view is a special case.
   // When it's open picker should work like closed, cause we are just showing text field
@@ -83,7 +82,7 @@ export function usePickerState<TInput, TDateValue>(
 
       if (needClosePicker) {
         setIsOpen(false);
-        // setInitialDate(acceptedDate);
+        setInitialDate(acceptedDate);
         if (onAccept) {
           onAccept(acceptedDate);
         }
@@ -96,8 +95,8 @@ export function usePickerState<TInput, TDateValue>(
     () => ({
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
-      onAccept: () => acceptDate(draftState.draft, true),
-      onDismiss: () => acceptDate(draftState.committed, true),
+      onAccept: () => acceptDate(draftState.committed, true),
+      onDismiss: () => acceptDate(initialDate, true),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
         dispatch({ type: 'update', payload: now });
@@ -110,9 +109,8 @@ export function usePickerState<TInput, TDateValue>(
       isOpen,
       utils,
       draftState.draft,
-      draftState.committed,
       valueManager.emptyValue,
-      // initialDate,
+      initialDate,
     ],
   );
 

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -108,7 +108,7 @@ export function usePickerState<TInput, TDateValue>(
       disableCloseOnSelect,
       isOpen,
       utils,
-      draftState.draft,
+      draftState.committed,
       valueManager.emptyValue,
       initialDate,
     ],

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -71,7 +71,7 @@ export function usePickerState<TInput, TDateValue>(
   }
 
   // TODO need to reconsider whether initialDate variable is necessary.
-  const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
+  // const [initialDate, setInitialDate] = React.useState<TDateValue>(draftState.committed);
 
   // Mobile keyboard view is a special case.
   // When it's open picker should work like closed, cause we are just showing text field
@@ -83,7 +83,7 @@ export function usePickerState<TInput, TDateValue>(
 
       if (needClosePicker) {
         setIsOpen(false);
-        setInitialDate(acceptedDate);
+        // setInitialDate(acceptedDate);
         if (onAccept) {
           onAccept(acceptedDate);
         }
@@ -112,7 +112,7 @@ export function usePickerState<TInput, TDateValue>(
       draftState.draft,
       draftState.committed,
       valueManager.emptyValue,
-      initialDate,
+      // initialDate,
     ],
   );
 

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -95,7 +95,7 @@ export function usePickerState<TInput, TDateValue>(
     () => ({
       open: isOpen,
       onClear: () => acceptDate(valueManager.emptyValue, true),
-      onAccept: () => acceptDate(draftState.committed, true),
+      onAccept: () => acceptDate(draftState.draft, true),
       onDismiss: () => acceptDate(initialDate, true),
       onSetToday: () => {
         const now = utils.date() as TDateValue;
@@ -108,7 +108,7 @@ export function usePickerState<TInput, TDateValue>(
       disableCloseOnSelect,
       isOpen,
       utils,
-      draftState.committed,
+      draftState.draft,
       valueManager.emptyValue,
       initialDate,
     ],

--- a/packages/mui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
+++ b/packages/mui-lab/src/internal/pickers/wrappers/DesktopWrapper.tsx
@@ -23,7 +23,7 @@ function DesktopWrapper(props: InternalDesktopWrapperProps) {
     children,
     DateInputProps,
     KeyboardDateInputComponent,
-    onDismiss,
+    onAccept,
     open,
     PopperProps,
     PaperProps,
@@ -45,7 +45,7 @@ function DesktopWrapper(props: InternalDesktopWrapperProps) {
         TransitionComponent={TransitionComponent}
         PopperProps={PopperProps}
         PaperProps={PaperProps}
-        onClose={onDismiss}
+        onClose={onAccept}
         onClear={onClear}
         clearText={clearText}
         clearable={clearable}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes mui/material-ui#31919, fixes mui/material-ui#31853, fixes mui/material-ui#31278, and fixes mui/mui-x#4358

All of these issues are caused by the newly introduced state `initialDate` in mui/material-ui#30768

@hbjORbj designed it to call `setInitialDate` whenever we close the picker. This design works on mobile, but does not make sense on the desktop, because on the desktop we could change the value of the date when the picker is closed.

To solve this problem, I implemented 1) when we close the Picker on the desktop, we should expect it has the same effect as the `OK` button on the mobile, instead of the `CANCEL` button 2) we should call `setInitialDate` just before we open the picker, instead of before closing the picker

Although 1) could solve all issues now, 2) would make the program more intuitive and avoid issues in the future.

I will write some test cases for this in the future.

Also, I think my pull request is more elegant than mui/material-ui#31793 and mui/material-ui#31093