### PR TITLE
[Paper] Typing error when trying to pass `component` to `PaperProps` of `Drawer`

### DIFF
--- a/packages/mui-material/src/Dialog/Dialog.spec.tsx
+++ b/packages/mui-material/src/Dialog/Dialog.spec.tsx
@@ -4,3 +4,7 @@ import { Dialog } from '@mui/material';
 function optionalChildrenTest() {
   <Dialog open />;
 }
+
+function PaperPropsTest() {
+  <Dialog PaperProps={{ component: 'form' }} open />;
+}

--- a/packages/mui-material/src/Drawer/Drawer.spec.tsx
+++ b/packages/mui-material/src/Drawer/Drawer.spec.tsx
@@ -1,0 +1,8 @@
+import { Drawer, Paper } from '@mui/material';
+import * as React from 'react';
+
+function PaperPropsTest() {
+  <Drawer PaperProps={{ component: Paper }} variant="permanent">
+    Drawer content
+  </Drawer>;
+}

--- a/packages/mui-material/src/IconButton/IconButton.d.ts
+++ b/packages/mui-material/src/IconButton/IconButton.d.ts
@@ -82,7 +82,7 @@ declare const IconButton: ExtendButtonBase<IconButtonTypeMap>;
 
 export type IconButtonProps<
   D extends React.ElementType = IconButtonTypeMap['defaultComponent'],
-  P = {},
+  P = { component?: React.ElementType },
 > = OverrideProps<IconButtonTypeMap<P, D>, D>;
 
 export default IconButton;

--- a/packages/mui-material/src/MenuItem/MenuItem.d.ts
+++ b/packages/mui-material/src/MenuItem/MenuItem.d.ts
@@ -65,7 +65,7 @@ declare const MenuItem: ExtendButtonBase<MenuItemTypeMap>;
 
 export type MenuItemProps<
   D extends React.ElementType = MenuItemTypeMap['defaultComponent'],
-  P = {},
+  P = { component?: React.ElementType },
 > = OverrideProps<MenuItemTypeMap<P, D>, D>;
 
 export default MenuItem;

--- a/packages/mui-material/src/Paper/Paper.d.ts
+++ b/packages/mui-material/src/Paper/Paper.d.ts
@@ -56,7 +56,7 @@ declare const Paper: OverridableComponent<PaperTypeMap>;
 
 export type PaperProps<
   D extends React.ElementType = PaperTypeMap['defaultComponent'],
-  P = {},
+  P = { component?: React.ElementType },
 > = OverrideProps<PaperTypeMap<P, D>, D>;
 
 export default Paper;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/27703
Closes https://github.com/mui/material-ui/issues/32392

Problem:
- the interface `PaperProps` doesn't have `component` as a key
- e.g., `<Drawer PaperProps={{ component:"..." }} ... />` displays a Typescript error
- e.g., `<Dialog PaperProps={{ component:"..." }} ... />` displays a Typescript error

Before:
- [Codesandbox](https://codesandbox.io/s/empty-cherry-9nvlcu)

After:
- [Codesandbox](https://codesandbox.io/s/floral-grass-b0ing0?file=/src/Demo.tsx)