### PR TITLE
[pickers] Add deprecations when importing pickers from the lab

### DIFF
--- a/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  CalendarPicker as XCalendarPicker,
+  CalendarPickerProps,
+} from '@mui/x-date-pickers/CalendarPicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The CalendarPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { CalendarPicker } from '@mui/x-date-pickers'`",
+        "or `import { CalendarPicker } from '@mui/x-date-pickers/CalendarPicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type CalendarPickerComponent = (<TDate>(
+  props: CalendarPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const CalendarPicker = React.forwardRef(function DeprecatedCalendarPicker<TDate>(
+  props: CalendarPickerProps<TDate>,
+) {
+  warn();
+
+  return <XCalendarPicker {...props} />;
+}) as CalendarPickerComponent;
+
+export default CalendarPicker;

--- a/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -10,8 +10,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The CalendarPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The CalendarPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { CalendarPicker } from '@mui/x-date-pickers'`",
         "or `import { CalendarPicker } from '@mui/x-date-pickers/CalendarPicker'`",

--- a/packages/mui-lab/src/CalendarPicker/index.ts
+++ b/packages/mui-lab/src/CalendarPicker/index.ts
@@ -1,7 +1,6 @@
-export {
-  CalendarPicker as default,
-  calendarPickerClasses,
-} from '@mui/x-date-pickers/CalendarPicker';
+export { default } from './CalendarPicker';
+
+export { calendarPickerClasses } from '@mui/x-date-pickers/CalendarPicker';
 
 export type {
   CalendarPickerClassKey,

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The CalendarPickerSkeleton component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The CalendarPickerSkeleton component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { CalendarPickerSkeleton } from '@mui/x-date-pickers'`",
         "or `import { CalendarPickerSkeleton } from '@mui/x-date-pickers/CalendarPickerSkeleton'`",

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  CalendarPickerSkeleton as XCalendarPickerSkeleton,
+  CalendarPickerSkeletonProps,
+} from '@mui/x-date-pickers/CalendarPickerSkeleton';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The CalendarPickerSkeleton component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { CalendarPickerSkeleton } from '@mui/x-date-pickers'`",
+        "or `import { CalendarPickerSkeleton } from '@mui/x-date-pickers/CalendarPickerSkeleton'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type CalendarPickerSkeletonComponent = ((
+  props: CalendarPickerSkeletonProps & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const CalendarPickerSkeleton = React.forwardRef(function DeprecatedCalendarPickerSkeleton(
+  props: CalendarPickerSkeletonProps,
+) {
+  warn();
+
+  return <XCalendarPickerSkeleton {...props} />;
+}) as CalendarPickerSkeletonComponent;
+
+export default CalendarPickerSkeleton;

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   CalendarPickerSkeleton as XCalendarPickerSkeleton,
   CalendarPickerSkeletonProps,
@@ -38,5 +39,16 @@ const CalendarPickerSkeleton = React.forwardRef(function DeprecatedCalendarPicke
 
   return <XCalendarPickerSkeleton {...props} />;
 }) as CalendarPickerSkeletonComponent;
+
+CalendarPickerSkeleton.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+} as any;
 
 export default CalendarPickerSkeleton;

--- a/packages/mui-lab/src/CalendarPickerSkeleton/index.ts
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/index.ts
@@ -1,5 +1,6 @@
+export { default } from './CalendarPickerSkeleton';
+
 export {
-  CalendarPickerSkeleton as default,
   calendarPickerSkeletonClasses,
   getCalendarPickerSkeletonUtilityClass,
 } from '@mui/x-date-pickers/CalendarPickerSkeleton';

--- a/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { ClockPicker as XClockPicker, ClockPickerProps } from '@mui/x-date-pickers/ClockPicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The ClockPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { ClockPicker } from '@mui/x-date-pickers'`",
+        "or `import { ClockPicker } from '@mui/x-date-pickers/ClockPicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type ClockPickerComponent = (<TDate>(
+  props: ClockPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const ClockPicker = React.forwardRef(function DeprecatedClockPicker<TDate>(
+  props: ClockPickerProps<TDate>,
+) {
+  warn();
+
+  return <XClockPicker {...props} />;
+}) as ClockPickerComponent;
+
+export default ClockPicker;

