### PR TITLE
[InputLabel] Document the `size` prop

### DIFF
--- a/docs/pages/material-ui/api/input-label.json
+++ b/docs/pages/material-ui/api/input-label.json
@@ -15,6 +15,10 @@
     "margin": { "type": { "name": "enum", "description": "'dense'" } },
     "required": { "type": { "name": "bool" } },
     "shrink": { "type": { "name": "bool" } },
+    "size": {
+      "type": { "name": "enum", "description": "'normal'<br>&#124;&nbsp;'small'" },
+      "default": "'normal'"
+    },
     "sx": {
       "type": {
         "name": "union",

--- a/docs/translations/api-docs/input-label/input-label.json
+++ b/docs/translations/api-docs/input-label/input-label.json
@@ -11,6 +11,7 @@
     "margin": "If <code>dense</code>, will adjust vertical spacing. This is normally obtained via context from FormControl.",
     "required": "if <code>true</code>, the label will indicate that the <code>input</code> is required.",
     "shrink": "If <code>true</code>, the label is shrunk.",
+    "size": "The size of the component.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/the-sx-prop/\">`sx` page</a> for more details.",
     "variant": "The variant to use."
   },

--- a/packages/mui-material/src/InputLabel/InputLabel.d.ts
+++ b/packages/mui-material/src/InputLabel/InputLabel.d.ts
@@ -46,6 +46,11 @@ export interface InputLabelProps extends StandardProps<FormLabelProps> {
    */
   shrink?: boolean;
   /**
+   * The size of the component.
+   * @default 'normal'
+   */
+  size?: 'small' | 'normal';
+  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx?: SxProps<Theme>;

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -207,6 +207,11 @@ InputLabel.propTypes /* remove-proptypes */ = {
    */
   shrink: PropTypes.bool,
   /**
+   * The size of the component.
+   * @default 'normal'
+   */
+  size: PropTypes.oneOf(['normal', 'small']),
+  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([


### PR DESCRIPTION
For component [`InputLabel`](https://mui.com/material-ui/api/input-label/), add missing property `size` with values `normal` (by default) and `small` to the propTypes and TypeScript types. The functionality was already implemented.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- [x] I reviewed it in the website documentation.
