### PR TITLE
[docs] New WAI-ARIA guidelines location

### DIFF
--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -3518,7 +3518,7 @@ Here are some highlights ✨:
 - [Buttons] Consolidate ripple props type declarations (#15843) @lychyi
 - [IconButton] Add disable ripple props (#15864) @lychyi
 - [ListItemText] Update classes type definitions (#15822) @davjo664
-- [Tabs] Hide scrollbar on MacOS (#15762) @Umerbhat
+- [Tabs] Hide scrollbar on macOS (#15762) @Umerbhat
 - [Tooltip] Fix alignment issues (#15811) @pkmnct
 - [styles] Add MuiLink to ComponentsPropsList (#15814) @stuartgrigg
 

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Button component and hook
 components: ButtonUnstyled
 githubLabel: 'component: button'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#button
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 ---
 
 # Unstyled button
@@ -43,7 +43,7 @@ You can even use SVGs, as the following demo illustrates:
 Similarly to the native HTML `<button>` element, the `ButtonUnstyled` component can't receive focus when it's disabled.
 This may reduce its accessibility, as screen readers won't be able to announce the existence and state of the button.
 
-The `focusableWhenDisabled` prop lets you change this behavior.  
+The `focusableWhenDisabled` prop lets you change this behavior.
 When this prop is set, the underlying button does not set the `disabled` prop.
 Instead, `aria-disabled` is used, which makes the button focusable.
 

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Menu components and hooks
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#menu
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
 packageName: '@mui/base'
 ---
 

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Modal component
 components: ModalUnstyled
 githubLabel: 'component: modal'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 packageName: '@mui/base'
 ---
 
@@ -113,7 +113,7 @@ If the user needs to interact with another part of the page—for example, to in
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#dialog_modal)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/)
 
 - All interactive elements must have an [accessible name](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby). Use the `aria-labelledby="id..."` to give your `Modal` component an accessible name.
   You can also use `aria-describedby="id..."` to provide a description of the `Modal`:
@@ -125,5 +125,5 @@ If the user needs to interact with another part of the page—for example, to in
   </Modal>
   ```
 
-- Follow the [WAI-ARIA authoring practices](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html) to help you set the initial focus on the most relevant element based on the content of the modal.
+- Follow the [WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/dialog.html) to help you set the initial focus on the most relevant element based on the content of the modal.
   > ⚠ **Note:** a modal window can sit on top of either the parent application, or another modal window. _All_ windows under the topmost modal are **inert**, meaning the user cannot interact with them. This can lead to [conflicting behaviors](#focus-trap).

--- a/docs/data/base/components/popper/popper.md
+++ b/docs/data/base/components/popper/popper.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Popper component
 components: PopperUnstyled
 githubLabel: 'component: Popper'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#tooltip
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 packageName: '@mui/base'
 ---
 

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Select components and hook
 components: SelectUnstyled, MultiSelectUnstyled, OptionUnstyled, OptionGroupUnstyled
 githubLabel: 'component: select'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#combobox
+waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html
 packageName: '@mui/base'
 ---
 

--- a/docs/data/base/components/slider/slider.md
+++ b/docs/data/base/components/slider/slider.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Slider component and hook
 components: SliderUnstyled
 githubLabel: 'component: slider'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#slider
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/
 packageName: '@mui/base'
 ---
 
@@ -53,7 +53,7 @@ To let users set the start and end of a range on a slider, provide an array of v
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/)
 
 The component handles most of the work necessary to make it accessible.
 However, you need to make sure that:

--- a/docs/data/base/components/switch/switch.md
+++ b/docs/data/base/components/switch/switch.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Switch component and hook
 components: SwitchUnstyled
 githubLabel: 'component: switch'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#switch
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/switch/
 packageName: '@mui/base'
 ---
 

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -3,7 +3,7 @@ product: base
 title: Unstyled React Tabs components
 components: TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
 githubLabel: 'component: tabs'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#tabpanel
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 packageName: '@mui/base'
 ---
 
@@ -57,7 +57,7 @@ The `TabUnstyled` component provides the `component` prop to handle this use cas
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#tabpanel)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
 
 The following steps are necessary to make the tab component suite accessible to assistive technology:
 
@@ -70,7 +70,7 @@ The demos below illustrate the proper use of ARIA labels.
 
 By default, when using keyboard navigation, the tab components open via **manual activation**—that is, the next panel is displayed only after the user activates the tab with either <kbd class="key">Space</kbd>, <kbd class="key">Enter</kbd>, or a mouse click.
 
-This is the preferable behavior for tabs in most cases, acccording to [the WAI-ARIA authoring practices](https://www.w3.org/TR/wai-aria-practices/#kbd_selection_follows_focus).
+This is the preferable behavior for tabs in most cases, acccording to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 Alternatively, you can set the panels to be displayed automatically when their corresponding tabs are in focus—this behavior of the selection following the focus is known as **automatic activation**.
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -2,7 +2,7 @@
 product: joy-ui
 title: React Button component
 githubLabel: 'component: button'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#button
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 unstyled: /base/react-button/
 ---
 

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -4,7 +4,7 @@ title: React Accordion component
 components: Accordion, AccordionActions, AccordionDetails, AccordionSummary
 githubLabel: 'component: accordion'
 materialDesign: https://material.io/archive/guidelines/components/expansion-panels.html
-waiAria: https://www.w3.org/TR/wai-aria-practices/#accordion
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/
 ---
 
 # Accordion
@@ -54,7 +54,7 @@ Be sure to identify bottlenecks first and then try out these optimization strate
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#accordion)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)
 
 For optimal accessibility we recommend setting `id` and `aria-controls` on the
 `AccordionSummary`. The `Accordion` will derive the necessary `aria-labelledby`

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -3,7 +3,7 @@ product: material-ui
 title: React Alert component
 components: Alert, AlertTitle
 githubLabel: 'component: alert'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#alert
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 ---
 
 # Alert
@@ -76,7 +76,7 @@ The `color` prop will override the default color for the specified severity.
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#alert)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/alert/)
 
 When the component is dynamically displayed, the content is automatically announced by most screen readers. At this time, screen readers do not inform users of alerts that are present when the page loads.
 

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -3,7 +3,7 @@ product: material-ui
 title: React Autocomplete component
 components: TextField, Popper, Autocomplete
 githubLabel: 'component: autocomplete'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#combobox
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
 ---
 
 # Autocomplete
@@ -346,7 +346,7 @@ If you provide a custom `ListboxComponent` prop, you need to make sure that the 
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#combobox)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
 
 We encourage the usage of a label for the textbox.
 The component implements the WAI-ARIA authoring practices.

--- a/docs/data/material/components/breadcrumbs/breadcrumbs.md
+++ b/docs/data/material/components/breadcrumbs/breadcrumbs.md
@@ -3,7 +3,7 @@ product: material-ui
 title: React Breadcrumbs component
 components: Breadcrumbs, Link, Typography
 githubLabel: 'component: breadcrumbs'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#breadcrumb
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/
 ---
 
 # Breadcrumbs
@@ -49,7 +49,7 @@ You can learn more about this in the [overrides documentation page](/material-ui
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#breadcrumb)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)
 
 Be sure to add a `aria-label` description on the `Breadcrumbs` component.
 

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -4,7 +4,7 @@ title: React Button component
 components: Button, IconButton, ButtonBase, LoadingButton
 materialDesign: https://material.io/components/buttons
 githubLabel: 'component: button'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#button
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 unstyled: /base/react-button/
 ---
 

--- a/docs/data/material/components/checkboxes/checkboxes.md
+++ b/docs/data/material/components/checkboxes/checkboxes.md
@@ -4,7 +4,7 @@ title: React Checkbox component
 components: Checkbox, FormControl, FormGroup, FormLabel, FormControlLabel
 materialDesign: https://material.io/components/selection-controls#checkboxes
 githubLabel: 'component: checkbox'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#checkbox
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 ---
 
 # Checkbox
@@ -90,7 +90,7 @@ You can learn more about this in the [overrides documentation page](/material-ui
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#checkbox)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/)
 
 - All form controls should have labels, and this includes radio buttons, checkboxes, and switches. In most cases, this is done by using the `<label>` element ([FormControlLabel](/material-ui/api/form-control-label/)).
 - When a label can't be used, it's necessary to add an attribute directly to the input component.

--- a/docs/data/material/components/css-baseline/css-baseline.md
+++ b/docs/data/material/components/css-baseline/css-baseline.md
@@ -89,7 +89,7 @@ const theme = createTheme({
 });
 ```
 
-Be aware, however, that using this utility (and customizing `-webkit-scrollbar`) forces MacOS to always show the scrollbar.
+Be aware, however, that using this utility (and customizing `-webkit-scrollbar`) forces macOS to always show the scrollbar.
 
 ### Color scheme
 

--- a/docs/data/material/components/dialogs/dialogs.md
+++ b/docs/data/material/components/dialogs/dialogs.md
@@ -4,7 +4,7 @@ title: React Dialog component
 components: Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Slide
 githubLabel: 'component: dialog'
 materialDesign: https://material.io/components/dialogs
-waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 ---
 
 # Dialog

--- a/docs/data/material/components/links/links.md
+++ b/docs/data/material/components/links/links.md
@@ -2,7 +2,7 @@
 product: material-ui
 components: Link
 githubLabel: 'component: link'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#link
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/link/
 ---
 
 # Links
@@ -45,7 +45,7 @@ Here is a [more detailed guide](/material-ui/guides/routing/#link).
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#link)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/link/)
 
 - When providing the content for the link, avoid generic descriptions like "click here" or "go to".
   Instead, use [specific descriptions](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).

--- a/docs/data/material/components/menus/menus.md
+++ b/docs/data/material/components/menus/menus.md
@@ -4,7 +4,7 @@ title: React Menu component
 components: Menu, MenuItem, MenuList, ClickAwayListener, Popover, Popper
 githubLabel: 'component: menu'
 materialDesign: https://material.io/components/menus
-waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
 unstyled: /base/react-menu/
 ---
 

--- a/docs/data/material/components/modal/modal.md
+++ b/docs/data/material/components/modal/modal.md
@@ -3,7 +3,7 @@ product: material-ui
 title: React Modal component
 components: Modal
 githubLabel: 'component: modal'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#dialog_modal
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 unstyled: /base/react-modal/
 ---
 
@@ -107,7 +107,7 @@ In the event the users need to interact with another part of the page, e.g. with
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#dialog_modal)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/)
 
 - Be sure to add `aria-labelledby="id..."`, referencing the modal title, to the `Modal`.
   Additionally, you may give a description of your modal with the `aria-describedby="id..."` prop on the `Modal`.
@@ -119,5 +119,5 @@ In the event the users need to interact with another part of the page, e.g. with
   </Modal>
   ```
 
-- The [WAI-ARIA authoring practices](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html) can help you set the initial focus on the most relevant element, based on your modal content.
+- The [WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/dialog.html) can help you set the initial focus on the most relevant element, based on your modal content.
 - Keep in mind that a "modal window" overlays on either the primary window or another modal window. Windows under a modal are **inert**. That is, users cannot interact with content outside an active modal window. This might create [conflicting behaviors](#focus-trap).

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -3,6 +3,7 @@ product: material-ui
 title: React Select component
 components: Select, NativeSelect
 githubLabel: 'component: select'
+waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html
 unstyled: /base/react-select/
 ---
 

--- a/docs/data/material/components/slider/slider.md
+++ b/docs/data/material/components/slider/slider.md
@@ -4,7 +4,7 @@ title: React Slider component
 components: Slider
 githubLabel: 'component: slider'
 materialDesign: https://material.io/components/sliders
-waiAria: https://www.w3.org/TR/wai-aria-practices/#slider
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/
 unstyled: /base/react-slider/
 ---
 
@@ -135,7 +135,7 @@ Increasing _x_ by one increases the represented value by factor _2_.
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#slider)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/)
 
 The component handles most of the work necessary to make it accessible.
 However, you need to make sure that:

--- a/docs/data/material/components/speed-dial/speed-dial.md
+++ b/docs/data/material/components/speed-dial/speed-dial.md
@@ -4,7 +4,7 @@ title: React Speed dial component
 components: SpeedDial, SpeedDialAction, SpeedDialIcon
 githubLabel: 'component: speed dial'
 materialDesign: https://material.io/components/buttons-floating-action-button#types-of-transitions
-waiAria: https://www.w3.org/TR/wai-aria-practices/#menubutton
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
 ---
 
 # Speed dial

--- a/docs/data/material/components/tables/tables.md
+++ b/docs/data/material/components/tables/tables.md
@@ -3,7 +3,7 @@ product: material-ui
 title: React Table component
 components: Table, TableBody, TableCell, TableContainer, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel
 githubLabel: 'component: table'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#table
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/table/
 materialDesign: https://material.io/components/data-tables
 ---
 

--- a/docs/data/material/components/tabs/tabs.md
+++ b/docs/data/material/components/tabs/tabs.md
@@ -4,7 +4,7 @@ title: React Tabs component
 components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
 githubLabel: 'component: tabs'
 materialDesign: https://material.io/components/tabs
-waiAria: https://www.w3.org/TR/wai-aria-practices/#tabpanel
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 unstyled: /base/react-tabs/
 ---
 
@@ -25,7 +25,7 @@ A basic example with tab panels.
 ## Experimental API
 
 `@mui/lab` offers utility components that inject props to implement accessible tabs
-following [WAI-ARIA authoring practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel).
+following [WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 {{"demo": "LabTabs.js"}}
 
@@ -139,7 +139,7 @@ Here is a [more detailed guide](/material-ui/guides/routing/#tabs).
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#tabpanel)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/)
 
 The following steps are needed in order to provide necessary information for assistive technologies:
 
@@ -153,7 +153,7 @@ extra work.
 ### Keyboard navigation
 
 The components implement keyboard navigation using the "manual activation" behavior. If you want to switch to the
-"selection automatically follows focus" behavior you have pass `selectionFollowsFocus` to the `Tabs` component. The WAI-ARIA authoring practices have a detailed guide on [how to decide when to make selection automatically follow focus](https://www.w3.org/TR/wai-aria-practices/#kbd_selection_follows_focus).
+"selection automatically follows focus" behavior you have pass `selectionFollowsFocus` to the `Tabs` component. The WAI-ARIA authoring practices have a detailed guide on [how to decide when to make selection automatically follow focus](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#x6-4-deciding-when-to-make-selection-automatically-follow-focus).
 
 #### Demo
 

--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -4,7 +4,7 @@ title: React Tooltip component
 components: Tooltip
 githubLabel: 'component: tooltip'
 materialDesign: https://material.io/components/tooltips
-waiAria: https://www.w3.org/TR/wai-aria-practices/#tooltip
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 ---
 
 # Tooltip
@@ -141,7 +141,7 @@ On mobile, the tooltip is displayed when the user longpresses the element and hi
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#tooltip)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)
 
 By default, the tooltip only labels its child element.
 This is notably different from `title` which can either label **or** describe its child depending on whether the child already has a label.

--- a/docs/data/material/components/tree-view/tree-view.md
+++ b/docs/data/material/components/tree-view/tree-view.md
@@ -3,7 +3,7 @@ product: material-ui
 title: Tree view React component
 components: TreeView, TreeItem
 githubLabel: 'component: tree view'
-waiAria: https://www.w3.org/TR/wai-aria-practices/#TreeView
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
 packageName: '@mui/lab'
 ---
 
@@ -101,7 +101,7 @@ If it is true:
 
 ## Accessibility
 
-(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#TreeView)
+(WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/)
 
 The component follows the WAI-ARIA authoring practices.
 

--- a/docs/pages/blog/2020-q2-update.md
+++ b/docs/pages/blog/2020-q2-update.md
@@ -48,7 +48,7 @@ Here are the most significant improvements since March 2020:
   After English, Chinese, and Brazilian, the languages that would benefit the most from translation are **Russian** and **Spanish**.<br />
   Feel free to [get stuck into](https://translate.mui.com/) if you are a native speaker and able to give a hand with either of these two languages.
 
-- 🗂 A new extension of the Tab API [in the lab](/material-ui/react-tabs/#experimental-api) implements accessible tabs following [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tabpanel) authoring practices.
+- 🗂 A new extension of the Tab API [in the lab](/material-ui/react-tabs/#experimental-api) implements accessible tabs following [WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) authoring practices.
 
 ```jsx
 <TabContext value={value}>

--- a/docs/translations/api-docs/menu-list/menu-list.json
+++ b/docs/translations/api-docs/menu-list/menu-list.json
@@ -1,5 +1,5 @@
 {
-  "componentDescription": "A permanently displayed menu following https://www.w3.org/TR/wai-aria-practices/#menubutton.\nIt's exposed to help customization of the [`Menu`](/material-ui/api/menu/) component if you\nuse it separately you need to move focus into the component manually. Once\nthe focus is placed inside the component it is fully keyboard accessible.",
+  "componentDescription": "A permanently displayed menu following https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/.\nIt's exposed to help customization of the [`Menu`](/material-ui/api/menu/) component if you\nuse it separately you need to move focus into the component manually. Once\nthe focus is placed inside the component it is fully keyboard accessible.",
   "propDescriptions": {
     "autoFocus": "If <code>true</code>, will focus the <code>[role=&quot;menu&quot;]</code> container and move into tab order.",
     "autoFocusItem": "If <code>true</code>, will focus the first menuitem if <code>variant=&quot;menu&quot;</code> or selected item if <code>variant=&quot;selectedMenu&quot;</code>.",

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -356,7 +356,7 @@ export default function useAutocomplete(props) {
     }
 
     // Scroll active descendant into view.
-    // Logic copied from https://www.w3.org/TR/wai-aria-practices/examples/listbox/js/listbox.js
+    // Logic copied from https://www.w3.org/WAI/ARIA/apg/example-index/combobox/js/select-only.js
     //
     // Consider this API instead once it has a better browser support:
     // .scrollIntoView({ scrollMode: 'if-needed', block: 'nearest' });

--- a/packages/mui-lab/src/TreeItem/TreeItem.js
+++ b/packages/mui-lab/src/TreeItem/TreeItem.js
@@ -256,7 +256,7 @@ const TreeItem = React.forwardRef(function TreeItem(inProps, ref) {
      *
      * If the tree does not support multiple selection, aria-selected
      * is set to true for the selected node and it is not present on any other node in the tree.
-     * Source: https://www.w3.org/TR/wai-aria-practices/#TreeView
+     * Source: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
      */
     ariaSelected = true;
   }

--- a/packages/mui-material-next/src/Tabs/Tabs.js
+++ b/packages/mui-material-next/src/Tabs/Tabs.js
@@ -106,7 +106,7 @@ const TabsScroller = styled('div', {
     width: '100%',
   }),
   ...(ownerState.hideScrollbar && {
-    // Hide dimensionless scrollbar on MacOS
+    // Hide dimensionless scrollbar on macOS
     scrollbarWidth: 'none', // Firefox
     '&::-webkit-scrollbar': {
       display: 'none', // Safari + Chrome
@@ -151,7 +151,7 @@ const TabsScrollbarSize = styled(ScrollbarSize, {
 })({
   overflowX: 'auto',
   overflowY: 'hidden',
-  // Hide dimensionless scrollbar on MacOS
+  // Hide dimensionless scrollbar on macOS
   scrollbarWidth: 'none', // Firefox
   '&::-webkit-scrollbar': {
     display: 'none', // Safari + Chrome

--- a/packages/mui-material/src/MenuList/MenuList.d.ts
+++ b/packages/mui-material/src/MenuList/MenuList.d.ts
@@ -42,7 +42,7 @@ export type MenuListTypeMap<P = {}, D extends React.ElementType = 'ul'> = Extend
 export type MenuListClassKey = keyof NonNullable<MenuListTypeMap['props']['classes']>;
 
 /**
- * A permanently displayed menu following https://www.w3.org/TR/wai-aria-practices/#menubutton.
+ * A permanently displayed menu following https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/.
  * It's exposed to help customization of the [`Menu`](https://mui.com/material-ui/api/menu/) component if you
  * use it separately you need to move focus into the component manually. Once
  * the focus is placed inside the component it is fully keyboard accessible.

--- a/packages/mui-material/src/MenuList/MenuList.js
+++ b/packages/mui-material/src/MenuList/MenuList.js
@@ -87,7 +87,7 @@ function moveFocus(
 }
 
 /**
- * A permanently displayed menu following https://www.w3.org/TR/wai-aria-practices/#menubutton.
+ * A permanently displayed menu following https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/.
  * It's exposed to help customization of the [`Menu`](/material-ui/api/menu/) component if you
  * use it separately you need to move focus into the component manually. Once
  * the focus is placed inside the component it is fully keyboard accessible.

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -308,8 +308,8 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         ' ',
         'ArrowUp',
         'ArrowDown',
-        // The native select doesn't respond to enter on MacOS, but it's recommended by
-        // https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
+        // The native select doesn't respond to enter on macOS, but it's recommended by
+        // https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html
         'Enter',
       ];
 

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -152,7 +152,7 @@ const TabsScroller = styled('div', {
     width: '100%',
   }),
   ...(ownerState.hideScrollbar && {
-    // Hide dimensionless scrollbar on MacOS
+    // Hide dimensionless scrollbar on macOS
     scrollbarWidth: 'none', // Firefox
     '&::-webkit-scrollbar': {
       display: 'none', // Safari + Chrome
@@ -218,7 +218,7 @@ const TabsScrollbarSize = styled(ScrollbarSize, {
 })({
   overflowX: 'auto',
   overflowY: 'hidden',
-  // Hide dimensionless scrollbar on MacOS
+  // Hide dimensionless scrollbar on macOS
   scrollbarWidth: 'none', // Firefox
   '&::-webkit-scrollbar': {
     display: 'none', // Safari + Chrome


### PR DESCRIPTION
This changed with https://twitter.com/w3c_wai/status/1527321803634274310 last week. Same as https://github.com/mui/mui-x/pull/4957

e.g. https://deploy-preview-32865--material-ui.netlify.app/base/react-select/