### PR TITLE
[Joy] Add `extendSxProp` to Link

### DIFF
--- a/docs/pages/experiments/joy/link.tsx
+++ b/docs/pages/experiments/joy/link.tsx
@@ -165,7 +165,7 @@ export default function JoyButton() {
             </li>
           </ul>
           <Box sx={{ my: 2 }}>
-            <Link startDecorator={<Loader />} disabled sx={{ my: 2 }}>
+            <Link startDecorator={<Loader />} disabled my={2}>
               Processing...
             </Link>
             <Link
@@ -185,6 +185,7 @@ export default function JoyButton() {
                   HIRING!
                 </Box>
               }
+              sx={{ ml: 1, color: 'primary.500' }}
             >
               Careers
             </Link>

--- a/packages/mui-joy/src/Link/Link.spec.tsx
+++ b/packages/mui-joy/src/Link/Link.spec.tsx
@@ -34,6 +34,9 @@ import * as React from 'react';
 <Link underline="none" />;
 <Link underline="hover" />;
 
+// extend sx
+<Link fontWeight="md" my={1} />;
+
 // @ts-expect-error there is no variant `filled`
 <Link variant="filled" />;
 

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -1,3 +1,6 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { OverridableComponent } from '@mui/types';
 import {
@@ -5,9 +8,7 @@ import {
   unstable_useForkRef as useForkRef,
   unstable_useIsFocusVisible as useIsFocusVisible,
 } from '@mui/utils';
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
-import * as React from 'react';
+import { unstable_extendSxProp as extendSxProp } from '@mui/system';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import { getLinkUtilityClass } from './linkClasses';
@@ -67,14 +68,11 @@ const LinkRoot = styled('a', {
       ...(ownerState.underline === 'hover' && {
         textDecoration: 'none',
         '&:hover': {
-          textDecoration: 'underline',
+          textDecorationLine: 'underline',
         },
       }),
       ...(ownerState.underline === 'always' && {
         textDecoration: 'underline',
-        '&:hover': {
-          textDecorationColor: 'inherit',
-        },
       }),
       ...(ownerState.startDecorator && {
         verticalAlign: 'bottom', // to make the link align with the parent's content
@@ -89,6 +87,9 @@ const LinkRoot = styled('a', {
       margin: 0, // Remove the margin in Safari
       borderRadius: theme.vars.radius.xs,
       padding: 0, // Remove the padding in Firefox
+      textDecorationColor: `rgba(${
+        theme.vars.palette[ownerState.color!]?.mainChannel
+      } / var(--Link-underlineOpacity, 0.72))`,
       ...(ownerState.variant
         ? {
             paddingInline: '0.25em', // better than left, right because it also works with writing mode.
@@ -139,16 +140,17 @@ const LinkRoot = styled('a', {
 });
 
 const Link = React.forwardRef(function Link(inProps, ref) {
-  const props = useThemeProps<typeof inProps & LinkProps>({
+  const { color = 'primary', ...themeProps } = useThemeProps<typeof inProps & LinkProps>({
     props: inProps,
     name: 'MuiLink',
   });
 
   const nested = React.useContext(TypographyContext);
 
+  const props = extendSxProp(themeProps) as LinkProps;
+
   const {
     className,
-    color = 'primary',
     component = 'a',
     children,
     disabled = false,

--- a/packages/mui-joy/src/Link/LinkProps.ts
+++ b/packages/mui-joy/src/Link/LinkProps.ts
@@ -1,6 +1,12 @@
 import React from 'react';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
-import { ColorPaletteProp, TypographySystem, VariantProp, SxProps } from '../styles/types';
+import {
+  ColorPaletteProp,
+  TypographySystem,
+  VariantProp,
+  SxProps,
+  SystemProps,
+} from '../styles/types';
 
 export type LinkSlot = 'root' | 'startDecorator' | 'endDecorator';
 
@@ -9,55 +15,56 @@ export interface LinkPropsVariantOverrides {}
 export interface LinkPropsColorOverrides {}
 
 export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
-  props: P & {
-    /**
-     * The content of the component.
-     */
-    children?: React.ReactNode;
-    /**
-     * The color of the link.
-     * @default 'primary'
-     */
-    color?: OverridableStringUnion<ColorPaletteProp, LinkPropsColorOverrides>;
-    /**
-     * If `true`, the component is disabled.
-     * @default false
-     */
-    disabled?: boolean;
-    /**
-     * Element placed after the children.
-     */
-    endDecorator?: React.ReactNode;
-    /**
-     * Applies the theme typography styles.
-     * @default 'body1'
-     */
-    level?: keyof TypographySystem | 'inherit';
-    /**
-     * If `true`, the ::after psuedo element is added to cover the area of interaction.
-     * The parent of the overlay Link should have `relative` CSS position.
-     * @default false
-     */
-    overlay?: boolean;
-    /**
-     * Element placed before the children.
-     */
-    startDecorator?: React.ReactNode;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps;
-    /**
-     * Controls when the link should have an underline.
-     * @default 'hover'
-     */
-    underline?: 'none' | 'hover' | 'always';
-    /**
-     * Applies the theme link styles.
-     * @default 'plain'
-     */
-    variant?: OverridableStringUnion<VariantProp, LinkPropsVariantOverrides>;
-  };
+  props: P &
+    Omit<SystemProps, 'color'> & {
+      /**
+       * The content of the component.
+       */
+      children?: React.ReactNode;
+      /**
+       * The color of the link.
+       * @default 'primary'
+       */
+      color?: OverridableStringUnion<ColorPaletteProp, LinkPropsColorOverrides>;
+      /**
+       * If `true`, the component is disabled.
+       * @default false
+       */
+      disabled?: boolean;
+      /**
+       * Element placed after the children.
+       */
+      endDecorator?: React.ReactNode;
+      /**
+       * Applies the theme typography styles.
+       * @default 'body1'
+       */
+      level?: keyof TypographySystem | 'inherit';
+      /**
+       * If `true`, the ::after psuedo element is added to cover the area of interaction.
+       * The parent of the overlay Link should have `relative` CSS position.
+       * @default false
+       */
+      overlay?: boolean;
+      /**
+       * Element placed before the children.
+       */
+      startDecorator?: React.ReactNode;
+      /**
+       * The system prop that allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps;
+      /**
+       * Controls when the link should have an underline.
+       * @default 'hover'
+       */
+      underline?: 'none' | 'hover' | 'always';
+      /**
+       * Applies the theme link styles.
+       * @default 'plain'
+       */
+      variant?: OverridableStringUnion<VariantProp, LinkPropsVariantOverrides>;
+    };
   defaultComponent: D;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The Link should behave the same as Typography.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
