### PR TITLE
[system] Add `getColorSchemeSelector` util

### DIFF
--- a/docs/pages/experiments/joy/style-guide.tsx
+++ b/docs/pages/experiments/joy/style-guide.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Container from '@mui/material/Container';
+import Container from '@mui/joy/Container';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Typography from '@mui/joy/Typography';

--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -69,6 +69,7 @@ export interface Theme extends ThemeScales, RuntimeColorSystem {
     field: ThemeCSSVar | CustomVar,
     ...vars: (ThemeCSSVar | CustomVar)[]
   ) => string;
+  getColorSchemeSelector: (colorScheme: DefaultColorScheme | ExtendedColorScheme) => string;
 }
 
 export type SxProps = SystemSxProps<Theme>;

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -120,6 +120,7 @@ export default function createCssVarsProvider(options) {
       prefix,
       vars: rootVars,
       getCssVar: createGetCssVar(prefix),
+      getColorSchemeSelector: (targetColorScheme) => `[${attribute}="${targetColorScheme}"] &`,
     };
 
     const styleSheet = {};

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -122,19 +122,20 @@ describe('createCssVarsProvider', () => {
           colorSchemes: { light: { palette: { primary: { 500: '#ff5252' } } } },
         },
         defaultColorScheme: 'light',
-        prefix: 'mui',
       });
       const Text = () => {
         const theme = useTheme();
         return <div data-testid={`text`}>{theme.getColorSchemeSelector('light')}</div>;
       };
       render(
-        <CssVarsProvider>
+        <CssVarsProvider attribute="data-custom-color-scheme">
           <Text />
         </CssVarsProvider>,
       );
 
-      expect(screen.getByTestId('text').textContent).to.equal('[data-mui-color-scheme="light"] &');
+      expect(screen.getByTestId('text').textContent).to.equal(
+        '[data-custom-color-scheme="light"] &',
+      );
     });
 
     it('can access to allColorSchemes', () => {

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -116,6 +116,27 @@ describe('createCssVarsProvider', () => {
       expect(screen.getByTestId('text').textContent).to.equal('var(--mui-palette-primary-500)');
     });
 
+    it('provide getColorSchemeSelector util', () => {
+      const { CssVarsProvider } = createCssVarsProvider({
+        theme: {
+          colorSchemes: { light: { palette: { primary: { 500: '#ff5252' } } } },
+        },
+        defaultColorScheme: 'light',
+        prefix: 'mui',
+      });
+      const Text = () => {
+        const theme = useTheme();
+        return <div data-testid={`text`}>{theme.getColorSchemeSelector('light')}</div>;
+      };
+      render(
+        <CssVarsProvider>
+          <Text />
+        </CssVarsProvider>,
+      );
+
+      expect(screen.getByTestId('text').textContent).to.equal('[data-mui-color-scheme="light"] &');
+    });
+
     it('can access to allColorSchemes', () => {
       const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
         theme: {

--- a/test/regressions/fixtures/CssVarsProvider/ColorSchemeSelector.js
+++ b/test/regressions/fixtures/CssVarsProvider/ColorSchemeSelector.js
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { unstable_createCssVarsProvider as createCssVarsProvider, createBox } from '@mui/system';
+
+const Box = createBox();
+
+const { CssVarsProvider } = createCssVarsProvider({
+  theme: {
+    colorSchemes: {
+      light: {
+        background: {
+          default: '#fff',
+        },
+      },
+    },
+  },
+  defaultColorScheme: {
+    light: 'light',
+  },
+});
+
+export default function DarkModeSpecificity() {
+  return (
+    <CssVarsProvider modeStorageKey="dark-mode-specificity">
+      <Box
+        sx={(theme) => ({
+          p: 2,
+          color: '#fff',
+          [theme.getColorSchemeSelector('light')]: {
+            bgcolor: '#000',
+          },
+        })}
+      >
+        Background should be #000.
+      </Box>
+    </CssVarsProvider>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From https://github.com/mui/material-ui/pull/32835/files#r877687572, this PR adds a simple util to prevent hard-coded style like this:

```js
styled('div')(({ theme }) => ({
  [theme.getColorSchemeSelector('dark')]: {
     // becomes '[data-mui-color-scheme="dark"] &'
     ...styles for dark mode
  }
})
```

without this util, the bug appears when developers provide a custom attribute to `CssVarsProvider`:

```js
<CssVarsProvider attribute="data-company-color-scheme">

// HTML
<html data-company-color-scheme="dark">
```

Unit and regression tests are added.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
