### PR TITLE
[Joy] use `textColor` prop for Typography and Link

### DIFF
--- a/docs/data/joy/components/badge/NumberBadge.js
+++ b/docs/data/joy/components/badge/NumberBadge.js
@@ -21,7 +21,7 @@ export default function ColorBadge() {
         <IconButton size="sm" onClick={() => setCount((c) => c - 1)}>
           <Remove />
         </IconButton>
-        <Typography fontWeight="md" color="text.secondary">
+        <Typography fontWeight="md" textColor="text.secondary">
           {count}
         </Typography>
         <IconButton size="sm" onClick={() => setCount((c) => c + 1)}>

--- a/docs/data/joy/components/badge/NumberBadge.tsx
+++ b/docs/data/joy/components/badge/NumberBadge.tsx
@@ -21,7 +21,7 @@ export default function ColorBadge() {
         <IconButton size="sm" onClick={() => setCount((c) => c - 1)}>
           <Remove />
         </IconButton>
-        <Typography fontWeight="md" color="text.secondary">
+        <Typography fontWeight="md" textColor="text.secondary">
           {count}
         </Typography>
         <IconButton size="sm" onClick={() => setCount((c) => c + 1)}>

--- a/docs/data/joy/components/card/CardCovers.js
+++ b/docs/data/joy/components/card/CardCovers.js
@@ -8,22 +8,22 @@ export default function CardCovers() {
   return (
     <Card sx={{ minWidth: 320 }}>
       <CardCover sx={{ bgcolor: 'rgba(0,0,0,0.4)' }}>
-        <Typography fontSize="50px" fontWeight="lg" color="#fff" ml={2}>
+        <Typography fontSize="50px" fontWeight="lg" textColor="#fff" ml={2}>
           3
         </Typography>
       </CardCover>
       <CardCover sx={{ bgcolor: 'rgba(0,0,0,0.4)' }}>
-        <Typography fontSize="50px" fontWeight="lg" color="#fff" ml={6}>
+        <Typography fontSize="50px" fontWeight="lg" textColor="#fff" ml={6}>
           2
         </Typography>
       </CardCover>
       <CardCover sx={{ bgcolor: 'rgba(0,0,0,0.4)' }}>
-        <Typography fontSize="50px" fontWeight="lg" color="#fff" ml={10}>
+        <Typography fontSize="50px" fontWeight="lg" textColor="#fff" ml={10}>
           1
         </Typography>
       </CardCover>
       <CardContent sx={{ bgcolor: 'rgba(0,0,0,0.5)' }}>
-        <Typography level="h2" ml={12} mr={2} color="#fff">
+        <Typography level="h2" ml={12} mr={2} textColor="#fff">
           Content
         </Typography>
       </CardContent>

--- a/docs/data/joy/components/card/CardCovers.tsx
+++ b/docs/data/joy/components/card/CardCovers.tsx
@@ -8,22 +8,22 @@ export default function CardCovers() {
   return (
     <Card sx={{ minWidth: 320 }}>
       <CardCover sx={{ bgcolor: 'rgba(0,0,0,0.4)' }}>
-        <Typography fontSize="50px" fontWeight="lg" color="#fff" ml={2}>
+        <Typography fontSize="50px" fontWeight="lg" textColor="#fff" ml={2}>
           3
         </Typography>
       </CardCover>
       <CardCover sx={{ bgcolor: 'rgba(0,0,0,0.4)' }}>
-        <Typography fontSize="50px" fontWeight="lg" color="#fff" ml={6}>
+        <Typography fontSize="50px" fontWeight="lg" textColor="#fff" ml={6}>
           2
         </Typography>
       </CardCover>
       <CardCover sx={{ bgcolor: 'rgba(0,0,0,0.4)' }}>
-        <Typography fontSize="50px" fontWeight="lg" color="#fff" ml={10}>
+        <Typography fontSize="50px" fontWeight="lg" textColor="#fff" ml={10}>
           1
         </Typography>
       </CardCover>
       <CardContent sx={{ bgcolor: 'rgba(0,0,0,0.5)' }}>
-        <Typography level="h2" ml={12} mr={2} color="#fff">
+        <Typography level="h2" ml={12} mr={2} textColor="#fff">
           Content
         </Typography>
       </CardContent>

--- a/docs/data/joy/components/card/GradientCover.js
+++ b/docs/data/joy/components/card/GradientCover.js
@@ -21,10 +21,13 @@ export default function GradientCover() {
         }}
       />
       <CardContent sx={{ justifyContent: 'flex-end' }}>
-        <Typography level="h2" fontSize="lg" color="#fff" mb={1}>
+        <Typography level="h2" fontSize="lg" textColor="#fff" mb={1}>
           Yosemite National Park
         </Typography>
-        <Typography startDecorator={<LocationOnRoundedIcon />} color="neutral.300">
+        <Typography
+          startDecorator={<LocationOnRoundedIcon />}
+          textColor="neutral.300"
+        >
           California, USA
         </Typography>
       </CardContent>

--- a/docs/data/joy/components/card/GradientCover.tsx
+++ b/docs/data/joy/components/card/GradientCover.tsx
@@ -21,10 +21,13 @@ export default function GradientCover() {
         }}
       />
       <CardContent sx={{ justifyContent: 'flex-end' }}>
-        <Typography level="h2" fontSize="lg" color="#fff" mb={1}>
+        <Typography level="h2" fontSize="lg" textColor="#fff" mb={1}>
           Yosemite National Park
         </Typography>
-        <Typography startDecorator={<LocationOnRoundedIcon />} color="neutral.300">
+        <Typography
+          startDecorator={<LocationOnRoundedIcon />}
+          textColor="neutral.300"
+        >
           California, USA
         </Typography>
       </CardContent>

--- a/docs/data/joy/components/card/MediaCover.js
+++ b/docs/data/joy/components/card/MediaCover.js
@@ -22,7 +22,7 @@ export default function BasicCard() {
           <Typography
             level="h6"
             fontWeight="lg"
-            color="#fff"
+            textColor="#fff"
             mt={{ xs: 12, sm: 18 }}
           >
             Image
@@ -47,7 +47,7 @@ export default function BasicCard() {
           <Typography
             level="h6"
             fontWeight="lg"
-            color="#fff"
+            textColor="#fff"
             mt={{ xs: 12, sm: 18 }}
           >
             Video

--- a/docs/data/joy/components/card/MediaCover.tsx
+++ b/docs/data/joy/components/card/MediaCover.tsx
@@ -22,7 +22,7 @@ export default function BasicCard() {
           <Typography
             level="h6"
             fontWeight="lg"
-            color="#fff"
+            textColor="#fff"
             mt={{ xs: 12, sm: 18 }}
           >
             Image
@@ -47,7 +47,7 @@ export default function BasicCard() {
           <Typography
             level="h6"
             fontWeight="lg"
-            color="#fff"
+            textColor="#fff"
             mt={{ xs: 12, sm: 18 }}
           >
             Video

--- a/docs/data/joy/components/card/RowCard.js
+++ b/docs/data/joy/components/card/RowCard.js
@@ -25,7 +25,7 @@ export default function InteractiveCard() {
         </AspectRatio>
       </CardOverflow>
       <CardContent>
-        <Typography fontWeight="md" color="success.plainColor" mb={0.5}>
+        <Typography fontWeight="md" textColor="success.plainColor" mb={0.5}>
           Yosemite Park
         </Typography>
         <Typography level="body2">California, USA</Typography>

--- a/docs/data/joy/components/card/RowCard.tsx
+++ b/docs/data/joy/components/card/RowCard.tsx
@@ -25,7 +25,7 @@ export default function InteractiveCard() {
         </AspectRatio>
       </CardOverflow>
       <CardContent>
-        <Typography fontWeight="md" color="success.plainColor" mb={0.5}>
+        <Typography fontWeight="md" textColor="success.plainColor" mb={0.5}>
           Yosemite Park
         </Typography>
         <Typography level="body2">California, USA</Typography>

--- a/docs/pages/experiments/joy/checkbox.tsx
+++ b/docs/pages/experiments/joy/checkbox.tsx
@@ -279,13 +279,13 @@ export default function JoyCheckbox() {
               >
                 <ListItem variant="soft" color="danger">
                   <Checkbox label="Declined Payment" color="danger" checked overlay />
-                  <Typography color="inherit" sx={{ ml: 'auto' }}>
+                  <Typography textColor="inherit" sx={{ ml: 'auto' }}>
                     8
                   </Typography>
                 </ListItem>
                 <ListItem variant="soft" color="warning">
                   <Checkbox label="Delivery Error" color="warning" checked overlay />
-                  <Typography color="inherit" sx={{ ml: 'auto' }}>
+                  <Typography textColor="inherit" sx={{ ml: 'auto' }}>
                     24
                   </Typography>
                 </ListItem>

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -319,7 +319,7 @@ const components: {
           color="primary"
           placeholder="Placeholder"
           startDecorator={<Typography color="inherit">$</Typography>}
-          endDecorator={<Typography color="text.tertiary">USD</Typography>}
+          endDecorator={<Typography textColor="text.tertiary">USD</Typography>}
           {...props}
         />
         <Input placeholder="Placeholder" color="danger" endDecorator={<Info />} {...props} />

--- a/docs/pages/experiments/joy/components.tsx
+++ b/docs/pages/experiments/joy/components.tsx
@@ -318,7 +318,7 @@ const components: {
         <Input
           color="primary"
           placeholder="Placeholder"
-          startDecorator={<Typography color="inherit">$</Typography>}
+          startDecorator={<Typography textColor="inherit">$</Typography>}
           endDecorator={<Typography textColor="text.tertiary">USD</Typography>}
           {...props}
         />

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -854,9 +854,9 @@ export default function JoyList() {
               </ListItemDecorator>
               <div>
                 <Typography>Brunch this weekend?</Typography>
-                <Typography level="body2" color="text.primary">
+                <Typography level="body2" textColor="text.primary">
                   Ali Connors{' '}
-                  <Typography color="text.secondary">
+                  <Typography textColor="text.secondary">
                     {' '}
                     — I&apos;ll be in your neighborhood doing errands this…
                   </Typography>
@@ -878,9 +878,9 @@ export default function JoyList() {
               </ListItemDecorator>
               <div>
                 <Typography>Summer BBQ</Typography>
-                <Typography level="body2" color="text.primary">
+                <Typography level="body2" textColor="text.primary">
                   to Scott, Alex, Jennifer{' '}
-                  <Typography color="text.secondary">
+                  <Typography textColor="text.secondary">
                     {' '}
                     — Wish I could come, but I&apos;m out of town this…
                   </Typography>
@@ -1092,7 +1092,7 @@ export default function JoyList() {
             </List>
             <List size="lg" sx={{ mt: 1 }}>
               <ListItem>
-                <Typography color="text.secondary">Large size</Typography>
+                <Typography textColor="text.secondary">Large size</Typography>
               </ListItem>
               <ListItem>
                 <ListItemDecorator>

--- a/docs/pages/experiments/joy/radio.tsx
+++ b/docs/pages/experiments/joy/radio.tsx
@@ -116,7 +116,7 @@ export default function JoyRadio() {
                   <ListItem component="div">
                     <ListItemContent>
                       <Radio label="Thin" value="Thin" color="warning" />
-                      <Typography level="body3" ml="28px" mt={0.5} color="warning.400">
+                      <Typography level="body3" ml="28px" mt={0.5} textColor="warning.400">
                         This might make your pizza too crispy.
                       </Typography>
                     </ListItemContent>
@@ -276,7 +276,7 @@ export default function JoyRadio() {
               variant="soft"
               sx={{ p: 2, display: 'flex', gap: 2, my: 2, borderRadius: '18px' }}
             >
-              <Typography level="body3" color="text.primary">
+              <Typography level="body3" textColor="text.primary">
                 <Typography fontWeight="md">
                   Choose from two anti-reflective glass options.
                 </Typography>{' '}
@@ -391,13 +391,13 @@ export default function JoyRadio() {
                       <Typography sx={{ display: 'flex' }}>
                         <Typography level="inherit" fontWeight="md" flexGrow={1}>
                           Small <br />
-                          <Typography fontWeight="normal" fontSize="sm" color="text.secondary">
+                          <Typography fontWeight="normal" fontSize="sm" textColor="text.secondary">
                             Description
                           </Typography>
                         </Typography>
                         <Typography level="inherit" fontWeight="md" textAlign="right">
                           $40 <br />
-                          <Typography fontWeight="normal" fontSize="sm" color="text.secondary">
+                          <Typography fontWeight="normal" fontSize="sm" textColor="text.secondary">
                             per month
                           </Typography>
                         </Typography>

--- a/docs/pages/experiments/joy/switch.tsx
+++ b/docs/pages/experiments/joy/switch.tsx
@@ -142,7 +142,7 @@ export default function JoySwitch() {
             <Switch endDecorator="On" checked size="sm" />
           </Box>
           <Box>
-            <Typography color="info.textColor">Fluent</Typography>
+            <Typography color="info">Fluent</Typography>
             {(
               [
                 { checked: false, variant: 'outlined' },
@@ -183,7 +183,7 @@ export default function JoySwitch() {
             ))}
           </Box>
           <Box>
-            <Typography color="info.textColor">iOS</Typography>
+            <Typography color="info">iOS</Typography>
             {(
               [
                 { checked: false },
@@ -211,7 +211,7 @@ export default function JoySwitch() {
             ))}
           </Box>
           <Box>
-            <Typography color="info.textColor">strapi</Typography>
+            <Typography color="info">strapi</Typography>
             {(
               [
                 { checked: false, color: 'danger' },
@@ -236,7 +236,7 @@ export default function JoySwitch() {
             ))}
           </Box>
           <Box>
-            <Typography color="info.textColor">Material</Typography>
+            <Typography color="info">Material</Typography>
             {(
               [
                 { checked: false, variant: 'solid' },
@@ -274,7 +274,7 @@ export default function JoySwitch() {
             ))}
           </Box>
           <Box>
-            <Typography color="info.textColor">Chakra UI</Typography>
+            <Typography color="info">Chakra UI</Typography>
             {[
               { checked: false },
               { checked: true },
@@ -303,7 +303,7 @@ export default function JoySwitch() {
             ))}
           </Box>
           <Box>
-            <Typography color="info.textColor">Tailwind UI</Typography>
+            <Typography color="info">Tailwind UI</Typography>
             {([{ checked: false }, { checked: true, color: 'info' }] as const).map(
               (data, index) => (
                 <Switch
@@ -340,7 +340,7 @@ export default function JoySwitch() {
             ))}
           </Box>
           <Box>
-            <Typography color="info.textColor">Mantine</Typography>
+            <Typography color="info">Mantine</Typography>
             {(
               [
                 { checked: false, variant: 'outlined' },

--- a/docs/pages/experiments/joy/typography.tsx
+++ b/docs/pages/experiments/joy/typography.tsx
@@ -121,11 +121,11 @@ export default function JoyTypography() {
           <Typography sx={{ '--Typography-gap': '2px' }}>
             Keep me updated about the new features and upcoming improvements (by doing this you
             accept the{' '}
-            <Typography color="primary.textColor" startDecorator={<Info />}>
+            <Typography textColor="primary.textColor" startDecorator={<Info />}>
               Terms
             </Typography>{' '}
             and the{' '}
-            <Typography color="primary.textColor" endDecorator={<Outbound />}>
+            <Typography textColor="primary.textColor" endDecorator={<Outbound />}>
               privacy policy
             </Typography>
             ).
@@ -134,7 +134,7 @@ export default function JoyTypography() {
         <Box sx={{ my: 2 }}>
           <Typography
             endDecorator={
-              <Typography color="text.secondary" fontSize="sm">
+              <Typography textColor="text.secondary" fontSize="sm">
                 20
               </Typography>
             }
@@ -143,7 +143,7 @@ export default function JoyTypography() {
           </Typography>
           <Typography
             endDecorator={
-              <Typography color="text.secondary" fontSize="sm">
+              <Typography textColor="text.secondary" fontSize="sm">
                 7
               </Typography>
             }
@@ -174,7 +174,7 @@ export default function JoyTypography() {
             fontSize="xl4"
             lineHeight={1}
             startDecorator={
-              <Typography fontSize="lg" color="text.secondary">
+              <Typography fontSize="lg" textColor="text.secondary">
                 $
               </Typography>
             }
@@ -210,6 +210,19 @@ export default function JoyTypography() {
             dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
             mollit anim id est laborum.
+          </Typography>
+        </Box>
+        <Box sx={{ my: 2 }}>
+          <Typography
+            variant="soft"
+            color="primary"
+            startDecorator={<Info />}
+            py={1}
+            px={1}
+            borderRadius="xs"
+            display="inline-flex"
+          >
+            This is a test.
           </Typography>
         </Box>
       </Box>

--- a/packages/mui-joy/src/Link/Link.spec.tsx
+++ b/packages/mui-joy/src/Link/Link.spec.tsx
@@ -18,6 +18,8 @@ import * as React from 'react';
 <Link color="warning" />;
 <Link color="neutral" />;
 
+<Link textColor="neutral.500" />;
+
 // `level`
 <Link level="h2" />;
 <Link level="h3" />;

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -145,14 +145,18 @@ const LinkRoot = styled('a', {
 });
 
 const Link = React.forwardRef(function Link(inProps, ref) {
-  const { color = 'primary', ...themeProps } = useThemeProps<typeof inProps & LinkProps>({
+  const {
+    color = 'primary',
+    textColor,
+    ...themeProps
+  } = useThemeProps<typeof inProps & LinkProps>({
     props: inProps,
     name: 'JoyLink',
   });
 
   const nested = React.useContext(TypographyContext);
 
-  const props = extendSxProp(themeProps) as LinkProps;
+  const props = extendSxProp({ ...themeProps, color: textColor }) as LinkProps;
 
   const {
     className,

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -316,11 +316,7 @@ Link.propTypes /* remove-proptypes */ = {
   /**
    * The system color.
    */
-  textColor: /* @typescript-to-proptypes-ignore */ PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    PropTypes.object,
-  ]),
+  textColor: PropTypes /* @typescript-to-proptypes-ignore */.any,
   /**
    * Controls when the link should have an underline.
    * @default 'hover'

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -314,6 +314,14 @@ Link.propTypes /* remove-proptypes */ = {
     PropTypes.object,
   ]),
   /**
+   * The system color.
+   */
+  textColor: /* @typescript-to-proptypes-ignore */ PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
    * Controls when the link should have an underline.
    * @default 'hover'
    */

--- a/packages/mui-joy/src/Link/LinkProps.ts
+++ b/packages/mui-joy/src/Link/LinkProps.ts
@@ -47,6 +47,10 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
        */
       overlay?: boolean;
       /**
+       * The system color.
+       */
+      textColor?: SystemProps['color'];
+      /**
        * Element placed before the children.
        */
       startDecorator?: React.ReactNode;

--- a/packages/mui-joy/src/Typography/Typography.spec.tsx
+++ b/packages/mui-joy/src/Typography/Typography.spec.tsx
@@ -16,3 +16,12 @@ function Link(props: JSX.IntrinsicElements['a']) {
 <Typography component="div" href="/">
   Text
 </Typography>;
+
+<Typography color="primary" />;
+<Typography color="neutral" />;
+<Typography color="danger" />;
+<Typography color="info" />;
+<Typography color="success" />;
+<Typography color="warning" />;
+
+<Typography textColor="neutral.500" />;

--- a/packages/mui-joy/src/Typography/Typography.tsx
+++ b/packages/mui-joy/src/Typography/Typography.tsx
@@ -121,7 +121,7 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
 
   const nested = React.useContext(TypographyContext);
 
-  const props = extendSxProp({ ...themeProps, color: textColor });
+  const props = extendSxProp({ ...themeProps, color: textColor }) as TypographyProps;
 
   const {
     className,
@@ -165,7 +165,7 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
         ref={ref}
         ownerState={ownerState}
         className={clsx(classes.root, className)}
-        {...(other as TypographyProps)}
+        {...other}
       >
         {startDecorator && (
           <StartDecorator ownerState={ownerState} className={classes.startDecorator}>

--- a/packages/mui-joy/src/Typography/Typography.tsx
+++ b/packages/mui-joy/src/Typography/Typography.tsx
@@ -202,9 +202,12 @@ Typography.propTypes /* remove-proptypes */ = {
    */
   className: PropTypes.string,
   /**
-   * @ignore
+   * The color of the component. It supports those theme colors that make sense for this component.
    */
-  color: PropTypes /* @typescript-to-proptypes-ignore */.any,
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['context', 'danger', 'info', 'neutral', 'primary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
   /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
@@ -266,6 +269,18 @@ Typography.propTypes /* remove-proptypes */ = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  /**
+   * The system color.
+   */
+  textColor: /* @typescript-to-proptypes-ignore */ PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf(['outlined', 'plain', 'soft', 'solid']),
 } as any;
 
 export default Typography;

--- a/packages/mui-joy/src/Typography/Typography.tsx
+++ b/packages/mui-joy/src/Typography/Typography.tsx
@@ -272,11 +272,7 @@ Typography.propTypes /* remove-proptypes */ = {
   /**
    * The system color.
    */
-  textColor: /* @typescript-to-proptypes-ignore */ PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.func,
-    PropTypes.object,
-  ]),
+  textColor: PropTypes /* @typescript-to-proptypes-ignore */.any,
   /**
    * The variant to use.
    */

--- a/packages/mui-joy/src/Typography/TypographyProps.ts
+++ b/packages/mui-joy/src/Typography/TypographyProps.ts
@@ -1,13 +1,23 @@
 import * as React from 'react';
-import { OverrideProps } from '@mui/types';
+import { OverrideProps, OverridableStringUnion } from '@mui/types';
 import { TypographyClasses } from './typographyClasses';
-import { TypographySystem, SxProps, SystemProps } from '../styles/types';
+import {
+  ColorPaletteProp,
+  TypographySystem,
+  SxProps,
+  SystemProps,
+  VariantProp,
+} from '../styles/types';
 
 export type TypographySlot = 'root' | 'startDecorator' | 'endDecorator';
 
+export interface TypographyPropsColorOverrides {}
+
+export interface TypographyPropsVariantOverrides {}
+
 export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P &
-    SystemProps & {
+    Omit<SystemProps, 'color'> & {
       /**
        * The content of the component.
        */
@@ -16,6 +26,10 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
        * Override or extend the styles applied to the component.
        */
       classes?: Partial<TypographyClasses>;
+      /**
+       * The color of the component. It supports those theme colors that make sense for this component.
+       */
+      color?: OverridableStringUnion<ColorPaletteProp, TypographyPropsColorOverrides>;
       /**
        * Element placed after the children.
        */
@@ -62,9 +76,17 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
        */
       startDecorator?: React.ReactNode;
       /**
+       * The system color.
+       */
+      textColor?: SystemProps['color'];
+      /**
        * The system prop that allows defining system overrides as well as additional CSS styles.
        */
       sx?: SxProps;
+      /**
+       * The variant to use.
+       */
+      variant?: OverridableStringUnion<VariantProp, TypographyPropsVariantOverrides>;
     };
   defaultComponent: D;
 }

--- a/packages/mui-joy/src/Typography/typographyClasses.ts
+++ b/packages/mui-joy/src/Typography/typographyClasses.ts
@@ -29,6 +29,26 @@ export interface TypographyClasses {
   startDecorator: string;
   /** Styles applied to the endDecorator element */
   endDecorator: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="neutral"`. */
+  colorNeutral: string;
+  /** Styles applied to the root element if `color="danger"`. */
+  colorDanger: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** Styles applied to the root element if `variant="plain"`. */
+  variantPlain: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  variantOutlined: string;
+  /** Styles applied to the root element if `variant="soft"`. */
+  variantSoft: string;
+  /** Styles applied to the root element if `variant="solid"`. */
+  variantSolid: string;
 }
 
 export type TypographyClassKey = keyof TypographyClasses;
@@ -52,6 +72,16 @@ const typographyClasses: TypographyClasses = generateUtilityClasses('JoyTypograp
   'gutterBottom',
   'startDecorator',
   'endDecorator',
+  'colorPrimary',
+  'colorNeutral',
+  'colorDanger',
+  'colorInfo',
+  'colorSuccess',
+  'colorWarning',
+  'variantPlain',
+  'variantOutlined',
+  'variantSoft',
+  'variantSolid',
 ]);
 
 export default typographyClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Joy will follow the [approach](https://github.com/mui/material-ui/issues/32141#issuecomment-1105176854). This will give the same experience throughout the components.

**Usage**

```js
<Typography color="primary" variant="soft" /> // the combination of variant and color palette
<Link color="success" variant="soft" /> // the combination of variant and color palette

<Typography textColor="neutral.500" /> // CSS color prop, similar to `sx={{ color: 'neutral.500' }}`
<Link textColor="neutral.500" /> // CSS color prop, similar to `sx={{ color: 'neutral.500' }}`
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
