### PR TITLE
[core] Extract `MuiPage` interface to separate file

### DIFF
--- a/docs/src/MuiPage.ts
+++ b/docs/src/MuiPage.ts
@@ -1,0 +1,38 @@
+export interface MuiPage {
+  pathname: string;
+  children?: MuiPage[];
+  disableDrawer?: boolean;
+  icon?: string;
+  /**
+   * Indicates if the pages are regarding some legacy API.
+   */
+  legacy?: boolean;
+  /**
+   * Indicates if the pages are only available in some plan.
+   * @default 'community'
+   */
+  plan?: 'community' | 'pro' | 'premium';
+  /**
+   * In case the children have pathnames out of pathname value, use this field to scope other pathnames
+   */
+  scopePathnames?: string[];
+  /**
+   * Pages are considered to be ordered depth-first.
+   * If a page should be excluded from this order, set `order: false`.
+   * You want to set `inSideNav: false` if you don't want the page to appear in an ordered list e.g. for previous/next page navigation.
+   */
+  inSideNav?: boolean;
+  /**
+   * Props spread to the Link component
+   */
+  linkProps?: Record<string, unknown>;
+  subheader?: string;
+  /**
+   * Overrides the default page title.
+   */
+  title?: string;
+}
+
+export interface OrderedMuiPage extends MuiPage {
+  ordered?: true;
+}

--- a/docs/src/MuiPage.ts
+++ b/docs/src/MuiPage.ts
@@ -13,7 +13,8 @@ export interface MuiPage {
    */
   plan?: 'community' | 'pro' | 'premium';
   /**
-   * In case the children have pathnames out of pathname value, use this field to scope other pathnames
+   * In case the children have pathnames out of pathname value, use this field to scope other pathnames.
+   * Pathname can be partial, e.g. '/components/' will cover '/components/button/' and '/components/link/'.
    */
   scopePathnames?: string[];
   /**

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -1,43 +1,5 @@
 import pagesApi from './pagesApi';
-
-export interface MuiPage {
-  pathname: string;
-  children?: MuiPage[];
-  disableDrawer?: boolean;
-  icon?: string;
-  /**
-   * Indicates if the pages are regarding some legacy API.
-   */
-  legacy?: boolean;
-  /**
-   * Indicates if the pages are only available in some plan.
-   * @default 'community'
-   */
-  plan?: 'community' | 'pro' | 'premium';
-  /**
-   * In case the children have pathnames out of pathname value, use this field to scope other pathnames
-   */
-  scopePathnames?: string[];
-  /**
-   * Pages are considered to be ordered depth-first.
-   * If a page should be excluded from this order, set `order: false`.
-   * You want to set `inSideNav: false` if you don't want the page to appear in an ordered list e.g. for previous/next page navigation.
-   */
-  inSideNav?: boolean;
-  /**
-   * Props spread to the Link component
-   */
-  linkProps?: Record<string, unknown>;
-  subheader?: string;
-  /**
-   * Overrides the default page title.
-   */
-  title?: string;
-}
-
-export interface OrderedMuiPage extends MuiPage {
-  ordered?: true;
-}
+import type { MuiPage, OrderedMuiPage } from './MuiPage';
 
 const pages: readonly MuiPage[] = [
   {
@@ -368,4 +330,5 @@ const pages: readonly MuiPage[] = [
   { pathname: '/blog', title: 'Blog', icon: 'BookIcon' },
 ];
 
+export type { MuiPage, OrderedMuiPage };
 export default pages;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In MUI X, we want to use `MuiPage` interface, but since we have `noImplicitAny` enabled, TS compiler throws the following error:
```sh
../node_modules/@mui/monorepo/docs/src/pages.ts(1,22): error TS7016: Could not find a declaration file for module './pagesApi'.
```

To solve this issue, I've extracted interfaces to a separate file, so that we can use them in MUI X without issues.
`pages.ts` still exports those interfaces to avoid changes in other parts of the codebase.

I've also updated `scopePathnames` description to mention that it can use partial pathname (see https://github.com/mui/mui-x/pull/4816)