### PR TITLE
[Link] Fix style overrides 5.6.0 regression

### DIFF
--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -160,6 +160,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
 
   return (
     <LinkRoot
+      color={color}
       className={clsx(classes.root, className)}
       classes={TypographyClasses}
       component={component}

--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -117,6 +117,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     sx,
     ...other
   } = props;
+  const sxColor = typeof sx === 'function' ? sx(theme).color : sx?.color;
 
   const {
     isFocusVisibleRef,
@@ -149,7 +150,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     ...props,
     // It is too complex to support any types of `sx`.
     // Need to find a better way to get rid of the color manipulation for `textDecorationColor`.
-    color: (typeof sx === 'function' ? sx(theme).color : sx?.color) || color,
+    color: (typeof sxColor === 'function' ? sxColor(theme) : sxColor) || color,
     component,
     focusVisible,
     underline,

--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -168,7 +168,10 @@ const Link = React.forwardRef(function Link(inProps, ref) {
       ref={handlerRef}
       ownerState={ownerState}
       variant={variant}
-      sx={[{ color: colorTransformations[color] || color }, ...(Array.isArray(sx) ? sx : [sx])]}
+      sx={[
+        ...(inProps.color ? [{ color: colorTransformations[color] || color }] : []),
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       {...other}
     />
   );

--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -43,6 +43,16 @@ describe('<Link />', () => {
     expect(container.firstChild).not.to.have.class('link-body2');
   });
 
+  it('using sx color as a function should not crash', () => {
+    expect(() =>
+      render(
+        <Link href="/" sx={{ color: (theme) => theme.palette.primary.light }}>
+          Test
+        </Link>,
+      ),
+    ).not.to.throw();
+  });
+
   describe('event callbacks', () => {
     it('should fire event callbacks', () => {
       const events = ['onBlur', 'onFocus'];

--- a/test/regressions/fixtures/Link/LinkColor.js
+++ b/test/regressions/fixtures/Link/LinkColor.js
@@ -10,14 +10,14 @@ export default function DeterminateLinearProgress() {
           MuiLink: {
             styleOverrides: {
               root: {
-                color: '#0068a9', // blue
+                color: '#fbca04', // orange
               },
             },
           },
         },
       })}
     >
-      <Link href="#unknown">#0068a9</Link>
+      <Link href="#unknown">#fbca04</Link>
       <Link href="#unknown" color="#ff5252">
         #ff5252
       </Link>

--- a/test/regressions/fixtures/Link/LinkColor.js
+++ b/test/regressions/fixtures/Link/LinkColor.js
@@ -27,6 +27,9 @@ export default function DeterminateLinearProgress() {
       <Link href="#unknown" sx={(theme) => ({ color: theme.palette.secondary.main })}>
         secondary
       </Link>
+      <Link href="#unknown" sx={{ color: (theme) => theme.palette.error.main }}>
+        error
+      </Link>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #32172
Closes #32183 

**Root cause**

The prop `color` (default as `primary`) is passed to `sx` internally which has higher priority than style overrides. This PR check the instance `color` prop before passing it to `sx`.

```js
<Link>...</Link> // ✅ style overrides (note that by overriding `textDecorationColor`, it removes the color calculation)
<Link color=...>...</Link> // goes to sx
<Link sx={{ color: ... }}> // goes to sx
```

> Argos change is expected.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
