### PR TITLE
[codemod] Allow for line breaks within theme.spacing parentheses

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.js
@@ -7,7 +7,7 @@ export default function transformer(file) {
       // `${theme.spacing(2)}px` -> theme.spacing(2)
       .replace(/`(-?)\${(-?)(theme\.spacing|spacing)\(([^{}]*)\)}px`/gm, '$3($1$2$4)')
       // `${theme.spacing(2)}px ${theme.spacing(4)}px` -> `${theme.spacing(2)} ${theme.spacing(4)}`
-      .replace(/(?<={(theme\.spacing|spacing)\(.*\)})px/gm, '')
+      .replace(/(?<={(theme\.spacing|spacing)\([^]*.*[^]*\)})px/gm, '')
       .replace(/((theme\.spacing|spacing)\(.*\))\s*\+\s*'px'/gm, '$1')
       .replace(
         /\${(theme.spacing|spacing)(\(.*\))\s*([+-])\s*([\d.]+)\s*}px/gm,

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/actual.js
@@ -11,3 +11,6 @@ padding: `${theme.spacing(2) - 1}px 0`
 `calc(100% - ${theme.spacing(itemHorzPadding) * 0.3}px)`
 `${-theme.spacing(1)}px`
 `-${theme.spacing(1)}px`
+padding: `${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(2)}px ${theme.spacing(
+  2
+)}px`,

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/actual.js
@@ -11,6 +11,6 @@ padding: `${theme.spacing(2) - 1}px 0`
 `calc(100% - ${theme.spacing(itemHorzPadding) * 0.3}px)`
 `${-theme.spacing(1)}px`
 `-${theme.spacing(1)}px`
-padding: `${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(2)}px ${theme.spacing(
+`${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(2)}px ${theme.spacing(
   2
-)}px`,
+)}px`

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/expected.js
@@ -11,3 +11,6 @@ padding: `calc(${theme.spacing(2)} - 1px) 0`
 `calc(100% - calc(${theme.spacing(itemHorzPadding)} * 0.3))`
 theme.spacing(-1)
 theme.spacing(-1)
+padding: `${theme.spacing(2)} ${theme.spacing(1)} ${theme.spacing(2)} ${theme.spacing(
+  2
+)}`,

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/expected.js
@@ -11,6 +11,6 @@ padding: `calc(${theme.spacing(2)} - 1px) 0`
 `calc(100% - calc(${theme.spacing(itemHorzPadding)} * 0.3))`
 theme.spacing(-1)
 theme.spacing(-1)
-padding: `${theme.spacing(2)} ${theme.spacing(1)} ${theme.spacing(2)} ${theme.spacing(
+`${theme.spacing(2)} ${theme.spacing(1)} ${theme.spacing(2)} ${theme.spacing(
   2
-)}`,
+)}`


### PR DESCRIPTION
Scenario can happen (and did occur in my app) with long lines due to `prettier` behavior

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
