### PR TITLE
[docs] Add small size Select demo

### DIFF
--- a/docs/data/material/components/selects/SelectSmall.js
+++ b/docs/data/material/components/selects/SelectSmall.js
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
+
+export default function SelectSmall() {
+  const [age, setAge] = React.useState('');
+
+  const handleChange = (event) => {
+    setAge(event.target.value);
+  };
+
+  return (
+    <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
+      <InputLabel id="demo-simple-select-disabled-label">Age</InputLabel>
+      <Select
+        labelId="demo-select-small"
+        id="demo-select-small"
+        value={age}
+        label="Age"
+        onChange={handleChange}
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        <MenuItem value={10}>Ten</MenuItem>
+        <MenuItem value={20}>Twenty</MenuItem>
+        <MenuItem value={30}>Thirty</MenuItem>
+      </Select>
+    </FormControl>
+  );
+}

--- a/docs/data/material/components/selects/SelectSmall.js
+++ b/docs/data/material/components/selects/SelectSmall.js
@@ -13,7 +13,7 @@ export default function SelectSmall() {
 
   return (
     <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-      <InputLabel id="demo-simple-select-disabled-label">Age</InputLabel>
+      <InputLabel id="demo-select-small">Age</InputLabel>
       <Select
         labelId="demo-select-small"
         id="demo-select-small"

--- a/docs/data/material/components/selects/SelectSmall.tsx
+++ b/docs/data/material/components/selects/SelectSmall.tsx
@@ -13,7 +13,7 @@ export default function SelectSmall() {
 
   return (
     <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-      <InputLabel id="demo-simple-select-disabled-label">Age</InputLabel>
+      <InputLabel id="demo-select-small">Age</InputLabel>
       <Select
         labelId="demo-select-small"
         id="demo-select-small"

--- a/docs/data/material/components/selects/SelectSmall.tsx
+++ b/docs/data/material/components/selects/SelectSmall.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+
+export default function SelectSmall() {
+  const [age, setAge] = React.useState('');
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setAge(event.target.value);
+  };
+
+  return (
+    <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
+      <InputLabel id="demo-simple-select-disabled-label">Age</InputLabel>
+      <Select
+        labelId="demo-select-small"
+        id="demo-select-small"
+        value={age}
+        label="Age"
+        onChange={handleChange}
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        <MenuItem value={10}>Ten</MenuItem>
+        <MenuItem value={20}>Twenty</MenuItem>
+        <MenuItem value={30}>Thirty</MenuItem>
+      </Select>
+    </FormControl>
+  );
+}

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -45,6 +45,10 @@ It shares the same styles and many of the same props. Refer to the respective co
 
 {{"demo": "SelectAutoWidth.js"}}
 
+### Small Size
+
+{{"demo": "SelectSmall.js"}}
+
 ### Other props
 
 {{"demo": "SelectOtherProps.js"}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Added demo in documentation to showcase demo of a select component with `size='small'` prop.

![image](https://user-images.githubusercontent.com/97230812/160822974-e64d7390-d0ac-4d7d-8645-646982ad1ee6.png)

Preview:
https://deploy-preview-32060--material-ui.netlify.app/components/selects/#small-size

closes #31348

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
