### PR TITLE
[core] Remove unnecessary `spacing` parameter from `createMixins` method

### DIFF
--- a/packages/mui-material/src/styles/createMixins.d.ts
+++ b/packages/mui-material/src/styles/createMixins.d.ts
@@ -1,5 +1,5 @@
 import * as CSS from 'csstype';
-import { Breakpoints, Spacing } from '@mui/system';
+import { Breakpoints } from '@mui/system';
 
 export type NormalCssProperties = CSS.Properties<number | string>;
 export type Fontface = CSS.AtRule.FontFace & { fallbacks?: CSS.AtRule.FontFace[] };
@@ -32,8 +32,4 @@ export interface MixinsOptions extends Partial<Mixins> {
   // ... use interface declaration merging to add custom mixin options
 }
 
-export default function createMixins(
-  breakpoints: Breakpoints,
-  spacing: Spacing,
-  mixins: MixinsOptions,
-): Mixins;
+export default function createMixins(breakpoints: Breakpoints, mixins: MixinsOptions): Mixins;

--- a/packages/mui-material/src/styles/createMixins.js
+++ b/packages/mui-material/src/styles/createMixins.js
@@ -1,4 +1,4 @@
-export default function createMixins(breakpoints, spacing, mixins) {
+export default function createMixins(breakpoints, mixins) {
   return {
     toolbar: {
       minHeight: 56,

--- a/packages/mui-material/src/styles/createMixins.test.js
+++ b/packages/mui-material/src/styles/createMixins.test.js
@@ -5,7 +5,7 @@ import createMixins from './createMixins';
 describe('createMixins', () => {
   it('should be able add other mixins', () => {
     const theme = createTheme();
-    const mixins = createMixins(theme.breakpoints, theme.spacing, { test: { display: 'block' } });
+    const mixins = createMixins(theme.breakpoints, { test: { display: 'block' } });
 
     expect(mixins.test).to.deep.equal({
       display: 'block',

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -24,7 +24,7 @@ function createTheme(options = {}, ...args) {
   const systemTheme = systemCreateTheme(options);
 
   let muiTheme = deepmerge(systemTheme, {
-    mixins: createMixins(systemTheme.breakpoints, systemTheme.spacing, mixinsInput),
+    mixins: createMixins(systemTheme.breakpoints, mixinsInput),
     palette,
     // Don't use [...shadows] until you've verified its transpiled code is not invoking the iterator protocol.
     shadows: shadows.slice(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `spacing` parameter is not being used in the method definition. 

I hope this is not a breaking change. 