--- a/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
@@ -7,8 +7,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The ClockPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The ClockPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { ClockPicker } from '@mui/x-date-pickers'`",
         "or `import { ClockPicker } from '@mui/x-date-pickers/ClockPicker'`",

--- a/packages/mui-lab/src/ClockPicker/index.ts
+++ b/packages/mui-lab/src/ClockPicker/index.ts
@@ -1,4 +1,5 @@
-export { ClockPicker as default, clockPickerClasses } from '@mui/x-date-pickers/ClockPicker';
+export { default } from './ClockPicker';
+export { clockPickerClasses } from '@mui/x-date-pickers/ClockPicker';
 export type {
   ClockPickerClasses,
   ClockPickerClassKey,

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -8,8 +8,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The DatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The DatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { DatePicker } from '@mui/x-date-pickers'`",
         "or `import { DatePicker } from '@mui/x-date-pickers/DatePicker'`",

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { DatePicker as XDatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The DatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { DatePicker } from '@mui/x-date-pickers'`",
+        "or `import { DatePicker } from '@mui/x-date-pickers/DatePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type DatePickerComponent = (<TDate>(
+  props: DatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const DatePicker = React.forwardRef(function DeprecatedDatePicker<TDate>(
+  props: DatePickerProps<TDate>,
+) {
+  warn();
+
+  return <XDatePicker {...props} />;
+}) as DatePickerComponent;
+
+export default DatePicker;

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { DatePicker as XDatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
 
 let warnedOnce = false;
@@ -35,5 +36,387 @@ const DatePicker = React.forwardRef(function DeprecatedDatePicker<TDate>(
 
   return <XDatePicker {...props} />;
 }) as DatePickerComponent;
+
+DatePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * Cancel text message.
+   * @default 'Cancel'
+   */
+  cancelText: PropTypes.node,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * CSS media query when `Mobile` mode will be changed to `Desktop`.
+   * @default '@media (pointer: fine)'
+   * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
+   */
+  desktopModeMediaQuery: PropTypes.string,
+  /**
+   * Props applied to the [`Dialog`](https://mui.com/material-ui/api/dialog/) element.
+   */
+  DialogProps: PropTypes.object,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Ok button text.
+   * @default 'OK'
+   */
+  okText: PropTypes.node,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Paper props passed down to [Paper](https://mui.com/material-ui/api/paper/) component.
+   */
+  PaperProps: PropTypes.object,
+  /**
+   * Popper props passed down to [Popper](https://mui.com/material-ui/api/popper/) component.
+   */
+  PopperProps: PropTypes.object,
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
+   * @default false
+   */
+  showTodayButton: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Today text message.
+   * @default 'Today'
+   */
+  todayText: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DatePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * Custom component for popper [Transition](https://mui.com/material-ui/transitions/#transitioncomponent-prop).
+   */
+  TransitionComponent: PropTypes.elementType,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
+} as any;
 
 export default DatePicker;

--- a/packages/mui-lab/src/DatePicker/index.ts
+++ b/packages/mui-lab/src/DatePicker/index.ts
@@ -1,2 +1,2 @@
-export { DatePicker as default } from '@mui/x-date-pickers/DatePicker';
+export { default } from './DatePicker';
 export type { DatePickerProps } from '@mui/x-date-pickers/DatePicker';

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  DateTimePicker as XDateTimePicker,
+  DateTimePickerProps,
+} from '@mui/x-date-pickers/DateTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The DateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { DateTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type DateTimePickerComponent = (<TDate>(
+  props: DateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const DateTimePicker = React.forwardRef(function DeprecatedDateTimePicker<TDate>(
+  props: DateTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XDateTimePicker {...props} />;
+}) as DateTimePickerComponent;
+
+export default DateTimePicker;

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   DateTimePicker as XDateTimePicker,
   DateTimePickerProps,
@@ -38,5 +39,464 @@ const DateTimePicker = React.forwardRef(function DeprecatedDateTimePicker<TDate>
 
   return <XDateTimePicker {...props} />;
 }) as DateTimePickerComponent;
+
+DateTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * Cancel text message.
+   * @default 'Cancel'
+   */
+  cancelText: PropTypes.node,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Date tab icon.
+   */
+  dateRangeIcon: PropTypes.node,
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * CSS media query when `Mobile` mode will be changed to `Desktop`.
+   * @default '@media (pointer: fine)'
+   * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
+   */
+  desktopModeMediaQuery: PropTypes.string,
+  /**
+   * Props applied to the [`Dialog`](https://mui.com/material-ui/api/dialog/) element.
+   */
+  DialogProps: PropTypes.object,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * To show tabs.
+   */
+  hideTabs: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
+  maxDateTime: PropTypes.any,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
+  minDateTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Ok button text.
+   * @default 'OK'
+   */
+  okText: PropTypes.node,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarOrClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Paper props passed down to [Paper](https://mui.com/material-ui/api/paper/) component.
+   */
+  PaperProps: PropTypes.object,
+  /**
+   * Popper props passed down to [Popper](https://mui.com/material-ui/api/popper/) component.
+   */
+  PopperProps: PropTypes.object,
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
+   * @default false
+   */
+  showTodayButton: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Time tab icon.
+   */
+  timeIcon: PropTypes.node,
+  /**
+   * Today text message.
+   * @default 'Today'
+   */
+  todayText: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DateTimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date & time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * Custom component for popper [Transition](https://mui.com/material-ui/transitions/#transitioncomponent-prop).
+   */
+  TransitionComponent: PropTypes.elementType,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']).isRequired,
+  ),
+} as any;
 
 export default DateTimePicker;

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The DateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The DateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { DateTimePicker } from '@mui/x-date-pickers'`",
         "or `import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'`",

--- a/packages/mui-lab/src/DateTimePicker/index.ts
+++ b/packages/mui-lab/src/DateTimePicker/index.ts
@@ -1,2 +1,2 @@
-export { DateTimePicker as default } from '@mui/x-date-pickers/DateTimePicker';
+export { default } from './DateTimePicker';
 export type { DateTimePickerProps } from '@mui/x-date-pickers/DateTimePicker';

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   DesktopDatePicker as XDesktopDatePicker,
   DesktopDatePickerProps,
@@ -38,5 +39,357 @@ const DesktopDatePicker = React.forwardRef(function DeprecatedDesktopDatePicker<
 
   return <XDesktopDatePicker {...props} />;
 }) as DesktopDatePickerComponent;
+
+DesktopDatePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Paper props passed down to [Paper](https://mui.com/material-ui/api/paper/) component.
+   */
+  PaperProps: PropTypes.object,
+  /**
+   * Popper props passed down to [Popper](https://mui.com/material-ui/api/popper/) component.
+   */
+  PopperProps: PropTypes.object,
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DatePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * Custom component for popper [Transition](https://mui.com/material-ui/transitions/#transitioncomponent-prop).
+   */
+  TransitionComponent: PropTypes.elementType,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
+} as any;
 
 export default DesktopDatePicker;

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The DesktopDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The DesktopDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { DesktopDatePicker } from '@mui/x-date-pickers'`",
         "or `import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker'`",

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  DesktopDatePicker as XDesktopDatePicker,
+  DesktopDatePickerProps,
+} from '@mui/x-date-pickers/DesktopDatePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The DesktopDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { DesktopDatePicker } from '@mui/x-date-pickers'`",
+        "or `import { DesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type DesktopDatePickerComponent = (<TDate>(
+  props: DesktopDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const DesktopDatePicker = React.forwardRef(function DeprecatedDesktopDatePicker<TDate>(
+  props: DesktopDatePickerProps<TDate>,
+) {
+  warn();
+
+  return <XDesktopDatePicker {...props} />;
+}) as DesktopDatePickerComponent;
+
+export default DesktopDatePicker;

--- a/packages/mui-lab/src/DesktopDatePicker/index.ts
+++ b/packages/mui-lab/src/DesktopDatePicker/index.ts
@@ -1,2 +1,2 @@
-export { DesktopDatePicker as default } from '@mui/x-date-pickers/DesktopDatePicker';
+export { default } from './DesktopDatePicker';
 export type { DesktopDatePickerProps } from '@mui/x-date-pickers/DesktopDatePicker';

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   DesktopDateTimePicker as XDesktopDateTimePicker,
   DesktopDateTimePickerProps,
@@ -38,5 +39,434 @@ const DesktopDateTimePicker = React.forwardRef(function DeprecatedDesktopDateTim
 
   return <XDesktopDateTimePicker {...props} />;
 }) as DesktopDateTimePickerComponent;
