### PR TITLE
[core] Avoid leaking @babel/runtime

### DIFF
--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -81,7 +81,7 @@ export default function SandboxDependencies(
         newDeps['@mui/material'] = versions['@mui/material'];
       }
 
-      // TODO: Where is this coming from and why does it need to be injected this way.
+      // TODO: consider if this configuration could be injected in a "cleaner" way.
       if ((window as any).muiDocConfig) {
         newDeps = (window as any).muiDocConfig.csbIncludePeerDependencies(newDeps, { versions });
       }
@@ -108,7 +108,7 @@ export default function SandboxDependencies(
       '@mui/joy': getMuiPackageVersion('joy'),
     };
 
-    // TODO: Where is this coming from and why does it need to be injected this way.
+    // TODO: consider if this configuration could be injected in a "cleaner" way.
     if ((window as any).muiDocConfig) {
       const muiCommitRef = process.env.PULL_REQUEST ? process.env.COMMIT_REF : undefined;
       versions = (window as any).muiDocConfig.csbGetVersions(versions, { muiCommitRef });

--- a/docs/src/modules/sandbox/StackBlitz.test.js
+++ b/docs/src/modules/sandbox/StackBlitz.test.js
@@ -39,7 +39,6 @@ describe('StackBlitz', () => {
           "import * as React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
       },
       dependencies: {
-        '@babel/runtime': 'latest',
         react: 'latest',
         '@mui/material': 'latest',
         'react-dom': 'latest',
@@ -73,7 +72,6 @@ describe('StackBlitz', () => {
           '{\n  "compilerOptions": {\n    "target": "es5",\n    "lib": [\n      "dom",\n      "dom.iterable",\n      "esnext"\n    ],\n    "allowJs": true,\n    "skipLibCheck": true,\n    "esModuleInterop": true,\n    "allowSyntheticDefaultImports": true,\n    "strict": true,\n    "forceConsistentCasingInFileNames": true,\n    "module": "esnext",\n    "moduleResolution": "node",\n    "resolveJsonModule": true,\n    "isolatedModules": true,\n    "noEmit": true,\n    "jsx": "react"\n  },\n  "include": [\n    "src"\n  ]\n}\n',
       },
       dependencies: {
-        '@babel/runtime': 'latest',
         react: 'latest',
         '@mui/material': 'latest',
         'react-dom': 'latest',

--- a/docs/src/modules/sandbox/StackBlitz.ts
+++ b/docs/src/modules/sandbox/StackBlitz.ts
@@ -27,8 +27,6 @@ const createReactApp = (demo: {
     // commitRef: process.env.PULL_REQUEST ? process.env.COMMIT_REF : undefined,
   });
 
-  dependencies['@babel/runtime'] = 'latest';
-
   return {
     title,
     description,


### PR DESCRIPTION
Test that we don't need this dependency. https://deploy-preview-32874--material-ui.netlify.app/material-ui/react-checkbox/

As a side note, the version of `@babel/runtime` must be compatible with the version of `@babel/plugin-transform-runtime` used. Leaving "latest" might create bugs

This is a quick follow-up on #32726 (happy that we now better support Joy & Base :)