### PR TITLE
[core] Test some TypeScript perf optimizations

### DIFF
--- a/docs/pages/material-ui/api/accordion-summary.json
+++ b/docs/pages/material-ui/api/accordion-summary.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/accordion-summary.json
+++ b/docs/pages/material-ui/api/accordion-summary.json
@@ -3,13 +3,7 @@
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "expandIcon": { "type": { "name": "node" } },
-    "focusVisibleClassName": { "type": { "name": "string" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    }
+    "focusVisibleClassName": { "type": { "name": "string" } }
   },
   "name": "AccordionSummary",
   "styles": {

--- a/docs/pages/material-ui/api/bottom-navigation-action.json
+++ b/docs/pages/material-ui/api/bottom-navigation-action.json
@@ -8,7 +8,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     },
     "value": { "type": { "name": "any" } }

--- a/docs/pages/material-ui/api/bottom-navigation-action.json
+++ b/docs/pages/material-ui/api/bottom-navigation-action.json
@@ -5,12 +5,6 @@
     "icon": { "type": { "name": "node" } },
     "label": { "type": { "name": "node" } },
     "showLabel": { "type": { "name": "bool" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    },
     "value": { "type": { "name": "any" } }
   },
   "name": "BottomNavigationAction",

--- a/docs/pages/material-ui/api/button.json
+++ b/docs/pages/material-ui/api/button.json
@@ -25,12 +25,6 @@
       "default": "'medium'"
     },
     "startIcon": { "type": { "name": "node" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
-      }
-    },
     "variant": {
       "type": {
         "name": "union",

--- a/docs/pages/material-ui/api/card-action-area.json
+++ b/docs/pages/material-ui/api/card-action-area.json
@@ -5,7 +5,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/card-action-area.json
+++ b/docs/pages/material-ui/api/card-action-area.json
@@ -1,13 +1,7 @@
 {
   "props": {
     "children": { "type": { "name": "node" } },
-    "classes": { "type": { "name": "object" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    }
+    "classes": { "type": { "name": "object" } }
   },
   "name": "CardActionArea",
   "styles": {

--- a/docs/pages/material-ui/api/fab.json
+++ b/docs/pages/material-ui/api/fab.json
@@ -21,12 +21,6 @@
       },
       "default": "'large'"
     },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    },
     "variant": {
       "type": {
         "name": "union",

--- a/docs/pages/material-ui/api/fab.json
+++ b/docs/pages/material-ui/api/fab.json
@@ -24,7 +24,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     },
     "variant": {

--- a/docs/pages/material-ui/api/icon-button.json
+++ b/docs/pages/material-ui/api/icon-button.json
@@ -25,12 +25,6 @@
         "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
-    },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
     }
   },
   "name": "IconButton",

--- a/docs/pages/material-ui/api/icon-button.json
+++ b/docs/pages/material-ui/api/icon-button.json
@@ -29,7 +29,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/list-item-button.json
+++ b/docs/pages/material-ui/api/list-item-button.json
@@ -13,13 +13,7 @@
     "disableGutters": { "type": { "name": "bool" } },
     "divider": { "type": { "name": "bool" } },
     "focusVisibleClassName": { "type": { "name": "string" } },
-    "selected": { "type": { "name": "bool" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    }
+    "selected": { "type": { "name": "bool" } }
   },
   "name": "ListItemButton",
   "styles": {

--- a/docs/pages/material-ui/api/list-item-button.json
+++ b/docs/pages/material-ui/api/list-item-button.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/list-item.json
+++ b/docs/pages/material-ui/api/list-item.json
@@ -49,7 +49,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "any<br>&#124;&nbsp;Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     }
   },

--- a/docs/pages/material-ui/api/list-item.json
+++ b/docs/pages/material-ui/api/list-item.json
@@ -49,7 +49,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/loading-button.json
+++ b/docs/pages/material-ui/api/loading-button.json
@@ -18,7 +18,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     },
     "variant": {

--- a/docs/pages/material-ui/api/loading-button.json
+++ b/docs/pages/material-ui/api/loading-button.json
@@ -15,12 +15,6 @@
       },
       "default": "'center'"
     },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    },
     "variant": {
       "type": {
         "name": "union",

--- a/docs/pages/material-ui/api/menu-item.json
+++ b/docs/pages/material-ui/api/menu-item.json
@@ -7,13 +7,7 @@
     "dense": { "type": { "name": "bool" } },
     "disableGutters": { "type": { "name": "bool" } },
     "divider": { "type": { "name": "bool" } },
-    "focusVisibleClassName": { "type": { "name": "string" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    }
+    "focusVisibleClassName": { "type": { "name": "string" } }
   },
   "name": "MenuItem",
   "styles": {

--- a/docs/pages/material-ui/api/menu-item.json
+++ b/docs/pages/material-ui/api/menu-item.json
@@ -11,7 +11,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/step-button.json
+++ b/docs/pages/material-ui/api/step-button.json
@@ -7,7 +7,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/step-button.json
+++ b/docs/pages/material-ui/api/step-button.json
@@ -3,13 +3,7 @@
     "children": { "type": { "name": "node" } },
     "classes": { "type": { "name": "object" } },
     "icon": { "type": { "name": "node" } },
-    "optional": { "type": { "name": "node" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    }
+    "optional": { "type": { "name": "node" } }
   },
   "name": "StepButton",
   "styles": {

--- a/docs/pages/material-ui/api/tab.json
+++ b/docs/pages/material-ui/api/tab.json
@@ -14,12 +14,6 @@
       "default": "'top'"
     },
     "label": { "type": { "name": "node" } },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    },
     "value": { "type": { "name": "any" } },
     "wrapped": { "type": { "name": "bool" } }
   },

--- a/docs/pages/material-ui/api/tab.json
+++ b/docs/pages/material-ui/api/tab.json
@@ -17,7 +17,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     },
     "value": { "type": { "name": "any" } },

