### PR TITLE
[TextField] Add a workaround for Safari CSS transition scale bug

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -83,7 +83,9 @@ const FilledInputRoot = styled(InputBaseRoot, {
         pointerEvents: 'none', // Transparent to the hover style.
       },
       [`&.${filledInputClasses.focused}:after`]: {
-        transform: 'scaleX(1)',
+        // translateX(0) is a workaround for Safari transform scale bug
+        // See https://github.com/mui/material-ui/issues/31766
+        transform: 'scaleX(1) translateX(0)',
       },
       [`&.${filledInputClasses.error}:after`]: {
         borderBottomColor: theme.palette.error.main,

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -68,7 +68,9 @@ const InputRoot = styled(InputBaseRoot, {
         pointerEvents: 'none', // Transparent to the hover style.
       },
       [`&.${inputClasses.focused}:after`]: {
-        transform: 'scaleX(1)',
+        // translateX(0) is a workaround for Safari transform scale bug
+        // See https://github.com/mui/material-ui/issues/31766
+        transform: 'scaleX(1) translateX(0)',
       },
       [`&.${inputClasses.error}:after`]: {
         borderBottomColor: theme.palette.error.main,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #31766 

Preview: https://deploy-preview-32188--material-ui.netlify.app/components/text-fields/#main-content