### PR TITLE
[Joy] Add `AvatarGroup` component

### DIFF
--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -99,6 +99,18 @@ export default function JoySvgIcon() {
             <Avatar src="/static/images/avatar/3.jpg" />
             <Avatar>+3</Avatar>
           </AvatarGroup>
+          <AvatarGroup sx={{ writingMode: 'vertical-rl' }}>
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <Avatar sx={{ transform: 'rotate(-90deg)' }}>+3</Avatar>
+          </AvatarGroup>
+          <AvatarGroup sx={{ flexDirection: 'row-reverse', writingMode: 'vertical-rl' }}>
+            <Avatar sx={{ transform: 'rotate(-90deg)' }}>+3</Avatar>
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+          </AvatarGroup>
         </Box>
         <Box sx={{ my: 2, display: 'flex', gap: 3 }}>
           <AvatarGroup variant="outlined">

--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -81,7 +81,17 @@ export default function JoySvgIcon() {
           <ColorSchemePicker />
         </Box>
         <Box sx={{ my: 2, display: 'flex', gap: 3 }}>
-          <AvatarGroup size="sm">
+          <AvatarGroup
+            size="sm"
+            sx={{
+              '& .MuiAvatar-root': {
+                '&:hover': {
+                  boxShadow: 'var(--Avatar-ring), var(--joy-shadow-md)',
+                  transform: 'translateY(-2px)',
+                },
+              },
+            }}
+          >
             <Avatar src="/static/images/avatar/1.jpg" />
             <Avatar src="/static/images/avatar/2.jpg" />
             <Avatar src="/static/images/avatar/3.jpg" />

--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -93,7 +93,7 @@ export default function JoySvgIcon() {
             <Avatar src="/static/images/avatar/2.jpg" />
             <Avatar src="/static/images/avatar/3.jpg" />
           </AvatarGroup>
-          <AvatarGroup size="lg" sx={{ '--Avatar-offset': '-0.5rem' }}>
+          <AvatarGroup size="lg" sx={{ '--AvatarGroup-gap': '-0.5rem' }}>
             <Avatar src="/static/images/avatar/1.jpg" />
             <Avatar src="/static/images/avatar/2.jpg" />
             <Avatar src="/static/images/avatar/3.jpg" />
@@ -136,7 +136,7 @@ export default function JoySvgIcon() {
               onClick={() => alert('clicked')}
               sx={{
                 borderRadius: '50%',
-                marginInlineStart: 'calc(-1 * var(--Avatar-offset))',
+                marginInlineStart: 'var(--Avatar-marginInlineStart)',
                 boxShadow: 'var(--Avatar-ring)',
               }}
             >
@@ -190,7 +190,7 @@ export default function JoySvgIcon() {
                 onClick={() => alert('clicked')}
                 sx={{
                   borderRadius: '50%',
-                  marginInlineStart: 'calc(-1 * var(--Avatar-offset))',
+                  marginInlineStart: 'var(--Avatar-marginInlineStart)',
                   boxShadow: 'var(--Avatar-ring)',
                 }}
               >

--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -1,11 +1,21 @@
-import Moon from '@mui/icons-material/DarkMode';
-import Sun from '@mui/icons-material/LightMode';
+/* eslint-disable no-alert */
+import * as React from 'react';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
 import Avatar from '@mui/joy/Avatar';
+import AvatarGroup from '@mui/joy/AvatarGroup';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
-import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import IconButton from '@mui/joy/IconButton';
+import List from '@mui/joy/List';
+import ListItem from '@mui/joy/ListItem';
+import ListItemButton from '@mui/joy/ListItemButton';
 import Typography from '@mui/joy/Typography';
-import * as React from 'react';
+import Sheet from '@mui/joy/Sheet';
+import PopperUnstyled from '@mui/base/PopperUnstyled';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import MoreVert from '@mui/icons-material/MoreVert';
+import Mouse from '@mui/icons-material/Mouse';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -41,6 +51,7 @@ const props = {
 } as const;
 
 export default function JoySvgIcon() {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   return (
     <CssVarsProvider
       theme={{
@@ -68,6 +79,132 @@ export default function JoySvgIcon() {
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3 }}>
           <ColorSchemePicker />
+        </Box>
+        <Box sx={{ my: 2, display: 'flex', gap: 3 }}>
+          <AvatarGroup size="sm">
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <Avatar>+3</Avatar>
+          </AvatarGroup>
+          <AvatarGroup sx={{ flexDirection: 'row-reverse' }}>
+            <Avatar>+3</Avatar>
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+          </AvatarGroup>
+          <AvatarGroup size="lg" sx={{ '--Avatar-offset': '-0.5rem' }}>
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <Avatar>+3</Avatar>
+          </AvatarGroup>
+        </Box>
+        <Box sx={{ my: 2, display: 'flex', gap: 3 }}>
+          <AvatarGroup variant="outlined">
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <Avatar sx={{ bgcolor: 'background.level1' }}>+3</Avatar>
+          </AvatarGroup>
+          <AvatarGroup variant="contained">
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <Avatar>+3</Avatar>
+          </AvatarGroup>
+        </Box>
+        <Box sx={{ my: 2, display: 'flex', gap: 3 }}>
+          <AvatarGroup>
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <IconButton
+              color="neutral"
+              onClick={() => alert('clicked')}
+              sx={{
+                borderRadius: '50%',
+                marginInlineStart: 'calc(-1 * var(--Avatar-offset))',
+                boxShadow: 'var(--Avatar-ring)',
+              }}
+            >
+              <MoreVert />
+            </IconButton>
+          </AvatarGroup>
+          <AvatarGroup variant="contained">
+            <Avatar src="/static/images/avatar/1.jpg" />
+            <Avatar src="/static/images/avatar/2.jpg" />
+            <Avatar src="/static/images/avatar/3.jpg" />
+            <Avatar
+              onMouseEnter={(event) => setAnchorEl(event.currentTarget)}
+              onMouseLeave={() => setAnchorEl(null)}
+            >
+              <Mouse />
+              <PopperUnstyled
+                open={Boolean(anchorEl)}
+                anchorEl={anchorEl}
+                disablePortal
+                placement="right-start"
+                style={{ zIndex: 1 }}
+              >
+                <Sheet
+                  variant="outlined"
+                  sx={{ mx: 0.5, py: 1, borderRadius: 'xs', minWidth: 160, boxShadow: 'md' }}
+                >
+                  <List size="sm" sx={{ '--List-item-paddingLeft': '0.5rem', '--List-gap': '0px' }}>
+                    <ListItem>
+                      <ListItemButton>Show all</ListItemButton>
+                    </ListItem>
+                    <ListItem>
+                      <ListItemButton>Add more people</ListItemButton>
+                    </ListItem>
+                    <ListItem>
+                      <ListItemButton>Go to settings</ListItemButton>
+                    </ListItem>
+                  </List>
+                </Sheet>
+              </PopperUnstyled>
+            </Avatar>
+          </AvatarGroup>
+        </Box>
+        <Box sx={{ my: 2, display: 'flex', gap: 3 }}>
+          <Sheet variant="light" sx={{ p: 2 }}>
+            <AvatarGroup>
+              <Avatar src="/static/images/avatar/1.jpg" />
+              <Avatar src="/static/images/avatar/2.jpg" />
+              <Avatar src="/static/images/avatar/3.jpg" />
+              <IconButton
+                color="neutral"
+                onClick={() => alert('clicked')}
+                sx={{
+                  borderRadius: '50%',
+                  marginInlineStart: 'calc(-1 * var(--Avatar-offset))',
+                  boxShadow: 'var(--Avatar-ring)',
+                }}
+              >
+                <MoreVert />
+              </IconButton>
+            </AvatarGroup>
+          </Sheet>
+          <Sheet variant="contained" color="danger" sx={{ p: 2 }}>
+            <AvatarGroup>
+              <Avatar src="/static/images/avatar/1.jpg" />
+              <Avatar src="/static/images/avatar/2.jpg" />
+              <Avatar src="/static/images/avatar/3.jpg" />
+              <Avatar>+99</Avatar>
+            </AvatarGroup>
+          </Sheet>
+          <Sheet variant="contained" color="primary" sx={{ p: 2 }}>
+            <AvatarGroup
+              size="sm"
+              sx={{ '--Avatar-ringColor': 'var(--joy-palette-primary-outlinedBorder)' }}
+            >
+              <Avatar src="/static/images/avatar/1.jpg" />
+              <Avatar src="/static/images/avatar/2.jpg" />
+              <Avatar src="/static/images/avatar/3.jpg" />
+              <Avatar>+99</Avatar>
+            </AvatarGroup>
+          </Sheet>
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
           {Object.entries(props).map(([propName, propValue]) => (

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -119,7 +119,7 @@ const components: {
       </AvatarGroup>
     ),
     cssVars: [
-      { id: '--AvatarGroup-gap', type: 'number', unit: 'px', defaultValue: 8 },
+      { id: '--AvatarGroup-gap', type: 'number', unit: 'px', defaultValue: -8 },
       { id: '--Avatar-ringSize', type: 'number', unit: 'px', defaultValue: 2 },
     ],
   },

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -119,7 +119,7 @@ const components: {
       </AvatarGroup>
     ),
     cssVars: [
-      { id: '--Avatar-offset', type: 'number', unit: 'px', defaultValue: 8 },
+      { id: '--AvatarGroup-gap', type: 'number', unit: 'px', defaultValue: 8 },
       { id: '--Avatar-ringSize', type: 'number', unit: 'px', defaultValue: 2 },
     ],
   },

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useRouter } from 'next/router';
 import { GlobalStyles } from '@mui/system';
 import { ThemeProvider } from '@mui/material/styles';
+import Avatar from '@mui/joy/Avatar';
+import AvatarGroup from '@mui/joy/AvatarGroup';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Checkbox from '@mui/joy/Checkbox';
@@ -106,6 +108,21 @@ const components: {
     inputProps?: React.AllHTMLAttributes<HTMLInputElement>;
   }[];
 }[] = [
+  {
+    name: 'AvatarGroup',
+    render: (props: any) => (
+      <AvatarGroup {...props}>
+        <Avatar src="/static/images/avatar/1.jpg" />
+        <Avatar src="/static/images/avatar/2.jpg" />
+        <Avatar src="/static/images/avatar/3.jpg" />
+        <Avatar>+3</Avatar>
+      </AvatarGroup>
+    ),
+    cssVars: [
+      { id: '--Avatar-offset', type: 'number', unit: 'px', defaultValue: 8 },
+      { id: '--Avatar-ringSize', type: 'number', unit: 'px', defaultValue: 2 },
+    ],
+  },
   {
     name: 'Button',
     render: (props: any) => (

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -46,7 +46,7 @@ const AvatarRoot = styled('div', {
       '--Avatar-size': '3rem',
       fontSize: theme.vars.fontSize.lg,
     }),
-    marginInlineStart: 'calc(-1 * var(--Avatar-offset))',
+    marginInlineStart: 'var(--Avatar-marginInlineStart)',
     boxShadow: `var(--Avatar-ring)${
       // @ts-ignore internal logic
       ownerState.sx?.boxShadow ? `, ${ownerState.sx?.boxShadow}` : ''

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -9,6 +9,7 @@ import styled from '../styles/styled';
 import Person from '../internal/svg-icons/Person';
 import { getAvatarUtilityClass } from './avatarClasses';
 import { AvatarProps, AvatarTypeMap } from './AvatarProps';
+import { AvatarGroupContext } from '../AvatarGroup/AvatarGroup';
 
 const useUtilityClasses = (ownerState: AvatarProps) => {
   const { size, variant, color, src, srcSet } = ownerState;
@@ -31,37 +32,40 @@ const AvatarRoot = styled('div', {
   name: 'MuiAvatar',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: AvatarProps }>(({ theme, ownerState }) => {
-  return [
-    {
-      ...(ownerState.size === 'sm' && {
-        '--Avatar-size': '2rem',
-        fontSize: theme.vars.fontSize.sm,
-      }),
-      ...(ownerState.size === 'md' && {
-        '--Avatar-size': '2.5rem',
-        fontSize: theme.vars.fontSize.md,
-      }),
-      ...(ownerState.size === 'lg' && {
-        '--Avatar-size': '3rem',
-        fontSize: theme.vars.fontSize.lg,
-      }),
-      fontFamily: theme.vars.fontFamily.body,
-      position: 'relative',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexShrink: 0,
-      width: 'var(--Avatar-size)',
-      height: 'var(--Avatar-size)',
-      lineHeight: 1,
-      borderRadius: '50%',
-      overflow: 'hidden',
-      userSelect: 'none',
-    },
-    theme.variants[ownerState.variant!]?.[ownerState.color!],
-  ];
-});
+})<{ ownerState: AvatarProps }>(({ theme, ownerState }) => [
+  {
+    ...(ownerState.size === 'sm' && {
+      '--Avatar-size': '2rem',
+      fontSize: theme.vars.fontSize.sm,
+    }),
+    ...(ownerState.size === 'md' && {
+      '--Avatar-size': '2.5rem',
+      fontSize: theme.vars.fontSize.md,
+    }),
+    ...(ownerState.size === 'lg' && {
+      '--Avatar-size': '3rem',
+      fontSize: theme.vars.fontSize.lg,
+    }),
+    marginInlineStart: 'calc(-1 * var(--Avatar-offset))',
+    boxShadow: `var(--Avatar-ring)${
+      // @ts-ignore internal logic
+      ownerState.sx?.boxShadow ? `, ${ownerState.sx?.boxShadow}` : ''
+    }`,
+    fontFamily: theme.vars.fontFamily.body,
+    fontWeight: theme.vars.fontWeight.md,
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: 'var(--Avatar-size)',
+    height: 'var(--Avatar-size)',
+    lineHeight: 1,
+    borderRadius: '50%',
+    userSelect: 'none',
+  },
+  theme.variants[ownerState.variant!]?.[ownerState.color!],
+]);
 
 const AvatarImg = styled('img', {
   name: 'MuiAvatar',
@@ -77,6 +81,7 @@ const AvatarImg = styled('img', {
   color: 'transparent',
   // Hide the image broken icon, only works on Chrome.
   textIndent: 10000,
+  borderRadius: '50%',
 });
 
 const AvatarFallback = styled(Person, {
@@ -137,19 +142,24 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
     name: 'MuiAvatar',
   });
 
+  const groupContext = React.useContext(AvatarGroupContext);
+
   const {
     alt,
     className,
-    color = 'neutral',
+    color: colorProp = 'neutral',
     component = 'div',
-    size = 'md',
-    variant = 'light',
+    size: sizeProp = 'md',
+    variant: variantProp = 'light',
     imgProps,
     src,
     srcSet,
     children: childrenProp,
     ...other
   } = props;
+  const color = inProps.color || groupContext?.color || colorProp;
+  const variant = inProps.variant || groupContext?.variant || variantProp;
+  const size = inProps.size || groupContext?.size || sizeProp;
 
   let children = null;
 

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -32,37 +32,39 @@ const AvatarRoot = styled('div', {
   name: 'MuiAvatar',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: AvatarProps }>(({ theme, ownerState }) => [
-  {
-    ...(ownerState.size === 'sm' && {
-      '--Avatar-size': '2rem',
-      fontSize: theme.vars.fontSize.sm,
-    }),
-    ...(ownerState.size === 'md' && {
-      '--Avatar-size': '2.5rem',
-      fontSize: theme.vars.fontSize.md,
-    }),
-    ...(ownerState.size === 'lg' && {
-      '--Avatar-size': '3rem',
-      fontSize: theme.vars.fontSize.lg,
-    }),
-    marginInlineStart: 'var(--Avatar-marginInlineStart)',
-    boxShadow: `var(--Avatar-ring)`,
-    fontFamily: theme.vars.fontFamily.body,
-    fontWeight: theme.vars.fontWeight.md,
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    width: 'var(--Avatar-size)',
-    height: 'var(--Avatar-size)',
-    lineHeight: 1,
-    borderRadius: '50%',
-    userSelect: 'none',
-  },
-  theme.variants[ownerState.variant!]?.[ownerState.color!],
-]);
+})<{ ownerState: AvatarProps }>(({ theme, ownerState }) => {
+  return [
+    {
+      ...(ownerState.size === 'sm' && {
+        '--Avatar-size': '2rem',
+        fontSize: theme.vars.fontSize.sm,
+      }),
+      ...(ownerState.size === 'md' && {
+        '--Avatar-size': '2.5rem',
+        fontSize: theme.vars.fontSize.md,
+      }),
+      ...(ownerState.size === 'lg' && {
+        '--Avatar-size': '3rem',
+        fontSize: theme.vars.fontSize.lg,
+      }),
+      marginInlineStart: 'var(--Avatar-marginInlineStart)',
+      boxShadow: `var(--Avatar-ring)`,
+      fontFamily: theme.vars.fontFamily.body,
+      fontWeight: theme.vars.fontWeight.md,
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+      width: 'var(--Avatar-size)',
+      height: 'var(--Avatar-size)',
+      lineHeight: 1,
+      borderRadius: '50%',
+      userSelect: 'none',
+    },
+    theme.variants[ownerState.variant!]?.[ownerState.color!],
+  ];
+});
 
 const AvatarImg = styled('img', {
   name: 'MuiAvatar',

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -47,10 +47,7 @@ const AvatarRoot = styled('div', {
       fontSize: theme.vars.fontSize.lg,
     }),
     marginInlineStart: 'var(--Avatar-marginInlineStart)',
-    boxShadow: `var(--Avatar-ring)${
-      // @ts-ignore internal logic
-      ownerState.sx?.boxShadow ? `, ${ownerState.sx?.boxShadow}` : ''
-    }`,
+    boxShadow: `var(--Avatar-ring)`,
     fontFamily: theme.vars.fontFamily.body,
     fontWeight: theme.vars.fontWeight.md,
     position: 'relative',

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.test.js
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from 'test/utils';
+import { ThemeProvider } from '@mui/joy/styles';
+import AvatarGroup, { avatarGroupClasses as classes } from '@mui/joy/AvatarGroup';
+import Avatar, { avatarClasses } from '@mui/joy/Avatar';
+
+describe('<AvatarGroup />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<AvatarGroup />, () => ({
+    classes,
+    inheritComponent: 'div',
+    render,
+    ThemeProvider,
+    muiName: 'MuiAvatarGroup',
+    refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: 'span',
+    testVariantProps: { variant: 'contained' },
+    skip: ['classesRoot', 'componentsProp'],
+  }));
+
+  it('provide context to Avatar', () => {
+    const { container } = render(
+      <AvatarGroup variant="contained" color="primary" size="sm">
+        <Avatar src="/" />
+      </AvatarGroup>,
+    );
+
+    const avatar = container.firstChild.firstChild;
+    expect(avatar).to.have.class(avatarClasses.colorPrimary);
+    expect(avatar).to.have.class(avatarClasses.variantContained);
+    expect(avatar).to.have.class(avatarClasses.sizeSm);
+  });
+});

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { OverridableComponent } from '@mui/types';
+import { useThemeProps } from '../styles';
+import styled from '../styles/styled';
+import { getAvatarGroupUtilityClass } from './avatarGroupClasses';
+import { AvatarGroupProps, AvatarGroupTypeMap } from './AvatarGroupProps';
+
+export const AvatarGroupContext = React.createContext<undefined | AvatarGroupProps>(undefined);
+
+const useUtilityClasses = () => {
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getAvatarGroupUtilityClass, {});
+};
+
+const AvatarGroupGroupRoot = styled('div', {
+  name: 'MuiAvatarGroup',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: AvatarGroupProps }>(({ ownerState, theme }) => ({
+  ...(ownerState.size === 'sm' && {
+    '--Avatar-offset': '0.375rem',
+    '--Avatar-ringSize': '2px',
+  }),
+  ...(ownerState.size === 'md' && {
+    '--Avatar-offset': '0.5rem',
+    '--Avatar-ringSize': '2px',
+  }),
+  ...(ownerState.size === 'lg' && {
+    '--Avatar-offset': '0.625rem',
+    '--Avatar-ringSize': '4px',
+  }),
+  '--Avatar-ring': `0 0 0 var(--Avatar-ringSize) var(--Avatar-ringColor, ${theme.vars.palette.background.body})`,
+  display: 'flex',
+  marginInlineStart: 'var(--Avatar-offset)',
+}));
+
+const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
+  const props = useThemeProps<typeof inProps & AvatarGroupProps>({
+    props: inProps,
+    name: 'MuiAvatarGroup',
+  });
+
+  const {
+    className,
+    color = 'neutral',
+    component = 'div',
+    size = 'md',
+    variant = 'light',
+    children,
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    color,
+    component,
+    size,
+    variant,
+  };
+
+  const classes = useUtilityClasses();
+
+  return (
+    <AvatarGroupContext.Provider value={ownerState}>
+      <AvatarGroupGroupRoot
+        as={component}
+        ownerState={ownerState}
+        className={clsx(classes.root, className)}
+        ref={ref}
+        {...other}
+      >
+        {children}
+      </AvatarGroupGroupRoot>
+    </AvatarGroupContext.Provider>
+  );
+}) as OverridableComponent<AvatarGroupTypeMap>;
+
+AvatarGroup.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Used to render icon or text elements inside the AvatarGroup if `src` is not set.
+   * This can be an element, or just a string.
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'neutral'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['danger', 'info', 'neutral', 'primary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * The size of the component.
+   * It accepts theme values between 'xs' and 'xl'.
+   * @default 'md'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['lg', 'md', 'sm']),
+    PropTypes.string,
+  ]),
+  /**
+   * The variant to use.
+   * @default 'light'
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['contained', 'light', 'outlined', 'text']),
+    PropTypes.string,
+  ]),
+} as any;
+
+export default AvatarGroup;

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
@@ -38,7 +38,7 @@ const AvatarGroupGroupRoot = styled('div', {
   '--Avatar-ring': `0 0 0 var(--Avatar-ringSize) var(--Avatar-ringColor, ${theme.vars.palette.background.body})`,
   '--Avatar-marginInlineStart': 'var(--AvatarGroup-gap)',
   display: 'flex',
-  marginInlineStart: 'var(--AvatarGroup-gap)',
+  marginInlineStart: 'calc(-1 * var(--AvatarGroup-gap))',
 }));
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
@@ -24,20 +24,21 @@ const AvatarGroupGroupRoot = styled('div', {
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: AvatarGroupProps }>(({ ownerState, theme }) => ({
   ...(ownerState.size === 'sm' && {
-    '--Avatar-offset': '0.375rem',
+    '--AvatarGroup-gap': '0.375rem',
     '--Avatar-ringSize': '2px',
   }),
   ...(ownerState.size === 'md' && {
-    '--Avatar-offset': '0.5rem',
+    '--AvatarGroup-gap': '0.5rem',
     '--Avatar-ringSize': '2px',
   }),
   ...(ownerState.size === 'lg' && {
-    '--Avatar-offset': '0.625rem',
+    '--AvatarGroup-gap': '0.625rem',
     '--Avatar-ringSize': '4px',
   }),
   '--Avatar-ring': `0 0 0 var(--Avatar-ringSize) var(--Avatar-ringColor, ${theme.vars.palette.background.body})`,
+  '--Avatar-marginInlineStart': 'calc(-1 * var(--AvatarGroup-gap))',
   display: 'flex',
-  marginInlineStart: 'var(--Avatar-offset)',
+  marginInlineStart: 'var(--AvatarGroup-gap)',
 }));
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
@@ -24,19 +24,19 @@ const AvatarGroupGroupRoot = styled('div', {
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: AvatarGroupProps }>(({ ownerState, theme }) => ({
   ...(ownerState.size === 'sm' && {
-    '--AvatarGroup-gap': '0.375rem',
+    '--AvatarGroup-gap': '-0.375rem',
     '--Avatar-ringSize': '2px',
   }),
   ...(ownerState.size === 'md' && {
-    '--AvatarGroup-gap': '0.5rem',
+    '--AvatarGroup-gap': '-0.5rem',
     '--Avatar-ringSize': '2px',
   }),
   ...(ownerState.size === 'lg' && {
-    '--AvatarGroup-gap': '0.625rem',
+    '--AvatarGroup-gap': '-0.625rem',
     '--Avatar-ringSize': '4px',
   }),
   '--Avatar-ring': `0 0 0 var(--Avatar-ringSize) var(--Avatar-ringColor, ${theme.vars.palette.background.body})`,
-  '--Avatar-marginInlineStart': 'calc(-1 * var(--AvatarGroup-gap))',
+  '--Avatar-marginInlineStart': 'var(--AvatarGroup-gap)',
   display: 'flex',
   marginInlineStart: 'var(--AvatarGroup-gap)',
 }));

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroupProps.ts
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroupProps.ts
@@ -1,0 +1,27 @@
+import { OverrideProps } from '@mui/types';
+import * as React from 'react';
+import { SxProps } from '../styles/defaultTheme';
+import { AvatarProps } from '../Avatar';
+
+export type AvatarGroupSlot = 'root';
+
+export interface AvatarGroupTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P &
+    Pick<AvatarProps, 'color' | 'size' | 'variant'> & {
+      /**
+       * Used to render icon or text elements inside the AvatarGroup if `src` is not set.
+       * This can be an element, or just a string.
+       */
+      children?: React.ReactNode;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps;
+    };
+  defaultComponent: D;
+}
+
+export type AvatarGroupProps<
+  D extends React.ElementType = AvatarGroupTypeMap['defaultComponent'],
+  P = { component?: React.ElementType },
+> = OverrideProps<AvatarGroupTypeMap<P, D>, D>;

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroupProps.ts
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroupProps.ts
@@ -1,7 +1,7 @@
 import { OverrideProps } from '@mui/types';
 import * as React from 'react';
 import { SxProps } from '../styles/defaultTheme';
-import { AvatarProps } from '../Avatar';
+import { AvatarProps } from '../Avatar/AvatarProps';
 
 export type AvatarGroupSlot = 'root';
 

--- a/packages/mui-joy/src/AvatarGroup/avatarGroupClasses.ts
+++ b/packages/mui-joy/src/AvatarGroup/avatarGroupClasses.ts
@@ -1,0 +1,16 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export interface AvatarGroupClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type AvatarGroupClassKey = keyof AvatarGroupClasses;
+
+export function getAvatarGroupUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiAvatarGroup', slot);
+}
+
+const avatarGroupClasses: AvatarGroupClasses = generateUtilityClasses('MuiAvatarGroup', ['root']);
+
+export default avatarGroupClasses;

--- a/packages/mui-joy/src/AvatarGroup/index.ts
+++ b/packages/mui-joy/src/AvatarGroup/index.ts
@@ -1,0 +1,4 @@
+export { default } from './AvatarGroup';
+export * from './avatarGroupClasses';
+export { default as avatarGroupClasses } from './avatarGroupClasses';
+export * from './AvatarGroupProps';

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -4,6 +4,9 @@ export * from './styles';
 export { default as Avatar } from './Avatar';
 export * from './Avatar';
 
+export { default as AvatarGroup } from './AvatarGroup';
+export * from './AvatarGroup';
+
 export { default as Button } from './Button';
 export * from './Button';
 

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -8,6 +8,7 @@ import { ListProps, ListSlot } from '../List/ListProps';
 import { ListDividerProps, ListDividerSlot } from '../ListDivider/ListDividerProps';
 import { ListItemProps, ListItemSlot } from '../ListItem/ListItemProps';
 import { AvatarProps, AvatarSlot } from '../Avatar/AvatarProps';
+import { AvatarGroupProps, AvatarGroupSlot } from '../AvatarGroup/AvatarGroupProps';
 import { ListItemButtonProps, ListItemButtonSlot } from '../ListItemButton/ListItemButtonProps';
 import { ListItemContentProps, ListItemContentSlot } from '../ListItemContent/ListItemContentProps';
 import {
@@ -46,6 +47,10 @@ export interface Components<Theme = unknown> {
   MuiAvatar?: {
     defaultProps?: Partial<AvatarProps>;
     styleOverrides?: OverridesStyleRules<AvatarSlot, AvatarProps, Theme>;
+  };
+  MuiAvatarGroup?: {
+    defaultProps?: Partial<AvatarGroupProps>;
+    styleOverrides?: OverridesStyleRules<AvatarGroupSlot, AvatarGroupProps, Theme>;
   };
   MuiButton?: {
     defaultProps?: Partial<ButtonProps>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### 🖥 Preview
- [Demos](https://deploy-preview-31980--material-ui.netlify.app/experiments/joy/avatar/)
- [Playground](https://deploy-preview-31980--material-ui.netlify.app/experiments/joy/components/?name=AvatarGroup)

---

Inspired by https://github.com/mui/material-ui/issues/31958#issuecomment-1078617987.

Get rid of internal calculation about the number of extra to show which give developers full control of the extra number logic. This approach would reduce a lot of edge cases problem because we don't use `React.cloneElement` anymore, developers can wrap with whatever they want. Thanks to CSS variables, we don't introduce any class selector which makes customization so easy.

```js
// Material
<AvatarGroup max={4}>
  {items.map(() => <Avatar />}
</AvatarGroup>

// Joy
<AvatarGroup>
  {items.slice(0, 5).map(() => <Avatar />}
  <Avatar>+4</Avatar>
</AvatarGroup>
```

### Benefits

Joy solves these existing issues:

- https://github.com/mui/material-ui/issues/30789
  ```js
  <AvatarGroup sx={{ flexDirection: 'row-reverse' }}>
    <Avatar>+3</Avatar>
    <Avatar src="/static/images/avatar/1.jpg" />
    <Avatar src="/static/images/avatar/2.jpg" />
    <Avatar src="/static/images/avatar/3.jpg" />
  </AvatarGroup>
  ```

- https://github.com/mui/material-ui/issues/27677
  ```js
  <AvatarGroup>
    <Avatar src="/static/images/avatar/1.jpg" />
    <Avatar src="/static/images/avatar/2.jpg" />
    <Avatar src="/static/images/avatar/3.jpg" />
    <IconButton
      color="neutral"
      onClick={() => alert('clicked')}
      sx={{
        borderRadius: '50%',
        marginInlineStart: 'var(--Avatar-marginInlineStart)',
        boxShadow: 'var(--Avatar-ring)',
      }}
    >
      <MoreVert />
    </IconButton>
  </AvatarGroup>
  ```
  
- https://github.com/mui/material-ui/issues/31958
  ```js
  <AvatarGroup variant="contained">
    <Avatar src="/static/images/avatar/1.jpg" />
    <Avatar src="/static/images/avatar/2.jpg" />
    <Avatar src="/static/images/avatar/3.jpg" />
    <Avatar
      onMouseEnter={(event) => setAnchorEl(event.currentTarget)}
      onMouseLeave={() => setAnchorEl(null)}
    >
      <Mouse />
      <PopperUnstyled
        open={Boolean(anchorEl)}
        anchorEl={anchorEl}
        disablePortal
        placement="right-start"
        style={{ zIndex: 1 }}
      >
        ...content
      </PopperUnstyled>
    </Avatar>
  </AvatarGroup>
  ```

### Benchmark
|                          | Material   | Joy        | % change   |
| ------------------------ | ---------- | ---------- | ---------- |
| Avatar                   | 254        | 279        | +9.84       |
| AvatarGroup              | 222        | 131        | -40.99     |
| total                    | 476        | 410        | -13.87     |
---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