--- a/docs/pages/material-ui/api/table-sort-label.json
+++ b/docs/pages/material-ui/api/table-sort-label.json
@@ -8,13 +8,7 @@
       "default": "'asc'"
     },
     "hideSortIcon": { "type": { "name": "bool" } },
-    "IconComponent": { "type": { "name": "elementType" }, "default": "ArrowDownwardIcon" },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
-    }
+    "IconComponent": { "type": { "name": "elementType" }, "default": "ArrowDownwardIcon" }
   },
   "name": "TableSortLabel",
   "styles": {

--- a/docs/pages/material-ui/api/table-sort-label.json
+++ b/docs/pages/material-ui/api/table-sort-label.json
@@ -12,7 +12,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/toggle-button.json
+++ b/docs/pages/material-ui/api/toggle-button.json
@@ -27,7 +27,7 @@
     "sx": {
       "type": {
         "name": "union",
-        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
       }
     }
   },

--- a/docs/pages/material-ui/api/toggle-button.json
+++ b/docs/pages/material-ui/api/toggle-button.json
@@ -23,12 +23,6 @@
         "description": "'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;string"
       },
       "default": "'medium'"
-    },
-    "sx": {
-      "type": {
-        "name": "union",
-        "description": "any<br>&#124;&nbsp;func<br>&#124;&nbsp;object<br>&#124;&nbsp;{ __@iterator@91: func, concat: func, entries: func, every: func, filter: func, find: func, findIndex: func, flat: func, flatMap: func, forEach: func, includes: func, indexOf: func, join: func, keys: func, lastIndexOf: func, length: number, map: func, reduce: func, reduceRight: func, slice: func, some: func, toLocaleString: func, toString: func, values: func }"
-      }
     }
   },
   "name": "ToggleButton",

--- a/docs/translations/api-docs/accordion-summary/accordion-summary.json
+++ b/docs/translations/api-docs/accordion-summary/accordion-summary.json
@@ -4,8 +4,7 @@
     "children": "The content of the component.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "expandIcon": "The icon to display as the expand indicator.",
-    "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/HEAD/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/HEAD/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json
+++ b/docs/translations/api-docs/bottom-navigation-action/bottom-navigation-action.json
@@ -6,7 +6,6 @@
     "icon": "The icon to display.",
     "label": "The label element.",
     "showLabel": "If <code>true</code>, the <code>BottomNavigationAction</code> will show its label. By default, only the selected <code>BottomNavigationAction</code> inside <code>BottomNavigation</code> will show its label.<br>The prop defaults to the value (<code>false</code>) inherited from the parent BottomNavigation component.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "value": "You can provide your own value. Otherwise, we fallback to the child position index."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/button/button.json
+++ b/docs/translations/api-docs/button/button.json
@@ -14,7 +14,6 @@
     "href": "The URL to link to when the button is clicked. If defined, an <code>a</code> element will be used as the root node.",
     "size": "The size of the component. <code>small</code> is equivalent to the dense button styling.",
     "startIcon": "Element placed before the children.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/card-action-area/card-action-area.json
