### PR TITLE
[Link] Fix color transformation

### DIFF
--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -158,7 +158,6 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     <LinkRoot
       className={clsx(classes.root, className)}
       classes={TypographyClasses}
-      color={color}
       component={component}
       onBlur={handleBlur}
       onFocus={handleFocus}

--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -112,6 +112,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     TypographyClasses,
     underline = 'always',
     variant = 'inherit',
+    sx,
     ...other
   } = props;
 
@@ -144,7 +145,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
 
   const ownerState = {
     ...props,
-    color,
+    color: sx?.color || color,
     component,
     focusVisible,
     underline,
@@ -164,6 +165,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
       ref={handlerRef}
       ownerState={ownerState}
       variant={variant}
+      sx={{ color: colorTransformations[color] || color, ...sx }}
       {...other}
     />
   );

--- a/test/regressions/fixtures/Link/LinkColor.js
+++ b/test/regressions/fixtures/Link/LinkColor.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Link from '@mui/material/Link';
+
+export default function DeterminateLinearProgress() {
+  return (
+    <ThemeProvider
+      theme={createTheme({
+        components: {
+          MuiLink: {
+            styleOverrides: {
+              root: {
+                color: '#0068a9', // blue
+              },
+            },
+          },
+        },
+      })}
+    >
+      <Link href="#unknown">#0068a9</Link>
+      <Link href="#unknown" color="#ff5252">
+        #ff5252
+      </Link>
+      <Link href="#unknown" sx={{ color: '#ff5252' }}>
+        #ff5252
+      </Link>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #31857

### Root cause

The `Link` inherit `Typography`. As a result, the styles injection order looks like this (order by the highest to the lowest priority):

Link
- sx
- theme.styleOverrides
- Typography
   - sx
   - theme.styleOverrides
   
When `color` prop is passed to `Link`(`<Link color="#ff5252">`), it is sent to the Typography which is then turned to sx at the end. The `sx` of typography could not win the `theme.styleOverrides` of the Link, this is why it causes the issue.

### Fix

This PR passes color to Link's `sx` directly and add a regression test.

---
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
