### PR TITLE
[docs] Fix 404 link in the code

### DIFF
--- a/packages/mui-lab/src/DateRangePicker/DateRangePicker.ts
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePicker.ts
@@ -13,7 +13,7 @@ const warn = () => {
         "You should use `import { DateRangePicker } from '@mui/x-date-pickers-pro'`",
         "or `import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker'`",
         '',
-        'More information about this migration on our [blog](https://mui.com/blog/lab-pickers-to-mui-x/)',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
       ].join('\n'),
     );
 

--- a/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.ts
+++ b/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.ts
@@ -12,7 +12,7 @@ const warn = () => {
         "You should use `import { DateRangePickerDay } from '@mui/x-date-pickers-pro'`",
         "or `import { DateRangePickerDay } from '@mui/x-date-pickers-pro/DateRangePickerDay'`",
         '',
-        'More information about this migration on our [blog](https://mui.com/blog/lab-pickers-to-mui-x/)',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
       ].join('\n'),
     );
 

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.ts
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.ts
@@ -13,7 +13,7 @@ const warn = () => {
         "You should use `import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro'`",
         "or `import { DesktopDateRangePicker } from '@mui/x-date-pickers-pro/DesktopDateRangePicker'`",
         '',
-        'More information about this migration on our [blog](https://mui.com/blog/lab-pickers-to-mui-x/)',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
       ].join('\n'),
     );
 

--- a/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.ts
+++ b/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.ts
@@ -13,7 +13,7 @@ const warn = () => {
         "You should use `import { MobileDateRangePicker } from '@mui/x-date-pickers-pro'`",
         "or `import { MobileDateRangePicker } from '@mui/x-date-pickers-pro/MobileDateRangePicker'`",
         '',
-        'More information about this migration on our [blog](https://mui.com/blog/lab-pickers-to-mui-x/)',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
       ].join('\n'),
     );
 

--- a/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.ts
+++ b/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.ts
@@ -13,7 +13,7 @@ const warn = () => {
         "You should use `import { StaticDateRangePicker } from '@mui/x-date-pickers-pro'`",
         "or `import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker'`",
         '',
-        'More information about this migration on our [blog](https://mui.com/blog/lab-pickers-to-mui-x/)',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
       ].join('\n'),
     );
 


### PR DESCRIPTION
In #32048 we renamed the blog post URL without checking if it was linked hence this bug: https://codesandbox.io/s/basicdaterangepicker-material-demo-forked-sqpul5

<img width="518" alt="Screenshot 2022-04-16 at 13 06 13" src="https://user-images.githubusercontent.com/3165635/163672617-6e0d5c41-c6c0-462b-b947-b0d7011bf006.png">

I noticed the issue in doing a review on an MUI Store author template submission. Considering it's a blog post, the URL is never supposed to change, so I assume that we don't need to rely on `/r/*`, e.g.

https://github.com/mui/material-ui/blob/09a50b290888a02d9da8461b4b9d940f62879552/docs/public/_redirects#L13

like we do when we link docs from the source.