### PR TITLE
[docs] Fix the docs for production class generation

### DIFF
--- a/docs/data/styles/advanced/advanced-pt.md
+++ b/docs/data/styles/advanced/advanced-pt.md
@@ -444,7 +444,7 @@ const className = `${sheetName}-${ruleName}-${identifier}`;
 const productionPrefix = 'jss';
 const identifier = 123;
 
-const className = `${productionPrefix}-${identifier}`;
+const className = `${productionPrefix}${identifier}`;
 ```
 
 Quando as seguintes condições são atendidas, os nomes das classes são **determinísticos**:

--- a/docs/data/styles/advanced/advanced-zh.md
+++ b/docs/data/styles/advanced/advanced-zh.md
@@ -448,7 +448,7 @@ const useStyles = makeStyles({
 > const productionPrefix = 'jss';
 > const identifier = 123;
 > 
-> const className = `${productionPrefix}-${identifier}`;
+> const className = `${productionPrefix}${identifier}`;
 > ```
 > 
 > 当满足以下条件时，类名是 **确定的**：

--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -447,7 +447,7 @@ const className = `${sheetName}-${ruleName}-${identifier}`;
 const productionPrefix = 'jss';
 const identifier = 123;
 
-const className = `${productionPrefix}-${identifier}`;
+const className = `${productionPrefix}${identifier}`;
 ```
 
 However, when the following conditions are met, the class names are **deterministic**:


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The docs are not aligned with the actual code. At this very moment the class generation for the "dev" environment and the "prod" environment is different:
1. "dev":
<img width="256" alt="image" src="https://user-images.githubusercontent.com/27646234/159369081-d693b1fe-8afc-4bfa-9afa-1c37ccf97870.png">

2. "prod":
<img width="140" alt="image" src="https://user-images.githubusercontent.com/27646234/159369115-ae5e8fe1-ee85-42bc-9d1a-28b463a52464.png">

^ notice no hyphen before the counter ID in the prod one

See also the code:
https://github.com/mui/material-ui/blob/master/packages/mui-styles/src/createGenerateClassName/createGenerateClassName.js#L69

I believe it's a typo, but changing this logic would introduce a breaking change probably, so I'm suggesting at least updating the docs.
