### PR TITLE
[website] Remove copy button on marketing pages

### DIFF
--- a/docs/src/components/home/AdvancedShowcase.tsx
+++ b/docs/src/components/home/AdvancedShowcase.tsx
@@ -1733,7 +1733,12 @@ export default function DataTable() {
             },
           }}
         >
-          <HighlightedCode component={MarkdownElement} code={code} language="jsx" />
+          <HighlightedCode
+            copyButtonHidden
+            component={MarkdownElement}
+            code={code}
+            language="jsx"
+          />
         </Box>
       }
     />

--- a/docs/src/components/home/CoreShowcase.tsx
+++ b/docs/src/components/home/CoreShowcase.tsx
@@ -275,7 +275,12 @@ export default function CoreShowcase() {
               {startLine !== undefined && (
                 <FlashCode startLine={startLine} endLine={endLine} sx={{ mx: -2 }} />
               )}
-              <HighlightedCode component={MarkdownElement} code={componentCode} language="jsx" />
+              <HighlightedCode
+                copyButtonHidden
+                component={MarkdownElement}
+                code={componentCode}
+                language="jsx"
+              />
               <StylingInfo appeared={customized} sx={{ mb: -2, mx: -2 }} />
             </Box>
           </Box>

--- a/docs/src/components/productCore/CoreComponents.tsx
+++ b/docs/src/components/productCore/CoreComponents.tsx
@@ -310,7 +310,12 @@ export default function CoreComponents() {
               }}
             >
               <Box sx={{ height: 'calc(100% + 40px)', overflow: 'auto', m: -2, p: 2 }}>
-                <HighlightedCode component={MarkdownElement} code={CODES[demo]} language="jsx" />
+                <HighlightedCode
+                  copyButtonHidden
+                  component={MarkdownElement}
+                  code={CODES[demo]}
+                  language="jsx"
+                />
               </Box>
               <Box
                 sx={{

--- a/docs/src/components/productCore/CoreStyling.tsx
+++ b/docs/src/components/productCore/CoreStyling.tsx
@@ -300,7 +300,12 @@ export default function CoreStyling() {
             >
               <Box sx={{ position: 'relative', '&& pre': { bgcolor: 'transparent' } }}>
                 <Box sx={{ position: 'relative', zIndex: 1 }}>
-                  <HighlightedCode component={MarkdownElement} code={code} language="jsx" />
+                  <HighlightedCode
+                    copyButtonHidden
+                    component={MarkdownElement}
+                    code={code}
+                    language="jsx"
+                  />
                 </Box>
                 <FlashCode startLine={startLine[index]} endLine={endLine[index]} sx={{ mx: -1 }} />
               </Box>

--- a/docs/src/components/productCore/CoreTheming.tsx
+++ b/docs/src/components/productCore/CoreTheming.tsx
@@ -131,7 +131,12 @@ export default function CoreTheming() {
               />
             </Frame.Demo>
             <Frame.Info sx={{ maxHeight: 300, overflow: 'auto' }}>
-              <HighlightedCode component={MarkdownElement} code={code} language="jsx" />
+              <HighlightedCode
+                copyButtonHidden
+                component={MarkdownElement}
+                code={code}
+                language="jsx"
+              />
             </Frame.Info>
           </Frame>
         </Grid>

--- a/docs/src/components/productX/XDataGrid.tsx
+++ b/docs/src/components/productX/XDataGrid.tsx
@@ -209,7 +209,12 @@ export default function XDataGrid() {
           >
             <Box sx={{ position: 'relative' }}>
               <Box sx={{ position: 'relative', zIndex: 1 }}>
-                <HighlightedCode component={MarkdownElement} code={code} language="jsx" />
+                <HighlightedCode
+                  copyButtonHidden
+                  component={MarkdownElement}
+                  code={code}
+                  language="jsx"
+                />
               </Box>
               {demo && <FlashCode startLine={startLine[demo]} sx={{ mx: -2 }} />}
               <StylingInfo

--- a/docs/types/docs.d.ts
+++ b/docs/types/docs.d.ts
@@ -9,6 +9,8 @@ declare module 'docs/src/modules/components/HighlightedCode' {
      * plain string
      */
     code: string;
+    copyButtonHidden?: boolean;
+    copyButtonProps?: JSX.IntrinsicElements['button'];
     /**
      * short identifier of the code language
      * see @mui/markdown/prism for possible languages


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Currently, the code block on marketing pages displays the copy button. We don't need the copy button on these pages. This PR specifies the `copyButtonHidden` prop to all `HighlightedCode` in marketing pages.

<img width="609" alt="Screen Shot 2565-05-06 at 12 08 43" src="https://user-images.githubusercontent.com/18292247/167070663-67efc72c-eb69-4736-9ea1-3326bb39bb66.png">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
