### PR TITLE
Batch small changes

### DIFF
--- a/docs/data/base/components/popper/popper.md
+++ b/docs/data/base/components/popper/popper.md
@@ -23,7 +23,7 @@ githubLabel: 'component: Popper'
 
 - Clicking away does not hide the `Popper` component. If you need this behavior, you can use [`ClickAwayListener`](/base/react-click-away-listener/)
 
-**Bundle size**: 📦 [8 kB gzipped](/size-snapshot).
+**Bundle size**: 📦 [8.1 kB gzipped](/size-snapshot).
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/material/components/popper/popper.md
+++ b/docs/data/material/components/popper/popper.md
@@ -15,7 +15,7 @@ Some important features of the `Popper` component:
 
 - 🕷 Popper relies on the 3rd party library ([Popper.js](https://popper.js.org/)) for perfect positioning.
 - 💄 It's an alternative API to react-popper. It aims for simplicity.
-- 📦 [8 kB gzipped](/size-snapshot).
+- 📦 [17.3 kB gzipped](/size-snapshot).
 - The children is [`Portal`](/components/portal/) to the body of the document to avoid rendering problems.
   You can disable this behavior with `disablePortal`.
 - The scroll isn't blocked like with the [`Popover`](/components/popover/) component.

--- a/packages/mui-material/src/Grow/Grow.js
+++ b/packages/mui-material/src/Grow/Grow.js
@@ -21,10 +21,8 @@ const styles = {
   },
 };
 
-/**
- * Conditionally apply a workaround for the CSS transition bug in Safari 15.4.
- * Remove this workaround once the Safari bug is fixed.
- */
+// TODO v6: remove
+// Conditionally apply a workaround for the CSS transition bug in Safari 15.4.
 const isSafari154 =
   typeof navigator !== 'undefined' &&
   /^((?!chrome|android).)*safari/i.test(navigator.userAgent) &&


### PR DESCRIPTION
* Updated the bundle size of the Popper (as per https://github.com/mui/material-ui/pull/30118#pullrequestreview-909551493)
* Added a TODO comment to remove the Safari CSS transition bug workaround (https://github.com/mui/material-ui/pull/31975#discussion_r836310706)