### PR TITLE
[docs] Sync package description with the docs

### DIFF
--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0-alpha.75",
   "private": false,
   "author": "MUI Team",
-  "description": "Unstyled React components with which to implement custom design systems.",
+  "description": "Unstyled React components and low-level hooks.",
   "main": "./src/index.js",
   "keywords": [
     "react",

--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.0-alpha.30",
   "private": false,
   "author": "MUI Team",
-  "description": "Material Design components built using @mui/base.",
+  "description": "v6-alpha: React components that implement Google's Material Design",
   "main": "./src/index.ts",
   "keywords": [
     "react",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -3,7 +3,7 @@
   "version": "5.6.0",
   "private": false,
   "author": "MUI Team",
-  "description": "Quickly build beautiful React apps. MUI is a simple and customizable component library to build faster, beautiful, and more accessible React applications. Follow your own design system, or start with Material Design.",
+  "description": "React components that implement Google's Material Design.",
   "main": "./src/index.ts",
   "keywords": [
     "react",

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -3,7 +3,7 @@
   "version": "5.6.0",
   "private": false,
   "author": "MUI Team",
-  "description": "MUI Theming - The React theme context to be shared between `@mui/styles` and `@mui/material`.",
+  "description": "Private - The React theme context to be shared between `@mui/styles` and `@mui/material`.",
   "main": "./src/index.js",
   "keywords": [
     "react",

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -3,7 +3,7 @@
   "version": "5.6.0",
   "private": false,
   "author": "MUI Team",
-  "description": "MUI Styles - The styling solution of MUI.",
+  "description": "MUI Styles - The legacy JSS-based styling solution of Material UI.",
   "main": "./src/index.js",
   "keywords": [
     "react",

--- a/packages/typescript-to-proptypes/package.json
+++ b/packages/typescript-to-proptypes/package.json
@@ -3,9 +3,6 @@
   "version": "5.0.0",
   "private": true,
   "description": "Generate proptypes from TypeScript declarations",
-  "engines": {
-    "node": ">=10.3.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mui/material-ui.git",


### PR DESCRIPTION
This change is related to #32181

it's synching the npm packages description with

<img width="545" alt="Screenshot 2022-04-09 at 13 22 11" src="https://user-images.githubusercontent.com/3165635/162569700-deae28a1-bfa9-4a35-8b2c-93d0fcda0f97.png">
 