### PR TITLE
[ButtonGroup] Fix style to use `last-child`

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -80,7 +80,8 @@ const ButtonGroupRoot = styled('div', {
   }),
   [`& .${buttonGroupClasses.grouped}`]: {
     minWidth: 40,
-    '&:not(:first-of-type)': {
+    // https://github.com/emotion-js/emotion/issues/1178
+    '&:not(style) + *,& > style * + * + * + *': {
       ...(ownerState.orientation === 'horizontal' && {
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,
@@ -98,68 +99,70 @@ const ButtonGroupRoot = styled('div', {
           marginTop: -1,
         }),
     },
-    '&:not(:last-of-type)': {
-      ...(ownerState.orientation === 'horizontal' && {
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-      }),
-      ...(ownerState.orientation === 'vertical' && {
-        borderBottomRightRadius: 0,
-        borderBottomLeftRadius: 0,
-      }),
-      ...(ownerState.variant === 'text' &&
-        ownerState.orientation === 'horizontal' && {
-          borderRight: `1px solid ${
-            theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
-          }`,
+    // https://github.com/emotion-js/emotion/issues/1105
+    '&:not(:last-child)/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */':
+      {
+        ...(ownerState.orientation === 'horizontal' && {
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0,
         }),
-      ...(ownerState.variant === 'text' &&
-        ownerState.orientation === 'vertical' && {
-          borderBottom: `1px solid ${
-            theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
-          }`,
+        ...(ownerState.orientation === 'vertical' && {
+          borderBottomRightRadius: 0,
+          borderBottomLeftRadius: 0,
         }),
-      ...(ownerState.variant === 'text' &&
-        ownerState.color !== 'inherit' && {
-          borderColor: alpha(theme.palette[ownerState.color].main, 0.5),
-        }),
-      ...(ownerState.variant === 'outlined' &&
-        ownerState.orientation === 'horizontal' && {
-          borderRightColor: 'transparent',
-        }),
-      ...(ownerState.variant === 'outlined' &&
-        ownerState.orientation === 'vertical' && {
-          borderBottomColor: 'transparent',
-        }),
-      ...(ownerState.variant === 'contained' &&
-        ownerState.orientation === 'horizontal' && {
-          borderRight: `1px solid ${theme.palette.grey[400]}`,
-          [`&.${buttonGroupClasses.disabled}`]: {
-            borderRight: `1px solid ${theme.palette.action.disabled}`,
-          },
-        }),
-      ...(ownerState.variant === 'contained' &&
-        ownerState.orientation === 'vertical' && {
-          borderBottom: `1px solid ${theme.palette.grey[400]}`,
-          [`&.${buttonGroupClasses.disabled}`]: {
-            borderBottom: `1px solid ${theme.palette.action.disabled}`,
-          },
-        }),
-      ...(ownerState.variant === 'contained' &&
-        ownerState.color !== 'inherit' && {
-          borderColor: theme.palette[ownerState.color].dark,
-        }),
-      '&:hover': {
+        ...(ownerState.variant === 'text' &&
+          ownerState.orientation === 'horizontal' && {
+            borderRight: `1px solid ${
+              theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+            }`,
+          }),
+        ...(ownerState.variant === 'text' &&
+          ownerState.orientation === 'vertical' && {
+            borderBottom: `1px solid ${
+              theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+            }`,
+          }),
+        ...(ownerState.variant === 'text' &&
+          ownerState.color !== 'inherit' && {
+            borderColor: alpha(theme.palette[ownerState.color].main, 0.5),
+          }),
         ...(ownerState.variant === 'outlined' &&
           ownerState.orientation === 'horizontal' && {
-            borderRightColor: 'currentColor',
+            borderRightColor: 'transparent',
           }),
         ...(ownerState.variant === 'outlined' &&
           ownerState.orientation === 'vertical' && {
-            borderBottomColor: 'currentColor',
+            borderBottomColor: 'transparent',
           }),
+        ...(ownerState.variant === 'contained' &&
+          ownerState.orientation === 'horizontal' && {
+            borderRight: `1px solid ${theme.palette.grey[400]}`,
+            [`&.${buttonGroupClasses.disabled}`]: {
+              borderRight: `1px solid ${theme.palette.action.disabled}`,
+            },
+          }),
+        ...(ownerState.variant === 'contained' &&
+          ownerState.orientation === 'vertical' && {
+            borderBottom: `1px solid ${theme.palette.grey[400]}`,
+            [`&.${buttonGroupClasses.disabled}`]: {
+              borderBottom: `1px solid ${theme.palette.action.disabled}`,
+            },
+          }),
+        ...(ownerState.variant === 'contained' &&
+          ownerState.color !== 'inherit' && {
+            borderColor: theme.palette[ownerState.color].dark,
+          }),
+        '&:hover': {
+          ...(ownerState.variant === 'outlined' &&
+            ownerState.orientation === 'horizontal' && {
+              borderRightColor: 'currentColor',
+            }),
+          ...(ownerState.variant === 'outlined' &&
+            ownerState.orientation === 'vertical' && {
+              borderBottomColor: 'currentColor',
+            }),
+        },
       },
-    },
     '&:hover': {
       ...(ownerState.variant === 'contained' && {
         boxShadow: 'none',

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -81,7 +81,7 @@ const ButtonGroupRoot = styled('div', {
   [`& .${buttonGroupClasses.grouped}`]: {
     minWidth: 40,
     // https://github.com/emotion-js/emotion/issues/1178
-    '&:not(style) + *,& > style * + * + * + *': {
+    '&:not(style) + *': {
       ...(ownerState.orientation === 'horizontal' && {
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -81,7 +81,7 @@ const ButtonGroupRoot = styled('div', {
   [`& .${buttonGroupClasses.grouped}`]: {
     minWidth: 40,
     // https://github.com/emotion-js/emotion/issues/1178
-    '&:not(style) + *': {
+    '& + *': {
       ...(ownerState.orientation === 'horizontal' && {
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,

--- a/test/regressions/fixtures/ButtonGroup/ChildElementStyle.js
+++ b/test/regressions/fixtures/ButtonGroup/ChildElementStyle.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+
+export default function ChildElementStyle() {
+  return (
+    <ButtonGroup>
+      <Button href="#">Send2</Button>
+      <Button>Send4</Button>
+      <Button href="#">Send2</Button>
+      <Button>Send3</Button>
+      <Button href="#">Send3</Button>
+    </ButtonGroup>
+  );
+}

--- a/test/regressions/fixtures/ButtonGroup/ChildStyleElement.js
+++ b/test/regressions/fixtures/ButtonGroup/ChildStyleElement.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+
+export default function ChildElementStyle() {
+  return (
+    <ButtonGroup variant="contained">
+      <style />
+      <Button href="#">Send2</Button>
+      <Button>Send4</Button>
+      <Button>Send3</Button>
+      <Button href="#">Send3</Button>
+    </ButtonGroup>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
`last-of-type` or `first-of-type` will look up different elements as two queues, so the style will be invalidated when customizing the `button` component

I looked at the information https://github.com/emotion-js/emotion/issues/1178#issuecomment-585188751 https://github.com/emotion-js/emotion/issues/1105 `last-child` should be safe

I'm not sure if accept situation, if sure, please let me know if I need to add a test case Thanks! 🤔

demo: https://codesandbox.io/s/suspicious-mopsa-o1bqtu?file=/index.html

- Fixes #31210 and #29224

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
