### PR TITLE
[docs] Simplify customization examples in ButtonUnstyled demos

### DIFF
--- a/docs/data/base/components/button/UnstyledButtonsSimple.js
+++ b/docs/data/base/components/button/UnstyledButtonsSimple.js
@@ -9,7 +9,7 @@ const blue = {
   700: '#0059B2',
 };
 
-const CustomButtonRoot = styled('button')`
+const CustomButton = styled(ButtonUnstyled)`
   font-family: IBM Plex Sans, sans-serif;
   font-weight: bold;
   font-size: 0.875rem;
@@ -39,10 +39,6 @@ const CustomButtonRoot = styled('button')`
     cursor: not-allowed;
   }
 `;
-
-function CustomButton(props) {
-  return <ButtonUnstyled {...props} component={CustomButtonRoot} />;
-}
 
 export default function UnstyledButtonsSimple() {
   return (

--- a/docs/data/base/components/button/UnstyledButtonsSimple.tsx
+++ b/docs/data/base/components/button/UnstyledButtonsSimple.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
-import ButtonUnstyled, {
-  buttonUnstyledClasses,
-  ButtonUnstyledProps,
-} from '@mui/base/ButtonUnstyled';
+import ButtonUnstyled, { buttonUnstyledClasses } from '@mui/base/ButtonUnstyled';
 import { styled } from '@mui/system';
 
 const blue = {
@@ -12,7 +9,7 @@ const blue = {
   700: '#0059B2',
 };
 
-const CustomButtonRoot = styled('button')`
+const CustomButton = styled(ButtonUnstyled)`
   font-family: IBM Plex Sans, sans-serif;
   font-weight: bold;
   font-size: 0.875rem;
@@ -42,10 +39,6 @@ const CustomButtonRoot = styled('button')`
     cursor: not-allowed;
   }
 `;
-
-function CustomButton(props: ButtonUnstyledProps) {
-  return <ButtonUnstyled {...props} component={CustomButtonRoot} />;
-}
 
 export default function UnstyledButtonsSimple() {
   return (

--- a/docs/data/base/components/button/UnstyledButtonsSpan.js
+++ b/docs/data/base/components/button/UnstyledButtonsSpan.js
@@ -9,7 +9,7 @@ const blue = {
   700: '#0059B2',
 };
 
-const CustomButtonRoot = styled('span')`
+const CustomButtonRoot = styled(ButtonUnstyled)`
   font-family: IBM Plex Sans, sans-serif;
   font-weight: bold;
   font-size: 0.875rem;
@@ -41,7 +41,7 @@ const CustomButtonRoot = styled('span')`
 `;
 
 function CustomButton(props) {
-  return <ButtonUnstyled {...props} component={CustomButtonRoot} />;
+  return <CustomButtonRoot {...props} component="span" />;
 }
 
 export default function UnstyledButtonsSpan() {

--- a/docs/data/base/components/button/UnstyledButtonsSpan.tsx
+++ b/docs/data/base/components/button/UnstyledButtonsSpan.tsx
@@ -12,7 +12,7 @@ const blue = {
   700: '#0059B2',
 };
 
-const CustomButtonRoot = styled('span')`
+const CustomButtonRoot = styled(ButtonUnstyled)`
   font-family: IBM Plex Sans, sans-serif;
   font-weight: bold;
   font-size: 0.875rem;
@@ -44,7 +44,7 @@ const CustomButtonRoot = styled('span')`
 `;
 
 function CustomButton(props: ButtonUnstyledProps) {
-  return <ButtonUnstyled {...props} component={CustomButtonRoot} />;
+  return <CustomButtonRoot {...props} component="span" />;
 }
 
 export default function UnstyledButtonsSpan() {


### PR DESCRIPTION
ButtonUnstyled demos show the simpler `styled(ButtonUnstyled)` approach where possible. 
It reduced the number of rendered components and allow additional customization (like rendering an `a` instead of a `button`).

https://deploy-preview-32092--material-ui.netlify.app/base/react-button/