### PR TITLE
[ButtonBase] Ensure type prop is passed down when custom component is used

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -266,9 +266,15 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     ComponentProp = 'a';
   }
 
-  const buttonProps = {};
+  const buttonProps = {
+    type,
+  };
+
+  if (typeof ComponentProp === 'string' && ComponentProp !== 'button') {
+    buttonProps.type = undefined;
+  }
+
   if (ComponentProp === 'button') {
-    buttonProps.type = type;
     buttonProps.disabled = disabled;
   } else {
     if (ComponentProp !== 'a' || !other.href) {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -84,7 +84,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     onDragLeave,
     tabIndex = 0,
     TouchRippleProps,
-    type = 'button',
+    type,
     ...other
   } = props;
 
@@ -266,15 +266,10 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     ComponentProp = 'a';
   }
 
-  const buttonProps = {
-    type,
-  };
-
-  if (typeof ComponentProp === 'string' && ComponentProp !== 'button') {
-    buttonProps.type = undefined;
-  }
+  const buttonProps = {};
 
   if (ComponentProp === 'button') {
+    buttonProps.type = type === undefined ? 'button' : type;
     buttonProps.disabled = disabled;
   } else {
     if (ComponentProp !== 'a' || !other.href) {
@@ -334,6 +329,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
       onTouchStart={handleTouchStart}
       ref={handleRef}
       tabIndex={disabled ? -1 : tabIndex}
+      type={type}
       {...buttonProps}
       {...other}
     >

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -117,6 +117,31 @@ describe('<ButtonBase />', () => {
       expect(button).to.have.property('nodeName', 'SPAN');
       expect(button).to.have.attribute('href', 'https://google.com');
     });
+
+    it('should allow to set type prop when component is not a button', () => {
+      const MockButton = React.forwardRef((props, ref) => (
+        <button data-testid="mockButton" {...props} ref={ref} />
+      ));
+
+      const { getByRole } = render(
+        // @ts-ignore
+        <ButtonBase component={MockButton} type="submit">
+          Hello
+        </ButtonBase>,
+      );
+      const button = getByRole('button');
+      expect(button).to.have.attribute('type', 'submit');
+    });
+
+    it('should not set type prop when component is an anchor', () => {
+      const { getByText } = render(
+        <ButtonBase component="a" type="submit">
+          Hello
+        </ButtonBase>,
+      );
+      const button = getByText('Hello');
+      expect(button).not.to.have.attribute('type', 'submit');
+    });
   });
 
   describe('event callbacks', () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -133,14 +133,14 @@ describe('<ButtonBase />', () => {
       expect(button).to.have.attribute('type', 'submit');
     });
 
-    it('should not set type prop when component is an anchor', () => {
+    it('should allow setting type attribute explicitly even when component is an anchor', () => {
       const { getByText } = render(
         <ButtonBase component="a" type="submit">
           Hello
         </ButtonBase>,
       );
       const button = getByText('Hello');
-      expect(button).not.to.have.attribute('type', 'submit');
+      expect(button).to.have.attribute('type', 'submit');
     });
   });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -118,7 +118,7 @@ describe('<ButtonBase />', () => {
       expect(button).to.have.attribute('href', 'https://google.com');
     });
 
-    it('should allow to set type prop when component is not a button', () => {
+    it('should allow setting type attribute when component is not a button', () => {
       const MockButton = React.forwardRef((props, ref) => (
         <button data-testid="mockButton" {...props} ref={ref} />
       ));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


