### PR TITLE
[website] Add privacy policy link to website's footer

### DIFF
--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -120,6 +120,7 @@ export default function AppFooter() {
               </Box>
             </Box>
             <Link href={ROUTES.support}>Support</Link>
+            <Link href={ROUTES.privacyPolicy}>Privacy policy</Link>
             <Link target="_blank" rel="noopener noreferrer" href="mailto:contact@mui.com">
               Contact us
             </Link>

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -49,7 +49,7 @@ const ROUTES = {
   support: FEATURE_TOGGLE.enable_redirects
     ? '/material-ui/getting-started/support/#professional-support-premium'
     : '/getting-started/support/#professional-support-premium',
-  privacyPolicy: 'https://mui.com/legal/privacy/',
+  privacyPolicy: 'https://mui.com/store/legal/privacy/',
   goldSponsor: FEATURE_TOGGLE.enable_redirects
     ? '/material-ui/discover-more/backers/#gold'
     : '/discover-more/backers/#gold/',

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -49,7 +49,7 @@ const ROUTES = {
   support: FEATURE_TOGGLE.enable_redirects
     ? '/material-ui/getting-started/support/#professional-support-premium'
     : '/getting-started/support/#professional-support-premium',
-  privacyPolicy: 'https://mui.com/store/legal/privacy/',
+  privacyPolicy: 'https://mui.com/store/privacy/',
   goldSponsor: FEATURE_TOGGLE.enable_redirects
     ? '/material-ui/discover-more/backers/#gold'
     : '/discover-more/backers/#gold/',

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -49,6 +49,7 @@ const ROUTES = {
   support: FEATURE_TOGGLE.enable_redirects
     ? '/material-ui/getting-started/support/#professional-support-premium'
     : '/getting-started/support/#professional-support-premium',
+  privacyPolicy: 'https://mui.com/legal/privacy/',
   goldSponsor: FEATURE_TOGGLE.enable_redirects
     ? '/material-ui/discover-more/backers/#gold'
     : '/discover-more/backers/#gold/',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow up on the email you sent @oliviertassinari. 
Might as well wait for you to finish there so we can merge this one.

https://deploy-preview-32080--material-ui.netlify.app/

---

Olivier's Edit: needed for https://support.google.com/cloud/answer/9110914

> The Privacy Policy must be visible to users, hosted within the domain of your website, and linked from the OAuth consent screen on the Google API Console.

We need to use Google OAuth for Google Spreadsheet integration with MUI Toolpad.