### PR TITLE
[docs] Base Menu style revisions and final review

### DIFF
--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -73,4 +73,4 @@ Using the hooks allows you to take full control over the rendered components, th
 
 {{"demo": "UseMenu.js"}}
 
-Unstyled components and their corresponding hooks work interchangeably with one another—for example, you can create a `MenuItemUnstyled` component that contains menu items built with the `useMenuItem` hook.
+Unstyled components and their corresponding hooks work interchangeably with one another—for example, you can create a `MenuUnstyled` component that contains menu items built with the `useMenuItem` hook.

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -8,7 +8,7 @@ waiAria: https://www.w3.org/TR/wai-aria-practices/#menu
 
 # Unstyled menu
 
-<p class="description">The `MenuUnstyled` component provides your users with a list of choices on temporary surfaces.</p>
+<p class="description">The menu components provide your users with a list of options on temporary surfaces.</p>
 
 ## MenuUnstyled and MenuItemUnstyled components
 

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -57,7 +57,7 @@ Just like `MenuUnstyled`, it can be customized by setting the `component` or `co
 `MenuItemUnstyled` can set the following classes:
 
 - `Mui-disabled` - set when the MenuItem has the `disabled` prop
-- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation
+- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation.
   This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
 
 ## The useMenu and useMenuItem hooks

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -1,14 +1,14 @@
 ---
 product: base
-title: React Menu unstyled component and hook
+title: Unstyled React Menu components and hook
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menu
 ---
 
-# Menu
+# Unstyled menu
 
-<p class="description">Menus display a list of choices on temporary surfaces.</p>
+<p class="description">The `MenuUnstyled` component provides your users with a list of choices on temporary surfaces.</p>
 
 ## MenuUnstyled and MenuItemUnstyled components
 
@@ -17,10 +17,10 @@ import MenuUnstyled from '@mui/base/MenuUnstyled';
 import MenuItemUnstyled from '@mui/base/MenuItemUnstyled';
 ```
 
-The MenuUnstyled components can be used to create custom menus.
-It renders a list of items in a popup and allows mouse and keyboard navigation through them.
+You can use the `MenuUnstyled` component to create custom menus.
+It renders a list of items in a popup that users can navigate through with a mouse or keyboard.
 
-When not customized, the MenuItem renders a plain `ul` element.
+When not customized, the `MenuItemUnstyled` component renders a plain `<ul>` element.
 
 ### Basic usage
 
@@ -28,10 +28,9 @@ When not customized, the MenuItem renders a plain `ul` element.
 
 ### Wrapping MenuItems
 
-MenuItemUnstyled components don't have to be direct descendants of the MenuUnstyled.
-Developers can wrap them in arbitrary components to achieve desired appearance.
+`MenuItemUnstyled` components don't have to be direct chilrden of a `MenuUnstyled` component. You can wrap them in any component needed to achieve the desired appearance.
 
-Additionally, MenuUnstyled may contain non-interactive children (such as help text).
+In addition to `MenuItemUnstyled` components, the `MenuUnstyled` component can also contain non-interactive children, such as help text.
 
 {{"demo": "WrappedMenuItems.js"}}
 
