### PR TITLE
[docs] Update Learn page copy and resource list

### DIFF
--- a/docs/data/material/getting-started/learn/learn.md
+++ b/docs/data/material/getting-started/learn/learn.md
@@ -1,4 +1,4 @@
-# Learn MUI
+# Learning Resources
 
 <p class="description">New to MUI? It's easy to learn if you know where to start! This guide will help you to get started quickly.</p>
 

--- a/docs/data/material/getting-started/learn/learn.md
+++ b/docs/data/material/getting-started/learn/learn.md
@@ -4,7 +4,7 @@
 
 ## Your first component
 
-The following code snippet contains everything you need to start building an app with Material UI, beginning with the `<Button>` component:
+The following code snippet demonstrates a basic Material UI app that features a `<Button>` component:
 
 ```jsx
 import * as React from 'react';

--- a/docs/data/material/getting-started/learn/learn.md
+++ b/docs/data/material/getting-started/learn/learn.md
@@ -1,61 +1,65 @@
 # Learning Resources
 
-<p class="description">New to MUI? It's easy to learn if you know where to start! This guide will help you to get started quickly.</p>
+<p class="description">New to Material UI? Get up to speed quickly with our curated list of learning resources.</p>
 
-Developers come to MUI from different backgrounds and with different learning styles. Whether you prefer a more theoretical or practical approach, we hope you'll find this section helpful.
-Like any unfamiliar technology, MUI does have a learning curve. With practice and some patience, you will soon get the hang of it.
+## Your first component
 
-## First example
+The following code snippet contains everything you need to start building an app with Material UI, beginning with the `<Button>` component:
 
-The [usage page](/getting-started/usage/#quick-start) contains a small MUI example with a live editor.
-Even if you don't know anything about MUI yet, try changing the code and see how it affects the result.
+```jsx
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import Button from '@mui/material/Button';
+
+function App() {
+  return (
+    <Button variant="contained" color="primary">
+      Hello World
+    </Button>
+  );
+}
+
+ReactDOM.render(<App />, document.querySelector('#app'));
+```
+
+In the interactive demo below, try changing the code and see how it affects the output. (Hint: change `variant` to `"outlined"` and `color` to `"secondary"`. For more options, see the [`Button` component page](components/buttons/).)
+
+{{"demo": "../usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Example projects
 
-There are [some example projects](/getting-started/example-projects/) available, providing the infrastructure needed to develop and deploy websites in React.
+Visit the [example projects](/getting-started/example-projects/) page to see how we recommend implementing Material UI with various React libraries and frameworks like Next.js, Gatsby, Create React App, and more.
 
 ## Templates
 
-This [selection of basic templates](/getting-started/templates/) will help you get started building your app.
+Check out our [selection of basic templates](/getting-started/templates/) to get started building your next app more quickly.
 
 ## Recommended resources
 
-> ⚠️ Note that the resources linked below are using MUI v4, which is not the latest major version. As v5 has been released recently, it will take some time till new contents are created. If you have created any learning material for v5, let us know and we can link them here.
+Beyond our official documentation, there are countless members of our community who create fantastic tutorials and guides for working with Material UI.
 
-When first learning MUI, you might find third-party blog posts, books and video courses more helpful than the official documentation.
-Here are some recommended resources, some of which are free.
+The following is a curated list of some of the best third-party resources we've found—both free and paid—for learning how to build beautiful apps with our components.
+
+> **Note:** as of Spring 2022, the paid resources available all refer to outdated versions of Material UI (before v5) so unless you're using an older version, you will be more successful with the free resources.
 
 ### Free
 
-- **Introduction to MUI**: a series of videos covering all the important MUI components.
-  - 📹 [The videos](https://www.youtube.com/watch?v=pHclLuRolzE&list=PLQg6GaokU5CwiVmsZ0d_9Zsg_DnIP_xwr)
-- **Customize MUI for your project**: a look at how you can customize MUI to align with your company identity (design system) and products
-  - 📹 [The videos](https://www.youtube.com/watch?v=bDkB3LoQKxs)
-- **Meet MUI — your new favorite user interface library**: a blog post that guides you in building a Todo MVC while covering some important concepts of MUI.
-  - 📝 [The blog post](https://www.freecodecamp.org/news/meet-your-material-ui-your-new-favorite-user-interface-library-6349a1c88a8c/)
-- **Learn React & MUI**: a series of videos covering all the important MUI components.
-  - 📹 [The videos](https://www.youtube.com/watch?v=xm4LX5fJKZ8&list=PLcCp4mjO-z98WAu4sd0eVha1g-NMfzHZk)
-- **Getting Started With MUI For React**: a blog post that guides you in building a simple card list.
-  - 📝 [The blog post](https://medium.com/codingthesmartway-com-blog/getting-started-with-material-ui-for-react-material-design-for-react-364b2688b555)
-  - 📹 [The video](https://www.youtube.com/watch?v=PWadEeOuv5o)
-- **Elegant UX in React with MUI**: a blog post covering some important MUI concepts.
-  - 📝 [The blog post](https://www.digitalocean.com/community/tutorials/react-material-ui)
+- [**Material UI v5 Crash Course**](https://www.youtube.com/watch?v=o1chMISeTC0) video by Laith Harb: everything you need to know to start building with the latest version of Material UI.
+
+- [**React + Material UI - From Zero to Hero**](https://www.youtube.com/playlist?list=PLDxCaNaYIuUlG5ZqoQzFE27CUOoQvOqnQ) video series by The Atypical Developer: build along with this in-depth series, from basic installation through advanced component implementation.
+
+- [**Next.js 11 Setup with Material UI v5**](https://www.youtube.com/watch?v=IFaFFmPYyMI) by Leo Roese: learn how to integrate Material UI into your Next.js app, using Emotion as the style engine.
+
+- [**Create a Responsive Navigation Bar with Material UI v5**](https://www.youtube.com/watch?v=lUkxSnJ7aDw) by Nikhil Thadani: detailed walkthrough using Material UI with Create React App.
+
+- [**The Clever Dev**](https://www.youtube.com/channel/UCb6AZy0_D1y661PMZck3jOw) and [**The Smart Devpreneur**](https://smartdevpreneur.com/category/javascript/material-ui/) by Jon M: dozens of high-quality videos and articles digging deep into the nuts and bolts of Material UI.
 
 ### Paid
 
-- **Implement high fidelity designs**: Bridge the gap between Design & Development. Break down detailed designs and bring them to life with MUI and React.
+- [**Implement High Fidelity Designs with Material-UI and ReactJS**](https://www.udemy.com/course/implement-high-fidelity-designs-with-material-ui-and-reactjs/) course by Zachary Reese: Bridge the gap between design & development. Break down detailed designs and bring them to life with Material UI (v4) and React.
 
-  - 💻 [The Course](https://www.udemy.com/course/implement-high-fidelity-designs-with-material-ui-and-reactjs/)
+- [**Material UI with React**](https://bonsaiilabs.com/courseDetail/material-ui-with-react/) course by bonsaiilabs: Learn the fundamentals of Google Material Design and how to develop an end-to-end flight search and booking application using Material UI and React.
 
-- **Apply Google Material Design**: This course teaches the fundamentals of Google Material Design and how to develop an end-to-end flight search and booking application using MUI and React.
+- [**React Material UI Cookbook**](https://www.amazon.com/gp/product/1789615224/) by Adam Boduch: Build modern-day applications by implementing Material Design principles in React, using Material UI.
 
-  - 📹 [Watch Course Trailer](https://www.youtube.com/watch?v=hhZ6yFvCWho)
-  - 💻 [The Course](https://bonsaiilabs.com/courseDetail/material-ui-with-react/)
-
-- **Cookbook**: Build modern-day applications by implementing Material Design principles in React, using MUI.
-  - 📘 [The book](https://www.amazon.com/gp/product/1789615224/)
-
-[![cookbook](/static/blog/material-ui-v4-is-out/cookbook.png)](https://www.amazon.com/gp/product/1789615224/)
-
-- **Builder Book**: Learn how to build a full-stack JavaScript and SaaS web application from scratch, using a Modern JavaScript stack and MUI.
-  - 📘 [The book](https://builderbook.org/)
+- [**Builder Book**](https://builderbook.org/) by Kelly and Timur: Learn how to build a full-stack JavaScript and SaaS web application from scratch, using a modern JavaScript stack and Material UI (v4).

--- a/docs/data/material/getting-started/learn/learn.md
+++ b/docs/data/material/getting-started/learn/learn.md
@@ -40,7 +40,7 @@ Beyond our official documentation, there are countless members of our community 
 
 The following is a curated list of some of the best third-party resources we've found—both free and paid—for learning how to build beautiful apps with our components.
 
-> **Note:** as of Spring 2022, the paid resources available all refer to outdated versions of Material UI (before v5) so unless you're using an older version, you will be more successful with the free resources.
+> **Note:** as of the second quarter of 2022, the paid resources available all refer to outdated versions of Material UI (before v5) so unless you're using an older version, you will be more successful with the free resources.
 
 ### Free
 

--- a/docs/data/material/getting-started/learn/learn.md
+++ b/docs/data/material/getting-started/learn/learn.md
@@ -1,4 +1,4 @@
-# Learning Resources
+# Learning resources
 
 <p class="description">New to Material UI? Get up to speed quickly with our curated list of learning resources.</p>
 
@@ -38,9 +38,7 @@ Check out our [selection of basic templates](/getting-started/templates/) to get
 
 Beyond our official documentation, there are countless members of our community who create fantastic tutorials and guides for working with Material UI.
 
-The following is a curated list of some of the best third-party resources we've found—both free and paid—for learning how to build beautiful apps with our components.
-
-> **Note:** as of the second quarter of 2022, the paid resources available all refer to outdated versions of Material UI (before v5) so unless you're using an older version, you will be more successful with the free resources.
+The following is a curated list of some of the best third-party resources we've found for learning how to build beautiful apps with our components.
 
 ### Free
 
@@ -53,13 +51,3 @@ The following is a curated list of some of the best third-party resources we've 
 - [**Create a Responsive Navigation Bar with Material UI v5**](https://www.youtube.com/watch?v=lUkxSnJ7aDw) by Nikhil Thadani: detailed walkthrough using Material UI with Create React App.
 
 - [**The Clever Dev**](https://www.youtube.com/channel/UCb6AZy0_D1y661PMZck3jOw) and [**The Smart Devpreneur**](https://smartdevpreneur.com/category/javascript/material-ui/) by Jon M: dozens of high-quality videos and articles digging deep into the nuts and bolts of Material UI.
-
-### Paid
-
-- [**Implement High Fidelity Designs with Material-UI and ReactJS**](https://www.udemy.com/course/implement-high-fidelity-designs-with-material-ui-and-reactjs/) course by Zachary Reese: Bridge the gap between design & development. Break down detailed designs and bring them to life with Material UI (v4) and React.
-
-- [**Material UI with React**](https://bonsaiilabs.com/courseDetail/material-ui-with-react/) course by bonsaiilabs: Learn the fundamentals of Google Material Design and how to develop an end-to-end flight search and booking application using Material UI and React.
-
-- [**React Material UI Cookbook**](https://www.amazon.com/gp/product/1789615224/) by Adam Boduch: Build modern-day applications by implementing Material Design principles in React, using Material UI.
-
-- [**Builder Book**](https://builderbook.org/) by Kelly and Timur: Learn how to build a full-stack JavaScript and SaaS web application from scratch, using a modern JavaScript stack and Material UI (v4).

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -43,7 +43,7 @@ const pages: readonly MuiPage[] = [
       { pathname: '/getting-started/usage' },
       { pathname: '/getting-started/example-projects' },
       { pathname: '/getting-started/templates' },
-      { pathname: '/getting-started/learn' },
+      { pathname: '/getting-started/learn', title: 'Learning resources' },
       { pathname: '/getting-started/faq', title: 'FAQs' },
       { pathname: '/getting-started/supported-components' },
       { pathname: '/getting-started/supported-platforms' },

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -164,7 +164,7 @@
     "/getting-started/usage": "Usage",
     "/getting-started/example-projects": "Example Projects",
     "/getting-started/templates": "Templates",
-    "/getting-started/learn": "Learn",
+    "/getting-started/learn": "Learning resources",
     "/getting-started/faq": "FAQs",
     "/getting-started/supported-components": "Supported Components",
     "/getting-started/supported-platforms": "Supported Platforms",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://deploy-preview-31989--material-ui.netlify.app/getting-started/learn/

This PR revises the Learn page, primarily to replace outdated third-party resources with newer v5 content that the community has created. 

I also took the liberty of dropping the Usage demo directly into this doc rather than linking to the Quick Start page, to encourage the reader to stay in one place and make it easier for them to play around.

One question: Is it worthwhile to continue to list the outdated paid resources? I added a note to underscore this fact, but I would still hate to set someone up for failure by recommending that they spend money on outdated info.

<img width="898" alt="Screen Shot 2022-03-25 at 1 40 12 PM" src="https://user-images.githubusercontent.com/71297412/160181959-20c7d45a-9196-4ff6-be29-b3e522622471.png">

