### PR TITLE
[InputAdornment] Add support for CSS variables

### DIFF
--- a/docs/pages/experiments/material-ui/input-adornment.tsx
+++ b/docs/pages/experiments/material-ui/input-adornment.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import {
+  Experimental_CssVarsProvider as CssVarsProvider,
+  useColorScheme,
+} from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import { InputAdornment, TextField } from '@mui/material';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+export default function CssVarsTemplate() {
+  return (
+    <CssVarsProvider>
+      <CssBaseline />
+      <Container sx={{ my: 5 }}>
+        <Box sx={{ pb: 2 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(256px, 1fr))',
+            gridAutoRows: 'minmax(160px, auto)',
+            gap: 2,
+            '& > div': {
+              placeSelf: 'center',
+            },
+          }}
+        >
+          <Box>
+            <TextField
+              label="With normal TextField"
+              id="outlined-start-adornment"
+              sx={{ m: 1, width: '25ch' }}
+              InputProps={{
+                startAdornment: <InputAdornment position="start">kg</InputAdornment>,
+              }}
+            />
+          </Box>
+          <Box>
+            <TextField
+              label="With normal TextField"
+              id="filled-start-adornment"
+              sx={{ m: 1, width: '25ch' }}
+              InputProps={{
+                endAdornment: <InputAdornment position="end">kg</InputAdornment>,
+              }}
+              variant="filled"
+            />
+          </Box>
+        </Box>
+      </Container>
+    </CssVarsProvider>
+  );
+}

--- a/packages/mui-material/src/InputAdornment/InputAdornment.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.js
@@ -47,7 +47,7 @@ const InputAdornmentRoot = styled('div', {
   maxHeight: '2em',
   alignItems: 'center',
   whiteSpace: 'nowrap',
-  color: theme.palette.action.active,
+  color: (theme.vars || theme).palette.action.active,
   ...(ownerState.variant === 'filled' && {
     // Styles applied to the root element if `variant="filled"`.
     [`&.${inputAdornmentClasses.positionStart}&:not(.${inputAdornmentClasses.hiddenLabel})`]: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

one of https://github.com/mui/material-ui/issues/32049

Preview: https://deploy-preview---material-ui.netlify.app/experiments/material-ui/input-adornment/

cc: https://github.com/orgs/mui/teams/contributors