### PR TITLE
[docs] Fix TOC layout for large screen

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -10,14 +10,14 @@ import { useTranslate } from 'docs/src/modules/utils/i18n';
 import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBanner';
 
 const Nav = styled('nav')(({ theme }) => ({
-  top: 'var(--MuiDocs-header-height)',
+  top: 0,
   order: 1,
   width: 240,
   flexShrink: 0,
   position: 'sticky',
-  height: 'calc(100vh - var(--MuiDocs-header-height))',
+  height: '100vh',
   overflowY: 'auto',
-  padding: theme.spacing(2, 4, 2, 0),
+  padding: theme.spacing('calc(var(--MuiDocs-header-height) + 1rem)', 4, 2, 0),
   display: 'none',
   [theme.breakpoints.up('sm')]: {
     display: 'block',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
### Issue
On a large screen, if the content is short, the TOC is pushed up behind the header. Fixed by setting the height to be `100vh` and increase the padding-top instead (The old approach also use the height + padding so there should be no regression).

<img width="632" alt="Screen Shot 2565-03-23 at 09 55 10" src="https://user-images.githubusercontent.com/18292247/159614864-44420761-1b29-4f7c-ac95-a62329294584.png">

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
