### PR TITLE
[TabUnstyled] Define ownerState and slot props' types

### DIFF
--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.spec.tsx
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.spec.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import TabUnstyled, { TabUnstyledRootSlotProps } from '@mui/base/TabUnstyled';
+
+function Root(props: TabUnstyledRootSlotProps) {
+  const { ownerState, ...other } = props;
+  return <div data-active={ownerState.active} {...other} />;
+}
+
+const styledTab = <TabUnstyled components={{ Root }} />;

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx
@@ -6,8 +6,10 @@ import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import composeClasses from '../composeClasses';
 import appendOwnerState from '../utils/appendOwnerState';
 import { getTabUnstyledUtilityClass } from './tabUnstyledClasses';
-import TabUnstyledProps, { TabUnstyledTypeMap } from './TabUnstyledProps';
+import { TabUnstyledProps, TabUnstyledTypeMap } from './TabUnstyled.types';
 import useTab from './useTab';
+import { WithOptionalOwnerState } from '../utils';
+import { TabUnstyledRootSlotProps } from '..';
 
 const useUtilityClasses = (ownerState: { selected: boolean; disabled: boolean }) => {
   const { selected, disabled } = ownerState;
@@ -74,18 +76,19 @@ const TabUnstyled = React.forwardRef<unknown, TabUnstyledProps>(function TabUnst
   const classes = useUtilityClasses(ownerState);
 
   const TabRoot: React.ElementType = component ?? components.Root ?? 'button';
-  const tabRootProps = appendOwnerState(TabRoot, { ...other, ...componentsProps.root }, ownerState);
-
-  return (
-    <TabRoot
-      {...getRootProps()}
-      {...tabRootProps}
-      className={clsx(classes.root, componentsProps.root?.className, className)}
-      ref={ref}
-    >
-      {children}
-    </TabRoot>
+  const tabRootProps: WithOptionalOwnerState<TabUnstyledRootSlotProps> = appendOwnerState(
+    TabRoot,
+    {
+      ...getRootProps(),
+      ...other,
+      ...componentsProps.root,
+      className: clsx(classes.root, componentsProps.root?.className, className),
+      ref,
+    },
+    ownerState,
   );
+
+  return <TabRoot {...tabRootProps}>{children}</TabRoot>;
 }) as OverridableComponent<TabUnstyledTypeMap>;
 
 TabUnstyled.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { OverridableComponent } from '@mui/types';
 import clsx from 'clsx';
+import { OverridableComponent } from '@mui/types';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import composeClasses from '../composeClasses';
 import appendOwnerState from '../utils/appendOwnerState';
 import { getTabUnstyledUtilityClass } from './tabUnstyledClasses';
-import { TabUnstyledProps, TabUnstyledTypeMap } from './TabUnstyled.types';
+import {
+  TabUnstyledProps,
+  TabUnstyledTypeMap,
+  TabUnstyledRootSlotProps,
+} from './TabUnstyled.types';
 import useTab from './useTab';
 import { WithOptionalOwnerState } from '../utils';
-import { TabUnstyledRootSlotProps } from '..';
 
 const useUtilityClasses = (ownerState: { selected: boolean; disabled: boolean }) => {
   const { selected, disabled } = ownerState;

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
@@ -1,5 +1,7 @@
-import { OverrideProps } from '@mui/types';
+import { OverrideProps, Simplify } from '@mui/types';
+import React from 'react';
 import { ButtonUnstyledOwnProps } from '../ButtonUnstyled';
+import { UseTabRootSlotProps } from './useTab.types';
 
 interface TabUnstyledComponentsPropsOverrides {}
 
@@ -30,7 +32,7 @@ export interface TabUnstyledOwnProps
   };
 }
 
-type TabUnstyledProps<
+export type TabUnstyledProps<
   D extends React.ElementType = TabUnstyledTypeMap['defaultComponent'],
   P = {},
 > = OverrideProps<TabUnstyledTypeMap<P, D>, D> & {
@@ -47,4 +49,17 @@ export interface TabUnstyledTypeMap<P = {}, D extends React.ElementType = 'butto
   defaultComponent: D;
 }
 
-export default TabUnstyledProps;
+export type TabUnstyledOwnerState = TabUnstyledProps & {
+  active: boolean;
+  focusVisible: boolean;
+  disabled: boolean;
+  selected: boolean;
+};
+
+export type TabUnstyledRootSlotProps = Simplify<
+  UseTabRootSlotProps & {
+    className?: string;
+    ref: React.Ref<any>;
+    ownerState: TabUnstyledOwnerState;
+  }
+>;

--- a/packages/mui-base/src/TabUnstyled/index.ts
+++ b/packages/mui-base/src/TabUnstyled/index.ts
@@ -1,6 +1,8 @@
 export { default } from './TabUnstyled';
+export * from './TabUnstyled.types';
+
 export { default as tabUnstyledClasses } from './tabUnstyledClasses';
 export * from './tabUnstyledClasses';
-export type { default as TabUnstyledProps } from './TabUnstyledProps';
+
 export { default as useTab } from './useTab';
-export * from './useTab';
+export * from './useTab.types';

--- a/packages/mui-base/src/TabUnstyled/useTab.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.ts
@@ -1,25 +1,12 @@
 import { useTabContext, getTabId, getPanelId } from '../TabsUnstyled';
 import { useButton } from '../ButtonUnstyled';
+import { UseTabParameters, UseTabRootSlotProps } from './useTab.types';
+import { EventHandlers } from '../utils';
 
