### PR TITLE
[Badge] Fix TypeScript error when adding style overrides for Badge

### DIFF
--- a/packages/mui-material/src/Badge/Badge.d.ts
+++ b/packages/mui-material/src/Badge/Badge.d.ts
@@ -31,40 +31,7 @@ export type BadgeTypeMap<
     /**
      * Override or extend the styles applied to the component.
      */
-    classes?: Partial<BadgeClasses> & {
-      /** Styles applied to the badge `span` element if `color="primary"`. */
-      colorPrimary?: string;
-      /** Styles applied to the badge `span` element if `color="secondary"`. */
-      colorSecondary?: string;
-      /** Styles applied to the badge `span` element if `color="error"`. */
-      colorError?: string;
-      /** Styles applied to the badge `span` element if `color="info"`. */
-      colorInfo?: string;
-      /** Styles applied to the badge `span` element if `color="success"`. */
-      colorSuccess?: string;
-      /** Styles applied to the badge `span` element if `color="warning"`. */
-      colorWarning?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangular"`. */
-      anchorOriginTopRightRectangular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangular"`. */
-      anchorOriginBottomRightRectangular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangular"`. */
-      anchorOriginTopLeftRectangular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangular"`. */
-      anchorOriginBottomLeftRectangular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'right' }} overlap="circular"`. */
-      anchorOriginTopRightCircular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circular"`. */
-      anchorOriginBottomRightCircular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'left' }} overlap="circular"`. */
-      anchorOriginTopLeftCircular?: string;
-      /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circular"`. */
-      anchorOriginBottomLeftCircular?: string;
-      /** Class name applied to the badge `span` element if `overlap="rectangular"`. */
-      overlapRectangular?: string;
-      /** Class name applied to the badge `span` element if `overlap="circular"`. */
-      overlapCircular?: string;
-    };
+    classes?: Partial<BadgeClasses>;
     /**
      * @ignore
      */

--- a/packages/mui-material/src/Badge/Badge.spec.tsx
+++ b/packages/mui-material/src/Badge/Badge.spec.tsx
@@ -3,7 +3,7 @@ import Badge from '@mui/material/Badge';
 
 function classesTest() {
   return (
-    <Badge badgeContent={4} classes={{ badge: 'testBadgeClassName' }}>
+    <Badge badgeContent={4} classes={{ badge: 'testBadgeClassName', colorInfo: 'colorInfoClass' }}>
       <div>Hello World</div>
     </Badge>
   );

--- a/packages/mui-material/src/Badge/badgeClasses.ts
+++ b/packages/mui-material/src/Badge/badgeClasses.ts
@@ -20,6 +20,38 @@ export interface BadgeClasses {
   anchorOriginBottomLeft: string;
   /** State class applied to the badge `span` element if `invisible={true}`. */
   invisible: string;
+  /** Styles applied to the badge `span` element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the badge `span` element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the badge `span` element if `color="error"`. */
+  colorError: string;
+  /** Styles applied to the badge `span` element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the badge `span` element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the badge `span` element if `color="warning"`. */
+  colorWarning: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'right' }} overlap="rectangular"`. */
+  anchorOriginTopRightRectangular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'right' }} overlap="rectangular"`. */
+  anchorOriginBottomRightRectangular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'left' }} overlap="rectangular"`. */
+  anchorOriginTopLeftRectangular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'left' }} overlap="rectangular"`. */
+  anchorOriginBottomLeftRectangular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'right' }} overlap="circular"`. */
+  anchorOriginTopRightCircular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'right' }} overlap="circular"`. */
+  anchorOriginBottomRightCircular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'top', 'left' }} overlap="circular"`. */
+  anchorOriginTopLeftCircular: string;
+  /** Class name applied to the badge `span` element if `anchorOrigin={{ 'bottom', 'left' }} overlap="circular"`. */
+  anchorOriginBottomLeftCircular: string;
+  /** Class name applied to the badge `span` element if `overlap="rectangular"`. */
+  overlapRectangular: string;
+  /** Class name applied to the badge `span` element if `overlap="circular"`. */
+  overlapCircular: string;
 }
 
 export type BadgeClassKey = keyof BadgeClasses;

--- a/packages/mui-material/src/styles/createTheme.spec.ts
+++ b/packages/mui-material/src/styles/createTheme.spec.ts
@@ -78,6 +78,13 @@ const theme = createTheme();
           },
         },
       },
+      MuiBadge: {
+        styleOverrides: {
+          colorInfo: {
+            backgroundColor: '#232323',
+          },
+        },
+      },
     },
   });
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #32699

Regression from #31974

Basically `BadgeClasses` should contain all the CSS classes.