### PR TITLE
[DateRangePicker] Focusing start date after accept event

### DIFF
--- a/packages/mui-lab/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePickerInput.tsx
@@ -123,34 +123,33 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
     }
   };
 
-  const openRangeStartSelectiononFocus=()=>{
+  const openRangeStartSelectiononFocus = () => {
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('start');
     }
     if (!readOnly && !disableOpenPicker && !end) {
       openPicker();
     }
-  }
+  };
 
-  const openRangeEndSelectionOnClick=()=>{
+  const openRangeEndSelectionOnClick = () => {
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('end');
     }
     if (!readOnly && !disableOpenPicker) {
       openPicker();
     }
-  }
+  };
 
   const openRangeEndSelectionOnFocus = () => {
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('end');
-
     }
     if (!readOnly && !disableOpenPicker && !start) {
       openPicker();
     }
-  }
-  
+  };
+
   const openOnFocus = wrapperVariant === 'desktop';
   const startInputProps = useMaskedInput({
     ...other,
@@ -165,7 +164,7 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
       focused: open && currentlySelectingRangeEnd === 'start',
     },
     inputProps: {
-      onClick: openRangeStartSelectionOnClick ,
+      onClick: openRangeStartSelectionOnClick,
       onFocus: openOnFocus ? openRangeStartSelectiononFocus : undefined,
     },
   });
@@ -183,8 +182,8 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
       focused: open && currentlySelectingRangeEnd === 'end',
     },
     inputProps: {
-      onChange: start && end ? closePicker: undefined,
-      onClick:  openRangeEndSelectionOnClick ,
+      onChange: start && end ? closePicker : undefined,
+      onClick: openRangeEndSelectionOnClick,
       onFocus: openOnFocus ? openRangeEndSelectionOnFocus : undefined,
     },
   });

--- a/packages/mui-lab/src/DateRangePicker/DateRangePickerInput.tsx
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePickerInput.tsx
@@ -51,6 +51,7 @@ export interface DateRangeInputProps
   startText: React.ReactNode;
   endText: React.ReactNode;
   validationError: DateRangeValidationError;
+  closePicker: () => void;
 }
 
 /**
@@ -68,6 +69,7 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
     onChange,
     open,
     openPicker,
+    closePicker,
     rawValue,
     rawValue: [start, end],
     readOnly,
@@ -112,7 +114,7 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
     lazyHandleChangeCallback([utils.date(start), date], inputString);
   };
 
-  const openRangeStartSelection = () => {
+  const openRangeStartSelectionOnClick = () => {
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('start');
     }
@@ -121,15 +123,34 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
     }
   };
 
-  const openRangeEndSelection = () => {
+  const openRangeStartSelectiononFocus=()=>{
+    if (setCurrentlySelectingRangeEnd) {
+      setCurrentlySelectingRangeEnd('start');
+    }
+    if (!readOnly && !disableOpenPicker && !end) {
+      openPicker();
+    }
+  }
+
+  const openRangeEndSelectionOnClick=()=>{
     if (setCurrentlySelectingRangeEnd) {
       setCurrentlySelectingRangeEnd('end');
     }
     if (!readOnly && !disableOpenPicker) {
       openPicker();
     }
-  };
+  }
 
+  const openRangeEndSelectionOnFocus = () => {
+    if (setCurrentlySelectingRangeEnd) {
+      setCurrentlySelectingRangeEnd('end');
+
+    }
+    if (!readOnly && !disableOpenPicker && !start) {
+      openPicker();
+    }
+  }
+  
   const openOnFocus = wrapperVariant === 'desktop';
   const startInputProps = useMaskedInput({
     ...other,
@@ -144,8 +165,8 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
       focused: open && currentlySelectingRangeEnd === 'start',
     },
     inputProps: {
-      onClick: !openOnFocus ? openRangeStartSelection : undefined,
-      onFocus: openOnFocus ? openRangeStartSelection : undefined,
+      onClick: openRangeStartSelectionOnClick ,
+      onFocus: openOnFocus ? openRangeStartSelectiononFocus : undefined,
     },
   });
 
@@ -162,8 +183,9 @@ const DateRangePickerInput = React.forwardRef(function DateRangePickerInput(
       focused: open && currentlySelectingRangeEnd === 'end',
     },
     inputProps: {
-      onClick: !openOnFocus ? openRangeEndSelection : undefined,
-      onFocus: openOnFocus ? openRangeEndSelection : undefined,
+      onChange: start && end ? closePicker: undefined,
+      onClick:  openRangeEndSelectionOnClick ,
+      onFocus: openOnFocus ? openRangeEndSelectionOnFocus : undefined,
     },
   });
 

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.test.tsx
@@ -317,14 +317,15 @@ describe('<DesktopDateRangePicker />', () => {
       />,
     );
 
-    fireEvent.focus(screen.getAllByRole('textbox')[0]);
+    fireEvent.click(screen.getAllByRole('textbox')[0]);
+    // console.log("🚀 ~ file: DesktopDateRangePicker.test.tsx ~ line 321 ~ it ~ screen", screen.getAllByRole('textbox')[0].getByText())
     expect(screen.getByText('May 2019')).toBeVisible();
 
-    fireEvent.focus(screen.getAllByRole('textbox')[1]);
+    fireEvent.click(screen.getAllByRole('textbox')[1]);
     expect(screen.getByText('October 2019')).toBeVisible();
 
     // scroll back
-    fireEvent.focus(screen.getAllByRole('textbox')[0]);
+    fireEvent.click(screen.getAllByRole('textbox')[0]);
     expect(screen.getByText('May 2019')).toBeVisible();
   });
 
@@ -339,7 +340,7 @@ describe('<DesktopDateRangePicker />', () => {
       />,
     );
 
-    fireEvent.focus(screen.getAllByRole('textbox')[0]);
+    fireEvent.click(screen.getAllByRole('textbox')[0]);
     expect(screen.getByRole('tooltip')).toBeVisible();
   });
 

--- a/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
+++ b/packages/mui-lab/src/internal/pickers/hooks/usePickerState.ts
@@ -146,6 +146,7 @@ export function usePickerState<TInput, TDateValue>(
       open: isOpen,
       rawValue: value,
       openPicker: () => setIsOpen(true),
+      closePicker: () => setIsOpen(false),
     }),
     [onChange, isOpen, value, setIsOpen],
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

[DateRangePicker] Focusing start date after accept event 