### PR TITLE
[docs] Base Badge style revisions and final review

### DIFF
--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -1,6 +1,6 @@
 ---
 product: base
-title: Unstyled React badge
+title: Unstyled React Badge component
 components: BadgeUnstyled
 githubLabel: 'component: badge'
 packageName: '@mui/base'
@@ -8,7 +8,7 @@ packageName: '@mui/base'
 
 # Unstyled badge
 
-<p class="description">Badge generates a small badge to the top-right of its child(ren).</p>
+<p class="description">The `BadgeUnstyled` component generates a small label in the upper-right corner of its children elements.</p>
 
 ```js
 import BadgeUnstyled from '@mui/base/BadgeUnstyled';
@@ -22,28 +22,31 @@ import BadgeUnstyled from '@mui/base/BadgeUnstyled';
 
 ## Badge visibility
 
-The visibility of badges can be controlled using the `invisible` prop.
-If a badge is invisible, it has the `MuiBadge-invisible` class.
-It is up to the developer to provide styles that actually hide the badge.
+You can control the visibility of a `BadgeUnstyled` by using the `invisible` prop.
+Setting a badge to `invisible` does not actually hide it—instead, this prop adds the `MuiBadge-invisible` class to the badge, which you can target with styles to hide however you prefer:
 
 {{"demo": "BadgeVisibility.js"}}
 
-The badge hides automatically when `badgeContent` is zero. You can override this with the `showZero` prop.
+## Numerical badges
+
+The following props are useful when `badgeContent` is a number.
+
+### The showZero prop
+
+By default, badges automatically hide when `badgeContent={0}`. You can override this behavior with the `showZero` prop:
 
 {{"demo": "ShowZeroBadge.js"}}
 
-## Maximum value
+### The max prop
 
-You can use the `max` prop to cap the value of the badge content.
-It is set to 99 by default.
-
-Note that `badgeContent` should be a number (or convertible to a number) for this to work.
+You can use the `max` prop to set a maximum value for `badgeContent`.
+The default is "99".
 
 {{"demo": "BadgeMax.js"}}
 
 ## Accessibility
 
 You can't rely on the content of the badge to be announced correctly.
-You should provide a full description, for instance, with `aria-label`:
+The `Badge` component requires a full description with `aria-label`:
 
 {{"demo": "AccessibleBadges.js", "defaultCodeOpen": false}}

--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -8,7 +8,7 @@ packageName: '@mui/base'
 
 # Unstyled badge
 
-<p class="description">The `BadgeUnstyled` component generates a small label in the upper-right corner of its children elements.</p>
+<p class="description">The `BadgeUnstyled` component generates a small label attached to its children elements.</p>
 
 ```js
 import BadgeUnstyled from '@mui/base/BadgeUnstyled';

--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -8,7 +8,7 @@ packageName: '@mui/base'
 
 # Unstyled badge
 
-<p class="description">The `BadgeUnstyled` component generates a small label attached to its children elements.</p>
+<p class="description">The `BadgeUnstyled` component generates a small label that is attached to its children elements.</p>
 
 ```js
 import BadgeUnstyled from '@mui/base/BadgeUnstyled';
@@ -46,7 +46,7 @@ The default is 99.
 
 ## Accessibility
 
-You can't rely on the content of the badge to be announced correctly.
-The `Badge` component requires a full description with `aria-label`:
+Screen readers may not provide the user with enough information about a badge's contents.
+To make your `BadgeUnstyled` accessible, you must provide a full description with `aria-label`:
 
 {{"demo": "AccessibleBadges.js", "defaultCodeOpen": false}}

--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -40,7 +40,7 @@ By default, badges automatically hide when `badgeContent={0}`. You can override 
 ### The max prop
 
 You can use the `max` prop to set a maximum value for `badgeContent`.
-The default is "99".
+The default is 99.
 
 {{"demo": "BadgeMax.js"}}
 

--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -46,7 +46,7 @@ The default is 99.
 
 ## Accessibility
 
-Screen readers may not provide the user with enough information about a badge's contents.
+Screen readers may not provide users with enough information about a badge's contents.
 To make your `BadgeUnstyled` accessible, you must provide a full description with `aria-label`:
 
 {{"demo": "AccessibleBadges.js", "defaultCodeOpen": false}}

--- a/docs/pages/base/api/form-control-unstyled.json
+++ b/docs/pages/base/api/form-control-unstyled.json
@@ -18,6 +18,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/base/components/form-control/\">Form Control</a></li></ul>",
+  "demos": "<ul><li><a href=\"/base/react-form-control/\">Form Control</a></li></ul>",
   "cssComponent": false
 }


### PR DESCRIPTION
This PR applies the style guide to the Base Badge document.

Beyond style changes, I rewrote a couple sections for clarity, and I've also proposed some reorganizing: since some of the props only apply to numerical badges, I created a section to group them together.