### PR TITLE
[core] Fix 4.x release:publish

### DIFF
--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-codemod/**/*.test.js'",
     "prebuild": "rimraf lib",
-    "build": "node ../../scripts/build cjs --out-dir ./lib",
+    "build": "node ../../scripts/build cjs --out-dir ./build && cpy README.md build && cpy package.json build",
     "release": "yarn build && npm publish"
   },
   "repository": {


### PR DESCRIPTION
release:publish assumes `/build` which `material-ui-codemod` was lacking.
