### PR TITLE
[Tabs] Fix `TabIndicatorProps` prop missing `sx` prop

### DIFF
--- a/packages/mui-material/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material/src/Tabs/Tabs.d.ts
@@ -88,7 +88,7 @@ export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof Button
      * Props applied to the tab indicator element.
      * @default  {}
      */
-    TabIndicatorProps?: React.HTMLAttributes<HTMLDivElement>;
+    TabIndicatorProps?: React.HTMLAttributes<HTMLDivElement> & { sx?: SxProps<Theme> };
     /**
      * Props applied to the [`TabScrollButton`](/material-ui/api/tab-scroll-button/) element.
      * @default {}

--- a/packages/mui-material/src/Tabs/Tabs.spec.tsx
+++ b/packages/mui-material/src/Tabs/Tabs.spec.tsx
@@ -13,3 +13,5 @@ function testOnChange() {
 }
 
 const TabTest = () => <Tabs TabIndicatorProps={{ style: { backgroundColor: 'green' } }} />;
+
+const TabIndicatorSxTest = () => <Tabs TabIndicatorProps={{ sx: {} }} />;


### PR DESCRIPTION
closes #32490

Adds `sx` prop to `TabIndicatorProps` type