### PR TITLE
[core] Add CI check that the PR has label

### DIFF
--- a/.github/workflows/check-if-pr-has-label.yml
+++ b/.github/workflows/check-if-pr-has-label.yml
@@ -1,0 +1,16 @@
+name: Check if PR has label
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled]
+
+jobs:
+  test-label-applied:
+  # Tests that label is added on the PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mnajdova/github-action-required-labels@v2.0
+        with:
+          mode: minimum
+          count: 1
+          labels: ""


### PR DESCRIPTION
Tested in https://github.com/dimovi91/material-ui/pull/10, but apparently can also be tested on the PR itself :)) 

For the check, I've forked https://github.com/mheap/github-action-required-labels and added option for checking just minimum num of labels without needing to specify list of labels that should be applied.