### PR TITLE
[system] Simplify stylesheet injection logic

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -122,7 +122,8 @@ export default function createCssVarsProvider(options) {
       getCssVar: createGetCssVar(prefix),
     };
 
-    const styleSheet = {};
+    const defaultColorSchemeStyleSheet = {};
+    const otherColorSchemesStyleSheet = {};
 
     Object.entries(colorSchemes).forEach(([key, scheme]) => {
       const {
@@ -156,10 +157,10 @@ export default function createCssVarsProvider(options) {
         return defaultColorScheme.light;
       })();
       if (key === resolvedDefaultColorScheme) {
-        styleSheet[colorSchemeSelector] = css;
+        defaultColorSchemeStyleSheet[colorSchemeSelector] = css;
       } else {
-        styleSheet[
-          `${colorSchemeSelector === ':root' ? 'html' : colorSchemeSelector}[${attribute}="${key}"]`
+        otherColorSchemesStyleSheet[
+          `${colorSchemeSelector === ':root' ? '' : colorSchemeSelector}[${attribute}="${key}"]`
         ] = css;
       }
     });
@@ -228,7 +229,8 @@ export default function createCssVarsProvider(options) {
         }}
       >
         <GlobalStyles styles={{ [colorSchemeSelector]: rootCss }} />
-        <GlobalStyles styles={styleSheet} />
+        <GlobalStyles styles={defaultColorSchemeStyleSheet} />
+        <GlobalStyles styles={otherColorSchemesStyleSheet} />
         <ThemeProvider theme={resolveTheme ? resolveTheme(theme) : theme}>{children}</ThemeProvider>
       </ColorSchemeContext.Provider>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Due to #32628, the stylesheet creation is forced to be:

```js
html[data-mui-color-scheme="dark"] { ... }
```

Other elements can't leverage the stylesheet because it is fixed to `html`. I think the better way is to make sure that the default color scheme stylesheet is injected before the rest of the color schemes (which is the change in this PR).

We have a regression test covered, so I will merge once the CIs are green. cc @mnajdova 

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
