### PR TITLE
[l10n] Fix typo in csCZ translation of Pagination component

### DIFF
--- a/packages/mui-material/src/locale/index.ts
+++ b/packages/mui-material/src/locale/index.ts
@@ -594,7 +594,7 @@ export const csCZ: Localization = {
         'aria-label': 'Navigace stránkováním',
         getItemAriaLabel: (type, page, selected) => {
           if (type === 'page') {
-            return `${selected ? '' : 'Jít na '}${page} stránku`;
+            return `${selected ? '' : 'Jít na '}${page}. stránku`;
           }
           if (type === 'first') {
             return 'Jít na první stránku';


### PR DESCRIPTION
Fixed a typo in the csCZ translation of Pagination component.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
