### PR TITLE
[docs] Base Form Control style revisions and final review

### DIFF
--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -1,6 +1,6 @@
 ---
 product: base
-title: React form control
+title: Unstyled React Form Control component and hook
 components: FormControlUnstyled
 githubLabel: 'component: FormControl'
 packageName: '@mui/base'
@@ -9,50 +9,51 @@ packageName: '@mui/base'
 # Unstyled form control
 
 <p class="description">
-  The FormControlUnstyled is a utility that lets you associate a form input with auxillary components,
-  such as labels, error indicators or helper text.
+  The <code>FormControlUnstyled</code> is a utility that lets you associate a form input with auxillary components, such as labels, error indicators, or helper text.
 </p>
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## FormControlUnstyled
 
-FormControlUnstyled wraps an input and other components, enabling to reflect the input's state in these other components.
+`FormControlUnstyled` wraps an input with other associated components in order to make the state of the input available to those components.
 
 For instance, you may want to show an additional element asking the user to enter a value if the input is empty, or display a warning icon if the entered value is incorrect.
 
 {{"demo": "BasicFormControl.js"}}
 
-The FormControlUnstyled provides a context that can be read by the useFormControlUnstyledContext hook.
-
 ## useFormControlUnstyledContext hook
 
-The useFormControl hook can be used to enable integration between custom form inputs and FormControlUnstyled.
-Additionally, you can read the form control's state and react to its changes in a custom component.
+The `FormControlUnstyled` component provides a context that can be read by the `useFormControlUnstyledContext` hook.
 
-The demo below shows both.
-`CustomInput` is a wrapper around a native HTML `input` that adds FormControlUnstyled integration.
-`ControlStateDisplay` reads the state of the form control and displays it as text.
+## The useFormControl hook
+
+You can use the `useFormControl` hook to enable integration between custom form inputs and `FormControlUnstyled`.
+You can also use it to read the form control's state and react to its changes in a custom component.
+
+The demo below shows both:
+
+- `CustomInput` is a wrapper around a native HTML `<input>` that adds `FormControlUnstyled` integration.
+- `ControlStateDisplay` reads the state of the form control and displays it as text.
 
 {{"demo": "UseFormControl.js", "defaultCodeOpen": false}}
 
-Note that even though FormControlUnstyled supports both controlled and uncontrolled-style API
+Note that even though `FormControlUnstyled` supports both controlled and uncontrolled-style API
 (i.e. it accepts `value` and `defaultValue` props), `useFormControlUnstyledContext` returns only the controlled `value`.
-This way, you don't have to implement both in your custom input - FormControlUnstyled does this for you.
+This way, you don't have to implement both in your custom input—`FormControlUnstyled` does this for you.
 
 `useFormControlUnstyledContext` returns an object with the following fields:
 
-| Name       | Type    | Description                                                                                                                                                            |
-| ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `disabled` | boolean | Represents the value of the FormControlUnstyled's `disabled` prop.                                                                                                     |
-| `error`    | boolean | Represents the value of the FormControlUnstyled's `error` prop. Note that it is not calculated automatically (i.e. it's not set when `required: true` and `value: ''`) |
-| `filled`   | boolean | Set to `true` if `value` is not empty.                                                                                                                                 |
-| `focused`  | boolean | Set to `true` if the wrapped input has received focus.                                                                                                                 |
-| `required` | boolean | Represents the value of the FormControlUnstyled's `required` prop.                                                                                                     |
-| `value`    | unknown | The current value of the form control.                                                                                                                                 |
+| Name       | Type    | Description                                                                                                                                                                         |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disabled` | boolean | Represents the value of the FormControlUnstyled's `disabled` prop.                                                                                                                  |
+| `error`    | boolean | Represents the value of the `FormControlUnstyled` component's `error` prop. Note that it is not calculated automatically (i.e. it's not set when `required: true` and `value: ''`). |
+| `filled`   | boolean | Set to `true` if `value` is not empty.                                                                                                                                              |
+| `focused`  | boolean | Set to `true` if the wrapped input has received focus.                                                                                                                              |
+| `required` | boolean | Represents the value of the `FormControlUnstyled` component's `required` prop.                                                                                                      |
+| `value`    | unknown | The current value of the form control.                                                                                                                                              |
 
-Additionally, the following callbacks are a part of the returned object.
-They are meant to be used when creating custom inputs.
+The following callbacks are also part of the returned object—they are meant to be used when creating custom inputs:
 
 | Name       | Type                      | Description                                                   |
 | ---------- | ------------------------- | ------------------------------------------------------------- |

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -9,12 +9,12 @@ packageName: '@mui/base'
 # Unstyled form control
 
 <p class="description">
-  The <code>FormControlUnstyled</code> is a utility that lets you associate a form input with auxillary components, such as labels, error indicators, or helper text.
+  The <code>FormControlUnstyled</code> component is a utility that lets you associate a form input with auxillary components, such as labels, error indicators, or helper text.
 </p>
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
-## FormControlUnstyled
+## Basic usage
 
 `FormControlUnstyled` wraps an input with other associated components in order to make the state of the input available to those components.
 

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -26,9 +26,7 @@ For instance, you may want to show an additional element asking the user to ente
 
 The `FormControlUnstyled` component provides a context that can be read by the `useFormControlUnstyledContext` hook.
 
-## The useFormControl hook
-
-You can use the `useFormControl` hook to enable integration between custom form inputs and `FormControlUnstyled`.
+You can use the `useFormControlUnstyledContext` hook to enable integration between custom form inputs and `FormControlUnstyled`.
 You can also use it to read the form control's state and react to its changes in a custom component.
 
 The demo below shows both:


### PR DESCRIPTION
This PR implements the style guide on the `FormControlUnstyled` doc. This one is pretty straightforward—I don't see any clarifications needed.

https://deploy-preview-32309--material-ui.netlify.app/base/react-form-control/