### PR TITLE
[List] Fix `PreventScroll` prop messy scroll behavior on autoFocus in ListItemButton

### DIFF
--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -128,6 +128,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     divider = false,
     focusVisibleClassName,
     selected = false,
+    preventScroll = false,
     ...other
   } = props;
 
@@ -142,7 +143,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
   useEnhancedEffect(() => {
     if (autoFocus) {
       if (listItemRef.current) {
-        listItemRef.current.focus();
+        listItemRef.current.focus({ preventScroll });
       } else if (process.env.NODE_ENV !== 'production') {
         console.error(
           'MUI: Unable to set focus to a ListItemButton whose component has not been rendered.',
@@ -216,6 +217,10 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * @default false
    */
   dense: PropTypes.bool,
+  /**
+   * Prevent scroll on autoFocus
+   */
+  preventScroll: PropTypes.bool, 
   /**
    * If `true`, the component is disabled.
    * @default false

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -143,7 +143,9 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
   useEnhancedEffect(() => {
     if (autoFocus) {
       if (listItemRef.current) {
-        listItemRef.current.focus({ preventScroll });
+        setTimeout(() => {
+          listItemRef.current.focus({ preventScroll });
+        }, 0);
       } else if (process.env.NODE_ENV !== 'production') {
         console.error(
           'MUI: Unable to set focus to a ListItemButton whose component has not been rendered.',
@@ -218,10 +220,6 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    */
   dense: PropTypes.bool,
   /**
-   * Prevent scroll on autoFocus
-   */
-  preventScroll: PropTypes.bool, 
-  /**
    * If `true`, the component is disabled.
    * @default false
    */
@@ -245,6 +243,10 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * if needed.
    */
   focusVisibleClassName: PropTypes.string,
+  /**
+   * Prevent scroll on autoFocus
+   */
+  preventScroll: PropTypes.bool, 
   /**
    * Use to apply selected styling.
    * @default false

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -152,7 +152,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
         );
       }
     }
-  }, [autoFocus]);
+  }, [autoFocus, preventScroll]);
 
   const ownerState = {
     ...props,
@@ -245,6 +245,7 @@ ListItemButton.propTypes /* remove-proptypes */ = {
   focusVisibleClassName: PropTypes.string,
   /**
    * Prevent scroll on autoFocus
+   * @default false
    */
   preventScroll: PropTypes.bool,
   /**

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -246,7 +246,7 @@ ListItemButton.propTypes /* remove-proptypes */ = {
   /**
    * Prevent scroll on autoFocus
    */
-  preventScroll: PropTypes.bool, 
+  preventScroll: PropTypes.bool,
   /**
    * Use to apply selected styling.
    * @default false


### PR DESCRIPTION
`react-window` and `react-virtualized-auto-sizer` handle scroll. There is an overlap that brings a messy scroll behavior