### PR TITLE
[system] Fix color scheme specificity

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -159,7 +159,7 @@ export default function createCssVarsProvider(options) {
         styleSheet[colorSchemeSelector] = css;
       } else {
         styleSheet[
-          `${colorSchemeSelector === ':root' ? '' : colorSchemeSelector}[${attribute}="${key}"]`
+          `${colorSchemeSelector === ':root' ? 'html' : colorSchemeSelector}[${attribute}="${key}"]`
         ] = css;
       }
     });

--- a/test/regressions/fixtures/CssVarsProvider/DarkModeSpecificity.js
+++ b/test/regressions/fixtures/CssVarsProvider/DarkModeSpecificity.js
@@ -33,7 +33,7 @@ const DarkMode = () => {
 
 export default function DarkModeSpecificity() {
   return (
-    <CssVarsProvider>
+    <CssVarsProvider modeStorageKey="dark-mode-specificity">
       <DarkMode />
       <div style={{ background: 'var(--background-default)', color: '#888', padding: '1rem' }}>
         Background should be #000.

--- a/test/regressions/fixtures/CssVarsProvider/DarkModeSpecificity.js
+++ b/test/regressions/fixtures/CssVarsProvider/DarkModeSpecificity.js
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/system';
+
+const { CssVarsProvider } = createCssVarsProvider({
+  theme: {
+    colorSchemes: {
+      light: {
+        background: {
+          default: '#e5e5e5',
+        },
+      },
+      dark: {
+        background: {
+          default: '#000',
+        },
+      },
+    },
+  },
+  defaultColorScheme: {
+    light: 'light',
+    dark: 'dark',
+  },
+});
+
+export default function DarkModeSpecificity() {
+  return (
+    <CssVarsProvider
+      defaultMode="dark"
+      theme={{
+        colorSchemes: {
+          dark: {
+            background: {
+              default: '#121212',
+            },
+          },
+        },
+      }}
+    >
+      <div
+        style={{ background: 'var(--palette-background-default)', color: '#888', padding: '1rem' }}
+      >
+        Background should be #121212.
+      </div>
+    </CssVarsProvider>
+  );
+}

--- a/test/regressions/fixtures/CssVarsProvider/DarkModeSpecificity.js
+++ b/test/regressions/fixtures/CssVarsProvider/DarkModeSpecificity.js
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/system';
 
-const { CssVarsProvider } = createCssVarsProvider({
+const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
   theme: {
     colorSchemes: {
-      light: {
-        background: {
-          default: '#e5e5e5',
-        },
-      },
+      // test that styles order injection does not matter (dark comes before light).
       dark: {
         background: {
           default: '#000',
+        },
+      },
+      light: {
+        background: {
+          default: '#e5e5e5',
         },
       },
     },
@@ -22,24 +23,20 @@ const { CssVarsProvider } = createCssVarsProvider({
   },
 });
 
+const DarkMode = () => {
+  const { setMode } = useColorScheme();
+  React.useEffect(() => {
+    setMode('dark');
+  }, [setMode]);
+  return null;
+};
+
 export default function DarkModeSpecificity() {
   return (
-    <CssVarsProvider
-      defaultMode="dark"
-      theme={{
-        colorSchemes: {
-          dark: {
-            background: {
-              default: '#121212',
-            },
-          },
-        },
-      }}
-    >
-      <div
-        style={{ background: 'var(--palette-background-default)', color: '#888', padding: '1rem' }}
-      >
-        Background should be #121212.
+    <CssVarsProvider>
+      <DarkMode />
+      <div style={{ background: 'var(--background-default)', color: '#888', padding: '1rem' }}>
+        Background should be #000.
       </div>
     </CssVarsProvider>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## The problem

The attribute specificity generated by `CssVarsProvider` is currently the same:

```css
:root // light mode
[data-mui-color-scheme="dark"] // dark mode
```

This means stylesheet injection order matters. If I customize only the `dark` color scheme like this:

```js
<CssVarsProvider theme={{ colorSchemes: { dark: { ... }}}>

// It turns out that the theme before generated CSS variables can be:
{
  colorSchemes: {
    dark: {...}, // dark comes before light in the object
    light: {...},
  }
}
```

It creates these styles in the `head` and since both of them have the same specificity, the `:root` wins and dark mode does not work:

```html
<style>[data-mui-color-scheme="dark"] { ...variables }</style>
<style>:root { ...variables }</style> // this wins in dark mode
```

## The fix

This PR increases the specificity to the color scheme so that order of injection does not matter:

```html
<style>html[data-mui-color-scheme="dark"] { ...variables }</style> // this wins in dark mode
<style>:root { ...variables }</style>
```

## Test

I don't think we can write a unit test, given this is how CSS works, so I create a regression instead. If something has changed and seems wrong, the regression test will cover this issue. You can check the result from Argos.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
