### PR TITLE
[docs] Update `useAutocomplete` demos to use `Mui-focused` class

### DIFF
--- a/docs/data/material/components/autocomplete/CustomizedHook.js
+++ b/docs/data/material/components/autocomplete/CustomizedHook.js
@@ -4,6 +4,7 @@ import { useAutocomplete } from '@mui/base/AutocompleteUnstyled';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import { styled } from '@mui/material/styles';
+import { autocompleteClasses } from '@mui/material/Autocomplete';
 
 const Root = styled('div')(
   ({ theme }) => `
@@ -144,7 +145,7 @@ const Listbox = styled('ul')(
     }
   }
 
-  & li[data-focus='true'] {
+  & li.${autocompleteClasses.focused} {
     background-color: ${theme.palette.mode === 'dark' ? '#003b57' : '#e6f7ff'};
     cursor: pointer;
 

--- a/docs/data/material/components/autocomplete/CustomizedHook.tsx
+++ b/docs/data/material/components/autocomplete/CustomizedHook.tsx
@@ -6,6 +6,7 @@ import {
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import { styled } from '@mui/material/styles';
+import { autocompleteClasses } from '@mui/material/Autocomplete';
 
 const Root = styled('div')(
   ({ theme }) => `
@@ -145,7 +146,7 @@ const Listbox = styled('ul')(
     }
   }
 
-  & li[data-focus='true'] {
+  & li.${autocompleteClasses.focused} {
     background-color: ${theme.palette.mode === 'dark' ? '#003b57' : '#e6f7ff'};
     cursor: pointer;
 

--- a/docs/data/material/components/autocomplete/GitHubLabel.js
+++ b/docs/data/material/components/autocomplete/GitHubLabel.js
@@ -31,9 +31,10 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
       '&[aria-selected="true"]': {
         backgroundColor: 'transparent',
       },
-      '&[data-focus="true"], &[data-focus="true"][aria-selected="true"]': {
-        backgroundColor: theme.palette.action.hover,
-      },
+      [`&.${autocompleteClasses.focused}, &.${autocompleteClasses.focused}[aria-selected="true"]`]:
+        {
+          backgroundColor: theme.palette.action.hover,
+        },
     },
   },
   [`&.${autocompleteClasses.popperDisablePortal}`]: {

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -39,9 +39,10 @@ const StyledAutocompletePopper = styled('div')(({ theme }) => ({
       '&[aria-selected="true"]': {
         backgroundColor: 'transparent',
       },
-      '&[data-focus="true"], &[data-focus="true"][aria-selected="true"]': {
-        backgroundColor: theme.palette.action.hover,
-      },
+      [`&.${autocompleteClasses.focused}, &.${autocompleteClasses.focused}[aria-selected="true"]`]:
+        {
+          backgroundColor: theme.palette.action.hover,
+        },
     },
   },
   [`&.${autocompleteClasses.popperDisablePortal}`]: {

--- a/docs/data/material/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useAutocomplete } from '@mui/base/AutocompleteUnstyled';
 import { styled } from '@mui/material/styles';
+import { autocompleteClasses } from '@mui/material/Autocomplete';
 
 const Label = styled('label')({
   display: 'block',
@@ -23,7 +24,7 @@ const Listbox = styled('ul')(({ theme }) => ({
   overflow: 'auto',
   maxHeight: 200,
   border: '1px solid rgba(0,0,0,.25)',
-  '& li[data-focus="true"]': {
+  [`& li.${autocompleteClasses.focused}`]: {
     backgroundColor: '#4a8df6',
     color: 'white',
     cursor: 'pointer',

--- a/docs/data/material/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/material/components/autocomplete/UseAutocomplete.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useAutocomplete } from '@mui/base/AutocompleteUnstyled';
 import { styled } from '@mui/material/styles';
+import { autocompleteClasses } from '@mui/material/Autocomplete';
 
 const Label = styled('label')({
   display: 'block',
@@ -23,7 +24,7 @@ const Listbox = styled('ul')(({ theme }) => ({
   overflow: 'auto',
   maxHeight: 200,
   border: '1px solid rgba(0,0,0,.25)',
-  '& li[data-focus="true"]': {
+  [`& li.${autocompleteClasses.focused}`]: {
     backgroundColor: '#4a8df6',
     color: 'white',
     cursor: 'pointer',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #32563 

`data-focus` attribute was removed in #26181. So we can't select with it anymore in CSS.

**Preview:** https://deploy-preview-32757--material-ui.netlify.app/material-ui/react-autocomplete/#useautocomplete