### PR TITLE
[docs] Add date-pickers product identifier

### DIFF
--- a/docs/data/material/components/pickers/lab-date-and-time-pickers.md
+++ b/docs/data/material/components/pickers/lab-date-and-time-pickers.md
@@ -4,7 +4,7 @@
 
 ## Why have the picker components been moved to MUI X?
 
-MUI X components are built for complex use cases. Date and time pickers are difficult to pull off correctly, so they deserve the special attention that they will receive as part of MUI X. To learn more, check out the [blog post about the move](/blog/lab-pickers-to-mui-x/).
+MUI X components are built for complex use cases. Date and time pickers are difficult to pull off correctly, so they deserve the special attention that they will receive as part of MUI X. To learn more, check out the [blog post about the move](/blog/lab-date-pickers-to-mui-x/).
 
 ## How do I migrate?
 

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -17,6 +17,6 @@
   {
     "id": 59,
     "title": "📣 <b>Date and time pickers have been moved to MUI X</b>",
-    "text": "<a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"lab-date-pickers-to-mui-x/\" href=\"/blog/lab-date-pickers-to-mui-x/\">Go to the post to</a> find out about the reasons behind this afford and how to migrate from lab to MUI X."
+    "text": "<a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"lab-date-pickers-to-mui-x/\" href=\"/blog/lab-date-pickers-to-mui-x/\">Go to the post to</a> find out about the reasons behind this effort and how to migrate from lab to MUI X."
   }
 ]

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -16,7 +16,7 @@
   },
   {
     "id": 59,
-    "title": "📣 <b>Date and time pickers has been moved to MUI X</b>",
+    "title": "📣 <b>Date and time pickers have been moved to MUI X</b>",
     "text": "<a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"lab-date-pickers-to-mui-x/\" href=\"/blog/lab-date-pickers-to-mui-x/\">Go to the post to</a> find out what why they are moved from the lab to MUI X and how to migrate."
   }
 ]

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -17,6 +17,6 @@
   {
     "id": 59,
     "title": "📣 <b>Date and time pickers have been moved to MUI X</b>",
-    "text": "<a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"lab-date-pickers-to-mui-x/\" href=\"/blog/lab-date-pickers-to-mui-x/\">Go to the post to</a> find out what why they are moved from the lab to MUI X and how to migrate."
+    "text": "<a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"lab-date-pickers-to-mui-x/\" href=\"/blog/lab-date-pickers-to-mui-x/\">Go to the post to</a> find out about the reasons behind this afford and how to migrate from lab to MUI X."
   }
 ]

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -13,5 +13,10 @@
     "id": 58,
     "title": "🚀 <b>The 2021 MUI developer survey results are out</b> — here's what we discovered",
     "text": "Your feedback helps us to build better products. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"2021-developer-survey-results/\" href=\"/blog/2021-developer-survey-results/\">Go to the post to</a> find out what we learned about your needs in our annual survey."
+  },
+  {
+    "id": 59,
+    "title": "📣 <b>Date and time pickers has been moved to MUI X</b>",
+    "text": "<a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"lab-date-pickers-to-mui-x/\" href=\"/blog/lab-date-pickers-to-mui-x/\">Go to the post to</a> find out what why they are moved from the lab to MUI X and how to migrate."
   }
 ]

