### PR TITLE
[core] Update @types/react peer dep for mui-styles

### DIFF
--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -38,7 +38,7 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.0",
+    "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Not sure why this skipped in #32236, maybe it was intentional.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Without this change I get the following error with npm

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: react-starter-template@0.0.0
npm ERR! Found: react@18.1.0
npm ERR! node_modules/react
npm ERR!   react@"18.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0" from @mui/styles@5.6.2
npm ERR! node_modules/@mui/styles
npm ERR!   @mui/styles@"5.6.2" from the root project
```
