### PR TITLE
[TouchRipple] Allows call imperative methods without event

### DIFF
--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -185,12 +185,12 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
         fakeElement = false, // For test purposes
       } = options;
 
-      if (event.type === 'mousedown' && ignoringMouseDown.current) {
+      if (event?.type === 'mousedown' && ignoringMouseDown.current) {
         ignoringMouseDown.current = false;
         return;
       }
 
-      if (event.type === 'touchstart') {
+      if (event?.type === 'touchstart') {
         ignoringMouseDown.current = true;
       }
 
@@ -211,6 +211,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
 
       if (
         center ||
+        event === undefined ||
         (event.clientX === 0 && event.clientY === 0) ||
         (!event.clientX && !event.touches)
       ) {
@@ -238,7 +239,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
       }
 
       // Touche devices
-      if (event.touches) {
+      if (event?.touches) {
         // check that this isn't another touchstart due to multitouch
         // otherwise we will only clear a single timer when unmounting while two
         // are running
@@ -271,7 +272,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
 
     // The touch interaction occurs too quickly.
     // We still want to show ripple effect.
-    if (event.type === 'touchend' && startTimerCommit.current) {
+    if (event?.type === 'touchend' && startTimerCommit.current) {
       startTimerCommit.current();
       startTimerCommit.current = null;
       startTimer.current = setTimeout(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

According to the typescript interface of the `TouchRipple` the ref should allows to call start and stop without the `event` argument. 

```tsx
export interface TouchRippleActions {
  start: (
    event?: React.SyntheticEvent,
    options?: StartActionOptions,
    callback?: () => void,
  ) => void;
  pulsate: (event?: React.SyntheticEvent) => void;
  stop: (event?: React.SyntheticEvent, callback?: () => void) => void;
}
```


But `events` properties such as `event.type` are used in `start` and `stop` methods which makes them return an error. WHen calling `rippleRef.current.stop()`