### PR TITLE
[Docs] - interoperability - fix CSS modules example

### DIFF
--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -504,6 +504,7 @@ export default function CssModulesPriority() {
 If you attempt to style the Slider,
 you will likely need to affect some of the Slider's child elements, for example the thumb.
 In MUI, all child elements have an increased specificity of 2: `.parent .child {}`. When writing overrides, you need to do the same.
+It's important to keep in mind that CSS Modules adds an unique id to each class, and that id won't be present on the MUI provided children class. To escape from that, CSS Modules provides a functionality, the `:global` selector.
 
 The following examples override the slider's `thumb` style in addition to the custom styles on the slider itself.
 
@@ -520,7 +521,7 @@ The following examples override the slider's `thumb` style in addition to the cu
   color: #2e8b57;
 }
 
-.slider .MuiSlider-thumb {
+.slider :global .MuiSlider-thumb {
   border-radius: 1px;
 }
 ```


### PR DESCRIPTION
Fix the CSS Modules example on styling deeper elements.
CSS Modules generate a unique ID for each class, and the previous example wasn't working because it didn't take that into account.

**How to test**

1. Go to [this Codesandbox example](https://codesandbox.io/s/css-modules-forked-zc5u0t?file=/src/CssModulesSlider.module.css)
2. Erase the ":global" and sees the CSS loses its effect.


- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
