### PR TITLE
[docs] Allows to use `import '<library name>'` in demonstrations

### DIFF
--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -114,6 +114,7 @@ import '@mui/material/Grid';
 import '@mui/material/styles';
 import '@mui/lab/AdapterDateFns';
 import '@mui/lab';
+import 'exceljs';
 `;
 
     expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
@@ -125,6 +126,7 @@ import '@mui/lab';
       '@mui/material': 'latest',
       '@mui/lab': 'latest',
       'date-fns': 'latest',
+      exceljs: 'latest',
     });
   });
 

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -106,6 +106,28 @@ import { LocalizationProvider as MuiPickersLocalizationProvider, KeyboardTimePic
     });
   });
 
+  it('should support import for side effect', () => {
+    const source = `
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import '@mui/material/Grid';
+import '@mui/material/styles';
+import '@mui/lab/AdapterDateFns';
+import '@mui/lab';
+`;
+
+    expect(getDependencies(source, { codeLanguage: 'JS' })).to.deep.equal({
+      react: 'latest',
+      'react-dom': 'latest',
+      'prop-types': 'latest',
+      '@emotion/react': 'latest',
+      '@emotion/styled': 'latest',
+      '@mui/material': 'latest',
+      '@mui/lab': 'latest',
+      'date-fns': 'latest',
+    });
+  });
+
   it('can collect required @types packages', () => {
     expect(getDependencies(s1, { codeLanguage: 'TS' })).to.deep.equal({
       react: 'latest',

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -184,22 +184,17 @@ export function getDependencies(
   let m: RegExpExecArray | null = null;
   // eslint-disable-next-line no-cond-assign
   while ((m = re.exec(raw))) {
-    let name;
-
-    if (m[2]) {
-      // full import
-      // handle scope names
-      name = m[2].charAt(0) === '@' ? m[2].split('/', 2).join('/') : m[2].split('/', 1)[0];
-    } else {
-      name = m[1];
-    }
+    const fullName = m[2] ?? m[1];
+    // handle scope names
+    const name =
+      fullName.charAt(0) === '@' ? fullName.split('/', 2).join('/') : fullName.split('/', 1)[0];
 
     if (!deps[name]) {
       deps[name] = versions[name] ? versions[name] : 'latest';
     }
 
     // e.g date-fns
-    const dateAdapterMatch = m[2].match(/^@mui\/lab\/(Adapter.*)/);
+    const dateAdapterMatch = fullName.match(/^@mui\/lab\/(Adapter.*)/);
     if (dateAdapterMatch !== null) {
       const packageName = dateAdapterPackageMapping[dateAdapterMatch[1]];
       if (packageName === undefined) {


### PR DESCRIPTION
In X repo, we would like to use in demonstrations the following imports to specify to codesanbox that the 'exceljs' library is required for this specific demo
```js
import 'exceljs'
```

Reading `m[2]` throw an error and block codesandbox generation, because the regexp matching returns the following array

```js
import 'exceljs' // => ["import 'exceljs'", 'exceljs', undefined]
import {} from 'exceljs' // => ["import 'exceljs'", undefined, 'exceljs']
```