### PR TITLE
[codemod] Fix variant prop placement

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/variant-prop.js
+++ b/packages/mui-codemod/src/v5.0.0/variant-prop.js
@@ -13,7 +13,7 @@ export default function transformer(file, api, options) {
     );
 
     if (!variant) {
-      attributes.push(j.jsxAttribute(j.jsxIdentifier('variant'), j.literal('standard')));
+      attributes.unshift(j.jsxAttribute(j.jsxIdentifier('variant'), j.literal('standard')));
     }
   }
 

--- a/packages/mui-codemod/src/v5.0.0/variant-prop.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/variant-prop.test/expected.js
@@ -6,15 +6,15 @@ import FormControl from '@material-ui/core/FormControl';
 export default function TextFieldComponent(props) {
   return (
     <div>
-      <TextField {...props} variant="standard" />
+      <TextField variant="standard" {...props} />
       <TextField variant="outlined" />
       <TextField variant="standard" />
       <TextField variant="filled" />
-      <Select {...props} variant="standard" />
+      <Select variant="standard" {...props} />
       <Select variant="outlined" />
       <Select variant="standard" />
       <Select variant="filled" />
-      <FormControl {...props} variant="standard" />
+      <FormControl variant="standard" {...props} />
       <FormControl variant="outlined" />
       <FormControl variant="standard" />
       <FormControl variant="filled" />


### PR DESCRIPTION
A spread of props onto an element could contain a variant. If so, that should win over the variant added by the codemod, so adding the codemod variant to the beginning of the props rather than the end.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
