### PR TITLE
[docs] `tabIndex={0}` for `PinnedSubheaderList`

### DIFF
--- a/docs/data/material/components/lists/PinnedSubheaderList.js
+++ b/docs/data/material/components/lists/PinnedSubheaderList.js
@@ -17,6 +17,7 @@ export default function PinnedSubheaderList() {
         '& ul': { padding: 0 },
       }}
       subheader={<li />}
+      tabIndex={0}
     >
       {[0, 1, 2, 3, 4].map((sectionId) => (
         <li key={`section-${sectionId}`}>

--- a/docs/data/material/components/lists/PinnedSubheaderList.tsx
+++ b/docs/data/material/components/lists/PinnedSubheaderList.tsx
@@ -17,6 +17,7 @@ export default function PinnedSubheaderList() {
         '& ul': { padding: 0 },
       }}
       subheader={<li />}
+      tabIndex={0}
     >
       {[0, 1, 2, 3, 4].map((sectionId) => (
         <li key={`section-${sectionId}`}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Make the `PinnedSubheaderList` snippet reachable by VoiceOver and a keyboard (tabbing).