### PR TITLE
[docs] Fix sidenav mobile color

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -44,92 +44,107 @@ const Item = styled(
   {
     shouldForwardProp: (prop) => prop !== 'depth' && prop !== 'hasIcon' && prop !== 'subheader',
   },
-)(({ theme, hasIcon, depth, subheader }) => ({
-  ...theme.typography.body2,
-  display: 'flex',
-  alignItems: 'center',
-  borderRadius: 5,
-  outline: 0,
-  width: '100%',
-  paddingTop: 5,
-  paddingBottom: 5,
-  justifyContent: 'flex-start',
-  fontWeight: theme.typography.fontWeightMedium,
-  transition: theme.transitions.create(['color', 'background-color'], {
-    duration: theme.transitions.duration.shortest,
-  }),
-  fontSize: theme.typography.pxToRem(14),
-  textDecoration: 'none',
-  paddingLeft: 31 + (depth > 2 ? (depth - 2) * 10 : 0),
-  color: theme.palette.text.secondary,
-  ...(depth === 0 && {
-    color: theme.palette.text.primary,
-  }),
-  ...(subheader && {
-    marginTop: theme.spacing(1),
-    textTransform: 'uppercase',
-    letterSpacing: '.08rem',
-    fontWeight: theme.typography.fontWeightBold,
-    fontSize: theme.typography.pxToRem(11),
-    color: theme.palette.grey[600],
-  }),
-  ...(hasIcon && {
-    paddingLeft: 2,
-  }),
-  '&.app-drawer-active': {
-    color: theme.palette.mode === 'dark' ? theme.palette.primary[300] : theme.palette.primary[600],
-    backgroundColor:
-      theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.primary[50],
-    '&:hover': {
-      backgroundColor: alpha(
-        theme.palette.primary.main,
-        theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
-      ),
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+)(({ theme, hasIcon, depth, subheader }) => {
+  const color = {
+    color: theme.palette.text.secondary,
+    ...(depth === 0 && {
+      color: theme.palette.text.primary,
+    }),
+    ...(subheader && {
+      color: theme.palette.grey[600],
+    }),
+  };
+
+  return {
+    ...theme.typography.body2,
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: 5,
+    outline: 0,
+    width: '100%',
+    paddingTop: 5,
+    paddingBottom: 5,
+    justifyContent: 'flex-start',
+    fontWeight: theme.typography.fontWeightMedium,
+    transition: theme.transitions.create(['color', 'background-color'], {
+      duration: theme.transitions.duration.shortest,
+    }),
+    fontSize: theme.typography.pxToRem(14),
+    textDecoration: 'none',
+    paddingLeft: 31 + (depth > 2 ? (depth - 2) * 10 : 0),
+    ...color,
+    ...(subheader && {
+      marginTop: theme.spacing(1),
+      textTransform: 'uppercase',
+      letterSpacing: '.08rem',
+      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(11),
+    }),
+    ...(hasIcon && {
+      paddingLeft: 2,
+    }),
+    '&.app-drawer-active': {
+      color:
+        theme.palette.mode === 'dark' ? theme.palette.primary[300] : theme.palette.primary[600],
+      backgroundColor:
+        theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.primary[50],
+      '&:hover': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
+        ),
+        '@media (hover: none)': {
+          backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+        },
+      },
+      '&.Mui-focusVisible': {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
+        ),
       },
     },
+    '& .MuiChip-root': {
+      marginTop: '2px',
+    },
+    ...(!subheader && {
+      '&:hover': {
+        color: theme.palette.mode === 'dark' ? '#fff' : theme.palette.common.black,
+        backgroundColor:
+          theme.palette.mode === 'dark'
+            ? alpha(theme.palette.primaryDark[700], 0.4)
+            : theme.palette.grey[50],
+        '@media (hover: none)': {
+          color: color.color,
+          backgroundColor: 'transparent',
+        },
+      },
+    }),
     '&.Mui-focusVisible': {
-      backgroundColor: alpha(
-        theme.palette.primary.main,
-        theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
-      ),
+      backgroundColor: theme.palette.action.focus,
     },
-  },
-  '& .MuiChip-root': {
-    marginTop: '2px',
-  },
-  ...(!subheader && {
-    '&:hover': {
-      color: theme.palette.mode === 'dark' ? '#fff' : theme.palette.common.black,
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? alpha(theme.palette.primaryDark[700], 0.4)
-          : theme.palette.grey[50],
+    [theme.breakpoints.up('md')]: {
+      paddingTop: 3,
+      paddingBottom: 3,
     },
-  }),
-  '&.Mui-focusVisible': {
-    backgroundColor: theme.palette.action.focus,
-  },
-  [theme.breakpoints.up('md')]: {
-    paddingTop: 3,
-    paddingBottom: 3,
-  },
-  '& .ItemButtonIcon': {
-    marginLeft: 'auto !important',
-    marginRight: '5px',
-  },
-  '&:hover .ItemButtonIcon': {
-    color: theme.palette.text.primary,
-  },
-}));
+    '& .ItemButtonIcon': {
+      marginLeft: 'auto !important',
+      marginRight: '5px',
+      color: theme.palette.primary.main,
+    },
+    '&:hover .ItemButtonIcon': {
+      color: theme.palette.text.primary,
+      '@media (hover: none)': {
+        color: theme.palette.primary.main,
+      },
+    },
+  };
+});
 
 const ItemButtonIcon = styled(KeyboardArrowRightRoundedIcon, {
   shouldForwardProp: (prop) => prop !== 'open',
-})(({ open, theme }) => ({
+})(({ open }) => ({
   fontSize: '1rem',
-  color: theme.palette.primary.main,
   transform: open && 'rotate(90deg)',
 }));
 


### PR DESCRIPTION
This PR is easier to review without whitespace: https://github.com/mui/material-ui/pull/32324/files?diff=unified&w=1

---

Add `@media (hover: none)` to fix the style on mobile. See how the nav item keeps the hover style even after I remove the finger. This is wrong, to **always** add `@media (hover: none)`. 

**Before**

https://user-images.githubusercontent.com/3165635/163673288-060e495d-9fd7-4a2c-9371-6f291ca0d915.mp4

**After**

https://deploy-preview-32324--material-ui.netlify.app/material-ui/getting-started/installation/