### PR TITLE
[docs] Add What doesn't count as a breaking change?

### DIFF
--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -39,7 +39,7 @@ v6 will completely remove the support of IE 11.
 
 <!-- #stable-snapshot -->
 
-MUI supports [Node.js](https://github.com/nodejs/node) starting with version 12.17 (or 12.0 with `--experimental-modules` enabled) for server-side rendering.
+MUI supports [Node.js](https://github.com/nodejs/node) starting with version 12.0 for server-side rendering.
 This aims to match the [LTS versions that are in maintenance](https://github.com/nodejs/Release#release-schedule) mode.
 
 ### CSS prefixing

--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -40,7 +40,7 @@ v6 will completely remove the support of IE 11.
 <!-- #stable-snapshot -->
 
 MUI supports [Node.js](https://github.com/nodejs/node) starting with version 12.0 for server-side rendering.
-This aims to match the [LTS versions that are in maintenance](https://github.com/nodejs/Release#release-schedule) mode.
+The objective is to support Node.js down to the [last version in maintenance mode](https://github.com/nodejs/Release#release-schedule).
 
 ### CSS prefixing
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -94,7 +94,7 @@ For teams and organizations that require additional support for older versions, 
 
 ### Long-term support (LTS)
 
-MUI will continue to give security updates and regressions support (for example, if there's any regression caused by Chrome, React, etc.) to the version prior to the current major until the next one is released.
+MUI will continue to provide security updates and regression support (for example, if there are any regressions caused by Chrome, React, etc.) to the version prior to the current major version.
 
 ## Deprecation practices
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -36,7 +36,7 @@ The version number is incremented based on the level of change included in the r
 
 ## What doesn't count as a breaking change?
 
-We call "breaking changes" those that require updating your codebase when upgrading to a new version, to the exception of:
+We call "breaking changes" those that require updating your codebase when upgrading to a new version, with the exception of:
 
 - **APIs starting with "unstable\_"**. These are provided as experimental features whose APIs we are not yet confident in.
   By releasing these with an `unstable_` prefix, we can iterate faster and get to a stable API sooner, or simply learn that we don't need the API/feature in the first place.
@@ -44,9 +44,9 @@ We call "breaking changes" those that require updating your codebase when upgrad
 - **Undocumented APIs and internal data structures**. If you access internal properties, there is no warranty. You are on your own.
 - **Development warnings**. Since these don't affect production behavior, we may add new warnings or modify existing warnings in between major versions.
   In fact, this is what allows us to reliably warn about upcoming breaking changes.
-- **Pre-releases versions**. We provide pre-releases versions as a way to test new features early, but we need the flexibility to make changes based on what we learn in the pre-release period.
+- **Pre-releases versions**. We provide pre-release versions as a way to test new features early, but we need the flexibility to make changes based on what we learn in the pre-release period.
   If you use these versions, note that APIs may change before the stable release.
-- **Small CSS changes**. Visual design changes that have a very low probability to negatively impact your UI are not considered breaking.
+- **Small CSS changes**. Visual design changes that have a very low probability of negatively impacting your UI are not considered breaking.
 
 In general, we don't release the above changes in patch releases.
 
@@ -58,7 +58,7 @@ In general, you can expect the following release cycle:
 
 - A **major** release every 12 months.
 - 1-3 **minor** releases for each major release.
-- A **patch** release every week (anytime for urgent bug fix).
+- A **patch** release every week (anytime for an urgent bug fix).
 
 ## Release schedule
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -17,19 +17,21 @@ You can use it to see what changes are coming and provide better feedback to MUI
 
 ## Versioning strategy
 
-Stability ensures that reusable components and libraries, tutorials, tools, and learned practices don't become obsolete unexpectedly. Stability is essential for the ecosystem around MUI to thrive.
+Stability ensures that reusable components and libraries, tutorials, tools, and learned practices don't become obsolete unexpectedly.
+Stability is essential for the ecosystem around MUI to thrive.
 
-This document contains the practices that are followed to provide you with a leading-edge UI library, balanced with stability, ensuring that future changes are always introduced in a predictable way.
+This document contains the practices that are followed to provide you with a leading-edge UI library, balanced with stability, ensuring that future changes are always introduced predictably.
 
 MUI follows [Semantic Versioning 2.0.0](https://semver.org/).
 MUI version numbers have three parts: `major.minor.patch`.
 The version number is incremented based on the level of change included in the release.
 
-- **Major releases** contain significant new features, some but minimal developer assistance is expected during the update. When updating to a new major release, you may need to run update scripts, refactor code, run additional tests, and learn new APIs.
+- **Major releases** contain significant new features, some but minimal developer assistance is expected during the update.
+  When updating to a new major release, you may need to run update scripts, refactor code, run additional tests, and learn new APIs.
 - **Minor releases** contain important new features.
-  Minor releases are fully backward-compatible; no developer assistance is expected during update, but you can optionally modify your apps and libraries to begin using new APIs, features, and capabilities that were added in the release.
+  Minor releases are fully backward-compatible; no developer assistance is expected during the update, but you can optionally modify your apps and libraries to begin using new APIs, features, and capabilities that were added in the release.
 - **Patch releases** are low risk, contain bug fixes and small new features.
-  No developer assistance is expected during update.
+  No developer assistance is expected during the update.
 
 ## Release frequency
 
@@ -39,16 +41,17 @@ In general, you can expect the following release cycle:
 
 - A **major** release every 12 months.
 - 1-3 **minor** releases for each major release.
-- A **patch** release every week (anytime for urgent bugfix).
+- A **patch** release every week (anytime for urgent bug fix).
 
 ## Release schedule
 
-| Date           | Version | Status   |
-| :------------- | :------ | :------- |
-| May 2018       | v1.0.0  | Released |
-| September 2018 | v3.0.0  | Released |
-| May 2019       | v4.0.0  | Released |
-| September 2021 | v5.0.0  | Released |
+| Date           | Version | Status           |
+| :------------- | :------ | :--------------- |
+| ?              | v6.0.0  | Work not started |
+| September 2021 | v5.0.0  | Released         |
+| May 2019       | v4.0.0  | Released         |
+| September 2018 | v3.0.0  | Released         |
+| May 2018       | v1.0.0  | Released         |
 
 You can follow the [milestones](https://github.com/mui/material-ui/milestones) for a more detailed overview.
 
@@ -76,16 +79,15 @@ For teams and organizations that require additional support for older versions, 
 
 ### Long-term support (LTS)
 
-MUI will continue to give security updates and regressions support (for example, if there's any regression caused by Chrome, React, etc) to the version prior to the current major until the next one is released.
+MUI will continue to give security updates and regressions support (for example, if there's any regression caused by Chrome, React, etc.) to the version prior to the current major until the next one is released.
 
 ## Deprecation practices
 
 Sometimes **"breaking changes"**, such as the removal of support for select APIs and features, are necessary.
-
 To make these transitions as easy as possible:
 
-- The number of breaking changes is minimized, and migration tools provided when possible.
-- The deprecation policy described below is followed, so that you have time to update your apps to the latest APIs and best practices.
+- The number of breaking changes is minimized, and migration tools are provided when possible (codemods).
+- The deprecation policy described below is followed so that you have time to update your apps to the latest APIs and best practices.
 
 ### Deprecation policy
 
@@ -93,3 +95,15 @@ To make these transitions as easy as possible:
 - When a deprecation is announced, recommended update path is provided.
 - Existing use of a stable API during the deprecation period is supported, so your code will keep working during that period.
 - Peer dependency updates (React) that require changes to your apps are only made in a major release.
+
+### What counts as a breaking change?
+
+In general, we don’t bump the major version number for changes to:
+
+- **APIs starting with unstable\_**. These are provided as experimental features whose APIs we are not yet confident in.
+  By releasing these with an `unstable_` prefix, we can iterate faster and get to a stable API sooner, or simply learn that we don't need the API/feature in the first place.
+- **Undocumented APIs and internal data structures**. If you access internal properties, there is no warranty. You are on your own.
+- **Development warnings**. Since these don’t affect production behavior, we may add new warnings or modify existing warnings in between major versions.
+  In fact, this is what allows us to reliably warn about upcoming breaking changes.
+- **Pre-releases versions**. We provide pre-releases versions as a way to test new features early, but we need the flexibility to make changes based on what we learn in the pre-release period.
+  If you use these versions, note that APIs may change before the stable release.

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -48,7 +48,6 @@ We call "breaking changes" those that require updating your codebase when upgrad
   If you use these versions, note that APIs may change before the stable release.
 - **Small CSS changes**. Visual design changes that have a very low probability of negatively impacting your UI are not considered breaking.
 
-
 ## Release frequency
 
 A regular schedule of releases helps you plan and coordinate your updates with the continuing evolution of MUI.

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -102,6 +102,7 @@ In general, we don’t bump the major version number for changes to:
 
 - **APIs starting with unstable\_**. These are provided as experimental features whose APIs we are not yet confident in.
   By releasing these with an `unstable_` prefix, we can iterate faster and get to a stable API sooner, or simply learn that we don't need the API/feature in the first place.
+- **APIs documented as experimental**. Same as the above.
 - **Undocumented APIs and internal data structures**. If you access internal properties, there is no warranty. You are on your own.
 - **Development warnings**. Since these don’t affect production behavior, we may add new warnings or modify existing warnings in between major versions.
   In fact, this is what allows us to reliably warn about upcoming breaking changes.

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -107,3 +107,4 @@ In general, we don’t bump the major version number for changes to:
   In fact, this is what allows us to reliably warn about upcoming breaking changes.
 - **Pre-releases versions**. We provide pre-releases versions as a way to test new features early, but we need the flexibility to make changes based on what we learn in the pre-release period.
   If you use these versions, note that APIs may change before the stable release.
+- **Small CSS changes**. Visual design changes that have a very low probability to negatively impact your UI are not considered breaking, we release them in minor releases.

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -96,7 +96,7 @@ To make these transitions as easy as possible:
 - Existing use of a stable API during the deprecation period is supported, so your code will keep working during that period.
 - Peer dependency updates (React) that require changes to your apps are only made in a major release.
 
-### What counts as a breaking change?
+### What doesn't count as a breaking change?
 
 In general, we don’t bump the major version number for changes to:
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -103,7 +103,7 @@ MUI will continue to give security updates and regressions support (for example,
 Sometimes "breaking changes", such as the removal of support for select APIs and features, are necessary.
 To make these transitions as easy as possible:
 
-- The number of breaking changes is minimized, and migration tools are provided when possible (codemods).
+- The number of breaking changes is minimized, and migration tools are provided when possible (e.g. codemods).
 - The deprecation policy described below is followed so that you have time to update your apps to the latest APIs and best practices.
 
 ### Deprecation policy

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -26,7 +26,7 @@ MUI follows [Semantic Versioning 2.0.0](https://semver.org/).
 MUI version numbers have three parts: `major.minor.patch`.
 The version number is incremented based on the level of change included in the release.
 
-- **Major releases** contain significant new features, some but minimal developer assistance is expected during the update.
+- **Major releases** contain significant new features, some developer assistance is expected during the update.
   These releases include [breaking changes](#what-doesnt-count-as-a-breaking-change).
   When updating to a new major release, you may need to run update scripts, refactor code, run additional tests, and learn new APIs.
 - **Minor releases** contain important new features.
@@ -48,7 +48,6 @@ We call "breaking changes" those that require updating your codebase when upgrad
   If you use these versions, note that APIs may change before the stable release.
 - **Small CSS changes**. Visual design changes that have a very low probability of negatively impacting your UI are not considered breaking.
 
-In general, we don't release the above changes in patch releases.
 
 ## Release frequency
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -27,11 +27,28 @@ MUI version numbers have three parts: `major.minor.patch`.
 The version number is incremented based on the level of change included in the release.
 
 - **Major releases** contain significant new features, some but minimal developer assistance is expected during the update.
+  These releases include [breaking changes](#what-doesnt-count-as-a-breaking-change).
   When updating to a new major release, you may need to run update scripts, refactor code, run additional tests, and learn new APIs.
 - **Minor releases** contain important new features.
   Minor releases are fully backward-compatible; no developer assistance is expected during the update, but you can optionally modify your apps and libraries to begin using new APIs, features, and capabilities that were added in the release.
 - **Patch releases** are low risk, contain bug fixes and small new features.
   No developer assistance is expected during the update.
+
+## What doesn't count as a breaking change?
+
+We call "breaking changes" those that require updating your codebase when upgrading to a new version, to the exception of:
+
+- **APIs starting with "unstable\_"**. These are provided as experimental features whose APIs we are not yet confident in.
+  By releasing these with an `unstable_` prefix, we can iterate faster and get to a stable API sooner, or simply learn that we don't need the API/feature in the first place.
+- **APIs documented as experimental**. Same as the above.
+- **Undocumented APIs and internal data structures**. If you access internal properties, there is no warranty. You are on your own.
+- **Development warnings**. Since these don't affect production behavior, we may add new warnings or modify existing warnings in between major versions.
+  In fact, this is what allows us to reliably warn about upcoming breaking changes.
+- **Pre-releases versions**. We provide pre-releases versions as a way to test new features early, but we need the flexibility to make changes based on what we learn in the pre-release period.
+  If you use these versions, note that APIs may change before the stable release.
+- **Small CSS changes**. Visual design changes that have a very low probability to negatively impact your UI are not considered breaking.
+
+In general, we don't release the above changes in patch releases.
 
 ## Release frequency
 
@@ -83,7 +100,7 @@ MUI will continue to give security updates and regressions support (for example,
 
 ## Deprecation practices
 
-Sometimes **"breaking changes"**, such as the removal of support for select APIs and features, are necessary.
+Sometimes "breaking changes", such as the removal of support for select APIs and features, are necessary.
 To make these transitions as easy as possible:
 
 - The number of breaking changes is minimized, and migration tools are provided when possible (codemods).
@@ -94,18 +111,3 @@ To make these transitions as easy as possible:
 - Deprecated features are announced in the changelog, and when possible, with warnings at runtime.
 - When a deprecation is announced, recommended update path is provided.
 - Existing use of a stable API during the deprecation period is supported, so your code will keep working during that period.
-- Peer dependency updates (React) that require changes to your apps are only made in a major release.
-
-### What doesn't count as a breaking change?
-
-In general, we don’t bump the major version number for changes to:
-
-- **APIs starting with unstable\_**. These are provided as experimental features whose APIs we are not yet confident in.
-  By releasing these with an `unstable_` prefix, we can iterate faster and get to a stable API sooner, or simply learn that we don't need the API/feature in the first place.
-- **APIs documented as experimental**. Same as the above.
-- **Undocumented APIs and internal data structures**. If you access internal properties, there is no warranty. You are on your own.
-- **Development warnings**. Since these don’t affect production behavior, we may add new warnings or modify existing warnings in between major versions.
-  In fact, this is what allows us to reliably warn about upcoming breaking changes.
-- **Pre-releases versions**. We provide pre-releases versions as a way to test new features early, but we need the flexibility to make changes based on what we learn in the pre-release period.
-  If you use these versions, note that APIs may change before the stable release.
-- **Small CSS changes**. Visual design changes that have a very low probability to negatively impact your UI are not considered breaking, we release them in minor releases.

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -94,7 +94,7 @@ For teams and organizations that require additional support for older versions, 
 
 ### Long-term support (LTS)
 
-MUI will continue to provide security updates and regression support (for example, if there are any regressions caused by Chrome, React, etc.) to the version prior to the current major version.
+MUI will continue to provide security updates and support for regressions for one version prior to the current major version, for example regressions caused by external factors such as browser updates, or changes to upstream dependencies.
 
 ## Deprecation practices
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -62,7 +62,7 @@ In general, you can expect the following release cycle:
 
 | Date           | Version | Status           |
 | :------------- | :------ | :--------------- |
-| ?              | v6.0.0  | Work not started |
+| TBA            | v6.0.0  | Work not started |
 | September 2021 | v5.0.0  | Released         |
 | May 2019       | v4.0.0  | Released         |
 | September 2018 | v3.0.0  | Released         |


### PR DESCRIPTION
https://deploy-preview-32850--material-ui.netlify.app/versions/#what-doesnt-count-as-a-breaking-change

This PR does some cleanup on the page and adds a `What doesn't count as a breaking change?` section. I have kept it simple. I didn't add anything new to how we function right now, it's copied from https://reactjs.org/docs/faq-versioning.html.

The work on this PR sparked ⚡️ from https://github.com/mui/mui-store/pull/165#discussion_r874910623. Terminology-wise, I think that we should push forward with this convention: "experimental" for docs and `unstable_` for API. 

As a next step, we can consider adding to the list of what is not warranting a major:

- Types changes
- Test changes because some low-level things changed