+++ b/docs/translations/api-docs/card-action-area/card-action-area.json
@@ -2,8 +2,7 @@
   "componentDescription": "",
   "propDescriptions": {
     "children": "The content of the component.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/fab/fab.json
+++ b/docs/translations/api-docs/fab/fab.json
@@ -10,7 +10,6 @@
     "disableRipple": "If <code>true</code>, the ripple effect is disabled.",
     "href": "The URL to link to when the button is clicked. If defined, an <code>a</code> element will be used as the root node.",
     "size": "The size of the component. <code>small</code> is equivalent to the dense button styling.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/icon-button/icon-button.json
+++ b/docs/translations/api-docs/icon-button/icon-button.json
@@ -8,8 +8,7 @@
     "disableFocusRipple": "If <code>true</code>, the  keyboard focus ripple is disabled.",
     "disableRipple": "If <code>true</code>, the ripple effect is disabled.<br>⚠️ Without a ripple there is no styling for :focus-visible by default. Be sure to highlight the element by applying separate styles with the <code>.Mui-focusVisible</code> class.",
     "edge": "If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape).",
-    "size": "The size of the component. <code>small</code> is equivalent to the dense button styling.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "size": "The size of the component. <code>small</code> is equivalent to the dense button styling."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/list-item-button/list-item-button.json
+++ b/docs/translations/api-docs/list-item-button/list-item-button.json
@@ -11,8 +11,7 @@
     "disableGutters": "If <code>true</code>, the left and right padding is removed.",
     "divider": "If <code>true</code>, a 1px light border is added to the bottom of the list item.",
     "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/HEAD/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed.",
-    "selected": "Use to apply selected styling.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "selected": "Use to apply selected styling."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/loading-button/loading-button.json
+++ b/docs/translations/api-docs/loading-button/loading-button.json
@@ -7,7 +7,6 @@
     "loading": "If <code>true</code>, the loading indicator is shown.",
     "loadingIndicator": "Element placed before the children if the button is in loading state. The node should contain an element with <code>role=&quot;progressbar&quot;</code> with an accessible name. By default we render a <code>CircularProgress</code> that is labelled by the button itself.",
     "loadingPosition": "The loading indicator can be positioned on the start, end, or the center of the button.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },
   "classDescriptions": {

--- a/docs/translations/api-docs/menu-item/menu-item.json
+++ b/docs/translations/api-docs/menu-item/menu-item.json
@@ -8,8 +8,7 @@
     "dense": "If <code>true</code>, compact vertical padding designed for keyboard and mouse input is used. The prop defaults to the value inherited from the parent Menu component.",
     "disableGutters": "If <code>true</code>, the left and right padding is removed.",
     "divider": "If <code>true</code>, a 1px light border is added to the bottom of the menu item.",
-    "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/HEAD/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "focusVisibleClassName": "This prop can help identify which element has keyboard focus. The class name will be applied when the element gains the focus through keyboard interaction. It&#39;s a polyfill for the <a href=\"https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo\">CSS :focus-visible selector</a>. The rationale for using this feature <a href=\"https://github.com/WICG/focus-visible/blob/HEAD/explainer.md\">is explained here</a>. A <a href=\"https://github.com/WICG/focus-visible\">polyfill can be used</a> to apply a <code>focus-visible</code> class to other components if needed."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/step-button/step-button.json
+++ b/docs/translations/api-docs/step-button/step-button.json
@@ -4,8 +4,7 @@
     "children": "Can be a <code>StepLabel</code> or a node to place inside <code>StepLabel</code> as children.",
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "icon": "The icon displayed by the step label.",
-    "optional": "The optional node to display.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "optional": "The optional node to display."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/tab/tab.json
+++ b/docs/translations/api-docs/tab/tab.json
@@ -9,7 +9,6 @@
     "icon": "The icon to display.",
     "iconPosition": "The position of the icon relative to the label.",
     "label": "The label element.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "value": "You can provide your own value. Otherwise, we fallback to the child position index.",
     "wrapped": "Tab labels appear in a single row. They can use a second line if needed."
   },

--- a/docs/translations/api-docs/table-sort-label/table-sort-label.json
+++ b/docs/translations/api-docs/table-sort-label/table-sort-label.json
@@ -6,8 +6,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "direction": "The current sort direction.",
     "hideSortIcon": "Hide sort icon when active is false.",
-    "IconComponent": "Sort icon to use.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details."
+    "IconComponent": "Sort icon to use."
   },
   "classDescriptions": {
     "root": { "description": "Styles applied to the root element." },

--- a/docs/translations/api-docs/toggle-button/toggle-button.json
+++ b/docs/translations/api-docs/toggle-button/toggle-button.json
@@ -12,7 +12,6 @@
     "onClick": "Callback fired when the button is clicked.<br><br><strong>Signature:</strong><br><code>function(event: React.MouseEvent&lt;HTMLElement&gt;, value: any) =&gt; void</code><br><em>event:</em> The event source of the callback.<br><em>value:</em> of the selected button.",
     "selected": "If <code>true</code>, the button is rendered in an active state.",
     "size": "The size of the component. The prop defaults to the value inherited from the parent ToggleButtonGroup component.",
-    "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "value": "The value to associate with the button when selected in a ToggleButtonGroup."
   },
   "classDescriptions": {

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.d.ts
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.d.ts
@@ -1,7 +1,5 @@
 import { ExtendButton, ExtendButtonTypeMap, ButtonClasses } from '@mui/material/Button';
 import { OverrideProps } from '@mui/material/OverridableComponent';
-import { Theme } from '@mui/material/styles';
-import { SxProps } from '@mui/system';
 
 export type LoadingButtonTypeMap<
   P = {},
@@ -46,10 +44,6 @@ export type LoadingButtonTypeMap<
      * @default 'center'
      */
     loadingPosition?: 'start' | 'end' | 'center';
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -255,40 +255,6 @@ LoadingButton.propTypes /* remove-proptypes */ = {
     return null;
   }),
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * The variant to use.
    * @default 'text'
    */

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -258,9 +258,35 @@ LoadingButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * The variant to use.

--- a/packages/mui-material-next/src/Tab/Tab.d.ts
+++ b/packages/mui-material-next/src/Tab/Tab.d.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
-import { Theme } from '@mui/material/styles';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '@mui/material/ButtonBase';
 import { OverrideProps } from '@mui/material/OverridableComponent';
 import { TabClasses } from './tabClasses';