+
+DesktopDateTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Date tab icon.
+   */
+  dateRangeIcon: PropTypes.node,
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * To show tabs.
+   */
+  hideTabs: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
+  maxDateTime: PropTypes.any,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
+  minDateTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarOrClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Paper props passed down to [Paper](https://mui.com/material-ui/api/paper/) component.
+   */
+  PaperProps: PropTypes.object,
+  /**
+   * Popper props passed down to [Popper](https://mui.com/material-ui/api/popper/) component.
+   */
+  PopperProps: PropTypes.object,
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Time tab icon.
+   */
+  timeIcon: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DateTimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date & time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * Custom component for popper [Transition](https://mui.com/material-ui/transitions/#transitioncomponent-prop).
+   */
+  TransitionComponent: PropTypes.elementType,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']).isRequired,
+  ),
+} as any;
 
 export default DesktopDateTimePicker;

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The DesktopDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The DesktopDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { DesktopDateTimePicker } from '@mui/x-date-pickers'`",
         "or `import { DesktopDateTimePicker } from '@mui/x-date-pickers/DesktopDateTimePicker'`",

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  DesktopDateTimePicker as XDesktopDateTimePicker,
+  DesktopDateTimePickerProps,
+} from '@mui/x-date-pickers/DesktopDateTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The DesktopDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { DesktopDateTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { DesktopDateTimePicker } from '@mui/x-date-pickers/DesktopDateTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type DesktopDateTimePickerComponent = (<TDate>(
+  props: DesktopDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const DesktopDateTimePicker = React.forwardRef(function DeprecatedDesktopDateTimePicker<TDate>(
+  props: DesktopDateTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XDesktopDateTimePicker {...props} />;
+}) as DesktopDateTimePickerComponent;
+
+export default DesktopDateTimePicker;

--- a/packages/mui-lab/src/DesktopDateTimePicker/index.ts
+++ b/packages/mui-lab/src/DesktopDateTimePicker/index.ts
@@ -1,2 +1,2 @@
-export { DesktopDateTimePicker as default } from '@mui/x-date-pickers/DesktopDateTimePicker';
+export { default } from './DesktopDateTimePicker';
 export type { DesktopDateTimePickerProps } from '@mui/x-date-pickers/DesktopDateTimePicker';

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   DesktopTimePicker as XDesktopTimePicker,
   DesktopTimePickerProps,
@@ -38,5 +39,288 @@ const DesktopTimePicker = React.forwardRef(function DeprecatedDesktopTimePicker<
 
   return <XDesktopTimePicker {...props} />;
 }) as DesktopTimePickerComponent;
+
+DesktopTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   */
+  components: PropTypes.shape({
+    OpenPickerIcon: PropTypes.elementType,
+  }),
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {ClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Paper props passed down to [Paper](https://mui.com/material-ui/api/paper/) component.
+   */
+  PaperProps: PropTypes.object,
+  /**
+   * Popper props passed down to [Popper](https://mui.com/material-ui/api/popper/) component.
+   */
+  PopperProps: PropTypes.object,
+  /**
+   * Make picker read only.
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default TimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * Custom component for popper [Transition](https://mui.com/material-ui/transitions/#transitioncomponent-prop).
+   */
+  TransitionComponent: PropTypes.elementType,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
+} as any;
 
 export default DesktopTimePicker;

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The DesktopTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The DesktopTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { DesktopTimePicker } from '@mui/x-date-pickers'`",
         "or `import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker'`",

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  DesktopTimePicker as XDesktopTimePicker,
+  DesktopTimePickerProps,
+} from '@mui/x-date-pickers/DesktopTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The DesktopTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { DesktopTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { DesktopTimePicker } from '@mui/x-date-pickers/DesktopTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type DesktopTimePickerComponent = (<TDate>(
+  props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const DesktopTimePicker = React.forwardRef(function DeprecatedDesktopTimePicker<TDate>(
+  props: DesktopTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XDesktopTimePicker {...props} />;
+}) as DesktopTimePickerComponent;
+
+export default DesktopTimePicker;

--- a/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   LocalizationProvider as XLocalizationProvider,
   LocalizationProviderProps,
@@ -38,5 +39,16 @@ const LocalizationProvider = React.forwardRef(function DeprecatedLocalizationPro
 
   return <XLocalizationProvider {...props} />;
 }) as LocalizationProviderComponent;
+
+LocalizationProvider.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+} as any;
 
 export default LocalizationProvider;

--- a/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The LocalizationProvider component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The LocalizationProvider component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { LocalizationProvider } from '@mui/x-date-pickers'`",
         "or `import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'`",

--- a/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  LocalizationProvider as XLocalizationProvider,
+  LocalizationProviderProps,
+} from '@mui/x-date-pickers/LocalizationProvider';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The LocalizationProvider component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { LocalizationProvider } from '@mui/x-date-pickers'`",
+        "or `import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type LocalizationProviderComponent = ((
+  props: LocalizationProviderProps & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const LocalizationProvider = React.forwardRef(function DeprecatedLocalizationProvider(
+  props: LocalizationProviderProps,
+) {
+  warn();
+
+  return <XLocalizationProvider {...props} />;
+}) as LocalizationProviderComponent;
+
+export default LocalizationProvider;

--- a/packages/mui-lab/src/LocalizationProvider/index.ts
+++ b/packages/mui-lab/src/LocalizationProvider/index.ts
@@ -1,2 +1,2 @@
-export { LocalizationProvider as default } from '@mui/x-date-pickers/LocalizationProvider';
+export { default } from './LocalizationProvider';
 export type { LocalizationProviderProps } from '@mui/x-date-pickers/LocalizationProvider';

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   MobileDatePicker as XMobileDatePicker,
   MobileDatePickerProps,
@@ -38,5 +39,369 @@ const MobileDatePicker = React.forwardRef(function DeprecatedMobileDatePicker<TD
 
   return <XMobileDatePicker {...props} />;
 }) as MobileDatePickerComponent;
+
+MobileDatePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * Cancel text message.
+   * @default 'Cancel'
+   */
+  cancelText: PropTypes.node,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * Props applied to the [`Dialog`](https://mui.com/material-ui/api/dialog/) element.
+   */
+  DialogProps: PropTypes.object,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Ok button text.
+   * @default 'OK'
+   */
+  okText: PropTypes.node,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
+   * @default false
+   */
+  showTodayButton: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Today text message.
+   * @default 'Today'
+   */
+  todayText: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DatePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
+} as any;
 
 export default MobileDatePicker;

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The MobileDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The MobileDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { MobileDatePicker } from '@mui/x-date-pickers'`",
         "or `import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'`",

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  MobileDatePicker as XMobileDatePicker,
+  MobileDatePickerProps,
+} from '@mui/x-date-pickers/MobileDatePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The MobileDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { MobileDatePicker } from '@mui/x-date-pickers'`",
+        "or `import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type MobileDatePickerComponent = (<TDate>(
+  props: MobileDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const MobileDatePicker = React.forwardRef(function DeprecatedMobileDatePicker<TDate>(
+  props: MobileDatePickerProps<TDate>,
+) {
+  warn();
+
+  return <XMobileDatePicker {...props} />;
+}) as MobileDatePickerComponent;
+
+export default MobileDatePicker;