-export interface UseTabProps {
-  /**
-   * You can provide your own value. Otherwise, we fall back to the child position index.
-   */
-  value?: number | string;
-  /**
-   * Callback invoked when new value is being set.
-   */
-  onChange?: (event: React.SyntheticEvent, value: number | string) => void;
-  onClick?: React.MouseEventHandler;
-  disabled?: boolean;
-  onFocus?: React.FocusEventHandler;
-  ref: React.Ref<any>;
-}
+const useTab = (parameters: UseTabParameters) => {
+  const { value: valueProp, onChange, onClick, onFocus } = parameters;
 
-const useTab = (props: UseTabProps) => {
-  const { value: valueProp, onChange, onClick, onFocus } = props;
-
-  const { getRootProps: getRootPropsButton, ...otherButtonProps } = useButton(props);
+  const { getRootProps: getRootPropsButton, ...otherButtonProps } = useButton(parameters);
 
   const context = useTabContext();
   if (context === null) {
@@ -38,37 +25,52 @@ const useTab = (props: UseTabProps) => {
     disabled: otherButtonProps.disabled,
   };
 
-  const handleFocus = (event: React.FocusEvent<HTMLButtonElement, Element>) => {
-    if (selectionFollowsFocus && !selected) {
-      if (onChange) {
-        onChange(event, value);
+  const createHandleFocus =
+    (otherHandlers: EventHandlers) => (event: React.FocusEvent<HTMLButtonElement, Element>) => {
+      otherHandlers.onFocus?.(event);
+      if (event.defaultPrevented) {
+        return;
       }
-      context.onSelected(event, value);
-    }
 
-    if (onFocus) {
-      onFocus(event);
-    }
-  };
+      if (selectionFollowsFocus && !selected) {
+        if (onChange) {
+          onChange(event, value);
+        }
 
-  const handleClick = (event: React.MouseEvent<Element, MouseEvent>) => {
-    if (!selected) {
-      if (onChange) {
-        onChange(event, value);
+        context.onSelected(event, value);
       }
-      context.onSelected(event, value);
-    }
 
-    if (onClick) {
-      onClick(event);
-    }
-  };
+      if (onFocus) {
+        onFocus(event);
+      }
+    };
 
-  const getRootProps = (otherHandlers?: Record<string, React.EventHandler<any>>) => {
+  const createHandleClick =
+    (otherHandlers: EventHandlers) => (event: React.MouseEvent<Element, MouseEvent>) => {
+      otherHandlers.onClick?.(event);
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (!selected) {
+        if (onChange) {
+          onChange(event, value);
+        }
+        context.onSelected(event, value);
+      }
+
+      if (onClick) {
+        onClick(event);
+      }
+    };
+
+  const getRootProps = <TOther extends EventHandlers>(
+    otherHandlers: TOther = {} as TOther,
+  ): UseTabRootSlotProps<TOther> => {
     const buttonResolvedProps = getRootPropsButton({
-      onClick: handleClick,
-      onFocus: handleFocus,
       ...otherHandlers,
+      onClick: createHandleClick(otherHandlers),
+      onFocus: createHandleFocus(otherHandlers),
     });
 
     return {

--- a/packages/mui-base/src/TabUnstyled/useTab.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.ts
@@ -19,8 +19,8 @@ const useTab = (parameters: UseTabParameters) => {
 
   const a11yAttributes = {
     role: 'tab',
-    'aria-controls': getPanelId(context, value),
-    id: getTabId(context, value),
+    'aria-controls': getPanelId(context, value) ?? undefined,
+    id: getTabId(context, value) ?? undefined,
     'aria-selected': selected,
     disabled: otherButtonProps.disabled,
   };

--- a/packages/mui-base/src/TabUnstyled/useTab.types.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.types.ts
@@ -1,0 +1,32 @@
+import React from 'react';
+import { UseButtonRootSlotProps } from '../ButtonUnstyled';
+
+export interface UseTabParameters {
+  /**
+   * You can provide your own value. Otherwise, we fall back to the child position index.
+   */
+  value?: number | string;
+  /**
+   * Callback invoked when new value is being set.
+   */
+  onChange?: (event: React.SyntheticEvent, value: number | string) => void;
+  onClick?: React.MouseEventHandler;
+  disabled?: boolean;
+  onFocus?: React.FocusEventHandler;
+  ref: React.Ref<any>;
+}
+
+interface UseTabRootSlotEventHandlers {
+  onClick: React.MouseEventHandler;
+  onFocus: React.FocusEventHandler;
+}
+
+export type UseTabRootSlotProps<TOther = {}> = UseButtonRootSlotProps<
+  UseTabRootSlotEventHandlers & TOther
+> & {
+  'aria-controls': string | null;
+  'aria-selected': boolean;
+  disabled: boolean;
+  id: string | null;
+  role: React.AriaRole;
+};

--- a/packages/mui-base/src/TabUnstyled/useTab.types.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.types.ts
@@ -17,16 +17,16 @@ export interface UseTabParameters {
 }
 
 interface UseTabRootSlotEventHandlers {
-  onClick: React.MouseEventHandler;
-  onFocus: React.FocusEventHandler;
+  onClick?: React.MouseEventHandler;
+  onFocus?: React.FocusEventHandler;
 }
 
 export type UseTabRootSlotProps<TOther = {}> = UseButtonRootSlotProps<
   UseTabRootSlotEventHandlers & TOther
 > & {
-  'aria-controls': string | null;
-  'aria-selected': boolean;
+  'aria-controls': React.AriaAttributes['aria-controls'];
+  'aria-selected': React.AriaAttributes['aria-selected'];
   disabled: boolean;
-  id: string | null;
+  id: string | undefined;
   role: React.AriaRole;
 };


### PR DESCRIPTION
* Defined types for TabUnstyled's ownerState, useTab, and its slots.
* Renamed types and files according to #31415