### PR TITLE
[TabPanelUnstyled] Define ownerState and slot props' types

### DIFF
--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.spec.tsx
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import TabPanelUnstyled from '@mui/base/TabPanelUnstyled';
-import { TabPanelUnstyledRootSlotProps } from './TabPanelUnstyled.types';
+import TabPanelUnstyled, { TabPanelUnstyledRootSlotProps } from '@mui/base/TabPanelUnstyled';
 
 function Root(props: TabPanelUnstyledRootSlotProps) {
   const { ownerState, ...other } = props;

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.spec.tsx
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.spec.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import TabPanelUnstyled from '@mui/base/TabPanelUnstyled';
+import { TabPanelUnstyledRootSlotProps } from './TabPanelUnstyled.types';
+
+function Root(props: TabPanelUnstyledRootSlotProps) {
+  const { ownerState, ...other } = props;
+  return <div data-hidden={ownerState.hidden} {...other} />;
+}
+
+const styledTabPanel = <TabPanelUnstyled components={{ Root }} value={0} />;

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.tsx
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
-import { appendOwnerState } from '../utils';
+import { appendOwnerState, WithOptionalOwnerState } from '../utils';
 import composeClasses from '../composeClasses';
 import { getTabPanelUnstyledUtilityClass } from './tabPanelUnstyledClasses';
 import useTabPanel from './useTabPanel';
-import TabPanelUnstyledProps, { TabPanelUnstyledTypeMap } from './TabPanelUnstyledProps';
+import {
+  TabPanelUnstyledProps,
+  TabPanelUnstyledRootSlotProps,
+  TabPanelUnstyledTypeMap,
+} from './TabPanelUnstyled.types';
 
 const useUtilityClasses = (ownerState: { hidden: boolean }) => {
   const { hidden } = ownerState;
@@ -51,23 +55,20 @@ const TabPanelUnstyled = React.forwardRef<unknown, TabPanelUnstyledProps>(functi
   const classes = useUtilityClasses(ownerState);
 
   const TabPanelRoot: React.ElementType = component ?? components.Root ?? 'div';
-  const tabPanelRootProps = appendOwnerState(
+  const tabPanelRootProps: WithOptionalOwnerState<TabPanelUnstyledRootSlotProps> = appendOwnerState(
     TabPanelRoot,
-    { ...other, ...componentsProps.root },
+    {
+      ...getRootProps(),
+      role: 'tabpanel',
+      ...other,
+      ...componentsProps.root,
+      ref,
+      className: clsx(classes.root, componentsProps.root?.className, className),
+    },
     ownerState,
   );
 
-  return (
-    <TabPanelRoot
-      {...getRootProps()}
-      ref={ref}
-      role="tabpanel"
-      {...tabPanelRootProps}
-      className={clsx(classes.root, componentsProps.root?.className, className)}
-    >
-      {!hidden && children}
-    </TabPanelRoot>
-  );
+  return <TabPanelRoot {...tabPanelRootProps}>{!hidden && children}</TabPanelRoot>;
 }) as OverridableComponent<TabPanelUnstyledTypeMap>;
 
 TabPanelUnstyled.propTypes /* remove-proptypes */ = {

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
@@ -1,5 +1,6 @@
-import React from 'react';
+import * as React from 'react';
 import { OverrideProps } from '@mui/types';
+import { UseTabPanelRootSlotProps } from './useTabPanel.types';
 
 interface TabPanelUnstyledComponentsPropsOverrides {}
 
@@ -36,7 +37,7 @@ export interface TabPanelUnstyledTypeMap<P = {}, D extends React.ElementType = '
   defaultComponent: D;
 }
 
-type TabPanelUnstyledProps<
+export type TabPanelUnstyledProps<
   D extends React.ElementType = TabPanelUnstyledTypeMap['defaultComponent'],
   P = {},
 > = OverrideProps<TabPanelUnstyledTypeMap<P, D>, D> & {
@@ -48,4 +49,14 @@ type TabPanelUnstyledProps<
   component?: D;
 };
 
-export default TabPanelUnstyledProps;
+export type TabPanelUnstyledOwnerState = TabPanelUnstyledProps & {
+  hidden: boolean;
+};
+
+export type TabPanelUnstyledRootSlotProps = UseTabPanelRootSlotProps & {
+  children?: React.ReactNode;
+  className?: string;
+  ownerState: TabPanelUnstyledOwnerState;
+  ref: React.Ref<any>;
+  role: React.AriaRole;
+};

--- a/packages/mui-base/src/TabPanelUnstyled/index.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/index.ts
@@ -5,4 +5,3 @@ export { default as tabPanelUnstyledClasses } from './tabPanelUnstyledClasses';
 export * from './tabPanelUnstyledClasses';
 
 export { default as useTabPanel } from './useTabPanel';
-export * from './useTabPanel';

--- a/packages/mui-base/src/TabPanelUnstyled/index.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/index.ts
@@ -1,6 +1,8 @@
 export { default } from './TabPanelUnstyled';
+export * from './TabPanelUnstyled.types';
+
 export { default as tabPanelUnstyledClasses } from './tabPanelUnstyledClasses';
 export * from './tabPanelUnstyledClasses';
-export type { default as TabPanelUnstyledProps } from './TabPanelUnstyledProps';
+
 export { default as useTabPanel } from './useTabPanel';
 export * from './useTabPanel';

--- a/packages/mui-base/src/TabPanelUnstyled/useTabPanel.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/useTabPanel.ts
@@ -1,14 +1,8 @@
 import { useTabContext, getPanelId, getTabId } from '../TabsUnstyled';
+import { UseTabPanelParameters } from './useTabPanel.types';
 
-export interface UseTabPanelProps {
-  /**
-   * The value of the TabPanel. It will be shown when the Tab with the corresponding value is selected.
-   */
-  value: number | string;
-}
-
-const useTabPanel = (props: UseTabPanelProps) => {
-  const { value } = props;
+const useTabPanel = (parameters: UseTabPanelParameters) => {
+  const { value } = parameters;
 
   const context = useTabContext();
   if (context === null) {
@@ -21,9 +15,9 @@ const useTabPanel = (props: UseTabPanelProps) => {
 
   const getRootProps = () => {
     return {
-      'aria-labelledby': tabId,
+      'aria-labelledby': tabId ?? undefined,
       hidden,
-      id,
+      id: id ?? undefined,
     };
   };
 

--- a/packages/mui-base/src/TabPanelUnstyled/useTabPanel.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/useTabPanel.types.ts
@@ -1,0 +1,12 @@
+export interface UseTabPanelParameters {
+  /**
+   * The value of the TabPanel. It will be shown when the Tab with the corresponding value is selected.
+   */
+  value: number | string;
+}
+
+export interface UseTabPanelRootSlotProps {
+  'aria-labelledby'?: string;
+  hidden?: boolean;
+  id?: string;
+}


### PR DESCRIPTION
* Defined types for TabPanelUnstyled's ownerState, its slots, and useTabPanel
* Renamed types and files according to #31415