### PR TITLE
[Joy] Add `Chip` component

### DIFF
--- a/docs/pages/experiments/joy/avatar.tsx
+++ b/docs/pages/experiments/joy/avatar.tsx
@@ -50,7 +50,7 @@ const props = {
   variant: ['contained', 'outlined', 'light'],
 } as const;
 
-export default function JoySvgIcon() {
+export default function JoyAvatar() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   return (
     <CssVarsProvider>

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -13,6 +13,9 @@ import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
 import ThumbUp from '@mui/icons-material/ThumbUp';
 import DeleteForever from '@mui/icons-material/DeleteForever';
+import LocationOn from '@mui/icons-material/LocationOn';
+import DirectionsBike from '@mui/icons-material/DirectionsBike';
+import AlarmOn from '@mui/icons-material/AlarmOn';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -90,7 +93,7 @@ export default function JoyChip() {
               <Avatar
                 size="sm"
                 src={`/static/images/avatar/1.jpg`}
-                sx={{ ml: '-4px', my: '-4px', '--Avatar-size': '28px' }}
+                sx={{ m: 'calc(-1 * var(--Chip-paddingBlock))', mr: 0, '--Avatar-size': '28px' }}
               />
             }
             endDecorator={<CheckIcon />}
@@ -193,6 +196,38 @@ export default function JoyChip() {
                 </Chip>
               ))}
             </Box>
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            {(['light', 'outlined'] as const).map((variant) => (
+              <React.Fragment key={variant}>
+                <Chip
+                  color="neutral"
+                  variant={variant}
+                  size="sm"
+                  endDecorator={<ChipDelete />}
+                  sx={{ '--Chip-delete-size': '16px' }}
+                >
+                  <LocationOn sx={{ mr: 0.5 }} /> Portland
+                </Chip>
+                <Chip
+                  color="neutral"
+                  variant={variant}
+                  size="sm"
+                  endDecorator={<ChipDelete />}
+                  sx={{ '--Chip-delete-size': '16px' }}
+                >
+                  <DirectionsBike sx={{ mr: 0.5 }} /> Biking
+                </Chip>
+              </React.Fragment>
+            ))}
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            <Chip variant="light" startDecorator={<Sun />}>
+              Turn on lights
+            </Chip>
+            <Chip variant="light" startDecorator={<AlarmOn />}>
+              Set alarm
+            </Chip>
           </Box>
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -1,0 +1,108 @@
+import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import ThumbUp from '@mui/icons-material/ThumbUp';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import Chip from '@mui/joy/Chip';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import Typography from '@mui/joy/Typography';
+import * as React from 'react';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+      sx={{ minWidth: 40, p: '0.25rem' }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+const props = {
+  size: ['sm', 'md', 'lg'],
+  color: ['primary', 'danger', 'info', 'success', 'warning', 'neutral'],
+  variant: ['contained', 'outlined', 'light'],
+  disabled: [true, false],
+  clickable: [true, false],
+} as const;
+
+export default function JoyChip() {
+  return (
+    <CssVarsProvider>
+      <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
+        <Box sx={{ px: 3 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+          {/* Without decorators */}
+          {Object.entries(props).map(([propName, propValue]) => (
+            <Box
+              key={propName}
+              sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+            >
+              <Typography sx={{ textDecoration: 'underline' }}>{propName}</Typography>
+              {propValue.map((value) => (
+                <Box
+                  key={`${value}-without-decorator`}
+                  sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                >
+                  <Chip label={`${propName}: ${value}`} {...{ [propName]: value }} />
+                  {value && (
+                    <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                      {value}
+                    </Typography>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          ))}
+          {/* With decorators */}
+          {Object.entries(props).map(([propName, propValue]) => (
+            <Box
+              key={propName}
+              sx={{ display: 'flex', flexDirection: 'column', gap: 5, p: 2, alignItems: 'center' }}
+            >
+              <Typography sx={{ textDecoration: 'underline' }}>{propName}</Typography>
+              {propValue.map((value) => (
+                <Box
+                  key={`${value}-with-decorator`}
+                  sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                >
+                  <Chip
+                    startDecorator={<ThumbUp />}
+                    endDecorator={<ArrowDropDown />}
+                    label={`${propName}: ${value}`}
+                    {...{ [propName]: value }}
+                  />
+                  {value && (
+                    <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
+                      {value}
+                    </Typography>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </CssVarsProvider>
+  );
+}

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -1,10 +1,13 @@
 import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
+import CheckIcon from '@mui/icons-material/Check';
 import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
 import ThumbUp from '@mui/icons-material/ThumbUp';
+import Avatar from '@mui/joy/Avatar';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Chip from '@mui/joy/Chip';
+import ChipDelete from '@mui/joy/ChipDelete';
 import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
 import Typography from '@mui/joy/Typography';
 import * as React from 'react';
@@ -50,6 +53,33 @@ export default function JoyChip() {
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3 }}>
           <ColorSchemePicker />
+        </Box>
+        {/* Examples */}
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5, mt: 5 }}>
+          {['Benny', 'Jun', 'Danilo', 'Marija', 'Michal', 'Olivier'].map((name) => (
+            <Chip variant="light" endDecorator={<ChipDelete />}>
+              {name}
+            </Chip>
+          ))}
+        </Box>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5, mt: 5 }}>
+          {['Benny', 'Jun', 'Danilo', 'Marija', 'Michal', 'Olivier'].map((name, index) => (
+            <Chip
+              sx={{
+                paddingLeft: 0,
+                justifyContent: 'flex-start',
+                borderRadius: 20,
+                width: '11%',
+                height: 40,
+              }}
+              variant="contained"
+              color="success"
+              startDecorator={<Avatar size="sm" src={`/static/images/avatar/${index + 1}.jpg`} />}
+              endDecorator={<CheckIcon />}
+            >
+              {name}
+            </Chip>
+          ))}
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
           {/* Without decorators */}

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -55,31 +55,36 @@ export default function JoyChip() {
           <ColorSchemePicker />
         </Box>
         {/* Examples */}
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5, mt: 5 }}>
-          {['Benny', 'Jun', 'Danilo', 'Marija', 'Michal', 'Olivier'].map((name) => (
-            <Chip variant="light" endDecorator={<ChipDelete />}>
-              {name}
-            </Chip>
-          ))}
-        </Box>
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5, mt: 5 }}>
-          {['Benny', 'Jun', 'Danilo', 'Marija', 'Michal', 'Olivier'].map((name, index) => (
-            <Chip
-              sx={{
-                paddingLeft: 0,
-                justifyContent: 'flex-start',
-                borderRadius: 20,
-                width: '11%',
-                height: 40,
-              }}
-              variant="contained"
-              color="success"
-              startDecorator={<Avatar size="sm" src={`/static/images/avatar/${index + 1}.jpg`} />}
-              endDecorator={<CheckIcon />}
-            >
-              {name}
-            </Chip>
-          ))}
+        <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 5, mt: 5 }}>
+          <Chip endDecorator={<ChipDelete />}>Benny</Chip>
+          <Chip variant="light" startDecorator={<ChipDelete />}>
+            Benny
+          </Chip>
+          <Chip
+            variant="contained"
+            color="success"
+            size="sm"
+            startDecorator={
+              <Avatar
+                size="sm"
+                src={`/static/images/avatar/1.jpg`}
+                sx={{ ml: '-4px', my: '-4px', '--Avatar-size': '28px' }}
+              />
+            }
+            endDecorator={<CheckIcon />}
+          >
+            Benny
+          </Chip>
+          <Chip
+            variant="outlined"
+            color="neutral"
+            size="lg"
+            startDecorator={<Avatar size="sm" src={`/static/images/avatar/1.jpg`} />}
+            endDecorator={<CheckIcon fontSize="md" sx={{ mr: 0.25 }} />}
+            sx={{ '--Chip-radius': '8px' }}
+          >
+            Benny
+          </Chip>
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
           {/* Without decorators */}
@@ -116,11 +121,10 @@ export default function JoyChip() {
                   key={`${value}-with-decorator`}
                   sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
                 >
-                  <Chip
-                    startDecorator={<ThumbUp />}
-                    endDecorator={<ArrowDropDown />}
-                    {...{ [propName]: value }}
-                  >{`${propName}: ${value}`}</Chip>
+                  <Chip endDecorator={<ArrowDropDown />} {...{ [propName]: value }}>
+                    <ThumbUp sx={{ mr: 'var(--Chip-gap)' }} />
+                    {`${propName}: ${value}`}
+                  </Chip>
                   {value !== undefined && (
                     <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
                       {`${value}`}

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -64,10 +64,10 @@ export default function JoyChip() {
                   key={`${value}-without-decorator`}
                   sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
                 >
-                  <Chip label={`${propName}: ${value}`} {...{ [propName]: value }} />
-                  {value && (
+                  <Chip {...{ [propName]: value }}>{`${propName}: ${value}`}</Chip>
+                  {value !== undefined && (
                     <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
-                      {value}
+                      {`${value}`}
                     </Typography>
                   )}
                 </Box>
@@ -89,12 +89,11 @@ export default function JoyChip() {
                   <Chip
                     startDecorator={<ThumbUp />}
                     endDecorator={<ArrowDropDown />}
-                    label={`${propName}: ${value}`}
                     {...{ [propName]: value }}
-                  />
-                  {value && (
+                  >{`${propName}: ${value}`}</Chip>
+                  {value !== undefined && (
                     <Typography level="body3" sx={{ textAlign: 'center', mt: '4px' }}>
-                      {value}
+                      {`${value}`}
                     </Typography>
                   )}
                 </Box>

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -1,16 +1,17 @@
-import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
-import CheckIcon from '@mui/icons-material/Check';
-import Moon from '@mui/icons-material/DarkMode';
-import Sun from '@mui/icons-material/LightMode';
-import ThumbUp from '@mui/icons-material/ThumbUp';
+/* eslint-disable no-alert */
+import * as React from 'react';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
 import Avatar from '@mui/joy/Avatar';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Chip from '@mui/joy/Chip';
 import ChipDelete from '@mui/joy/ChipDelete';
-import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
 import Typography from '@mui/joy/Typography';
-import * as React from 'react';
+import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
+import CheckIcon from '@mui/icons-material/Check';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import ThumbUp from '@mui/icons-material/ThumbUp';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -44,7 +45,6 @@ const props = {
   color: ['primary', 'danger', 'info', 'success', 'warning', 'neutral'],
   variant: ['contained', 'outlined', 'light'],
   disabled: [true, false],
-  clickable: [true, false],
 } as const;
 
 export default function JoyChip() {
@@ -57,7 +57,28 @@ export default function JoyChip() {
         {/* Examples */}
         <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 5, mt: 5 }}>
           <Chip endDecorator={<ChipDelete />}>Benny</Chip>
+          <Chip disabled endDecorator={<ChipDelete />}>
+            Benny
+          </Chip>
           <Chip variant="light" startDecorator={<ChipDelete />}>
+            Benny
+          </Chip>
+          <Chip variant="light" onClick={() => alert('hey')}>
+            Benny
+          </Chip>
+          <Chip variant="light" startDecorator={<ChipDelete />} onClick={() => alert('hey')}>
+            Benny
+          </Chip>
+          <Chip
+            variant="light"
+            endDecorator={<ChipDelete />}
+            componentsProps={{
+              action: {
+                component: 'a',
+                href: '#unknown',
+              },
+            }}
+          >
             Benny
           </Chip>
           <Chip
@@ -81,6 +102,17 @@ export default function JoyChip() {
             size="lg"
             startDecorator={<Avatar size="sm" src={`/static/images/avatar/1.jpg`} />}
             endDecorator={<CheckIcon fontSize="md" sx={{ mr: 0.25 }} />}
+            onClick={() => alert('hey')}
+            sx={{ '--Chip-radius': '8px' }}
+          >
+            Benny
+          </Chip>
+          <Chip
+            variant="outlined"
+            color="neutral"
+            size="lg"
+            startDecorator={<Avatar src={`/static/images/avatar/1.jpg`} size="sm" />}
+            endDecorator={<ChipDelete variant="text" />}
             sx={{ '--Chip-radius': '8px' }}
           >
             Benny

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -12,6 +12,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
 import ThumbUp from '@mui/icons-material/ThumbUp';
+import DeleteForever from '@mui/icons-material/DeleteForever';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -117,6 +118,82 @@ export default function JoyChip() {
           >
             Benny
           </Chip>
+          <Chip
+            variant="outlined"
+            color="danger"
+            size="sm"
+            endDecorator={
+              <ChipDelete color="danger" variant="text">
+                <DeleteForever />
+              </ChipDelete>
+            }
+            sx={{ '--Chip-radius': '12px' }}
+          >
+            Clear
+          </Chip>
+          <Chip
+            variant="outlined"
+            color="danger"
+            size="sm"
+            onClick={() => {}}
+            endDecorator={<DeleteForever />}
+            sx={{ '--Chip-radius': '12px', minHeight: '28px' }}
+          >
+            Clear
+          </Chip>
+        </Box>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+            gap: 5,
+            my: 3,
+          }}
+        >
+          <Box sx={(theme) => ({ p: 0.5, borderRadius: 'sm', ...theme.variants.outlined.neutral })}>
+            {['Apple', 'Mango', 'Pineapple', 'Strawberry', 'Mixberry'].map((item) => (
+              <Chip
+                key={item}
+                variant="outlined"
+                endDecorator={<ChipDelete sx={{ boxShadow: 'xs' }} />}
+                sx={{ mb: 0.5, mr: 0.5 }}
+              >
+                {item}
+              </Chip>
+            ))}
+          </Box>
+          <Box>
+            <Typography level="h2" fontSize="lg" id="refine-title" mb={1}>
+              Refine results
+            </Typography>
+            <Box
+              role="group"
+              aria-labelledby="refine-title"
+              sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}
+            >
+              {[
+                'Top Rated',
+                'Men',
+                'Black',
+                'Red',
+                'Green',
+                'Blue',
+                'Turquoise',
+                'Shoes',
+                'Watches',
+              ].map((item) => (
+                <Chip
+                  key={item}
+                  color="neutral"
+                  variant="outlined"
+                  endDecorator={<ChipDelete variant="text" />}
+                  sx={{ '--Chip-radius': '10px' }}
+                >
+                  {item}
+                </Chip>
+              ))}
+            </Box>
+          </Box>
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
           {/* Without decorators */}

--- a/docs/pages/experiments/joy/chip.tsx
+++ b/docs/pages/experiments/joy/chip.tsx
@@ -61,7 +61,7 @@ export default function JoyChip() {
         {/* Examples */}
         <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 5, mt: 5 }}>
           <Chip endDecorator={<ChipDelete />}>Benny</Chip>
-          <Chip disabled endDecorator={<ChipDelete />}>
+          <Chip disabled onClick={() => {}} endDecorator={<ChipDelete />}>
             Benny
           </Chip>
           <Chip variant="light" startDecorator={<ChipDelete />}>

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-alert */
 import * as React from 'react';
 import { useRouter } from 'next/router';
 import { GlobalStyles } from '@mui/system';
@@ -11,6 +12,8 @@ import Card from '@mui/joy/Card';
 import CardCover from '@mui/joy/CardCover';
 import CardContent from '@mui/joy/CardContent';
 import CardOverflow from '@mui/joy/CardOverflow';
+import Chip from '@mui/joy/Chip';
+import ChipDelete from '@mui/joy/ChipDelete';
 import Checkbox from '@mui/joy/Checkbox';
 import IconButton from '@mui/joy/IconButton';
 import Link from '@mui/joy/Link';
@@ -39,6 +42,7 @@ import StarBorder from '@mui/icons-material/StarBorder';
 import Favorite from '@mui/icons-material/FavoriteBorder';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import PlayArrow from '@mui/icons-material/PlayArrow';
+import Delete from '@mui/icons-material/Delete';
 import LocationOn from '@mui/icons-material/LocationOnOutlined';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { brandingDarkTheme } from 'docs/src/modules/brandingTheme';
@@ -477,6 +481,126 @@ const components: {
     cssVars: [
       { id: '--Card-padding', type: 'number', unit: 'px', defaultValue: 16 },
       { id: '--Card-radius', type: 'number', unit: 'px', defaultValue: 8 },
+    ],
+  },
+  {
+    name: 'Chip',
+    render: (props: any) => (
+      <React.Fragment>
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          <Chip
+            variant="light"
+            size="sm"
+            startDecorator={
+              <Avatar
+                src="/static/images/avatar/1.jpg"
+                variant="outlined"
+                sx={{ '--Avatar-size': '24px', borderColor: 'background.body' }}
+              />
+            }
+            {...props}
+          >
+            Robert Stark
+          </Chip>
+          <Chip
+            variant="light"
+            startDecorator={
+              <Avatar
+                src="/static/images/avatar/2.jpg"
+                size="sm"
+                variant="outlined"
+                sx={{ borderColor: 'background.body' }}
+              />
+            }
+            {...props}
+          >
+            Robert Stark
+          </Chip>
+          <Chip
+            variant="light"
+            size="lg"
+            startDecorator={
+              <Avatar
+                src="/static/images/avatar/3.jpg"
+                variant="outlined"
+                sx={{ borderColor: 'background.body', '--variant-outlinedBorderWidth': '2px' }}
+              />
+            }
+            {...props}
+          >
+            Robert Stark
+          </Chip>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Chip variant="outlined" onClick={() => alert('test')} {...props}>
+            Delete
+            <Delete sx={{ ml: 0.5, mr: -0.5 }} />
+          </Chip>
+          <Chip variant="outlined" color="success" onClick={() => alert('test')} {...props}>
+            <Info sx={{ mr: 0.5, ml: -0.5 }} />
+            Info
+          </Chip>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Chip variant="light" color="neutral" endDecorator={<ChipDelete />} {...props}>
+            Fruit
+          </Chip>
+          <Chip
+            variant="light"
+            color="neutral"
+            endDecorator={<ChipDelete variant="outlined" />}
+            {...props}
+          >
+            Fruit
+          </Chip>
+          <Chip
+            variant="outlined"
+            color="neutral"
+            endDecorator={<ChipDelete variant="light" />}
+            {...props}
+          >
+            Fruit
+          </Chip>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Chip
+            startDecorator={<Favorite sx={{ ml: 0.5 }} />}
+            variant="outlined"
+            color="danger"
+            onClick={() => {}}
+            {...props}
+          >
+            Favorite
+          </Chip>
+          <Chip
+            startDecorator={<Favorite sx={{ ml: 0.5 }} />}
+            variant="outlined"
+            color="neutral"
+            onClick={() => {}}
+            {...props}
+          >
+            Favorite
+          </Chip>
+          <Chip
+            startDecorator={<Favorite sx={{ ml: 0.5 }} />}
+            variant="outlined"
+            color="neutral"
+            onClick={() => {}}
+            {...props}
+          >
+            Favorite
+          </Chip>
+        </Box>
+      </React.Fragment>
+    ),
+    cssVars: [
+      { id: '--Icon-fontSize', type: 'number', unit: 'px', defaultValue: 18 },
+      { id: '--Chip-radius', type: 'number', unit: 'px', defaultValue: 24 },
+      { id: '--Chip-gap', type: 'number', unit: 'px', defaultValue: 6 },
+      { id: '--Chip-paddingBlock', type: 'number', unit: 'px', defaultValue: 4 },
+      { id: '--Chip-paddingInline', type: 'number', unit: 'px', defaultValue: 12 },
+      { id: '--Chip-delete-size', type: 'number', unit: 'px', defaultValue: 24 },
+      { id: '--Chip-delete-radius', type: 'number', unit: 'px' },
     ],
   },
 ];

--- a/docs/pages/experiments/joy/svg-icon.tsx
+++ b/docs/pages/experiments/joy/svg-icon.tsx
@@ -1,45 +1,11 @@
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
 import SvgIcon from '@mui/joy/SvgIcon';
 import Typography from '@mui/joy/Typography';
 import * as React from 'react';
-// @ts-ignore
-import { jsx as _jsx } from 'react/jsx-runtime';
-
-function createSvgIcon(path: any, displayName: any, initialProps?: any) {
-  const Component = (props: any, ref: any) =>
-    (
-      <SvgIcon
-        data-testid={`${displayName}Icon`}
-        ref={ref}
-        viewBox="0 0 24 24"
-        fontSize="extraLarge"
-        {...initialProps}
-        {...props}
-        sx={{ ...initialProps?.sx, ...props.sx }}
-      >
-        {path}
-      </SvgIcon>
-    ) as unknown as typeof SvgIcon;
-
-  // @ts-ignore
-  return React.memo(React.forwardRef(Component));
-}
-
-export const Moon = createSvgIcon(
-  _jsx('path', {
-    d: 'M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1z',
-  }),
-  'DarkMode',
-);
-
-export const Sun = createSvgIcon(
-  _jsx('path', {
-    d: 'M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37c-.39-.39-1.03-.39-1.41 0-.39.39-.39 1.03 0 1.41l1.06 1.06c.39.39 1.03.39 1.41 0 .39-.39.39-1.03 0-1.41l-1.06-1.06zm1.06-10.96c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36c.39-.39.39-1.03 0-1.41-.39-.39-1.03-.39-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z',
-  }),
-  'LightMode',
-);
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -248,7 +248,7 @@ Avatar.propTypes /* remove-proptypes */ = {
   imgProps: PropTypes.object,
   /**
    * The size of the component.
-   * It accepts theme values between 'xs' and 'xl'.
+   * It accepts theme values between 'sm' and 'lg'.
    * @default 'md'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -59,7 +59,7 @@ const AvatarRoot = styled('div', {
       width: 'var(--Avatar-size)',
       height: 'var(--Avatar-size)',
       lineHeight: 1,
-      borderRadius: '50%',
+      borderRadius: 'var(--Avatar-radius, 50%)',
       userSelect: 'none',
     },
     theme.variants[ownerState.variant!]?.[ownerState.color!],
@@ -80,7 +80,7 @@ const AvatarImg = styled('img', {
   color: 'transparent',
   // Hide the image broken icon, only works on Chrome.
   textIndent: 10000,
-  borderRadius: '50%',
+  borderRadius: 'var(--Avatar-radius, 50%)',
 });
 
 const AvatarFallback = styled(Person, {

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -70,7 +70,7 @@ const AvatarImg = styled('img', {
   name: 'MuiAvatar',
   slot: 'Img',
   overridesResolver: (props, styles) => styles.img,
-})<{ ownerState: AvatarProps }>({
+})<{ ownerState: AvatarProps }>(({ ownerState }) => ({
   width: '100%',
   height: '100%',
   textAlign: 'center',
@@ -80,8 +80,11 @@ const AvatarImg = styled('img', {
   color: 'transparent',
   // Hide the image broken icon, only works on Chrome.
   textIndent: 10000,
-  borderRadius: 'var(--Avatar-radius, 50%)',
-});
+  borderRadius:
+    ownerState.variant === 'outlined'
+      ? `calc(var(--Avatar-radius, 50%) - var(--variant-outlinedBorderWidth, 0px))`
+      : 'var(--Avatar-radius, 50%)',
+}));
 
 const AvatarFallback = styled(Person, {
   name: 'MuiAvatar',

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -35,7 +35,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
     };
     /**
      * The size of the component.
-     * It accepts theme values between 'xs' and 'xl'.
+     * It accepts theme values between 'sm' and 'lg'.
      * @default 'md'
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', AvatarPropsSizeOverrides>;

--- a/packages/mui-joy/src/Avatar/avatarClasses.ts
+++ b/packages/mui-joy/src/Avatar/avatarClasses.ts
@@ -15,7 +15,7 @@ export interface AvatarClasses {
   colorSuccess: string;
   /** Styles applied to the root element if `color="warning"`. */
   colorWarning: string;
-  /** Styles applied to the fallback icon */
+  /** Styles applied to the fallback icon. */
   fallback: string;
   /** Styles applied to the root element if `size="sm"`. */
   sizeSm: string;

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.tsx
@@ -111,7 +111,7 @@ AvatarGroup.propTypes /* remove-proptypes */ = {
   component: PropTypes.elementType,
   /**
    * The size of the component.
-   * It accepts theme values between 'xs' and 'xl'.
+   * It accepts theme values between 'sm' and 'lg'.
    * @default 'md'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([

--- a/packages/mui-joy/src/Chip/Chip.spec.tsx
+++ b/packages/mui-joy/src/Chip/Chip.spec.tsx
@@ -1,0 +1,34 @@
+import Chip from '@mui/joy/Chip';
+import * as React from 'react';
+
+<Chip />;
+
+<Chip component="div" />;
+
+// `variant`
+<Chip />;
+<Chip variant="light" />;
+<Chip variant="outlined" />;
+<Chip variant="contained" />;
+
+// `color`
+<Chip color="primary" />;
+<Chip color="danger" />;
+<Chip color="info" />;
+<Chip color="success" />;
+<Chip color="warning" />;
+<Chip color="neutral" />;
+
+// `size`
+<Chip size="sm" />;
+<Chip size="md" />;
+<Chip size="lg" />;
+
+// @ts-expect-error there is no variant `filled`
+<Chip variant="filled" />;
+
+// @ts-expect-error there is no color `secondary`
+<Chip color="secondary" />;
+
+// @ts-expect-error there is no size `xl2`
+<Chip size="xl2" />;

--- a/packages/mui-joy/src/Chip/Chip.test.js
+++ b/packages/mui-joy/src/Chip/Chip.test.js
@@ -18,7 +18,7 @@ describe('<Chip />', () => {
     testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
     testComponentPropWith: 'span',
     testVariantProps: { variant: 'light' },
-    skip: ['classesRoot', 'componentsProp'],
+    skip: ['classesRoot', 'componentsProp', 'themeVariants'],
   }));
 
   describe('prop: variant', () => {

--- a/packages/mui-joy/src/Chip/Chip.test.js
+++ b/packages/mui-joy/src/Chip/Chip.test.js
@@ -21,6 +21,30 @@ describe('<Chip />', () => {
     skip: ['classesRoot', 'componentsProp', 'themeVariants'],
   }));
 
+  it('renders children', () => {
+    const { getByText } = render(
+      <Chip>
+        <span>test</span>
+      </Chip>,
+    );
+
+    expect(getByText('test')).toBeVisible();
+  });
+
+  describe('decorator', () => {
+    it('should render startDecorator element', () => {
+      const { getByText } = render(<Chip startDecorator="foo" />);
+
+      expect(getByText('foo')).to.have.class(classes.startDecorator);
+    });
+
+    it('should render endDecorator element', () => {
+      const { getByText } = render(<Chip endDecorator="bar" />);
+
+      expect(getByText('bar')).to.have.class(classes.endDecorator);
+    });
+  });
+
   describe('prop: variant', () => {
     it('contained by default', () => {
       const { getByTestId } = render(<Chip data-testid="root" />);
@@ -68,23 +92,25 @@ describe('<Chip />', () => {
     });
   });
 
-  describe('prop: clickable', () => {
-    it('renders as a clickable chip when `clickable` is `true`', () => {
-      const { getByTestId } = render(<Chip data-testid="root" clickable />);
+  describe('clickable', () => {
+    it('renders action element when `onClick` is provided', () => {
+      const { getByRole } = render(<Chip onClick={() => {}} />);
 
-      expect(getByTestId('root')).to.have.class(classes.clickable);
+      expect(getByRole('button')).toBeVisible();
     });
 
-    it('renders as a non-clickable chip when `clickable` is `false`', () => {
-      const { getByTestId } = render(<Chip data-testid="root" />);
+    it('renders action element when `componentsProps.action` is provided', () => {
+      const { getByRole } = render(<Chip componentsProps={{ action: {} }} />);
 
-      expect(getByTestId('root')).not.to.have.class(classes.clickable);
+      expect(getByRole('button')).toBeVisible();
     });
 
-    it('renders as a clickable chip when `onClick` is passed', () => {
-      const { getByTestId } = render(<Chip data-testid="root" onClick={() => {}} />);
+    it('renders custom action element', () => {
+      const { getByRole } = render(
+        <Chip componentsProps={{ action: { component: 'a', href: '#' } }} />,
+      );
 
-      expect(getByTestId('root')).to.have.class(classes.clickable);
+      expect(getByRole('link')).to.have.attr('href', '#');
     });
   });
 
@@ -99,6 +125,12 @@ describe('<Chip />', () => {
       const { getByTestId } = render(<Chip data-testid="root" />);
 
       expect(getByTestId('root')).not.to.have.class(classes.disabled);
+    });
+
+    it('renders disabled action element', () => {
+      const { getByRole } = render(<Chip disabled onClick={() => {}} />);
+
+      expect(getByRole('button')).to.have.attr('disabled');
     });
   });
 });

--- a/packages/mui-joy/src/Chip/Chip.test.js
+++ b/packages/mui-joy/src/Chip/Chip.test.js
@@ -22,10 +22,10 @@ describe('<Chip />', () => {
   }));
 
   describe('prop: variant', () => {
-    it('light by default', () => {
+    it('contained by default', () => {
       const { getByTestId } = render(<Chip data-testid="root" />);
 
-      expect(getByTestId('root')).to.have.class(classes.variantLight);
+      expect(getByTestId('root')).to.have.class(classes.variantContained);
     });
 
     ['outlined', 'light', 'contained'].forEach((variant) => {
@@ -38,10 +38,10 @@ describe('<Chip />', () => {
   });
 
   describe('prop: color', () => {
-    it('adds a neutral class by default', () => {
+    it('adds a primary class by default', () => {
       const { getByTestId } = render(<Chip data-testid="root" />);
 
-      expect(getByTestId('root')).to.have.class(classes.colorNeutral);
+      expect(getByTestId('root')).to.have.class(classes.colorPrimary);
     });
 
     ['primary', 'success', 'info', 'danger', 'neutral', 'warning'].forEach((color) => {

--- a/packages/mui-joy/src/Chip/Chip.test.js
+++ b/packages/mui-joy/src/Chip/Chip.test.js
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from 'test/utils';
+import { ThemeProvider } from '@mui/joy/styles';
+import Chip, { chipClasses as classes } from '@mui/joy/Chip';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+
+describe('<Chip />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Chip />, () => ({
+    classes,
+    inheritComponent: 'div',
+    render,
+    ThemeProvider,
+    muiName: 'MuiChip',
+    refInstanceof: window.HTMLDivElement,
+    testDeepOverrides: { slotName: 'label', slotClassName: classes.label },
+    testComponentPropWith: 'span',
+    testVariantProps: { variant: 'light' },
+    skip: ['classesRoot', 'componentsProp'],
+  }));
+
+  describe('prop: variant', () => {
+    it('light by default', () => {
+      const { getByTestId } = render(<Chip data-testid="root" />);
+
+      expect(getByTestId('root')).to.have.class(classes.variantLight);
+    });
+
+    ['outlined', 'light', 'contained'].forEach((variant) => {
+      it(`should render ${variant}`, () => {
+        const { getByTestId } = render(<Chip data-testid="root" variant={variant} />);
+
+        expect(getByTestId('root')).to.have.class(classes[`variant${capitalize(variant)}`]);
+      });
+    });
+  });
+
+  describe('prop: color', () => {
+    it('adds a neutral class by default', () => {
+      const { getByTestId } = render(<Chip data-testid="root" />);
+
+      expect(getByTestId('root')).to.have.class(classes.colorNeutral);
+    });
+
+    ['primary', 'success', 'info', 'danger', 'neutral', 'warning'].forEach((color) => {
+      it(`should render ${color}`, () => {
+        const { getByTestId } = render(<Chip data-testid="root" color={color} />);
+
+        expect(getByTestId('root')).to.have.class(classes[`color${capitalize(color)}`]);
+      });
+    });
+  });
+
+  describe('prop: size', () => {
+    it('md by default', () => {
+      const { getByTestId } = render(<Chip data-testid="root" />);
+
+      expect(getByTestId('root')).to.have.class(classes.sizeMd);
+    });
+    ['sm', 'md', 'lg'].forEach((size) => {
+      it(`should render ${size}`, () => {
+        const { getByTestId } = render(<Chip data-testid="root" size={size} />);
+
+        expect(getByTestId('root')).to.have.class(classes[`size${capitalize(size)}`]);
+      });
+    });
+  });
+
+  describe('prop: clickable', () => {
+    it('renders as a clickable chip when `clickable` is `true`', () => {
+      const { getByTestId } = render(<Chip data-testid="root" clickable />);
+
+      expect(getByTestId('root')).to.have.class(classes.clickable);
+    });
+
+    it('renders as a non-clickable chip when `clickable` is `false`', () => {
+      const { getByTestId } = render(<Chip data-testid="root" />);
+
+      expect(getByTestId('root')).not.to.have.class(classes.clickable);
+    });
+
+    it('renders as a clickable chip when `onClick` is passed', () => {
+      const { getByTestId } = render(<Chip data-testid="root" onClick={() => {}} />);
+
+      expect(getByTestId('root')).to.have.class(classes.clickable);
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('renders as a disabled chip when `disabled` is `true`', () => {
+      const { getByTestId } = render(<Chip data-testid="root" disabled />);
+
+      expect(getByTestId('root')).to.have.class(classes.disabled);
+    });
+
+    it('renders as a non-disabled chip when `disabled` is `false`', () => {
+      const { getByTestId } = render(<Chip data-testid="root" />);
+
+      expect(getByTestId('root')).not.to.have.class(classes.disabled);
+    });
+  });
+});

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -48,7 +48,6 @@ const ChipRoot = styled('div', {
         ownerState.clickable || ownerState.variant !== 'outlined'
           ? '0.25rem'
           : 'calc(0.25rem - var(--variant-outlinedBorderWidth, 0px))',
-      '--Chip-color': theme.variants[ownerState.variant!]?.[ownerState.color!].color,
       '--Chip-radius': '1.5rem',
       '--Chip-delete-radius': `max(var(--Chip-radius) - var(--Chip-paddingBlock), min(var(--Chip-paddingBlock) / 2, var(--Chip-radius) / 2))`,
       '--Avatar-radius': `max(var(--Chip-radius) - var(--Chip-paddingBlock), min(var(--Chip-paddingBlock) / 2, var(--Chip-radius) / 2))`,

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -56,7 +56,7 @@ const ChipRoot = styled('div', {
         '--Chip-gap': '0.25rem',
         '--Chip-paddingInline': '0.5rem',
         '--Chip-delete-size': '1.25rem',
-        '--Icon-fontSize': '1rem',
+        '--Icon-fontSize': '0.875rem',
         minHeight: '1.5rem',
         fontSize: theme.vars.fontSize.xs,
       }),

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -1,17 +1,23 @@
-import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { OverridableComponent } from '@mui/types';
-import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
+import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import { unstable_composeClasses as composeClasses, useButton } from '@mui/base';
+import { OverridableComponent } from '@mui/types';
+import {
+  unstable_capitalize as capitalize,
+  unstable_useId as useId,
+  unstable_useForkRef as useForkRef,
+} from '@mui/utils';
 import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
 import { getChipUtilityClass } from './chipClasses';
 import { ChipProps, ChipTypeMap } from './ChipProps';
-import ChipColorContext from './ChipColorContext';
+import ChipContext from './ChipContext';
 
-const useUtilityClasses = (ownerState: ChipProps) => {
-  const { disabled, size, color, clickable, variant } = ownerState;
+const useUtilityClasses = (
+  ownerState: ChipProps & { focusVisible: boolean; clickable: boolean },
+) => {
+  const { disabled, size, color, clickable, variant, focusVisible } = ownerState;
 
   const slots = {
     root: [
@@ -22,6 +28,7 @@ const useUtilityClasses = (ownerState: ChipProps) => {
       variant && `variant${capitalize(variant)}`,
       clickable && 'clickable',
     ],
+    action: ['action', focusVisible && 'focusVisible'],
     label: ['label', size && `label${capitalize(size)}`],
     startDecorator: ['startDecorator'],
     endDecorator: ['endDecorator'],
@@ -30,44 +37,25 @@ const useUtilityClasses = (ownerState: ChipProps) => {
   return composeClasses(slots, getChipUtilityClass, {});
 };
 
-// base paddingBlock for the all chip sizes
-const PADDING_BLOCK = '0.25rem';
-
-const ChipStartDecorator = styled('span', {
-  name: 'MuiChip',
-  slot: 'StartDecorator',
-  overridesResolver: (props, styles) => styles.startDecorator,
-})<{ ownerState: ChipProps }>({
-  display: 'inherit',
-  marginInlineEnd: 'var(--Chip-gap)',
-  marginInlineStart: `calc(-1 * (var(--Chip-paddingInline) - ${PADDING_BLOCK}))`,
-});
-
-const ChipEndDecorator = styled('span', {
-  name: 'MuiChip',
-  slot: 'EndDecorator',
-  overridesResolver: (props, styles) => styles.endDecorator,
-})<{ ownerState: ChipProps }>({
-  display: 'inherit',
-  marginInlineStart: 'var(--Chip-gap)',
-  marginInlineEnd: `calc(-1 * (var(--Chip-paddingInline) - ${PADDING_BLOCK}))`,
-});
-
 const ChipRoot = styled('div', {
   name: 'MuiChip',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ChipProps }>(({ theme, ownerState }) => {
+})<{ ownerState: ChipProps & { clickable: boolean } }>(({ theme, ownerState }) => {
   return [
     {
+      '--Chip-paddingBlock': ownerState.clickable
+        ? '0.25rem'
+        : 'calc(0.25rem - var(--variant-outlinedBorderWidth, 0px))',
       '--Chip-color': theme.variants[ownerState.variant!]?.[ownerState.color!].color,
       '--Chip-radius': '1.5rem',
-      '--Chip-delete-radius': `max(var(--Chip-radius) - ${PADDING_BLOCK}, min(${PADDING_BLOCK} / 2, var(--Chip-radius) / 2))`,
-      '--Avatar-radius': `max(var(--Chip-radius) - ${PADDING_BLOCK}, min(${PADDING_BLOCK} / 2, var(--Chip-radius) / 2))`,
+      '--Chip-delete-radius': `max(var(--Chip-radius) - var(--Chip-paddingBlock), min(var(--Chip-paddingBlock) / 2, var(--Chip-radius) / 2))`,
+      '--Avatar-radius': `max(var(--Chip-radius) - var(--Chip-paddingBlock), min(var(--Chip-paddingBlock) / 2, var(--Chip-radius) / 2))`,
       ...(ownerState.size === 'sm' && {
         '--Chip-minHeight': '1.5rem',
         '--Chip-gap': '0.25rem',
         '--Chip-paddingInline': '0.5rem',
+        '--Chip-delete-size': '1.25rem',
         '--Icon-fontSize': '1rem',
         fontSize: theme.vars.fontSize.xs,
       }),
@@ -75,6 +63,7 @@ const ChipRoot = styled('div', {
         '--Chip-minHeight': '2rem',
         '--Chip-gap': '0.375rem',
         '--Chip-paddingInline': '0.75rem',
+        '--Chip-delete-size': '1.5rem',
         '--Icon-fontSize': '1.125rem',
         fontSize: theme.vars.fontSize.sm,
       }),
@@ -82,11 +71,12 @@ const ChipRoot = styled('div', {
         '--Chip-minHeight': '2.5rem',
         '--Chip-gap': '0.5rem',
         '--Chip-paddingInline': '1rem',
+        '--Chip-delete-size': '2rem',
         '--Icon-fontSize': '1.25rem',
         fontSize: theme.vars.fontSize.md,
       }),
       minHeight: 'var(--Chip-minHeight)',
-      paddingBlock: PADDING_BLOCK,
+      paddingBlock: 'var(--Chip-paddingBlock)',
       paddingInline: 'var(--Chip-paddingInline)',
       borderRadius: 'var(--Chip-radius)',
       position: 'relative',
@@ -102,10 +92,87 @@ const ChipRoot = styled('div', {
       verticalAlign: 'middle',
       boxSizing: 'border-box',
     },
-    theme.variants[ownerState.variant!]?.[ownerState.color!],
-    theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+    ...(!ownerState.clickable
+      ? [
+          theme.variants[ownerState.variant!]?.[ownerState.color!],
+          theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+        ]
+      : [
+          {
+            color: theme.vars.palette[ownerState.color!]?.[`${ownerState.variant!}Color`],
+          },
+        ]),
   ];
 });
+
+const ChipLabel = styled('span', {
+  name: 'MuiChip',
+  slot: 'Label',
+  overridesResolver: (props, styles) => styles.label,
+})<{ ownerState: ChipProps & { clickable: boolean } }>(({ ownerState }) => ({
+  display: 'inherit',
+  alignItems: 'center',
+  ...(ownerState.clickable && {
+    zIndex: 1,
+    pointerEvents: 'none',
+  }),
+}));
+
+const ChipAction = styled('button', {
+  name: 'MuiChip',
+  slot: 'Action',
+  overridesResolver: (props, styles) => styles.action,
+})<{ ownerState: ChipProps }>(({ theme, ownerState }) => [
+  {
+    position: 'absolute',
+    zIndex: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    border: 'none',
+    padding: 'initial',
+    margin: 'initial',
+    backgroundColor: 'initial',
+    textDecoration: 'none',
+    borderRadius: 'inherit',
+    transition:
+      'background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+  },
+  theme.focus.default,
+  theme.variants[ownerState.variant!]?.[ownerState.color!],
+  theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
+  theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
+  theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+]);
+
+const ChipStartDecorator = styled('span', {
+  name: 'MuiChip',
+  slot: 'StartDecorator',
+  overridesResolver: (props, styles) => styles.startDecorator,
+})<{ ownerState: ChipProps & { clickable: boolean } }>(({ ownerState }) => ({
+  display: 'inherit',
+  marginInlineEnd: 'var(--Chip-gap)',
+  marginInlineStart: `calc(-1 * (var(--Chip-paddingInline) - var(--Chip-paddingBlock)))`,
+  ...(ownerState.clickable && {
+    zIndex: 1,
+    pointerEvents: 'none',
+  }),
+}));
+
+const ChipEndDecorator = styled('span', {
+  name: 'MuiChip',
+  slot: 'EndDecorator',
+  overridesResolver: (props, styles) => styles.endDecorator,
+})<{ ownerState: ChipProps & { clickable: boolean } }>(({ ownerState }) => ({
+  display: 'inherit',
+  marginInlineStart: 'var(--Chip-gap)',
+  marginInlineEnd: `calc(-1 * (var(--Chip-paddingInline) - var(--Chip-paddingBlock)))`,
+  ...(ownerState.clickable && {
+    zIndex: 1,
+    pointerEvents: 'none',
+  }),
+}));
 
 /**
  * Chips represent complex entities in small blocks, such as a contact.
@@ -115,27 +182,35 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const {
     children,
     className,
-    clickable: clickableProp,
+    componentsProps = {},
     color = 'primary',
-    component: ComponentProp,
-    disabled = false,
+    component,
     onClick,
+    disabled = false,
     size = 'md',
     variant = 'contained',
     startDecorator,
     endDecorator,
     ...other
   } = props;
+  const { component: actionComponent, ...actionProps } = componentsProps.action || {};
 
-  const chipRef = React.useRef(null);
-  const handleRef = useForkRef(chipRef, ref);
-  const clickable = clickableProp !== false && onClick ? true : clickableProp;
-  const component = ComponentProp || 'div';
+  const clickable = !!onClick || !!componentsProps.action;
+  const id = useId(componentsProps.action?.id);
+  const actionRef = React.useRef<HTMLElement | null>(null);
+  const handleActionRef = useForkRef(actionRef, actionProps.ref);
+  const { focusVisible, getRootProps } = useButton({
+    ...actionProps,
+    component: actionComponent,
+    ref: handleActionRef,
+  });
 
   const ownerState = {
     ...props,
     component,
+    onClick,
     disabled,
+    focusVisible,
     size,
     color,
     clickable,
@@ -145,28 +220,55 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <ChipColorContext.Provider value={color}>
+    <ChipContext.Provider value={{ disabled, variant, color }}>
       <ChipRoot
         as={component}
         className={clsx(classes.root, className)}
-        onClick={onClick}
-        ref={handleRef}
+        ref={ref}
         ownerState={ownerState}
         {...other}
       >
+        {clickable && (
+          <ChipAction
+            aria-labelledby={id}
+            {...actionProps}
+            // @ts-expect-error getRootProps typings should be fixed.
+            {...getRootProps({ onClick, ...actionProps })}
+            as={actionComponent}
+            className={clsx(classes.action, actionProps.className)}
+            ownerState={ownerState}
+          />
+        )}
+
         {startDecorator && (
-          <ChipStartDecorator className={classes.startDecorator} ownerState={ownerState}>
+          <ChipStartDecorator
+            {...componentsProps.startDecorator}
+            className={clsx(classes.startDecorator, componentsProps.startDecorator?.className)}
+            ownerState={ownerState}
+          >
             {startDecorator}
           </ChipStartDecorator>
         )}
-        {children}
+
+        <ChipLabel
+          id={id}
+          {...componentsProps.label}
+          className={clsx(classes.label, componentsProps.label?.className)}
+          ownerState={ownerState}
+        >
+          {children}
+        </ChipLabel>
         {endDecorator && (
-          <ChipEndDecorator className={classes.endDecorator} ownerState={ownerState}>
+          <ChipEndDecorator
+            {...componentsProps.endDecorator}
+            className={clsx(classes.endDecorator, componentsProps.endDecorator?.className)}
+            ownerState={ownerState}
+          >
             {endDecorator}
           </ChipEndDecorator>
         )}
       </ChipRoot>
-    </ChipColorContext.Provider>
+    </ChipContext.Provider>
   );
 }) as OverridableComponent<ChipTypeMap>;
 
@@ -184,15 +286,6 @@ Chip.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
-   * If `true`, the chip will appear clickable, and will raise when pressed,
-   * even if the onClick prop is not defined.
-   * If `false`, the chip will not appear clickable, even if onClick prop is defined.
-   * This can be used, for example,
-   * along with the component prop to indicate an anchor Chip is clickable.
-   * Note: this controls the UI and does not affect the onClick event.
-   */
-  clickable: PropTypes.bool,
-  /**
    * The color of the component. It supports those theme colors that make sense for this component.
    * @default 'primary'
    */
@@ -205,6 +298,17 @@ Chip.propTypes /* remove-proptypes */ = {
    * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
+  /**
+   * The props used for each slot inside the Input.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    action: PropTypes.object,
+    endDecorator: PropTypes.object,
+    label: PropTypes.object,
+    root: PropTypes.object,
+    startDecorator: PropTypes.object,
+  }),
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -174,7 +174,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const ownerState = {
     ...props,
     component,
-    disabled: clickable && disabled ? true : undefined,
+    disabled,
     size,
     color,
     clickable,

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -44,38 +44,38 @@ const ChipRoot = styled('div', {
 })<{ ownerState: ChipProps & { clickable: boolean } }>(({ theme, ownerState }) => {
   return [
     {
-      '--Chip-paddingBlock': ownerState.clickable
-        ? '0.25rem'
-        : 'calc(0.25rem - var(--variant-outlinedBorderWidth, 0px))',
+      '--Chip-paddingBlock':
+        ownerState.clickable || ownerState.variant !== 'outlined'
+          ? '0.25rem'
+          : 'calc(0.25rem - var(--variant-outlinedBorderWidth, 0px))',
       '--Chip-color': theme.variants[ownerState.variant!]?.[ownerState.color!].color,
       '--Chip-radius': '1.5rem',
       '--Chip-delete-radius': `max(var(--Chip-radius) - var(--Chip-paddingBlock), min(var(--Chip-paddingBlock) / 2, var(--Chip-radius) / 2))`,
       '--Avatar-radius': `max(var(--Chip-radius) - var(--Chip-paddingBlock), min(var(--Chip-paddingBlock) / 2, var(--Chip-radius) / 2))`,
       ...(ownerState.size === 'sm' && {
-        '--Chip-minHeight': '1.5rem',
         '--Chip-gap': '0.25rem',
         '--Chip-paddingInline': '0.5rem',
         '--Chip-delete-size': '1.25rem',
         '--Icon-fontSize': '1rem',
+        minHeight: '1.5rem',
         fontSize: theme.vars.fontSize.xs,
       }),
       ...(ownerState.size === 'md' && {
-        '--Chip-minHeight': '2rem',
         '--Chip-gap': '0.375rem',
         '--Chip-paddingInline': '0.75rem',
         '--Chip-delete-size': '1.5rem',
         '--Icon-fontSize': '1.125rem',
+        minHeight: '2rem',
         fontSize: theme.vars.fontSize.sm,
       }),
       ...(ownerState.size === 'lg' && {
-        '--Chip-minHeight': '2.5rem',
         '--Chip-gap': '0.5rem',
         '--Chip-paddingInline': '1rem',
         '--Chip-delete-size': '2rem',
         '--Icon-fontSize': '1.25rem',
+        minHeight: '2.5rem',
         fontSize: theme.vars.fontSize.md,
       }),
-      minHeight: 'var(--Chip-minHeight)',
       paddingBlock: 'var(--Chip-paddingBlock)',
       paddingInline: 'var(--Chip-paddingInline)',
       borderRadius: 'var(--Chip-radius)',

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -1,5 +1,4 @@
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import ButtonBase from '@mui/material/ButtonBase';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import clsx from 'clsx';
@@ -78,42 +77,44 @@ const ChipRoot = styled('div', {
   return [
     {
       ...(ownerState.size === 'sm' && {
-        '--Chip-height': '1.5rem',
-        '--Chip-border-radius': '0.75rem',
-        fontSize: theme.vars.fontSize.sm,
+        '--Chip-radius': '1rem',
+        '--Chip-fontSize': theme.vars.fontSize.xs,
       }),
       ...(ownerState.size === 'md' && {
-        '--Chip-height': '2rem',
-        '--Chip-border-radius': '1rem',
-        fontSize: theme.vars.fontSize.md,
+        '--Chip-radius': '1.25rem',
+        '--Chip-fontSize': theme.vars.fontSize.sm,
       }),
       ...(ownerState.size === 'lg' && {
-        '--Chip-height': '2.5rem',
-        '--Chip-border-radius': '1.25rem',
-        fontSize: theme.vars.fontSize.lg,
+        '--Chip-radius': '1.5rem',
+        '--Chip-fontSize': theme.vars.fontSize.md,
       }),
+      '--Chip-paddingX': '0.5rem',
+      '--Chip-label-paddingX': '0.2rem',
+      '--Chip-delete-radius':
+        'max(var(--Chip-radius) - var(--Chip-paddingX), min(var(--Chip-paddingX) / 2, var(--Chip-radius) / 2))',
+      padding: '0.25rem var(--Chip-paddingX)',
+      borderRadius: 'var(--Chip-radius)',
+      fontSize: 'var(--Chip-fontSize)',
+      position: 'relative',
       maxWidth: '100%',
       fontFamily: theme.vars.fontFamily.body,
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
-      height: 'var(--Chip-height)',
-      borderRadius: 'var(--Chip-border-radius)',
       whiteSpace: 'nowrap',
       transition:
         'background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-      // label will inherit this from root, then `clickable` class overrides this for both
-      cursor: 'default',
       // We disable the focus ring for mouse, touch and keyboard users.
       outline: 0,
       textDecoration: 'none',
-      border: 0, // Remove `button` border
-      padding: 0, // Remove `button` padding
       verticalAlign: 'middle',
       boxSizing: 'border-box',
       ...(ownerState.disabled && {
         opacity: 0.5,
         pointerEvents: 'none',
+      }),
+      ...(ownerState.clickable && {
+        cursor: 'pointer',
       }),
     },
     theme.variants[ownerState.variant!]?.[ownerState.color!],
@@ -124,22 +125,23 @@ const ChipLabel = styled('span', {
   name: 'MuiChip',
   slot: 'Label',
   overridesResolver: (props, styles) => styles.label,
-})<{ ownerState: ChipProps }>(({ ownerState }) => ({
+})<{ ownerState: ChipProps }>(({ theme, ownerState }) => ({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  ...(ownerState.size === 'sm' && {
-    paddingLeft: 8,
-    paddingRight: 8,
-  }),
-  ...(ownerState.size === 'md' && {
-    paddingLeft: 12,
-    paddingRight: 12,
-  }),
-  ...(ownerState.size === 'lg' && {
-    paddingLeft: 16,
-    paddingRight: 16,
-  }),
+  padding: '0 var(--Chip-label-paddingX)',
+  '& > button': {
+    fontSize: 'var(--Chip-fontSize)',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 0,
+    padding: 0,
+    border: 'none',
+    background: 'none',
+    ...theme.variants[ownerState.variant!]?.[ownerState.color!],
+  },
 }));
 
 /**
@@ -165,7 +167,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const chipRef = React.useRef(null);
   const handleRef = useForkRef(chipRef, ref);
   const clickable = clickableProp !== false && onClick ? true : clickableProp;
-  const component = clickable ? ButtonBase : ComponentProp || 'div';
+  const component = ComponentProp || 'div';
 
   const ownerState = {
     ...props,
@@ -202,7 +204,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
     >
       {startDecorator}
       <ChipLabel className={clsx(classes.label)} ownerState={ownerState}>
-        {children}
+        {clickable ? <button type="button">{children}</button> : children}
       </ChipLabel>
       {endDecorator}
     </ChipRoot>

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -174,7 +174,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const ownerState = {
     ...props,
     component,
-    disabled,
+    disabled: clickable && disabled ? true : undefined,
     size,
     color,
     clickable,
@@ -199,7 +199,6 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
     <ChipRoot
       as={component}
       className={clsx(classes.root, className)}
-      disabled={clickable && disabled ? true : undefined}
       onClick={onClick}
       ref={handleRef}
       ownerState={ownerState}

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -28,7 +28,7 @@ const useUtilityClasses = (
       variant && `variant${capitalize(variant)}`,
       clickable && 'clickable',
     ],
-    action: ['action', focusVisible && 'focusVisible'],
+    action: ['action', disabled && 'disabled', focusVisible && 'focusVisible'],
     label: ['label', size && `label${capitalize(size)}`],
     startDecorator: ['startDecorator'],
     endDecorator: ['endDecorator'],
@@ -200,6 +200,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const actionRef = React.useRef<HTMLElement | null>(null);
   const handleActionRef = useForkRef(actionRef, actionProps.ref);
   const { focusVisible, getRootProps } = useButton({
+    disabled,
     ...actionProps,
     component: actionComponent,
     ref: handleActionRef,

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -153,12 +153,12 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
     children,
     className,
     clickable: clickableProp,
-    color = 'neutral',
+    color = 'primary',
     component: ComponentProp,
     disabled = false,
     onClick,
     size = 'md',
-    variant = 'light',
+    variant = 'contained',
     startDecorator: startDecoratorProp,
     endDecorator: endDecoratorProp,
     ...other
@@ -235,7 +235,7 @@ Chip.propTypes /* remove-proptypes */ = {
   clickable: PropTypes.bool,
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
-   * @default 'neutral'
+   * @default 'primary'
    */
   color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['danger', 'info', 'neutral', 'primary', 'success', 'warning']),
@@ -274,7 +274,7 @@ Chip.propTypes /* remove-proptypes */ = {
   startDecorator: PropTypes.node,
   /**
    * The variant to use.
-   * @default 'light'
+   * @default 'contained'
    */
   variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['contained', 'light', 'outlined', 'text']),

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -33,41 +33,19 @@ const ChipStartDecorator = styled('span', {
   name: 'MuiChip',
   slot: 'StartDecorator',
   overridesResolver: (props, styles) => styles.startDecorator,
-})<{ ownerState: ChipProps }>(({ ownerState }) => ({
+})<{ ownerState: ChipProps }>({
   display: 'inherit',
-  ...(ownerState.size === 'sm' && {
-    marginLeft: 8,
-    marginRight: 8,
-  }),
-  ...(ownerState.size === 'md' && {
-    marginLeft: 12,
-    marginRight: 12,
-  }),
-  ...(ownerState.size === 'lg' && {
-    marginLeft: 16,
-    marginRight: 16,
-  }),
-}));
+  margin: '0 var(--Chip-decorator-marginX)',
+});
 
 const ChipEndDecorator = styled('span', {
   name: 'MuiChip',
   slot: 'EndDecorator',
   overridesResolver: (props, styles) => styles.endDecorator,
-})<{ ownerState: ChipProps }>(({ ownerState }) => ({
+})<{ ownerState: ChipProps }>({
   display: 'inherit',
-  ...(ownerState.size === 'sm' && {
-    marginLeft: 8,
-    marginRight: 8,
-  }),
-  ...(ownerState.size === 'md' && {
-    marginLeft: 12,
-    marginRight: 12,
-  }),
-  ...(ownerState.size === 'lg' && {
-    marginLeft: 16,
-    marginRight: 16,
-  }),
-}));
+  margin: '0 var(--Chip-decorator-marginX)',
+});
 
 const ChipRoot = styled('div', {
   name: 'MuiChip',
@@ -88,8 +66,10 @@ const ChipRoot = styled('div', {
         '--Chip-radius': '1.5rem',
         '--Chip-fontSize': theme.vars.fontSize.md,
       }),
+      '--Chip-color': theme.variants[ownerState.variant!]?.[ownerState.color!].color,
       '--Chip-paddingX': '0.5rem',
       '--Chip-label-paddingX': '0.2rem',
+      '--Chip-decorator-marginX': '0.5rem',
       '--Chip-delete-radius':
         'max(var(--Chip-radius) - var(--Chip-paddingX), min(var(--Chip-paddingX) / 2, var(--Chip-radius) / 2))',
       padding: '0.25rem var(--Chip-paddingX)',
@@ -125,7 +105,7 @@ const ChipLabel = styled('span', {
   name: 'MuiChip',
   slot: 'Label',
   overridesResolver: (props, styles) => styles.label,
-})<{ ownerState: ChipProps }>(({ theme, ownerState }) => ({
+})<{ ownerState: ChipProps }>({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
@@ -140,26 +120,9 @@ const ChipLabel = styled('span', {
     padding: 0,
     border: 'none',
     background: 'none',
-    ...theme.variants[ownerState.variant!]?.[ownerState.color!],
+    color: 'var(--Chip-color)',
   },
-}));
-
-const ChipDeleteComponent = styled('button', {
-  name: 'MuiChipDelete',
-  slot: 'Root',
-})`
-  width: 20px;
-  height: 20px;
-  font-size: 10px;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  border: 1px solid #888;
-  border-radius: 'var(--Chip-delete-radius)';
-  cursor: pointer;
-`;
-
-export const ChipDelete = () => <ChipDeleteComponent>{'X'}</ChipDeleteComponent>;
+});
 
 /**
  * Chips represent complex entities in small blocks, such as a contact.

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -144,6 +144,23 @@ const ChipLabel = styled('span', {
   },
 }));
 
+const ChipDeleteComponent = styled('button', {
+  name: 'MuiChipDelete',
+  slot: 'Root',
+})`
+  width: 20px;
+  height: 20px;
+  font-size: 10px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid #888;
+  border-radius: 'var(--Chip-delete-radius)';
+  cursor: pointer;
+`;
+
+export const ChipDelete = () => <ChipDeleteComponent>{'X'}</ChipDeleteComponent>;
+
 /**
  * Chips represent complex entities in small blocks, such as a contact.
  */

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -1,11 +1,7 @@
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import ButtonBase from '@mui/material/ButtonBase';
 import { OverridableComponent } from '@mui/types';
-import {
-  unstable_capitalize as capitalize,
-  unstable_unsupportedProp as unsupportedProp,
-  unstable_useForkRef as useForkRef,
-} from '@mui/utils';
+import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -152,12 +148,12 @@ const ChipLabel = styled('span', {
 const Chip = React.forwardRef(function Chip(inProps, ref) {
   const props = useThemeProps<typeof inProps & ChipProps>({ props: inProps, name: 'MuiChip' });
   const {
+    children,
     className,
     clickable: clickableProp,
     color = 'neutral',
     component: ComponentProp,
     disabled = false,
-    label,
     onClick,
     size = 'md',
     variant = 'light',
@@ -206,7 +202,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
     >
       {startDecorator}
       <ChipLabel className={clsx(classes.label)} ownerState={ownerState}>
-        {label}
+        {children}
       </ChipLabel>
       {endDecorator}
     </ChipRoot>
@@ -219,10 +215,9 @@ Chip.propTypes /* remove-proptypes */ = {
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * This prop isn't supported.
-   * Use the `component` prop if you need to change the children structure.
+   * The content of the component.
    */
-  children: unsupportedProp,
+  children: PropTypes.node,
   /**
    * @ignore
    */
@@ -258,10 +253,6 @@ Chip.propTypes /* remove-proptypes */ = {
    * Element placed after the children.
    */
   endDecorator: PropTypes.node,
-  /**
-   * The content of the component.
-   */
-  label: PropTypes.node,
   /**
    * @ignore
    */

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -1,0 +1,293 @@
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import ButtonBase from '@mui/material/ButtonBase';
+import { OverridableComponent } from '@mui/types';
+import {
+  unstable_capitalize as capitalize,
+  unstable_unsupportedProp as unsupportedProp,
+  unstable_useForkRef as useForkRef,
+} from '@mui/utils';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import { useThemeProps } from '../styles';
+import styled from '../styles/styled';
+import { getChipUtilityClass } from './chipClasses';
+import { ChipProps, ChipTypeMap } from './ChipProps';
+
+const useUtilityClasses = (ownerState: ChipProps) => {
+  const { disabled, size, color, clickable, variant } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      disabled && 'disabled',
+      color && `color${capitalize(color)}`,
+      size && `size${capitalize(size)}`,
+      variant && `variant${capitalize(variant)}`,
+      clickable && 'clickable',
+    ],
+    label: ['label', size && `label${capitalize(size)}`],
+    startDecorator: ['startDecorator'],
+    endDecorator: ['endDecorator'],
+  };
+
+  return composeClasses(slots, getChipUtilityClass, {});
+};
+
+const ChipStartDecorator = styled('span', {
+  name: 'MuiChip',
+  slot: 'StartDecorator',
+  overridesResolver: (props, styles) => styles.startDecorator,
+})<{ ownerState: ChipProps }>(({ ownerState }) => ({
+  display: 'inherit',
+  ...(ownerState.size === 'sm' && {
+    marginLeft: 8,
+    marginRight: 8,
+  }),
+  ...(ownerState.size === 'md' && {
+    marginLeft: 12,
+    marginRight: 12,
+  }),
+  ...(ownerState.size === 'lg' && {
+    marginLeft: 16,
+    marginRight: 16,
+  }),
+}));
+
+const ChipEndDecorator = styled('span', {
+  name: 'MuiChip',
+  slot: 'EndDecorator',
+  overridesResolver: (props, styles) => styles.endDecorator,
+})<{ ownerState: ChipProps }>(({ ownerState }) => ({
+  display: 'inherit',
+  ...(ownerState.size === 'sm' && {
+    marginLeft: 8,
+    marginRight: 8,
+  }),
+  ...(ownerState.size === 'md' && {
+    marginLeft: 12,
+    marginRight: 12,
+  }),
+  ...(ownerState.size === 'lg' && {
+    marginLeft: 16,
+    marginRight: 16,
+  }),
+}));
+
+const ChipRoot = styled('div', {
+  name: 'MuiChip',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: ChipProps }>(({ theme, ownerState }) => {
+  return [
+    {
+      ...(ownerState.size === 'sm' && {
+        '--Chip-height': '1.5rem',
+        '--Chip-border-radius': '0.75rem',
+        fontSize: theme.vars.fontSize.sm,
+      }),
+      ...(ownerState.size === 'md' && {
+        '--Chip-height': '2rem',
+        '--Chip-border-radius': '1rem',
+        fontSize: theme.vars.fontSize.md,
+      }),
+      ...(ownerState.size === 'lg' && {
+        '--Chip-height': '2.5rem',
+        '--Chip-border-radius': '1.25rem',
+        fontSize: theme.vars.fontSize.lg,
+      }),
+      maxWidth: '100%',
+      fontFamily: theme.vars.fontFamily.body,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: 'var(--Chip-height)',
+      borderRadius: 'var(--Chip-border-radius)',
+      whiteSpace: 'nowrap',
+      transition:
+        'background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+      // label will inherit this from root, then `clickable` class overrides this for both
+      cursor: 'default',
+      // We disable the focus ring for mouse, touch and keyboard users.
+      outline: 0,
+      textDecoration: 'none',
+      border: 0, // Remove `button` border
+      padding: 0, // Remove `button` padding
+      verticalAlign: 'middle',
+      boxSizing: 'border-box',
+      ...(ownerState.disabled && {
+        opacity: 0.5,
+        pointerEvents: 'none',
+      }),
+    },
+    theme.variants[ownerState.variant!]?.[ownerState.color!],
+  ];
+});
+
+const ChipLabel = styled('span', {
+  name: 'MuiChip',
+  slot: 'Label',
+  overridesResolver: (props, styles) => styles.label,
+})<{ ownerState: ChipProps }>(({ ownerState }) => ({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  ...(ownerState.size === 'sm' && {
+    paddingLeft: 8,
+    paddingRight: 8,
+  }),
+  ...(ownerState.size === 'md' && {
+    paddingLeft: 12,
+    paddingRight: 12,
+  }),
+  ...(ownerState.size === 'lg' && {
+    paddingLeft: 16,
+    paddingRight: 16,
+  }),
+}));
+
+/**
+ * Chips represent complex entities in small blocks, such as a contact.
+ */
+const Chip = React.forwardRef(function Chip(inProps, ref) {
+  const props = useThemeProps<typeof inProps & ChipProps>({ props: inProps, name: 'MuiChip' });
+  const {
+    className,
+    clickable: clickableProp,
+    color = 'neutral',
+    component: ComponentProp,
+    disabled = false,
+    label,
+    onClick,
+    size = 'md',
+    variant = 'light',
+    startDecorator: startDecoratorProp,
+    endDecorator: endDecoratorProp,
+    ...other
+  } = props;
+
+  const chipRef = React.useRef(null);
+  const handleRef = useForkRef(chipRef, ref);
+  const clickable = clickableProp !== false && onClick ? true : clickableProp;
+  const component = clickable ? ButtonBase : ComponentProp || 'div';
+
+  const ownerState = {
+    ...props,
+    component,
+    disabled,
+    size,
+    color,
+    clickable,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  const startDecorator = startDecoratorProp && (
+    <ChipStartDecorator className={classes.startDecorator} ownerState={ownerState}>
+      {startDecoratorProp}
+    </ChipStartDecorator>
+  );
+
+  const endDecorator = endDecoratorProp && (
+    <ChipEndDecorator className={classes.endDecorator} ownerState={ownerState}>
+      {endDecoratorProp}
+    </ChipEndDecorator>
+  );
+
+  return (
+    <ChipRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      disabled={clickable && disabled ? true : undefined}
+      onClick={onClick}
+      ref={handleRef}
+      ownerState={ownerState}
+      {...other}
+    >
+      {startDecorator}
+      <ChipLabel className={clsx(classes.label)} ownerState={ownerState}>
+        {label}
+      </ChipLabel>
+      {endDecorator}
+    </ChipRoot>
+  );
+}) as OverridableComponent<ChipTypeMap>;
+
+Chip.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * This prop isn't supported.
+   * Use the `component` prop if you need to change the children structure.
+   */
+  children: unsupportedProp,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, the chip will appear clickable, and will raise when pressed,
+   * even if the onClick prop is not defined.
+   * If `false`, the chip will not appear clickable, even if onClick prop is defined.
+   * This can be used, for example,
+   * along with the component prop to indicate an anchor Chip is clickable.
+   * Note: this controls the UI and does not affect the onClick event.
+   */
+  clickable: PropTypes.bool,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'neutral'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['danger', 'info', 'neutral', 'primary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Element placed after the children.
+   */
+  endDecorator: PropTypes.node,
+  /**
+   * The content of the component.
+   */
+  label: PropTypes.node,
+  /**
+   * @ignore
+   */
+  onClick: PropTypes.func,
+  /**
+   * The size of the component.
+   * It accepts theme values between 'sm' and 'lg'.
+   * @default 'md'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['lg', 'md', 'sm']),
+    PropTypes.string,
+  ]),
+  /**
+   * Element placed before the children.
+   */
+  startDecorator: PropTypes.node,
+  /**
+   * The variant to use.
+   * @default 'light'
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['contained', 'light', 'outlined', 'text']),
+    PropTypes.string,
+  ]),
+} as any;
+
+export default Chip;

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -93,6 +93,9 @@ const ChipRoot = styled('div', {
       }),
       ...(ownerState.clickable && {
         cursor: 'pointer',
+        '&:hover': {
+          opacity: 0.8,
+        },
       }),
     },
     theme.variants[ownerState.variant!]?.[ownerState.color!],

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -35,7 +35,7 @@ const ChipStartDecorator = styled('span', {
   overridesResolver: (props, styles) => styles.startDecorator,
 })<{ ownerState: ChipProps }>({
   display: 'inherit',
-  margin: '0 var(--Chip-decorator-marginX)',
+  padding: '0 0.2rem',
 });
 
 const ChipEndDecorator = styled('span', {
@@ -44,7 +44,7 @@ const ChipEndDecorator = styled('span', {
   overridesResolver: (props, styles) => styles.endDecorator,
 })<{ ownerState: ChipProps }>({
   display: 'inherit',
-  margin: '0 var(--Chip-decorator-marginX)',
+  padding: '0 0.2rem',
 });
 
 const ChipRoot = styled('div', {
@@ -68,8 +68,6 @@ const ChipRoot = styled('div', {
       }),
       '--Chip-color': theme.variants[ownerState.variant!]?.[ownerState.color!].color,
       '--Chip-paddingX': '0.5rem',
-      '--Chip-label-paddingX': '0.2rem',
-      '--Chip-decorator-marginX': '0.5rem',
       '--Chip-delete-radius':
         'max(var(--Chip-radius) - var(--Chip-paddingX), min(var(--Chip-paddingX) / 2, var(--Chip-radius) / 2))',
       padding: '0.25rem var(--Chip-paddingX)',
@@ -109,7 +107,7 @@ const ChipLabel = styled('span', {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  padding: '0 var(--Chip-label-paddingX)',
+  padding: '0 0.2rem',
   '& > button': {
     fontSize: 'var(--Chip-fontSize)',
     cursor: 'pointer',

--- a/packages/mui-joy/src/Chip/ChipColorContext.ts
+++ b/packages/mui-joy/src/Chip/ChipColorContext.ts
@@ -1,6 +1,0 @@
-import * as React from 'react';
-import { ChipProps } from './ChipProps';
-
-const ChipColorContext = React.createContext<ChipProps['color']>(undefined);
-
-export default ChipColorContext;

--- a/packages/mui-joy/src/Chip/ChipColorContext.ts
+++ b/packages/mui-joy/src/Chip/ChipColorContext.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { ChipProps } from './ChipProps';
+
+const ChipColorContext = React.createContext<ChipProps['color']>(undefined);
+
+export default ChipColorContext;

--- a/packages/mui-joy/src/Chip/ChipContext.ts
+++ b/packages/mui-joy/src/Chip/ChipContext.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { ChipProps } from './ChipProps';
+
+const ChipColorContext = React.createContext<Pick<ChipProps, 'disabled' | 'variant' | 'color'>>({
+  disabled: undefined,
+  variant: undefined,
+  color: undefined,
+});
+
+export default ChipColorContext;

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -1,5 +1,5 @@
-import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import * as React from 'react';
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/defaultTheme';
 import { ColorPaletteProp, VariantProp } from '../styles/types';
 

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { SxProps } from '../styles/defaultTheme';
 import { ColorPaletteProp, VariantProp } from '../styles/types';
 
+export type ChipSlot = 'root' | 'label' | 'startDecorator' | 'endDecorator'; 
+
 export interface ChipPropsColorOverrides {}
 export interface ChipPropsSizeOverrides {}
 export interface ChipPropsVariantOverrides {}

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { SxProps } from '../styles/defaultTheme';
 import { ColorPaletteProp, VariantProp } from '../styles/types';
 
-export type ChipSlot = 'root' | 'label' | 'startDecorator' | 'endDecorator'; 
+export type ChipSlot = 'root' | 'label' | 'startDecorator' | 'endDecorator';
 
 export interface ChipPropsColorOverrides {}
 export interface ChipPropsSizeOverrides {}

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -1,0 +1,70 @@
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import * as React from 'react';
+import { SxProps } from '../styles/defaultTheme';
+import { ColorPaletteProp, VariantProp } from '../styles/types';
+
+export interface ChipPropsColorOverrides {}
+export interface ChipPropsSizeOverrides {}
+export interface ChipPropsVariantOverrides {}
+
+export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P & {
+    /**
+     * This prop isn't supported.
+     * Use the `component` prop if you need to change the children structure.
+     */
+    children?: null;
+    /**
+     * If `true`, the chip will appear clickable, and will raise when pressed,
+     * even if the onClick prop is not defined.
+     * If `false`, the chip will not appear clickable, even if onClick prop is defined.
+     * This can be used, for example,
+     * along with the component prop to indicate an anchor Chip is clickable.
+     * Note: this controls the UI and does not affect the onClick event.
+     */
+    clickable?: boolean;
+    /**
+     * The color of the component. It supports those theme colors that make sense for this component.
+     * @default 'neutral'
+     */
+    color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, ChipPropsColorOverrides>;
+    /**
+     * If `true`, the component is disabled.
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * Element placed after the children.
+     */
+    endDecorator?: React.ReactNode;
+    /**
+     * The content of the component.
+     */
+    label?: React.ReactNode;
+    /**
+     * The size of the component.
+     * It accepts theme values between 'sm' and 'lg'.
+     * @default 'md'
+     */
+    size?: OverridableStringUnion<'sm' | 'md' | 'lg', ChipPropsSizeOverrides>;
+    /**
+     * Element placed before the children.
+     */
+    startDecorator?: React.ReactNode;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps;
+    /**
+     * The variant to use.
+     * @default 'light'
+     */
+    variant?: OverridableStringUnion<Exclude<VariantProp, 'text'>, ChipPropsVariantOverrides>;
+  };
+  defaultComponent: D;
+}
+
+export type ChipProps<
+  D extends React.ElementType = ChipTypeMap['defaultComponent'],
+  P = { component?: React.ElementType },
+> = OverrideProps<ChipTypeMap<P, D>, D>;

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -26,7 +26,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
     clickable?: boolean;
     /**
      * The color of the component. It supports those theme colors that make sense for this component.
-     * @default 'neutral'
+     * @default 'primary'
      */
     color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, ChipPropsColorOverrides>;
     /**
@@ -54,7 +54,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
     sx?: SxProps;
     /**
      * The variant to use.
-     * @default 'light'
+     * @default 'contained'
      */
     variant?: OverridableStringUnion<Exclude<VariantProp, 'text'>, ChipPropsVariantOverrides>;
   };

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -12,10 +12,9 @@ export interface ChipPropsVariantOverrides {}
 export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
     /**
-     * This prop isn't supported.
-     * Use the `component` prop if you need to change the children structure.
+     * The content of the component.
      */
-    children?: null;
+    children?: React.ReactNode;
     /**
      * If `true`, the chip will appear clickable, and will raise when pressed,
      * even if the onClick prop is not defined.
@@ -39,10 +38,6 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      * Element placed after the children.
      */
     endDecorator?: React.ReactNode;
-    /**
-     * The content of the component.
-     */
-    label?: React.ReactNode;
     /**
      * The size of the component.
      * It accepts theme values between 'sm' and 'lg'.

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -3,7 +3,7 @@ import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/defaultTheme';
 import { ColorPaletteProp, VariantProp } from '../styles/types';
 
-export type ChipSlot = 'root' | 'label' | 'startDecorator' | 'endDecorator';
+export type ChipSlot = 'root' | 'label' | 'action' | 'startDecorator' | 'endDecorator';
 
 export interface ChipPropsColorOverrides {}
 export interface ChipPropsSizeOverrides {}
@@ -12,18 +12,24 @@ export interface ChipPropsVariantOverrides {}
 export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P & {
     /**
+     * The props used for each slot inside the Input.
+     * @default {}
+     */
+    componentsProps?: {
+      root?: JSX.IntrinsicElements['div'];
+      label?: JSX.IntrinsicElements['span'];
+      action?: React.HTMLAttributes<HTMLElement> & {
+        href?: string;
+        component?: React.ElementType;
+        ref?: React.Ref<HTMLElement>;
+      };
+      startDecorator?: JSX.IntrinsicElements['span'];
+      endDecorator?: JSX.IntrinsicElements['span'];
+    };
+    /**
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * If `true`, the chip will appear clickable, and will raise when pressed,
-     * even if the onClick prop is not defined.
-     * If `false`, the chip will not appear clickable, even if onClick prop is defined.
-     * This can be used, for example,
-     * along with the component prop to indicate an anchor Chip is clickable.
-     * Note: this controls the UI and does not affect the onClick event.
-     */
-    clickable?: boolean;
     /**
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'primary'

--- a/packages/mui-joy/src/Chip/chipClasses.ts
+++ b/packages/mui-joy/src/Chip/chipClasses.ts
@@ -1,0 +1,81 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export interface ChipClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `onClick` is defined or `clickable={true}`. */
+  clickable: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="neutral"`. */
+  colorNeutral: string;
+  /** Styles applied to the root element if `color="danger"`. */
+  colorDanger: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** Styles applied to the endDecorator element if supplied. */
+  endDecorator: string;
+  /** State class applied to the root element if keyboard focused. */
+  focusVisible: string;
+  /** Styles applied to the label `span` element. */
+  label: string;
+  /** Styles applied to the label `span` element if `size="sm"`. */
+  labelSm: string;
+  /** Styles applied to the label `span` element if `size="md"`. */
+  labelMd: string;
+  /** Styles applied to the label `span` element if `size="lg"`. */
+  labelLg: string;
+  /** Styles applied to the root element if `size="sm"`. */
+  sizeSm: string;
+  /** Styles applied to the root element if `size="md"`. */
+  sizeMd: string;
+  /** Styles applied to the root element if `size="lg"`. */
+  sizeLg: string;
+  /** Styles applied to the startDecorator element if supplied. */
+  startDecorator: string;
+  /** Styles applied to the root element if `variant="contained"`. */
+  variantContained: string;
+  /** Styles applied to the root element if `variant="light"`. */
+  variantLight: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  variantOutlined: string;
+}
+
+export type ChipClassKey = keyof ChipClasses;
+
+export function getChipUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiChip', slot);
+}
+
+const chipClasses: ChipClasses = generateUtilityClasses('MuiChip', [
+  'root',
+  'clickable',
+  'colorPrimary',
+  'colorNeutral',
+  'colorDanger',
+  'colorInfo',
+  'colorSuccess',
+  'colorWarning',
+  'disabled',
+  'endDecorator',
+  'focusVisible',
+  'label',
+  'labelSm',
+  'labelMd',
+  'labelLg',
+  'sizeSm',
+  'sizeMd',
+  'sizeLg',
+  'startDecorator',
+  'variantContained',
+  'variantLight',
+  'variantOutlined',
+]);
+
+export default chipClasses;

--- a/packages/mui-joy/src/Chip/chipClasses.ts
+++ b/packages/mui-joy/src/Chip/chipClasses.ts
@@ -3,8 +3,6 @@ import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 export interface ChipClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element if `onClick` is defined or `clickable={true}`. */
-  clickable: string;
   /** Styles applied to the root element if `color="primary"`. */
   colorPrimary: string;
   /** Styles applied to the root element if `color="neutral"`. */

--- a/packages/mui-joy/src/Chip/index.ts
+++ b/packages/mui-joy/src/Chip/index.ts
@@ -1,0 +1,4 @@
+export { default } from './Chip';
+export { default as chipClasses } from './chipClasses';
+export * from './chipClasses';
+export * from './ChipProps';

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.test.js
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.test.js
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from 'test/utils';
+import { ThemeProvider } from '@mui/joy/styles';
+import Chip from '@mui/joy/Chip';
+import ChipDelete, { chipDeleteClasses as classes } from '@mui/joy/ChipDelete';
+
+describe('<ChipDelete />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<ChipDelete />, () => ({
+    classes,
+    inheritComponent: 'button',
+    render,
+    ThemeProvider,
+    muiName: 'MuiChipDelete',
+    refInstanceof: window.HTMLButtonElement,
+    testComponentPropWith: 'span',
+    testVariantProps: { variant: 'light' },
+    skip: ['classesRoot', 'componentsProp'],
+  }));
+
+  describe('Chip context', () => {
+    it('disabled', () => {
+      const { getByRole } = render(
+        <Chip disabled>
+          <ChipDelete />
+        </Chip>,
+      );
+      expect(getByRole('button')).to.have.attr('disabled');
+    });
+
+    it('change variant according to the Chip', () => {
+      const { getByRole } = render(
+        <Chip variant="light">
+          <ChipDelete />
+        </Chip>,
+      );
+      expect(getByRole('button')).to.have.class(classes.variantContained);
+    });
+
+    it('use variant prop if provided', () => {
+      const { getByRole } = render(
+        <Chip variant="light">
+          <ChipDelete variant="outlined" />
+        </Chip>,
+      );
+      expect(getByRole('button')).to.have.class(classes.variantOutlined);
+    });
+
+    it('change color according to the Chip', () => {
+      const { getByRole } = render(
+        <Chip color="danger">
+          <ChipDelete />
+        </Chip>,
+      );
+      expect(getByRole('button')).to.have.class(classes.colorDanger);
+    });
+
+    it('use color prop if provided', () => {
+      const { getByRole } = render(
+        <Chip color="danger">
+          <ChipDelete color="neutral" />
+        </Chip>,
+      );
+      expect(getByRole('button')).to.have.class(classes.colorNeutral);
+    });
+  });
+});

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -32,6 +32,9 @@ const ChipDeleteRoot = styled('button', {
   border: 'none',
   background: 'none',
   padding: '0px',
+  '&:hover': {
+    opacity: 0.8,
+  },
 });
 
 const DeleteIcon = createSvgIcon(

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -116,7 +116,7 @@ ChipDelete.propTypes /* remove-proptypes */ = {
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * @ignore
+   * If provided, it will replace the default icon.
    */
   children: PropTypes.node,
   /**

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -54,7 +54,7 @@ const ChipDeleteRoot = styled('button', {
 const chipVariantMapping = {
   outlined: 'light',
   light: 'contained',
-  contained: 'contained',
+  contained: 'light',
 } as const;
 
 const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -9,6 +9,7 @@ import styled from '../styles/styled';
 import Close from '../internal/svg-icons/Close';
 import { getChipDeleteUtilityClass } from './chipDeleteClasses';
 import { ChipDeleteProps, ChipDeleteTypeMap } from './ChipDeleteProps';
+import ChipColorContext from '../Chip/ChipColorContext';
 
 const useUtilityClasses = () => {
   const slots = {
@@ -47,7 +48,15 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
     name: 'MuiChipDelete',
   });
 
-  const { className, component, variant = 'contained', color = 'primary', ...other } = props;
+  const {
+    className,
+    component,
+    variant = 'contained',
+    color: colorProp = 'primary',
+    ...other
+  } = props;
+  const chipColor = React.useContext(ChipColorContext);
+  const color = inProps.color || chipColor || colorProp;
 
   const buttonRef = React.useRef<HTMLElement | null>(null);
   const handleRef = useForkRef(buttonRef, ref);

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -2,18 +2,25 @@ import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { OverridableComponent } from '@mui/types';
-import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { unstable_capitalize as capitalize, unstable_useForkRef as useForkRef } from '@mui/utils';
 import { unstable_composeClasses as composeClasses, useButton } from '@mui/base';
 import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
 import Close from '../internal/svg-icons/Close';
 import { getChipDeleteUtilityClass } from './chipDeleteClasses';
 import { ChipDeleteProps, ChipDeleteTypeMap } from './ChipDeleteProps';
-import ChipColorContext from '../Chip/ChipColorContext';
+import ChipContext from '../Chip/ChipContext';
 
-const useUtilityClasses = () => {
+const useUtilityClasses = (ownerState: ChipDeleteProps & { focusVisible: boolean }) => {
+  const { focusVisible, variant, color, disabled } = ownerState;
   const slots = {
-    root: ['root'],
+    root: [
+      'root',
+      disabled && 'disabled',
+      focusVisible && 'focusVisible',
+      variant && `variant${capitalize(variant)}`,
+      color && `color${capitalize(color)}`,
+    ],
   };
 
   return composeClasses(slots, getChipDeleteUtilityClass, {});
@@ -25,12 +32,14 @@ const ChipDeleteRoot = styled('button', {
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: ChipDeleteProps }>(({ theme, ownerState }) => [
   {
+    pointerEvents: 'visible', // force the ChipDelete to be hoverable because the decorator can have pointerEvents 'none'
     width: 'var(--Chip-delete-size, 1.5rem)',
     height: 'var(--Chip-delete-size, 1.5rem)',
     display: 'inline-flex',
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: 'var(--Chip-delete-radius)',
+    zIndex: 1, // overflow above sibling button or anchor
     border: 'none', // reset user agent stylesheet
     background: 'none', // reset user agent stylesheet
     padding: '0px', // reset user agent stylesheet
@@ -42,6 +51,12 @@ const ChipDeleteRoot = styled('button', {
   theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
 ]);
 
+const chipVariantMapping = {
+  outlined: 'light',
+  light: 'contained',
+  contained: 'contained',
+} as const;
+
 const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
   const props = useThemeProps<typeof inProps & ChipDeleteProps>({
     props: inProps,
@@ -51,30 +66,35 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
   const {
     className,
     component,
-    variant = 'contained',
-    color: colorProp = 'primary',
+    variant: variantProp,
+    color: colorProp,
+    disabled: disabledProp,
     ...other
   } = props;
-  const chipColor = React.useContext(ChipColorContext);
-  const color = inProps.color || chipColor || colorProp;
+  const chipContext = React.useContext(ChipContext);
+  const color = colorProp || chipContext.color || 'primary';
+  const variant = variantProp || chipVariantMapping[chipContext.variant!] || 'contained';
+  const disabled = disabledProp ?? chipContext.disabled;
 
   const buttonRef = React.useRef<HTMLElement | null>(null);
   const handleRef = useForkRef(buttonRef, ref);
 
   const { focusVisible, getRootProps } = useButton({
     ...props,
+    disabled,
     component,
     ref: handleRef,
   });
 
   const ownerState = {
     ...props,
+    disabled,
     variant,
     color,
     focusVisible,
   };
 
-  const classes = useUtilityClasses();
+  const classes = useUtilityClasses(ownerState);
 
   return (
     <ChipDeleteRoot
@@ -103,10 +123,24 @@ ChipDelete.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   * @default 'primary'
+   */
+  color: PropTypes.oneOf(['danger', 'info', 'neutral', 'primary', 'success', 'warning']),
+  /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
    */
   component: PropTypes.elementType,
+  /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The variant to use.
+   * @default 'contained'
+   */
+  variant: PropTypes.oneOf(['contained', 'light', 'outlined', 'text']),
 } as any;
 
 export default ChipDelete;

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -1,11 +1,12 @@
-import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { OverridableComponent } from '@mui/types';
+import * as React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import { OverridableComponent } from '@mui/types';
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { unstable_composeClasses as composeClasses, useButton } from '@mui/base';
 import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
-import createSvgIcon from '../utils/createSvgIcon';
+import Close from '../internal/svg-icons/Close';
 import { getChipDeleteUtilityClass } from './chipDeleteClasses';
 import { ChipDeleteProps, ChipDeleteTypeMap } from './ChipDeleteProps';
 
@@ -21,26 +22,24 @@ const ChipDeleteRoot = styled('button', {
   name: 'MuiChipDelete',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ChipDeleteProps }>({
-  color: 'var(--Chip-color)',
-  fontSize: 'var(--Chip-fontSize)',
-  display: 'inline-flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  borderRadius: 'var(--Chip-delete-radius)',
-  cursor: 'pointer',
-  border: 'none',
-  background: 'none',
-  padding: '0px',
-  '&:hover': {
-    opacity: 0.8,
+})<{ ownerState: ChipDeleteProps }>(({ theme, ownerState }) => [
+  {
+    width: 'var(--Chip-delete-size, 1.5rem)',
+    height: 'var(--Chip-delete-size, 1.5rem)',
+    display: 'inline-flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 'var(--Chip-delete-radius)',
+    border: 'none', // reset user agent stylesheet
+    background: 'none', // reset user agent stylesheet
+    padding: '0px', // reset user agent stylesheet
   },
-});
-
-const DeleteIcon = createSvgIcon(
-  <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z" />,
-  'Delete',
-);
+  theme.focus.default,
+  theme.variants[ownerState.variant!]?.[ownerState.color!],
+  theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
+  theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
+  theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
+]);
 
 const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
   const props = useThemeProps<typeof inProps & ChipDeleteProps>({
@@ -48,9 +47,23 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
     name: 'MuiChipDelete',
   });
 
-  const { className, component, ...other } = props;
+  const { className, component, variant = 'contained', color = 'primary', ...other } = props;
 
-  const ownerState = props;
+  const buttonRef = React.useRef<HTMLElement | null>(null);
+  const handleRef = useForkRef(buttonRef, ref);
+
+  const { focusVisible, getRootProps } = useButton({
+    ...props,
+    component,
+    ref: handleRef,
+  });
+
+  const ownerState = {
+    ...props,
+    variant,
+    color,
+    focusVisible,
+  };
 
   const classes = useUtilityClasses();
 
@@ -58,11 +71,11 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
     <ChipDeleteRoot
       as={component}
       className={clsx(classes.root, className)}
-      ref={ref}
       ownerState={ownerState}
       {...other}
+      {...getRootProps()}
     >
-      <DeleteIcon />
+      <Close />
     </ChipDeleteRoot>
   );
 }) as OverridableComponent<ChipDeleteTypeMap>;

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -1,0 +1,87 @@
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { OverridableComponent } from '@mui/types';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import { useThemeProps } from '../styles';
+import styled from '../styles/styled';
+import createSvgIcon from '../utils/createSvgIcon';
+import { getChipDeleteUtilityClass } from './chipDeleteClasses';
+import { ChipDeleteProps, ChipDeleteTypeMap } from './ChipDeleteProps';
+
+const useUtilityClasses = () => {
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getChipDeleteUtilityClass, {});
+};
+
+const ChipDeleteRoot = styled('button', {
+  name: 'MuiChipDelete',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: ChipDeleteProps }>({
+  color: 'var(--Chip-color)',
+  fontSize: 'var(--Chip-fontSize)',
+  display: 'inline-flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: 'var(--Chip-delete-radius)',
+  cursor: 'pointer',
+  border: 'none',
+  background: 'none',
+  padding: '0px',
+});
+
+const DeleteIcon = createSvgIcon(
+  <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z" />,
+  'Delete',
+);
+
+const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
+  const props = useThemeProps<typeof inProps & ChipDeleteProps>({
+    props: inProps,
+    name: 'MuiChipDelete',
+  });
+
+  const { className, component, ...other } = props;
+
+  const ownerState = props;
+
+  const classes = useUtilityClasses();
+
+  return (
+    <ChipDeleteRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      ref={ref}
+      ownerState={ownerState}
+      {...other}
+    >
+      <DeleteIcon />
+    </ChipDeleteRoot>
+  );
+}) as OverridableComponent<ChipDeleteTypeMap>;
+
+ChipDelete.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+} as any;
+
+export default ChipDelete;

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -66,6 +66,7 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
   const {
     className,
     component,
+    children,
     variant: variantProp,
     color: colorProp,
     disabled: disabledProp,
@@ -104,7 +105,7 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
       {...other}
       {...getRootProps()}
     >
-      <Close />
+      {children ?? <Close />}
     </ChipDeleteRoot>
   );
 }) as OverridableComponent<ChipDeleteTypeMap>;

--- a/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
+++ b/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
@@ -1,10 +1,30 @@
-import { OverrideProps } from '@mui/types';
 import * as React from 'react';
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import { SxProps } from '../styles/defaultTheme';
+import { ColorPaletteProp, VariantProp } from '../styles/types';
 
 export type ChipDeleteSlot = 'root';
 
+export interface ChipPropsColorOverrides {}
+export interface ChipPropsVariantOverrides {}
+
 export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button'> {
-  props: P & {};
+  props: P & {
+    /**
+     * The color of the component. It supports those theme colors that make sense for this component.
+     * @default 'primary'
+     */
+    color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, ChipPropsColorOverrides>;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps;
+    /**
+     * The variant to use.
+     * @default 'contained'
+     */
+    variant?: OverridableStringUnion<Exclude<VariantProp, 'text'>, ChipPropsVariantOverrides>;
+  };
   defaultComponent: D;
 }
 

--- a/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
+++ b/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
@@ -5,8 +5,8 @@ import { ColorPaletteProp, VariantProp } from '../styles/types';
 
 export type ChipDeleteSlot = 'root';
 
-export interface ChipPropsColorOverrides {}
-export interface ChipPropsVariantOverrides {}
+export interface ChipDeletePropsColorOverrides {}
+export interface ChipDeletePropsVariantOverrides {}
 
 export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button'> {
   props: P & {
@@ -14,7 +14,10 @@ export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button
      * The color of the component. It supports those theme colors that make sense for this component.
      * @default 'primary'
      */
-    color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, ChipPropsColorOverrides>;
+    color?: OverridableStringUnion<
+      Exclude<ColorPaletteProp, 'context'>,
+      ChipDeletePropsColorOverrides
+    >;
     /**
      * If provided, it will replace the default icon.
      */
@@ -27,7 +30,7 @@ export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button
      * The variant to use.
      * @default 'contained'
      */
-    variant?: OverridableStringUnion<VariantProp, ChipPropsVariantOverrides>;
+    variant?: OverridableStringUnion<VariantProp, ChipDeletePropsVariantOverrides>;
   };
   defaultComponent: D;
 }

--- a/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
+++ b/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
@@ -23,7 +23,7 @@ export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button
      * The variant to use.
      * @default 'contained'
      */
-    variant?: OverridableStringUnion<Exclude<VariantProp, 'text'>, ChipPropsVariantOverrides>;
+    variant?: OverridableStringUnion<VariantProp, ChipPropsVariantOverrides>;
   };
   defaultComponent: D;
 }

--- a/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
+++ b/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
@@ -1,0 +1,14 @@
+import { OverrideProps } from '@mui/types';
+import * as React from 'react';
+
+export type ChipDeleteSlot = 'root';
+
+export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button'> {
+  props: P & {};
+  defaultComponent: D;
+}
+
+export type ChipDeleteProps<
+  D extends React.ElementType = ChipDeleteTypeMap['defaultComponent'],
+  P = { component?: React.ElementType },
+> = OverrideProps<ChipDeleteTypeMap<P, D>, D>;

--- a/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
+++ b/packages/mui-joy/src/ChipDelete/ChipDeleteProps.ts
@@ -16,6 +16,10 @@ export interface ChipDeleteTypeMap<P = {}, D extends React.ElementType = 'button
      */
     color?: OverridableStringUnion<Exclude<ColorPaletteProp, 'context'>, ChipPropsColorOverrides>;
     /**
+     * If provided, it will replace the default icon.
+     */
+    children?: React.ReactNode;
+    /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */
     sx?: SxProps;

--- a/packages/mui-joy/src/ChipDelete/chipDeleteClasses.ts
+++ b/packages/mui-joy/src/ChipDelete/chipDeleteClasses.ts
@@ -1,0 +1,14 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export interface ChipDeleteClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export function getChipDeleteUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiChipDelete', slot);
+}
+
+const chipDeleteClasses: ChipDeleteClasses = generateUtilityClasses('MuiChipDelete', ['root']);
+
+export default chipDeleteClasses;

--- a/packages/mui-joy/src/ChipDelete/chipDeleteClasses.ts
+++ b/packages/mui-joy/src/ChipDelete/chipDeleteClasses.ts
@@ -3,12 +3,44 @@ import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 export interface ChipDeleteClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="neutral"`. */
+  colorNeutral: string;
+  /** Styles applied to the root element if `color="danger"`. */
+  colorDanger: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** Styles applied to the root element if `variant="text"`. */
+  variantText: string;
+  /** Styles applied to the root element if `variant="contained"`. */
+  variantContained: string;
+  /** Styles applied to the root element if `variant="light"`. */
+  variantLight: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  variantOutlined: string;
 }
 
 export function getChipDeleteUtilityClass(slot: string): string {
   return generateUtilityClass('MuiChipDelete', slot);
 }
 
-const chipDeleteClasses: ChipDeleteClasses = generateUtilityClasses('MuiChipDelete', ['root']);
+const chipDeleteClasses: ChipDeleteClasses = generateUtilityClasses('MuiChipDelete', [
+  'root',
+  'colorPrimary',
+  'colorNeutral',
+  'colorDanger',
+  'colorInfo',
+  'colorSuccess',
+  'colorWarning',
+  'variantText',
+  'variantContained',
+  'variantLight',
+  'variantOutlined',
+]);
 
 export default chipDeleteClasses;

--- a/packages/mui-joy/src/ChipDelete/index.ts
+++ b/packages/mui-joy/src/ChipDelete/index.ts
@@ -1,0 +1,1 @@
+export { ChipDelete as default } from '../Chip/Chip';

--- a/packages/mui-joy/src/ChipDelete/index.ts
+++ b/packages/mui-joy/src/ChipDelete/index.ts
@@ -1,1 +1,4 @@
-export { ChipDelete as default } from '../Chip/Chip';
+export { default } from './ChipDelete';
+export * from './chipDeleteClasses';
+export { default as chipDeleteClasses } from './chipDeleteClasses';
+export * from './ChipDeleteProps';

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -53,6 +53,7 @@ export { default as Chip } from './Chip';
 export * from './Chip';
 
 export { default as ChipDelete } from './ChipDelete';
+export * from './ChipDelete';
 
 export { default as FormLabel } from './FormLabel';
 export * from './FormLabel';

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -52,6 +52,8 @@ export * from './Checkbox';
 export { default as Chip } from './Chip';
 export * from './Chip';
 
+export { default as ChipDelete } from './ChipDelete';
+
 export { default as FormLabel } from './FormLabel';
 export * from './FormLabel';
 

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -49,6 +49,9 @@ export * from './Sheet';
 export { default as Checkbox } from './Checkbox';
 export * from './Checkbox';
 
+export { default as Chip } from './Chip';
+export * from './Chip';
+
 export { default as FormLabel } from './FormLabel';
 export * from './FormLabel';
 

--- a/packages/mui-joy/src/internal/svg-icons/Close.tsx
+++ b/packages/mui-joy/src/internal/svg-icons/Close.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import createSvgIcon from '../../utils/createSvgIcon';
+
+/**
+ * @ignore - internal component.
+ */
+export default createSvgIcon(
+  <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />,
+  'Close',
+);

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -24,6 +24,7 @@ import { SvgIconProps, SvgIconSlot } from '../SvgIcon/SvgIconProps';
 import { SwitchProps, SwitchSlot } from '../Switch/SwitchProps';
 import { TextFieldProps, TextFieldSlot } from '../TextField/TextFieldProps';
 import { TypographyProps, TypographySlot } from '../Typography/TypographyProps';
+import { ChipProps, ChipSlot } from '../Chip/ChipProps';
 
 export type OverridesStyleRules<
   ClassKey extends string = string,
@@ -116,6 +117,10 @@ export interface Components<Theme = unknown> {
   MuiCheckbox?: {
     defaultProps?: Partial<CheckboxProps>;
     styleOverrides?: OverridesStyleRules<CheckboxSlot, CheckboxProps, Theme>;
+  };
+  MuiChip?: {
+    defaultProps?: Partial<ChipProps>;
+    styleOverrides?: OverridesStyleRules<ChipSlot, ChipProps, Theme>;
   };
   MuiFormLabel?: {
     defaultProps?: Partial<FormLabelProps>;

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -25,6 +25,7 @@ import { SwitchProps, SwitchSlot } from '../Switch/SwitchProps';
 import { TextFieldProps, TextFieldSlot } from '../TextField/TextFieldProps';
 import { TypographyProps, TypographySlot } from '../Typography/TypographyProps';
 import { ChipProps, ChipSlot } from '../Chip/ChipProps';
+import { ChipDeleteProps, ChipDeleteSlot } from '../ChipDelete/ChipDeleteProps';
 
 export type OverridesStyleRules<
   ClassKey extends string = string,
@@ -121,6 +122,10 @@ export interface Components<Theme = unknown> {
   MuiChip?: {
     defaultProps?: Partial<ChipProps>;
     styleOverrides?: OverridesStyleRules<ChipSlot, ChipProps, Theme>;
+  };
+  MuiChipDelete?: {
+    defaultProps?: Partial<ChipDeleteProps>;
+    styleOverrides?: OverridesStyleRules<ChipDeleteSlot, ChipDeleteProps, Theme>;
   };
   MuiFormLabel?: {
     defaultProps?: Partial<FormLabelProps>;

--- a/packages/mui-joy/src/styles/defaultTheme.ts
+++ b/packages/mui-joy/src/styles/defaultTheme.ts
@@ -340,8 +340,8 @@ const internalDefaultTheme = {
   focus: {
     default: {
       '&.Mui-focusVisible, &:focus-visible': {
-        outline: '4px solid',
-        outlineColor: 'var(--joy-palette-focusVisible)',
+        outlineOffset: 0, // reset user agent stylesheet
+        outline: '4px solid var(--joy-palette-focusVisible)',
       },
     },
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**This PR includes:**
- correcting typos in Joy `SvgIcon` demo / Joy `Avatar` demo / Joy `Avatar` API code
- addition of Joy `Chip` component
- tests for Joy `Chip` component

**Props**: `startDecorator`, `endDecorator`, `color`, `size`, `variant`, `disabled`

**Default values**:
- `color`: `primary`
- `size`: `md`
- `variant`: `contained`
- `disabled`: `false`

I removed `onDelete`, `icon`, `avatar`, `label`, `clickable` and `deleteIcon` props and added `startDecorator` / `endDecorator` following up with this [discussion](https://github.com/mui/material-ui/pull/31873#discussion_r830919915)

Preview: https://deploy-preview-31983--material-ui.netlify.app/experiments/joy/chip/

**Lines of code comparison**
|                          | Material   | Joy        | % change   |
| ------------------------ | ---------- | ---------- | ---------- |
| Chip                     | 560        | 350        | -37.50     |
| ChipDelete               |            | 148        |            |
| total                    | 560        | 498        | -11.07     |