### PR TITLE
[docs] Fix link to the material icons

### DIFF
--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/components/material-icons/",
+  "homepage": "https://mui.com/material-ui/material-icons/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/guides/styled-engine/",
+  "homepage": "https://mui.com/material-ui/guides/styled-engine/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/guides/styled-engine/",
+  "homepage": "https://mui.com/material-ui/guides/styled-engine/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"


### PR DESCRIPTION
It got forgotten