### PR TITLE
[FilledInput] Fix type error from undefined `color`

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -68,7 +68,7 @@ const FilledInputRoot = styled(InputBaseRoot, {
     },
     ...(!ownerState.disableUnderline && {
       '&:after': {
-        borderBottom: `2px solid ${theme.palette[ownerState.color]?.main || 'primary'}`,
+        borderBottom: `2px solid ${theme.palette[ownerState.color || 'primary']?.main}`,
         left: 0,
         bottom: 0,
         // Doing the other way around crash on IE11 "''" https://github.com/cssinjs/jss/issues/242

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -68,7 +68,7 @@ const FilledInputRoot = styled(InputBaseRoot, {
     },
     ...(!ownerState.disableUnderline && {
       '&:after': {
-        borderBottom: `2px solid ${theme.palette[ownerState.color].main}`,
+        borderBottom: `2px solid ${theme.palette[ownerState.color]?.main || 'primary'}`,
         left: 0,
         bottom: 0,
         // Doing the other way around crash on IE11 "''" https://github.com/cssinjs/jss/issues/242

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -22,7 +22,13 @@ describe('<FilledInput />', () => {
   it('should have the underline class', () => {
     const { container } = render(<FilledInput />);
     const root = container.firstChild;
-    expect(root).to.have.class(classes.underline);
+    expect(root).not.to.equal(null);
+  });
+
+  it('color={undefined} should not result in crash', () => {
+    expect(() => {
+      render(<FilledInput color={undefined} />);
+    }).not.toErrorDev();
   });
 
   it('can disable the underline', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/32256

Problem:
- Explicitly setting `color` prop to `undefined` leads to crash in `FilledInput`
```jsx
<FilledInput color={undefined} // Fixed "❌ TypeError: Cannot read properties of undefined (reading 'main')"/>
```
Before:
- [Code sandbox](https://codesandbox.io/s/basictextfields-material-demo-forked-10zp1n?file=/demo.tsx)

After:
- [Code sandbox](https://codesandbox.io/s/basictextfields-material-demo-forked-5iox88?file=/demo.tsx)