### PR TITLE
[Grow] Add a workaround for Safari 15.4 CSS transition bug

### DIFF
--- a/packages/mui-material/src/Grow/Grow.js
+++ b/packages/mui-material/src/Grow/Grow.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { elementAcceptingRef } from '@mui/utils';
 import { Transition } from 'react-transition-group';
 import useTheme from '../styles/useTheme';
-import { reflow, getTransitionProps } from '../transitions/utils';
+import { getTransitionProps, reflow } from '../transitions/utils';
 import useForkRef from '../utils/useForkRef';
 
 function getScale(value) {
@@ -20,6 +20,15 @@ const styles = {
     transform: 'none',
   },
 };
+
+/**
+ * Conditionally apply a workaround for the CSS transition bug in Safari 15.4.
+ * Remove this workaround once the Safari bug is fixed.
+ */
+const isSafari154 =
+  typeof navigator !== 'undefined' &&
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent) &&
+  /version\/15\.[4-9]/i.test(navigator.userAgent);
 
 /**
  * The Grow transition is used by the [Tooltip](/components/tooltips/) and
@@ -96,7 +105,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
         delay,
       }),
       theme.transitions.create('transform', {
-        duration: duration * 0.666,
+        duration: isSafari154 ? duration : duration * 0.666,
         delay,
         easing: transitionTimingFunction,
       }),
@@ -137,13 +146,13 @@ const Grow = React.forwardRef(function Grow(props, ref) {
         delay,
       }),
       theme.transitions.create('transform', {
-        duration: duration * 0.666,
-        delay: delay || duration * 0.333,
+        duration: isSafari154 ? duration : duration * 0.666,
+        delay: isSafari154 ? delay : delay || duration * 0.333,
         easing: transitionTimingFunction,
       }),
     ].join(',');
 
-    node.style.opacity = '0';
+    node.style.opacity = 0;
     node.style.transform = getScale(0.75);
 
     if (onExit) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Introducing a temporary workaround for CSS transition regression in Safari 15.4

WebKit tickets:
 - https://bugs.webkit.org/show_bug.cgi?id=238067
 - https://bugs.webkit.org/show_bug.cgi?id=237972  

Note: this workaround does not address the case of concurrent CSS transitions on independent components (e.g. Speed Dial)

Resolves #31380

Preview: https://deploy-preview-31975--material-ui.netlify.app/components/transitions/#grow