### PR TITLE
[codemod] Leave numeric arguments to breakpoints functions unchanged

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/theme-breakpoints.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-breakpoints.js
@@ -22,7 +22,10 @@ export default function transformer(file, api, options) {
     })
     .forEach((path) => {
       path.node.arguments.forEach((node) => {
-        node.value = map[node.value];
+        const replacementValue = map[node.value];
+        if (replacementValue !== undefined) {
+          node.value = replacementValue;
+        }
       });
     });
 
@@ -36,7 +39,10 @@ export default function transformer(file, api, options) {
     })
     .forEach((path) => {
       const node = path.node.arguments[1];
-      node.value = map[node.value];
+      const replacementValue = map[node.value];
+      if (replacementValue !== undefined) {
+        node.value = replacementValue;
+      }
     });
 
   return root.toSource(printOptions);

--- a/packages/mui-codemod/src/v5.0.0/theme-breakpoints.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-breakpoints.test/actual.js
@@ -1,4 +1,5 @@
 theme.breakpoints.down('sm')
 theme.breakpoints.down('xl')
+theme.breakpoints.down(360)
 theme.breakpoints.between('sm', 'md')
 theme.breakpoints.between('sm', 'xl')

--- a/packages/mui-codemod/src/v5.0.0/theme-breakpoints.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-breakpoints.test/expected.js
@@ -1,4 +1,5 @@
 theme.breakpoints.down('md')
 theme.breakpoints.down('xl')
+theme.breakpoints.down(360)
 theme.breakpoints.between('sm', 'lg')
 theme.breakpoints.between('sm', 'xl')


### PR DESCRIPTION
The codemod was previously changing numeric values to `undefined`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
