### PR TITLE
[typescript] Typescript error for `fontSizeMedium` class in theming `SvgIcon`

### DIFF
--- a/docs/pages/material-ui/api/svg-icon.json
+++ b/docs/pages/material-ui/api/svg-icon.json
@@ -40,6 +40,7 @@
       "colorDisabled",
       "fontSizeInherit",
       "fontSizeSmall",
+      "fontSizeMedium",
       "fontSizeLarge"
     ],
     "globalClasses": {},

--- a/docs/translations/api-docs/svg-icon/svg-icon.json
+++ b/docs/translations/api-docs/svg-icon/svg-icon.json
@@ -50,6 +50,11 @@
       "nodeName": "the root element",
       "conditions": "<code>fontSize=\"small\"</code>"
     },
+    "fontSizeMedium": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>fontSize=\"medium\"</code>"
+    },
     "fontSizeLarge": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -1,7 +1,8 @@
-import * as React from 'react';
 import { expect } from 'chai';
 import { describeConformance, createRenderer } from 'test/utils';
 import SvgIcon, { svgIconClasses as classes } from '@mui/material/SvgIcon';
+import * as React from 'react';
+import capitalize from '../utils/capitalize';
 
 describe('<SvgIcon />', () => {
   const { render } = createRenderer();
@@ -95,6 +96,14 @@ describe('<SvgIcon />', () => {
 
       expect(container.firstChild).to.have.class(classes.fontSizeInherit);
     });
+
+    ['small', 'medium', 'large'].map((fontSize) =>
+      it('should render the correct fontSize class', () => {
+        const { container } = render(<SvgIcon fontSize={fontSize}>{path}</SvgIcon>);
+
+        expect(container.firstChild).to.have.class(classes[`fontSize${capitalize(fontSize)}`]);
+      }),
+    );
   });
 
   describe('prop: inheritViewBox', () => {

--- a/packages/mui-material/src/SvgIcon/svgIconClasses.ts
+++ b/packages/mui-material/src/SvgIcon/svgIconClasses.ts
@@ -17,6 +17,8 @@ export interface SvgIconClasses {
   fontSizeInherit: string;
   /** Styles applied to the root element if `fontSize="small"`. */
   fontSizeSmall: string;
+  /** Styles applied to the root element if `fontSize="medium"`. */
+  fontSizeMedium: string;
   /** Styles applied to the root element if `fontSize="large"`. */
   fontSizeLarge: string;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/32292

Problem:
- `fontSizeMedium` class is missing from Material `SvgIconClasses` interface, leading to a TS error when trying to theme the component using key `fontSizeMedium`

Before:
- [code sandbox](https://codesandbox.io/s/nostalgic-leaf-vp0909)

After:
- [code sandbox](https://codesandbox.io/s/youthful-cray-4trt8m?file=/src/Demo.tsx)