### PR TITLE
[Textfield] change default value of component from p to div

### DIFF
--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -68,7 +68,7 @@ const FormHelperText = React.forwardRef(function FormHelperText(inProps, ref) {
   const {
     children,
     className,
-    component = 'p',
+    component = 'div',
     disabled,
     error,
     filled,

--- a/packages/mui-material/src/FormHelperText/FormHelperText.test.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.test.js
@@ -9,9 +9,9 @@ describe('<FormHelperText />', () => {
 
   describeConformance(<FormHelperText />, () => ({
     classes,
-    inheritComponent: 'p',
+    inheritComponent: 'div',
     render,
-    refInstanceof: window.HTMLParagraphElement,
+    refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'div',
     muiName: 'MuiFormHelperText',
     testVariantProps: { size: 'small' },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR is in response to [https://github.com/mui/material-ui/issues/32289](url). 

FormHelperText is the underlying component that causes the issue. Since the component props default value is p the children prop can only accept elements that are inline elements. In the above mentioned issue the user passed a block element as a prop to helperText which causes the validateDomNesting error to occur in console.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Comments:
In the same file the FormHelperTextRoot component is taking in a paragraph tag as its default tag value. I don't know if changing the prop component to div would have any effect on that at all.
