### PR TITLE
[Menu] Fix context menu open position

### DIFF
--- a/docs/data/material/components/menus/ContextMenu.js
+++ b/docs/data/material/components/menus/ContextMenu.js
@@ -11,8 +11,8 @@ export default function ContextMenu() {
     setContextMenu(
       contextMenu === null
         ? {
-            mouseX: event.clientX - 2,
-            mouseY: event.clientY - 4,
+            mouseX: event.clientX + 2,
+            mouseY: event.clientY - 6,
           }
         : // repeated contextmenu when it is already open closes it with Chrome 84 on Ubuntu
           // Other native context menus might behave different.

--- a/docs/data/material/components/menus/ContextMenu.tsx
+++ b/docs/data/material/components/menus/ContextMenu.tsx
@@ -14,8 +14,8 @@ export default function ContextMenu() {
     setContextMenu(
       contextMenu === null
         ? {
-            mouseX: event.clientX - 2,
-            mouseY: event.clientY - 4,
+            mouseX: event.clientX + 2,
+            mouseY: event.clientY - 6,
           }
         : // repeated contextmenu when it is already open closes it with Chrome 84 on Ubuntu
           // Other native context menus might behave different.


### PR DESCRIPTION
Solve one part of https://twitter.com/rsms/status/1522583516265029633 "is the first item perfectly aligned 1px adjacent to the pointer hit pixel?" a point made by rsms. At least, it's how macOS 12, Windows 11, and Figma behave.

### Before
https://mui.com/material-ui/react-menu/#context-menu

<img width="287" alt="Screenshot 2022-05-06 at 21 57 25" src="https://user-images.githubusercontent.com/3165635/167208365-d49dd991-c8cf-4fca-9307-1e34f8137d82.png">

### After
https://deploy-preview-32661--material-ui.netlify.app/material-ui/react-menu/#context-menu

<img width="288" alt="Screenshot 2022-05-06 at 21 59 52" src="https://user-images.githubusercontent.com/3165635/167208689-4974be32-3c65-45ef-b36a-3bd0c75e2c24.png">

---

Does click-drag-release work properly? Nop, but it's pretty hard, maybe overkill for us 🙃. I have also seen https://react-spectrum.adobe.com/react-spectrum/Menu.html support this correctly.

--- 

**Off-topic**. @michaldudak in https://mui.com/base/react-menu/#basic-usage, I think that we will want to reconsider the demo, there are regressions from https://mui.com/material-ui/react-menu/ that would likely not fly in production:

1. Clicking the menu when open doesn't click it, it blinks

https://user-images.githubusercontent.com/3165635/167211100-48b4e5c8-640b-42a8-bdb0-efacf5523f60.mp4

2. We display a language picker, but it's a menu component, this doesn't match (it would match with a select docs page)
3. The menu items are always mounted, even when closed:

<img width="373" alt="Screenshot 2022-05-06 at 22 21 00" src="https://user-images.githubusercontent.com/3165635/167211280-ead52d28-122c-4d1d-bae9-8d9d84e36565.png">

4. We should prevent users to select text, either by using button or user-select: none 

<img width="237" alt="Screenshot 2022-05-06 at 22 27 45" src="https://user-images.githubusercontent.com/3165635/167211999-d1293e28-0983-4e99-8678-308d2b266155.png">

---

I have asked for review the owners of this component

<img width="378" alt="Screenshot 2022-05-06 at 21 59 11" src="https://user-images.githubusercontent.com/3165635/167213475-b6561eed-9b66-46be-a8e0-6e8cf9a3d69c.png">

