### PR TITLE
[docs] Fix VirtualElement Popper demo crash and text deselection

### DIFF
--- a/docs/data/material/components/popper/VirtualElementPopper.js
+++ b/docs/data/material/components/popper/VirtualElementPopper.js
@@ -13,20 +13,24 @@ export default function VirtualElementPopper() {
   };
 
   const handleMouseUp = () => {
-    const selection = window.getSelection();
+    // `selection` might not be updated, so we wait for the next event cycle
+    // before proceeding.
+    setTimeout(() => {
+      const selection = window.getSelection();
 
-    // Resets when the selection has a length of 0
-    if (!selection || selection.anchorOffset === selection.focusOffset) {
-      handleClose();
-      return;
-    }
+      // Resets when the selection has a length of 0
+      if (!selection || selection.anchorOffset === selection.focusOffset) {
+        handleClose();
+        return;
+      }
 
-    const rect = selection.getRangeAt(0).getBoundingClientRect();
+      const rect = selection.getRangeAt(0).getBoundingClientRect();
 
-    setOpen(true);
-    setAnchorEl({
-      getBoundingClientRect: () => rect,
-    });
+      setOpen(true);
+      setAnchorEl({
+        getBoundingClientRect: () => rect,
+      });
+    }, 0);
   };
 
   const id = open ? 'virtual-element-popper' : undefined;

--- a/docs/data/material/components/popper/VirtualElementPopper.js
+++ b/docs/data/material/components/popper/VirtualElementPopper.js
@@ -21,12 +21,11 @@ export default function VirtualElementPopper() {
       return;
     }
 
-    const getBoundingClientRect = () =>
-      selection.getRangeAt(0).getBoundingClientRect();
+    const rect = selection.getRangeAt(0).getBoundingClientRect();
 
     setOpen(true);
     setAnchorEl({
-      getBoundingClientRect,
+      getBoundingClientRect: () => rect,
     });
   };
 

--- a/docs/data/material/components/popper/VirtualElementPopper.tsx
+++ b/docs/data/material/components/popper/VirtualElementPopper.tsx
@@ -13,20 +13,24 @@ export default function VirtualElementPopper() {
   };
 
   const handleMouseUp = () => {
-    const selection = window.getSelection();
+    // `selection` might not be updated, so we wait for the next event cycle
+    // before proceeding.
+    setTimeout(() => {
+      const selection = window.getSelection();
 
-    // Resets when the selection has a length of 0
-    if (!selection || selection.anchorOffset === selection.focusOffset) {
-      handleClose();
-      return;
-    }
+      // Resets when the selection has a length of 0
+      if (!selection || selection.anchorOffset === selection.focusOffset) {
+        handleClose();
+        return;
+      }
 
-    const rect = selection.getRangeAt(0).getBoundingClientRect();
+      const rect = selection.getRangeAt(0).getBoundingClientRect();
 
-    setOpen(true);
-    setAnchorEl({
-      getBoundingClientRect: () => rect,
-    });
+      setOpen(true);
+      setAnchorEl({
+        getBoundingClientRect: () => rect,
+      });
+    }, 0);
   };
 
   const id = open ? 'virtual-element-popper' : undefined;

--- a/docs/data/material/components/popper/VirtualElementPopper.tsx
+++ b/docs/data/material/components/popper/VirtualElementPopper.tsx
@@ -21,12 +21,11 @@ export default function VirtualElementPopper() {
       return;
     }
 
-    const getBoundingClientRect = () =>
-      selection.getRangeAt(0).getBoundingClientRect();
+    const rect = selection.getRangeAt(0).getBoundingClientRect();
 
     setOpen(true);
     setAnchorEl({
-      getBoundingClientRect,
+      getBoundingClientRect: () => rect,
     });
   };
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The demo will no longer crash when moving the cursor out of the demo box. Additionally, the Popper will properly close when deselecting text.

The linked issue has a video of the old behavior. This PR will change it to the following:

https://user-images.githubusercontent.com/36072821/162474564-bac30c36-e492-4686-bd8d-9dae1d9a71a7.mp4

Closes #32106
