### PR TITLE
[docs] Fix TOC-related styles not being applied when disableAd=true

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -43,17 +43,15 @@ const StyledAppContainer = styled(AppContainer, {
       '&& .description.ad': {
         marginBottom: 40,
       },
-      ...(!disableToc && {
-        [theme.breakpoints.up('sm')]: {
-          width: `calc(100% - var(--MuiDocs-toc-width))`,
-        },
-      }),
-      ...(!disableToc && {
-        [theme.breakpoints.up('lg')]: {
-          paddingLeft: '60px',
-          paddingRight: '60px',
-        },
-      }),
+    }),
+    ...(!disableToc && {
+      [theme.breakpoints.up('sm')]: {
+        width: `calc(100% - var(--MuiDocs-toc-width))`,
+      },
+      [theme.breakpoints.up('lg')]: {
+        paddingLeft: '60px',
+        paddingRight: '60px',
+      },
     }),
   };
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In MUI X I've noticed that some pages have horizontal scroll on smaller screens, for example:
https://mui.com/x/react-data-grid/state/

https://user-images.githubusercontent.com/13808724/167820544-5cc4250b-5c90-4431-841d-940390956da7.mov

I've tracked this down to this:
https://github.com/mui/material-ui/blob/7028a342fe7ab097d3264cc4d42e028b37b71ced/docs/src/modules/components/AppLayoutDocs.js#L39-L57

Here you can see that `!disableToc` styles are nested inside `!disableAd` styles, so they are not applied unless `disableAd=false`. The page in MUI X I've linked above has `disableAd=true`, and missing TOC-related style cause horizontal scroll.
This seems to be a regression from [`bf225c3` (#27150)](https://github.com/mui/material-ui/pull/27150/commits/bf225c31ccae201676e8cc382a3aa381398301f6#diff-887bd243079b0617f6c0b9125c7ef12adc7b06d155709b0ec775ea496de5e105)

TOC-related styles should be applied regardless `disableAd` prop, so I've moved them one level up.

In core repo I've found only one page affected by this issue - https://mui.com/material-ui/discover-more/backers/.

<img width="1201" alt="Screenshot 2022-05-11 at 11 53 23" src="https://user-images.githubusercontent.com/13808724/167822860-5b4dea19-0413-4b90-bced-4f134bc8f3f4.png">

Same page with the fix: https://deploy-preview-32733--material-ui.netlify.app/material-ui/discover-more/backers/.