### PR TITLE
[core] Prepare Next config for React 18

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -58,7 +58,12 @@ module.exports = {
     // next includes node_modules in webpack externals. Some of those have dependencies
     // on the aliases defined above. If a module is an external those aliases won't be used.
     // We need tell webpack to not consider those packages as externals.
-    if (options.isServer) {
+    if (
+      options.isServer &&
+      // Next executes this twice on the server with React 18 (once per runtime).
+      // We only care about Node runtime at this point.
+      (options.nextRuntime === undefined || options.nextRuntime === 'nodejs')
+    ) {
       const [nextExternals, ...externals] = config.externals;
 
       if (externals.length > 0) {


### PR DESCRIPTION
Next.js introduced another runtime when ran with React 18 (https://nextjs.org/docs/advanced-features/react-18/switchable-runtime). Even when the Edge runtime is not enabled, Next executes the config in the context of it, causing problems with our webpack externals check.

This PR adds a guard to run our checks only on Node runtime. It is backwards compatible with React 17.
