### PR TITLE
[utils] Fix deepmerge incorrect type

### DIFF
--- a/docs/src/components/home/MaterialDesignComponents.tsx
+++ b/docs/src/components/home/MaterialDesignComponents.tsx
@@ -432,7 +432,7 @@ export function buildTheme(theme: Theme): ThemeOptions {
       },
       MuiTooltip: theme.components?.MuiTooltip,
       MuiPaper: theme.components?.MuiPaper,
-      MuiTableCell: deepmerge(theme.components?.MuiTableCell || {}, {
+      MuiTableCell: deepmerge(theme.components?.MuiTableCell, {
         styleOverrides: {
           root: {
             borderColor:

--- a/docs/src/components/home/MaterialDesignComponents.tsx
+++ b/docs/src/components/home/MaterialDesignComponents.tsx
@@ -432,7 +432,7 @@ export function buildTheme(theme: Theme): ThemeOptions {
       },
       MuiTooltip: theme.components?.MuiTooltip,
       MuiPaper: theme.components?.MuiPaper,
-      MuiTableCell: deepmerge(theme.components?.MuiTableCell, {
+      MuiTableCell: deepmerge(theme.components?.MuiTableCell || {}, {
         styleOverrides: {
           root: {
             borderColor:

--- a/packages/mui-joy/src/styles/ThemeProvider.tsx
+++ b/packages/mui-joy/src/styles/ThemeProvider.tsx
@@ -29,11 +29,13 @@ export default function ThemeProvider({
   };
 }>) {
   const { components, ...filteredTheme } = theme || {};
-  let mergedTheme = deepmerge(defaultTheme, filteredTheme) as JoyTheme & { components: Components };
+
+  let mergedTheme = deepmerge(defaultTheme, filteredTheme);
+
   mergedTheme = {
     ...mergedTheme,
     vars: mergedTheme,
-    components: components!,
-  };
+    components,
+  } as JoyTheme & { components: Components };
   return <SystemThemeProvider theme={mergedTheme}>{children}</SystemThemeProvider>;
 }

--- a/packages/mui-joy/src/styles/ThemeProvider.tsx
+++ b/packages/mui-joy/src/styles/ThemeProvider.tsx
@@ -29,11 +29,11 @@ export default function ThemeProvider({
   };
 }>) {
   const { components, ...filteredTheme } = theme || {};
-  let mergedTheme = deepmerge(defaultTheme, filteredTheme);
+  let mergedTheme = deepmerge(defaultTheme, filteredTheme) as JoyTheme & { components: Components };
   mergedTheme = {
     ...mergedTheme,
     vars: mergedTheme,
-    components,
-  } as JoyTheme & { components: Components };
+    components: components!,
+  };
   return <SystemThemeProvider theme={mergedTheme}>{children}</SystemThemeProvider>;
 }

--- a/packages/mui-utils/src/deepmerge.spec.ts
+++ b/packages/mui-utils/src/deepmerge.spec.ts
@@ -45,3 +45,116 @@ const sx = deepmerge(style, style1);
 expectType<{ foo: { color: string; fontSize: number } }, typeof sx>(sx);
 
 expectType<{ '&.Mui-disabled': undefined }, typeof result>(result);
+
+const notTarget = deepmerge(undefined, { bar: 1 });
+
+expectType<{}, typeof notTarget>(notTarget);
+
+const notSource = deepmerge({ foo: 1 }, undefined);
+
+expectType<{ foo: number }, typeof notSource>(notSource);
+
+const anyTarget = deepmerge(false, { bar: 1 });
+
+expectType<{}, typeof anyTarget>(anyTarget);
+
+const anyTarget1 = deepmerge(null, { bar: 1 });
+
+expectType<{}, typeof anyTarget1>(anyTarget1);
+
+const anyTarget2 = deepmerge('', { bar: 1 });
+
+expectType<{}, typeof anyTarget2>(anyTarget2);
+
+const anyTarget3 = deepmerge(1, { bar: 1 });
+
+expectType<{}, typeof anyTarget3>(anyTarget3);
+
+const anyTarget4 = deepmerge(NaN, { bar: 1 });
+
+expectType<{}, typeof anyTarget4>(anyTarget4);
+
+const anyTarget5 = deepmerge([], { bar: 1 });
+
+expectType<{}, typeof anyTarget5>(anyTarget5);
+
+const anyTarget6 = deepmerge(() => {}, { bar: 1 });
+
+expectType<{}, typeof anyTarget6>(anyTarget6);
+
+const anyTarget7 = deepmerge([1], { bar: 1 });
+
+expectType<{}, typeof anyTarget7>(anyTarget7);
+
+const anyTarget8 = deepmerge(
+  () => {
+    return { foo: 1 };
+  },
+  { bar: 1 },
+);
+
+expectType<{}, typeof anyTarget8>(anyTarget8);
+
+const anyTarget9 = deepmerge(new Set([1, 2]), { bar: 1 });
+
+expectType<{}, typeof anyTarget9>(anyTarget9);
+
+const anyTarget10 = deepmerge(Symbol(''), { bar: 1 });
+
+expectType<{}, typeof anyTarget10>(anyTarget10);
+
+const anyTarget11 = deepmerge(new Map([['a', 1]]), { bar: 1 });
+
+expectType<{}, typeof anyTarget11>(anyTarget11);
+
+// any source...
+
+const anySource = deepmerge({ bar: 1 }, false);
+
+expectType<{ bar: number }, typeof anySource>(anySource);
+
+const anySource1 = deepmerge({ bar: 1 }, null);
+
+expectType<{ bar: number }, typeof anySource1>(anySource1);
+
+const anySource2 = deepmerge({ bar: 1 }, '');
+
+expectType<{ bar: number }, typeof anySource2>(anySource2);
+
+const anySource3 = deepmerge({ bar: 1 }, 1);
+
+expectType<{ bar: number }, typeof anySource3>(anySource3);
+
+const anySource4 = deepmerge({ bar: 1 }, NaN);
+
+expectType<{ bar: number }, typeof anySource4>(anySource4);
+
+const anySource5 = deepmerge({ bar: 1 }, []);
+
+expectType<{ bar: number }, typeof anySource5>(anySource5);
+
+const anySource6 = deepmerge({ bar: 1 }, () => {});
+
+expectType<{ bar: number }, typeof anySource6>(anySource6);
+
+const anySource7 = deepmerge({ bar: 1 }, [1]);
+
+expectType<{ bar: number }, typeof anySource7>(anySource7);
+
+const anySource8 = deepmerge({ bar: 1 }, () => {
+  return { foo: 2 };
+});
+
+expectType<{ bar: number }, typeof anySource8>(anySource8);
+
+const anySource9 = deepmerge({ bar: 1 }, new Set([1, 2]));
+
+expectType<{ bar: number }, typeof anySource9>(anySource9);
+
+const anySource10 = deepmerge({ bar: 1 }, Symbol(''));
+
+expectType<{ bar: number }, typeof anySource9>(anySource10);
+
+const anySource11 = deepmerge({ bar: 1 }, new Map([['a', 1]]));
+
+expectType<{ bar: number }, typeof anySource11>(anySource11);

--- a/packages/mui-utils/src/deepmerge.spec.ts
+++ b/packages/mui-utils/src/deepmerge.spec.ts
@@ -1,0 +1,47 @@
+import { expectType } from '@mui/types';
+import deepmerge from './deepmerge';
+
+const a = { foo: 1 };
+
+const value = deepmerge(a, { bar: 1 });
+
+value.bar;
+value.foo;
+
+const value1 = deepmerge(a, a);
+
+expectType<{ foo: number }, typeof value1>(value1);
+expectType<{ foo: number; bar: number }, typeof value>(value);
+
+const element1 = document.createElement('div');
+const element2 = document.createElement('div');
+
+const elementi = deepmerge(element1, element2);
+const elementii = deepmerge({ element: element1 }, { elements: element2 });
+
+type Same = typeof elementii extends { elements: HTMLDivElement; element: HTMLDivElement }
+  ? true
+  : false;
+
+expectType<Same, true>(true);
+expectType<HTMLDivElement, typeof elementi>(elementi);
+
+const style = { foo: { color: 'red' } };
+const style1 = { foo: { fontSize: 13 } };
+
+const result = deepmerge(
+  {
+    '&.Mui-disabled': {
+      color: 'red',
+    },
+  },
+  {
+    '&.Mui-disabled': undefined,
+  },
+);
+
+const sx = deepmerge(style, style1);
+
+expectType<{ foo: { color: string; fontSize: number } }, typeof sx>(sx);
+
+expectType<{ '&.Mui-disabled': undefined }, typeof result>(result);

--- a/packages/mui-utils/src/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import deepmerge from './deepmerge';
 
 describe('deepmerge', () => {
@@ -44,5 +45,23 @@ describe('deepmerge', () => {
       foo: { baz: 'test', bar: 'test' },
       bar: 'test',
     });
+  });
+
+  it('not an object, returns {}', () => {
+    expect(deepmerge([], { b: 1 })).to.deep.equal({});
+
+    expect(deepmerge({ b: 1 }, [1])).to.deep.equal({ b: 1 });
+
+    expect(deepmerge(() => {}, { b: 1 })).to.deep.equal({});
+
+    expect(deepmerge({ b: 1 }, () => {})).to.deep.equal({ b: 1 });
+
+    expect(deepmerge(new Map([[1, 0]]), { b: 1 })).to.deep.equal({});
+
+    expect(deepmerge({ b: 1 }, new Map([[1, 0]]))).to.deep.equal({ b: 1 });
+
+    expect(deepmerge(new Set([[1, 0]]), { b: 1 })).to.deep.equal({});
+
+    expect(deepmerge({ b: 1 }, new Set([[1, 0]]))).to.deep.equal({ b: 1 });
   });
 });

--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -1,53 +1,78 @@
 export function isPlainObject(item: unknown) {
   return item !== null && typeof item === 'object' && item.constructor === Object;
 }
-
 export interface DeepmergeOptions {
   clone?: boolean;
 }
 
+type AnyObject = Record<PropertyKey, any>;
+
 export type Deepmerge<A, B> = {
   [key in keyof A | keyof B]: key extends keyof B
     ? key extends keyof A
-      ? B[key] extends Record<keyof any, any>
-        ? A[key] extends Record<keyof any, any>
+      ? B[key] extends AnyObject
+        ? A[key] extends AnyObject
           ? Deepmerge<A[key], B[key]>
           : B[key]
         : B[key]
       : B[key]
     : key extends keyof A
     ? A[key]
-    : never;
+    : {};
 };
 
-function deepmerge<A extends Record<keyof any, any>, B extends Record<keyof any, any>>(
-  target: A,
-  source: B,
-  options?: DeepmergeOptions,
-): B extends A ? A : Deepmerge<A, B>;
-function deepmerge<A extends Record<keyof any, any>, B extends Record<keyof any, any>>(
+export type IsPlainObject<A, B> = A extends AnyObject
+  ? A extends any[] | ((...props: any[]) => any) | Set<any> | Map<any, any>
+    ? {}
+    : B extends AnyObject
+    ? B extends any[] | ((...props: any[]) => any) | Set<any> | Map<any, any>
+      ? A
+      : A extends B
+      ? A
+      : Deepmerge<A, B>
+    : A
+  : {};
+
+function deepmerge<A, B>(
   target: A,
   source: B,
   options: DeepmergeOptions = { clone: true },
-): Deepmerge<A, B> {
-  const output = options.clone ? { ...target } : target;
+): IsPlainObject<A, B> {
+  if (isPlainObject(target)) {
+    if (!isPlainObject(source)) {
+      // @ts-expect-error shorthand
+      return target;
+    }
 
-  if (isPlainObject(target) && isPlainObject(source)) {
-    Object.keys(source).forEach((key) => {
+    const output = options.clone ? { ...target } : target;
+
+    Object.keys(source as AnyObject).forEach((key) => {
       // Avoid prototype pollution
       if (key === '__proto__') {
         return;
       }
 
-      if (isPlainObject(source[key]) && key in target && isPlainObject(target[key])) {
-        output[key as keyof B | keyof A] = deepmerge(target[key], source[key], options);
+      if (
+        isPlainObject((source as AnyObject)[key]) &&
+        key in target &&
+        isPlainObject((target as AnyObject)[key])
+      ) {
+        output[key as keyof A] = deepmerge(
+          (target as AnyObject)[key],
+          (source as AnyObject)[key],
+          options,
+        );
       } else {
-        output[key as keyof B | keyof A] = source[key];
+        output[key as keyof A] = (source as AnyObject)[key];
       }
     });
+
+    // @ts-expect-error shorthand
+    return output;
   }
 
-  return output;
+  // @ts-expect-error shorthand
+  return {};
 }
 
 export default deepmerge;

--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -6,12 +6,12 @@ export interface DeepmergeOptions {
   clone?: boolean;
 }
 
-type Assign<A, B> = {
+export type Deepmerge<A, B> = {
   [key in keyof A | keyof B]: key extends keyof B
     ? key extends keyof A
       ? B[key] extends Record<keyof any, any>
         ? A[key] extends Record<keyof any, any>
-          ? Assign<A[key], B[key]>
+          ? Deepmerge<A[key], B[key]>
           : B[key]
         : B[key]
       : B[key]
@@ -24,13 +24,13 @@ function deepmerge<A extends Record<keyof any, any>, B extends Record<keyof any,
   target: A,
   source: B,
   options?: DeepmergeOptions,
-): B extends A ? A : Assign<A, B>;
+): B extends A ? A : Deepmerge<A, B>;
 function deepmerge<A extends Record<keyof any, any>, B extends Record<keyof any, any>>(
   target: A,
   source: B,
   options: DeepmergeOptions = { clone: true },
-): Assign<A, B> {
-  const output: A & B = options.clone ? { ...target } : target;
+): Deepmerge<A, B> {
+  const output = options.clone ? { ...target } : target;
 
   if (isPlainObject(target) && isPlainObject(source)) {
     Object.keys(source).forEach((key) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
```ts
const a = { foo: 1 };

const value = deepmerge(a, { bar: 1 });

// typeof value = { foo:number } 
value.bar; // error before
value.foo;
// now typeof value = {foo:number, bar:number}
```
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