--- a/packages/mui-lab/src/MobileDatePicker/index.ts
+++ b/packages/mui-lab/src/MobileDatePicker/index.ts
@@ -1,2 +1,2 @@
-export { MobileDatePicker as default } from '@mui/x-date-pickers/MobileDatePicker';
+export { default } from './MobileDatePicker';
 export type { MobileDatePickerProps } from '@mui/x-date-pickers/MobileDatePicker';

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   MobileDateTimePicker as XMobileDateTimePicker,
   MobileDateTimePickerProps,
@@ -38,5 +39,446 @@ const MobileDateTimePicker = React.forwardRef(function DeprecatedMobileDateTimeP
 
   return <XMobileDateTimePicker {...props} />;
 }) as MobileDateTimePickerComponent;
+
+MobileDateTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * Cancel text message.
+   * @default 'Cancel'
+   */
+  cancelText: PropTypes.node,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Date tab icon.
+   */
+  dateRangeIcon: PropTypes.node,
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * Props applied to the [`Dialog`](https://mui.com/material-ui/api/dialog/) element.
+   */
+  DialogProps: PropTypes.object,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * To show tabs.
+   */
+  hideTabs: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
+  maxDateTime: PropTypes.any,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
+  minDateTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Ok button text.
+   * @default 'OK'
+   */
+  okText: PropTypes.node,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarOrClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
+   * @default false
+   */
+  showTodayButton: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Time tab icon.
+   */
+  timeIcon: PropTypes.node,
+  /**
+   * Today text message.
+   * @default 'Today'
+   */
+  todayText: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DateTimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date & time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']).isRequired,
+  ),
+} as any;
 
 export default MobileDateTimePicker;

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  MobileDateTimePicker as XMobileDateTimePicker,
+  MobileDateTimePickerProps,
+} from '@mui/x-date-pickers/MobileDateTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The MobileDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { MobileDateTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type MobileDateTimePickerComponent = (<TDate>(
+  props: MobileDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const MobileDateTimePicker = React.forwardRef(function DeprecatedMobileDateTimePicker<TDate>(
+  props: MobileDateTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XMobileDateTimePicker {...props} />;
+}) as MobileDateTimePickerComponent;
+
+export default MobileDateTimePicker;

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The MobileDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The MobileDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { MobileDateTimePicker } from '@mui/x-date-pickers'`",
         "or `import { MobileDateTimePicker } from '@mui/x-date-pickers/MobileDateTimePicker'`",

--- a/packages/mui-lab/src/MobileDateTimePicker/index.ts
+++ b/packages/mui-lab/src/MobileDateTimePicker/index.ts
@@ -1,2 +1,2 @@
-export { MobileDateTimePicker as default } from '@mui/x-date-pickers/MobileDateTimePicker';
+export { default } from './MobileDateTimePicker';
 export type { MobileDateTimePickerProps } from '@mui/x-date-pickers/MobileDateTimePicker';

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The MobileTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The MobileTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { MobileTimePicker } from '@mui/x-date-pickers'`",
         "or `import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker'`",

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   MobileTimePicker as XMobileTimePicker,
   MobileTimePickerProps,
@@ -38,5 +39,300 @@ const MobileTimePicker = React.forwardRef(function DeprecatedMobileTimePicker<TD
 
   return <XMobileTimePicker {...props} />;
 }) as MobileTimePickerComponent;
