### PR TITLE
[website] Optimize conversion to store

### DIFF
--- a/docs/data/material/getting-started/templates/templates.md
+++ b/docs/data/material/getting-started/templates/templates.md
@@ -27,6 +27,6 @@ So far we have demos for a dashboard, sign in page, sign up page, blog page, che
 
 ## Premium templates
 
-Looking for something more? You can find complete templates & themes in the <a href="https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store" data-ga-event-category="store" data-ga-event-action="click" data-ga-event-label="templates">premium template section</a>.
+Looking for something more? You can find complete templates & themes in the <a href="https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store">premium template section</a>.
 
-<a href="https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store" data-ga-event-category="store" data-ga-event-action="click" data-ga-event-label="templates"><img src="/static/images/themes-light.jpg" alt="react templates" /></a>
+<a href="https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=templates-store"><img src="/static/images/themes-light.jpg" alt="react templates" /></a>

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -236,6 +236,11 @@ const pages = [
       { pathname: '/material-ui/discover-more/languages' },
     ],
   },
+  {
+    pathname: 'https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=sidenav',
+    title: 'Templates',
+    icon: 'ReaderIcon',
+  },
 ];
 
 export default pages;

--- a/docs/src/components/home/DesignKits.tsx
+++ b/docs/src/components/home/DesignKits.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { styled, alpha } from '@mui/material/styles';
 import Avatar, { AvatarProps } from '@mui/material/Avatar';
 import Box, { BoxProps } from '@mui/material/Box';
-import ROUTES from 'docs/src/route';
 import Slide from 'docs/src/components/animation/Slide';
 import FadeDelay from 'docs/src/components/animation/FadeDelay';
 
@@ -54,7 +53,15 @@ const DesignToolLink = React.forwardRef<
     <Anchor
       ref={ref}
       aria-label="Go to MUI Store"
-      href={{ figma: ROUTES.storeFigma, sketch: ROUTES.storeSketch, xd: ROUTES.storeXD }[brand]}
+      href={
+        {
+          figma:
+            'https://mui.com/store/items/figma-react/?utm_source=marketing&utm_medium=referral&utm_campaign=home-products',
+          sketch:
+            'https://mui.com/store/items/sketch-react/?utm_source=marketing&utm_medium=referral&utm_campaign=home-products',
+          xd: 'https://mui.com/store/items/adobe-xd-react/?utm_source=marketing&utm_medium=referral&utm_campaign=home-products',
+        }[brand]
+      }
       target="_blank"
       {...props}
     >

--- a/docs/src/components/home/StoreTemplatesBanner.tsx
+++ b/docs/src/components/home/StoreTemplatesBanner.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { styled, alpha, useTheme } from '@mui/material/styles';
 import Box, { BoxProps } from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import ROUTES from 'docs/src/route';
 import LaunchRounded from '@mui/icons-material/LaunchRounded';
 import Slide from 'docs/src/components/animation/Slide';
 import FadeDelay from 'docs/src/components/animation/FadeDelay';
@@ -43,12 +42,12 @@ const Anchor = styled('a')({
 });
 
 const linkMapping = {
-  'minimal-dashboard': ROUTES.storeTemplateMinimalDashboard,
-  theFront: ROUTES.storeTheFront,
-  'material-app': ROUTES.storeTemplateMaterialApp,
-  flexy: ROUTES.storeFlexy,
-  berry: ROUTES.storeTemplateBerry,
-  webbee: ROUTES.storeTemplateWebbee,
+  minimal: 'https://mui.com/store/items/minimal-dashboard/',
+  theFront: 'https://mui.com/store/items/the-front-landing-page/',
+  miro: 'https://mui.com/store/items/mira-pro-react-material-admin-dashboard/',
+  flexy: 'https://mui.com/store/items/flexy-react-admin-dashboard/',
+  berry: 'https://mui.com/store/items/berry-react-material-admin/',
+  webbee: 'https://mui.com/store/items/webbee-landing-page/',
 };
 const brands = Object.keys(linkMapping) as Array<keyof typeof linkMapping>;
 