@@ -40,10 +38,6 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
      * The label element.
      */
     label?: React.ReactNode;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
     /**
      * You can provide your own value. Otherwise, we fallback to the child position index.
      */

--- a/packages/mui-material-next/src/Tab/Tab.js
+++ b/packages/mui-material-next/src/Tab/Tab.js
@@ -238,40 +238,6 @@ Tab.propTypes /* remove-proptypes */ = {
    */
   label: PropTypes.node,
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * You can provide your own value. Otherwise, we fallback to the child position index.
    */
   value: PropTypes.any,

--- a/packages/mui-material-next/src/Tab/Tab.js
+++ b/packages/mui-material-next/src/Tab/Tab.js
@@ -241,9 +241,35 @@ Tab.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * You can provide your own value. Otherwise, we fallback to the child position index.

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.d.ts
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.d.ts
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
-import { Theme } from '..';
 import { AccordionSummaryClasses } from './accordionSummaryClasses';
 
 export type AccordionSummaryTypeMap<
@@ -22,10 +20,6 @@ export type AccordionSummaryTypeMap<
      * The icon to display as the expand indicator.
      */
     expandIcon?: React.ReactNode;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.js
@@ -174,40 +174,6 @@ AccordionSummary.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   onClick: PropTypes.func,
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
 };
 
 export default AccordionSummary;

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.js
@@ -178,9 +178,35 @@ AccordionSummary.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.d.ts
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.d.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
-import { Theme } from '..';
 import { ButtonBaseTypeMap, ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { BottomNavigationActionClasses } from './bottomNavigationActionClasses';
@@ -35,10 +33,6 @@ export type BottomNavigationActionTypeMap<
      * The prop defaults to the value (`false`) inherited from the parent BottomNavigation component.
      */
     showLabel?: boolean;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
     /**
      * You can provide your own value. Otherwise, we fallback to the child position index.
      */

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
@@ -161,40 +161,6 @@ BottomNavigationAction.propTypes /* remove-proptypes */ = {
    */
   showLabel: PropTypes.bool,
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * You can provide your own value. Otherwise, we fallback to the child position index.
    */
   value: PropTypes.any,

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.js
@@ -164,9 +164,35 @@ BottomNavigationAction.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * You can provide your own value. Otherwise, we fallback to the child position index.

--- a/packages/mui-material/src/Box/Box.d.ts
+++ b/packages/mui-material/src/Box/Box.d.ts
@@ -1,6 +1,6 @@
 import { SxProps, SystemProps } from '@mui/system';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
-import { Theme } from '../styles';
+import { BaseTheme as Theme } from '../styles/BaseTheme.types';
 
 export interface BoxTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &

--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { DistributiveOmit, OverridableStringUnion } from '@mui/types';
-import { SxProps } from '@mui/system';
-import { BaseTheme as Theme } from '../styles/BaseTheme.types';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 import { ButtonClasses } from './buttonClasses';
@@ -74,10 +72,6 @@ export type ButtonTypeMap<
      * Element placed before the children.
      */
     startIcon?: React.ReactNode;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
     /**
      * The variant to use.
      * @default 'text'

--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DistributiveOmit, OverridableStringUnion } from '@mui/types';
 import { SxProps } from '@mui/system';
-import { Theme } from '../styles';
+import { BaseTheme as Theme } from '../styles/BaseTheme.types';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 import { ButtonClasses } from './buttonClasses';

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -443,14 +443,6 @@ Button.propTypes /* remove-proptypes */ = {
    */
   startIcon: PropTypes.node,
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
-    PropTypes.func,
-    PropTypes.object,
-  ]),
-  /**
    * @ignore
    */
   type: PropTypes.oneOfType([PropTypes.oneOf(['button', 'reset', 'submit']), PropTypes.string]),

--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { Theme } from '../styles';
+import { BaseTheme as Theme } from '../styles/BaseTheme.types';
 import { TouchRippleActions, TouchRippleProps } from './TouchRipple';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 import { ButtonBaseClasses } from './buttonBaseClasses';

--- a/packages/mui-material/src/ButtonBase/TouchRipple.d.ts
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InternalStandardProps as StandardProps } from '..';
+import { InternalStandardProps as StandardProps } from '../InternalStandardProps.types';
 import { TouchRippleClasses, TouchRippleClassKey } from './touchRippleClasses';
 
 export { TouchRippleClassKey };

--- a/packages/mui-material/src/CardActionArea/CardActionArea.d.ts
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.d.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
-import { Theme } from '..';
 import { ButtonBaseTypeMap, ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { CardActionAreaClasses } from './cardActionAreaClasses';
@@ -12,10 +10,6 @@ export type CardActionAreaTypeMap<P, D extends React.ElementType> = ExtendButton
      */
     classes?: Partial<CardActionAreaClasses>;
     focusVisibleClassName?: string;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -99,40 +99,6 @@ CardActionArea.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   focusVisibleClassName: PropTypes.string,
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
 };
 
 export default CardActionArea;

