### PR TITLE
[docs] Sync h1 with side nav label

### DIFF
--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -1,15 +1,14 @@
 ---
 product: material-ui
-title: Material icons
 components: Icon, SvgIcon
 materialDesign: https://material.io/design/iconography/system-icons.html
 packageName: '@mui/icons-material'
 githubLabel: 'package: icons'
 ---
 
-# Browse material icons
+# Material Icons
 
-<p class="description">2,000+ React Material icons ready-to-use from the official website.</p>
+<p class="description">2,000+ React Material Icons ready-to-use from the official website.</p>
 
 The following npm package,
 [@mui/icons-material](https://www.npmjs.com/package/@mui/icons-material),

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -8,7 +8,7 @@ githubLabel: 'package: icons'
 
 # Material Icons
 
-<p class="description">2,000+ React Material Icons ready-to-use from the official website.</p>
+<p class="description">2,000+ ready-to-use React Material Icons from the official website.</p>
 
 The following npm package,
 [@mui/icons-material](https://www.npmjs.com/package/@mui/icons-material),


### PR DESCRIPTION
It seems to get changed in #32048, I assume it wasn't intended since off the purpose of the PR. In practice, I think that keeping the side nav label, h1, and title as close as possible would be better:

- side nav === h1 helps to not disorient users once they click on a link. It gives them a confirmation that they are on the right page (when I open a load of tabs, it personally helps me).
- h1 === title helps with SEO that it stays on topic and often both are taken into account for the ranking.

I'm capitalizing the "Icons" exceptionally because it seems to be the convention when searching for "XX icons" on Google.

https://deploy-preview-32235--material-ui.netlify.app/material-ui/material-icons/