### PR TITLE
[Slider] Do not render marks that are out of min and max bounds

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -693,49 +693,51 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       <span className={classes.rail} />
       <span className={classes.track} style={trackStyle} />
       <input value={values.join(',')} name={name} type="hidden" />
-      {marks.map((mark, index) => {
-        const percent = valueToPercent(mark.value, min, max);
-        const style = axisProps[axis].offset(percent);
+      {marks
+        .filter((mark) => mark.value <= max && mark.value >= min)
+        .map((mark, index) => {
+          const percent = valueToPercent(mark.value, min, max);
+          const style = axisProps[axis].offset(percent);
 
-        let markActive;
-        if (track === false) {
-          markActive = values.indexOf(mark.value) !== -1;
-        } else {
-          markActive =
-            (track === 'normal' &&
-              (range
-                ? mark.value >= values[0] && mark.value <= values[values.length - 1]
-                : mark.value <= values[0])) ||
-            (track === 'inverted' &&
-              (range
-                ? mark.value <= values[0] || mark.value >= values[values.length - 1]
-                : mark.value >= values[0]));
-        }
+          let markActive;
+          if (track === false) {
+            markActive = values.indexOf(mark.value) !== -1;
+          } else {
+            markActive =
+              (track === 'normal' &&
+                (range
+                  ? mark.value >= values[0] && mark.value <= values[values.length - 1]
+                  : mark.value <= values[0])) ||
+              (track === 'inverted' &&
+                (range
+                  ? mark.value <= values[0] || mark.value >= values[values.length - 1]
+                  : mark.value >= values[0]));
+          }
 
-        return (
-          <React.Fragment key={mark.value}>
-            <span
-              style={style}
-              data-index={index}
-              className={clsx(classes.mark, {
-                [classes.markActive]: markActive,
-              })}
-            />
-            {mark.label != null ? (
+          return (
+            <React.Fragment key={mark.value}>
               <span
-                aria-hidden
-                data-index={index}
                 style={style}
-                className={clsx(classes.markLabel, {
-                  [classes.markLabelActive]: markActive,
+                data-index={index}
+                className={clsx(classes.mark, {
+                  [classes.markActive]: markActive,
                 })}
-              >
-                {mark.label}
-              </span>
-            ) : null}
-          </React.Fragment>
-        );
-      })}
+              />
+              {mark.label != null ? (
+                <span
+                  aria-hidden
+                  data-index={index}
+                  style={style}
+                  className={clsx(classes.markLabel, {
+                    [classes.markLabelActive]: markActive,
+                  })}
+                >
+                  {mark.label}
+                </span>
+              ) : null}
+            </React.Fragment>
+          );
+        })}
       {values.map((value, index) => {
         const percent = valueToPercent(value, min, max);
         const style = axisProps[axis].offset(percent);

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -573,6 +573,25 @@ describe('<Slider />', () => {
     expect(container.querySelectorAll(`.${classes.mark}[data-index="2"]`).length).to.equal(1);
   });
 
+  it('should not render marks that are out of min&max bounds', () => {
+    const { container } = render(
+      <Slider
+        marks={[
+          { value: -1, label: -1 },
+          { value: 0, label: 0 },
+          { value: 100, label: 100 },
+          { value: 101, label: 101 },
+        ]}
+        defaultValue={0}
+      />,
+    );
+
+    expect(container.querySelectorAll(`.${classes.markLabel}`).length).to.equal(2);
+    expect(container.querySelectorAll(`.${classes.mark}`).length).to.equal(2);
+    expect(container.querySelectorAll(`.${classes.markLabel}`)[0].textContent).to.equal('0');
+    expect(container.querySelectorAll(`.${classes.markLabel}`)[1].textContent).to.equal('100');
+  });
+
   describe('prop: ValueLabelComponent', () => {
     it('receives the formatted value', () => {
       function ValueLabelComponent(props) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This fixes an issue when Slider component renders marks that are out of `min` and `max` bounds, e.g. when user wants to render a mark for `120` value when min is `0` and max is `100`. See [CodeSandbox](https://codesandbox.io/s/nostalgic-raman-7szz2j?file=/src/Demo.tsx) for reference.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
