### PR TITLE
[Link] Allow null color

### DIFF
--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -67,7 +67,7 @@ const LinkRoot = styled(Typography, {
     }),
     ...(ownerState.underline === 'always' && {
       textDecoration: 'underline',
-      textDecorationColor: color !== 'inherit' ? alpha(color, 0.4) : undefined,
+      textDecorationColor: color !== 'inherit' && color !== null ? alpha(color, 0.4) : undefined,
       '&:hover': {
         textDecorationColor: 'inherit',
       },


### PR DESCRIPTION
Allowing `null` for `color` would provide the same functionality that a value of `initial` used to provide which is to avoid adding any color styles and therefore get the default link color for the browser. `inherit` will explicitly set the color to the current **text** color which would generally be different than the default link color (e.g. black vs. blue).

Related Issue: #32510
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

If this approach makes sense to the team, I can take care of adding a test and updating the documentation. The main alternative would be to have an explicit value for this purpose (like the previously supported `initial`).
