### PR TITLE
[docs] Adds Badge link to Base doc nav

### DIFF
--- a/docs/data/base/pages.ts
+++ b/docs/data/base/pages.ts
@@ -18,6 +18,7 @@ const pages = [
         pathname: '/base/components/inputs',
         subheader: 'inputs',
         children: [
+          { pathname: '/base/react-badge', title: 'Badge' },
           { pathname: '/base/react-button', title: 'Button' },
           { pathname: '/base/react-input', title: 'Input' },
           { pathname: '/base/react-select', title: 'Select' },

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -186,6 +186,7 @@
     "/base/getting-started/installation": "Installation",
     "/base/react-": "Components",
     "inputs": "Inputs",
+    "/base/react-badge": "Badge",
     "/base/react-button": "Button",
     "/base/react-input": "Input",
     "/base/react-select": "Select",


### PR DESCRIPTION
This PR is a tiny fix to add a link to the MUI Base `BadgeUnstyled` document in the side nav—it appears to have been overlooked.