--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -103,9 +103,35 @@ CardActionArea.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/Fab/Fab.d.ts
+++ b/packages/mui-material/src/Fab/Fab.d.ts
@@ -1,6 +1,5 @@
 import { OverridableStringUnion } from '@mui/types';
-import { SxProps } from '@mui/system';
-import { PropTypes, Theme } from '..';
+import { PropTypes } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { FabClasses } from './fabClasses';
@@ -61,10 +60,6 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      * @default 'circular'
      */
     variant?: OverridableStringUnion<'circular' | 'extended', FabPropsVariantOverrides>;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -240,40 +240,6 @@ Fab.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * The variant to use.
    * @default 'circular'
    */

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -243,9 +243,35 @@ Fab.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * The variant to use.

--- a/packages/mui-material/src/IconButton/IconButton.d.ts
+++ b/packages/mui-material/src/IconButton/IconButton.d.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
 import { OverridableStringUnion } from '@mui/types';
-import { Theme } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { IconButtonClasses } from './iconButtonClasses';
@@ -57,10 +55,6 @@ export type IconButtonTypeMap<
      * @default 'medium'
      */
     size?: OverridableStringUnion<'small' | 'medium' | 'large', IconButtonPropsSizeOverrides>;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -236,9 +236,35 @@ IconButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/IconButton/IconButton.js
+++ b/packages/mui-material/src/IconButton/IconButton.js
@@ -232,40 +232,6 @@ IconButton.propTypes /* remove-proptypes */ = {
     PropTypes.oneOf(['small', 'medium', 'large']),
     PropTypes.string,
   ]),
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
 };
 
 export default IconButton;

--- a/packages/mui-material/src/InternalStandardProps.types.ts
+++ b/packages/mui-material/src/InternalStandardProps.types.ts
@@ -1,0 +1,22 @@
+import { DistributiveOmit } from '@mui/types';
+import { StyledComponentProps } from './styles/StyledComponentProps.types';
+
+/**
+ * @internal
+ * ONLY USE FROM WITHIN mui/material-ui
+ *
+ * Internal helper type for conform (describeConformance) components
+ * However, we don't declare classes on this type.
+ * It is recommended to declare them manually with an interface so that each class can have a separate JSDoc.
+ */
+export type InternalStandardProps<C, Removals extends keyof C = never> = DistributiveOmit<
+  C,
+  'classes' | Removals
+> &
+  // each component declares it's classes in a separate interface for proper JSDoc
+  StyledComponentProps<never> & {
+    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
+    // TODO: Remove implicit props. Up to each component.
+    className?: string;
+    style?: React.CSSProperties;
+  };

--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { Theme } from '../styles';
+import { BaseTheme as Theme } from '../styles/BaseTheme.types';
 import { ExtendButtonBase } from '../ButtonBase';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ListItemClasses } from './listItemClasses';

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -445,36 +445,9 @@ ListItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.any,
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
   ]),
 };
 

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -445,9 +445,36 @@ ListItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
+    PropTypes.any,
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
-import { Theme } from '../styles';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { ListItemButtonClasses } from './listItemButtonClasses';
@@ -52,10 +50,6 @@ export interface ListItemButtonBaseProps {
    * @default false
    */
   selected?: boolean;
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx?: SxProps<Theme>;
 }
 
 export type ListItemButtonTypeMap<

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -245,40 +245,6 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * @default false
    */
   selected: PropTypes.bool,
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
 };
 
 export default ListItemButton;

--- a/packages/mui-material/src/ListItemButton/ListItemButton.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.js
@@ -249,9 +249,35 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/MenuItem/MenuItem.d.ts
+++ b/packages/mui-material/src/MenuItem/MenuItem.d.ts
@@ -1,5 +1,3 @@
-import { SxProps } from '@mui/system';
-import { Theme } from '../styles';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { MenuItemClasses } from './menuItemClasses';
@@ -42,10 +40,6 @@ export type MenuItemTypeMap<P = {}, D extends React.ElementType = 'li'> = Extend
      * @default false
      */
     selected?: boolean;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -267,9 +267,35 @@ MenuItem.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * @default 0

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -264,40 +264,6 @@ MenuItem.propTypes /* remove-proptypes */ = {
    */
   selected: PropTypes.bool,
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * @default 0
    */
   tabIndex: PropTypes.number,

--- a/packages/mui-material/src/OverridableComponent.d.ts
+++ b/packages/mui-material/src/OverridableComponent.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DistributiveOmit } from '@mui/types';
-import { StyledComponentProps } from './styles';
+import { StyledComponentProps } from './styles/StyledComponentProps.types';
 
 /**
  * A component whose root component can be controlled via a `component` prop.

--- a/packages/mui-material/src/StepButton/StepButton.d.ts
+++ b/packages/mui-material/src/StepButton/StepButton.d.ts
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
 import { ButtonBaseTypeMap, ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
-import { Theme } from '../styles';
 import { StepButtonClasses } from './stepButtonClasses';
 
 /**
@@ -28,10 +26,6 @@ export type StepButtonTypeMap<P, D extends React.ElementType> = ExtendButtonBase
      * The optional node to display.
      */
     optional?: React.ReactNode;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 

