### PR TITLE
[website] Allow linking pricing FAQ

### DIFF
--- a/docs/src/components/pricing/EarlyBird.tsx
+++ b/docs/src/components/pricing/EarlyBird.tsx
@@ -9,7 +9,7 @@ import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRou
 
 export default function EarlyBird() {
   return (
-    <Container sx={{ pt: 2, pb: { xs: 2, sm: 4, md: 8 }, scrollMarginTop: '80px' }} id="early-bird">
+    <Container sx={{ pt: 2, pb: { xs: 2, sm: 4, md: 8 }, scrollMarginTop: 80 }} id="early-bird">
       <Stack
         sx={{
           borderRadius: 1,

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -229,7 +229,7 @@ export default function FAQ() {
   }
   return (
     <Container sx={{ py: { xs: 4, sm: 6, md: 8 } }}>
-      <Typography variant="h2" sx={{ mb: { xs: 2, sm: 4 } }}>
+      <Typography variant="h2" sx={{ mb: { xs: 2, sm: 4 }, scrollMarginTop: 80 }} id="faq">
         Frequently asked questions
       </Typography>
       <Grid container spacing={2}>


### PR DESCRIPTION
Make it possible to link the FAQ directly https://mui.com/pricing/#faq from https://mui.com/store/items/mui-x-pro/.

https://deploy-preview-32845--material-ui.netlify.app/pricing/#faq