### PR TITLE
[core] Fix running docs:api on Windows

### DIFF
--- a/docs/scripts/buildApiUtils.ts
+++ b/docs/scripts/buildApiUtils.ts
@@ -272,7 +272,7 @@ export const getBaseComponentInfo = (filename: string): ComponentInfo => {
       const allMarkdowns = findPagesMarkdownNew()
         .filter((markdown) => {
           if (migratedBaseComponents.some((component) => filename.includes(component))) {
-            return markdown.filename.match(/\/data\/base\//);
+            return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
           }
           return true;
         })


### PR DESCRIPTION
One of the changes introduced in #32081 made the `docs:api` script unable to find Base components demos on Windows.