### PR TITLE
[Joy] Miscellaneous fixes 2

### DIFF
--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -312,7 +312,7 @@ const components: {
       </React.Fragment>
     ),
     cssVars: [
-      { id: '--Input-height', type: 'number', unit: 'px', defaultValue: 40 },
+      { id: '--Input-minHeight', type: 'number', unit: 'px', defaultValue: 40 },
       { id: '--Input-radius', type: 'number', unit: 'px', defaultValue: 8 },
       { id: '--Input-gutter', type: 'number', unit: 'px', defaultValue: 12 },
       { id: '--Input-gap', type: 'number', unit: 'px', defaultValue: 8 },

--- a/docs/pages/experiments/joy/input.tsx
+++ b/docs/pages/experiments/joy/input.tsx
@@ -92,7 +92,7 @@ export default function JoyTypography() {
               </Button>
             }
           />
-          <Box sx={{ display: 'flex' }}>
+          <Box sx={{ display: 'flex', height: 56 }}>
             <Input
               placeholder="Placeholder"
               color="success"

--- a/packages/mui-joy/src/Avatar/Avatar.test.js
+++ b/packages/mui-joy/src/Avatar/Avatar.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { createRenderer, describeConformance, fireEvent } from 'test/utils';
+import { ThemeProvider } from '@mui/joy/styles';
 import Avatar, { avatarClasses as classes } from '@mui/joy/Avatar';
 import { unstable_capitalize as capitalize } from '@mui/utils';
-import { spy } from 'sinon';
 import PersonIcon from '../internal/svg-icons/Person';
 
 describe('<Avatar />', () => {
@@ -13,16 +14,13 @@ describe('<Avatar />', () => {
     classes,
     inheritComponent: 'div',
     render,
+    ThemeProvider,
     muiName: 'MuiAvatar',
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
-    skip: [
-      'themeVariants',
-      'classesRoot',
-      'componentsProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-    ],
+    testDeepOverrides: { slotName: 'fallback', slotClassName: classes.fallback },
+    testVariantProps: { variant: 'contained' },
+    skip: ['classesRoot', 'componentsProp'],
   }));
 
   describe('prop: variant', () => {

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -1,12 +1,12 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
-import * as React from 'react';
-import Person from '../internal/svg-icons/Person';
 import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
+import Person from '../internal/svg-icons/Person';
 import { getAvatarUtilityClass } from './avatarClasses';
 import { AvatarProps, AvatarTypeMap } from './AvatarProps';
 
@@ -67,27 +67,23 @@ const AvatarImg = styled('img', {
   name: 'MuiAvatar',
   slot: 'Img',
   overridesResolver: (props, styles) => styles.img,
-})(() => {
-  return [
-    {
-      width: '100%',
-      height: '100%',
-      textAlign: 'center',
-      // Handle non-square image. The property isn't supported by IE11.
-      objectFit: 'cover',
-      // Hide alt text.
-      color: 'transparent',
-      // Hide the image broken icon, only works on Chrome.
-      textIndent: 10000,
-    },
-  ];
+})<{ ownerState: AvatarProps }>({
+  width: '100%',
+  height: '100%',
+  textAlign: 'center',
+  // Handle non-square image. The property isn't supported by IE11.
+  objectFit: 'cover',
+  // Hide alt text.
+  color: 'transparent',
+  // Hide the image broken icon, only works on Chrome.
+  textIndent: 10000,
 });
 
 const AvatarFallback = styled(Person, {
   name: 'MuiAvatar',
   slot: 'Fallback',
   overridesResolver: (props, styles) => styles.fallback,
-})({
+})<{ ownerState: AvatarProps }>({
   width: '64%',
   height: '64%',
 });
@@ -174,14 +170,21 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
 
   if (hasImgNotFailing) {
     children = (
-      <AvatarImg alt={alt} src={src} srcSet={srcSet} className={classes.img} {...imgProps} />
+      <AvatarImg
+        alt={alt}
+        src={src}
+        srcSet={srcSet}
+        className={classes.img}
+        ownerState={ownerState}
+        {...imgProps}
+      />
     );
   } else if (childrenProp != null) {
     children = childrenProp;
   } else if (hasImg && alt) {
     children = alt[0];
   } else {
-    children = <AvatarFallback className={classes.fallback} />;
+    children = <AvatarFallback className={classes.fallback} ownerState={ownerState} />;
   }
 
   return (

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { SxProps } from '../styles/defaultTheme';
 import { ColorPaletteProp, VariantProp } from '../styles/types';
 
-export type AvatarSlot = 'root';
+export type AvatarSlot = 'root' | 'img' | 'fallback';
 
 export interface AvatarPropsColorOverrides {}
 export interface AvatarPropsVariantOverrides {}

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -38,17 +38,17 @@ const InputRoot = styled('div', {
   {
     ...(ownerState.size === 'sm' && {
       '--Input-gutter': '0.5rem',
-      '--Input-height': '32px',
+      '--Input-minHeight': '32px',
       '--Icon-fontSize': '1.25rem',
     }),
     ...(ownerState.size === 'md' && {
       '--Input-gutter': '0.75rem', // gutter is the padding-x
-      '--Input-height': '40px',
+      '--Input-minHeight': '40px',
       '--Icon-fontSize': '1.5rem',
     }),
     ...(ownerState.size === 'lg' && {
       '--Input-gutter': '1rem',
-      '--Input-height': '48px',
+      '--Input-minHeight': '48px',
       '--Input-gap': '0.75rem',
       '--Icon-fontSize': '1.75rem',
     }),
@@ -60,7 +60,7 @@ const InputRoot = styled('div', {
     '--Input-focusedHighlight':
       theme.palette[ownerState.color === 'neutral' ? 'primary' : ownerState.color!]?.[500],
     boxSizing: 'border-box',
-    height: `var(--Input-height)`,
+    minHeight: `var(--Input-minHeight)`,
     minWidth: 0, // forces the Input to stay inside a container by default
     ...(ownerState.fullWidth && {
       width: '100%',

--- a/packages/mui-joy/src/styles/defaultTheme.ts
+++ b/packages/mui-joy/src/styles/defaultTheme.ts
@@ -339,7 +339,7 @@ const internalDefaultTheme = {
   },
   focus: {
     default: {
-      '&.Mui-focusVisible': {
+      '&.Mui-focusVisible, &:focus-visible': {
         outline: '4px solid',
         outlineColor: 'var(--joy-palette-focusVisible)',
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Input: use `minHeight` instead of `height` (easier when use with other component, take a look at subscribe input in https://deploy-preview-31971--material-ui.netlify.app/experiments/joy/input/)
- Avatar: add missing `ownerState` to slots

---
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
