### PR TITLE
[docs] Simplify header DOM structure

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -221,13 +221,11 @@ function createRender(context) {
           hash,
         });
       }
-      const headingId = `heading-${hash}`;
 
       return [
-        `<h${level} id="${headingId}">`,
-        `<span class="anchor-link" id="${hash}"></span>`,
+        `<h${level} id="${hash}">`,
         headingHtml,
-        `<a aria-labelledby="${headingId}" class="anchor-link-style" href="#${hash}" tabindex="-1">`,
+        `<a aria-labelledby="${hash}" class="anchor-link-style" href="#${hash}" tabindex="-1">`,
         '<svg><use xlink:href="#anchor-link-icon" /></svg>',
         '</a>',
         `</h${level}>`,

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -189,13 +189,11 @@ function getTranslatedHeader(t, header) {
 function Heading(props) {
   const { hash, level: Level = 'h2' } = props;
   const t = useTranslate();
-  const headingId = `heading-${hash}`;
 
   return (
-    <Level id={headingId}>
-      <span className="anchor-link" id={hash} />
+    <Level id={hash}>
       {getTranslatedHeader(t, hash)}
-      <a aria-labelledby={headingId} className="anchor-link-style" href={`#${hash}`} tabIndex={-1}>
+      <a aria-labelledby={hash} className="anchor-link-style" href={`#${hash}`} tabIndex={-1}>
         <svg>
           <use xlinkHref="#anchor-link-icon" />
         </svg>

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -27,7 +27,7 @@ const Main = styled('main', {
     },
   }),
   [theme.breakpoints.up('lg')]: {
-    width: `calc(100% - var(--MuiDocs-navDrawer-width))`,
+    width: 'calc(100% - var(--MuiDocs-navDrawer-width))',
   },
 }));
 
@@ -46,7 +46,7 @@ const StyledAppContainer = styled(AppContainer, {
     }),
     ...(!disableToc && {
       [theme.breakpoints.up('sm')]: {
-        width: `calc(100% - var(--MuiDocs-toc-width))`,
+        width: 'calc(100% - var(--MuiDocs-toc-width))',
       },
       [theme.breakpoints.up('lg')]: {
         paddingLeft: '60px',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -328,6 +328,7 @@ export default function AppSearch() {
 
                 let hash = parseUrl.hash;
 
+                // TODO: Remove after the next Algolia crawl
                 if (['lvl2', 'lvl3'].includes(item.type)) {
                   // remove '#heading-' from `href` url so that the link targets <span class="anchor-link"> inside <h2> or <h3>
                   // this will make the title appear under the Header

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -11,9 +11,6 @@ const Root = styled('div')(({ theme }) => ({
     color: theme.palette.mode === 'dark' ? theme.palette.grey[200] : theme.palette.text.primary,
   },
   wordBreak: 'break-word',
-  '& h2, & h3': {
-    scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
-  },
   '& pre': {
     margin: theme.spacing(2, 'auto'),
     padding: theme.spacing(2),
@@ -105,6 +102,7 @@ const Root = styled('div')(({ theme }) => ({
     }),
   },
   '& h1, & h2, & h3, & h4': {
+    scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
     '& code': {
       fontSize: 'inherit',
       lineHeight: 'inherit',

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -11,9 +11,8 @@ const Root = styled('div')(({ theme }) => ({
     color: theme.palette.mode === 'dark' ? theme.palette.grey[200] : theme.palette.text.primary,
   },
   wordBreak: 'break-word',
-  '& .anchor-link': {
-    marginTop: -96,
-    position: 'absolute',
+  '& h2, & h3': {
+    scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
   },
   '& pre': {
     margin: theme.spacing(2, 'auto'),


### PR DESCRIPTION
https://deploy-preview-32844--material-ui.netlify.app/material-ui/react-autocomplete/#grouped

This change goes in the same direction as https://github.com/twbs/bootstrap/pull/30273. It's about removing this DOM node for each header:

<img width="425" alt="Screenshot 2022-05-21 at 15 51 13" src="https://user-images.githubusercontent.com/3165635/169654696-5650870a-d129-4d8e-9e44-416f0d775e96.png">

From a browser support perspective, the use of `scroll-margin-top` seems all good: https://caniuse.com/mdn-css_properties_scroll-margin-top.

---

**Next**: I think that we should add a default value in the Typography for everybody, see https://github.com/mui/mui-store/pull/149.

For those who don't have access:

<img width="770" alt="Screenshot 2022-05-21 at 15 55 28" src="https://user-images.githubusercontent.com/3165635/169654874-723c2ab2-8d4d-4cc0-a92c-48c589d9b68f.png">