+
+MobileTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * Cancel text message.
+   * @default 'Cancel'
+   */
+  cancelText: PropTypes.node,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   */
+  components: PropTypes.shape({
+    OpenPickerIcon: PropTypes.elementType,
+  }),
+  /**
+   * Props applied to the [`Dialog`](https://mui.com/material-ui/api/dialog/) element.
+   */
+  DialogProps: PropTypes.object,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Ok button text.
+   * @default 'OK'
+   */
+  okText: PropTypes.node,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {ClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Make picker read only.
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
+   * @default false
+   */
+  showTodayButton: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Today text message.
+   * @default 'Today'
+   */
+  todayText: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default TimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
+} as any;
 
 export default MobileTimePicker;

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  MobileTimePicker as XMobileTimePicker,
+  MobileTimePickerProps,
+} from '@mui/x-date-pickers/MobileTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The MobileTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { MobileTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { MobileTimePicker } from '@mui/x-date-pickers/MobileTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type MobileTimePickerComponent = (<TDate>(
+  props: MobileTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const MobileTimePicker = React.forwardRef(function DeprecatedMobileTimePicker<TDate>(
+  props: MobileTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XMobileTimePicker {...props} />;
+}) as MobileTimePickerComponent;
+
+export default MobileTimePicker;

--- a/packages/mui-lab/src/MobileTimePicker/index.ts
+++ b/packages/mui-lab/src/MobileTimePicker/index.ts
@@ -1,2 +1,2 @@
-export { MobileTimePicker as default } from '@mui/x-date-pickers/MobileTimePicker';
+export { default } from './MobileTimePicker';
 export type { MobileTimePickerProps } from '@mui/x-date-pickers/MobileTimePicker';

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { MonthPicker as XMonthPicker, MonthPickerProps } from '@mui/x-date-pickers/MonthPicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The MonthPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { MonthPicker } from '@mui/x-date-pickers'`",
+        "or `import { MonthPicker } from '@mui/x-date-pickers/MonthPicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type MonthPickerComponent = (<TDate>(
+  props: MonthPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const MonthPicker = React.forwardRef(function DeprecatedMonthPicker<TDate>(
+  props: MonthPickerProps<TDate>,
+) {
+  warn();
+
+  return <XMonthPicker {...props} />;
+}) as MonthPickerComponent;
+
+export default MonthPicker;

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -7,8 +7,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The MonthPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The MonthPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { MonthPicker } from '@mui/x-date-pickers'`",
         "or `import { MonthPicker } from '@mui/x-date-pickers/MonthPicker'`",

--- a/packages/mui-lab/src/MonthPicker/index.ts
+++ b/packages/mui-lab/src/MonthPicker/index.ts
@@ -1,6 +1,3 @@
-export {
-  MonthPicker as default,
-  getMonthPickerUtilityClass,
-  monthPickerClasses,
-} from '@mui/x-date-pickers/MonthPicker';
+export { default } from './MonthPicker';
+export { getMonthPickerUtilityClass, monthPickerClasses } from '@mui/x-date-pickers/MonthPicker';
 export type { MonthPickerClassKey, MonthPickerProps } from '@mui/x-date-pickers/MonthPicker';

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -8,8 +8,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The PickersDay component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The PickersDay component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { PickersDay } from '@mui/x-date-pickers'`",
         "or `import { PickersDay } from '@mui/x-date-pickers/PickersDay'`",

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { PickersDay as XPickersDay, PickersDayProps } from '@mui/x-date-pickers/PickersDay';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The PickersDay component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { PickersDay } from '@mui/x-date-pickers'`",
+        "or `import { PickersDay } from '@mui/x-date-pickers/PickersDay'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type PickersDayComponent = (<TDate>(
+  props: PickersDayProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const PickersDay = React.forwardRef(function DeprecatedPickersDay<TDate>(
+  props: PickersDayProps<TDate>,
+) {
+  warn();
+
+  return <XPickersDay {...props} />;
+}) as PickersDayComponent;
+
+export default PickersDay;

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { PickersDay as XPickersDay, PickersDayProps } from '@mui/x-date-pickers/PickersDay';
 
 let warnedOnce = false;
@@ -35,5 +36,16 @@ const PickersDay = React.forwardRef(function DeprecatedPickersDay<TDate>(
 
   return <XPickersDay {...props} />;
 }) as PickersDayComponent;
+
+PickersDay.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+} as any;
 
 export default PickersDay;

--- a/packages/mui-lab/src/PickersDay/index.ts
+++ b/packages/mui-lab/src/PickersDay/index.ts
@@ -1,6 +1,3 @@
-export {
-  PickersDay as default,
-  pickersDayClasses,
-  getPickersDayUtilityClass,
-} from '@mui/x-date-pickers/PickersDay';
+export { default } from './PickersDay';
+export { pickersDayClasses, getPickersDayUtilityClass } from '@mui/x-date-pickers/PickersDay';
 export type { PickersDayClassKey, PickersDayProps } from '@mui/x-date-pickers/PickersDay';

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  StaticDatePicker as XStaticDatePicker,
+  StaticDatePickerProps,
+} from '@mui/x-date-pickers/StaticDatePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The StaticDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { StaticDatePicker } from '@mui/x-date-pickers'`",
+        "or `import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type StaticDatePickerComponent = (<TDate>(
+  props: StaticDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const StaticDatePicker = React.forwardRef(function DeprecatedStaticDatePicker<TDate>(
+  props: StaticDatePickerProps<TDate>,
+) {
+  warn();
+
+  return <XStaticDatePicker {...props} />;
+}) as StaticDatePickerComponent;
+
+export default StaticDatePicker;

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The StaticDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The StaticDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { StaticDatePicker } from '@mui/x-date-pickers'`",
         "or `import { StaticDatePicker } from '@mui/x-date-pickers/StaticDatePicker'`",

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   StaticDatePicker as XStaticDatePicker,
   StaticDatePickerProps,
@@ -38,5 +39,336 @@ const StaticDatePicker = React.forwardRef(function DeprecatedStaticDatePicker<TD
 
   return <XStaticDatePicker {...props} />;
 }) as StaticDatePickerComponent;
+
+StaticDatePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'month', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DatePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['day', 'month', 'year']).isRequired),
+} as any;
 
 export default StaticDatePicker;

--- a/packages/mui-lab/src/StaticDatePicker/index.ts
+++ b/packages/mui-lab/src/StaticDatePicker/index.ts
@@ -1,2 +1,2 @@
-export { StaticDatePicker as default } from '@mui/x-date-pickers/StaticDatePicker';
+export { default } from './StaticDatePicker';
 export type { StaticDatePickerProps } from '@mui/x-date-pickers/StaticDatePicker';

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  StaticDateTimePicker as XStaticDateTimePicker,
+  StaticDateTimePickerProps,
+} from '@mui/x-date-pickers/StaticDateTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The StaticDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { StaticDateTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { StaticDateTimePicker } from '@mui/x-date-pickers/StaticDateTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type StaticDateTimePickerComponent = (<TDate>(
+  props: StaticDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const StaticDateTimePicker = React.forwardRef(function DeprecatedStaticDateTimePicker<TDate>(
+  props: StaticDateTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XStaticDateTimePicker {...props} />;
+}) as StaticDateTimePickerComponent;
+
+export default StaticDateTimePicker;

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The StaticDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The StaticDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { StaticDateTimePicker } from '@mui/x-date-pickers'`",
         "or `import { StaticDateTimePicker } from '@mui/x-date-pickers/StaticDateTimePicker'`",

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   StaticDateTimePicker as XStaticDateTimePicker,
   StaticDateTimePickerProps,
@@ -38,5 +39,413 @@ const StaticDateTimePicker = React.forwardRef(function DeprecatedStaticDateTimeP
 
   return <XStaticDateTimePicker {...props} />;
 }) as StaticDateTimePickerComponent;
+
+StaticDateTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * If `true`, `onChange` is fired on click even if the same date is selected.
+   * @default false
+   */
+  allowSameDateSelection: PropTypes.bool,
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   * @default {}
+   */
+  components: PropTypes.shape({
+    LeftArrowButton: PropTypes.elementType,
+    LeftArrowIcon: PropTypes.elementType,
+    OpenPickerIcon: PropTypes.elementType,
+    RightArrowButton: PropTypes.elementType,
+    RightArrowIcon: PropTypes.elementType,
+    SwitchViewButton: PropTypes.elementType,
+    SwitchViewIcon: PropTypes.elementType,
+  }),
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  componentsProps: PropTypes.shape({
+    leftArrowButton: PropTypes.object,
+    rightArrowButton: PropTypes.object,
+    switchViewButton: PropTypes.object,
+  }),
+  /**
+   * Date tab icon.
+   */
+  dateRangeIcon: PropTypes.node,
+  /**
+   * Default calendar month displayed when `value={null}`.
+   */
+  defaultCalendarMonth: PropTypes.any,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disableFuture: PropTypes.bool,
+  /**
+   * If `true`, todays date is rendering without highlighting with circle.
+   * @default false
+   */
+  disableHighlightToday: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * @default false
+   */
+  disablePast: PropTypes.bool,
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * Get aria-label text for switching between views button.
+   * @param {CalendarPickerView} currentView The view from which we want to get the button text.
+   * @returns {string} The label of the view.
+   */
+  getViewSwitchingButtonText: PropTypes.func,
+  /**
+   * To show tabs.
+   */
+  hideTabs: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Left arrow icon aria-label text.
+   */
+  leftArrowButtonText: PropTypes.string,
+  /**
+   * If `true` renders `LoadingComponent` in calendar instead of calendar view.
+   * Can be used to preload information and show it in calendar.
+   * @default false
+   */
+  loading: PropTypes.bool,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max selectable date. @DateIOType
+   */
+  maxDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set max time in each day use `maxTime`.
+   */
+  maxDateTime: PropTypes.any,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min selectable date. @DateIOType
+   */
+  minDate: PropTypes.any,
+  /**
+   * Minimal selectable moment of time with binding to date, to set min time in each day use `minTime`.
+   */
+  minDateTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback firing on month change. @DateIOType
+   * @template TDate
+   * @param {TDate} month The new month.
+   */
+  onMonthChange: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {CalendarOrClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Callback firing on year change @DateIOType.
+   * @template TDate
+   * @param {TDate} year The new year.
+   */
+  onYearChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Make picker read only.
+   * @default false
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Disable heavy animations.
+   * @default typeof navigator !== 'undefined' && /(android)/i.test(navigator.userAgent)
+   */
+  reduceAnimations: PropTypes.bool,
+  /**
+   * Custom renderer for day. Check the [PickersDay](https://mui.com/x/api/date-pickers/pickers-day/) component.
+   * @template TDate
+   * @param {TDate} day The day to render.
+   * @param {Array<TDate | null>} selectedDates The dates currently selected.
+   * @param {PickersDayProps<TDate>} pickersDayProps The props of the day to render.
+   * @returns {JSX.Element} The element representing the day.
+   */
+  renderDay: PropTypes.func,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Component displaying when passed `loading` true.
+   * @returns {React.ReactNode} The node to render when loading.
+   * @default () => <span data-mui-test="loading-progress">...</span>
+   */
+  renderLoading: PropTypes.func,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Right arrow icon aria-label text.
+   */
+  rightArrowButtonText: PropTypes.string,
+  /**
+   * Disable specific date. @DateIOType
+   * @template TDate
+   * @param {TDate} day The date to check.
+   * @returns {boolean} If `true` the day will be disabled.
+   */
+  shouldDisableDate: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * Disable specific years dynamically.
+   * Works like `shouldDisableDate` but for year selection view @DateIOType.
+   * @template TDate
+   * @param {TDate} year The year to test.
+   * @returns {boolean} Return `true` if the year should be disabled.
+   */
+  shouldDisableYear: PropTypes.func,
+  /**
+   * If `true`, days that have `outsideCurrentMonth={true}` are displayed.
+   * @default false
+   */
+  showDaysOutsideCurrentMonth: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Time tab icon.
+   */
+  timeIcon: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default DateTimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select date & time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(
+    PropTypes.oneOf(['day', 'hours', 'minutes', 'month', 'seconds', 'year']).isRequired,
+  ),
+} as any;
 
 export default StaticDateTimePicker;

--- a/packages/mui-lab/src/StaticDateTimePicker/index.ts
+++ b/packages/mui-lab/src/StaticDateTimePicker/index.ts
@@ -1,2 +1,2 @@
-export { StaticDateTimePicker as default } from '@mui/x-date-pickers/StaticDateTimePicker';
+export { default } from './StaticDateTimePicker';
 export type { StaticDateTimePickerProps } from '@mui/x-date-pickers/StaticDateTimePicker';

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  StaticTimePicker as XStaticTimePicker,
+  StaticTimePickerProps,
+} from '@mui/x-date-pickers/StaticTimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The StaticTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { StaticTimePicker } from '@mui/x-date-pickers'`",
+        "or `import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type StaticTimePickerComponent = (<TDate>(
+  props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const StaticTimePicker = React.forwardRef(function DeprecatedStaticTimePicker<TDate>(
+  props: StaticTimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XStaticTimePicker {...props} />;
+}) as StaticTimePickerComponent;
+
+export default StaticTimePicker;

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import {
   StaticTimePicker as XStaticTimePicker,
   StaticTimePickerProps,
@@ -38,5 +39,267 @@ const StaticTimePicker = React.forwardRef(function DeprecatedStaticTimePicker<TD
 
   return <XStaticTimePicker {...props} />;
 }) as StaticTimePickerComponent;
