### PR TITLE
[SliderUnstyled] Fix `disabledSwap` not being respected in `onChangeCommitted`

### DIFF
--- a/packages/mui-base/src/SliderUnstyled/useSlider.ts
+++ b/packages/mui-base/src/SliderUnstyled/useSlider.ts
@@ -490,7 +490,7 @@ export default function useSlider(props: UseSliderProps) {
       return;
     }
 
-    const { newValue } = getFingerNewValue({ finger, values });
+    const { newValue } = getFingerNewValue({ finger, move: true, values });
 
     setActive(-1);
     if (nativeEvent.type === 'touchend') {

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1182,7 +1182,7 @@ describe('<Slider />', () => {
       );
       fireEvent.touchMove(
         document.body,
-        createTouches([{ identifier: 1, clientX: 31, clientY: 0 }]),
+        createTouches([{ identifier: 1, clientX: 40, clientY: 0 }]),
       );
       expect(handleChange.args[0][1]).to.deep.equal([15, 30]);
       expect(handleChange.args[1][1]).to.deep.equal([30, 30]);

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1162,6 +1162,32 @@ describe('<Slider />', () => {
       expect(handleChange.args[1][1]).to.deep.equal([20, 20]);
       expect(document.activeElement).to.have.attribute('data-index', '1');
     });
+
+    it('should bound the value when moving the first behind the second', () => {
+      const handleChange = spy();
+      const { container } = render(
+        <Slider defaultValue={[20, 30]} disableSwap onChange={handleChange} />,
+      );
+
+      stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+        width: 100,
+        height: 10,
+        bottom: 10,
+        left: 0,
+      }));
+
+      fireEvent.touchStart(
+        container.firstChild,
+        createTouches([{ identifier: 1, clientX: 15, clientY: 0 }]),
+      );
+      fireEvent.touchMove(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 31, clientY: 0 }]),
+      );
+      expect(handleChange.args[0][1]).to.deep.equal([15, 30]);
+      expect(handleChange.args[1][1]).to.deep.equal([30, 30]);
+      expect(document.activeElement).to.have.attribute('data-index', '0');
+    });
   });
 
   describe('prop: size', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #32381 

Added `move: true` on getFingerNewValue in handleTouchEnd. Because at the 'touchEnd' the value is moved and we want to get 'previousIndex' for activeIndex. Not the 'closest'. (lines 418-422).