### PR TITLE
[system] Fix `borderRadius` errors when used inside `CssVarsProvider`

### DIFF
--- a/packages/mui-material/src/styles/CssVarsProvider.test.js
+++ b/packages/mui-material/src/styles/CssVarsProvider.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen } from 'test/utils';
+import Box from '@mui/material/Box';
 import { Experimental_CssVarsProvider as CssVarsProvider, useTheme } from '@mui/material/styles';
 
 describe('[Material UI] CssVarsProvider', () => {
@@ -326,6 +327,42 @@ describe('[Material UI] CssVarsProvider', () => {
       );
 
       expect(container.firstChild?.textContent).not.to.equal('focus');
+    });
+  });
+
+  it("should use numeric values in system's spacing", function test() {
+    if (/jsdom/.test(window.navigator.userAgent) || !/WebKit/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const { getByTestId } = render(
+      <CssVarsProvider enableColorScheme enableSystem>
+        <Box
+          data-testid="box-1"
+          sx={{
+            borderRadius: '50%',
+          }}
+        />
+        <Box
+          data-testid="box-2"
+          sx={{
+            borderRadius: 4,
+          }}
+        />
+      </CssVarsProvider>,
+    );
+
+    expect(getByTestId('box-1')).toHaveComputedStyle({
+      borderTopLeftRadius: '50%',
+      borderTopRightRadius: '50%',
+      borderBottomLeftRadius: '50%',
+      borderBottomRightRadius: '50%',
+    });
+    expect(getByTestId('box-2')).toHaveComputedStyle({
+      borderTopLeftRadius: '16px',
+      borderTopRightRadius: '16px',
+      borderBottomLeftRadius: '16px',
+      borderBottomRightRadius: '16px',
     });
   });
 });

--- a/packages/mui-system/src/spacing.js
+++ b/packages/mui-system/src/spacing.js
@@ -93,11 +93,7 @@ const paddingKeys = [
 const spacingKeys = [...marginKeys, ...paddingKeys];
 
 export function createUnaryUnit(theme, themeKey, defaultValue, propName) {
-  let themeSpacing = getPath(theme, themeKey) ?? defaultValue;
-  if (typeof themeSpacing === 'string') {
-    // Check the non CSS var value
-    themeSpacing = getPath(theme, themeKey, false) ?? defaultValue;
-  }
+  const themeSpacing = getPath(theme, themeKey, false) ?? defaultValue;
 
   if (typeof themeSpacing === 'number') {
     return (abs) => {

--- a/packages/mui-system/src/spacing.js
+++ b/packages/mui-system/src/spacing.js
@@ -93,7 +93,11 @@ const paddingKeys = [
 const spacingKeys = [...marginKeys, ...paddingKeys];
 
 export function createUnaryUnit(theme, themeKey, defaultValue, propName) {
-  const themeSpacing = getPath(theme, themeKey) ?? defaultValue;
+  let themeSpacing = getPath(theme, themeKey) ?? defaultValue;
+  if (typeof themeSpacing === 'string') {
+    // Check the non CSS var value
+    themeSpacing = getPath(theme, themeKey, false) ?? defaultValue;
+  }
 
   if (typeof themeSpacing === 'number') {
     return (abs) => {

--- a/packages/mui-system/src/style.js
+++ b/packages/mui-system/src/style.js
@@ -2,13 +2,13 @@ import { unstable_capitalize as capitalize } from '@mui/utils';
 import responsivePropType from './responsivePropType';
 import { handleBreakpoints } from './breakpoints';
 
-export function getPath(obj, path) {
+export function getPath(obj, path, checkVars = true) {
   if (!path || typeof path !== 'string') {
     return null;
   }
 
   // Check if CSS variables are used
-  if (obj && obj.vars) {
+  if (obj && obj.vars && checkVars) {
     const val = `vars.${path}`
       .split('.')
       .reduce((acc, item) => (acc && acc[item] ? acc[item] : null), obj);


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/32804