### PR TITLE
[Link] Fix `sx` color to support callback 

### DIFF
--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -6,6 +6,7 @@ import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { alpha, getPath } from '@mui/system';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
+import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import useIsFocusVisible from '../utils/useIsFocusVisible';
 import useForkRef from '../utils/useForkRef';
@@ -98,6 +99,7 @@ const LinkRoot = styled(Typography, {
 });
 
 const Link = React.forwardRef(function Link(inProps, ref) {
+  const theme = useTheme();
   const props = useThemeProps({
     props: inProps,
     name: 'MuiLink',
@@ -145,7 +147,9 @@ const Link = React.forwardRef(function Link(inProps, ref) {
 
   const ownerState = {
     ...props,
-    color: sx?.color || color,
+    // It is too complex to support any types of `sx`.
+    // Need to find a better way to get rid of the color manipulation for `textDecorationColor`.
+    color: (typeof sx === 'function' ? sx(theme).color : sx?.color) || color,
     component,
     focusVisible,
     underline,
@@ -164,7 +168,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
       ref={handlerRef}
       ownerState={ownerState}
       variant={variant}
-      sx={{ color: colorTransformations[color] || color, ...sx }}
+      sx={[{ color: colorTransformations[color] || color }, ...(Array.isArray(sx) ? sx : [sx])]}
       {...other}
     />
   );

--- a/test/regressions/fixtures/Link/LinkColor.js
+++ b/test/regressions/fixtures/Link/LinkColor.js
@@ -24,6 +24,9 @@ export default function DeterminateLinearProgress() {
       <Link href="#unknown" sx={{ color: '#ff5252' }}>
         #ff5252
       </Link>
+      <Link href="#unknown" sx={(theme) => ({ color: theme.palette.secondary.main })}>
+        #ff5252
+      </Link>
     </ThemeProvider>
   );
 }

--- a/test/regressions/fixtures/Link/LinkColor.js
+++ b/test/regressions/fixtures/Link/LinkColor.js
@@ -25,7 +25,7 @@ export default function DeterminateLinearProgress() {
         #ff5252
       </Link>
       <Link href="#unknown" sx={(theme) => ({ color: theme.palette.secondary.main })}>
-        #ff5252
+        secondary
       </Link>
     </ThemeProvider>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The change introduced in https://github.com/mui/material-ui/pull/32045 does not support `sx` as array or callback which causes this bug in the doc. Luckily, it is not released yet 😅

<img width="254" alt="Screen Shot 2565-04-03 at 15 27 11" src="https://user-images.githubusercontent.com/18292247/161419057-49e8a95c-a784-4b4a-a7c6-ea69f0adb4ac.png">

This PR fixes it, however, it is not perfect for the `textDecorationColor`. We should find a better way to get rid of the color manipulation in the future.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
