### PR TITLE
[Tabs] Scroll by width of the first visible tab if only one tab is partially visible

### DIFF
--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -443,10 +443,28 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
     scroll(scrollValue);
   };
 
+  const getFirstVisibleTab = (tabs) => {
+    const containerSize = tabsRef.current[clientSize];
+    const containerStartBound = Math.round(tabsRef.current[scrollStart]);
+
+    const containerEndBound = Math.round(containerStartBound + containerSize);
+
+    const offset = vertical ? 'offsetTop' : 'offsetLeft';
+    return tabs.find((tab) => {
+      const centerPoint = tab[offset] + tab[clientSize] / 2;
+      return centerPoint >= containerStartBound && centerPoint <= containerEndBound;
+    });
+  };
+
   const getScrollSize = () => {
     const containerSize = tabsRef.current[clientSize];
     let totalSize = 0;
     const children = Array.from(tabListRef.current.children);
+    const firstVisibleTab = getFirstVisibleTab(children);
+
+    if (firstVisibleTab && firstVisibleTab[clientSize] > containerSize) {
+      return firstVisibleTab[clientSize];
+    }
 
     for (let i = 0; i < children.length; i += 1) {
       const tab = children[i];
@@ -455,6 +473,7 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
       }
       totalSize += tab[clientSize];
     }
+
     return totalSize;
   };
 

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -446,7 +446,6 @@ const Tabs = React.forwardRef(function Tabs(inProps, ref) {
   const getFirstVisibleTab = (tabs) => {
     const containerSize = tabsRef.current[clientSize];
     const containerStartBound = Math.round(tabsRef.current[scrollStart]);
-
     const containerEndBound = Math.round(containerStartBound + containerSize);
 
     const offset = vertical ? 'offsetTop' : 'offsetLeft';

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -692,6 +692,56 @@ describe('<Tabs />', () => {
       clock.tick(1000);
       expect(tablistContainer.scrollLeft).equal(100);
     });
+
+    it('should horizontally scroll by width of partially visible item', () => {
+      const { container, getByRole, getAllByRole } = render(
+        <Tabs value={0} variant="scrollable" scrollButtons style={{ width: 200 }}>
+          <Tab style={{ width: 220, minWidth: 'auto' }} />
+          <Tab style={{ width: 200, minWidth: 'auto' }} />
+          <Tab style={{ width: 200, minWidth: 'auto' }} />
+        </Tabs>,
+      );
+      const tablistContainer = getByRole('tablist').parentElement;
+      const tabs = getAllByRole('tab');
+      Object.defineProperty(tablistContainer, 'clientWidth', { value: 200 });
+      Object.defineProperty(tabs[0], 'clientWidth', { value: 220 });
+      Object.defineProperty(tabs[1], 'clientWidth', { value: 200 });
+      Object.defineProperty(tabs[2], 'clientWidth', { value: 200 });
+      Object.defineProperty(tablistContainer, 'scrollWidth', { value: 620 });
+
+      tablistContainer.scrollLeft = 0;
+      fireEvent.click(findScrollButton(container, 'right'));
+      clock.tick(1000);
+      expect(tablistContainer.scrollLeft).equal(220);
+    });
+
+    it('should vertically scroll by width of partially visible item', () => {
+      const { container, getByRole, getAllByRole } = render(
+        <Tabs
+          value={0}
+          variant="scrollable"
+          orientation="vertical"
+          scrollButtons
+          style={{ height: 100 }}
+        >
+          <Tab style={{ height: 48 }} />
+          <Tab style={{ height: 60 }} />
+          <Tab style={{ height: 60 }} />
+        </Tabs>,
+      );
+      const tablistContainer = getByRole('tablist').parentElement;
+      const tabs = getAllByRole('tab');
+      Object.defineProperty(tablistContainer, 'clientHeight', { value: 100 });
+      Object.defineProperty(tabs[0], 'clientHeight', { value: 48 });
+      Object.defineProperty(tabs[1], 'clientHeight', { value: 60 });
+      Object.defineProperty(tabs[2], 'clientHeight', { value: 60 });
+      Object.defineProperty(tablistContainer, 'scrollHeight', { value: 168 });
+
+      tablistContainer.scrollTop = 0;
+      fireEvent.click(findScrollButton(container, 'right'));
+      clock.tick(1000);
+      expect(tablistContainer.scrollTop).equal(48);
+    });
   });
 
   describe('scroll into view behavior', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Currently, you're not able to scroll tabs when the container is narrow enough to have only one tab (partially) visible. This is my proposed solution, which would scroll by the width of the first visible tab in such a case.

Fixes https://github.com/mui/material-ui/issues/32748
