### PR TITLE
[docs] Fix copy button childNode not found

### DIFF
--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -77,6 +77,10 @@ const InitCodeCopy = () => {
         const btn = elm.querySelector('.MuiCode-copy') as HTMLButtonElement | null;
         if (btn) {
           const keyNode = btn.childNodes[1]?.childNodes[1];
+          if (!keyNode) {
+            // skip the logic if the btn is not generated from the markdown.
+            return;
+          }
           keyNode.textContent = keyNode?.textContent?.replace('$key', key) || null;
           btn.addEventListener('click', async function handleClick(event) {
             const trigger = event.currentTarget as HTMLButtonElement;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

It is breaking the dev environment. I am not sure why this does not happen before at the time I introduced this logic. I'm merging this as soon as the CIs are green to unblock other branches that encounter the error.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
