### PR TITLE
[Popover] Export `getOffsetTop` & `getOffsetLeft` from Popover's index and add typings

### DIFF
--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -133,6 +133,13 @@ export interface PopoverActions {
   updatePosition(): void;
 }
 
+export function getOffsetTop(rect: DOMRect, vertical: number | 'center' | 'bottom' | 'top'): number;
+
+export function getOffsetLeft(
+  rect: DOMRect,
+  horizontal: number | 'center' | 'right' | 'left',
+): number;
+
 /**
  *
  * Demos:

--- a/packages/mui-material/src/Popover/index.js
+++ b/packages/mui-material/src/Popover/index.js
@@ -1,4 +1,5 @@
 export { default } from './Popover';
 
+export * from './Popover';
 export { default as popoverClasses } from './popoverClasses';
 export * from './popoverClasses';


### PR DESCRIPTION
Wondering if there's a reason why `getOffsetTop` and `getOffsetLeft` aren't exported from the index? They're actually exported from the main `Popover.js` file but not from the index or typings. Almost seems like a miss.

We've found use for these when programmatically supplying a position to the Popover component (i.e. `anchorReference: 'anchorPosition'` and `anchorPostion: { top, left }`).

To use them, we have to ts-ignore the line due to the lack of typings and import from the 4th level which is meant to be _private_.

```ts
// @ts-ignore
import { getOffsetLeft, getOffsetTop } from '@mui/material/Popover/Popover';
```

It'd be nice to have them public

```ts
import { getOffsetLeft, getOffsetTop } from '@mui/material/Popover';
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
