### PR TITLE
[base] Add `@mui/types` to dependencies

### DIFF
--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -53,14 +53,12 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@emotion/is-prop-valid": "^1.1.2",
+    "@mui/types": "^7.1.3",
     "@mui/utils": "^5.4.4",
     "@popperjs/core": "^2.11.4",
     "clsx": "^1.1.1",
     "prop-types": "^15.7.2",
     "react-is": "^17.0.2"
-  },
-  "devDependencies": {
-    "@mui/types": "^7.1.3"
   },
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Currently, `@mui/types` is set to devDependencies.
If `@mui/base` is used by itself in a typescript project, type resolution will not work.

https://github.com/mui/material-ui/blob/1470c720c615bbb0ba3860c2dacf3d8627e5bfb5/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx#L4

This PR added `@mui/types` to dependencies like [other packages](https://github.com/mui/material-ui/blob/1470c720c615bbb0ba3860c2dacf3d8627e5bfb5/packages/mui-material/package.json#L66).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
