### PR TITLE
[website] Add store to the footer and "hiring" chip adjustment

### DIFF
--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -86,6 +86,7 @@ export default function AppFooter() {
               Explore
             </Typography>
             <Link href={ROUTES.documentation}>Documentation</Link>
+            <Link href={ROUTES.store}>Store</Link>
             <Link href={ROUTES.blog}>Blog</Link>
             <Link href={ROUTES.showcase}>Showcase</Link>
             <Link href={ROUTES.roadmap}>Roadmap</Link>

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -111,10 +111,11 @@ export default function AppFooter() {
                   fontWeight: 700,
                   textTransform: 'uppercase',
                   color: '#fff',
+                  letterSpacing: '0.1rem',
                   backgroundColor: (theme) =>
                     theme.palette.mode === 'dark'
-                      ? theme.palette.error[800]
-                      : theme.palette.error.main,
+                      ? theme.palette.success[900]
+                      : theme.palette.success.main,
                 }}
               >
                 Hiring


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In light of MUI X's Premium release, I've realized we weren't linking the Store in the footer—so there you go. Additionally, changed the "hiring" chip color to green as red was seeming a bit strange as red is usually attributed to "unavailable/error".
