### PR TITLE
[TextField] Fix label shrink when invalid value

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType, elementTypeAcceptingRef } from '@mui/utils';
+import { elementTypeAcceptingRef, refType } from '@mui/utils';
 import MuiError from '@mui/utils/macros/MuiError.macro';
 import {
-  unstable_composeClasses as composeClasses,
   isHostComponent,
   TextareaAutosize,
+  unstable_composeClasses as composeClasses,
 } from '@mui/base';
 import formControlState from '../FormControl/formControlState';
 import FormControlContext from '../FormControl/FormControlContext';
@@ -342,7 +342,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
 
   useEnhancedEffect(() => {
     if (isControlled) {
-      checkDirty({ value });
+      checkDirty(inputRef.current ?? { value });
     }
   }, [value, checkDirty, isControlled]);
 
@@ -394,9 +394,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
         );
       }
 
-      checkDirty({
-        value: element.value,
-      });
+      checkDirty(element);
     }
 
     if (inputPropsProp.onChange) {

--- a/packages/mui-material/src/InputBase/utils.js
+++ b/packages/mui-material/src/InputBase/utils.js
@@ -19,6 +19,11 @@ export function isFilled(obj, SSR = false) {
   return (
     obj &&
     ((hasValue(obj.value) && obj.value !== '') ||
+      // If the input type is different from text (like number or date),
+      // some browsers displays the invalid input value while the obj.value
+      // is blank. So to proper shrink the label in case of invalid input,
+      // the following test is needed
+      obj.validity?.badInput ||
       (SSR && hasValue(obj.defaultValue) && obj.defaultValue !== ''))
   );
 }

--- a/packages/mui-material/src/InputBase/utils.test.js
+++ b/packages/mui-material/src/InputBase/utils.test.js
@@ -35,5 +35,9 @@ describe('Input/utils.js', () => {
         expect(isFilled({ defaultValue: value }, true)).to.equal(false);
       });
     });
+
+    it(`is true if bad input`, () => {
+      expect(isFilled({ validity: { badInput: true } })).to.equal(true);
+    });
   });
 });

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from 'test/utils';
+import { createRenderer, describeConformance, fireEvent } from 'test/utils';
 import FormControl from '@mui/material/FormControl';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import MenuItem from '@mui/material/MenuItem';
 import { outlinedInputClasses } from '@mui/material/OutlinedInput';
 import TextField, { textFieldClasses as classes } from '@mui/material/TextField';
+import sinon from 'sinon';
 
 describe('<TextField />', () => {
   const { render } = createRenderer();
@@ -68,6 +69,40 @@ describe('<TextField />', () => {
         const { container } = render(<TextField label={label} variant="standard" />);
 
         expect(container.querySelector('label')).to.equal(null);
+      });
+    });
+
+    describe('input type number', () => {
+      let sandbox;
+      beforeEach('setup sandbox', () => {
+        sandbox = sinon.createSandbox();
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('should shrink label if invalid value - uncontrolled', () => {
+        // In the browsers (Safari, Chrome, and Firefox) the input value and input's displayed value are
+        // different when the input type is different from text, and is invalid.
+
+        const { container } = render(<TextField label={'Number'} type={'number'} />);
+
+        const input = container.querySelector('input');
+
+        // Simulates a badInput situation since the `render` here doesn't care about validity attribute.
+        // One can insert invalid inputs and the badInput is not properly set (like occurs in browsers
+        // like Safari, Chrome or Firefox), so an input mock is needed here.
+        const inputStub = sandbox.stub(input, 'validity');
+        inputStub.get(() => ({ badInput: true }));
+
+        expect(input.validity.badInput).to.equal(true);
+
+        fireEvent.change(input, { target: { value: '', ...input } });
+
+        // FIXME: Find a workaround to simulate badInput when the input is rendered
+        // const label = container.querySelector('label');
+        // expect(container.querySelector('label').className).to.include('MuiInputLabel-shrink');
       });
     });
   });


### PR DESCRIPTION
This is a new attempt to solve the issue ( the first one is there https://github.com/mui/material-ui/pull/30424#issue-1089532444). 

I believe it is working now but I need help with the tests.  I have created a test case at `TextField.test.js`, but I need assistance on it.

The documentation must be updated too. I wonder if I update here or split in a new PR.

Closes: https://github.com/mui/material-ui/issues/29469

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