@@ -64,7 +63,7 @@ const StoreTemplateLink = React.forwardRef<
     <Anchor
       ref={ref}
       aria-label="Go to MUI Store"
-      href={linkMapping[brand]}
+      href={`${linkMapping[brand]}?utm_source=marketing&utm_medium=referral&utm_campaign=home-cta`}
       target="_blank"
       {...props}
     >

--- a/docs/src/components/productDesignKit/DesignKitDemo.tsx
+++ b/docs/src/components/productDesignKit/DesignKitDemo.tsx
@@ -17,7 +17,6 @@ import Highlighter from 'docs/src/components/action/Highlighter';
 import More from 'docs/src/components/action/More';
 import Frame from 'docs/src/components/action/Frame';
 import Link from 'docs/src/modules/components/Link';
-import ROUTES from 'docs/src/route';
 
 const DEMOS = ['Components', 'Branding', 'Iconography'];
 
@@ -65,7 +64,11 @@ export default function TemplateDemo() {
                 />
               </Highlighter>
             ))}
-            <More component={Link} href={ROUTES.storeDesign} noLinkStyle />
+            <More
+              component={Link}
+              href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=design-cta3#design"
+              noLinkStyle
+            />
           </Group>
         </Grid>
         <Grid item xs={12} md={6}>
