### PR TITLE
Update FAB PropTypes to include PropTypes.string

### DIFF
--- a/docs/pages/material-ui/api/fab.json
+++ b/docs/pages/material-ui/api/fab.json
@@ -4,8 +4,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'default'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'"
+        "name": "union",
+        "description": "'default'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
       },
       "default": "'default'"
     },

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -194,15 +194,18 @@ Fab.propTypes /* remove-proptypes */ = {
    * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
    * @default 'default'
    */
-  color: PropTypes.oneOf([
-    'default',
-    'error',
-    'info',
-    'inherit',
-    'primary',
-    'secondary',
-    'success',
-    'warning',
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf([
+      'default',
+      'error',
+      'info',
+      'inherit',
+      'primary',
+      'secondary',
+      'success',
+      'warning',
+    ]),
+    PropTypes.string,
   ]),
   /**
    * The component used for the root node.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hello!

I noticed passing a color of a custom color added in the theme would work correctly for the actual styling of the FAB, but would still report a PropType error about the string color I provided not being in the list of appropriate options. I added `PropTypes.string` similar to how other components do color PropType to account for custom colors.

![2022-05-17_16-27-09](https://user-images.githubusercontent.com/3970573/168913074-d54b4e95-5d5e-4063-98c9-c2c41d19aedf.png)

