### PR TITLE
[docs] Correct links to prevent 301 redirects

### DIFF
--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -49,7 +49,7 @@ Instead, `aria-disabled` is used, which makes the button focusable.
 
 This should be used whenever the disabled button needs to be read by screen readers.
 
-MUI Base uses this prop internally in [menu items](/base/react-menu), making it possible to use the keyboard to navigate to disabled items (in compliance with [ARIA guidelines](https://www.w3.org/TR/wai-aria-practices-1.2/#h-note-17)).
+MUI Base uses this prop internally in [menu items](/base/react-menu/), making it possible to use the keyboard to navigate to disabled items (in compliance with [ARIA guidelines](https://www.w3.org/TR/wai-aria-practices-1.2/#h-note-17)).
 
 {{"demo": "UnstyledButtonsDisabledFocus.js"}}
 

--- a/docs/data/base/components/trap-focus/trap-focus.md
+++ b/docs/data/base/components/trap-focus/trap-focus.md
@@ -10,7 +10,7 @@ packageName: '@mui/base'
 
 <p class="description">The <code>TrapFocus</code> component prevents the user's focus from escaping its children components.</p>
 
-`TrapFocus` is a utility component that is useful when implementing an overlay such as a [modal dialog](/base/react-modal), which should block all interactions outside of it while open.
+`TrapFocus` is a utility component that is useful when implementing an overlay such as a [modal dialog](/base/react-modal/), which should block all interactions outside of it while open.
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 


### PR DESCRIPTION
Added trailing slash to links to prevent redirects.

https://app.ahrefs.com/site-audit/3524616/11/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CredirectChainUrls%2CisRedirectLoop%2CincomingAllLinks%2CincomingRedirect%2Corigin&filterCollapsed=true&filterId=808b08e88c934ee19e04fdec4ed87a5a&issueId=c64d12c1-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating