### PR TITLE
[docs] Fix broken link in the test contributing guide

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -133,7 +133,7 @@ If you want to `grep` for certain tests add `-g STRING_TO_GREP` though for devel
 
 First, we have the **unit test** suite.
 It uses [mocha](https://mochajs.org) and a thin wrapper around `@testing-library/react`.
-Here is an [example](https://github.com/mui/material-ui/blob/814fb60bbd8e500517b2307b6a297a638838ca89/packages/material-ui/src/Dialog/Dialog.test.js#L71-L80) with the `Dialog` component.
+Here is an [example](https://github.com/mui/material-ui/blob/6d9f42a637184a3b3cb552d2591e2cf39653025d/packages/mui-material/src/Dialog/Dialog.test.js#L60-L69) with the `Dialog` component.
 
 Next, we have the **integration** tests. They are mostly used for components that
 act as composite widgets like `Select` or `Menu`.

--- a/test/README.md
+++ b/test/README.md
@@ -133,7 +133,7 @@ If you want to `grep` for certain tests add `-g STRING_TO_GREP` though for devel
 
 First, we have the **unit test** suite.
 It uses [mocha](https://mochajs.org) and a thin wrapper around `@testing-library/react`.
-Here is an [example](https://github.com/mui/material-ui/blob/814fb60bbd8e500517b2307b6a297a638838ca89/packages/mui-material/src/Dialog/Dialog.test.js#L71-L80) with the `Dialog` component.
+Here is an [example](https://github.com/mui/material-ui/blob/814fb60bbd8e500517b2307b6a297a638838ca89/packages/material-ui/src/Dialog/Dialog.test.js#L71-L80) with the `Dialog` component.
 
 Next, we have the **integration** tests. They are mostly used for components that
 act as composite widgets like `Select` or `Menu`.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hi, I found a problem for which I don't even see the point of opening an issue, because the changes are tiny.
In the instructions for writing tests there is a link (Example) that leads directly to page 404.
I opened this file manually and saw that the url is different from the one specified in the link.
The only difference is in the name of the packages (mui-material vs. material-ui).
Well, I corrected it.
