### PR TITLE
[Autocomplete] Add disableClearOnSelect prop

### DIFF
--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -28,6 +28,7 @@
       "default": "props.multiple ? [] : null"
     },
     "disableClearable": { "type": { "name": "bool" } },
+    "disableClearOnSelect": { "type": { "name": "bool" } },
     "disableCloseOnSelect": { "type": { "name": "bool" } },
     "disabled": { "type": { "name": "bool" } },
     "disabledItemsFocusable": { "type": { "name": "bool" } },

--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -15,6 +15,7 @@
     "componentsProps": "The props used for each slot inside.",
     "defaultValue": "The default value. Use when the component is not controlled.",
     "disableClearable": "If <code>true</code>, the input can&#39;t be cleared.",
+    "disableClearOnSelect": "If <code>true</code>, the input&#39;s text is clear when a value is selected.",
     "disableCloseOnSelect": "If <code>true</code>, the popup won&#39;t close when a value is selected.",
     "disabled": "If <code>true</code>, the component is disabled.",
     "disabledItemsFocusable": "If <code>true</code>, will allow focus on disabled items.",

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.d.ts
@@ -93,6 +93,11 @@ export interface UseAutocompleteProps<
    */
   disableClearable?: DisableClearable;
   /**
+   * If `true`, the input's text is clear when a value is selected.
+   * @default false
+   */
+  disableClearOnSelect?: boolean;
+  /**
    * If `true`, the popup won't close when a value is selected.
    * @default false
    */

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -78,6 +78,7 @@ export default function useAutocomplete(props) {
     componentName = 'useAutocomplete',
     defaultValue = props.multiple ? [] : null,
     disableClearable = false,
+    disableClearOnSelect = false,
     disableCloseOnSelect = false,
     disabledItemsFocusable = false,
     disableListWrap = false,
@@ -159,6 +160,9 @@ export default function useAutocomplete(props) {
       if (!isOptionSelected && !clearOnBlur) {
         return;
       }
+      if (multiple && disableClearOnSelect) {
+        return;
+      }
       let newInputValue;
       if (multiple) {
         newInputValue = '';
@@ -179,7 +183,16 @@ export default function useAutocomplete(props) {
         onInputChange(event, newInputValue, 'reset');
       }
     },
-    [getOptionLabel, inputValue, multiple, onInputChange, setInputValueState, clearOnBlur, value],
+    [
+      getOptionLabel,
+      inputValue,
+      multiple,
+      onInputChange,
+      setInputValueState,
+      clearOnBlur,
+      value,
+      disableClearOnSelect,
+    ],
   );
 
   const prevValue = React.useRef();

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -369,6 +369,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     componentsProps = {},
     defaultValue = props.multiple ? [] : null,
     disableClearable = false,
+    disableClearOnSelect = false,
     disableCloseOnSelect = false,
     disabled = false,
     disabledItemsFocusable = false,
@@ -751,6 +752,11 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * @default false
    */
   disableClearable: PropTypes.bool,
+  /**
+   * If `true`, the input's text is clear when a value is selected.
+   * @default false
+   */
+  disableClearOnSelect: PropTypes.bool,
   /**
    * If `true`, the popup won't close when a value is selected.
    * @default false

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1291,6 +1291,33 @@ describe('<Autocomplete />', () => {
     });
   });
 
+  describe('prop: disableClearOnSelect', () => {
+    it('should not clear the input with `multiple` enabled', () => {
+      render(
+        <Autocomplete
+          multiple
+          disableClearOnSelect
+          options={['one']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const testbox = screen.getByRole('combobox');
+
+      act(() => {
+        testbox.focus();
+        fireEvent.change(document.activeElement, { target: { value: 'o' } });
+      });
+
+      const listbox = screen.getByRole('listbox');
+      const firstOption = listbox.querySelector('li');
+      act(() => {
+        fireEvent.click(firstOption);
+      });
+
+      expect(testbox.value).to.equal('o');
+    });
+  });
+
   describe('warnings', () => {
     beforeEach(() => {
       PropTypes.resetWarningCache();


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Description
This PR adds a `disableClearOnSelect` prop to the `<Autocomplete/>` component. This prop prevents clearing the input value when a user selects one of options. This prop only make sense to be used alongside `multiple` prop (and probably `disableCloseOnSelect` for better UX). 

## The problem:
### Before

The user wants to select all the movies in ‘The Lord of the Rings’ franchise. Without this prop it has to use the filtering mechanism three times to get the expected result. I’m glad he/she didn’t want to choose all ‘Star Wars’ movies! :sweat_smile:



https://user-images.githubusercontent.com/39658211/163356864-6a0b6c94-1735-493c-bb90-f43ee2a380ac.mov


### After

With this prop the user doesn’t have to repeat the filtering. It gives us smoother overall experience in this case. 


https://user-images.githubusercontent.com/39658211/163356909-d3c8d8f9-fbd3-4c57-85a2-0f09626b61d0.mov

Cheers

