### PR TITLE
[docs] Update demo config for React 18

### DIFF
--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -12,15 +12,14 @@ function jsDemo(demoData, options) {
       'demo.js': demoData.raw,
       'index.js': `
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';
 import Demo from './demo';
 
-ReactDOM.render(
+ReactDOM.createRoot(document.querySelector("#root")).render(
   <StyledEngineProvider injectFirst>
     <Demo />
-  </StyledEngineProvider>,
-  document.querySelector("#root")
+  </StyledEngineProvider>
 );
     `.trim(),
     },
@@ -38,15 +37,14 @@ function tsDemo(demoData, options) {
       'demo.tsx': demoData.raw,
       'index.tsx': `
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';
 import Demo from './demo';
 
-ReactDOM.render(
+ReactDOM.createRoot(document.querySelector("#root")).render(
   <StyledEngineProvider injectFirst>
     <Demo />
-  </StyledEngineProvider>,
-  document.querySelector("#root")
+  </StyledEngineProvider>
 );
     `.trim(),
       'tsconfig.json': `{


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-32130--material-ui.netlify.app/components/buttons/#basic-button

The demos, when opened in CodeSandbox/StackBlitz, are still using `ReactDOM.render` instead of  `ReactDOM.createRoot`. There's a console message warning about that:

<img width="500" src="https://user-images.githubusercontent.com/42154031/161604497-d8fd649d-b265-4930-8fd0-9d041137d922.png" alt="image" style="max-width: 100%;">
