### PR TITLE
[core] Add next.js eslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -223,6 +223,15 @@ module.exports = {
       },
     },
     {
+      files: ['docs/**/*.*'],
+      extends: ['plugin:@next/next/recommended'],
+      rules: {
+        '@next/next/no-html-link-for-pages': ['error', 'docs/pages/'],
+
+        '@next/next/no-img-element': ['off'],
+      },
+    },
+    {
       files: ['docs/src/modules/components/**/*.js'],
       rules: {
         'material-ui/no-hardcoded-labels': [

--- a/docs/pages/experiments/joy/checkbox.tsx
+++ b/docs/pages/experiments/joy/checkbox.tsx
@@ -13,6 +13,7 @@ import Moon from '@mui/icons-material/DarkMode';
 import Sun from '@mui/icons-material/LightMode';
 import Close from '@mui/icons-material/Close';
 import Done from '@mui/icons-material/Done';
+import Script from 'next/script';
 
 const ColorSchemePicker = () => {
   const { mode, setMode } = useColorScheme();
@@ -160,13 +161,9 @@ const Pattern = () => {
 export default function JoyCheckbox() {
   return (
     <CssVarsProvider>
-      <Head>
-        <script
-          type="module"
-          src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"
-        />
-        <script noModule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js" />
-      </Head>
+      <Script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js" />
+      <Script noModule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js" />
+
       <Box sx={{ py: 5, maxWidth: { md: 1152, xl: 1536 }, mx: 'auto' }}>
         <Box sx={{ px: 3 }}>
           <ColorSchemePicker />

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@eps1lon/enzyme-adapter-react-17": "^0.1.0",
+    "@next/eslint-plugin-next": "^12.1.6",
     "@octokit/rest": "^18.12.0",
     "@playwright/test": "1.17.1",
     "@rollup/plugin-replace": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,6 +2400,13 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.5.tgz#a21ba6708022d630402ca2b340316e69a0296dfc"
   integrity sha512-+34yUJslfJi7Lyx6ELuN8nWcOzi27izfYnZIC1Dqv7kmmfiBVxgzR3BXhlvEMTKC2IRJhXVs2FkMY+buQe3k7Q==
 
+"@next/eslint-plugin-next@^12.1.6":
+  version "12.1.6"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-12.1.6.tgz#dde3f98831f15923b25244588d924c716956292e"
+  integrity sha512-yNUtJ90NEiYFT6TJnNyofKMPYqirKDwpahcbxBgSIuABwYOdkGwzos1ZkYD51Qf0diYwpQZBeVqElTk7Q2WNqw==
+  dependencies:
+    glob "7.1.7"
+
 "@next/swc-android-arm-eabi@12.1.5":
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.5.tgz#36729ab3dfd7743e82cfe536b43254dcb146620c"
@@ -8256,6 +8263,18 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@7.2.0, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@~7.2.0:
   version "7.2.0"


### PR DESCRIPTION
Copying from toolpad https://github.com/mui/mui-toolpad/pull/430

**Edit**

The plugin uses optional chaining. The build runs on node 12 which doesn't fully support ES2020 yet. Closing this PR until node is upgraded.