### PR TITLE
[website] Mark DataGrid Column spanning done on Pricing page

### DIFF
--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -546,7 +546,7 @@ const communityData: Record<string, React.ReactNode> = {
   'Material UI': yes,
   // MUI X
   'data-grid/column-groups': pending,
-  'data-grid/column-spanning': pending,
+  'data-grid/column-spanning': yes,
   'data-grid/column-resizing': no,
   'data-grid/column-reorder': no,
   'data-grid/column-pinning': no,
@@ -600,7 +600,7 @@ const proData: Record<string, React.ReactNode> = {
   'Material UI': yes,
   // MUI X
   'data-grid/column-groups': pending,
-  'data-grid/column-spanning': pending,
+  'data-grid/column-spanning': yes,
   'data-grid/column-resizing': yes,
   'data-grid/column-reorder': yes,
   'data-grid/column-pinning': yes,
@@ -654,7 +654,7 @@ const premiumData: Record<string, React.ReactNode> = {
   'Material UI': yes,
   // MUI X
   'data-grid/column-groups': pending,
-  'data-grid/column-spanning': pending,
+  'data-grid/column-spanning': yes,
   'data-grid/column-resizing': yes,
   'data-grid/column-reorder': yes,
   'data-grid/column-pinning': yes,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Column spanning was released today in https://github.com/mui/mui-x/releases/tag/v5.9.0
