### PR TITLE
[website] Update MUI X license redirect link

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -19,7 +19,7 @@
 /r/issue-template-next https://codesandbox.io/s/material-ui-issue-next-o7xkt
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/ts-issue-template https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEHOCcQyGFijBkAGzJ06BOaPzAIouABEsICAAoAlKzsXDwAmvJQQhAqWBpAA 302
-/r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants
+/r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants 302
 /r/x-license https://mui.com/store/items/material-ui-pro/ 302
 /r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 302
 /r/migration-v4 /guides/migration-v4/

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -23,8 +23,6 @@
 /r/x-license https://mui.com/store/legal/mui-x-eula/ 301
 /r/migration-v4 /guides/migration-v4/
 
-/x/license/ https://mui.com/store/legal/mui-x-eula/ 301
-
 # Legacy redirection
 # Added in chronological order (the last line is the most recent one)
 # To be removed 3+ years after being introduced
@@ -83,274 +81,207 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /discover-more/team/ /about/ 301
 /api/data-grid/grid-export-csv-options/ /x/api/data-grid/grid-csv-export-options/ 301
 # 2022
-## MUI X
 /components/data-grid/* /x/react-data-grid/:splat 301
 /:lang/components/data-grid/* /:lang/x/react-data-grid/:splat 301
-
 /api/data-grid/* /x/api/data-grid/:splat 301
 ### specific to current supported languages, to prevent this redirect: /x/api/data-grid/* => /x/x/api/data-grid/*
 /zh/api/data-grid/* /zh/x/api/data-grid/:splat 301
 /pt/api/data-grid/* /pt/x/api/data-grid/:splat 301
-
 /components/date-picker/ /x/react-date-pickers/date-picker/ 301
 /:lang/components/date-picker/ /:lang/x/react-date-pickers/date-picker/ 301
-
 /components/date-range-picker/ /x/react-date-pickers/date-range-picker/ 301
 /:lang/components/date-range-picker/ /:lang/x/react-date-pickers/date-range-picker/ 301
-
 /components/date-time-picker/ /x/react-date-pickers/date-time-picker/ 301
 /:lang/components/date-time-picker/ /:lang/x/react-date-pickers/date-time-picker/ 301
-
 /components/time-picker/ /x/react-date-pickers/time-picker/ 301
 /:lang/components/time-picker/ /:lang/x/react-date-pickers/time-picker/ 301
-
 /api/date-picker/ /x/api/date-pickers/date-picker/ 301
 /zh/api/date-picker/ /zh/x/api/date-pickers/date-picker/ 301
 /pt/api/date-picker/ /pt/x/api/date-pickers/date-picker/ 301
-
 /api/date-range-picker/ /x/api/date-pickers/date-range-picker/ 301
 /zh/api/date-range-picker/ /zh/x/api/date-pickers/date-range-picker/ 301
 /pt/api/date-range-picker/ /pt/x/api/date-pickers/date-range-picker/ 301
-
 /api/date-range-picker-day/ /x/api/date-pickers/date-range-picker-day/ 301
 /zh/api/date-range-picker-day/ /zh/x/api/date-pickers/date-range-picker-day/ 301
 /pt/api/date-range-picker-day/ /pt/x/api/date-pickers/date-range-picker-day/ 301
-
 /api/date-time-picker/ /x/api/date-pickers/date-time-picker/ 301
 /zh/api/date-time-picker/ /zh/x/api/date-pickers/date-time-picker/ 301
 /pt/api/date-time-picker/ /pt/x/api/date-pickers/date-time-picker/ 301
-
 /api/desktop-date-picker/ /x/api/date-pickers/desktop-date-picker/ 301
 /zh/api/desktop-date-picker/ /zh/x/api/date-pickers/desktop-date-picker/ 301
 /pt/api/desktop-date-picker/ /pt/x/api/date-pickers/desktop-date-picker/ 301
-
 /api/desktop-date-range-picker/ /x/api/date-pickers/desktop-date-range-picker/ 301
 /zh/api/desktop-date-range-picker/ /zh/x/api/date-pickers/desktop-date-range-picker/ 301
 /pt/api/desktop-date-range-picker/ /pt/x/api/date-pickers/desktop-date-range-picker/ 301
-
 /api/desktop-date-time-picker/ /x/api/date-pickers/desktop-date-time-picker/ 301
 /zh/api/desktop-date-time-picker/ /zh/x/api/date-pickers/desktop-date-time-picker/ 301
 /pt/api/desktop-date-time-picker/ /pt/x/api/date-pickers/desktop-date-time-picker/ 301
-
 /api/desktop-time-picker/ /x/api/date-pickers/desktop-time-picker/ 301
 /zh/api/desktop-time-picker/ /zh/x/api/date-pickers/desktop-time-picker/ 301
 /pt/api/desktop-time-picker/ /pt/x/api/date-pickers/desktop-time-picker/ 301
-
 /api/calendar-picker/ /x/api/date-pickers/calendar-picker/ 301
 /zh/api/calendar-picker/ /zh/x/api/date-pickers/calendar-picker/ 301
 /pt/api/calendar-picker/ /pt/x/api/date-pickers/calendar-picker/ 301
-
 /api/calendar-picker-skeleton/ /x/api/date-pickers/calendar-picker-skeleton/ 301
 /zh/api/calendar-picker-skeleton/ /zh/x/api/date-pickers/calendar-picker-skeleton/ 301
 /pt/api/calendar-picker-skeleton/ /pt/x/api/date-pickers/calendar-picker-skeleton/ 301
-
 /api/mobile-date-picker/ /x/api/date-pickers/mobile-date-picker/ 301
 /zh/api/mobile-date-picker/ /zh/x/api/date-pickers/mobile-date-picker/ 301
 /pt/api/mobile-date-picker/ /pt/x/api/date-pickers/mobile-date-picker/ 301
-
 /api/month-picker/ /x/api/date-pickers/month-picker/ 301
 /zh/api/month-picker/ /zh/x/api/date-pickers/month-picker/ 301
 /pt/api/month-picker/ /pt/x/api/date-pickers/month-picker/ 301
-
 /api/pickers-day/ /x/api/date-pickers/pickers-day/ 301
 /zh/api/pickers-day/ /zh/x/api/date-pickers/pickers-day/ 301
 /pt/api/pickers-day/ /pt/x/api/date-pickers/pickers-day/ 301
-
 /api/static-date-picker/ /x/api/date-pickers/static-date-picker/ 301
 /zh/api/static-date-picker/ /zh/x/api/date-pickers/static-date-picker/ 301
 /pt/api/static-date-picker/ /pt/x/api/date-pickers/static-date-picker/ 301
-
 /api/year-picker/ /x/api/date-pickers/year-picker/ 301
 /zh/api/year-picker/ /zh/x/api/date-pickers/year-picker/ 301
 /pt/api/year-picker/ /pt/x/api/date-pickers/year-picker/ 301
-
 /api/mobile-date-range-picker/ /x/api/date-pickers/mobile-date-range-picker/ 301
 /zh/api/mobile-date-range-picker/ /zh/x/api/date-pickers/mobile-date-range-picker/ 301
 /pt/api/mobile-date-range-picker/ /pt/x/api/date-pickers/mobile-date-range-picker/ 301
-
 /api/static-date-range-picker/ /x/api/date-pickers/static-date-range-picker/ 301
 /zh/api/static-date-range-picker/ /zh/x/api/date-pickers/static-date-range-picker/ 301
 /pt/api/static-date-range-picker/ /pt/x/api/date-pickers/static-date-range-picker/ 301
-
 /api/mobile-date-time-picker/ /x/api/date-pickers/mobile-date-time-picker/ 301
 /zh/api/mobile-date-time-picker/ /zh/x/api/date-pickers/mobile-date-time-picker/ 301
 /pt/api/mobile-date-time-picker/ /pt/x/api/date-pickers/mobile-date-time-picker/ 301
-
 /api/static-date-time-picker/ /x/api/date-pickers/static-date-time-picker/ 301
 /zh/api/static-date-time-picker/ /zh/x/api/date-pickers/static-date-time-picker/ 301
 /pt/api/static-date-time-picker/ /pt/x/api/date-pickers/static-date-time-picker/ 301
-
 /api/clock-picker/ /x/api/date-pickers/clock-picker/ 301
 /zh/api/clock-picker/ /zh/x/api/date-pickers/clock-picker/ 301
 /pt/api/clock-picker/ /pt/x/api/date-pickers/clock-picker/ 301
-
 /api/mobile-time-picker/ /x/api/date-pickers/mobile-time-picker/ 301
 /zh/api/mobile-time-picker/ /zh/x/api/date-pickers/mobile-time-picker/ 301
 /pt/api/mobile-time-picker/ /pt/x/api/date-pickers/mobile-time-picker/ 301
-
 /api/static-time-picker/ /x/api/date-pickers/static-time-picker/ 301
 /zh/api/static-time-picker/ /zh/x/api/date-pickers/static-time-picker/ 301
 /pt/api/static-time-picker/ /pt/x/api/date-pickers/static-time-picker/ 301
-
 /api/time-picker/ /x/api/date-pickers/time-picker/ 301
 /zh/api/time-picker/ /zh/x/api/date-pickers/time-picker/ 301
 /pt/api/time-picker/ /pt/x/api/date-pickers/time-picker/ 301
-
-## MUI Core
 /styles/* /system/styles/:splat 301
 /:lang/styles/* /:lang/system/styles/:splat 301
-
 /getting-started/* /material-ui/getting-started/:splat 301
 /pt/getting-started/* /pt/material-ui/getting-started/:splat 301
 /zh/getting-started/* /zh/material-ui/getting-started/:splat 301
-
 /customization/* /material-ui/customization/:splat 301
 /pt/customization/* /pt/material-ui/customization/:splat 301
 /zh/customization/* /zh/material-ui/customization/:splat 301
-
 /guides/classname-generator/ /material-ui/experimental-api/classname-generator/ 301
 /pt/guides/classname-generator/ /pt/material-ui/experimental-api/classname-generator/ 301
 /zh/guides/classname-generator/ /zh/material-ui/experimental-api/classname-generator/ 301
-
 /guides/* /material-ui/guides/:splat 301
 /pt/guides/* /pt/material-ui/guides/:splat 301
 /zh/guides/* /zh/material-ui/guides/:splat 301
-
 /discover-more/* /material-ui/discover-more/:splat 301
 /pt/discover-more/* /pt/material-ui/discover-more/:splat 301
 /zh/discover-more/* /zh/material-ui/discover-more/:splat 301
-
 ### Exceptions
 /components/icons/ /material-ui/icons/ 301
 /pt/components/icons/ /pt/material-ui/icons/ 301
 /zh/components/icons/ /zh/material-ui/icons/ 301
-
 /components/material-icons/ /material-ui/material-icons/ 301
 /pt/components/material-icons/ /pt/material-ui/material-icons/ 301
 /zh/components/material-icons/ /zh/material-ui/material-icons/ 301
-
 /components/transitions/ /material-ui/transitions/ 301
 /pt/components/transitions/ /pt/material-ui/transitions/ 301
 /zh/components/transitions/ /zh/material-ui/transitions/ 301
-
 /components/pickers/ /material-ui/lab-date-and-time-pickers/ 301
 /pt/components/pickers/ /pt/material-ui/lab-date-and-time-pickers/ 301
 /zh/components/pickers/ /zh/material-ui/lab-date-and-time-pickers/ 301
-
 /components/about-the-lab/ /material-ui/about-the-lab/ 301
 /pt/components/about-the-lab/ /pt/material-ui/about-the-lab/ 301
 /zh/components/about-the-lab/ /zh/material-ui/about-the-lab/ 301
-
 /components/trap-focus/ /base/react-trap-focus/ 301
 /pt/components/trap-focus/ /pt/base/react-trap-focus/ 301
 /zh/components/trap-focus/ /zh/base/react-trap-focus/ 301
-
 /system/box/ /system/react-box/ 301
 /:lang/system/box/ /:lang/system/react-box/ 301
-
 ### React plural
 /components/tabs/ /material-ui/react-tabs/ 301
 /pt/components/tabs/ /pt/material-ui/react-tabs/ 301
 /zh/components/tabs/ /zh/material-ui/react-tabs/ 301
-
 /components/breadcrumbs/ /material-ui/react-breadcrumbs/ 301
 /pt/components/breadcrumbs/ /pt/material-ui/react-breadcrumbs/ 301
 /zh/components/breadcrumbs/ /zh/material-ui/react-breadcrumbs/ 301
-
 /components/checkboxes/ /material-ui/react-checkbox/ 301
 /pt/components/checkboxes/ /pt/material-ui/react-checkbox/ 301
 /zh/components/checkboxes/ /zh/material-ui/react-checkbox/ 301
-
 /components/switches/ /material-ui/react-switch/ 301
 /pt/components/switches/ /pt/material-ui/react-switch/ 301
 /zh/components/switches/ /zh/material-ui/react-switch/ 301
-
 /components/buttons/ /material-ui/react-button/ 301
 /pt/components/buttons/ /pt/material-ui/react-button/ 301
 /zh/components/buttons/ /zh/material-ui/react-button/ 301
-
 /components/radio-buttons/ /material-ui/react-radio-button/ 301
 /pt/components/radio-buttons/ /pt/material-ui/react-radio-button/ 301
 /zh/components/radio-buttons/ /zh/material-ui/react-radio-button/ 301
-
 /components/selects/ /material-ui/react-select/ 301
 /pt/components/selects/ /pt/material-ui/react-select/ 301
 /zh/components/selects/ /zh/material-ui/react-select/ 301
-
 /components/text-fields/ /material-ui/react-text-field/ 301
 /pt/components/text-fields/ /pt/material-ui/react-text-field/ 301
 /zh/components/text-fields/ /zh/material-ui/react-text-field/ 301
-
 /components/avatars/ /material-ui/react-avatar/ 301
 /pt/components/avatars/ /pt/material-ui/react-avatar/ 301
 /zh/components/avatars/ /zh/material-ui/react-avatar/ 301
-
 /components/badges/ /material-ui/react-badge/ 301
 /pt/components/badges/ /pt/material-ui/react-badge/ 301
 /zh/components/badges/ /zh/material-ui/react-badge/ 301
-
 /components/chips/ /material-ui/react-chip/ 301
 /pt/components/chips/ /pt/material-ui/react-chip/ 301
 /zh/components/chips/ /zh/material-ui/react-chip/ 301
-
 /components/dividers/ /material-ui/react-divider/ 301
 /pt/components/dividers/ /pt/material-ui/react-divider/ 301
 /zh/components/dividers/ /zh/material-ui/react-divider/ 301
-
 /components/lists/ /material-ui/react-list/ 301
 /pt/components/lists/ /pt/material-ui/react-list/ 301
 /zh/components/lists/ /zh/material-ui/react-list/ 301
-
 /components/tables/ /material-ui/react-table/ 301
 /pt/components/tables/ /pt/material-ui/react-table/ 301
 /zh/components/tables/ /zh/material-ui/react-table/ 301
-
 /components/tooltips/ /material-ui/react-tooltip/ 301
 /pt/components/tooltips/ /pt/material-ui/react-tooltip/ 301
 /zh/components/tooltips/ /zh/material-ui/react-tooltip/ 301
-
 /components/dialogs/ /material-ui/react-dialog/ 301
 /pt/components/dialogs/ /pt/material-ui/react-dialog/ 301
 /zh/components/dialogs/ /zh/material-ui/react-dialog/ 301
-
 /components/snackbars/ /material-ui/react-snackbar/ 301
 /pt/components/snackbars/ /pt/material-ui/react-snackbar/ 301
 /zh/components/snackbars/ /zh/material-ui/react-snackbar/ 301
-
 /components/cards/ /material-ui/react-card/ 301
 /pt/components/cards/ /pt/material-ui/react-card/ 301
 /zh/components/cards/ /zh/material-ui/react-card/ 301
-
 /components/drawers/ /material-ui/react-drawer/ 301
 /pt/components/drawers/ /pt/material-ui/react-drawer/ 301
 /zh/components/drawers/ /zh/material-ui/react-drawer/ 301
-
 /components/links/ /material-ui/react-link/ 301
 /pt/components/links/ /pt/material-ui/react-link/ 301
 /zh/components/links/ /zh/material-ui/react-link/ 301
-
 /components/menus/ /material-ui/react-menu/ 301
 /pt/components/menus/ /pt/material-ui/react-menu/ 301
 /zh/components/menus/ /zh/material-ui/react-menu/ 301
-
 /components/steppers/ /material-ui/react-stepper/ 301
 /pt/components/steppers/ /pt/material-ui/react-stepper/ 301
 /zh/components/steppers/ /zh/material-ui/react-stepper/ 301
-
 /components/* /material-ui/react-:splat 301
 /pt/components/* /pt/material-ui/react-:splat 301
 /zh/components/* /zh/material-ui/react-:splat 301
-
 /api/unstable-trap-focus/ /base/api/trap-focus/ 301
 /zh/api/unstable-trap-focus/ /zh/base/api/trap-focus/ 301
 /pt/api/unstable-trap-focus/ /pt/base/api/trap-focus/ 301
-
 /api/* /material-ui/api/:splat 301
 /zh/api/* /zh/material-ui/api/:splat 301
 /pt/api/* /pt/material-ui/api/:splat 301
-
 /company/about/ /about/ 301
 /company/jobs/ /careers/ 301
+/x/license/ https://mui.com/store/legal/mui-x-eula/ 301
+#2023
 
 ## Localization
 /fr/* /:splat 301

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -20,10 +20,9 @@
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/ts-issue-template https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEHOCcQyGFijBkAGzJ06BOaPzAIouABEsICAAoAlKzsXDwAmvJQQhAqWBpAA 302
 /r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants
-/r/x-license https://mui.com/store/items/material-ui-pro/
-/r/migration-v4 /material-ui/guides/migration-v4/
+/r/migration-v4 /guides/migration-v4/
 
-/x/license/ https://docs.google.com/document/d/1nkd5JP5wCefo6UwpVi6PnbTaw8DxhstkCZlfHV5ZgfI/edit?usp=sharing 301
+/x/license https://mui.com/store/legal/mui-x-eula/ 301
 
 # Legacy redirection
 # Added in chronological order (the last line is the most recent one)

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -20,7 +20,8 @@
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/ts-issue-template https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEHOCcQyGFijBkAGzJ06BOaPzAIouABEsICAAoAlKzsXDwAmvJQQhAqWBpAA 302
 /r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants
-/r/x-license https://mui.com/store/legal/mui-x-eula/ 301
+/r/x-license https://mui.com/store/items/material-ui-pro/ 301
+/r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 301
 /r/migration-v4 /guides/migration-v4/
 
 # Legacy redirection

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -20,9 +20,10 @@
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/ts-issue-template https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEHOCcQyGFijBkAGzJ06BOaPzAIouABEsICAAoAlKzsXDwAmvJQQhAqWBpAA 302
 /r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants
+/r/x-license https://mui.com/store/legal/mui-x-eula/ 301
 /r/migration-v4 /guides/migration-v4/
 
-/x/license https://mui.com/store/legal/mui-x-eula/ 301
+/x/license/ https://mui.com/store/legal/mui-x-eula/ 301
 
 # Legacy redirection
 # Added in chronological order (the last line is the most recent one)

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -22,7 +22,7 @@
 /r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants 302
 /r/x-license https://mui.com/store/items/material-ui-pro/ 302
 /r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 302
-/r/migration-v4 /guides/migration-v4/
+/r/migration-v4 /material-ui/guides/migration-v4/
 
 # Legacy redirection
 # Added in chronological order (the last line is the most recent one)

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -20,8 +20,8 @@
 /r/issue-template-latest https://codesandbox.io/s/material-ui-issue-latest-s2dsx
 /r/ts-issue-template https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEHOCcQyGFijBkAGzJ06BOaPzAIouABEsICAAoAlKzsXDwAmvJQQhAqWBpAA 302
 /r/custom-component-variants /material-ui/customization/how-to-customize/#adding-new-component-variants
-/r/x-license https://mui.com/store/items/material-ui-pro/ 301
-/r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 301
+/r/x-license https://mui.com/store/items/material-ui-pro/ 302
+/r/x-license-eula https://mui.com/store/legal/mui-x-eula/ 302
 /r/migration-v4 /guides/migration-v4/
 
 # Legacy redirection


### PR DESCRIPTION
1. Fix https://github.com/mui/material-ui/blob/6eabacaf0e79a52f65f1147bbf4b835c79d4f4d1/docs/public/_redirects#L26 that points to the wrong location after:
https://github.com/mui/mui-store/pull/139
2. Add a new code redirection for the LICENSE files: https://unpkg.com/@mui/x-data-grid-pro@5.10.0/LICENSE

Next:

- [ ] Use `/r/x-license-eula` where relevant.
- [ ] Stop using `/x/license/`, it's now legacy.