### PR TITLE
[Joy] Improve theme focus to be more flexible

### DIFF
--- a/docs/pages/experiments/joy/radio.tsx
+++ b/docs/pages/experiments/joy/radio.tsx
@@ -549,7 +549,6 @@ export default function JoyRadio() {
             my: 3,
             gap: 2,
             '& > div': {
-              borderRadius: '4px',
               bgcolor: 'background.level1',
               display: 'flex',
               flexDirection: 'column',
@@ -559,7 +558,6 @@ export default function JoyRadio() {
               minWidth: 120,
             },
             '& .MuiRadio-root': {
-              '--Radio-action-radius': '4px',
               '&.Mui-checked': {
                 '& .MuiRadio-action': {
                   inset: -1,
@@ -581,7 +579,7 @@ export default function JoyRadio() {
             },
           }}
         >
-          <Sheet variant="outlined">
+          <Sheet variant="outlined" sx={{ borderRadius: 'sm' }}>
             <Radio id="website" value="website" checkedIcon={<CheckCircle />} />
             <Avatar variant="light" size="lg" />
             <Typography
@@ -594,7 +592,7 @@ export default function JoyRadio() {
               Website
             </Typography>
           </Sheet>
-          <Sheet variant="outlined">
+          <Sheet variant="outlined" sx={{ borderRadius: 'sm' }}>
             <Radio id="documents" value="documents" checkedIcon={<CheckCircle />} />
             <Avatar variant="light" size="lg" />
             <Typography
@@ -607,7 +605,7 @@ export default function JoyRadio() {
               Documents
             </Typography>
           </Sheet>
-          <Sheet variant="outlined">
+          <Sheet variant="outlined" sx={{ borderRadius: 'sm' }}>
             <Radio id="social-account" value="social-account" checkedIcon={<CheckCircle />} />
             <Avatar variant="light" size="lg" />
             <Typography

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -110,11 +110,11 @@ const ButtonRoot = styled('button', {
         fontSize: theme.vars.fontSize.sm,
       }),
       ...(ownerState.size === 'lg' && theme.typography.h6),
+      ...(ownerState.fullWidth && {
+        width: '100%',
+      }),
+      [theme.focus.selector]: theme.focus.default,
     },
-    ownerState.fullWidth && {
-      width: '100%',
-    },
-    theme.focus.default,
     theme.variants[ownerState.variant!]?.[ownerState.color!],
     theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
     theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],

--- a/packages/mui-joy/src/Checkbox/Checkbox.tsx
+++ b/packages/mui-joy/src/Checkbox/Checkbox.tsx
@@ -124,7 +124,7 @@ const CheckboxAction = styled('span', {
     // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
     transition:
       'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-    ...theme.focus.default,
+    [theme.focus.selector]: theme.focus.default,
   },
   ...(ownerState.disableIcon
     ? [

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -139,8 +139,8 @@ const ChipAction = styled('button', {
     borderRadius: 'inherit',
     transition:
       'background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+    [theme.focus.selector]: theme.focus.default,
   },
-  theme.focus.default,
   theme.variants[ownerState.variant!]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.tsx
@@ -43,8 +43,8 @@ const ChipDeleteRoot = styled('button', {
     border: 'none', // reset user agent stylesheet
     background: 'none', // reset user agent stylesheet
     padding: '0px', // reset user agent stylesheet
+    [theme.focus.selector]: theme.focus.default,
   },
-  theme.focus.default,
   theme.variants[ownerState.variant!]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],

--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -68,8 +68,8 @@ const IconButtonRoot = styled('button', {
     // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
     transition:
       'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+    [theme.focus.selector]: theme.focus.default,
   },
-  theme.focus.default,
   theme.variants[ownerState.variant!]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -81,7 +81,6 @@ const LinkRoot = styled('a', {
       }),
       display: 'inline-flex',
       alignItems: 'center',
-      position: 'relative',
       WebkitTapHighlightColor: 'transparent',
       backgroundColor: 'transparent', // Reset default value
       // We disable the focus ring for mouse, touch and keyboard users.
@@ -109,27 +108,28 @@ const LinkRoot = styled('a', {
       '&::-moz-focus-inner': {
         borderStyle: 'none', // Remove Firefox dotted outline.
       },
-      ...(ownerState.overlay && {
-        position: 'initial',
-        '&::after': {
-          content: '""',
-          display: 'block',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          right: 0,
-          borderRadius: `var(--Link-overlayRadius)`,
-          margin: `var(--Link-overlayMargin)`,
-        },
-      }),
-    },
-    !ownerState.overlay && theme.focus.default,
-    ownerState.overlay && {
-      '&.Mui-focusVisible::after': {
-        outline: '4px solid',
-        outlineColor: theme.vars.palette.focusVisible,
-      },
+      ...(ownerState.overlay
+        ? {
+            position: 'initial',
+            '&::after': {
+              content: '""',
+              display: 'block',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              bottom: 0,
+              right: 0,
+              borderRadius: `var(--Link-overlayRadius, var(--internal-action-radius, inherit))`,
+              margin: `var(--Link-overlayMargin)`,
+            },
+            [`${theme.focus.selector}`]: {
+              '&::after': theme.focus.default,
+            },
+          }
+        : {
+            position: 'relative',
+            [theme.focus.selector]: theme.focus.default,
+          }),
     },
     ownerState.variant && theme.variants[ownerState.variant]?.[ownerState.color!],
     ownerState.variant && theme.variants[`${ownerState.variant}Hover`]?.[ownerState.color!],

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -93,8 +93,8 @@ const ListItemButtonRoot = styled('div', {
       paddingRight:
         'calc(var(--List-item-paddingRight) + var(--List-item-endActionWidth, var(--internal-endActionWidth, 0px)) - var(--variant-outlinedBorderWidth))', // --internal variable makes it possible to customize the actionWidth from the top List
     }),
+    [theme.focus.selector]: theme.focus.default,
   },
-  theme.focus.default,
   theme.variants[ownerState.variant!]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
   theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -140,7 +140,7 @@ const RadioAction = styled('span', {
     // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
     transition:
       'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-    ...theme.focus.default,
+    [theme.focus.selector]: theme.focus.default,
   },
   ...(ownerState.disableIcon
     ? [

--- a/packages/mui-joy/src/Sheet/Sheet.tsx
+++ b/packages/mui-joy/src/Sheet/Sheet.tsx
@@ -37,7 +37,7 @@ const SheetRoot = styled('div', {
         variantStyle?.backgroundColor ||
         variantStyle?.background ||
         theme.vars.palette.background.body, // for sticky List
-      '--Link-overlayRadius': resolveSxValue({ theme, ownerState }, 'borderRadius'),
+      '--internal-action-radius': resolveSxValue({ theme, ownerState }, 'borderRadius'),
       // TODO: discuss the theme transition.
       // This value is copied from mui-material Sheet.
       transition: 'box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',

--- a/packages/mui-joy/src/Switch/Switch.tsx
+++ b/packages/mui-joy/src/Switch/Switch.tsx
@@ -123,7 +123,7 @@ const SwitchAction = styled('div', {
   left: 0,
   bottom: 0,
   right: 0,
-  ...theme.focus.default,
+  [theme.focus.selector]: theme.focus.default,
 }));
 
 const SwitchInput = styled('input', {

--- a/packages/mui-joy/src/styles/CssVarsProvider.test.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.test.tsx
@@ -450,7 +450,7 @@ describe('[Joy] CssVarsProvider', () => {
         </CssVarsProvider>,
       );
 
-      expect(container.firstChild?.textContent).to.equal('default');
+      expect(container.firstChild?.textContent).to.equal('selector,default');
     });
   });
 

--- a/packages/mui-joy/src/styles/defaultTheme.ts
+++ b/packages/mui-joy/src/styles/defaultTheme.ts
@@ -43,6 +43,7 @@ type ConcatDeep<T> = T extends Record<string | number, infer V>
 type NormalizeVars<T> = ConcatDeep<Split<T>>;
 
 export interface Focus {
+  selector: string;
   default: CSSObject;
 }
 
@@ -338,11 +339,10 @@ const internalDefaultTheme = {
     dark: darkColorSystem,
   },
   focus: {
+    selector: '&.Mui-focusVisible, &:focus-visible',
     default: {
-      '&.Mui-focusVisible, &:focus-visible': {
-        outlineOffset: 0, // reset user agent stylesheet
-        outline: '4px solid var(--joy-palette-focusVisible)',
-      },
+      outlineOffset: 0, // reset user agent stylesheet
+      outline: '4px solid var(--joy-palette-focusVisible)',
     },
   },
   typography: {

--- a/packages/mui-joy/src/styles/styled.spec.tsx
+++ b/packages/mui-joy/src/styles/styled.spec.tsx
@@ -25,8 +25,8 @@ const FocusStyle = styled('button')(({ theme }) => [
   {
     fontWeight: theme.vars.fontWeight.md,
     backgroundColor: theme.vars.palette.background.body,
+    [theme.focus.selector]: theme.focus.default,
   },
-  theme.focus.default,
 ]);
 
 const Variants = styled('button')(({ theme }) => [


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

`theme.focus` can be used with pseudo-elements as well. This PR adds `theme.focus.selector` and fix all the component focus to be:

```js
{
  [theme.focus.selector]: theme.focus.default,
}

// for pseudo element
{
  [theme.focus.selector]: {
    '&::after': theme.focus.default,
  }
}
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
