### PR TITLE
[MobileStepper] Add support for CSS vars

### DIFF
--- a/docs/pages/experiments/material-ui/mobile-stepper.tsx
+++ b/docs/pages/experiments/material-ui/mobile-stepper.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
   Experimental_CssVarsProvider as CssVarsProvider,
   useColorScheme,
-  useTheme
+  useTheme,
 } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import Box from '@mui/material/Box';
@@ -88,7 +88,6 @@ function TextMobileStepper() {
     </Box>
   );
 }
-
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();

--- a/docs/pages/experiments/material-ui/mobile-stepper.tsx
+++ b/docs/pages/experiments/material-ui/mobile-stepper.tsx
@@ -2,14 +2,93 @@ import * as React from 'react';
 import {
   Experimental_CssVarsProvider as CssVarsProvider,
   useColorScheme,
+  useTheme
 } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
-import { MobileStepper } from '@mui/material';
+import MobileStepper from '@mui/material/MobileStepper';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
+
+const steps = [
+  {
+    label: 'Select campaign settings',
+    description: `For each ad campaign that you create, you can control how much
+              you're willing to spend on clicks and conversions, which networks
+              and geographical locations you want your ads to show on, and more.`,
+  },
+  {
+    label: 'Create an ad group',
+    description: 'An ad group contains one or more ads which target a shared set of keywords.',
+  },
+  {
+    label: 'Create an ad',
+    description: `Try out different ad text to see what brings in the most customers,
+              and learn how to enhance your ads using features like ad extensions.
+              If you run into any problems with your ads, find out how to tell if
+              they're running and how to resolve approval issues.`,
+  },
+];
+
+function TextMobileStepper() {
+  const theme = useTheme();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const maxSteps = steps.length;
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  return (
+    <Box sx={{ maxWidth: 400, flexGrow: 1 }}>
+      <Paper
+        square
+        elevation={0}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: 50,
+          pl: 2,
+          bgcolor: 'background.default',
+        }}
+      >
+        <Typography>{steps[activeStep].label}</Typography>
+      </Paper>
+      <Box sx={{ height: 255, maxWidth: 400, width: '100%', p: 2 }}>
+        {steps[activeStep].description}
+      </Box>
+      <MobileStepper
+        variant="text"
+        steps={maxSteps}
+        position="static"
+        activeStep={activeStep}
+        nextButton={
+          <Button size="small" onClick={handleNext} disabled={activeStep === maxSteps - 1}>
+            Next
+            {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+          </Button>
+        }
+        backButton={
+          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+            {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+            Back
+          </Button>
+        }
+      />
+    </Box>
+  );
+}
+
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -38,11 +117,6 @@ const ColorSchemePicker = () => {
 };
 
 export default function CssVarsTemplate() {
-  const [activeStep, setStep] = React.useState(3);
-
-  const handleIncrease = () => setStep(activeStep + 1);
-  const handleDecrease = () => setStep(activeStep - 1);
-
   return (
     <CssVarsProvider>
       <CssBaseline />
@@ -64,12 +138,7 @@ export default function CssVarsTemplate() {
           <Box>Mobile Stepper</Box>
 
           <Box>
-            <MobileStepper
-              steps={20}
-              activeStep={activeStep}
-              backButton={<Button onClick={handleDecrease}>Decrement</Button>}
-              nextButton={<Button onClick={handleIncrease}>Increment</Button>}
-            />
+            <TextMobileStepper />
           </Box>
         </Box>
       </Container>

--- a/docs/pages/experiments/material-ui/mobile-stepper.tsx
+++ b/docs/pages/experiments/material-ui/mobile-stepper.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import {
+  Experimental_CssVarsProvider as CssVarsProvider,
+  useColorScheme,
+} from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import { MobileStepper } from '@mui/material';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+export default function CssVarsTemplate() {
+  const [activeStep, setStep] = React.useState(3);
+
+  const handleIncrease = () => setStep(activeStep + 1);
+  const handleDecrease = () => setStep(activeStep - 1);
+
+  return (
+    <CssVarsProvider>
+      <CssBaseline />
+      <Container sx={{ my: 5 }}>
+        <Box sx={{ pb: 2 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(256px, 1fr))',
+            gridAutoRows: 'minmax(160px, auto)',
+            gap: 2,
+            '& > div': {
+              placeSelf: 'center',
+            },
+          }}
+        >
+          <Box>Mobile Stepper</Box>
+
+          <Box>
+            <MobileStepper
+              steps={20}
+              activeStep={activeStep}
+              backButton={<Button onClick={handleDecrease}>Decrement</Button>}
+              nextButton={<Button onClick={handleIncrease}>Increment</Button>}
+            />
+          </Box>
+        </Box>
+      </Container>
+    </CssVarsProvider>
+  );
+}

--- a/packages/mui-material/src/MobileStepper/MobileStepper.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.js
@@ -37,21 +37,21 @@ const MobileStepperRoot = styled(Paper, {
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
-  background: theme.palette.background.default,
+  background: (theme.vars || theme).palette.background.default,
   padding: 8,
   ...(ownerState.position === 'bottom' && {
     position: 'fixed',
     bottom: 0,
     left: 0,
     right: 0,
-    zIndex: theme.zIndex.mobileStepper,
+    zIndex: (theme.vars || theme).zIndex.mobileStepper,
   }),
   ...(ownerState.position === 'top' && {
     position: 'fixed',
     top: 0,
     left: 0,
     right: 0,
-    zIndex: theme.zIndex.mobileStepper,
+    zIndex: (theme.vars || theme).zIndex.mobileStepper,
   }),
 }));
 
@@ -80,13 +80,13 @@ const MobileStepperDot = styled('div', {
     transition: theme.transitions.create('background-color', {
       duration: theme.transitions.duration.shortest,
     }),
-    backgroundColor: theme.palette.action.disabled,
+    backgroundColor: (theme.vars || theme).palette.action.disabled,
     borderRadius: '50%',
     width: 8,
     height: 8,
     margin: '0 2px',
     ...(dotActive && {
-      backgroundColor: theme.palette.primary.main,
+      backgroundColor: (theme.vars || theme).palette.primary.main,
     }),
   }),
 }));


### PR DESCRIPTION
Add support for CSS variables for the 
`MobileStepper` component (#32049).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section 
of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-32606--material-ui.netlify.app/experiments/material-ui/mobile-stepper/
