### PR TITLE
[Masonry] Place items to the left when there is less object than specified in `column` prop

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -16,6 +16,13 @@ export const parseToNumber = (val) => {
   return Number(val.replace('px', ''));
 };
 
+const lineBreakStyle = {
+  flexBasis: '100%',
+  width: 0,
+  margin: 0,
+  padding: 0,
+};
+
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
 
@@ -39,6 +46,7 @@ export const getStyle = ({ ownerState, theme }) => {
   };
 
   const stylesSSR = {};
+  // Only applicable for Server-Side Rendering
   if (ownerState.isSSR) {
     const orderStyleSSR = {};
     const defaultSpacing = Number(theme.spacing(ownerState.defaultSpacing).replace('px', ''));
@@ -263,12 +271,6 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
   }, [columns, spacing, children]);
 
   const handleRef = useForkRef(ref, masonryRef);
-  const lineBreakStyle = {
-    flexBasis: '100%',
-    width: 0,
-    margin: 0,
-    padding: 0,
-  };
 
   //  columns are likely to have different heights and hence can start to merge;
   //  a line break at the end of each column prevents columns from merging

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -38,7 +38,7 @@ export const getStyle = ({ ownerState, theme }) => {
     width: '100%',
     display: 'flex',
     flexFlow: 'column wrap',
-    alignContent: 'space-between',
+    alignContent: 'flex-start',
     boxSizing: 'border-box',
     '& > *': {
       boxSizing: 'border-box',

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -47,7 +47,7 @@ describe('<Masonry />', () => {
         display: 'flex',
         flexDirection: 'column',
         flexWrap: 'wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         marginTop: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
         marginRight: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
@@ -132,7 +132,7 @@ describe('<Masonry />', () => {
         width: '100%',
         display: 'flex',
         flexFlow: 'column wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
@@ -160,7 +160,7 @@ describe('<Masonry />', () => {
         width: '100%',
         display: 'flex',
         flexFlow: 'column wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
@@ -209,7 +209,7 @@ describe('<Masonry />', () => {
         width: '100%',
         display: 'flex',
         flexFlow: 'column wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
@@ -255,7 +255,7 @@ describe('<Masonry />', () => {
         width: '100%',
         display: 'flex',
         flexFlow: 'column wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
@@ -289,7 +289,7 @@ describe('<Masonry />', () => {
         width: '100%',
         display: 'flex',
         flexFlow: 'column wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
@@ -333,7 +333,7 @@ describe('<Masonry />', () => {
         width: '100%',
         display: 'flex',
         flexFlow: 'column wrap',
-        alignContent: 'space-between',
+        alignContent: 'flex-start',
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
