### PR TITLE
[docs] Allow function prop to return `undefined`

### DIFF
--- a/docs/src/modules/utils/generatePropDescription.ts
+++ b/docs/src/modules/utils/generatePropDescription.ts
@@ -21,6 +21,10 @@ function resolveType(type: NonNullable<doctrine.Tag['type']>): string {
     return 'null';
   }
 
+  if (type.type === 'UndefinedLiteral') {
+    return 'undefined';
+  }
+
   if (type.type === 'TypeApplication') {
     return `${resolveType(type.expression)}<${type.applications
       .map((typeApplication) => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

If a prop receives a function whose return has `undefined`, then `yarn docs:api` crashes with:

> TypeError: resolveType for 'UndefinedLiteral' not implemented

This can be tested applying the diff below:

```diff
diff --git a/packages/mui-material/src/Rating/Rating.d.ts b/packages/mui-material/src/Rating/Rating.d.ts
index 1eb262d4c4..704c4443f9 100644
--- a/packages/mui-material/src/Rating/Rating.d.ts
+++ b/packages/mui-material/src/Rating/Rating.d.ts
@@ -42,12 +42,12 @@ export interface RatingProps
    *
    * For localization purposes, you can use the provided [translations](/material-ui/guides/localization/).
    * @param {number} value The rating label's value to format.
-   * @returns {string}
+   * @returns {string | undefined}
    * @default function defaultLabelText(value) {
    *   return `${value} Star${value !== 1 ? 's' : ''}`;
    * }
    */
-  getLabelText?: (value: number) => string;
+  getLabelText?: (value: number) => string | undefined;
   /**
    * If `true`, only the selected icon will be highlighted.
    * @default false
```

The reason for this change is because in https://github.com/mui/mui-x/pull/4859 I added a prop to the  DataGrid which can return `null` and other values. I can't add `undefined` because the docs generator crashes.