### PR TITLE
[docs] Fixed wrong command for the `link-underline-hover` codemod

### DIFF
--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -697,7 +697,7 @@ Apply `underline="hover"` to `<Link />` that does not define `underline` prop (t
 ```
 
 ```sh
-npx @mui/codemod v5.0.0/icon-button-size <path>
+npx @mui/codemod v5.0.0/link-underline-hover <path>
 ```
 
 You can find more details about this breaking change in [the migration guide](https://mui.com/material-ui/guides/migration-v4/#link).


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
