### PR TITLE
[TextField] Fix `InputLabelProps={{ required: true }}` rendering incorrectly 

### DIFF
--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -109,8 +109,8 @@ const InputLabelRoot = styled(FormLabel, {
     ...(ownerState.shrink && {
       userSelect: 'none',
       pointerEvents: 'auto',
-      maxWidth: 'calc(133% - 24px)',
-      transform: 'translate(14px, -9px) scale(0.75)',
+      maxWidth: 'calc(150% - 24px)',
+      transform: 'translate(12px, -9px) scale(0.70)',
     }),
   }),
 }));


### PR DESCRIPTION
I have found a solution to this issue by changing the maxWidth and the transform in the InputLabel.js file

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/31797