### PR TITLE
[Tooltip] Fix children mouse over detection

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -372,6 +372,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       return;
     }
 
+    // Workaround for https://github.com/facebook/react/issues/7769
     if (!childNode) {
       setChildNode(event.currentTarget);
     }
@@ -423,8 +424,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
 
   const handleFocus = (event) => {
     // Workaround for https://github.com/facebook/react/issues/7769
-    // The autoFocus of React might trigger the event before the componentDidMount.
-    // We need to account for this eventuality.
     if (!childNode) {
       setChildNode(event.currentTarget);
     }

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -372,10 +372,16 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       return;
     }
 
+    // Workaround for https://github.com/facebook/react/issues/7769
+    // The autoFocus of React might trigger the event before the componentDidMount.
+    // We need to account for this eventuality.
+    if (!childNode) {
+      setChildNode(event.currentTarget);
+    }
     // Remove the title ahead of time.
     // We don't want to wait for the next render commit.
     // We would risk displaying two tooltips at the same time (native + this one).
-    if (childNode) {
+    else {
       childNode.removeAttribute('title');
     }
 

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -372,9 +372,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       return;
     }
 
-    // Workaround for https://github.com/facebook/react/issues/7769
-    // The autoFocus of React might trigger the event before the componentDidMount.
-    // We need to account for this eventuality.
     if (!childNode) {
       setChildNode(event.currentTarget);
     }

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -433,6 +433,23 @@ describe('<Tooltip />', () => {
       expect(getByRole('tooltip')).toBeVisible();
       expect(handleFocus.callCount).to.equal(1);
     });
+
+    it('should handle `onMouseOver` forwarding', () => {
+      const handleMouseOver = spy();
+      const { getByRole } = render(
+        <Tooltip enterDelay={100} title="Tooltip">
+          <button id="testChild" type="submit" onMouseOver={handleMouseOver}>
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+
+      fireEvent.mouseOver(getByRole('button'));
+      clock.tick(100);
+
+      expect(getByRole('tooltip')).toBeVisible();
+      expect(handleMouseOver.callCount).to.equal(1);
+    });
   });
 
   describe('prop: delay', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I believe this bug is also caused by https://github.com/facebook/react/issues/7769, where `Ref` effects are called after `Update`, therefore `childNode` (set by ref passed to child) is undefined. The issue is fixed for `onFocus` events in #14496, this PR applies the same fix for `onMouseOver` events. 

fixes #31198

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
