### PR TITLE
[docs] Add note about transparent background on the outlined Alert variant

### DIFF
--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -60,6 +60,9 @@ Two additional variants are available – outlined, and filled:
 
 {{"demo": "OutlinedAlerts.js"}}
 
+When using the outlined Alert with the [Snackbar component](/material-ui/react-snackbar/#customization), background content will be visible and bleed through the Alert.
+In this case add `sx={{ bgcolor: 'background.paper' }}` to the Alert component.
+
 ### Filled
 
 {{"demo": "FilledAlerts.js"}}

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -60,7 +60,7 @@ Two additional variants are available – outlined, and filled:
 
 {{"demo": "OutlinedAlerts.js"}}
 
-When using the outlined Alert with the [Snackbar component](/material-ui/react-snackbar/#customization), background content will be visible and bleed through the Alert.
+When using an outlined alert with the [`Snackbar` component](/material-ui/react-snackbar/#customization), background content will be visible and bleed through the alert by default.
 In this case add `sx={{ bgcolor: 'background.paper' }}` to the Alert component.
 
 ### Filled

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -61,7 +61,7 @@ Two additional variants are available – outlined, and filled:
 {{"demo": "OutlinedAlerts.js"}}
 
 When using an outlined alert with the [`Snackbar` component](/material-ui/react-snackbar/#customization), background content will be visible and bleed through the alert by default.
-In this case add `sx={{ bgcolor: 'background.paper' }}` to the Alert component.
+You can prevent this by adding `bgcolor: 'background.paper'` to the[`sx` prop](/material-ui/customization/how-to-customize/#the-sx-prop) on the `Alert` component.
 
 ### Filled
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Why
We were implementing the toast component using Snackbar and the outlined Alert variant, but the content was bleeding through (see #32797 ). First we assumed a problem with z-index or a positioning issue but it took us some time to figure out that the outlined variants don't have a background by design. 

### Changes
- [x] add note to outlined Alert variant to add a background when used with Snackbar component