### PR TITLE
[ButtonUnstyled] Fix keyboard navigation on customized elements

### DIFF
--- a/docs/data/base/components/button/UseButton.js
+++ b/docs/data/base/components/button/UseButton.js
@@ -47,7 +47,6 @@ const CustomButton = React.forwardRef(function CustomButton(props, ref) {
   const { active, disabled, focusVisible, getRootProps } = useButton({
     ...props,
     ref,
-    component: CustomButtonRoot,
   });
 
   const classes = {

--- a/docs/data/base/components/button/UseButton.tsx
+++ b/docs/data/base/components/button/UseButton.tsx
@@ -49,7 +49,6 @@ const CustomButton = React.forwardRef(function CustomButton(
   const { active, disabled, focusVisible, getRootProps } = useButton({
     ...props,
     ref,
-    component: CustomButtonRoot,
   });
 
   const classes = {

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -69,3 +69,9 @@ The `useButton` hook requires the `ref` of the element it's used on.
 Additionally, you need to provide the `component` prop (unless you intend to use the plain `button`).
 
 {{"demo": "UseButton.js", "defaultCodeOpen": true}}
+
+## Limitations
+
+If a `ButtonUnstyled` is customized with a non-button element (i.e. `<ButtonUnstyled component="span" />`), it will have the default behavior in relation to forms.
+That is, clicking on such button will not submit a form it's in.
+Similarily `<ButtonUnstyled component="span" type="reset">` will not reset its parent form.

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -72,6 +72,5 @@ Additionally, you need to provide the `component` prop (unless you intend to use
 
 ## Limitations
 
-If a `ButtonUnstyled` is customized with a non-button element (i.e. `<ButtonUnstyled component="span" />`), it will have the default behavior in relation to forms.
-That is, clicking on such button will not submit a form it's in.
+If a `ButtonUnstyled` is customized with a non-button element (i.e. `<ButtonUnstyled component="span" />`), it will not submit the form it's in when clicked.
 Similarly, `<ButtonUnstyled component="span" type="reset">` will not reset its parent form.

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -74,4 +74,4 @@ Additionally, you need to provide the `component` prop (unless you intend to use
 
 If a `ButtonUnstyled` is customized with a non-button element (i.e. `<ButtonUnstyled component="span" />`), it will have the default behavior in relation to forms.
 That is, clicking on such button will not submit a form it's in.
-Similarily `<ButtonUnstyled component="span" type="reset">` will not reset its parent form.
+Similarly, `<ButtonUnstyled component="span" type="reset">` will not reset its parent form.

--- a/docs/data/base/components/menu/UseMenu.js
+++ b/docs/data/base/components/menu/UseMenu.js
@@ -117,10 +117,7 @@ Menu.propTypes = {
 const MenuItem = React.forwardRef(function MenuItem(props, ref) {
   const { children, ...other } = props;
 
-  const { getRootProps, itemState } = useMenuItem({
-    component: 'li',
-    ref,
-  });
+  const { getRootProps, itemState } = useMenuItem({ ref });
 
   const classes = {
     'menu-item': true,

--- a/docs/data/base/components/menu/UseMenu.tsx
+++ b/docs/data/base/components/menu/UseMenu.tsx
@@ -122,10 +122,7 @@ const MenuItem = React.forwardRef(function MenuItem(
 ) {
   const { children, ...other } = props;
 
-  const { getRootProps, itemState } = useMenuItem({
-    component: 'li',
-    ref,
-  });
+  const { getRootProps, itemState } = useMenuItem({ ref });
 
   const classes = {
     'menu-item': true,

--- a/docs/pages/base/api/button-unstyled.json
+++ b/docs/pages/base/api/button-unstyled.json
@@ -6,7 +6,7 @@
         "description": "func<br>&#124;&nbsp;{ current?: { focusVisible: func } }"
       }
     },
-    "component": { "type": { "name": "elementType" }, "default": "'button'" },
+    "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
       "default": "{}"

--- a/docs/translations/api-docs/button-unstyled/button-unstyled.json
+++ b/docs/translations/api-docs/button-unstyled/button-unstyled.json
@@ -2,7 +2,7 @@
   "componentDescription": "The foundation for building custom-styled buttons.",
   "propDescriptions": {
     "action": "A ref for imperative actions. It currently only supports <code>focusVisible()</code> action.",
-    "component": "The component used for the Root slot. Either a string to use a HTML element or a component.",
+    "component": "The component used for the Root slot. Either a string to use a HTML element or a component. This is equivalent to <code>components.Root</code>. If both are provided, the <code>component</code> is used.",
     "components": "The components used for each slot inside the Button. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside the Button.",
     "disabled": "If <code>true</code>, the component is disabled.",

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.tsx
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.tsx
@@ -134,9 +134,9 @@ ButtonUnstyled.propTypes /* remove-proptypes */ = {
   /**
    * The component used for the Root slot.
    * Either a string to use a HTML element or a component.
-   * @default 'button'
+   * This is equivalent to `components.Root`. If both are provided, the `component` is used.
    */
-  component: PropTypes.elementType,
+  component: PropTypes /* @typescript-to-proptypes-ignore */.elementType,
   /**
    * The components used for each slot inside the Button.
    * Either a string to use a HTML element or a component.

--- a/packages/mui-base/src/ButtonUnstyled/useButton.test.tsx
+++ b/packages/mui-base/src/ButtonUnstyled/useButton.test.tsx
@@ -47,7 +47,7 @@ describe('useButton', () => {
       it('is set when triggered by mouse', () => {
         const TestComponent = () => {
           const buttonRef = React.useRef(null);
-          const { active, getRootProps } = useButton({ ref: buttonRef, component: 'span' });
+          const { active, getRootProps } = useButton({ ref: buttonRef });
 
           return <span {...getRootProps()} className={active ? 'active' : ''} />;
         };
@@ -63,7 +63,7 @@ describe('useButton', () => {
       it('is set when triggered by keyboard', () => {
         const TestComponent = () => {
           const buttonRef = React.useRef(null);
-          const { active, getRootProps } = useButton({ ref: buttonRef, component: 'span' });
+          const { active, getRootProps } = useButton({ ref: buttonRef });
 
           return <span {...getRootProps()} className={active ? 'active' : ''} />;
         };

--- a/packages/mui-base/src/ButtonUnstyled/useButton.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/useButton.types.ts
@@ -21,12 +21,6 @@ export type UseButtonRootSlotProps<TOther = {}> = Omit<TOther, keyof UseButtonRo
 
 export interface UseButtonParameters {
   /**
-   * The component used for the Root slot.
-   * Either a string to use a HTML element or a component.
-   * @default 'button'
-   */
-  component?: React.ElementType;
-  /**
    * If `true`, the component is disabled.
    * @default false
    */

--- a/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.tsx
+++ b/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.tsx
@@ -45,7 +45,6 @@ const MenuItemUnstyled = React.forwardRef(function MenuItemUnstyled(
   const Root = component ?? components.Root ?? 'li';
 
   const { getRootProps, itemState, focusVisible } = useMenuItem({
-    component: Root,
     disabled,
     ref,
     label,

--- a/packages/mui-base/src/MenuItemUnstyled/useMenuItem.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/useMenuItem.ts
@@ -5,7 +5,7 @@ import { useButton } from '../ButtonUnstyled';
 import { UseMenuItemParameters } from './useMenuItem.types';
 
 export default function useMenuItem(props: UseMenuItemParameters) {
-  const { component, disabled = false, ref, label } = props;
+  const { disabled = false, ref, label } = props;
 
   const id = useId();
   const menuContext = React.useContext(MenuUnstyledContext);
@@ -30,7 +30,6 @@ export default function useMenuItem(props: UseMenuItemParameters) {
   }, [id, registerItem, unregisterItem, disabled, ref, label]);
 
   const { getRootProps: getButtonProps, focusVisible } = useButton({
-    component,
     disabled,
     focusableWhenDisabled: true,
     ref: handleRef,

--- a/packages/mui-base/src/MenuItemUnstyled/useMenuItem.types.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/useMenuItem.types.ts
@@ -1,5 +1,4 @@
 export interface UseMenuItemParameters {
-  component: React.ElementType;
   disabled?: boolean;
   onClick?: React.MouseEventHandler<any>;
   ref: React.Ref<any>;

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -126,7 +126,6 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
     getOptionState,
     value,
   } = useSelect<TValue>({
-    buttonComponent: Button,
     buttonRef: handleButtonRef,
     defaultValue,
     disabled: disabledProp,

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -124,7 +124,6 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue>(
     getOptionState,
     value,
   } = useSelect({
-    buttonComponent: Button,
     buttonRef: handleButtonRef,
     defaultValue,
     disabled: disabledProp,

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -40,7 +40,6 @@ function useSelect<TValue>(props: UseSelectSingleParameters<TValue>): UseSelectS
 function useSelect<TValue>(props: UseSelectMultiParameters<TValue>): UseSelectMultiResult<TValue>;
 function useSelect<TValue>(props: UseSelectParameters<TValue>) {
   const {
-    buttonComponent,
     buttonRef: buttonRefProp,
     defaultValue,
     disabled = false,
@@ -206,7 +205,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     active: buttonActive,
     focusVisible: buttonFocusVisible,
   } = useButton({
-    component: buttonComponent,
     disabled,
     ref: handleButtonRef,
   });

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -28,7 +28,6 @@ export function isOptionGroup<TValue>(
 }
 
 interface UseSelectCommonProps<TValue> {
-  buttonComponent?: React.ElementType;
   buttonRef?: React.Ref<Element>;
   disabled?: boolean;
   listboxId?: string;

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -149,7 +149,6 @@ const Button = React.forwardRef(function Button(inProps, ref) {
 
   const { focusVisible, setFocusVisible, getRootProps } = useButton({
     ...props,
-    component: ComponentProp,
     ref: handleRef,
   });
 

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -203,7 +203,6 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
   const { focusVisible, getRootProps } = useButton({
     disabled,
     ...actionProps,
-    component: actionComponent,
     ref: handleActionRef,
   });
 

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -84,7 +84,6 @@ const ChipDelete = React.forwardRef(function ChipDelete(inProps, ref) {
   const { focusVisible, getRootProps } = useButton({
     ...props,
     disabled,
-    component,
     ref: handleRef,
   });
 

--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -100,7 +100,6 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
 
   const { focusVisible, setFocusVisible, getRootProps } = useButton({
     ...props,
-    component: ComponentProp,
     ref: handleRef,
   });
 

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -124,11 +124,8 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
   const buttonRef = React.useRef<HTMLElement | null>(null);
   const handleRef = useForkRef(buttonRef, ref);
 
-  const ComponentProp = component;
-
   const { focusVisible, setFocusVisible, getRootProps } = useButton({
     ...props,
-    component: ComponentProp,
     ref: handleRef,
   });
 


### PR DESCRIPTION
Fixed the detection of native elements in useButton. It should be now possible to trigger click events on ButtonUnstyled, which root is a <button> wrapped in a component.

Unfortunately, this is not unit-testable, as neither JSDOM, nor browsers trigger the click event when <kbd>Enter</kbd> or <kbd>Space</kbd> is pressed on a native button.

Also added a doc section about custom buttons not interacting with forms as their native counterparts.

Fixes #32193

---

The first commit contains the actual fix. The second is a cleanup of no longer needed `component` parameter from `useButton` (this makes it more in-line with other hooks that are not concerned about the `component` or `components`).