### PR TITLE
[docs] Fix wrong link to Material Icons

### DIFF
--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -12,7 +12,7 @@ materialDesign: https://material.io/design/iconography/system-icons.html
 
 MUI provides icons support in three ways:
 
-1. Standardized [Material Design icons](#material-svg-icons) exported as React components (SVG icons).
+1. Standardized [Material Icons](#material-svg-icons) exported as React components (SVG icons).
 1. With the [SvgIcon](#svgicon) component, a React wrapper for custom SVG icons.
 1. With the [Icon](#icon-font-icons) component, a React wrapper for custom font icons.
 
@@ -152,7 +152,7 @@ import { ReactComponent as StarIcon } from './star.svg';
 
 ### createSvgIcon
 
-The `createSvgIcon` utility component is used to create the [Material icons](#material-icons). It can be used to wrap an SVG path with an SvgIcon component.
+The `createSvgIcon` utility component is used to create the [Material Icons](#material-icons). It can be used to wrap an SVG path with an SvgIcon component.
 
 ```jsx
 const HomeIcon = createSvgIcon(
@@ -186,7 +186,7 @@ Note: [mdi-material-ui](https://github.com/TeamWertarbyte/mdi-material-ui) has a
 
 The `Icon` component will display an icon from any icon font that supports ligatures.
 As a prerequisite, you must include one, such as the
-[Material icon font](https://google.github.io/material-design-icons/#icon-font-for-the-web) in your project.
+[Material Icons font](https://google.github.io/material-design-icons/#icon-font-for-the-web) in your project.
 To use an icon simply wrap the icon name (font ligature) with the `Icon` component,
 for example:
 
@@ -199,7 +199,7 @@ import Icon from '@mui/material/Icon';
 By default, an Icon will inherit the current text color.
 Optionally, you can set the icon color using one of the theme color properties: `primary`, `secondary`, `action`, `error` & `disabled`.
 
-### Font Material icons
+### Font Material Icons
 
 `Icon` will by default set the correct base class name for the Material Icons font (filled variant).
 All you need to do is load the font, for instance, via Google Web Fonts:
@@ -260,7 +260,7 @@ Then, you can use the two-tone font directly:
 
 {{"demo": "FontAwesomeIcon.js"}}
 
-Note that the Font Awesome icons weren't designed like the Material Design icons (compare the two previous demos).
+Note that the Font Awesome icons weren't designed like the Material Icons (compare the two previous demos).
 The fa icons are cropped to use all the space available. You can adjust for this with a global override:
 
 ```js

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -12,7 +12,7 @@ githubLabel: 'package: icons'
 
 The following npm package,
 [@mui/icons-material](https://www.npmjs.com/package/@mui/icons-material),
-includes the 2,000+ official [Material icons](https://fonts.google.com/icons) converted to [`SvgIcon`](/material-ui/api/svg-icon/) components.
+includes the 2,000+ official [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to [`SvgIcon`](/material-ui/api/svg-icon/) components.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -51,7 +51,7 @@ For instance, via Google Web Fonts:
 
 ## Font icons
 
-To use the font `Icon` component, you must first add the [Material icons](https://fonts.google.com/icons) font.
+To use the font `Icon` component, you must first add the [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) font.
 Here are [some instructions](/material-ui/icons/#font-icons)
 on how to do so.
 For instance, via Google Web Fonts:

--- a/packages/mui-icons-material/README.md
+++ b/packages/mui-icons-material/README.md
@@ -1,6 +1,6 @@
 # @mui/icons-material
 
-This package provides the Google [Material icons](https://fonts.google.com/icons) packaged as a set of [React](https://facebook.github.io/react/) components.
+This package provides the Google [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to [`SvgIcon`](https://mui.com/material-ui/api/svg-icon/) components.
 
 ## Installation
 
@@ -35,8 +35,8 @@ yarn add @mui/material
 
 <!-- #default-branch-switch -->
 
-- [The documentation](https://mui.com/components/icons/#svg-material-icons)
-- [The icons search](https://mui.com/components/material-icons/)
+- [The documentation](https://mui.com/material-ui/icons/#svgicon)
+- [The icons search](https://mui.com/material-ui/material-icons/)
 
 ## Contributing
 


### PR DESCRIPTION
https://fonts.google.com/icons now shows Material Symbols by default, instead of Material Icons. This PR fixes this regression.

Related to #32846.

https://deploy-preview-32847--material-ui.netlify.app/material-ui/material-icons/