--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -111,40 +111,6 @@ StepButton.propTypes /* remove-proptypes */ = {
    * The optional node to display.
    */
   optional: PropTypes.node,
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
 };
 
 export default StepButton;

--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -115,9 +115,35 @@ StepButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/Tab/Tab.d.ts
+++ b/packages/mui-material/src/Tab/Tab.d.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
-import { Theme } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { TabClasses } from './tabClasses';
@@ -40,10 +38,6 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
      * The label element.
      */
     label?: React.ReactNode;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
     /**
      * You can provide your own value. Otherwise, we fallback to the child position index.
      */

--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -277,40 +277,6 @@ Tab.propTypes /* remove-proptypes */ = {
    */
   onFocus: PropTypes.func,
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * You can provide your own value. Otherwise, we fallback to the child position index.
    */
   value: PropTypes.any,

--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -280,9 +280,35 @@ Tab.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * You can provide your own value. Otherwise, we fallback to the child position index.

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.d.ts
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { SxProps } from '@mui/system';
-import { Theme } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { TableSortLabelClasses } from './tableSortLabelClasses';
@@ -38,10 +36,6 @@ export type TableSortLabelTypeMap<
      * @default ArrowDownwardIcon
      */
     IconComponent?: React.JSXElementConstructor<{ className: string }>;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
   };
   defaultComponent: D;
 }>;

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -160,40 +160,6 @@ TableSortLabel.propTypes /* remove-proptypes */ = {
    * @default ArrowDownwardIcon
    */
   IconComponent: PropTypes.elementType,
-  /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
 };
 
 export default TableSortLabel;

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.js
@@ -164,9 +164,35 @@ TableSortLabel.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
 };
 

--- a/packages/mui-material/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.d.ts
@@ -1,7 +1,5 @@
-import { SxProps } from '@mui/system';
 import { OverridableStringUnion } from '@mui/types';
 import * as React from 'react';
-import { Theme } from '..';
 import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { ToggleButtonClasses } from './toggleButtonClasses';
@@ -72,10 +70,6 @@ export type ToggleButtonTypeMap<
      * @default 'medium'
      */
     size?: OverridableStringUnion<'small' | 'medium' | 'large', ToggleButtonPropsSizeOverrides>;
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
     /**
      * The value to associate with the button when selected in a
      * ToggleButtonGroup.

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -223,40 +223,6 @@ ToggleButton.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
-   * The system prop that allows defining system overrides as well as additional CSS styles.
-   */
-  sx: PropTypes.oneOfType([
-    PropTypes.any,
-    PropTypes.func,
-    PropTypes.object,
-    PropTypes.shape({
-      '__@iterator@91': PropTypes.func.isRequired,
-      concat: PropTypes.func.isRequired,
-      entries: PropTypes.func.isRequired,
-      every: PropTypes.func.isRequired,
-      filter: PropTypes.func.isRequired,
-      find: PropTypes.func.isRequired,
-      findIndex: PropTypes.func.isRequired,
-      flat: PropTypes.func.isRequired,
-      flatMap: PropTypes.func.isRequired,
-      forEach: PropTypes.func.isRequired,
-      includes: PropTypes.func.isRequired,
-      indexOf: PropTypes.func.isRequired,
-      join: PropTypes.func.isRequired,
-      keys: PropTypes.func.isRequired,
-      lastIndexOf: PropTypes.func.isRequired,
-      length: PropTypes.number.isRequired,
-      map: PropTypes.func.isRequired,
-      reduce: PropTypes.func.isRequired,
-      reduceRight: PropTypes.func.isRequired,
-      slice: PropTypes.func.isRequired,
-      some: PropTypes.func.isRequired,
-      toLocaleString: PropTypes.func.isRequired,
-      toString: PropTypes.func.isRequired,
-      values: PropTypes.func.isRequired,
-    }),
-  ]),
-  /**
    * The value to associate with the button when selected in a
    * ToggleButtonGroup.
    */

