### PR TITLE
PreventScroll prop on autoFocus in ListItemButton

### DIFF
--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -128,6 +128,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     divider = false,
     focusVisibleClassName,
     selected = false,
+    preventScroll = false,
     ...other
   } = props;
 
@@ -142,7 +143,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
   useEnhancedEffect(() => {
     if (autoFocus) {
       if (listItemRef.current) {
-        listItemRef.current.focus();
+        listItemRef.current.focus({ preventScroll });
       } else if (process.env.NODE_ENV !== 'production') {
         console.error(
           'MUI: Unable to set focus to a ListItemButton whose component has not been rendered.',
@@ -216,6 +217,10 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * @default false
    */
   dense: PropTypes.bool,
+  /**
+   * Prevent scroll on autoFocus
+   */
+  preventScroll: PropTypes.bool, 
   /**
    * If `true`, the component is disabled.
    * @default false


### PR DESCRIPTION
`react-window` and `react-virtualized-auto-sizer` handle scroll. There is an overlap that brings a messy scroll behavior

