### PR TITLE
[typescript] Allow module augmentation for `Mixins`

### DIFF
--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -32,6 +32,7 @@ export {
   duration,
   easing,
 } from './createTransitions';
+export { Mixins } from './createMixins';
 export {
   Direction,
   Breakpoint,

--- a/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
+++ b/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
@@ -10,4 +10,4 @@ declare module '@mui/material/styles' {
 const theme = createTheme({ mixins: { customMixin: { paddingLeft: 2 } } });
 
 // ensure Mixins work
-const Example = styled('div')(({ theme: t }) => t.mixins.myCustomGuttersMixin);
+const Example = styled('div')(({ theme: t }) => t.mixins.customMixin);

--- a/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
+++ b/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
@@ -1,4 +1,5 @@
-import { createTheme, CSSProperties, styled } from '@mui/material/styles';
+import { Interpolation } from '@mui/system';
+import { createTheme, styled } from '@mui/material/styles';
 
 declare module '@mui/material/styles' {
   interface Mixins {

--- a/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
+++ b/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
@@ -2,7 +2,7 @@ import { createTheme, CSSProperties, styled } from '@mui/material/styles';
 
 declare module '@mui/material/styles' {
   interface Mixins {
-    customMixin: CSSProperties;
+    customMixin: Interpolation<{}>;
   }
 }
 

--- a/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
+++ b/packages/mui-material/test/typescript/moduleAugmentation/createTheme.spec.ts
@@ -1,0 +1,13 @@
+import { createTheme, CSSProperties, styled } from '@mui/material/styles';
+
+declare module '@mui/material/styles' {
+  interface Mixins {
+    customMixin: CSSProperties;
+  }
+}
+
+// ensure MixinsOptions work
+const theme = createTheme({ mixins: { customMixin: { paddingLeft: 2 } } });
+
+// ensure Mixins work
+const Example = styled('div')(({ theme: t }) => t.mixins.myCustomGuttersMixin);

--- a/packages/mui-material/test/typescript/moduleAugmentation/createTheme.tsconfig.json
+++ b/packages/mui-material/test/typescript/moduleAugmentation/createTheme.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig",
+  "files": ["createTheme.spec.ts"]
+}


### PR DESCRIPTION
I noticed while providing a solution to https://github.com/mui/material-ui/issues/32721 that we do not export the `Mixins` type from `@mui/material/styles`, leading to developers needing to declare module for it from a private path: `@mui/material/styles/createMixins`. 

The goal is to allow the following:

```diff
-declare module "@mui/material/styles/createMixins" {
+declare module "@mui/material/styles" {
   interface Mixins {
     myCustomGuttersMixin: CSSProperties;
   }
 }
```