### PR TITLE
Preserve leading comments within jss-to-tss-react

### DIFF
--- a/packages/mui-codemod/src/util/preserveLeadingComments.js
+++ b/packages/mui-codemod/src/util/preserveLeadingComments.js
@@ -1,0 +1,27 @@
+/**
+ * Preserves leading comments within a file modified by jscodeshift.  See
+ * https://github.com/facebook/jscodeshift/blob/main/recipes/retain-first-comment.md.
+ *
+ * Note that this may cause an extra blank line to be inserted.  See
+ * https://github.com/facebook/jscodeshift/issues/185.
+ *
+ * @param {import('jscodeshift').JSCodeshift} file
+ * @param {import('jscodeshift').Collection} api
+ */
+export default function preserveLeadingComments(j, root) {
+  const getFirstNode = () => root.find(j.Program).get('body', 0).node;
+
+  // Save the comments attached to the first node
+  const firstNode = getFirstNode();
+  const { comments } = firstNode;
+
+  return {
+    reapply: () => {
+      // If the first node has been modified or deleted, reattach the comments
+      const firstNode2 = getFirstNode();
+      if (firstNode2 !== firstNode) {
+        firstNode2.comments = comments;
+      }
+    },
+  };
+}

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.js
@@ -1,3 +1,5 @@
+import preserveLeadingComments from '../util/preserveLeadingComments';
+
 const ruleEndRegEx = /[^a-zA-Z0-9_]+/;
 
 function transformNestedKeys(j, comments, propValueNode, ruleRegEx, nestedKeys) {
@@ -172,6 +174,8 @@ export default function transformer(file, api, options) {
 
   const root = j(file.source);
   const printOptions = options.printOptions || { quote: 'single' };
+
+  const leadingComments = preserveLeadingComments(j, root);
 
   let importsChanged = false;
   let foundCreateStyles = false;
@@ -448,5 +452,8 @@ export default function transformer(file, api, options) {
       });
     });
   }
+
+  leadingComments.reapply();
+
   return root.toSource(printOptions);
 }

--- a/packages/mui-codemod/src/v5.0.0/material-ui-styles.js
+++ b/packages/mui-codemod/src/v5.0.0/material-ui-styles.js
@@ -1,3 +1,5 @@
+import preserveLeadingComments from '../util/preserveLeadingComments';
+
 /**
  * @param {import('jscodeshift').FileInfo} file
  * @param {import('jscodeshift').API} api
@@ -42,12 +44,7 @@ export default function transformer(file, api, options) {
 
   const stylesPackage = '@material-ui/styles';
 
-  // https://github.com/facebook/jscodeshift/blob/master/recipes/retain-first-comment.md
-  const getFirstNode = () => root.find(j.Program).get('body', 0).node;
-
-  // Save the comments attached to the first node
-  const firstNode = getFirstNode();
-  const { comments } = firstNode;
+  const leadingComments = preserveLeadingComments(j, root);
 
   root
     .find(j.ImportDeclaration)
@@ -102,11 +99,7 @@ export default function transformer(file, api, options) {
     .filter((path) => !path.node.specifiers.length)
     .remove();
 
-  // If the first node has been modified or deleted, reattach the comments
-  const firstNode2 = getFirstNode();
-  if (firstNode2 !== firstNode) {
-    firstNode2.comments = comments;
-  }
+  leadingComments.reapply();
 
   return root.toSource(printOptions);
 }


### PR DESCRIPTION
I have not added an automated test. Since preserving comments is (ideally) common behavior across several codemods, I wasn't sure about the best place to add a test.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
