### PR TITLE
[Autocomplete] Fix `getOptionLabel` callback getting the value instead of option object

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -151,6 +151,11 @@ export default function useAutocomplete(props) {
 
   const [focused, setFocused] = React.useState(false);
 
+  const calculatedOption = value
+    ? options.find((option) => isOptionEqualToValue(option, value))
+    : undefined;
+  const calculatedOptionLabel = calculatedOption ? getOptionLabelProp(calculatedOption) : value;
+
   const resetInputValue = React.useCallback(
     (event, newValue) => {
       // retain current `inputValue` if new option isn't selected and `clearOnBlur` is false
@@ -165,8 +170,7 @@ export default function useAutocomplete(props) {
       } else if (newValue == null) {
         newInputValue = '';
       } else {
-        const optionLabel = getOptionLabel(newValue);
-        newInputValue = typeof optionLabel === 'string' ? optionLabel : '';
+        newInputValue = typeof calculatedOptionLabel === 'string' ? calculatedOptionLabel : '';
       }
 
       if (inputValue === newInputValue) {
@@ -179,7 +183,15 @@ export default function useAutocomplete(props) {
         onInputChange(event, newInputValue, 'reset');
       }
     },
-    [getOptionLabel, inputValue, multiple, onInputChange, setInputValueState, clearOnBlur, value],
+    [
+      inputValue,
+      multiple,
+      onInputChange,
+      setInputValueState,
+      clearOnBlur,
+      value,
+      calculatedOptionLabel,
+    ],
   );
 
   const prevValue = React.useRef();
@@ -210,7 +222,7 @@ export default function useAutocomplete(props) {
   const [inputPristine, setInputPristine] = React.useState(true);
 
   const inputValueIsSelectedValue =
-    !multiple && value != null && inputValue === getOptionLabel(value);
+    !multiple && value != null && inputValue === calculatedOptionLabel;
 
   const popupOpen = open && !readOnly;
 

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -151,10 +151,15 @@ export default function useAutocomplete(props) {
 
   const [focused, setFocused] = React.useState(false);
 
-  const calculatedOption = value
-    ? options.find((option) => isOptionEqualToValue(option, value))
-    : undefined;
-  const calculatedOptionLabel = calculatedOption ? getOptionLabelProp(calculatedOption) : value;
+  const getCalculatedOptionLabel = React.useCallback(
+    (aValue) => {
+      const calculatedOption = aValue
+        ? options.find((option) => isOptionEqualToValue(option, aValue))
+        : options[0];
+      return calculatedOption ? getOptionLabelProp(calculatedOption) : aValue;
+    },
+    [options, isOptionEqualToValue, getOptionLabelProp],
+  );
 
   const resetInputValue = React.useCallback(
     (event, newValue) => {
@@ -170,7 +175,8 @@ export default function useAutocomplete(props) {
       } else if (newValue == null) {
         newInputValue = '';
       } else {
-        newInputValue = typeof calculatedOptionLabel === 'string' ? calculatedOptionLabel : '';
+        const optionLabel = getCalculatedOptionLabel(newValue);
+        newInputValue = typeof optionLabel === 'string' ? optionLabel : '';
       }
 
       if (inputValue === newInputValue) {
@@ -184,13 +190,13 @@ export default function useAutocomplete(props) {
       }
     },
     [
+      getCalculatedOptionLabel,
       inputValue,
       multiple,
       onInputChange,
       setInputValueState,
       clearOnBlur,
       value,
-      calculatedOptionLabel,
     ],
   );
 
@@ -222,7 +228,7 @@ export default function useAutocomplete(props) {
   const [inputPristine, setInputPristine] = React.useState(true);
 
   const inputValueIsSelectedValue =
-    !multiple && value != null && inputValue === calculatedOptionLabel;
+    !multiple && value != null && inputValue === getCalculatedOptionLabel(value);
 
   const popupOpen = open && !readOnly;
 

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -152,11 +152,12 @@ export default function useAutocomplete(props) {
   const [focused, setFocused] = React.useState(false);
 
   const getCalculatedOptionLabel = React.useCallback(
-    (aValue) => {
-      const calculatedOption = aValue
-        ? options.find((option) => isOptionEqualToValue(option, aValue))
-        : options[0];
-      return calculatedOption ? getOptionLabelProp(calculatedOption) : aValue;
+    (newValue) => {
+      const calculatedOption = newValue
+        ? options.find((option) => isOptionEqualToValue(option, newValue))
+        : undefined;
+
+      return calculatedOption ? getOptionLabelProp(calculatedOption) : undefined;
     },
     [options, isOptionEqualToValue, getOptionLabelProp],
   );

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1318,9 +1318,6 @@ describe('<Autocomplete />', () => {
           'MUI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
         !strictModeDoubleLoggingSupressed &&
           'MUI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
-        'MUI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
-        'MUI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
-        'MUI: The `getOptionLabel` method of Autocomplete returned undefined instead of a string',
       ]);
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal('a');

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2149,6 +2149,24 @@ describe('<Autocomplete />', () => {
       expect(textbox).to.have.property('value', 'ONE');
     });
 
+    it('should update the input value when getOptionLabel changes and options are objects', () => {
+      render(
+        <Autocomplete
+          value={'1'}
+          options={[
+            { label: 'one', value: '1' },
+            { label: 'two', value: '2' },
+            { label: 'three', value: '3' },
+          ]}
+          isOptionEqualToValue={(option, value) => option.value === value}
+          getOptionLabel={(option) => option.label}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const textbox = screen.getByRole('combobox');
+      expect(textbox).to.have.property('value', 'one');
+    });
+
     it('should not update the input value when users is focusing', () => {
       const { setProps } = render(
         <Autocomplete


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- Fixes https://github.com/mui/material-ui/issues/31192
