### PR TITLE
[Joy] Show Joy pages on master

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -20,9 +20,13 @@ const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDep
 
 const staging =
   process.env.REPOSITORY_URL === undefined || /mui\/material-ui$/.test(process.env.REPOSITORY_URL);
+
 if (staging) {
   // eslint-disable-next-line no-console
   console.log(`Staging deploy of ${process.env.REPOSITORY_URL || 'local repository'}`);
+} else {
+  // eslint-disable-next-line no-console
+  console.log('process.env.REPOSITORY_URL', process.env.REPOSITORY_URL);
 }
 
 module.exports = {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -171,7 +171,6 @@ module.exports = {
     PULL_REQUEST: process.env.PULL_REQUEST === 'true',
     REACT_STRICT_MODE: reactStrictMode,
     FEEDBACK_URL: process.env.FEEDBACK_URL,
-    SITE_NAME: process.env.SITE_NAME,
     // #default-branch-switch
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui/material-ui/blob/master',
     SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -190,11 +190,7 @@ module.exports = {
         if (process.env.PULL_REQUEST !== 'true' && page.pathname.startsWith('/experiments')) {
           return;
         }
-        if (
-          page.pathname.startsWith('/joy-ui') &&
-          process.env.PULL_REQUEST !== 'true' &&
-          !FEATURE_TOGGLE.enable_joy_scope
-        ) {
+        if (page.pathname.startsWith('/joy-ui') && !FEATURE_TOGGLE.enable_joy_scope) {
           return;
         }
         // The blog is not translated

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -19,14 +19,13 @@ const isDeployPreview = process.env.PULL_REQUEST === 'true';
 const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDeploy;
 
 const staging =
-  process.env.REPOSITORY_URL === undefined || /mui\/material-ui$/.test(process.env.REPOSITORY_URL);
+  process.env.REPOSITORY_URL === undefined ||
+  // The linked repository url comes from https://app.netlify.com/sites/material-ui/settings/deploys
+  /mui-org\/material-ui$/.test(process.env.REPOSITORY_URL);
 
 if (staging) {
   // eslint-disable-next-line no-console
   console.log(`Staging deploy of ${process.env.REPOSITORY_URL || 'local repository'}`);
-} else {
-  // eslint-disable-next-line no-console
-  console.log('process.env.REPOSITORY_URL', process.env.REPOSITORY_URL);
 }
 
 module.exports = {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -171,6 +171,7 @@ module.exports = {
     PULL_REQUEST: process.env.PULL_REQUEST === 'true',
     REACT_STRICT_MODE: reactStrictMode,
     FEEDBACK_URL: process.env.FEEDBACK_URL,
+    SITE_NAME: process.env.SITE_NAME,
     // #default-branch-switch
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui/material-ui/blob/master',
     SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -187,10 +187,10 @@ module.exports = {
       const prefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
 
       pages2.forEach((page) => {
-        if (process.env.PULL_REQUEST !== 'true' && page.pathname.startsWith('/experiments')) {
+        if (page.pathname.startsWith('/experiments') && !staging) {
           return;
         }
-        if (page.pathname.startsWith('/joy-ui') && !FEATURE_TOGGLE.enable_joy_scope) {
+        if (page.pathname.startsWith('/joy-ui') && !staging) {
           return;
         }
         // The blog is not translated

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -10,8 +10,5 @@ module.exports = {
   enable_mui_base_scope: true, // will be enabled after the migration
   enable_system_scope: true, // will be enabled after the migration
   enable_joy_scope:
-    process.env.NODE_ENV === 'development' ||
-    // material-ui site, works for all branches and pull requests
-    // ref: https://app.netlify.com/sites/material-ui/settings/general
-    process.env.SITE_ID === '64f32322-7c26-4008-b886-60800cd747b0',
+    process.env.NODE_ENV === 'development' || process.env.SITE_NAME === 'material-ui', // staging site
 };

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -9,6 +9,5 @@ module.exports = {
   enable_redirects: true, // related to new structure change
   enable_mui_base_scope: true, // will be enabled after the migration
   enable_system_scope: true, // will be enabled after the migration
-  enable_joy_scope:
-    process.env.NODE_ENV === 'development' || process.env.SITE_NAME === 'material-ui', // staging site
+  enable_joy_scope: process.env.NODE_ENV === 'development' || process.env.STAGING === true,
 };

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -9,5 +9,9 @@ module.exports = {
   enable_redirects: true, // related to new structure change
   enable_mui_base_scope: true, // will be enabled after the migration
   enable_system_scope: true, // will be enabled after the migration
-  enable_joy_scope: false,
+  enable_joy_scope:
+    process.env.NODE_ENV === 'development' ||
+    // material-ui site, works for all branches and pull requests
+    // ref: https://app.netlify.com/sites/material-ui/settings/general
+    process.env.SITE_ID === '64f32322-7c26-4008-b886-60800cd747b0',
 };

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -34,16 +34,11 @@ import systemPkgJson from '../../../../packages/mui-system/package.json';
 
 const savedScrollTop = {};
 
-const shouldShowJoy =
-  process.env.NODE_ENV === 'development' ||
-  process.env.PULL_REQUEST ||
-  FEATURE_TOGGLE.enable_joy_scope;
-
 const LinksWrapper = styled('div')(({ theme }) => {
   return {
     paddingLeft: theme.spacing(5.5),
     paddingTop: theme.spacing(1.5),
-    height: shouldShowJoy ? 162 : 124,
+    height: FEATURE_TOGGLE.enable_joy_scope ? 162 : 124,
     '& > a': {
       position: 'relative',
       display: 'flex',
@@ -218,7 +213,7 @@ function ProductDrawerButton(props) {
                 {"React components that implement Google's Material Design."}
               </Typography>
             </Link>
-            {shouldShowJoy && (
+            {FEATURE_TOGGLE.enable_joy_scope && (
               <Link href={ROUTES.joyDocs} sx={{ my: -0.5 }}>
                 <ProductLabel>Joy UI</ProductLabel>
                 <Typography color="text.secondary" variant="body2">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

@oliviertassinari pointed out that Joy pages should appear on the master branch (https://material-ui.netlify.app/) so that we can check them out (currently, they appear only on the pull requests which is not convenient to look at).

By using the existing `staging` environment variable.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
