### PR TITLE
[system] Fix prop types when the `fill` CSS property is used

### DIFF
--- a/docs/data/system/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/the-sx-prop/the-sx-prop.md
@@ -289,22 +289,6 @@ export default function App() {
 }
 ```
 
-### `fill` callback gives theme type as `any`
-
-Since `sx` can be an array type, there is a conflict in type of `Array.fill` and CSS's `fill` property when define value as a callback. As a workaround, you can explicitly define the theme like this:
-
-```tsx
-import { Theme } from '@mui/material/styles';
-
-<Box
-  sx={{
-    fill: (theme: Theme) => theme.palette.primary.main,
-  }}
-/>;
-```
-
-> Let us know or [submit a PR](https://github.com/mui/material-ui/pulls) if you have a proper way to fix this issue. 🙏
-
 ## Performance
 
 If you are interested in the performance tradeoff, you can find more details [here](/system/basics/#performance-tradeoff).

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -73,10 +73,8 @@ const faqData = [
       <React.Fragment>
         After you purchase a license, you'll receive a license key by email Once you have the
         license key, you need to follow the{' '}
-        <Link href="/x/advanced-components/#license-key-installation">
-          instructions
-        </Link>{' '}
-        necessary to set it up.
+        <Link href="/x/advanced-components/#license-key-installation">instructions</Link> necessary
+        to set it up.
       </React.Fragment>
     ),
   },

--- a/packages/mui-system/src/Box/Box.spec.tsx
+++ b/packages/mui-system/src/Box/Box.spec.tsx
@@ -86,3 +86,21 @@ function CssVariablesWithNestedSelectors() {
     }}
   />;
 }
+
+// The fill prop conflicts with the Array's fill functiom.
+// This test ensures that the callback value inside the sx prop
+// can be used without conflicting with the Array's fill function
+function TestFillPropCallback() {
+  <Box
+    sx={{
+      fill: (theme) => theme.palette.primary.main,
+    }}
+  />;
+  <Box
+    sx={[
+      {
+        fill: (theme) => theme.palette.primary.main,
+      },
+    ]}
+  />;
+}

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -69,7 +69,7 @@ export type SystemStyleObject<Theme extends object = {}> =
 export type SxProps<Theme extends object = {}> =
   | SystemStyleObject<Theme>
   | ((theme: Theme) => SystemStyleObject<Theme>)
-  | Array<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)>;
+  | ReadonlyArray<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)>;
 
 export interface StyleFunctionSx {
   (props: object): object;

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -69,7 +69,9 @@ export type SystemStyleObject<Theme extends object = {}> =
 export type SxProps<Theme extends object = {}> =
   | SystemStyleObject<Theme>
   | ((theme: Theme) => SystemStyleObject<Theme>)
-  | ReadonlyArray<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)>;
+  | ReadonlyArray<
+      boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)
+    >;
 
 export interface StyleFunctionSx {
   (props: object): object;


### PR DESCRIPTION
Fix of: [this](https://mui.com/system/the-sx-prop/#fill-callback-gives-theme-type-as-any)

Readonly array does not have properties such as fill, push, etc... So on this way we can safely replace Array with ReadonlyArray and our problem will disappear.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
