### PR TITLE
[core] Fix TS 4.7 compat issues

### DIFF
--- a/packages/material-ui/src/TableBody/TableBody.d.ts
+++ b/packages/material-ui/src/TableBody/TableBody.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { OverridableComponent, OverrideProps, OverridableTypeMap } from '../OverridableComponent';
 
-export interface TableBodyTypeMap<P = {}, D extends React.ElementType = 'tbody'> {
+export interface TableBodyTypeMap<P extends {} = {}, D extends React.ElementType = 'tbody'>
+  extends OverridableTypeMap {
   props: P;
   defaultComponent: D;
   classKey: TableBodyClassKey;
@@ -22,7 +23,7 @@ export type TableBodyClassKey = 'root';
 
 export type TableBodyProps<
   D extends React.ElementType = TableBodyTypeMap['defaultComponent'],
-  P = {}
+  P extends {} = {}
 > = OverrideProps<TableBodyTypeMap<P, D>, D>;
 
 export default TableBody;

--- a/packages/material-ui/src/TableContainer/TableContainer.d.ts
+++ b/packages/material-ui/src/TableContainer/TableContainer.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { OverridableComponent, OverrideProps, OverridableTypeMap } from '../OverridableComponent';
 
-export interface TableContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
+export interface TableContainerTypeMap<P extends {} = {}, D extends React.ElementType = 'div'>
+  extends OverridableTypeMap {
   props: P;
   defaultComponent: D;
   classKey: TableContainerClassKey;
@@ -22,7 +23,7 @@ export type TableContainerClassKey = 'root';
 
 export type TableContainerProps<
   D extends React.ElementType = TableContainerTypeMap['defaultComponent'],
-  P = {}
+  P extends {} = {}
 > = OverrideProps<TableContainerTypeMap<P, D>, D>;
 
 export default TableContainer;

--- a/packages/material-ui/src/TableFooter/TableFooter.d.ts
+++ b/packages/material-ui/src/TableFooter/TableFooter.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { OverridableComponent, OverrideProps, OverridableTypeMap } from '../OverridableComponent';
 
-export interface TableFooterTypeMap<P = {}, D extends React.ElementType = 'tfoot'> {
+export interface TableFooterTypeMap<P extends {} = {}, D extends React.ElementType = 'tfoot'>
+  extends OverridableTypeMap {
   props: P;
   defaultComponent: D;
   classKey: TableFooterClassKey;
@@ -22,7 +23,7 @@ export type TableFooterClassKey = 'root';
 
 export type TableFooterProps<
   D extends React.ElementType = TableFooterTypeMap['defaultComponent'],
-  P = {}
+  P extends {} = {}
 > = OverrideProps<TableFooterTypeMap<P, D>, D>;
 
 export default TableFooter;

--- a/packages/material-ui/src/TableHead/TableHead.d.ts
+++ b/packages/material-ui/src/TableHead/TableHead.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { OverridableComponent, OverrideProps, OverridableTypeMap } from '../OverridableComponent';
 
-export interface TableHeadTypeMap<P = {}, D extends React.ElementType = 'thead'> {
+export interface TableHeadTypeMap<P extends {} = {}, D extends React.ElementType = 'thead'>
+  extends OverridableTypeMap {
   props: P;
   defaultComponent: D;
   classKey: TableHeadClassKey;


### PR DESCRIPTION
Targetting 4.x but similar changes are probably required for current typings as well.

Fixes issues with TypeScript 4.7 canary (https://github.com/microsoft/TypeScript/pull/48366 specifically) that are blocking https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210