### PR TITLE
[Dialog] The `component` prop is not available in `DialogTitleProps`

### DIFF
--- a/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
@@ -1,5 +1,5 @@
-import { SxProps } from '@mui/system';
 import * as React from 'react';
+import { SxProps } from '@mui/system';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { Theme } from '../styles';
 import { TypographyTypeMap } from '../Typography';
@@ -40,7 +40,7 @@ declare const DialogTitle: OverridableComponent<DialogTitleTypeMap>;
 
 export type DialogTitleProps<
   D extends React.ElementType = DialogTitleTypeMap['defaultComponent'],
-  P = {},
+  P = { component?: React.ElementType },
 > = OverrideProps<DialogTitleTypeMap<P, D>, D>;
 
 export default DialogTitle;

--- a/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
@@ -1,21 +1,29 @@
-import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { InternalStandardProps as StandardProps, Theme } from '..';
+import * as React from 'react';
+import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { Theme } from '../styles';
+import { TypographyTypeMap } from '../Typography';
 import { DialogTitleClasses } from './dialogTitleClasses';
 
-export interface DialogTitleProps extends StandardProps<React.HTMLAttributes<HTMLHeadingElement>> {
-  /**
-   * The content of the component.
-   */
-  children?: React.ReactNode;
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<DialogTitleClasses>;
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx?: SxProps<Theme>;
+export interface DialogTitleTypeMap<
+  P = {},
+  D extends React.ElementType = TypographyTypeMap['defaultComponent'],
+> {
+  props: P & {
+    /**
+     * The content of the component.
+     */
+    children?: React.ReactNode;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<DialogTitleClasses>;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+  } & Omit<TypographyTypeMap['props'], 'classes'>;
+  defaultComponent: D;
 }
 
 /**
@@ -28,4 +36,11 @@ export interface DialogTitleProps extends StandardProps<React.HTMLAttributes<HTM
  *
  * - [DialogTitle API](https://mui.com/material-ui/api/dialog-title/)
  */
-export default function DialogTitle(props: DialogTitleProps): JSX.Element;
+declare const DialogContentText: OverridableComponent<DialogTitleTypeMap>;
+
+export type DialogContentTextProps<
+  D extends React.ElementType = DialogTitleTypeMap['defaultComponent'],
+  P = {},
+> = OverrideProps<DialogTitleTypeMap<P, D>, D>;
+
+export default DialogContentText;

--- a/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
@@ -36,11 +36,11 @@ export interface DialogTitleTypeMap<
  *
  * - [DialogTitle API](https://mui.com/material-ui/api/dialog-title/)
  */
-declare const DialogContentText: OverridableComponent<DialogTitleTypeMap>;
+declare const DialogTitle: OverridableComponent<DialogTitleTypeMap>;
 
-export type DialogContentTextProps<
+export type DialogTitleProps<
   D extends React.ElementType = DialogTitleTypeMap['defaultComponent'],
   P = {},
 > = OverrideProps<DialogTitleTypeMap<P, D>, D>;
 
-export default DialogContentText;
+export default DialogTitle;

--- a/packages/mui-material/src/DialogTitle/DialogTitle.spec.tsx
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.spec.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import DialogTitle from './DialogTitle';
+
+function DialogTitleTest() {
+  <DialogTitle component="h4" />;
+  <DialogTitle component="button" />;
+  <DialogTitle component="p" />;
+}

--- a/packages/mui-material/src/DialogTitle/DialogTitle.spec.tsx
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import DialogTitle from './DialogTitle';
+import { DialogTitle } from '@mui/material';
 
 function DialogTitleTest() {
   <DialogTitle component="h4" />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/32369

Before:
- [Codesandbox](https://codesandbox.io/s/loving-sound-koxqm3)

After:
- [Codesandbox](https://codesandbox.io/s/cold-wave-upqg21)