### PR TITLE
[website] Remove unnecessary `address` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -61,7 +61,6 @@
     "@types/react-window": "^1.8.5",
     "@types/styled-components": "5.1.25",
     "accept-language": "^3.0.18",
-    "address": "^1.1.2",
     "ast-types": "^0.14.2",
     "autoprefixer": "^10.4.7",
     "autosuggest-highlight": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3907,11 +3907,6 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
-address@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
-  integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
-
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"


### PR DESCRIPTION
Removes the apparently unused `address` dependency from the docs (as noted in #32678)

Closes https://github.com/mui/material-ui/pull/32678