### PR TITLE
[TabsUnstyled] Define ownerState and slot props' types

### DIFF
--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.spec.tsx
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.spec.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import TabsUnstyled, { TabsUnstyledRootSlotProps } from '@mui/base/TabsUnstyled';
+
+function Root(props: TabsUnstyledRootSlotProps) {
+  const { ownerState, ...other } = props;
+  return <div data-orientation={ownerState.orientation} {...other} />;
+}
+
+const styledTabs = <TabsUnstyled components={{ Root }} />;

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.test.tsx
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.test.tsx
@@ -10,9 +10,8 @@ import {
   createMount,
 } from 'test/utils';
 import Tab from '@mui/base/TabUnstyled';
-import Tabs, { tabsUnstyledClasses as classes } from '@mui/base/TabsUnstyled';
+import Tabs, { tabsUnstyledClasses as classes, TabsUnstyledProps } from '@mui/base/TabsUnstyled';
 import TabsList from '@mui/base/TabsListUnstyled';
-import TabsUnstyledProps from './TabsUnstyledProps';
 
 describe('<TabsUnstyled />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.tsx
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.tsx
@@ -2,10 +2,14 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
-import { appendOwnerState } from '../utils';
+import { appendOwnerState, WithOptionalOwnerState } from '../utils';
 import composeClasses from '../composeClasses';
 import { getTabsUnstyledUtilityClass } from './tabsUnstyledClasses';
-import TabsUnstyledProps, { TabsUnstyledTypeMap } from './TabsUnstyledProps';
+import {
+  TabsUnstyledProps,
+  TabsUnstyledRootSlotProps,
+  TabsUnstyledTypeMap,
+} from './TabsUnstyled.types';
 import useTabs from './useTabs';
 import Context from './TabsContext';
 
@@ -45,7 +49,7 @@ const TabsUnstyled = React.forwardRef<unknown, TabsUnstyledProps>((props, ref) =
     ...other
   } = props;
 
-  const { tabsContextValue, getRootProps } = useTabs(props);
+  const { tabsContextValue } = useTabs(props);
 
   const ownerState = {
     ...props,
@@ -56,19 +60,19 @@ const TabsUnstyled = React.forwardRef<unknown, TabsUnstyledProps>((props, ref) =
   const classes = useUtilityClasses(ownerState);
 
   const TabsRoot: React.ElementType = component ?? components.Root ?? 'div';
-  const tabsRootProps = appendOwnerState(
+  const tabsRootProps: WithOptionalOwnerState<TabsUnstyledRootSlotProps> = appendOwnerState(
     TabsRoot,
-    { ...other, ...componentsProps.root },
+    {
+      ...other,
+      ...componentsProps.root,
+      ref,
+      className: clsx(classes.root, componentsProps.root?.className, className),
+    },
     ownerState,
   );
 
   return (
-    <TabsRoot
-      {...getRootProps()}
-      {...tabsRootProps}
-      ref={ref}
-      className={clsx(classes.root, componentsProps.root?.className, className)}
-    >
+    <TabsRoot {...tabsRootProps}>
       <Context.Provider value={tabsContextValue}>{children}</Context.Provider>
     </TabsRoot>
   );

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
@@ -3,6 +3,10 @@ import { OverrideProps } from '@mui/types';
 
 interface TabsUnstyledComponentsPropsOverrides {}
 
+type TabsUnstyledOrientation = 'horizontal' | 'vertical';
+
+type TabsUnstyledDirection = 'ltr' | 'rtl';
+
 export interface TabsUnstyledOwnProps {
   /**
    * The content of the component.
@@ -21,12 +25,12 @@ export interface TabsUnstyledOwnProps {
    * The component orientation (layout flow direction).
    * @default 'horizontal'
    */
-  orientation?: 'horizontal' | 'vertical';
+  orientation?: TabsUnstyledOrientation;
   /**
    * The direction of the text.
    * @default 'ltr'
    */
-  direction?: 'ltr' | 'rtl';
+  direction?: TabsUnstyledDirection;
   className?: string;
   /**
    * The components used for each slot inside the Tabs.
@@ -59,7 +63,7 @@ export interface TabsUnstyledTypeMap<P = {}, D extends React.ElementType = 'div'
   defaultComponent: D;
 }
 
-type TabsUnstyledProps<
+export type TabsUnstyledProps<
   D extends React.ElementType = TabsUnstyledTypeMap['defaultComponent'],
   P = {},
 > = OverrideProps<TabsUnstyledTypeMap<P, D>, D> & {
@@ -71,4 +75,13 @@ type TabsUnstyledProps<
   component?: D;
 };
 
-export default TabsUnstyledProps;
+export type TabsUnstyledOwnerState = TabsUnstyledProps & {
+  orientation: TabsUnstyledOrientation;
+  direction: TabsUnstyledDirection;
+};
+
+export type TabsUnstyledRootSlotProps = {
+  ownerState: TabsUnstyledOwnerState;
+  ref: React.Ref<any>;
+  className?: string;
+};

--- a/packages/mui-base/src/TabsUnstyled/index.ts
+++ b/packages/mui-base/src/TabsUnstyled/index.ts
@@ -1,8 +1,12 @@
 export { default } from './TabsUnstyled';
+
 export { default as TabsContext } from './TabsContext';
 export * from './TabsContext';
+
 export { default as tabsUnstyledClasses } from './tabsUnstyledClasses';
 export * from './tabsUnstyledClasses';
-export type { default as TabsUnstyledProps } from './TabsUnstyledProps';
+
+export * from './TabsUnstyled.types';
+
 export { default as useTabs } from './useTabs';
 export * from './useTabs';

--- a/packages/mui-base/src/TabsUnstyled/useTabs.ts
+++ b/packages/mui-base/src/TabsUnstyled/useTabs.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { unstable_useControlled as useControlled, unstable_useId as useId } from '@mui/utils';
 
-export interface UseTabsProps {
+export interface UseTabsParameters {
   /**
    * The value of the currently selected `Tab`.
    * If you don't want any selected `Tab`, you can set this prop to `false`.
@@ -32,7 +32,7 @@ export interface UseTabsProps {
   selectionFollowsFocus?: boolean;
 }
 
-const useTabs = (props: UseTabsProps) => {
+const useTabs = (parameters: UseTabsParameters) => {
   const {
     value: valueProp,
     defaultValue,
@@ -40,7 +40,7 @@ const useTabs = (props: UseTabsProps) => {
     orientation,
     direction,
     selectionFollowsFocus,
-  } = props;
+  } = parameters;
 
   const [value, setValue] = useControlled({
     controlled: valueProp,
@@ -61,16 +61,11 @@ const useTabs = (props: UseTabsProps) => {
     [onChange, setValue],
   );
 
-  const getRootProps = () => {
-    return {};
-  };
-
   const tabsContextValue = React.useMemo(() => {
     return { idPrefix, value, onSelected, orientation, direction, selectionFollowsFocus };
   }, [idPrefix, value, onSelected, orientation, direction, selectionFollowsFocus]);
 
   return {
-    getRootProps,
     tabsContextValue,
   };
 };


### PR DESCRIPTION
* Defined types for TabUnstyled's ownerState and its slots.
* Renamed types and files according to #31415
* Removed `getRootProps` from the `useTabs` return value as it returned an empty object.