### PR TITLE
[system] Configurable attributes for libraries

### DIFF
--- a/docs/pages/experiments/joy/checkbox.tsx
+++ b/docs/pages/experiments/joy/checkbox.tsx
@@ -270,12 +270,12 @@ export default function JoyCheckbox() {
             </Typography>
             <Box role="group" aria-labelledby="filter-status">
               <List
-                sx={{
+                sx={(theme) => ({
                   '--List-item-radius': '4px',
-                  '[data-mui-color-scheme="light"] &': {
+                  [theme.getColorSchemeSelector('light')]: {
                     '--joy-palette-neutral-lightBg': 'var(--joy-palette-neutral-50)',
                   },
-                }}
+                })}
               >
                 <ListItem variant="soft" color="danger">
                   <Checkbox label="Declined Payment" color="danger" checked overlay />
@@ -320,17 +320,17 @@ export default function JoyCheckbox() {
             </Typography>
             <Box role="group" aria-labelledby="member">
               <List
-                sx={{
+                sx={(theme) => ({
                   '--List-item-radius': '4px',
                   '& .MuiCheckbox-root': {
                     mr: 'auto',
                     alignItems: 'center',
                     '--Checkbox-gap': '12px',
                   },
-                  '[data-mui-color-scheme="light"] &': {
+                  [theme.getColorSchemeSelector('light')]: {
                     '--joy-palette-neutral-lightBg': 'var(--joy-palette-neutral-50)',
                   },
-                }}
+                })}
               >
                 <ListItem>
                   <Checkbox disabled label="Friedrich Oberbrunner" overlay />

--- a/docs/pages/experiments/joy/list.tsx
+++ b/docs/pages/experiments/joy/list.tsx
@@ -318,7 +318,7 @@ function MuiNav() {
         '--joy-palette-primary-softBg': theme.vars.palette.primary[50],
         '--joy-palette-primary-softHoverBg': 'rgba(0, 127, 255, 0.12)',
         '--joy-palette-primary-softActiveBg': 'rgba(0, 127, 255, 0.12)',
-        '[data-mui-color-scheme="dark"] &': {
+        [theme.getColorSchemeSelector('dark')]: {
           '--joy-palette-text-primary': '#fff',
           '--joy-palette-text-secondary': theme.vars.palette.neutral[400],
           '--joy-palette-neutral-plainHoverBg': 'rgba(19, 47, 76, 0.4)',
@@ -436,7 +436,7 @@ const Firebash = () => {
     { icon: <Public />, label: 'Hosting' },
   ];
   return (
-    <Sheet data-mui-color-scheme="dark" sx={{ bgcolor: 'rgb(5, 30, 52)' }}>
+    <Sheet data-joy-color-scheme="dark" sx={{ bgcolor: 'rgb(5, 30, 52)' }}>
       <List
         sx={{
           '& *': {
@@ -588,13 +588,13 @@ const Gatsby = () => {
     <Box sx={{ maxWidth: 280, pl: '24px', bgcolor: 'background.body' }}>
       <List
         size="sm"
-        sx={{
+        sx={(theme) => ({
           '--joy-palette-primary-plainColor': '#8a4baf',
           '--joy-palette-neutral-plainHoverBg': 'transparent',
           '--joy-palette-neutral-plainActiveBg': 'transparent',
           '--joy-palette-primary-plainHoverBg': 'transparent',
           '--joy-palette-primary-plainActiveBg': 'transparent',
-          '[data-mui-color-scheme="dark"] &': {
+          [theme.getColorSchemeSelector('dark')]: {
             '--joy-palette-text-secondary': '#635e69',
             '--joy-palette-primary-plainColor': '#d48cff',
           },
@@ -621,7 +621,7 @@ const Gatsby = () => {
           '& [class*="startAction"]': {
             color: 'var(--joy-palette-text-tertiary)',
           },
-        }}
+        })}
       >
         <ListItem nested>
           <ListItem component="div" startAction={<ReceiptLong />}>

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -9,6 +9,9 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
   Theme
 >({
   theme: extendTheme(),
+  attribute: 'data-joy-color-scheme',
+  modeStorageKey: 'joy-mode',
+  colorSchemeStorageKey: 'joy-color-scheme',
   defaultColorScheme: {
     light: 'light',
     dark: 'dark',

--- a/packages/mui-material/src/styles/CssVarsProvider.js
+++ b/packages/mui-material/src/styles/CssVarsProvider.js
@@ -11,6 +11,9 @@ const {
   getInitColorSchemeScript,
 } = createCssVarsProvider({
   theme: defaultTheme,
+  attribute: 'data-mui-color-scheme',
+  modeStorageKey: 'mui-mode',
+  colorSchemeStorageKey: 'mui-color-scheme',
   defaultColorScheme: {
     light: 'light',
     dark: 'dark',

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -57,14 +57,6 @@ export interface CreateCssVarsProviderResult<ColorScheme extends string, ThemeIn
       Partial<CssVarsProviderConfig<ColorScheme>> & {
         theme?: ThemeInput;
         /**
-         * localStorage key used to store application `mode`
-         */
-        modeStorageKey?: string;
-        /**
-         * DOM attribute for applying color scheme
-         */
-        attribute?: string;
-        /**
          * The document used to perform `disableTransitionOnChange` feature
          * @default document
          */
@@ -79,10 +71,6 @@ export interface CreateCssVarsProviderResult<ColorScheme extends string, ThemeIn
          * @default ':root'
          */
         colorSchemeSelector?: string;
-        /**
-         * localStorage key used to store `colorScheme`
-         */
-        colorSchemeStorageKey?: string;
         /**
          * The window that attaches the 'storage' event listener
          * @default window

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -9,6 +9,21 @@ export interface ColorSchemeContextValue<SupportedColorScheme extends string>
 
 export interface CssVarsProviderConfig<ColorScheme extends string> {
   /**
+   * DOM attribute for applying color scheme
+   * @default 'data-color-scheme'
+   */
+  attribute?: string;
+  /**
+   * localStorage key used to store application `mode`
+   * @default 'mode'
+   */
+  modeStorageKey?: string;
+  /**
+   * localStorage key used to store `colorScheme`
+   * @default 'color-scheme'
+   */
+  colorSchemeStorageKey?: string;
+  /**
    * Design system default color scheme.
    * - provides string if the design system has one default color scheme (either light or dark)
    * - provides object if the design system has default light & dark color schemes
@@ -43,12 +58,10 @@ export interface CreateCssVarsProviderResult<ColorScheme extends string, ThemeIn
         theme?: ThemeInput;
         /**
          * localStorage key used to store application `mode`
-         * @default 'mui-mode'
          */
         modeStorageKey?: string;
         /**
          * DOM attribute for applying color scheme
-         * @default 'data-mui-color-scheme'
          */
         attribute?: string;
         /**
@@ -68,7 +81,6 @@ export interface CreateCssVarsProviderResult<ColorScheme extends string, ThemeIn
         colorSchemeSelector?: string;
         /**
          * localStorage key used to store `colorScheme`
-         * @default 'mui-color-scheme'
          */
         colorSchemeStorageKey?: string;
         /**

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -5,7 +5,7 @@ import { deepmerge, unstable_useEnhancedEffect as useEnhancedEffect } from '@mui
 import { GlobalStyles } from '@mui/styled-engine';
 import cssVarsParser from './cssVarsParser';
 import ThemeProvider from '../ThemeProvider';
-import getInitColorSchemeScript, {
+import systemGetInitColorSchemeScript, {
   DEFAULT_ATTRIBUTE,
   DEFAULT_COLOR_SCHEME_STORAGE_KEY,
   DEFAULT_MODE_STORAGE_KEY,
@@ -19,6 +19,9 @@ export const DISABLE_CSS_TRANSITION =
 export default function createCssVarsProvider(options) {
   const {
     theme: defaultTheme = {},
+    attribute: defaultAttribute = DEFAULT_ATTRIBUTE,
+    modeStorageKey: defaultModeStorageKey = DEFAULT_MODE_STORAGE_KEY,
+    colorSchemeStorageKey: defaultColorSchemeStorageKey = DEFAULT_COLOR_SCHEME_STORAGE_KEY,
     defaultMode: desisgnSystemMode = 'light',
     defaultColorScheme: designSystemColorScheme,
     disableTransitionOnChange: designSystemTransitionOnChange = false,
@@ -53,9 +56,9 @@ export default function createCssVarsProvider(options) {
     children,
     theme: themeProp = defaultTheme,
     prefix = designSystemPrefix,
-    modeStorageKey = DEFAULT_MODE_STORAGE_KEY,
-    colorSchemeStorageKey = DEFAULT_COLOR_SCHEME_STORAGE_KEY,
-    attribute = DEFAULT_ATTRIBUTE,
+    modeStorageKey = defaultModeStorageKey,
+    colorSchemeStorageKey = defaultColorSchemeStorageKey,
+    attribute = defaultAttribute,
     defaultMode = desisgnSystemMode,
     defaultColorScheme = designSystemColorScheme,
     disableTransitionOnChange = designSystemTransitionOnChange,
@@ -296,6 +299,14 @@ export default function createCssVarsProvider(options) {
      */
     theme: PropTypes.object,
   };
+
+  const getInitColorSchemeScript = (params) =>
+    systemGetInitColorSchemeScript({
+      attribute: defaultAttribute,
+      colorSchemeStorageKey: defaultColorSchemeStorageKey,
+      modeStorageKey: defaultModeStorageKey,
+      ...params,
+    });
 
   return { CssVarsProvider, useColorScheme, getInitColorSchemeScript };
 }

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -198,7 +198,7 @@ describe('createCssVarsProvider', () => {
       fireEvent.click(screen.getByRole('button', { name: 'change to dark' }));
 
       expect(screen.getByTestId('current-color-scheme').textContent).to.equal('dark');
-      expect(document.documentElement.getAttribute('data-mui-color-scheme')).to.equal('dark');
+      expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('dark');
     });
 
     it('display error if non-existed colorScheme is set', () => {

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-export const DEFAULT_MODE_STORAGE_KEY = 'mui-mode';
-export const DEFAULT_COLOR_SCHEME_STORAGE_KEY = 'mui-color-scheme';
-export const DEFAULT_ATTRIBUTE = 'data-mui-color-scheme';
+export const DEFAULT_MODE_STORAGE_KEY = 'mode';
+export const DEFAULT_COLOR_SCHEME_STORAGE_KEY = 'color-scheme';
+export const DEFAULT_ATTRIBUTE = 'data-color-scheme';
 
 export interface GetInitColorSchemeScriptOptions {
   /**
@@ -25,17 +25,17 @@ export interface GetInitColorSchemeScriptOptions {
   colorSchemeNode?: string;
   /**
    * localStorage key used to store `mode`
-   * @default 'mui-mode'
+   * @default 'mode'
    */
   modeStorageKey?: string;
   /**
    * localStorage key used to store `colorScheme`
-   * @default 'mui-color-scheme'
+   * @default 'color-scheme'
    */
   colorSchemeStorageKey?: string;
   /**
    * DOM attribute for applying color scheme
-   * @default 'data-mui-color-scheme'
+   * @default 'data-color-scheme'
    */
   attribute?: string;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Before**
Both Joy and Material UI has `<html data-mui-color-scheme="dark">` without configurable options.

**After**
Joy and Material UI and use their own prefix as a default values:

```js
// Material UI
<html data-mui-color-scheme="dark">

// Joy
<html data-joy-color-scheme="dark">
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
