### PR TITLE
[core] Update the proptypes scripts to support components in @mui/system

### DIFF
--- a/docs/data/system/flexbox/AlignContent.js
+++ b/docs/data/system/flexbox/AlignContent.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/AlignItems.js
+++ b/docs/data/system/flexbox/AlignItems.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/AlignSelf.js
+++ b/docs/data/system/flexbox/AlignSelf.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/FlexDirection.js
+++ b/docs/data/system/flexbox/FlexDirection.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/FlexGrow.js
+++ b/docs/data/system/flexbox/FlexGrow.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/FlexShrink.js
+++ b/docs/data/system/flexbox/FlexShrink.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/FlexWrap.js
+++ b/docs/data/system/flexbox/FlexWrap.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/JustifyContent.js
+++ b/docs/data/system/flexbox/JustifyContent.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/flexbox/Order.js
+++ b/docs/data/system/flexbox/Order.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/Gap.js
+++ b/docs/data/system/grid/Gap.js
@@ -24,6 +24,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/GridAutoColumns.js
+++ b/docs/data/system/grid/GridAutoColumns.js
@@ -24,6 +24,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/GridAutoFlow.js
+++ b/docs/data/system/grid/GridAutoFlow.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/GridAutoRows.js
+++ b/docs/data/system/grid/GridAutoRows.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/GridTemplateColumns.js
+++ b/docs/data/system/grid/GridTemplateColumns.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/GridTemplateRows.js
+++ b/docs/data/system/grid/GridTemplateRows.js
@@ -25,6 +25,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/docs/data/system/grid/RowAndColumnGap.js
+++ b/docs/data/system/grid/RowAndColumnGap.js
@@ -24,6 +24,9 @@ function Item(props) {
 }
 
 Item.propTypes = {
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
   sx: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool]),

--- a/packages/mui-joy/src/Box/Box.tsx
+++ b/packages/mui-joy/src/Box/Box.tsx
@@ -14,10 +14,10 @@ const Box = createBox({
 }) as OverridableComponent<BoxTypeMap>;
 
 Box.propTypes /* remove-proptypes */ = {
-  // --------------------------------- Warning ---------------------------------
-  // | The propTypes for the system components are NOT automatically generated |
-  // |  If you are updating the props, make sure to update the propTypes too   |
-  // ---------------------------------------------------------------------------
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
   /**
    * @ignore
    */
@@ -35,6 +35,6 @@ Box.propTypes /* remove-proptypes */ = {
     PropTypes.func,
     PropTypes.object,
   ]),
-};
+} as any;
 
 export default Box;

--- a/packages/mui-joy/src/Box/BoxProps.ts
+++ b/packages/mui-joy/src/Box/BoxProps.ts
@@ -6,8 +6,15 @@ export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &
     SystemProps<Theme> & {
       children?: React.ReactNode;
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
       component?: React.ElementType;
       ref?: React.Ref<unknown>;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
       sx?: SxProps<Theme>;
     };
   defaultComponent: D;

--- a/packages/mui-material/src/Box/Box.d.ts
+++ b/packages/mui-material/src/Box/Box.d.ts
@@ -6,8 +6,15 @@ export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &
     SystemProps<Theme> & {
       children?: React.ReactNode;
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
       component?: React.ElementType;
       ref?: React.Ref<unknown>;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
       sx?: SxProps<Theme>;
     };
   defaultComponent: D;

--- a/packages/mui-material/src/Box/Box.js
+++ b/packages/mui-material/src/Box/Box.js
@@ -12,10 +12,10 @@ const Box = createBox({
 });
 
 Box.propTypes /* remove-proptypes */ = {
-  // --------------------------------- Warning ---------------------------------
-  // | The propTypes for the system components are NOT automatically generated |
-  // |  If you are updating the props, make sure to update the propTypes too   |
-  // ---------------------------------------------------------------------------
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * @ignore
    */

--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -174,8 +174,15 @@ export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &
     SystemProps<Theme> & {
       children?: React.ReactNode;
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
       component?: React.ElementType;
       ref?: React.Ref<unknown>;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
       sx?: SxProps<Theme>;
     };
   defaultComponent: D;

--- a/packages/mui-system/src/Box/Box.js
+++ b/packages/mui-system/src/Box/Box.js
@@ -4,10 +4,10 @@ import createBox from '../createBox';
 const Box = createBox();
 
 Box.propTypes /* remove-proptypes */ = {
-  // --------------------------------- Warning ---------------------------------
-  // | The propTypes for the system components are NOT automatically generated |
-  // |  If you are updating the props, make sure to update the propTypes too   |
-  // ---------------------------------------------------------------------------
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * @ignore
    */

--- a/packages/typescript-to-proptypes/src/injector.ts
+++ b/packages/typescript-to-proptypes/src/injector.ts
@@ -132,6 +132,8 @@ function flattenTsAsExpression(node: object | null | undefined) {
   return node;
 }
 
+const systemComponents = ['Container', 'Box'];
+
 function plugin(
   propTypes: t.Program,
   options: InjectOptions = {},
@@ -379,6 +381,8 @@ function plugin(
           const arg = nodeInit.arguments[0];
           if (babelTypes.isArrowFunctionExpression(arg) || babelTypes.isFunctionExpression(arg)) {
             getFromProp(arg.params[0]);
+          } else if (systemComponents.includes(nodeName)) {
+            getFromProp(node);
           }
         }
       },


### PR DESCRIPTION
Follow up on https://github.com/mui/material-ui/pull/32295. I've realized after merging that the `typescript-to-proptypes` is an inhouse dependency that we can alter :)

We now have full support for generating prop types out of the `@mui/system` components. 