--- a/docs/pages/blog/lab-date-pickers-to-mui-x.js
+++ b/docs/pages/blog/lab-date-pickers-to-mui-x.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TopLayoutBlog from 'docs/src/modules/components/TopLayoutBlog';
-import { docs } from './lab-pickers-to-mui-x.md?@mui/markdown';
+import { docs } from './lab-date-pickers-to-mui-x.md?@mui/markdown';
 
 export default function Page() {
   return <TopLayoutBlog docs={docs} />;

--- a/docs/pages/blog/lab-date-pickers-to-mui-x.md
+++ b/docs/pages/blog/lab-date-pickers-to-mui-x.md
@@ -65,10 +65,10 @@ import DateRangePicker from '@mui/lab/DateRangePicker';
 import { DatePicker, DateRangePicker } from '@mui/lab';
 
 // after
-import DatePicker from '@mui/x-pickers/DatePicker';
-import DateRangePicker from '@mui/x-pickers-pro/DateRangePicker';
-import { DatePicker } from '@mui/x-pickers'; // DatePicker is also available in `@mui/x-pickers-pro`
-import { DateRangePicker } from '@mui/x-pickers-pro';
+import DatePicker from '@mui/x-date-pickers/DatePicker';
+import DateRangePicker from '@mui/x-date-pickers-pro/DateRangePicker';
+import { DatePicker } from '@mui/x-date-pickers'; // DatePicker is also available in `@mui/x-date-pickers-pro`
+import { DateRangePicker } from '@mui/x-date-pickers-pro';
 ```
 
 We have prepared a codemod to help you migrate your codebase from `@mui/lab` to `@mui/x-date-pickers` or `@mui/x-date-pickers-pro`:
@@ -83,5 +83,5 @@ You can find the documentation for the picker components in the [MUI X docs](htt
 
 ## What's next for the date and time pickers?
 
-For now, `@mui/x-pickers` and `@mui/x-pickers-pro` are in alpha.
+For now, `@mui/x-date-pickers` and `@mui/x-date-pickers-pro` are in alpha.
 Our next goal is to work on the stability and API consistency of these components to prepare a stable release.

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -157,6 +157,9 @@ function ProductDrawerButton(props) {
             width: 18,
             height: 18,
           },
+          '& > span': {
+            ml: '4px',
+          },
         })}
       >
         {props.productName}
@@ -556,8 +559,8 @@ function AppNavDrawer(props) {
                 component="a"
                 aria-label={t('goToHome')}
                 sx={{
-                  pr: 2,
-                  mr: 1,
+                  pr: '12px',
+                  mr: '4px',
                   borderRight: isProductScoped ? '1px solid' : '0px',
                   borderColor: (theme) =>
                     theme.palette.mode === 'dark'
@@ -614,9 +617,20 @@ function AppNavDrawer(props) {
                 name="Data Grid"
                 metadata="MUI X"
                 versionSelector={renderVersionSelector([
-                  // LIB_VERSION is set from the X repo
-                  { text: `v${process.env.LIB_VERSION}`, current: true },
+                  // DATA_GRID_VERSION is set from the X repo
+                  { text: `v${process.env.DATA_GRID_VERSION}`, current: true },
                   { text: 'v4', href: `https://v4.mui.com${languagePrefix}/components/data-grid/` },
+                ])}
+              />
+            )}
+            {(router.asPath.startsWith('/x/react-date-pickers') ||
+              router.asPath.startsWith('/x/api/date-pickers')) && (
+              <ProductIdentifier
+                name="Date pickers"
+                metadata="MUI X"
+                versionSelector={renderVersionSelector([
+                  // DATE_PICKERS_VERSION is set from the X repo
+                  { text: `v${process.env.DATE_PICKERS_VERSION}`, current: true },
                 ])}
               />
             )}

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -18,6 +18,7 @@ import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import BookRoundedIcon from '@mui/icons-material/BookRounded';
 import ChromeReaderModeRoundedIcon from '@mui/icons-material/ChromeReaderModeRounded';
 import TableViewRoundedIcon from '@mui/icons-material/TableViewRounded';
+import DateRangeRounded from '@mui/icons-material/DateRangeRounded';
 
 const iconsMap = {
   DescriptionIcon: ArticleRoundedIcon,
@@ -31,6 +32,7 @@ const iconsMap = {
   BookIcon: BookRoundedIcon,
   ReaderIcon: ChromeReaderModeRoundedIcon,
   TableViewIcon: TableViewRoundedIcon,
+  DatePickerIcon: DateRangeRounded,
 };
 
 const Item = styled(function Item({ component: Component = 'div', ...props }) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Add date-pickers product identifier
  <img width="314" alt="Screen Shot 2565-03-31 at 17 20 37" src="https://user-images.githubusercontent.com/18292247/161033962-d92cb223-7f60-4798-9e9c-13710ebd50f2.png">
- Use https://mui.com/components/material-icons/?query=date&selected=DateRange as date-pickers navigation icon
- Rename blog post URL to `/blog/lab-date-pickers-to-mui-x`
- Add notification about the blog post


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
