### PR TITLE
[tests] Add more tests to ignore falsy values

### DIFF
--- a/packages/mui-base/src/composeClasses/composeClasses.test.ts
+++ b/packages/mui-base/src/composeClasses/composeClasses.test.ts
@@ -86,9 +86,7 @@ describe('composeClasses', () => {
           slot: 'slotOverride',
         },
       ),
-    )
-  }).to.deep.equal({
+    ).to.deep.equal({
     root: 'MuiTest-root standardOverride MuiTest-standard',
     slot: 'slotOverride MuiTest-slot',
-  })
-});
+  });

--- a/packages/mui-base/src/composeClasses/composeClasses.test.ts
+++ b/packages/mui-base/src/composeClasses/composeClasses.test.ts
@@ -37,11 +37,47 @@ describe('composeClasses', () => {
     });
   });
 
-  it('should ignore false values', () => {
+  it('should ignore falsy values', () => {
     expect(
       composeClasses(
         {
           root: ['root', false, 'standard'],
+          slot: ['slot'],
+        },
+        (slot) => `MuiTest-${slot}`,
+        {
+          standard: 'standardOverride',
+          slot: 'slotOverride',
+        },
+      ),
+    ).to.deep.equal({
+      root: 'MuiTest-root standardOverride MuiTest-standard',
+      slot: 'slotOverride MuiTest-slot',
+    });
+  });
+  
+  expect(
+      composeClasses(
+        {
+          root: ['root', 0, 'standard'],
+          slot: ['slot'],
+        },
+        (slot) => `MuiTest-${slot}`,
+        {
+          standard: 'standardOverride',
+          slot: 'slotOverride',
+        },
+      ),
+    ).to.deep.equal({
+      root: 'MuiTest-root standardOverride MuiTest-standard',
+      slot: 'slotOverride MuiTest-slot',
+    });
+  });
+
+  expect(
+      composeClasses(
+        {
+          root: ['root', 0x0, 'standard'],
           slot: ['slot'],
         },
         (slot) => `MuiTest-${slot}`,

--- a/packages/mui-base/src/composeClasses/composeClasses.test.ts
+++ b/packages/mui-base/src/composeClasses/composeClasses.test.ts
@@ -68,10 +68,10 @@ describe('composeClasses', () => {
           slot: 'slotOverride',
         },
       ),
-    ).to.deep.equal({
-      root: 'MuiTest-root standardOverride MuiTest-standard',
-      slot: 'slotOverride MuiTest-slot',
-    });
+    )
+  }).to.deep.equal({
+    root: 'MuiTest-root standardOverride MuiTest-standard',
+    slot: 'slotOverride MuiTest-slot',
   });
 
   expect(
@@ -86,9 +86,9 @@ describe('composeClasses', () => {
           slot: 'slotOverride',
         },
       ),
-    ).to.deep.equal({
-      root: 'MuiTest-root standardOverride MuiTest-standard',
-      slot: 'slotOverride MuiTest-slot',
-    });
-  });
+    )
+  }).to.deep.equal({
+    root: 'MuiTest-root standardOverride MuiTest-standard',
+    slot: 'slotOverride MuiTest-slot',
+  })
 });


### PR DESCRIPTION
Add more tests to ensure that `composeClasses` ignores every false values possible.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
