### PR TITLE
[Dialog] support rtl direction in dialog

### DIFF
--- a/docs/pages/base/api/modal-unstyled.json
+++ b/docs/pages/base/api/modal-unstyled.json
@@ -23,6 +23,7 @@
     "disableRestoreFocus": { "type": { "name": "bool" } },
     "disableScrollLock": { "type": { "name": "bool" } },
     "hideBackdrop": { "type": { "name": "bool" } },
+    "isRtl": { "type": { "name": "bool" } },
     "keepMounted": { "type": { "name": "bool" } },
     "onBackdropClick": { "type": { "name": "func" } },
     "onClose": { "type": { "name": "func" } }

--- a/docs/pages/material-ui/api/modal.json
+++ b/docs/pages/material-ui/api/modal.json
@@ -26,6 +26,7 @@
     "disableRestoreFocus": { "type": { "name": "bool" } },
     "disableScrollLock": { "type": { "name": "bool" } },
     "hideBackdrop": { "type": { "name": "bool" } },
+    "isRtl": { "type": { "name": "bool" } },
     "keepMounted": { "type": { "name": "bool" } },
     "onBackdropClick": { "type": { "name": "func" } },
     "onClose": { "type": { "name": "func" } },

--- a/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
+++ b/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
@@ -17,6 +17,7 @@
     "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden or unmounted.",
     "disableScrollLock": "Disable the scroll lock behavior.",
     "hideBackdrop": "If <code>true</code>, the backdrop is not rendered.",
+    "isRtl": "Indicates whether the theme context has rtl direction. It is set automatically.",
     "keepMounted": "Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Modal.",
     "onBackdropClick": "Callback fired when the backdrop is clicked.",
     "onClose": "Callback fired when the component requests to be closed. The <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>.<br><br><strong>Signature:</strong><br><code>function(event: object, reason: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>reason:</em> Can be: <code>&quot;escapeKeyDown&quot;</code>, <code>&quot;backdropClick&quot;</code>.",

--- a/docs/translations/api-docs/modal/modal.json
+++ b/docs/translations/api-docs/modal/modal.json
@@ -16,6 +16,7 @@
     "disableRestoreFocus": "If <code>true</code>, the modal will not restore focus to previously focused element once modal is hidden or unmounted.",
     "disableScrollLock": "Disable the scroll lock behavior.",
     "hideBackdrop": "If <code>true</code>, the backdrop is not rendered.",
+    "isRtl": "Indicates whether the theme context has rtl direction. It is set automatically.",
     "keepMounted": "Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Modal.",
     "onBackdropClick": "Callback fired when the backdrop is clicked.",
     "onClose": "Callback fired when the component requests to be closed. The <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>.<br><br><strong>Signature:</strong><br><code>function(event: object, reason: string) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>reason:</em> Can be: <code>&quot;escapeKeyDown&quot;</code>, <code>&quot;backdropClick&quot;</code>.",

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.d.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.d.ts
@@ -96,6 +96,11 @@ export interface ModalUnstyledTypeMap<P = {}, D extends React.ElementType = 'div
      */
     hideBackdrop?: boolean;
     /**
+     * Indicates whether the theme context has rtl direction. It is set automatically.
+     * @default false
+     */
+    isRtl?: boolean;
+    /**
      * Always keep the children in the DOM.
      * This prop can be useful in SEO situation or
      * when you want to maximize the responsiveness of the Modal.

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
@@ -70,6 +70,7 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
     disableRestoreFocus = false,
     disableScrollLock = false,
     hideBackdrop = false,
+    isRtl = false,
     keepMounted = false,
     // private
     // eslint-disable-next-line react/prop-types
@@ -84,6 +85,8 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
     onTransitionExited,
     ...other
   } = props;
+
+  const dir = isRtl ? 'rtl' : 'ltr';
 
   const [exited, setExited] = React.useState(true);
   const modal = React.useRef({});
@@ -262,6 +265,7 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
           theme,
         })}
         {...other}
+        dir={dir}
         ref={handleRef}
         onKeyDown={handleKeyDown}
         className={clsx(classes.root, rootProps.className, className)}
@@ -393,6 +397,11 @@ ModalUnstyled.propTypes /* remove-proptypes */ = {
    * @default false
    */
   hideBackdrop: PropTypes.bool,
+  /**
+   * Indicates whether the theme context has rtl direction. It is set automatically.
+   * @default false
+   */
+  isRtl: PropTypes.bool,
   /**
    * Always keep the children in the DOM.
    * This prop can be useful in SEO situation or

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -6,6 +6,7 @@ import ModalUnstyled, { modalUnstyledClasses } from '@mui/base/ModalUnstyled';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import Backdrop from '../Backdrop';
+import useTheme from '../styles/useTheme';
 
 export const modalClasses = modalUnstyledClasses;
 
@@ -76,6 +77,9 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     ...other
   } = props;
 
+  const theme = useTheme();
+  const isRtl = theme.direction === 'rtl';
+
   const [exited, setExited] = React.useState(true);
 
   const commonProps = {
@@ -116,6 +120,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
       onTransitionEnter={() => setExited(false)}
       onTransitionExited={() => setExited(true)}
       ref={ref}
+      isRtl={isRtl}
       {...other}
       classes={classes}
       {...commonProps}
@@ -230,6 +235,11 @@ Modal.propTypes /* remove-proptypes */ = {
    * @default false
    */
   hideBackdrop: PropTypes.bool,
+  /**
+   * Indicates whether the theme context has rtl direction. It is set automatically.
+   * @default false
+   */
+  isRtl: PropTypes.bool,
   /**
    * Always keep the children in the DOM.
    * This prop can be useful in SEO situation or


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #32022 

`Modal` uses `Portal`, so It seems that `dir` attribute from `root` is not applied to `Modal` (includes `Dialog`), so I added a prop for `Modal` to check `dir`. If `dir` is `rtl`, `dir` attribute is passed to `Root` component in `ModalUnstyled`.
(I  referred to the `Slider` component.)

`Dialog` uses `Modal`, so the bug is fixed.

Here is my [Demo](https://codesandbox.io/s/quirky-darwin-690txc?file=/src/App.js) 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
