### PR TITLE
[website] Update the careers's page with the new roles

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -154,6 +154,12 @@ const openRolesData = [
         url: '/careers/react-support-engineer/',
       },
       {
+        title: 'React Engineer - Core',
+        description:
+        'You will strengthen the core components team, e.g. collaborate with the community to land contributions.',
+        url: '/careers/react-engineer-core/',
+      },
+      {
         title: 'React Engineer - X',
         description:
           'You will strengthen the advanced components team, build new ambitious complex features, work on strategic problems, and help grow the adoption.',
@@ -163,12 +169,6 @@ const openRolesData = [
         title: 'Product Engineer - Store',
         description: 'You will lead the technical and operational development of MUI Store.',
         url: '/careers/product-engineer/',
-      },
-      {
-        title: 'React Engineer - Core',
-        description:
-          'You will strengthen the core components team, e.g. collaborate with the community to land contributions.',
-        url: '/careers/react-engineer-core/',
       },
     ],
   },

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -148,35 +148,27 @@ const openRolesData = [
     title: 'Engineering',
     roles: [
       {
-        title: 'Full-stack Engineer - Toolpad',
-        description:
-          'You will join the MUI Toolpad team, to explore the role of MUI in the low code space and help bring the early prototypes to a usable product.',
-        url: '/careers/fullstack-engineer/',
-      },
-      {
         title: 'React Support Engineer - X',
         description:
           "You will provide support, remove blockers and unwrap potential features from reported issues for the advanced components team. You will directly impact developers' satisfaction and success.",
         url: '/careers/react-support-engineer/',
       },
-    ],
-  },
-];
-
-const nextRolesData = [
-  {
-    title: 'Engineering',
-    roles: [
       {
         title: 'React Engineer - X',
         description:
           'You will strengthen the advanced components team, build new ambitious complex features, work on strategic problems, and help grow the adoption.',
-        url: '/careers/react-engineer/',
+        url: '/careers/react-engineer-x/',
       },
       {
         title: 'Product Engineer - Store',
         description: 'You will lead the technical and operational development of MUI Store.',
         url: '/careers/product-engineer/',
+      },
+      {
+        title: 'React Engineer - Core',
+        description:
+          'You will strengthen the core components team, e.g. collaborate with the community to land contributions.',
+        url: '/careers/react-engineer-core/',
       },
     ],
   },
@@ -199,6 +191,45 @@ const nextRolesData = [
         description:
           "You will provide support for the customers of MUI Store. You will directly impact customers' satisfaction and success.",
         url: '/careers/support-agent/',
+      },
+    ],
+  },
+];
+
+const nextRolesData = [
+  {
+    title: 'Engineering',
+    roles: [
+      {
+        title: 'Engineering Manager - Toolpad',
+        description:
+          'You will grow the engineering team working on MUI Toolpad, from a small team to multiple.',
+        url: '/careers/engineering-manager/',
+      },
+      {
+        title: 'Full-stack Engineer - Toolpad',
+        description:
+          'You will join the MUI Toolpad team, to explore the role of MUI in the low code space and help bring the early prototypes to a usable product.',
+        url: '/careers/fullstack-engineer/',
+      },
+    ],
+  },
+  {
+    title: 'Sales',
+    roles: [
+      {
+        title: 'Account Executive',
+        description:
+          'You will build client relationships and manage the sales process from start to finish.',
+      },
+    ],
+  },
+  {
+    title: 'People',
+    roles: [
+      {
+        title: 'Technical Recruiter',
+        description: 'You will hire the next engineers joining the team.',
       },
     ],
   },

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -170,6 +170,11 @@ const openRolesData = [
         description: 'You will lead the technical and operational development of MUI Store.',
         url: '/careers/product-engineer/',
       },
+      {
+        title: 'Developer Experience Engineer - Core',
+        description: 'You will lead the technical and operational development of MUI Store.',
+        url: '/careers/developer-experience-engineer/',
+      },
     ],
   },
   {

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -156,7 +156,7 @@ const openRolesData = [
       {
         title: 'React Engineer - Core',
         description:
-        'You will strengthen the core components team, e.g. collaborate with the community to land contributions.',
+          'You will strengthen the core components team, e.g. collaborate with the community to land contributions.',
         url: '/careers/react-engineer-core/',
       },
       {
@@ -174,6 +174,11 @@ const openRolesData = [
         title: 'Developer Experience Engineer - Core',
         description: 'You will lead the technical and operational development of MUI Store.',
         url: '/careers/developer-experience-engineer/',
+      },
+      {
+        title: 'Engineering Manager - Toolpad',
+        description: 'You will grow the small engineering team currently working on MUI Toolpad.',
+        url: '/careers/engineering-manager/',
       },
     ],
   },
@@ -205,11 +210,6 @@ const nextRolesData = [
   {
     title: 'Engineering',
     roles: [
-      {
-        title: 'Engineering Manager - Toolpad',
-        description: 'You will grow the small engineering team currently working on MUI Toolpad.',
-        url: '/careers/engineering-manager/',
-      },
       {
         title: 'Full-stack Engineer - Toolpad',
         description:

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -202,14 +202,13 @@ const nextRolesData = [
     roles: [
       {
         title: 'Engineering Manager - Toolpad',
-        description:
-          'You will grow the engineering team working on MUI Toolpad, from a small team to multiple.',
+        description: 'You will grow the small engineering team currently working on MUI Toolpad.',
         url: '/careers/engineering-manager/',
       },
       {
         title: 'Full-stack Engineer - Toolpad',
         description:
-          'You will join the MUI Toolpad team, to explore the role of MUI in the low code space and help bring the early prototypes to a usable product.',
+          'You will join the MUI Toolpad team, to explore the role of MUI in the low code space and help bring the early prototype to a usable product.',
         url: '/careers/fullstack-engineer/',
       },
     ],

--- a/docs/pages/careers/developer-experience-engineer.js
+++ b/docs/pages/careers/developer-experience-engineer.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import {
+  demos,
+  docs,
+  demoComponents,
+} from 'docs/src/pages/careers/developer-experience-engineer.md?@mui/markdown';
+
+export default function Page() {
+  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+}

--- a/docs/pages/careers/engineering-manager.js
+++ b/docs/pages/careers/engineering-manager.js
@@ -4,7 +4,7 @@ import {
   demos,
   docs,
   demoComponents,
-} from 'docs/src/pages/careers/react-engineer.md?@mui/markdown';
+} from 'docs/src/pages/careers/engineering-manager.md?@mui/markdown';
 
 export default function Page() {
   return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;

--- a/docs/pages/careers/react-engineer-core.js
+++ b/docs/pages/careers/react-engineer-core.js
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
-import { demos, docs, demoComponents } from 'docs/src/pages/careers/designer.md?@mui/markdown';
+import {
+  demos,
+  docs,
+  demoComponents,
+} from 'docs/src/pages/careers/react-engineer-core.md?@mui/markdown';
 
 export default function Page() {
   return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;

--- a/docs/pages/careers/react-engineer-x.js
+++ b/docs/pages/careers/react-engineer-x.js
@@ -4,7 +4,7 @@ import {
   demos,
   docs,
   demoComponents,
-} from 'docs/src/pages/careers/developer-advocate.md?@mui/markdown';
+} from 'docs/src/pages/careers/react-engineer-x.md?@mui/markdown';
 
 export default function Page() {
   return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;

--- a/docs/src/pages/careers/ROLE_TEMPLATE.md
+++ b/docs/src/pages/careers/ROLE_TEMPLATE.md
@@ -37,7 +37,8 @@ XXXXXX
 
 XXXXXX
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ## About the role
 
@@ -63,7 +64,7 @@ Depending on the day, you'll:
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](https://mui.com/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/developer-advocate.md
+++ b/docs/src/pages/careers/developer-advocate.md
@@ -38,7 +38,7 @@ Your mission will be to be the voice of the developers of the community inside t
 We are looking for someone that can contribute to the following outcomes:
 
 - Amplify the need of the community so the product direction aims at what people need the most.
-- Improve the overall developer experience, resulting in better NPS & CSAT scores.
+- Improve the overall developer experience, resulting in better NPS & CSAT scores, e.g. though educational content.
 - Create momentum in the React community and drive adoption of the library.
 
 ## About the role

--- a/docs/src/pages/careers/developer-advocate.md
+++ b/docs/src/pages/careers/developer-advocate.md
@@ -48,7 +48,7 @@ We are looking for someone that can contribute to the following outcomes:
 You will be the first person focusing full-time on developer relations at MUI.
 You will lay the foundations for a team that could grow over time.
 
-Our solution empowers React developers to build awesome applications. It should be easy, it shouldn't require any advanced technical skills. Hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.. It should be easy, it shouldn't require any advanced technical skills. Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 

--- a/docs/src/pages/careers/developer-advocate.md
+++ b/docs/src/pages/careers/developer-advocate.md
@@ -48,7 +48,8 @@ We are looking for someone that can contribute to the following outcomes:
 You will be the first person focusing full-time on developer relations at MUI.
 You will lay the foundations for a team that could grow over time.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.. It should be easy, it shouldn't require any advanced technical skills. Hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 
@@ -102,7 +103,7 @@ For the right candidate:
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/developer-experience-engineer.md
+++ b/docs/src/pages/careers/developer-experience-engineer.md
@@ -45,7 +45,7 @@ We are looking for someone that can contribute to the following outcomes:
 
 You have a lot of feedback, more than we can process. It's an opportunity to challenge the state of the art in the React component dev tool space.
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
 ## About the role
 

--- a/docs/src/pages/careers/developer-experience-engineer.md
+++ b/docs/src/pages/careers/developer-experience-engineer.md
@@ -1,10 +1,10 @@
-# Developer Experience Engineer
+# Developer Experience Engineer - Core
 
 <p class="description">You will focus on providing experiences that delight developers using MUI. This role is mostly about MUI Core.</p>
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-7 to UTC+2).
+- Location: Remote (preference for UTC-6 to UTC+2).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - Level: [4 or above](https://docs.google.com/spreadsheets/d/1dDdPD-flNXlgZ0E3ZxVvCDx27RFuhVWJrcfcjNu_I8k/edit#gid=0).

--- a/docs/src/pages/careers/developer-experience-engineer.md
+++ b/docs/src/pages/careers/developer-experience-engineer.md
@@ -45,7 +45,8 @@ We are looking for someone that can contribute to the following outcomes:
 
 You have a lot of feedback, more than we can process. It's an opportunity to challenge the state of the art in the React component dev tool space.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ## About the role
 
@@ -94,7 +95,7 @@ For the right candidate:
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/engineering-manager.md
+++ b/docs/src/pages/careers/engineering-manager.md
@@ -1,6 +1,6 @@
 # Engineering Manager - Toolpad
 
-<p class="description">You will grow the engineering team working on MUI Toolpad, from a small team to multiple.</p>
+<p class="description">You will grow the small engineering team currently working on MUI Toolpad.</p>
 
 ## Details of the Role
 
@@ -42,9 +42,11 @@ We need help to structure & grow the engineering team.
 ### Why this is interesting
 
 Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
-Toolpad targets ~1/2 of this audience. While the team is still very small (5), we believe that the headcount on this product has the potential to grow +14% MoM until the end of 2023 (>70 people).
-Growing the engineering side will be full of challenges.
+Toolpad targets around half of this audience.
+While the team is still very small (5), we believe that the headcount on this product has needs to grow +14% MoM until the end of 2023 (>70 people).
+Growing the Toolpad engineering team will be full of challenges.
 
 ## About the role
 
@@ -58,6 +60,10 @@ Depending on the day, you'll:
 - Develop a great work environment.
 - Work directly with users and the engineering team to improve the product.
 - Improve our processes, e.g. the lifecycle of feature development from design through testing and release.
+
+For the right candidate:
+
+- Working with the Leadership to construct and execute a hiring plan to grow the engineering team on toolpad from one to multiple
 
 ## About you
 
@@ -76,7 +82,7 @@ Depending on the day, you'll:
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](https://mui.com/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/engineering-manager.md
+++ b/docs/src/pages/careers/engineering-manager.md
@@ -87,4 +87,4 @@ You can find the other perks & benefits on the [careers](https://mui.com/careers
 
 ## How to apply?
 
-[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=Engineering%20Manager&prefill_source=mui.com)
+[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=Engineering%20Manager%20-%20Toolpad&prefill_source=mui.com)

--- a/docs/src/pages/careers/engineering-manager.md
+++ b/docs/src/pages/careers/engineering-manager.md
@@ -1,6 +1,6 @@
-# XXXXXX
+# Engineering Manager - Toolpad
 
-<p class="description">XXXXXX.</p>
+<p class="description">You will grow the engineering team working on MUI Toolpad, from a small team to multiple.</p>
 
 ## Details of the Role
 
@@ -31,13 +31,20 @@ For additional details about the MUI team and culture, you can check our [career
 Both our open-source community and our premium products are growing fast (x2-3 YoY).
 We need talented people to keep that going!
 
-XXXXXX
+Our mission is to empower as many people as possible to build great UIs, faster.
+The faster and simpler it is, and the broader the audience that can create custom UIs, the better.
+We believe that the best way to improve on these dimensions is to eliminate [80%](https://www.youtube.com/watch?v=GnO7D5UaDig&t=2451s) of the code that has to be written.
+
+A few months back we started to work on [MUI Toolpad](https://github.com/mui/mui-toolpad), an ambitious project to deliver on this objective.
+We have found the beginning of a market fit in this low-code segment.
+We need help to structure & grow the engineering team.
 
 ### Why this is interesting
 
-XXXXXX
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Toolpad targets ~1/2 of this audience. While the team is still very small (5), we believe that the headcount on this product has the potential to grow +14% MoM until the end of 2023 (>70 people).
+Growing the engineering side will be full of challenges.
 
 ## About the role
 
@@ -45,20 +52,26 @@ Our solution empowers React developers to build awesome applications faster – 
 
 Depending on the day, you'll:
 
-- XXXXXX
-- XXXXXX
+- Hire and grow a diverse engineering team in a fast-scaling organization.
+- Cultivate excellence in the craft of the software your team builds.
+- Act as a servant leader for the engineers that report to you. You will support the career growth of individuals on your team.
+- Develop a great work environment.
+- Work directly with users and the engineering team to improve the product.
+- Improve our processes, e.g. the lifecycle of feature development from design through testing and release.
 
 ## About you
 
 ### Skills you should have
 
-- XXXXXX
-- XXXXXX
+- You've managed or supported a diverse, distributed engineers on small or large teams.
+- You have an interest in building a support structure for engineers to help them succeed.
+- You have phenomenal communication skills for working across the organization, capable of building strong relationships with peers and leadership.
+- You have had strong expertise and mastery of React or front-end development in the past.
+- You have deep empathy for users. You have experience with customer support or OSS community support.
 
 ### What would be nice if you had, but isn't required
 
-- XXXXXX
-- XXXXXX
+- **You've maintained an active repository before**. Maybe you've helped maintain a popular open-source repository, or perhaps you've worked on internal repositories that saw contributions from multiple teams. Previous experience with highly active repository workflows is a definite plus for this role.
 
 ## Benefits & Compensation
 
@@ -68,4 +81,4 @@ You can find the other perks & benefits on the [careers](https://mui.com/careers
 
 ## How to apply?
 
-[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=XXXXXX&prefill_source=mui.com)
+[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=Engineering%20Manager&prefill_source=mui.com)

--- a/docs/src/pages/careers/full-stack-engineer.md
+++ b/docs/src/pages/careers/full-stack-engineer.md
@@ -1,6 +1,6 @@
-# Full-stack Engineer
+# Full-stack Engineer - Toolpad
 
-<p class="description">We are looking for a full-stack engineer to pioneer the development of a new product vertical.</p>
+<p class="description">You will join the MUI Toolpad team, to explore the role of MUI in the low code space and help bring the early prototype to a usable product.</p>
 
 ## Details of the Role
 
@@ -97,7 +97,7 @@ We're looking for someone with both strong front-end and back-end skills. More i
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/full-stack-engineer.md
+++ b/docs/src/pages/careers/full-stack-engineer.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - Level: [4 or above](https://docs.google.com/spreadsheets/d/1dDdPD-flNXlgZ0E3ZxVvCDx27RFuhVWJrcfcjNu_I8k/edit#gid=0).

--- a/docs/src/pages/careers/people-operation-manager.md
+++ b/docs/src/pages/careers/people-operation-manager.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - We're a remote company, we prefer asynchronous communication over meetings.
@@ -39,7 +39,7 @@ We need somebody to lead our HR strategy including hiring, onboarding, diversity
 
 You'll have the freedom to implement processes and to drive change across the organization.
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 

--- a/docs/src/pages/careers/people-operation-manager.md
+++ b/docs/src/pages/careers/people-operation-manager.md
@@ -39,7 +39,8 @@ We need somebody to lead our HR strategy including hiring, onboarding, diversity
 
 You'll have the freedom to implement processes and to drive change across the organization.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 
@@ -80,7 +81,7 @@ You are curious, you enjoy taking risks, and learning.
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/product-engineer.md
+++ b/docs/src/pages/careers/product-engineer.md
@@ -37,7 +37,8 @@ The development and operations of the store are currently almost exclusively run
 
 You will get the opportunity to run MUI Store as a small start-up inside the company.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ## About the role
 
@@ -87,7 +88,7 @@ More important than specific technical skills though is that you're a strong pro
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/product-engineer.md
+++ b/docs/src/pages/careers/product-engineer.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - Level: [4 or above](https://docs.google.com/spreadsheets/d/1dDdPD-flNXlgZ0E3ZxVvCDx27RFuhVWJrcfcjNu_I8k/edit#gid=0).
@@ -37,7 +37,7 @@ The development and operations of the store are currently almost exclusively run
 
 You will get the opportunity to run MUI Store as a small start-up inside the company.
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
 ## About the role
 

--- a/docs/src/pages/careers/product-manager.md
+++ b/docs/src/pages/careers/product-manager.md
@@ -36,7 +36,8 @@ We believe that the best way to improve on these dimensions is to eliminate [80%
 
 ### Why this is interesting
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 But providing React components isn't enough.
 In our [last developer survey](/blog/2021-developer-survey-results/), we learned that the majority of our audience are full-stack developers.
@@ -74,7 +75,7 @@ Depending on the day, you'll:
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/product-manager.md
+++ b/docs/src/pages/careers/product-manager.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - We're a remote company, we prefer asynchronous communication over meetings.
@@ -36,7 +36,7 @@ We believe that the best way to improve on these dimensions is to eliminate [80%
 
 ### Why this is interesting
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
 But providing React components isn't enough.
 In our [last developer survey](/blog/2021-developer-survey-results/), we learned that the majority of our audience are full-stack developers.

--- a/docs/src/pages/careers/react-engineer-core.md
+++ b/docs/src/pages/careers/react-engineer-core.md
@@ -1,10 +1,10 @@
-# React Engineer - X
+# React Engineer - Core
 
-<p class="description">You will strengthen the advanced components team, build new ambitious complex features, work on strategic problems, and help grow the adoption.</p>
+<p class="description">You will strengthen the core components team, e.g. collaborate with the community to land contributions.</p>
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - Level: [4 or above](https://docs.google.com/spreadsheets/d/1dDdPD-flNXlgZ0E3ZxVvCDx27RFuhVWJrcfcjNu_I8k/edit#gid=0).
@@ -31,20 +31,18 @@ For additional details about the MUI team and culture, you can check our [career
 Both our open-source community and our premium products are growing fast (x2-3 YoY).
 We need talented people to keep that going!
 
-The advanced components team (MUI X) needs help.
-We have started with the [data grid](/x/react-data-grid/#commercial-version) component.
-We need to build new features on it and introduce new components.
-The enterprise version is built on the open-source version of the components.
+The core components team (MUI Core) needs help.
+They are working on 4 products (Material UI, MUI Base, Joy UI, and MUI System) with a tiny team.
 
-We also need help to continue to improve the health of the open-source product: make the advanced components easier to use, make it support more use cases, improve performance, make it more accessible, keeping up with the community, guiding developers to answers, and just generally being a positive presence in the open-source community.
+We also need help to continue to improve the health of the open-source product: make the core components easier to use, engage more with the community, polish all the details, make the components more accessible, guiding developers to answers, and just generally being a positive presence in the open-source community.
 
 ## About the role
 
 ### Why this is interesting
 
-The advanced components portfolio is still small, with a million interesting and challenging problems to solve.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+The core components are massively used, you will receive a lot of feedback from your work. The community has high expectations, they will push you to do better, every day.
 
 ### What you'll do on a day-to-day basis
 
@@ -125,4 +123,4 @@ You can find the other perks & benefits on the [careers](/careers/#perks-amp-ben
 
 ## How to apply?
 
-[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=React%20Engineer%20-%20X&prefill_source=mui.com)
+[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=React%20Engineer%20-%20Core&prefill_source=mui.com)

--- a/docs/src/pages/careers/react-engineer-core.md
+++ b/docs/src/pages/careers/react-engineer-core.md
@@ -40,9 +40,11 @@ We also need help to continue to improve the health of the open-source product: 
 
 ### Why this is interesting
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
-The core components are massively used, you will receive a lot of feedback from your work. The community has high expectations, they will push you to do better, every day.
+The core components are widely used, you will receive a lot of feedback on your work.
+The community has high expectations, they will push you to do better, every day.
 
 ### What you'll do on a day-to-day basis
 
@@ -52,7 +54,7 @@ Depending on the day, you'll:
   The future of MUI is discussed and planned in our public RFCs and issues.
   You'll be helping drive these conversations and guiding MUI toward the best possible solutions.
 - **Contribute to deep, meaningful refactors and feature releases**.
-  MUI is a complex codebase. Components we've shipped recently, such as the data grid have required months of dedicated, careful work.
+  MUI is a complex codebase. Components we've shipped recently, such as the unstyled components have required months of dedicated, careful work.
 - **Reduce friction**.
   A large amount of the work on MUI is reducing friction and making it easier to use.
   This might involve careful API design, identifying and fixing top bugs, creating easier to understand error messages, and writing documentation and blog posts about features you ship.
@@ -118,7 +120,7 @@ We're looking for someone with strong front-end skills. More important than spec
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/react-engineer-x.md
+++ b/docs/src/pages/careers/react-engineer-x.md
@@ -1,6 +1,6 @@
-# React Support Engineer - X
+# React Engineer - X
 
-<p class="description">You will provide support, remove blockers and unwrap potential features from reported issues for the advanced components team. You will directly impact developers' satisfaction and success.</p>
+<p class="description">You will strengthen the advanced components team, build new ambitious complex features, work on strategic problems, and help grow the adoption.</p>
 
 ## Details of the Role
 
@@ -31,53 +31,59 @@ For additional details about the MUI team and culture, you can check our [career
 Both our open-source community and our premium products are growing fast (x2-3 YoY).
 We need talented people to keep that going!
 
-We need a Support Engineer to solve friction points of users.
-We face challenges on multiple fronts:
+The advanced components team (MUI X) needs help.
+We have started with the [data grid](/x/react-data-grid/#commercial-version) component.
+We need to build new features on it and introduce new components.
+The enterprise version is built on the open-source version of the components.
 
-- As a result of this growth, we (will) have more users questions and feedback coming in than ever before.
-- The commercial version of the library is growing, but our community of developers is still small and has a reduced incentive to contribute compared to the community plan.
-- Software engineers at MUI are tasked with doing support, however, they could benefit from the help of a dedicated person in the company, for instance to improve the workflows and tooling.
-- The MUI X Premium plan will offer a technical advisor service, we need a Support Engineer to help deliver it.
+We also need help to continue to improve the health of the open-source product: make the advanced components easier to use, make it support more use cases, improve performance, make it more accessible, keeping up with the community, guiding developers to answers, and just generally being a positive presence in the open-source community.
 
 ## About the role
 
 ### Why this is interesting
 
-You will be a key member of the Developer Experience's team and will directly impact customer satisfaction and success.
-You will troubleshoot complex issues related to MUI.
-At MUI a Support Engineer is as considered as a Developer, it's a person that enjoys optimizing what already exists more than working on new shiny features.
+The advanced components portfolio is still small, with a million interesting and challenging problems to solve.
 
 Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 
-You will own the following responsibilities:
-
-- **Build product knowledge**. You will continually research and learn the current and future best practices of using MUI.
-- **Resolve users' issues**. You will solve these issues at two levels:
-  - On the surface, you will answer developers on GitHub, Zendesk, Twitter, email, Slack.
-  - At the root, you will create/update the documentation, fix bugs in collaboration with the relevant developer, and more.
-- **Provide feedback**. You will work alongside product managers to define and shape the product goals, roadmap, priorities, and strategy based on your frontline knowledge of customer needs.
-- **Operations**.
-  - You will establish key support metrics and identify how best to measure them.
-  - You will establish workflow to reduce 'time to response' and 'time to fix' that can scale to multiple team members.
-  - You will identify where internal tooling might be developed or obtained to improve support efficiency.
-
-For the right candidate:
-
-- Working with the Leadership to construct and execute on a hiring plan to grow the support team.
-
 Depending on the day, you'll:
 
-- **You'll be interacting with the users** on a regular basis, handling inbound support and feature requests (every developer helps with developer requests).
+- **Help guide architectural decisions**.
+  The future of MUI is discussed and planned in our public RFCs and issues.
+  You'll be helping drive these conversations and guiding MUI toward the best possible solutions.
+- **Contribute to deep, meaningful refactors and feature releases**.
+  MUI is a complex codebase. Components we've shipped recently, such as the data grid have required months of dedicated, careful work.
 - **Reduce friction**.
   A large amount of the work on MUI is reducing friction and making it easier to use.
   This might involve careful API design, identifying and fixing top bugs, creating easier to understand error messages, and writing documentation and blog posts about features you ship.
 - **Collaborate with the community**.
   Many small as well as meaningful fixes and features have been contributed by the community. Your role is to draw the best out of the community — to inspire those across the world to create and contribute through your reviews of their issues and pull requests.
 - **Experiment and play**. Great, unexpected features and heisenbug fixes have come from a number of sources — relentlessly methodical processes of elimination, free-flowing team collaboration, inspiration by adjacent libraries and projects, and difficult-to-explain individual strokes of brilliance. Whatever your preferred style is for creating new things that others might not have thought of, you'll find a welcome home on the team.
+- **Take ownership of features from idea/mockup to live deployment**.
+  You'll shape and guide the direction of crucial new features, including new components.
 - **Ship. Early and often**. You'll iterate and ship frequently.
   You'll have a real impact on the end-user experience and you'll love working on a team that builds stunning UIs and prioritizes delivering real user value as often as possible.
+- **You'll be interacting with the users** on a regular basis, handling inbound support and feature requests (every developer helps with developer requests).
+
+### The best parts of this job
+
+- **You'll be at the cutting edge of application development** — working on one of the fastest-growing UI libraries on the market.
+- **You'll be part of an active, open, friendly community** of developers that are excited about building awesome applications.
+- **Your role will be key to making MUI the go-to UI framework** for building applications, websites, and design systems with React.
+
+### The worst parts of this job
+
+- **Shifting context.**
+  You will necessarily have to shift context and dive into a different feature before the current one is done.
+  It may even be in an area of the codebase you're unfamiliar with or don't have a ton of understanding about.
+  It's fun, rewarding work, but it can be very challenging.
+- **We move quickly, but don't sacrifice quality**.
+  We ship early, often, and quickly. You may not be initially comfortable with the cadence with which we ship high-quality features and improvements to end-users. By doing so, we sacrifice on solving each problem 100% in exchange for fast feedback. Solving 50-70% of the issue with quality should be enough for any given iteration. Our users quickly tell us when we haven't pushed a solution far enough.
+- **MUI is a large codebase**. You may bang your head against the wall at times, and then write tests to assist future you 😌.
+  The work you will be doing is somewhat unique and idiosyncratic. You probably have not had a similar role before.
+- **In open-source, you're faced with a nonstop stream of bug reports and support requests**. That means you need to develop an intuition for when to ignore something, and when to dig in further.
 
 ## About you
 
@@ -88,6 +94,7 @@ We're looking for someone with strong front-end skills. More important than spec
 - **Expertise in the modern JavaScript ecosystem**.
   MUI is built on the shoulders of giants, making use of technologies such as ES2021, TypeScript, Node.js, React, Next.js, webpack, and Babel.
 - **A track record of demonstrating an eye for product and solving real-world user problems**. If you have a knack for solving problems at the root cause, shipping beautiful user interfaces and intuitive APIs, we want you on our team.
+- **Experience building and shipping production code in a team setting** with a passion for writing tested, performant, and high-quality code.
 - **Strong written and verbal communication skills**.
   As part of the team, you'll interface both directly and indirectly with community members and enterprise customers, and contribute to user documentation. Clear communication is fundamental in creating intuitive and compelling resources.
 - **Ability to dive into complex problems**.
@@ -118,4 +125,4 @@ You can find the other perks & benefits on the [careers](/careers/#perks-amp-ben
 
 ## How to apply?
 
-[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=React%20Support%20Engineer%20-%20X&prefill_source=mui.com)
+[Apply now for this position 📮](https://airtable.com/shrdqo1Z6srZXGcvh?prefill_Applying+for=React%20Engineer%20-%20X&prefill_source=mui.com)

--- a/docs/src/pages/careers/react-engineer-x.md
+++ b/docs/src/pages/careers/react-engineer-x.md
@@ -44,7 +44,8 @@ We also need help to continue to improve the health of the open-source product: 
 
 The advanced components portfolio is still small, with a million interesting and challenging problems to solve.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 
@@ -120,7 +121,7 @@ We're looking for someone with strong front-end skills. More important than spec
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/react-support-engineer.md
+++ b/docs/src/pages/careers/react-support-engineer.md
@@ -47,7 +47,8 @@ You will be a key member of the Developer Experience's team and will directly im
 You will troubleshoot complex issues related to MUI.
 At MUI a Support Engineer is as considered as a Developer, it's a person that enjoys optimizing what already exists more than working on new shiny features.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 
@@ -65,7 +66,7 @@ You will own the following responsibilities:
 
 For the right candidate:
 
-- Working with the Leadership to construct and execute on a hiring plan to grow the support team.
+- Working with the Leadership to construct and execute a hiring plan to grow the support team.
 
 Depending on the day, you'll:
 
@@ -113,7 +114,7 @@ We're looking for someone with strong front-end skills. More important than spec
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?

--- a/docs/src/pages/careers/support-agent.md
+++ b/docs/src/pages/careers/support-agent.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - We're a remote company, we prefer asynchronous communication over meetings.
@@ -38,7 +38,7 @@ The support on the store is currently almost exclusively done by the executive t
 
 You will be in the tech industry. We offer flexibility in your work day.
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 

--- a/docs/src/pages/careers/support-agent.md
+++ b/docs/src/pages/careers/support-agent.md
@@ -38,7 +38,8 @@ The support on the store is currently almost exclusively done by the executive t
 
 You will be in the tech industry. We offer flexibility in your work day.
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 

--- a/docs/src/pages/careers/technical-product-manager.md
+++ b/docs/src/pages/careers/technical-product-manager.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- Location: Remote (preference for UTC-6 to UTC+3).
+- Location: Remote (preference for UTC-6 to UTC+5).
 - Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501))
 - Start date: Immediately.
 - We're a remote company, we prefer asynchronous communication over meetings.
@@ -38,7 +38,7 @@ Our users are continuously providing feedback on the most important [pains they 
 
 ### Why this is interesting
 
-Our solution empowers React developers to build awesome applications – hundreds of thousands of developers use MUI every month.
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
 We are the second most used UI library in the world, after Bootstrap.
 
 Our enterprise components portfolio is still small, with a million interesting and challenging problems to solve.

--- a/docs/src/pages/careers/technical-product-manager.md
+++ b/docs/src/pages/careers/technical-product-manager.md
@@ -38,10 +38,10 @@ Our users are continuously providing feedback on the most important [pains they 
 
 ### Why this is interesting
 
-Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month. – hundreds of thousands of developers use MUI every month.
-We are the second most used UI library in the world, after Bootstrap.
-
 Our enterprise components portfolio is still small, with a million interesting and challenging problems to solve.
+
+Our solution empowers React developers to build awesome applications faster – we see over a million developers on MUI's docs every month.
+Hundreds of thousands of developers use MUI every month.
 
 ### What you'll do on a day-to-day basis
 
@@ -72,7 +72,7 @@ Depending on the day, you'll:
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location.
-We are ready to pay top market rates for a person that can significantly push the mission forward.
+We are ready to pay top market rates for a person that can clearly exceed the role's expectations.
 You can find the other perks & benefits on the [careers](/careers/#perks-amp-benefits) page.
 
 ## How to apply?


### PR DESCRIPTION
https://deploy-preview-32535--material-ui.netlify.app/careers/

We can close the designer and full-stack roles, they have been filled. Now, we can open the next roles. This should be inline with the plan for 2022 https://www.notion.so/mui-org/2022-goals-f5b6e1b14da84a718802fd56a8bdbe20#ae4e882ccc1b4fc2841518c3a688212f and aligned with the hiring priorities: https://www.notion.so/mui-org/Hiring-plan-eae823b3292249829dee677b21a53f0e

- React Support Engineer: A strong engineer that loves interacting with developers, more likely to be for the X team.
- React Engineer X: To help deliver on what we promised
- React Engineer Core: this speaks for itself, the community is asking for me

<img width="320" alt="Screenshot 2022-05-01 at 16 24 09" src="https://user-images.githubusercontent.com/3165635/166150238-4a847812-af9b-4da4-8ef0-39e627014f2e.png">
 
We are doing something that works, the community wants more. It could also be great to have an emphasis on a11y for this role.
 
- People Ops: to help us manage the chaos that starts to emerge, and support us until 50 people
- Support Agent - Store: there is too much for Matt to handle alone, with high opportunity cost.
- Product Engineer - Store: we have underinvested in the store.
- Engineering Manager for toolpad: someone that can scale up the team and free Jan time.
- Full-stack: I have put it as next. It's too early. We will have enough development horsepower to find a pre-market fit. Adding more developers won't help.

I have also prepared a bit on what could come next. It's still very blurry what could be the next priorities:

- Account Executive?
- Technical Recruiter?