### PR TITLE
[ClickAwayListener] Allow pointer up/down events to event handler

### DIFF
--- a/docs/pages/base/api/click-away-listener.json
+++ b/docs/pages/base/api/click-away-listener.json
@@ -6,7 +6,7 @@
     "mouseEvent": {
       "type": {
         "name": "enum",
-        "description": "'onClick'<br>&#124;&nbsp;'onMouseDown'<br>&#124;&nbsp;'onMouseUp'<br>&#124;&nbsp;false"
+        "description": "'onClick'<br>&#124;&nbsp;'onMouseDown'<br>&#124;&nbsp;'onMouseUp'<br>&#124;&nbsp;'onPointerDown'<br>&#124;&nbsp;'onPointerUp'<br>&#124;&nbsp;false"
       },
       "default": "'onClick'"
     },

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.test.js
@@ -260,7 +260,7 @@ describe('<ClickAwayListener />', () => {
       expect(handleClickAway.callCount).to.equal(0);
     });
 
-    it('should call `props.onClickAway` when the appropriate mouse event is triggered', () => {
+    it('should call `props.onClickAway` when mouse down is triggered', () => {
       const handleClickAway = spy();
       render(
         <ClickAwayListener onClickAway={handleClickAway} mouseEvent="onMouseDown">
@@ -270,6 +270,48 @@ describe('<ClickAwayListener />', () => {
       fireEvent.mouseUp(document.body);
       expect(handleClickAway.callCount).to.equal(0);
       fireEvent.mouseDown(document.body);
+      expect(handleClickAway.callCount).to.equal(1);
+      expect(handleClickAway.args[0].length).to.equal(1);
+    });
+
+    it('should call `props.onClickAway` when mouse up is triggered', () => {
+      const handleClickAway = spy();
+      render(
+        <ClickAwayListener onClickAway={handleClickAway} mouseEvent="onMouseUp">
+          <span />
+        </ClickAwayListener>,
+      );
+      fireEvent.mouseDown(document.body);
+      expect(handleClickAway.callCount).to.equal(0);
+      fireEvent.mouseUp(document.body);
+      expect(handleClickAway.callCount).to.equal(1);
+      expect(handleClickAway.args[0].length).to.equal(1);
+    });
+
+    it('should call `props.onClickAway` when pointer down is triggered', () => {
+      const handleClickAway = spy();
+      render(
+        <ClickAwayListener onClickAway={handleClickAway} mouseEvent="onPointerDown">
+          <span />
+        </ClickAwayListener>,
+      );
+      fireEvent.pointerUp(document.body);
+      expect(handleClickAway.callCount).to.equal(0);
+      fireEvent.pointerDown(document.body);
+      expect(handleClickAway.callCount).to.equal(1);
+      expect(handleClickAway.args[0].length).to.equal(1);
+    });
+
+    it('should call `props.onClickAway` when pointer up is triggered', () => {
+      const handleClickAway = spy();
+      render(
+        <ClickAwayListener onClickAway={handleClickAway} mouseEvent="onPointerUp">
+          <span />
+        </ClickAwayListener>,
+      );
+      fireEvent.pointerDown(document.body);
+      expect(handleClickAway.callCount).to.equal(0);
+      fireEvent.pointerUp(document.body);
       expect(handleClickAway.callCount).to.equal(1);
       expect(handleClickAway.args[0].length).to.equal(1);
     });

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
@@ -11,7 +11,7 @@ import {
 // TODO: return `EventHandlerName extends `on${infer EventName}` ? Lowercase<EventName> : never` once generatePropTypes runs with TS 4.1
 function mapEventPropToEvent(
   eventProp: ClickAwayMouseEventHandler | ClickAwayTouchEventHandler,
-): 'click' | 'mousedown' | 'mouseup' | 'touchstart' | 'touchend' {
+): 'click' | 'mousedown' | 'mouseup' | 'touchstart' | 'touchend' | 'pointerdown' | 'pointerup' {
   return eventProp.substring(2).toLowerCase() as any;
 }
 
@@ -22,7 +22,12 @@ function clickedRootScrollbar(event: MouseEvent, doc: Document) {
   );
 }
 
-type ClickAwayMouseEventHandler = 'onClick' | 'onMouseDown' | 'onMouseUp';
+type ClickAwayMouseEventHandler =
+  | 'onClick'
+  | 'onMouseDown'
+  | 'onMouseUp'
+  | 'onPointerDown'
+  | 'onPointerUp';
 type ClickAwayTouchEventHandler = 'onTouchStart' | 'onTouchEnd';
 
 export interface ClickAwayListenerProps {
@@ -228,7 +233,14 @@ ClickAwayListener.propTypes /* remove-proptypes */ = {
    * The mouse event to listen to. You can disable the listener by providing `false`.
    * @default 'onClick'
    */
-  mouseEvent: PropTypes.oneOf(['onClick', 'onMouseDown', 'onMouseUp', false]),
+  mouseEvent: PropTypes.oneOf([
+    'onClick',
+    'onMouseDown',
+    'onMouseUp',
+    'onPointerDown',
+    'onPointerUp',
+    false,
+  ]),
   /**
    * Callback fired when a "click away" event is detected.
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I encountered this situation today where using the `ClickAwayListener` was not triggering when components are use pointer events instead of click.

Arguably if we follow the philosophy described here https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events we should always think in terms of pointer inputs rather than click inputs since `pointer` includes `click`.

I've enabled the ability to provide the `down` and `up` pointer inputs to enable such situations.

I currently an overcoming this situation in my project by casting `onPointerUp` to `any`🥲
