### PR TITLE
[lab] Use range version of pickers package

### DIFF
--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -72,7 +72,7 @@
     "@mui/base": "5.0.0-alpha.78",
     "@mui/system": "^5.6.3",
     "@mui/utils": "^5.6.1",
-    "@mui/x-date-pickers": "5.0.0-alpha.0",
+    "@mui/x-date-pickers": "^5.0.0-alpha.0",
     "clsx": "^1.1.1",
     "prop-types": "^15.7.2",
     "react-is": "^17.0.2",


### PR DESCRIPTION
This should solve https://github.com/mui/mui-x/issues/4569 (at least partially)

Pros:
- Quick win that allows to reuse same version of `@mui/x-date-pickers` when using both `@mui/x-date-pickers` and `@mui/lab`. Should reduce the number of similar issues.

Cons:
- It doesn't guarantee deduplication of `@mui/x-date-pickers`. Depending on package manager, `@mui/x-date-pickers` may still be installed twice, even if version is the same.
- As pointed out by @flaviendelangle :
> A downside is that it lower the need to migrate to our package since the lab will also get the bug fixes
But since we added runtime warning when using the components on the lab, I guess people will migrate anyway if they updated to a version of the lab that just re-export our package. 