### PR TITLE
[docs] Fix small typo in the `styled()` utility page

### DIFF
--- a/docs/data/system/styled/styled-pt.md
+++ b/docs/data/system/styled/styled-pt.md
@@ -118,7 +118,7 @@ const MyStyledButton = (props) => (
   }}>
      {props.children}
   </button>
-})
+)
 ```
 
 ### The style definition varies slightly

--- a/docs/data/system/styled/styled-zh.md
+++ b/docs/data/system/styled/styled-zh.md
@@ -119,7 +119,7 @@ const MyStyledButton = (props) => (
   }}>
      {props.children}
   </button>
-})
+)
 ```
 
 ### The style definition varies slightly

--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -117,12 +117,14 @@ With `sx`:
 
 ```js
 const MyStyledButton = (props) => (
-  <button sx={{
-    mx: 1, // ✔️ this shortcut is specific to the `sx` prop,
-  }}>
-     {props.children}
+  <button
+    sx={{
+      mx: 1, // ✔️ this shortcut is specific to the `sx` prop,
+    }}
+  >
+    {props.children}
   </button>
-)
+);
 ```
 
 ### The style definition varies slightly

--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -122,7 +122,7 @@ const MyStyledButton = (props) => (
   }}>
      {props.children}
   </button>
-})
+)
 ```
 
 ### The style definition varies slightly


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixed a small typo by removing an extra curly bracket.