### PR TITLE
[docs] Fix wrong code snippet for overriding styles in theme with a callback value

### DIFF
--- a/docs/data/material/customization/theme-components/theme-components.md
+++ b/docs/data/material/customization/theme-components/theme-components.md
@@ -58,11 +58,13 @@ const theme = createTheme({
   components: {
     MuiButton: {
       styleOverrides: ({ ownerState }) => ({
-        ...(ownerState.variant === 'contained' &&
-          ownerState.color === 'primary' && {
-            backgroundColor: '#202020',
-            color: '#fff',
-          }),
+        root: ({ ownerState }) => ({
+          ...(ownerState.variant === 'contained' &&
+            ownerState.color === 'primary' && {
+              backgroundColor: '#202020',
+              color: '#fff',
+            }),
+        }),
       }),
     },
   },

--- a/docs/data/material/customization/theme-components/theme-components.md
+++ b/docs/data/material/customization/theme-components/theme-components.md
@@ -57,7 +57,7 @@ You can use these classes inside the `styleOverrides` key to modify the correspo
 const theme = createTheme({
   components: {
     MuiButton: {
-      styleOverrides: ({ ownerState }) => ({
+      styleOverrides: {
         root: ({ ownerState }) => ({
           ...(ownerState.variant === 'contained' &&
             ownerState.color === 'primary' && {
@@ -65,7 +65,7 @@ const theme = createTheme({
               color: '#fff',
             }),
         }),
-      }),
+      },
     },
   },
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #32760 

Callback as a value is in the CSS class properties not in the styleOverrides key. 

In any case, I think, this particular code snippet with the following description doesn't match:
```
Each component is composed of several different parts.
These parts correspond to classes that are available to the component—see the **CSS** section of the component's API page for a detailed list.
You can use these classes inside the `styleOverrides` key to modify the corresponding parts of the component.
```

Also this sub-section seems redundant with the section below: `Overrides based on props`. 

I would propose to remove this sub-section which was added in #31997. 

Preview: https://deploy-preview-32781--material-ui.netlify.app/material-ui/customization/theme-components/#global-style-overrides