### PR TITLE
[useAutocomplete] Fix unable to use the arrows key to select a list item in Firefox + VoiceOver

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -869,6 +869,16 @@ export default function useAutocomplete(props) {
       return;
     }
 
+    // Ignore the even when using Firefox + VoiceOver
+    if (
+      listboxRef.current !== null &&
+      event.relatedTarget &&
+      listboxRef.current.contains(event.relatedTarget)
+    ) {
+      setTimeout(() => inputRef.current.focus(), 0);
+      return;
+    }
+
     setFocused(false);
     firstFocus.current = true;
     ignoreFocus.current = false;


### PR DESCRIPTION
This PR fix for the issue https://github.com/mui/material-ui/issues/32892