+
+StaticTimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   */
+  components: PropTypes.shape({
+    OpenPickerIcon: PropTypes.elementType,
+  }),
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * Force static wrapper inner components to be rendered in mobile or desktop mode.
+   * @default 'mobile'
+   */
+  displayStaticWrapperAs: PropTypes.oneOf(['desktop', 'mobile']),
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {ClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Make picker read only.
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default TimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
+} as any;
 
 export default StaticTimePicker;

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -11,8 +11,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The StaticTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The StaticTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { StaticTimePicker } from '@mui/x-date-pickers'`",
         "or `import { StaticTimePicker } from '@mui/x-date-pickers/StaticTimePicker'`",

--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { TimePicker as XTimePicker, TimePickerProps } from '@mui/x-date-pickers/TimePicker';
 
 let warnedOnce = false;
@@ -35,5 +36,318 @@ const TimePicker = React.forwardRef(function DeprecatedTimePicker<TDate>(
 
   return <XTimePicker {...props} />;
 }) as TimePickerComponent;
+
+TimePicker.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * Regular expression to detect "accepted" symbols.
+   * @default /\dap/gi
+   */
+  acceptRegex: PropTypes.instanceOf(RegExp),
+  /**
+   * 12h/24h view for hour selection clock.
+   * @default false
+   */
+  ampm: PropTypes.bool,
+  /**
+   * Display ampm controls under the clock (instead of in the toolbar).
+   * @default false
+   */
+  ampmInClock: PropTypes.bool,
+  /**
+   * Cancel text message.
+   * @default 'Cancel'
+   */
+  cancelText: PropTypes.node,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * className applied to the root component.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, it shows the clear action in the picker dialog.
+   * @default false
+   */
+  clearable: PropTypes.bool,
+  /**
+   * Clear text message.
+   * @default 'Clear'
+   */
+  clearText: PropTypes.node,
+  /**
+   * The components used for each slot.
+   * Either a string to use an HTML element or a component.
+   */
+  components: PropTypes.shape({
+    OpenPickerIcon: PropTypes.elementType,
+  }),
+  /**
+   * CSS media query when `Mobile` mode will be changed to `Desktop`.
+   * @default '@media (pointer: fine)'
+   * @example '@media (min-width: 720px)' or theme.breakpoints.up("sm")
+   */
+  desktopModeMediaQuery: PropTypes.string,
+  /**
+   * Props applied to the [`Dialog`](https://mui.com/material-ui/api/dialog/) element.
+   */
+  DialogProps: PropTypes.object,
+  /**
+   * If `true` the popup or dialog will immediately close after submitting full date.
+   * @default `true` for Desktop, `false` for Mobile (based on the chosen wrapper and `desktopModeMediaQuery` prop).
+   */
+  disableCloseOnSelect: PropTypes.bool,
+  /**
+   * If `true`, the picker and text field are disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Do not ignore date part when validating min/max time.
+   * @default false
+   */
+  disableIgnoringDatePartForTimeValidation: PropTypes.bool,
+  /**
+   * Disable mask on the keyboard, this should be used rarely. Consider passing proper mask for your format.
+   * @default false
+   */
+  disableMaskedInput: PropTypes.bool,
+  /**
+   * Do not render open picker button (renders only text field with validation).
+   * @default false
+   */
+  disableOpenPicker: PropTypes.bool,
+  /**
+   * Accessible text that helps user to understand which time and view is selected.
+   * @template TDate
+   * @param {ClockPickerView} view The current view rendered.
+   * @param {TDate | null} time The current time.
+   * @param {MuiPickersAdapter<TDate>} adapter The current date adapter.
+   * @returns {string} The clock label.
+   * @default <TDate extends any>(
+   *   view: ClockView,
+   *   time: TDate | null,
+   *   adapter: MuiPickersAdapter<TDate>,
+   * ) =>
+   *   `Select ${view}. ${
+   *     time === null ? 'No time selected' : `Selected time is ${adapter.format(time, 'fullTime')}`
+   *   }`
+   */
+  getClockLabelText: PropTypes.func,
+  /**
+   * Get aria-label text for control that opens picker dialog. Aria-label text must include selected date. @DateIOType
+   * @template TDateValue
+   * @param {ParseableDate<TDateValue>} value The date from which we want to add an aria-text.
+   * @param {MuiPickersAdapter<TDateValue>} utils The utils to manipulate the date.
+   * @returns {string} The aria-text to render inside the dialog.
+   * @default (value, utils) => `Choose date, selected date is ${utils.format(utils.date(value), 'fullDate')}`
+   */
+  getOpenDialogAriaText: PropTypes.func,
+  /**
+   * @ignore
+   */
+  ignoreInvalidInputs: PropTypes.bool,
+  /**
+   * Props to pass to keyboard input adornment.
+   */
+  InputAdornmentProps: PropTypes.object,
+  /**
+   * Format string.
+   */
+  inputFormat: PropTypes.string,
+  /**
+   * @ignore
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({
+      current: PropTypes.object,
+    }),
+  ]),
+  /**
+   * @ignore
+   */
+  key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  label: PropTypes.node,
+  /**
+   * Custom mask. Can be used to override generate from format. (e.g. `__/__/____ __:__` or `__/__/____ __:__ _M`).
+   */
+  mask: PropTypes.string,
+  /**
+   * Max time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  maxTime: PropTypes.any,
+  /**
+   * Min time acceptable time.
+   * For input validation date part of passed object will be ignored if `disableIgnoringDatePartForTimeValidation` not specified.
+   */
+  minTime: PropTypes.any,
+  /**
+   * Step over minutes.
+   * @default 1
+   */
+  minutesStep: PropTypes.number,
+  /**
+   * Ok button text.
+   * @default 'OK'
+   */
+  okText: PropTypes.node,
+  /**
+   * Callback fired when date is accepted @DateIOType.
+   * @template TDateValue
+   * @param {TDateValue} date The date that was just accepted.
+   */
+  onAccept: PropTypes.func,
+  /**
+   * Callback fired when the value (the selected date) changes @DateIOType.
+   * @template TDate
+   * @param {DateRange<TDate>} date The new parsed date.
+   * @param {string} keyboardInputValue The current value of the keyboard input.
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the popup requests to be closed.
+   * Use in controlled mode (see open).
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback that fired when input value or new `value` prop validation returns **new** validation error (or value is valid after error).
+   * In case of validation error detected `reason` prop return non-null value and `TextField` must be displayed in `error` state.
+   * This can be used to render appropriate form error.
+   *
+   * [Read the guide](https://next.material-ui-pickers.dev/guides/forms) about form integration and error displaying.
+   * @DateIOType
+   *
+   * @template TError, TDateValue
+   * @param {TError} reason The reason why the current value is not valid.
+   * @param {TDateValue} value The invalid value.
+   */
+  onError: PropTypes.func,
+  /**
+   * Callback fired when the popup requests to be opened.
+   * Use in controlled mode (see open).
+   */
+  onOpen: PropTypes.func,
+  /**
+   * Callback fired on view change.
+   * @param {ClockPickerView} view The new view.
+   */
+  onViewChange: PropTypes.func,
+  /**
+   * Control the popup or dialog open state.
+   */
+  open: PropTypes.bool,
+  /**
+   * Props to pass to keyboard adornment button.
+   */
+  OpenPickerButtonProps: PropTypes.object,
+  /**
+   * First view to show.
+   */
+  openTo: PropTypes.oneOf(['hours', 'minutes', 'seconds']),
+  /**
+   * Force rendering in particular orientation.
+   */
+  orientation: PropTypes.oneOf(['landscape', 'portrait']),
+  /**
+   * Paper props passed down to [Paper](https://mui.com/material-ui/api/paper/) component.
+   */
+  PaperProps: PropTypes.object,
+  /**
+   * Popper props passed down to [Popper](https://mui.com/material-ui/api/popper/) component.
+   */
+  PopperProps: PropTypes.object,
+  /**
+   * Make picker read only.
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * The `renderInput` prop allows you to customize the rendered input.
+   * The `props` argument of this render prop contains props of [TextField](https://mui.com/material-ui/api/text-field/#props) that you need to forward.
+   * Pay specific attention to the `ref` and `inputProps` keys.
+   * @example ```jsx
+   * renderInput={props => <TextField {...props} />}
+   * ````
+   * @param {MuiTextFieldPropsType} props The props of the input.
+   * @returns {React.ReactNode} The node to render as the input.
+   */
+  renderInput: PropTypes.func.isRequired,
+  /**
+   * Custom formatter to be passed into Rifm component.
+   * @param {string} str The un-formatted string.
+   * @returns {string} The formatted string.
+   */
+  rifmFormatter: PropTypes.func,
+  /**
+   * Dynamically check if time is disabled or not.
+   * If returns `false` appropriate time point will ot be acceptable.
+   * @param {number} timeValue The value to check.
+   * @param {ClockPickerView} clockType The clock type of the timeValue.
+   * @returns {boolean} Returns `true` if the time should be disabled
+   */
+  shouldDisableTime: PropTypes.func,
+  /**
+   * If `true`, the today button is displayed. **Note** that `showClearButton` has a higher priority.
+   * @default false
+   */
+  showTodayButton: PropTypes.bool,
+  /**
+   * If `true`, show the toolbar even in desktop mode.
+   */
+  showToolbar: PropTypes.bool,
+  /**
+   * Today text message.
+   * @default 'Today'
+   */
+  todayText: PropTypes.node,
+  /**
+   * Component that will replace default toolbar renderer.
+   * @default TimePickerToolbar
+   */
+  ToolbarComponent: PropTypes.elementType,
+  /**
+   * Date format, that is displaying in toolbar.
+   */
+  toolbarFormat: PropTypes.string,
+  /**
+   * Mobile picker date value placeholder, displaying if `value` === `null`.
+   * @default '–'
+   */
+  toolbarPlaceholder: PropTypes.node,
+  /**
+   * Mobile picker title, displaying in the toolbar.
+   * @default 'Select time'
+   */
+  toolbarTitle: PropTypes.node,
+  /**
+   * Custom component for popper [Transition](https://mui.com/material-ui/transitions/#transitioncomponent-prop).
+   */
+  TransitionComponent: PropTypes.elementType,
+  /**
+   * The value of the picker.
+   */
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.instanceOf(Date),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
+   * Array of views to show.
+   */
+  views: PropTypes.arrayOf(PropTypes.oneOf(['hours', 'minutes', 'seconds']).isRequired),
+} as any;
 
 export default TimePicker;