@@ -39,39 +38,38 @@ Additionally, MenuUnstyled may contain non-interactive children (such as help te
 
 #### Slots
 
-The MenuUnstyled has two slots:
+`MenuUnstyled` has two slots:
 
-- Root - represents the popup container the menu is placed in.
+- Root - represents the popup container the menu is placed in; set to `PopperUnstyled` by default
   Can be customized by setting the `component` or `components.Root` props.
-  By default set to `PopperUnstyled`.
-- Listbox - set to `ul` by default.
+- Listbox - set to `<ul>` by default
 
-The MenuItemUnstyled has just the root slot.
-It renders `li` by default.
-Similarly to MenuUnstyled, it can be customized by setting the `component` or `components.Root` props.
+The `MenuItemUnstyled` component has one slot: the root, which renders an `<li>` element by default.
+Just like `MenuUnstyled`, it can be customized by setting the `component` or `components.Root` props.
 
 #### CSS classes
 
-The MenuUnstyled can set the following class:
+`MenuUnstyled` can set the following class:
 
-- `Mui-expanded` - set when the menu is open. This class is set on both Root and Popper slots.
+- `Mui-expanded` - set when the menu is open; this class is set on both Root and Popper slots
 
-The MenuItemUnstyled can set the following classes:
+`MenuItemUnstyled` can set the following classes:
 
-- `Mui-disabled` - set when the MenuItem has the `disabled` prop.
-- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation.
+- `Mui-disabled` - set when the MenuItem has the `disabled` prop
+- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation
   This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
 
-## useMenu and useMenuItem hooks
+## The useMenu and useMenuItem hooks
 
 ```jsx
 import { useMenu } from '@mui/base/MenuUnstyled';
 import { useMenuItem } from '@mui/base/MenuItemUnstyled';
 ```
 
-The useMenu and useMenuItem hooks provide even greater flexibility.
+You can use the `useMenu` and `useMenuItem` hooks to apply the functionality of the unstyled menu components to a different component.
+These hooks gives you the most customization options, but require more work to implement.
+Using the hooks allows you to take full control over the rendered components, their props and CSS classes.
 
 {{"demo": "UseMenu.js"}}
 
-It is possible to mix and match the built-in unstyled components and the ones made with hooks
-(i.e. having a custom MenuItem built with useMenuItem hook inside a MenuItemUnstyled).
+Unstyled components and their corresponding hooks work interchangeably with one another—for example, you can create a `MenuItemUnstyled` component that contains menu items built with the `useMenuItem` hook.

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -4,6 +4,7 @@ title: Unstyled React Menu components and hooks
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menu
+packageName: '@mui/base'
 ---
 
 # Unstyled menu

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -1,6 +1,6 @@
 ---
 product: base
-title: Unstyled React Menu components and hook
+title: Unstyled React Menu components and hooks
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
 waiAria: https://www.w3.org/TR/wai-aria-practices/#menu

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -41,7 +41,7 @@ In addition to `MenuItemUnstyled` components, the `MenuUnstyled` component can a
 
 `MenuUnstyled` has two slots:
 
-- Root - represents the popup container the menu is placed in; set to `PopperUnstyled` by default
+- Root - represents the popup container the menu is placed in; set to `PopperUnstyled` by default.
   Can be customized by setting the `component` or `components.Root` props.
 - Listbox - set to `<ul>` by default
 

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -21,7 +21,7 @@ import MenuItemUnstyled from '@mui/base/MenuItemUnstyled';
 You can use the `MenuUnstyled` component to create custom menus.
 It renders a list of items in a popup that users can navigate through with a mouse or keyboard.
 
-When not customized, the `MenuItemUnstyled` component renders a plain `<ul>` element.
+When not customized, the `MenuUnstyled` component renders a plain `<ul>` element.
 
 ### Basic usage
 

--- a/docs/pages/base/api/form-control-unstyled.json
+++ b/docs/pages/base/api/form-control-unstyled.json
@@ -18,6 +18,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/base/components/form-control/\">Form Control</a></li></ul>",
+  "demos": "<ul><li><a href=\"/base/react-form-control/\">Form Control</a></li></ul>",
   "cssComponent": false
 }


### PR DESCRIPTION
This PR applies the style guide to the Base Menu document. For this piece, the changes mostly amount to placing `MenuUnstyled` and `MenuItemUnstyled` inside back ticks.

This piece also answered the question I posed in #32095 about naming the hooks in the title—and the answer is no! The title of this one would be way too dense if I named both hooks there. I will update the others I've reviewed so far to reflect this.

Preview - https://deploy-preview-32097--material-ui.netlify.app/base/react-menu/