### PR TITLE
[ButtonBase] Start ripple pulsation only after mount

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -132,11 +132,19 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     [],
   );
 
+  const [mountedState, setMountedState] = React.useState(false);
+
   React.useEffect(() => {
-    if (focusVisible && focusRipple && !disableRipple) {
+    setMountedState(true);
+  }, []);
+
+  const enableTouchRipple = mountedState && !disableRipple && !disabled;
+
+  React.useEffect(() => {
+    if (focusVisible && focusRipple && !disableRipple && mountedState) {
       rippleRef.current.pulsate();
     }
-  }, [disableRipple, focusRipple, focusVisible]);
+  }, [disableRipple, focusRipple, focusVisible, mountedState]);
 
   function useRippleHandler(rippleAction, eventCallback, skipRippleAction = disableTouchRipple) {
     return useEventCallback((event) => {
@@ -301,14 +309,6 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
 
   const handleOwnRef = useForkRef(focusVisibleRef, buttonRef);
   const handleRef = useForkRef(ref, handleOwnRef);
-
-  const [mountedState, setMountedState] = React.useState(false);
-
-  React.useEffect(() => {
-    setMountedState(true);
-  }, []);
-
-  const enableTouchRipple = mountedState && !disableRipple && !disabled;
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Before: https://codesandbox.io/s/checkboxes-material-demo-forked-xrw1ff?file=/demo.tsx

After: https://codesandbox.io/s/checkboxes-material-demo-forked-vg2d2u?file=/demo.tsx

In React 18, any component derived from `ButtonBase` that receives focus during mount will crash when `rippleRef.current.pulsate()` is called. This happens because the `TouchRipple` is rendered conditionally to save resources on SSR. However, in React 18, the effect that sets the focus runs slightly faster than the effect responsible for updating the state to render the ripple. More information see https://github.com/facebook/react/issues/24102#issuecomment-1075524161

I noticed this bug when testing the compatibility of the DataGrid with React 18. In our case, we use `Checkbox` and when a cell switches from view to edit mode we need to focus the input component. To reproduce the crash in the DataGrid follow the steps below:

1. Open https://deploy-preview-4155--material-ui-x.netlify.app/components/data-grid/demo/
2. Scroll to the right to see the "Is filled" column
3. Click once in one of the cells of the "Is filled" column
4. Press <kbd>Enter</kbd>
5. 💥