### PR TITLE
[website] The studio finally has a name, use it

### DIFF
--- a/docs/data/material/components/cards/RecipeReviewCard.js
+++ b/docs/data/material/components/cards/RecipeReviewCard.js
@@ -100,7 +100,7 @@ export default function RecipeReviewCard() {
             15 to 18 minutes. Reduce heat to medium-low, add reserved shrimp and
             mussels, tucking them down into the rice, and cook again without
             stirring, until mussels have opened and rice is just tender, 5 to 7
-            minutes more. (Discard any mussels that don’t open.)
+            minutes more. (Discard any mussels that don&apos;t open.)
           </Typography>
           <Typography>
             Set aside off of the heat to let rest for 10 minutes, and then serve.

--- a/docs/data/material/components/cards/RecipeReviewCard.tsx
+++ b/docs/data/material/components/cards/RecipeReviewCard.tsx
@@ -104,7 +104,7 @@ export default function RecipeReviewCard() {
             15 to 18 minutes. Reduce heat to medium-low, add reserved shrimp and
             mussels, tucking them down into the rice, and cook again without
             stirring, until mussels have opened and rice is just tender, 5 to 7
-            minutes more. (Discard any mussels that don’t open.)
+            minutes more. (Discard any mussels that don&apos;t open.)
           </Typography>
           <Typography>
             Set aside off of the heat to let rest for 10 minutes, and then serve.

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -314,7 +314,7 @@ const teamMembers: Array<Profile> = [
   {
     src: '/static/branding/about/bharat.png',
     name: 'Bharat Kashyap',
-    title: 'MUI Studio engineer',
+    title: 'MUI Toolpad engineer',
     location: 'New Delhi, India',
     locationCountry: 'in',
     about: 'Trains 🚅 , architecture 🏛️ , and psychology 🧠 ',
@@ -324,7 +324,7 @@ const teamMembers: Array<Profile> = [
   {
     src: '/static/branding/about/jan.png',
     name: 'Jan Potoms',
-    title: 'MUI Studio engineer',
+    title: 'MUI Toolpad engineer',
     location: 'Brussels, Belgium',
     locationCountry: 'be',
     about: 'Always curious, I enjoy cinema and hiking',
@@ -333,7 +333,7 @@ const teamMembers: Array<Profile> = [
   {
     src: '/static/branding/about/prakhar.png',
     name: 'Prakhar Gupta',
-    title: 'MUI Studio PM',
+    title: 'MUI Toolpad PM',
     location: 'New Delhi, India',
     locationCountry: 'in',
     about: 'Into sports and hiking!',

--- a/docs/pages/blog/2021-developer-survey-results.md
+++ b/docs/pages/blog/2021-developer-survey-results.md
@@ -490,7 +490,7 @@ A large chunk of you didn't know what MUI X is prior to the survey, which makes 
 <p class="blog-description">1584 out of 1589 answered.</p>
 
 The results are not very different from last year, aside from a slight increase of respondents saying yes.
-The majority of respondents don’t use any paid libraries, but those who do are mostly using MUI X. This demonstrates that some of our assumptions and execution might be correct! Developers' needs appears to not be completely fulfilled by the OSS ecosystem.
+The majority of respondents don't use any paid libraries, but those who do are mostly using MUI X. This demonstrates that some of our assumptions and execution might be correct! Developers' needs appears to not be completely fulfilled by the OSS ecosystem.
 
 ### How can we improve the Data Grid for you?
 

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -159,9 +159,9 @@ const openRolesData = [
     title: 'Engineering',
     roles: [
       {
-        title: 'Full-stack Engineer - Studio',
+        title: 'Full-stack Engineer - Toolpad',
         description:
-          'You will join the MUI Studio team, to explore the role of MUI in the low code space and help bring the early prototypes to a usable product.',
+          'You will join the MUI Toolpad team, to explore the role of MUI in the low code space and help bring the early prototypes to a usable product.',
         url: '/careers/fullstack-engineer/',
       },
       {

--- a/docs/src/components/home/UserFeedbacks.tsx
+++ b/docs/src/components/home/UserFeedbacks.tsx
@@ -93,7 +93,7 @@ const TESTIMONIALS = [
   },
   {
     quote:
-      '“After much research on React component libraries, we decided to ditch our in-house library for MUI, using its powerful customization system to implement our Design System. This simple move did a rare thing in engineering: it lowered our maintenance costs while enhancing both developer and customer experience. All of this was done without sacrificing the organization’s branding and visual identity.”',
+      '“After much research on React component libraries, we decided to ditch our in-house library for MUI, using its powerful customization system to implement our Design System. This simple move did a rare thing in engineering: it lowered our maintenance costs while enhancing both developer and customer experience. All of this was done without sacrificing the organization&apos;s branding and visual identity.”',
     profile: {
       avatarSrc: 'https://avatars.githubusercontent.com/u/732422?s=58',
       avatarSrcSet: 'https://avatars.githubusercontent.com/u/732422?s=116 2x',

--- a/docs/src/components/home/UserFeedbacks.tsx
+++ b/docs/src/components/home/UserFeedbacks.tsx
@@ -55,7 +55,7 @@ const Feedback = ({
 const TESTIMONIALS = [
   {
     quote:
-      "“MUI offers a wide variety of high quality components that have allowed us to ship features faster. MUI has been used by more than a hundred engineers in our organization. What’s more, MUI's well architected customization system has allowed us to differentiate ourselves in the marketplace.”",
+      '"MUI offers a wide variety of high quality components that have allowed us to ship features faster. MUI has been used by more than a hundred engineers in our organization. What\'s more, MUI\'s well architected customization system has allowed us to differentiate ourselves in the marketplace."',
     profile: {
       avatarSrc: 'https://avatars.githubusercontent.com/u/28296253?s=58',
       avatarSrcSet: 'https://avatars.githubusercontent.com/u/28296253?s=116 2x',
@@ -74,7 +74,7 @@ const TESTIMONIALS = [
   },
   {
     quote:
-      "“MUI looks great and lets us deliver fast, thanks to their solid API design and documentation - it's refreshing to use a component library where you get everything you need from their site rather than Stack Overflow. We think the upcoming version, with extra themes and customizability, will make MUI even more of a game changer. We're extremely grateful to the team for the time and effort spent maintaining the project.”",
+      '"MUI looks great and lets us deliver fast, thanks to their solid API design and documentation - it\'s refreshing to use a component library where you get everything you need from their site rather than Stack Overflow. We think the upcoming version, with extra themes and customizability, will make MUI even more of a game changer. We\'re extremely grateful to the team for the time and effort spent maintaining the project."',
     profile: {
       avatarSrc: 'https://avatars.githubusercontent.com/u/197016?s=58',
       avatarSrcSet: 'https://avatars.githubusercontent.com/u/197016?s=116 2x',
@@ -93,7 +93,7 @@ const TESTIMONIALS = [
   },
   {
     quote:
-      '“After much research on React component libraries, we decided to ditch our in-house library for MUI, using its powerful customization system to implement our Design System. This simple move did a rare thing in engineering: it lowered our maintenance costs while enhancing both developer and customer experience. All of this was done without sacrificing the organization&apos;s branding and visual identity.”',
+      '"After much research on React component libraries, we decided to ditch our in-house library for MUI, using its powerful customization system to implement our Design System. This simple move did a rare thing in engineering: it lowered our maintenance costs while enhancing both developer and customer experience. All of this was done without sacrificing the organization\'s branding and visual identity."',
     profile: {
       avatarSrc: 'https://avatars.githubusercontent.com/u/732422?s=58',
       avatarSrcSet: 'https://avatars.githubusercontent.com/u/732422?s=116 2x',

--- a/docs/src/components/productCore/CoreHero.tsx
+++ b/docs/src/components/productCore/CoreHero.tsx
@@ -415,7 +415,7 @@ export default function Hero() {
                   <Typography variant="body2" color="text.secondary">
                     Not just a great valley, but a shrine to human foresight, the strength of
                     granite, the power of glaciers, the persistence of life, and the tranquility of
-                    the High Sierra. It’s famed for its giant, ancient sequoia trees, and the
+                    the High Sierra. It&apos;s famed for its giant, ancient sequoia trees, and the
                     granite cliffs of El Capitan and Half Dome.
                   </Typography>
                 </CardContent>

--- a/docs/src/components/productDesignKit/DesignKitFAQ.tsx
+++ b/docs/src/components/productDesignKit/DesignKitFAQ.tsx
@@ -18,7 +18,7 @@ const faqData = [
     summary: 'What long-term support do you offer?',
     detail: (
       <React.Fragment>
-        We think you’ll love the components we&apos;ve built so far, but we&apos;re planning to
+        We think you&apos;ll love the components we&apos;ve built so far, but we&apos;re planning to
         release more. We opened it up as soon as we had something useful, so that you can start
         getting value from it right away, and we&apos;ll be adding new features and components based
         on our own ideas, and on suggestions from early access customers.
@@ -168,7 +168,7 @@ export default function DesignKitFAQ() {
               </Typography>
             </Box>
             <Typography variant="body2" color="text.primary" sx={{ my: 1, textAlign: 'left' }}>
-              From community help to premium business support, we’re here to help.
+              From community help to premium business support, we&apos;re here to help.
             </Typography>
             <Button
               component="a"

--- a/docs/src/pages/careers/designer.md
+++ b/docs/src/pages/careers/designer.md
@@ -31,7 +31,7 @@ Currently, we have five main projects that are not at all related to MD:
   - [MUI Joy (working title)](https://github.com/mui/material-ui/discussions/29024): a second design system as an alternative to Material Design.
 - [MUI X](/x/): as mentioned, a growing set of advanced components.
   Today, the flagship is the [Data Grid](/components/data-grid/), a game-changing component for presenting large amounts of data, which integrates perfectly with MUI Core.
-- MUI Studio: a very recent endeavor aimed at exploring how our users can visually create apps 10x faster with the power of low-code and the flexibility of pro-code.
+- MUI Toolpad: a very recent endeavor aimed at exploring how our users can visually create apps 10x faster with the power of low-code and the flexibility of pro-code.
 
 We also know, especially due to [our annual developer survey](/blog/2021-developer-survey-results/), that design quality plays a huge part when developers are considering component library options.
 Therefore, we need to grow the design team to help us push these initiatives further.
@@ -46,14 +46,14 @@ Some criteria for applying to this role:
 - Start date: immediately.
 
 We need someone experienced enough to help two different teams with hard problems.
-You'll be responsible for ensuring that the MUI Studio and MUI X teams have spot-on design and product work.
+You'll be responsible for ensuring that the MUI Toolpad and MUI X teams have spot-on design and product work.
 Given that each product is at a different stage, at this moment we believe that one person is enough to oversee the design function for both teams.
 You'll have the freedom, trust, and help you need to balance and tackle all the work.
 You'll also be the second designer of a growing design team, so we'll also need your help to shape this growth.
 
 ### Here are a few initiatives you might work on
 
-- Help design the first version of MUI Studio, from early strategy to its look and feel.
+- Help design the first version of MUI Toolpad, from early strategy to its look and feel.
 - Evolve and refine the Data Grid UX for features such as filtering, column pinning, row editing, and more.
 - Help set the bar higher for MUI X documentation, from visual design to copywriting.
 - Support the design team growth by promoting design/product culture, and hiring new members.

--- a/docs/src/pages/careers/full-stack-engineer.md
+++ b/docs/src/pages/careers/full-stack-engineer.md
@@ -55,7 +55,7 @@ Depending on the day, you'll:
 
 - **Help guide architectural decisions**. You'll join us in defining and refining the initial product and also help bring the conversation public as the MVP grows. You'll also interface with other teams at MUI as you'll be building on top of their work.
 - **Contribute to implementing new features**. MUI is a complex codebase. It's built on top of cutting edge web technologies to build the low-code tool for the future.
-- **Reduce friction**. A large amount of the work on MUI Toolpad is reducing friction and making it easier to use. As our MVP grows, our focus will shift from “making it work” towards “making it easy to work with”.
+- **Reduce friction**. A large amount of the work on MUI Toolpad is reducing friction and making it easier to use. As our MVP grows, our focus will shift from "making it work" towards "making it easy to work with".
 - **Collaborate with the community**. MUI Toolpad will be open-sourced. As the community grows you'll act as a steward to steer it towards success. This includes reviewing issues, pull requests and questions, and guiding aspiring contributors to make meaningful contributions.
 - **Experiment and play**. Great, unexpected features and heisenbug fixes have come from a number of sources — relentlessly methodical processes of elimination, free-flowing team collaboration, inspiration by adjacent libraries and projects, and difficult-to-explain individual strokes of brilliance. Whatever your preferred style is for creating new things that others might not have thought of, you'll find a welcome home on the team.
 - **Take ownership of features from idea/mockup to live deployment**. You'll shape and guide the direction of crucial new features.

--- a/docs/src/pages/careers/full-stack-engineer.md
+++ b/docs/src/pages/careers/full-stack-engineer.md
@@ -35,13 +35,13 @@ Our mission is to empower as many people as possible to build great UIs, faster.
 The faster and simpler it is, and the broader the audience that can create custom UIs, the better.
 We believe that the best way to improve on these dimensions is to eliminate [80%](https://www.youtube.com/watch?v=GnO7D5UaDig&t=2451s) of the code that has to be written.
 
-We’re in the early stages of exploring what our role could be in the currently emerging low-code space. We’ve assembled a team to work on a new product and plan to bring it to market in 2022. We have made our initial research and need help to accelerate the development of our MVP.
+We're in the early stages of exploring what our role could be in the currently emerging low-code space. We've assembled a team to work on a new product and plan to bring it to market in 2022. We have made our initial research and need help to accelerate the development of our MVP.
 
 ## About the role
 
 ### Why this is interesting
 
-The MUI Studio application offers a wide variety of engineering challenges. Including
+The MUI Toolpad application offers a wide variety of engineering challenges. Including
 
 - In-browser sandboxing and manipulation of live web applications
 - Drag & drop visual editor
@@ -53,10 +53,10 @@ The MUI Studio application offers a wide variety of engineering challenges. Incl
 
 Depending on the day, you'll:
 
-- **Help guide architectural decisions**. You'll join us in defining and refining the initial product and also help bring the conversation public as the MVP grows. You’ll also interface with other teams at MUI as you’ll be building on top of their work.
-- **Contribute to implementing new features**. MUI is a complex codebase. It’s built on top of cutting edge web technologies to build the low-code tool for the future.
-- **Reduce friction**. A large amount of the work on MUI Studio is reducing friction and making it easier to use. As our MVP grows, our focus will shift from “making it work” towards “making it easy to work with”.
-- **Collaborate with the community**. MUI Studio will be open-sourced. As the community grows you’ll act as a steward to steer it towards success. This includes reviewing issues, pull requests and questions, and guiding aspiring contributors to make meaningful contributions.
+- **Help guide architectural decisions**. You'll join us in defining and refining the initial product and also help bring the conversation public as the MVP grows. You'll also interface with other teams at MUI as you'll be building on top of their work.
+- **Contribute to implementing new features**. MUI is a complex codebase. It's built on top of cutting edge web technologies to build the low-code tool for the future.
+- **Reduce friction**. A large amount of the work on MUI Toolpad is reducing friction and making it easier to use. As our MVP grows, our focus will shift from “making it work” towards “making it easy to work with”.
+- **Collaborate with the community**. MUI Toolpad will be open-sourced. As the community grows you'll act as a steward to steer it towards success. This includes reviewing issues, pull requests and questions, and guiding aspiring contributors to make meaningful contributions.
 - **Experiment and play**. Great, unexpected features and heisenbug fixes have come from a number of sources — relentlessly methodical processes of elimination, free-flowing team collaboration, inspiration by adjacent libraries and projects, and difficult-to-explain individual strokes of brilliance. Whatever your preferred style is for creating new things that others might not have thought of, you'll find a welcome home on the team.
 - **Take ownership of features from idea/mockup to live deployment**. You'll shape and guide the direction of crucial new features.
 - **Ship. Early and often**. You'll iterate and ship frequently. You'll have a real impact on the end-user experience and you'll love working on a team that builds stunning UIs and prioritizes delivering real user value as often as possible.
@@ -66,7 +66,7 @@ Depending on the day, you'll:
 
 - **You'll be at the cutting edge of application development** — working on one of the fastest-growing UI libraries on the market.
 - **You'll be part of an active, open, friendly community** of developers that are excited about building awesome applications.
-- **Your role will be key to making MUI Studio the go-to low code tool** for internal application building.
+- **Your role will be key to making MUI Toolpad the go-to low code tool** for internal application building.
 
 ## The worst parts of this job
 
@@ -80,8 +80,8 @@ We're looking for someone with both strong front-end and back-end skills. More i
 
 ### Skills you should have
 
-- **Expertise in the modern JavaScript ecosystem**. MUI Studio is built on the shoulders of giants, making use of technologies such as ES2021, TypeScript, Node.js, React, Next.js, webpack, and Babel.
-- **Expertise in backend development**. MUI Studio interfaces with multiple databases, both SQL and NoSQL, as well as APIs such as REST and GraphQL. You’ll need to be comfortable in learning and integrating new backend technologies fast. You'll need to have a good understanding of distributed systems and some knowledge of CRDTs is a plus.
+- **Expertise in the modern JavaScript ecosystem**. MUI Toolpad is built on the shoulders of giants, making use of technologies such as ES2021, TypeScript, Node.js, React, Next.js, webpack, and Babel.
+- **Expertise in backend development**. MUI Toolpad interfaces with multiple databases, both SQL and NoSQL, as well as APIs such as REST and GraphQL. You'll need to be comfortable in learning and integrating new backend technologies fast. You'll need to have a good understanding of distributed systems and some knowledge of CRDTs is a plus.
 - **A track record of demonstrating an eye for product and solving real-world user problems**. If you have a knack for solving problems at the root cause, shipping beautiful user interfaces and intuitive APIs, we want you on our team.
 - **Experience building and shipping production code in a team setting** with a passion for writing tested, performant, and high-quality code.
 - **Strong written and verbal communication skills**. As part of the team, you'll interface both directly and indirectly with community members and enterprise customers, and contribute to user documentation. Clear communication is fundamental in creating intuitive and compelling resources.

--- a/docs/src/pages/careers/full-stack-engineer.md
+++ b/docs/src/pages/careers/full-stack-engineer.md
@@ -102,7 +102,7 @@ You can find the other perks & benefits on the [careers](/careers/#perks-amp-ben
 
 ## How to apply?
 
-[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=Full-stack%20Engineer%20-%20Studio&prefill_source=mui.com)
+[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=Full-stack%20Engineer%20-%20Toolpad&prefill_source=mui.com)
 
 ## What happens next?
 

--- a/packages/mui-material/test/typescript/components.spec.tsx
+++ b/packages/mui-material/test/typescript/components.spec.tsx
@@ -268,7 +268,7 @@ const CardMediaTest = () => (
           without stirring, until most of the liquid is absorbed, 15 to 18 minutes. Reduce heat to
           medium-low, add reserved shrimp and mussels, tucking them down into the rice, and cook
           again without stirring, until mussels have opened and rice is just tender, 5 to 7 minutes
-          more. (Discard any mussels that don’t open.)
+          more. (Discard any mussels that don&apos;t open.)
         </Typography>
         <Typography>
           Set aside off of the heat to let rest for 10 minutes, and then serve.


### PR DESCRIPTION
"Studio" was the codename of our low-code initiative. We have finalized the public name https://www.notion.so/mui-org/Name-domain-for-Studio-aec19e9fcb6749e5b34ddcf9857c6386. The main interesting property of this name is that "MUI Toolpad" can be shortened to "Toolpad". Of course, we checked trademarks, SEO ranking difficulty, pronunciation, and other dimensions.