### PR TITLE
[CssBaseline] Add support for CSS vars

### DIFF
--- a/docs/pages/experiments/material-ui/css-baseline.tsx
+++ b/docs/pages/experiments/material-ui/css-baseline.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import {
+  Experimental_CssVarsProvider as CssVarsProvider,
+  useColorScheme,
+} from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Container from '@mui/material/Container';
+import Moon from '@mui/icons-material/DarkMode';
+import Sun from '@mui/icons-material/LightMode';
+import { Typography } from '@mui/material';
+
+const ColorSchemePicker = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? <Moon /> : <Sun />}
+    </Button>
+  );
+};
+
+export default function CssVarsTemplate() {
+  return (
+    <CssVarsProvider>
+      <CssBaseline />
+      <Container sx={{ my: 5 }}>
+        <Box sx={{ pb: 2 }}>
+          <ColorSchemePicker />
+        </Box>
+        <Box>
+          <Typography mt={2} variant="h1">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="h2">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="h3">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="h4">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="h5">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="h6">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="subtitle1">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="subtitle2">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="body1">
+            Hello World.
+          </Typography>
+          <Typography mt={2} variant="body2">
+            Hello World.
+          </Typography>
+        </Box>
+      </Container>
+    </CssVarsProvider>
+  );
+}

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -11,7 +11,7 @@ export const html = (theme, enableColorScheme) => ({
   boxSizing: 'border-box',
   // Fix font resize problem in iOS
   WebkitTextSizeAdjust: '100%',
-  ...(enableColorScheme && { colorScheme: (theme.vars || theme).palette.mode }),
+  ...(enableColorScheme && { colorScheme: theme.palette.mode }),
 });
 
 export const body = (theme) => ({

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -11,16 +11,16 @@ export const html = (theme, enableColorScheme) => ({
   boxSizing: 'border-box',
   // Fix font resize problem in iOS
   WebkitTextSizeAdjust: '100%',
-  ...(enableColorScheme && { colorScheme: theme.palette.mode }),
+  ...(enableColorScheme && { colorScheme: (theme.vars || theme).palette.mode }),
 });
 
 export const body = (theme) => ({
-  color: theme.palette.text.primary,
+  color: (theme.vars || theme).palette.text.primary,
   ...theme.typography.body1,
-  backgroundColor: theme.palette.background.default,
+  backgroundColor: (theme.vars || theme).palette.background.default,
   '@media print': {
     // Save printer ink.
-    backgroundColor: theme.palette.common.white,
+    backgroundColor: (theme.vars || theme).palette.common.white,
   },
 });
 
@@ -39,7 +39,7 @@ export const styles = (theme, enableColorScheme = false) => {
       // Add support for document.body.requestFullScreen().
       // Other elements, if background transparent, are not supported.
       '&::backdrop': {
-        backgroundColor: theme.palette.background.default,
+        backgroundColor: (theme.vars || theme).palette.background.default,
       },
     },
   };


### PR DESCRIPTION
Add support for CSS variables for the component API `CssBaseline` 
(#32049).`

Preview: https://deploy-preview-32618--material-ui.netlify.app/experiments/material-ui/css-baseline/

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing 
guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
