### PR TITLE
[docs] Fix icon color in `BadgeUnstyled` docs

### DIFF
--- a/docs/data/base/components/badge/AccessibleBadges.js
+++ b/docs/data/base/components/badge/AccessibleBadges.js
@@ -7,7 +7,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/AccessibleBadges.tsx
+++ b/docs/data/base/components/badge/AccessibleBadges.tsx
@@ -7,7 +7,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/BadgeMax.js
+++ b/docs/data/base/components/badge/BadgeMax.js
@@ -8,7 +8,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/BadgeMax.tsx
+++ b/docs/data/base/components/badge/BadgeMax.tsx
@@ -8,7 +8,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/BadgeVisibility.js
+++ b/docs/data/base/components/badge/BadgeVisibility.js
@@ -14,7 +14,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/BadgeVisibility.tsx
+++ b/docs/data/base/components/badge/BadgeVisibility.tsx
@@ -14,7 +14,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/ShowZeroBadge.js
+++ b/docs/data/base/components/badge/ShowZeroBadge.js
@@ -8,7 +8,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/ShowZeroBadge.tsx
+++ b/docs/data/base/components/badge/ShowZeroBadge.tsx
@@ -8,7 +8,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   list-style: none;
   font-family: IBM Plex Sans, sans-serif;

--- a/docs/data/base/components/badge/UnstyledBadge.js
+++ b/docs/data/base/components/badge/UnstyledBadge.js
@@ -6,7 +6,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   font-variant: tabular-nums;
   list-style: none;

--- a/docs/data/base/components/badge/UnstyledBadge.tsx
+++ b/docs/data/base/components/badge/UnstyledBadge.tsx
@@ -6,7 +6,6 @@ const StyledBadge = styled(BadgeUnstyled)`
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-  color: rgba(0, 0, 0, 0.85);
   font-size: 14px;
   font-variant: tabular-nums;
   list-style: none;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Mail icon is almost not visible in dark mode in the Base's Badge component docs. 
The `color` style is not needed because of which the SVG picks it up and applies in it's `fill: currentColor` property. 

Check the docs in both the modes:
**Before:** https://mui.com/base/react-badge/
**Now:** https://deploy-preview-32976--material-ui.netlify.app/base/react-badge/

If it looks good, I will approve the argos CI since there is difference in light mode (now it's just a bit darker `rgba(0, 0, 0, 0.7) -> rgb(0, 0, 0)`). 