@@ -172,13 +175,13 @@ export default function TemplateDemo() {
             <Frame.Info sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
               <Box sx={{ minWidth: 0 }}>
                 <Typography variant="body2" fontWeight={500} noWrap sx={{ mb: 0.5 }}>
-                  MUI for Figma
+                  e.g. MUI for Figma
                 </Typography>
               </Box>
               <Button
                 component={Link}
                 noLinkStyle
-                href={ROUTES.storeDesign}
+                href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=design-cta2#design"
                 endIcon={<LaunchRounded sx={{ '&&': { fontSize: 16 } }} />}
                 sx={{ ml: 'auto', color: 'primary.300' }}
               >

--- a/docs/src/components/productDesignKit/DesignKitHero.tsx
+++ b/docs/src/components/productDesignKit/DesignKitHero.tsx
@@ -8,7 +8,6 @@ import GradientText from 'docs/src/components/typography/GradientText';
 import HeroContainer from 'docs/src/layouts/HeroContainer';
 import IconImage from 'docs/src/components/icon/IconImage';
 import Link from 'docs/src/modules/components/Link';
-import ROUTES from 'docs/src/route';
 import {
   DesignKitImagesSet1,
   DesignKitImagesSet2,
@@ -44,7 +43,7 @@ export default function TemplateHero() {
           <Button
             component={Link}
             noLinkStyle
-            href={ROUTES.storeDesign}
+            href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=design-cta#design"
             size="large"
             variant="contained"
             endIcon={<KeyboardArrowRightRounded />}

--- a/docs/src/components/productTemplate/TemplateDemo.tsx
+++ b/docs/src/components/productTemplate/TemplateDemo.tsx
@@ -13,7 +13,6 @@ import Highlighter from 'docs/src/components/action/Highlighter';
 import Frame from 'docs/src/components/action/Frame';
 import LaunchRounded from '@mui/icons-material/LaunchRounded';
 import Link from 'docs/src/modules/components/Link';
-import ROUTES from 'docs/src/route';
 import DashboardRounded from '@mui/icons-material/DashboardRounded';
 import Layers from '@mui/icons-material/Layers';
 import ShoppingBag from '@mui/icons-material/ShoppingBag';
@@ -65,36 +64,36 @@ export default function TemplateDemo() {
   const TEMPLATES = {
     [DEMOS[0]]: [
       {
-        name: 'Flexy - React Admin Dashboard Template',
+        name: 'Flexy - React Material Dashboard (CRA + Next.js)',
         src: `/static/branding/store-templates/template-${mode}4.jpeg`,
-        href: ROUTES.storeFlexy,
+        href: 'https://mui.com/store/items/flexy-react-admin-dashboard/',
       },
       {
-        name: 'Minimal – Client & Admin Dashboard',
+        name: 'Minimal - Client & Admin Dashboard',
         src: `/static/branding/store-templates/template-${mode}1.jpeg`,
-        href: ROUTES.storeTemplateMinimalDashboard,
+        href: 'https://mui.com/store/items/minimal-dashboard/',
       },
       {
         name: 'Berry - React Material Admin Dashboard Template',
         src: `/static/branding/store-templates/template-${mode}5.jpeg`,
-        href: ROUTES.storeTemplateBerry,
+        href: 'https://mui.com/store/items/berry-react-material-admin/',
       },
       {
-        name: 'Material App Pro - React Admin Dashboard',
+        name: 'Mira Pro - React Material Admin Dashboard',
         src: `/static/branding/store-templates/template-${mode}3.jpeg`,
-        href: ROUTES.storeTemplateMaterialApp,
+        href: 'https://mui.com/store/items/mira-pro-react-material-admin-dashboard/',
       },
     ],
     [DEMOS[1]]: [
       {
         name: 'theFront - Multipurpose Template + UI Kit',
         src: `/static/branding/store-templates/template-${mode}2.jpeg`,
-        href: ROUTES.storeTheFront,
+        href: 'https://mui.com/store/items/the-front-landing-page/',
       },
       {
         name: 'Webbee - Multipurpose landing page UI Kit',
         src: `/static/branding/store-templates/template-${mode}6.jpeg`,
-        href: ROUTES.storeTemplateWebbee,
+        href: 'https://mui.com/store/items/webbee-landing-page/',
       },
     ],
     [DEMOS[2]]: [
@@ -137,7 +136,11 @@ export default function TemplateDemo() {
                 />
               </Highlighter>
             ))}
-            <More component={Link} href={ROUTES.storePopular} noLinkStyle />
+            <More
+              component={Link}
+              href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta2#populars"
+              noLinkStyle
+            />
           </Group>
         </Grid>
         <Grid item xs={12} md={6}>
@@ -188,7 +191,7 @@ export default function TemplateDemo() {
                       }}
                     >
                       <Link
-                        href={item.href}
+                        href={`${item.href}?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta2`}
                         noLinkStyle
                         target="_blank"
                         sx={{

--- a/docs/src/components/productTemplate/TemplateHero.tsx
+++ b/docs/src/components/productTemplate/TemplateHero.tsx
@@ -7,7 +7,6 @@ import GradientText from 'docs/src/components/typography/GradientText';
 import HeroContainer from 'docs/src/layouts/HeroContainer';
 import IconImage from 'docs/src/components/icon/IconImage';
 import Link from 'docs/src/modules/components/Link';
-import ROUTES from 'docs/src/route';
 import {
   StoreTemplatesSet1,
   StoreTemplatesSet2,
@@ -43,7 +42,7 @@ export default function TemplateHero() {
           <Button
             component={Link}
             noLinkStyle
-            href={ROUTES.storePopular}
+            href="https://mui.com/store/?utm_source=marketing&utm_medium=referral&utm_campaign=templates-cta#populars"
             size="large"
             variant="contained"
             endIcon={<KeyboardArrowRightRounded />}

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -65,19 +65,6 @@ const ROUTES = {
   dataGridFeaturesComparison: FEATURE_TOGGLE.enable_redirects
     ? '/x/react-data-grid/getting-started/#feature-comparison'
     : '/components/data-grid/getting-started/#feature-comparison',
-  storePopular: 'https://mui.com/store/#populars',
-  storeDesign: 'https://mui.com/store/#design',
-  storeFigma: 'https://mui.com/store/items/figma-react/',
-  storeSketch: 'https://mui.com/store/items/sketch-react/',
-  storeXD: 'https://mui.com/store/items/adobe-xd-react/',
-  storeTemplateMaterialApp: 'https://mui.com/store/items/material-app/',
-  storeTemplateBarza: 'https://mui.com/store/items/bazar-pro-react-ecommerce-template/',
-  storeTemplateMinimalFree: 'https://mui.com/store/items/minimal-dashboard-free/',
-  storeTemplateMinimalDashboard: 'https://mui.com/store/items/minimal-dashboard/',
-  storeTemplateBerry: 'https://mui.com/store/items/berry-react-material-admin/',
-  storeTemplateWebbee: 'https://mui.com/store/items/webbee-landing-page/',
-  storeTheFront: 'https://mui.com/store/items/the-front-landing-page/',
-  storeFlexy: 'https://mui.com/store/items/flexy-react-admin-dashboard/',
 };
 
 export default ROUTES;

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -331,6 +331,7 @@
     "/material-ui/discover-more/backers": "Sponsors & Backers",
     "/material-ui/discover-more/vision": "Vision",
     "/material-ui/discover-more/changelog": "Changelog",
-    "/material-ui/discover-more/languages": "Languages"
+    "/material-ui/discover-more/languages": "Languages",
+    "https://mui.com/store/?utm_source=docs&utm_medium=referral&utm_campaign=sidenav": "Templates"
   }
 }


### PR DESCRIPTION
https://deploy-preview-32646--material-ui.netlify.app/material-ui/getting-started/installation/

Fix drop of -26% of traffic to https://mui.com/store/ by adding the sidenav menu back:

<img width="311" alt="Screenshot 2022-05-06 at 02 14 50" src="https://user-images.githubusercontent.com/3165635/167046673-5d73cd5b-cda3-490a-b2e0-bd01c529ada7.png">

like in older versions of the docs, e.g. https://v5-0-6.mui.com/components/autocomplete/ and like in other products:

- Bootstrap https://getbootstrap.com/

<img width="502" alt="Screenshot 2022-05-06 at 02 21 06" src="https://user-images.githubusercontent.com/3165635/167047101-b5055a4e-6780-43b3-8a46-a175d272a832.png">

- Chakra https://chakra-ui.com/guides/principles

<img width="689" alt="Screenshot 2022-05-06 at 02 21 39" src="https://user-images.githubusercontent.com/3165635/167047164-cfd561c9-75f9-46f1-9dd8-d53351f466de.png">

- Tailwind CSS https://tailwindcss.com/docs/flex-basis

<img width="313" alt="Screenshot 2022-05-06 at 02 22 34" src="https://user-images.githubusercontent.com/3165635/167047221-1415249a-f899-413a-bb93-19db727306ab.png">

It even makes me wonder if we couldn't give the templates in the store more emphasis.

I have found this regression thanks to the events that we send on clicks. ["sidenav"](https://analytics.google.com/analytics/web/#/report/content-event-events/a106598593w159022482p160376982/_u.date00=20220101&_u.date01=20220131&explorer-segmentExplorer.segmentId=analytics.eventLabel&_r.drilldown=analytics.eventCategory:store&explorer-table.plotKeys=%5B%5D/) is gone since we deployed the docs split (our most effective traffic source from mui.com to mui.com/store:

<img width="517" alt="Screenshot 2022-05-06 at 02 15 41" src="https://user-images.githubusercontent.com/3165635/167046749-6b4a2beb-5439-4008-8442-3b11bbdca179.png">

I also use this as an opportunity to add all the UTM tags so we can use Google Analytics to identify changes in behavior. I hedge another regression of this nature in the future.

<img width="624" alt="Screenshot 2022-05-06 at 02 14 12" src="https://user-images.githubusercontent.com/3165635/167046638-e4489cc4-235a-442e-92a4-2b880bfb3c29.png">

