### PR TITLE
[FormHelperText] Add support for CSS variables

### DIFF
--- a/docs/pages/experiments/material-ui/form-helper-text.tsx
+++ b/docs/pages/experiments/material-ui/form-helper-text.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import {
+  Experimental_CssVarsProvider as CssVarsProvider,
+  useColorScheme,
+} from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import FormControl, { useFormControl } from '@mui/material/FormControl';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import FormHelperText from '@mui/material/FormHelperText';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+function MyFormHelperText() {
+  const { focused } = useFormControl() || {};
+
+  const helperText = React.useMemo(() => {
+    if (focused) {
+      return 'This field is being focused';
+    }
+
+    return 'Helper text';
+  }, [focused]);
+
+  return <FormHelperText>{helperText}</FormHelperText>;
+}
+
+export default function CssVarsTemplate() {
+  return (
+    <CssVarsProvider>
+      <CssBaseline />
+      <Container sx={{ my: 5 }}>
+        <Box sx={{ pb: 2 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(256px, 1fr))',
+            gridAutoRows: 'minmax(160px, auto)',
+            gap: 2,
+            '& > div': {
+              placeSelf: 'center',
+            },
+          }}
+        >
+          <Box component="form" noValidate autoComplete="off">
+            <FormControl sx={{ width: '25ch' }}>
+              <OutlinedInput placeholder="Please enter text" />
+              <MyFormHelperText />
+            </FormControl>
+          </Box>
+          <Box component="form" noValidate autoComplete="off">
+            <FormControl sx={{ width: '25ch' }}>
+              <OutlinedInput placeholder="Please enter text" />
+              <FormHelperText disabled>Disabled text</FormHelperText>
+            </FormControl>
+          </Box>
+          <Box component="form" noValidate autoComplete="off">
+            <FormControl sx={{ width: '25ch' }}>
+              <OutlinedInput placeholder="Please enter text" />
+              <FormHelperText error>Error text</FormHelperText>
+            </FormControl>
+          </Box>
+        </Box>
+      </Container>
+    </CssVarsProvider>
+  );
+}

--- a/packages/mui-material/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.js
@@ -41,7 +41,7 @@ const FormHelperTextRoot = styled('p', {
     ];
   },
 })(({ theme, ownerState }) => ({
-  color: theme.palette.text.secondary,
+  color: (theme.vars || theme).palette.text.secondary,
   ...theme.typography.caption,
   textAlign: 'left',
   marginTop: 3,
@@ -49,10 +49,10 @@ const FormHelperTextRoot = styled('p', {
   marginBottom: 0,
   marginLeft: 0,
   [`&.${formHelperTextClasses.disabled}`]: {
-    color: theme.palette.text.disabled,
+    color: (theme.vars || theme).palette.text.disabled,
   },
   [`&.${formHelperTextClasses.error}`]: {
-    color: theme.palette.error.main,
+    color: (theme.vars || theme).palette.error.main,
   },
   ...(ownerState.size === 'small' && {
     marginTop: 4,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

One of #32049 

**Preview:** https://deploy-preview-32596--material-ui.netlify.app/experiments/material-ui/form-helper-text/

cc: @mui/contributors 