--- a/packages/mui-material/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.js
@@ -226,9 +226,35 @@ ToggleButton.propTypes /* remove-proptypes */ = {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.any,
     PropTypes.func,
     PropTypes.object,
+    PropTypes.shape({
+      '__@iterator@91': PropTypes.func.isRequired,
+      concat: PropTypes.func.isRequired,
+      entries: PropTypes.func.isRequired,
+      every: PropTypes.func.isRequired,
+      filter: PropTypes.func.isRequired,
+      find: PropTypes.func.isRequired,
+      findIndex: PropTypes.func.isRequired,
+      flat: PropTypes.func.isRequired,
+      flatMap: PropTypes.func.isRequired,
+      forEach: PropTypes.func.isRequired,
+      includes: PropTypes.func.isRequired,
+      indexOf: PropTypes.func.isRequired,
+      join: PropTypes.func.isRequired,
+      keys: PropTypes.func.isRequired,
+      lastIndexOf: PropTypes.func.isRequired,
+      length: PropTypes.number.isRequired,
+      map: PropTypes.func.isRequired,
+      reduce: PropTypes.func.isRequired,
+      reduceRight: PropTypes.func.isRequired,
+      slice: PropTypes.func.isRequired,
+      some: PropTypes.func.isRequired,
+      toLocaleString: PropTypes.func.isRequired,
+      toString: PropTypes.func.isRequired,
+      values: PropTypes.func.isRequired,
+    }),
   ]),
   /**
    * The value to associate with the button when selected in a

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -23,7 +23,7 @@ export type StandardProps<
 
 export namespace PropTypes {
   // keeping the type structure for backwards compat
-  // eslint-disable-next-line @typescript-eslint/no-shadow, @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   type Color = 'inherit' | 'primary' | 'secondary' | 'default';
 }
 

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -21,44 +21,6 @@ export type StandardProps<
     style?: React.CSSProperties;
   };
 
-/**
- * @internal
- * ONLY USE FROM WITHIN mui/material-ui
- *
- * Internal helper type for conform (describeConformance) components
- * However, we don't declare classes on this type.
- * It is recommended to declare them manually with an interface so that each class can have a separate JSDoc.
- */
-export type InternalStandardProps<C, Removals extends keyof C = never> = DistributiveOmit<
-  C,
-  'classes' | Removals
-> &
-  // each component declares it's classes in a separate interface for proper JSDoc
-  StyledComponentProps<never> & {
-    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
-    // TODO: Remove implicit props. Up to each component.
-    className?: string;
-    style?: React.CSSProperties;
-  };
-
-export type PaletteMode = 'light' | 'dark';
-export interface Color {
-  50: string;
-  100: string;
-  200: string;
-  300: string;
-  400: string;
-  500: string;
-  600: string;
-  700: string;
-  800: string;
-  900: string;
-  A100: string;
-  A200: string;
-  A400: string;
-  A700: string;
-}
-
 export namespace PropTypes {
   // keeping the type structure for backwards compat
   // eslint-disable-next-line @typescript-eslint/no-shadow, @typescript-eslint/no-unused-vars
@@ -73,6 +35,10 @@ export { colors };
 export * from './styles';
 
 export * from './utils';
+
+export { Color, PaletteMode } from './styles/createPalette';
+
+export { InternalStandardProps } from './InternalStandardProps.types';
 
 export { default as Accordion } from './Accordion';
 export * from './Accordion';

--- a/packages/mui-material/src/styles/BaseTheme.types.ts
+++ b/packages/mui-material/src/styles/BaseTheme.types.ts
@@ -1,0 +1,18 @@
+import { Theme as SystemTheme } from '@mui/system';
+import { Mixins } from './createMixins';
+import { Palette } from './createPalette';
+import { Typography } from './createTypography';
+import { Shadows } from './shadows';
+import { Transitions } from './createTransitions';
+import { ZIndex } from './zIndex';
+
+// This is a basic theme interface, not including the components key
+export interface BaseTheme extends SystemTheme {
+  mixins: Mixins;
+  palette: Palette;
+  shadows: Shadows;
+  transitions: Transitions;
+  typography: Typography;
+  zIndex: ZIndex;
+  unstable_strictMode?: boolean;
+}

--- a/packages/mui-material/src/styles/StyledComponentProps.types.ts
+++ b/packages/mui-material/src/styles/StyledComponentProps.types.ts
@@ -1,0 +1,8 @@
+export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
+
+export interface StyledComponentProps<ClassKey extends string = string> {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<ClassNameMap<ClassKey>>;
+}

--- a/packages/mui-material/src/styles/createPalette.d.ts
+++ b/packages/mui-material/src/styles/createPalette.d.ts
@@ -1,4 +1,20 @@
-import { Color, PaletteMode } from '..';
+export type PaletteMode = 'light' | 'dark';
+export interface Color {
+  50: string;
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+  500: string;
+  600: string;
+  700: string;
+  800: string;
+  900: string;
+  A100: string;
+  A200: string;
+  A400: string;
+  A700: string;
+}
 
 export {};
 // use standalone interface over typeof colors/commons

--- a/packages/mui-material/src/styles/createPalette.d.ts
+++ b/packages/mui-material/src/styles/createPalette.d.ts
@@ -16,7 +16,6 @@ export interface Color {
   A700: string;
 }
 
-export {};
 // use standalone interface over typeof colors/commons
 // to enable module augmentation
 export interface CommonColors {

--- a/packages/mui-material/src/styles/createTheme.d.ts
+++ b/packages/mui-material/src/styles/createTheme.d.ts
@@ -19,9 +19,6 @@ export interface ThemeOptions extends Omit<SystemThemeOptions, 'zIndex'> {
   unstable_strictMode?: boolean;
 }
 
-// shut off automatic exporting for the `BaseTheme` above
-export {};
-
 /**
  * Our [TypeScript guide on theme customization](https://mui.com/material-ui/guides/typescript/#customization-of-theme) explains in detail how you would add custom properties.
  */

--- a/packages/mui-material/src/styles/createTheme.d.ts
+++ b/packages/mui-material/src/styles/createTheme.d.ts
@@ -1,11 +1,12 @@
-import { ThemeOptions as SystemThemeOptions, Theme as SystemTheme } from '@mui/system';
-import { Mixins, MixinsOptions } from './createMixins';
+import { ThemeOptions as SystemThemeOptions } from '@mui/system';
+import { MixinsOptions } from './createMixins';
 import { Palette, PaletteOptions } from './createPalette';
-import { Typography, TypographyOptions } from './createTypography';
+import { TypographyOptions } from './createTypography';
 import { Shadows } from './shadows';
-import { Transitions, TransitionsOptions } from './createTransitions';
-import { ZIndex, ZIndexOptions } from './zIndex';
+import { TransitionsOptions } from './createTransitions';
+import { ZIndexOptions } from './zIndex';
 import { Components } from './components';
+import { BaseTheme } from './BaseTheme.types';
 
 export interface ThemeOptions extends Omit<SystemThemeOptions, 'zIndex'> {
   mixins?: MixinsOptions;
@@ -15,16 +16,6 @@ export interface ThemeOptions extends Omit<SystemThemeOptions, 'zIndex'> {
   transitions?: TransitionsOptions;
   typography?: TypographyOptions | ((palette: Palette) => TypographyOptions);
   zIndex?: ZIndexOptions;
-  unstable_strictMode?: boolean;
-}
-
-interface BaseTheme extends SystemTheme {
-  mixins: Mixins;
-  palette: Palette;
-  shadows: Shadows;
-  transitions: Transitions;
-  typography: Typography;
-  zIndex: ZIndex;
   unstable_strictMode?: boolean;
 }
 

--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -77,15 +77,6 @@ export { ComponentsOverrides, ComponentNameToClassKey } from './overrides';
 export { Components } from './components';
 export { getUnit as unstable_getUnit, toUnitless as unstable_toUnitless } from './cssUtils';
 
-export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
-
-export interface StyledComponentProps<ClassKey extends string = string> {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<ClassNameMap<ClassKey>>;
-}
-
 export { default as makeStyles } from './makeStyles';
 export { default as withStyles } from './withStyles';
 export { default as withTheme } from './withTheme';
@@ -94,3 +85,4 @@ export * from './CssVarsProvider';
 
 export { default as experimental_extendTheme } from './experimental_extendTheme';
 export * from './experimental_extendTheme';
+export { ClassNameMap, StyledComponentProps } from './StyledComponentProps.types';


### PR DESCRIPTION
## TLDR

The optimization described below in **Learnings** won't make big difference in a bigger project, at least not based on the results of 

```sh
yarn tsc --generateTrace
```

Even if we are not loading all types in the components themselves, there are likely going to be usages of `createTheme` where all component's props will anyway be loaded.

I am going to investigate next the type checking phase (this is likely where we can make significant improvements)

## Summary

Just learning how to do [performance tracing for TypeScript](https://github.com/microsoft/TypeScript-wiki/blob/main/Performance-Tracing.md) and trying some optimizations along the way. It's still **too early to be reviewed**, but if you know more about this, feel free to share your input.

I am starting by testing a default create-react-app using TypeScript where the `App.tsx` is defined as:

```tsx
import * as React from 'react';
import Button from '@mui/material/Button';
import Box from '@mui/material/Box';

function App() {
  return (
    <div className="App">
      <Button variant='contained'>Button</Button>
      <Box sx={{ mt: 2, '& .some-class': { p: (theme) => theme.spacing(2) }}}>Box</Box>
    </div>
  );
}

export default App;

```

I've started by trying to optimize this part:

![image](https://user-images.githubusercontent.com/4512430/166410980-d0ea5ae6-5a7f-4411-8ee7-5e5ee90878ab.png)

> Note: Don't trust the number, I am just trying to see if I can get to pattern where `Button.d.ts` will be smaller than `Box.d.ts`.

This is how the chart looks with the build of the package in this PR:

![image](https://user-images.githubusercontent.com/4512430/166412551-ecf85e01-dad8-43bf-8587-60b120509915.png)

It is visible that the `Button.d.ts` now takes much smaller part of the overall `App.tsx` compilation time.

When this change is propagated to the `Box.d.ts` too, the `App.tsx` is no longer the biggest chunk in the parent's time:

![image](https://user-images.githubusercontent.com/4512430/166464042-601114b7-2544-4a50-9617-09a1f95ff260.png)


## Questions

- One thing I am not sure about is, whether there will be gains in improving the components' perf, if anyway in the project there is going to be used a `createTheme` and all types are anyway going to be loaded somewhere. Will this have effect in for example autocomplete of the component inside a file where none of the types from `createTheme` are being used? 

## Learnings

- We are importing the `Theme` in each component's definition files, but the default `Theme` contains the `components` key which basically loads all components' props. We don't even need this key for the `sx` prop to work.
- importing from an index.d.ts file is bad, as all types are being loaded, so I've tried to extract some types in a dedicated `*.types.ts` files so that they are not being defined and loaded from index. (not sure if I am correct about this one, but based on the numbers I saw it seems to be the case)
