### PR TITLE
[docs] Don't redirect on deploy preview

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -14,6 +14,9 @@ if (reactStrictMode) {
 }
 const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
 const vercelDeploy = Boolean(process.env.VERCEL);
+const isDeployPreview = process.env.PULL_REQUEST === 'true';
+// For crowdin PRs we want to build all locales for testing.
+const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDeploy;
 
 const staging =
   process.env.REPOSITORY_URL === undefined || /mui\/material-ui$/.test(process.env.REPOSITORY_URL);
@@ -172,6 +175,7 @@ module.exports = {
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui/material-ui/blob/master',
     SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
     STAGING: staging,
+    BUILD_ONLY_ENGLISH_LOCALE: buildOnlyEnglishLocale,
   },
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
@@ -218,8 +222,8 @@ module.exports = {
     }
 
     // We want to speed-up the build of pull requests.
-    // For crowdin PRs we want to build all locales for testing.
-    if (process.env.PULL_REQUEST === 'true' && !l10nPRInNetlify && !vercelDeploy) {
+    // For this, consider only English language on deploy previews, except for crowdin PRs.
+    if (buildOnlyEnglishLocale) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -55,7 +55,7 @@ function LanguageNegotiation() {
         acceptLanguage.get(navigator.language) ||
         userLanguage;
 
-      if (userLanguage !== preferedLanguage) {
+      if (userLanguage !== preferedLanguage && !process.env.BUILD_ONLY_ENGLISH_LOCALE) {
         window.location =
           preferedLanguage === 'en' ? canonicalAs : `/${preferedLanguage}${canonicalAs}`;
       }


### PR DESCRIPTION
Preview with the fix: https://deploy-preview-32399--material-ui.netlify.app/material-ui/getting-started/installation/

Preview to test the bug: https://deploy-preview-32458--material-ui.netlify.app/material-ui/getting-started/installation/

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

My cellphone is in Portuguese. When I open any deploy preview, it tries to redirect me to the translated page, but only the English language is included in the preview, so I see a 404 page. This PR disables the redirect for previews. To test the fix, you can add the Portuguese language to a browser and open the link above. In this PR it won't redirect, but with any other preview it should display a 404 error. Once approved I'll also fix this in MUI X.