### PR TITLE
[TextField] get variant from parent `FormControl`

### DIFF
--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -12,6 +12,8 @@ import InputLabel from '../InputLabel';
 import FormControl from '../FormControl';
 import FormHelperText from '../FormHelperText';
 import Select from '../Select';
+import formControlState from '../FormControl/formControlState';
+import useFormControl from '../FormControl/useFormControl';
 import { getTextFieldUtilityClass } from './textFieldClasses';
 
 const variantComponent = {
@@ -102,9 +104,18 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     SelectProps,
     type,
     value,
-    variant = 'outlined',
+    variant: variantProp = 'outlined',
     ...other
   } = props;
+
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['variant'],
+  });
+
+  const variant = fcs.variant || variantProp;
 
   const ownerState = {
     ...props,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #32718

I copy past the logic in `Select` to get the variant from `FormControl` and override the default one when specified