### PR TITLE
[FormControl] Disabled FormControl fires onClick event

### DIFF
--- a/docs/translations/api-docs/form-control/form-control.json
+++ b/docs/translations/api-docs/form-control/form-control.json
@@ -5,7 +5,7 @@
     "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "color": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#adding-new-colors\">palette customization guide</a>.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
-    "disabled": "If <code>true</code>, the label, input and helper text should be displayed in a disabled state.",
+    "disabled": "If <code>true</code>, the label, input and helper text should be displayed in a disabled state. Even if onClick prop is defined, the event will not be fired.",
     "error": "If <code>true</code>, the label is displayed in an error state.",
     "focused": "If <code>true</code>, the component is displayed in focused state.",
     "fullWidth": "If <code>true</code>, the component will take up the full width of its container.",

--- a/packages/mui-material/src/FormControl/FormControl.d.ts
+++ b/packages/mui-material/src/FormControl/FormControl.d.ts
@@ -30,6 +30,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
     >;
     /**
      * If `true`, the label, input and helper text should be displayed in a disabled state.
+     * Even if onClick prop is defined, the event will not be fired.
      * @default false
      */
     disabled?: boolean;

--- a/packages/mui-material/src/FormControl/FormControl.js
+++ b/packages/mui-material/src/FormControl/FormControl.js
@@ -264,6 +264,7 @@ FormControl.propTypes /* remove-proptypes */ = {
   component: PropTypes.elementType,
   /**
    * If `true`, the label, input and helper text should be displayed in a disabled state.
+   * Even if onClick prop is defined, the event will not be fired.
    * @default false
    */
   disabled: PropTypes.bool,

--- a/packages/mui-material/src/FormControl/FormControl.js
+++ b/packages/mui-material/src/FormControl/FormControl.js
@@ -92,6 +92,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     required = false,
     size = 'medium',
     variant = 'outlined',
+    onClick: onClickProp,
     ...other
   } = props;
 
@@ -109,6 +110,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     variant,
   };
 
+  const onClick = disabled ? null : onClickProp;
   const classes = useUtilityClasses(ownerState);
 
   const [adornedStart, setAdornedStart] = React.useState(() => {
@@ -219,6 +221,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
         ownerState={ownerState}
         className={clsx(classes.root, className)}
         ref={ref}
+        onClick={onClick}
         {...other}
       >
         {children}
@@ -290,6 +293,10 @@ FormControl.propTypes /* remove-proptypes */ = {
    * @default 'none'
    */
   margin: PropTypes.oneOf(['dense', 'none', 'normal']),
+  /**
+   * @ignore
+   */
+  onClick: PropTypes.func,
   /**
    * If `true`, the label will indicate that the `input` is required.
    * @default false

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer } from 'test/utils';
+import { describeConformance, act, createRenderer, fireEvent } from 'test/utils';
 import FormControl, { formControlClasses as classes } from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
 import Select from '@mui/material/Select';
@@ -100,6 +100,18 @@ describe('<FormControl />', () => {
 
       setProps({ disabled: true });
       expect(readContext.lastCall.args[0]).to.have.property('focused', false);
+    });
+
+    it('do not fire `onClick` event when `disabled` is `true`', () => {
+      const handleClick = spy();
+      const { container } = render(<FormControl disabled onClick={handleClick} />);
+      const root = container.firstChild;
+
+      act(() => {
+        root.click();
+      });
+
+      expect(handleClick.callCount).to.equal(0);
     });
   });
 

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer, fireEvent } from 'test/utils';
+import { describeConformance, act, createRenderer } from 'test/utils';
 import FormControl, { formControlClasses as classes } from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
 import Select from '@mui/material/Select';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/32560

Problem:
- `FormControl` fires an `onClick` event even if `disabled` prop is set to `true`
- The problem is reproducible in `TextField` as well since `TextField` extends `FormControl`

Before:
- [code sandbox](https://codesandbox.io/s/formpropstextfields-material-demo-forked-hso1vg?file=/demo.js)

After:
- [code sandbox](https://codesandbox.io/s/formpropstextfields-material-demo-forked-lokq8f?file=/demo.js)