### PR TITLE
[Link] Fix style overrides color prop

### DIFF
--- a/packages/mui-material/src/Link/Link.js
+++ b/packages/mui-material/src/Link/Link.js
@@ -6,7 +6,6 @@ import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { alpha, getPath } from '@mui/system';
 import capitalize from '../utils/capitalize';
 import styled from '../styles/styled';
-import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import useIsFocusVisible from '../utils/useIsFocusVisible';
 import useForkRef from '../utils/useForkRef';
@@ -99,7 +98,6 @@ const LinkRoot = styled(Typography, {
 });
 
 const Link = React.forwardRef(function Link(inProps, ref) {
-  const theme = useTheme();
   const props = useThemeProps({
     props: inProps,
     name: 'MuiLink',
@@ -117,7 +115,6 @@ const Link = React.forwardRef(function Link(inProps, ref) {
     sx,
     ...other
   } = props;
-  const sxColor = typeof sx === 'function' ? sx(theme).color : sx?.color;
 
   const {
     isFocusVisibleRef,
@@ -148,9 +145,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
 
   const ownerState = {
     ...props,
-    // It is too complex to support any types of `sx`.
-    // Need to find a better way to get rid of the color manipulation for `textDecorationColor`.
-    color: (typeof sxColor === 'function' ? sxColor(theme) : sxColor) || color,
+    color,
     component,
     focusVisible,
     underline,
@@ -171,7 +166,7 @@ const Link = React.forwardRef(function Link(inProps, ref) {
       ownerState={ownerState}
       variant={variant}
       sx={[
-        ...(inProps.color ? [{ color: colorTransformations[color] || color }] : []),
+        ...(!Object.keys(colorTransformations).includes(color) ? [{ color }] : []),
         ...(Array.isArray(sx) ? sx : [sx]),
       ]}
       {...other}

--- a/test/regressions/fixtures/Link/LinkColor.js
+++ b/test/regressions/fixtures/Link/LinkColor.js
@@ -4,32 +4,65 @@ import Link from '@mui/material/Link';
 
 export default function DeterminateLinearProgress() {
   return (
-    <ThemeProvider
-      theme={createTheme({
-        components: {
-          MuiLink: {
-            styleOverrides: {
-              root: {
-                color: '#fbca04', // orange
+    <div>
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiLink: {
+              styleOverrides: {
+                root: ({ ownerState, theme }) => ({
+                  ...(ownerState.color === 'secondary' && {
+                    color: theme.palette.error.main,
+                  }),
+                }),
+              },
+              variants: [
+                {
+                  props: { color: 'textPrimary' },
+                  style: ({ theme }) => ({
+                    color: theme.palette.warning.main,
+                  }),
+                },
+              ],
+            },
+          },
+        })}
+      >
+        <Link href="#unknown">primary</Link>
+        <Link href="#unknown" color="secondary">
+          error
+        </Link>
+        <Link href="#unknown" color="textPrimary">
+          warning
+        </Link>
+      </ThemeProvider>
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiLink: {
+              styleOverrides: {
+                root: {
+                  color: '#fbca04', // orange
+                },
               },
             },
           },
-        },
-      })}
-    >
-      <Link href="#unknown">#fbca04</Link>
-      <Link href="#unknown" color="#ff5252">
-        #ff5252
-      </Link>
-      <Link href="#unknown" sx={{ color: '#ff5252' }}>
-        #ff5252
-      </Link>
-      <Link href="#unknown" sx={(theme) => ({ color: theme.palette.secondary.main })}>
-        secondary
-      </Link>
-      <Link href="#unknown" sx={{ color: (theme) => theme.palette.error.main }}>
-        error
-      </Link>
-    </ThemeProvider>
+        })}
+      >
+        <Link href="#unknown">#fbca04</Link>
+        <Link href="#unknown" color="#ff5252">
+          #ff5252
+        </Link>
+        <Link href="#unknown" sx={{ color: '#ff5252' }}>
+          #ff5252 (primary underline)
+        </Link>
+        <Link href="#unknown" sx={(theme) => ({ color: theme.palette.secondary.main })}>
+          secondary
+        </Link>
+        <Link href="#unknown" sx={{ color: (theme) => theme.palette.error.main }}>
+          error
+        </Link>
+      </ThemeProvider>
+    </div>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #32574

**Before**: https://codesandbox.io/s/infallible-fog-n15fl3?file=/src/Demo.tsx
**After**: https://codesandbox.io/s/confident-sea-1kxjnj?file=/src/Demo.tsx

Changes in this PR:
- `styleOverrides` works for normal color prop (`primary`, `secondary`, ...etc)
- `sx` prop should not change the underline as stated in https://github.com/mui/material-ui/pull/32182/files#r847428212
- add more regression tests

> Argos change is expected.

**Scenarios**

```js
// ✅ v4 behavior, affect text color and underline. styleOverrides still works.
<Link />
<Link color="secondary" /> 

// ✅ v5 shorthand support, affect text color and underline. wins over styleOverrides
<Link color="primary.dark" />
<Link color="#ff5252" />

// ✅ v5 sx, affect only text color.
<Link sx={{ color: 'red' }} />
<Link sx={{ color: 'secondary.dark' }} />

// sx has higher specificity
<Link color="primary" sx={{ color: 'secondary.dark' }} /> // text color: secondary.dark, underline: primary
```
---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
