### PR TITLE
[docs] Change label on `FormControlLabelPlacement`

### DIFF
--- a/docs/data/material/components/radio-buttons/FormControlLabelPlacement.js
+++ b/docs/data/material/components/radio-buttons/FormControlLabelPlacement.js
@@ -8,7 +8,7 @@ import FormLabel from '@mui/material/FormLabel';
 export default function FormControlLabelPlacement() {
   return (
     <FormControl>
-      <FormLabel id="demo-form-control-label-placement">Label Placement</FormLabel>
+      <FormLabel id="demo-form-control-label-placement">Label placement</FormLabel>
       <RadioGroup
         row
         aria-labelledby="demo-form-control-label-placement"

--- a/docs/data/material/components/radio-buttons/FormControlLabelPlacement.js
+++ b/docs/data/material/components/radio-buttons/FormControlLabelPlacement.js
@@ -8,7 +8,7 @@ import FormLabel from '@mui/material/FormLabel';
 export default function FormControlLabelPlacement() {
   return (
     <FormControl>
-      <FormLabel id="demo-form-control-label-placement">labelPlacement</FormLabel>
+      <FormLabel id="demo-form-control-label-placement">Label Placement</FormLabel>
       <RadioGroup
         row
         aria-labelledby="demo-form-control-label-placement"

--- a/docs/data/material/components/radio-buttons/FormControlLabelPlacement.tsx
+++ b/docs/data/material/components/radio-buttons/FormControlLabelPlacement.tsx
@@ -8,7 +8,7 @@ import FormLabel from '@mui/material/FormLabel';
 export default function FormControlLabelPlacement() {
   return (
     <FormControl>
-      <FormLabel id="demo-form-control-label-placement">Label Placement</FormLabel>
+      <FormLabel id="demo-form-control-label-placement">Label placement</FormLabel>
       <RadioGroup
         row
         aria-labelledby="demo-form-control-label-placement"

--- a/docs/data/material/components/radio-buttons/FormControlLabelPlacement.tsx
+++ b/docs/data/material/components/radio-buttons/FormControlLabelPlacement.tsx
@@ -8,7 +8,7 @@ import FormLabel from '@mui/material/FormLabel';
 export default function FormControlLabelPlacement() {
   return (
     <FormControl>
-      <FormLabel id="demo-form-control-label-placement">labelPlacement</FormLabel>
+      <FormLabel id="demo-form-control-label-placement">Label Placement</FormLabel>
       <RadioGroup
         row
         aria-labelledby="demo-form-control-label-placement"


### PR DESCRIPTION
Edit label typo in code example to mutch markup.

[react-radio-button example](https://mui.com/material-ui/react-radio-button/#label-placement)

✍️ `<FormLabel id="demo-form-control-label-placement">labelPlacement</FormLabel>`

[checkboxes example](https://mui.com/material-ui/react-checkbox/#label-placement)

👍 `<FormLabel component="legend">Label placement</FormLabel>`