--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -8,8 +8,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The TimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The TimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { TimePicker } from '@mui/x-date-pickers'`",
         "or `import { TimePicker } from '@mui/x-date-pickers/TimePicker'`",

--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { TimePicker as XTimePicker, TimePickerProps } from '@mui/x-date-pickers/TimePicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The TimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { TimePicker } from '@mui/x-date-pickers'`",
+        "or `import { TimePicker } from '@mui/x-date-pickers/TimePicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type TimePickerComponent = (<TDate>(
+  props: TimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const TimePicker = React.forwardRef(function DeprecatedTimePicker<TDate>(
+  props: TimePickerProps<TDate>,
+) {
+  warn();
+
+  return <XTimePicker {...props} />;
+}) as TimePickerComponent;
+
+export default TimePicker;

--- a/packages/mui-lab/src/TimePicker/index.tsx
+++ b/packages/mui-lab/src/TimePicker/index.tsx
@@ -1,2 +1,2 @@
-export { TimePicker as default } from '@mui/x-date-pickers/TimePicker';
+export { default } from './TimePicker';
 export type { TimePickerProps } from '@mui/x-date-pickers/TimePicker';

--- a/packages/mui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/mui-lab/src/YearPicker/YearPicker.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { YearPicker as XYearPicker, YearPickerProps } from '@mui/x-date-pickers/YearPicker';
+
+let warnedOnce = false;
+
+const warn = () => {
+  if (!warnedOnce) {
+    console.warn(
+      [
+        'MUI: The YearPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
+        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        '',
+        "You should use `import { YearPicker } from '@mui/x-date-pickers'`",
+        "or `import { YearPicker } from '@mui/x-date-pickers/YearPicker'`",
+        '',
+        'More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.',
+      ].join('\n'),
+    );
+
+    warnedOnce = true;
+  }
+};
+
+type YearPickerComponent = (<TDate>(
+  props: YearPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
+) => JSX.Element) & { propTypes?: any };
+
+/**
+ * @ignore - do not document.
+ */
+const YearPicker = React.forwardRef(function DeprecatedYearPicker<TDate>(
+  props: YearPickerProps<TDate>,
+) {
+  warn();
+
+  return <XYearPicker {...props} />;
+}) as YearPickerComponent;
+
+export default YearPicker;

--- a/packages/mui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/mui-lab/src/YearPicker/YearPicker.tsx
@@ -7,8 +7,8 @@ const warn = () => {
   if (!warnedOnce) {
     console.warn(
       [
-        'MUI: The YearPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`',
-        'The import from `@mui/lab` will be removed in the first release of July 2022.',
+        'MUI: The YearPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`.',
+        'The component will no longer be exported from `@mui/lab` in the first release of July 2022.',
         '',
         "You should use `import { YearPicker } from '@mui/x-date-pickers'`",
         "or `import { YearPicker } from '@mui/x-date-pickers/YearPicker'`",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


The pickers have been moved to `@mui/x-date-pickers` since the 12th of April 2022.
Until now, we were re-exporting everything in `@mui/lab` without warning to give some time to stabilize them before forcing a migration.
But we now need to end the transition phase which is causing package duplication to some users using both `@mui/x-date-pickers` and `@mui/lab` for other components.
This PR adds clear warnings when using a picker component from the lab that those are deprecated.
The pickers will stop being re-exported from the lab during the 1st release of July 2022, at that point we will keep the warning but will not render anything anymore (like for `DateRangePicker` in `@mui/lab` currently).