### PR TITLE
[docs] Format number icons search

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -404,6 +404,10 @@ const Paper = styled(MuiPaper)(({ theme }) => ({
   width: '100%',
 }));
 
+function formatNumber(value) {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
 const Input = styled(InputBase)({
   marginLeft: 8,
   flex: 1,
@@ -558,7 +562,9 @@ export default function SearchIcons() {
             inputProps={{ 'aria-label': 'search icons' }}
           />
         </Paper>
-        <Typography sx={{ mb: 1 }}>{`${icons.length} matching results`}</Typography>
+        <Typography sx={{ mb: 1 }}>{`${formatNumber(
+          icons.length,
+        )} matching results`}</Typography>
         <Icons icons={icons} handleOpenClick={handleOpenClick} />
       </Grid>
       <DialogDetails


### PR DESCRIPTION
**Before**

<img width="277" alt="Screenshot 2022-04-10 at 14 38 43" src="https://user-images.githubusercontent.com/3165635/162618524-e6971336-e9d7-4b68-9035-3240254ee820.png">

https://mui.com/material-ui/material-icons/

**After**

<img width="305" alt="Screenshot 2022-04-10 at 14 37 30" src="https://user-images.githubusercontent.com/3165635/162618508-20b51d86-f423-4a9c-b450-d3371ceddde0.png">

https://deploy-preview-32239--material-ui.netlify.app/material-ui/material-icons/

---

Asking the review from Michal per https://www.notion.so/mui-org/b3671ef653dc421ea8ab4b6dcac755d2?v=392be6e77b744138b562c263c7cfafb4&p=2c123f5ccdb84f3b91c583463b620807