### PR TITLE
[blog] Fix anchor link scroll

### DIFF
--- a/docs/src/components/pricing/EarlyBird.tsx
+++ b/docs/src/components/pricing/EarlyBird.tsx
@@ -9,7 +9,14 @@ import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRou
 
 export default function EarlyBird() {
   return (
-    <Container sx={{ pt: 2, pb: { xs: 2, sm: 4, md: 8 }, scrollMarginTop: 80 }} id="early-bird">
+    <Container
+      sx={{
+        pt: 2,
+        pb: { xs: 2, sm: 4, md: 8 },
+        scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
+      }}
+      id="early-bird"
+    >
       <Stack
         sx={{
           borderRadius: 1,

--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -34,6 +34,8 @@ const Header = styled('header')(({ theme }) => ({
       : 'rgba(255,255,255,0.72)',
 }));
 
+const HEIGHT = 56;
+
 export default function AppHeader() {
   const changeTheme = useChangeTheme();
   const [mode, setMode] = React.useState<string | null>(null);
@@ -59,11 +61,11 @@ export default function AppHeader() {
       <GlobalStyles
         styles={{
           ':root': {
-            '--MuiDocs-header-height': '64px',
+            '--MuiDocs-header-height': `${HEIGHT}px`,
           },
         }}
       />
-      <Container sx={{ display: 'flex', alignItems: 'center', minHeight: 56 }}>
+      <Container sx={{ display: 'flex', alignItems: 'center', minHeight: HEIGHT }}>
         <Box
           component={Link}
           href={ROUTES.home}

--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { styled, alpha } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Container from '@mui/material/Container';
@@ -55,6 +56,13 @@ export default function AppHeader() {
 
   return (
     <Header>
+      <GlobalStyles
+        styles={{
+          ':root': {
+            '--MuiDocs-header-height': '64px',
+          },
+        }}
+      />
       <Container sx={{ display: 'flex', alignItems: 'center', minHeight: 56 }}>
         <Box
           component={Link}

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import { styled, alpha } from '@mui/material/styles';
 import NProgress from 'nprogress';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -200,6 +201,13 @@ function AppFrame(props) {
       </SkipLink>
       <MarkdownLinks />
       <StyledAppBar disablePermanent={disablePermanent}>
+        <GlobalStyles
+          styles={{
+            ':root': {
+              '--MuiDocs-header-height': '64px',
+            },
+          }}
+        />
         <Toolbar variant="dense" disableGutters>
           <NavIconButton
             edge="start"

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -108,7 +108,6 @@ function AppLayoutDocs(props) {
           ':root': {
             '--MuiDocs-navDrawer-width': '300px',
             '--MuiDocs-toc-width': '240px',
-            '--MuiDocs-header-height': '64px',
           },
         }}
       />


### PR DESCRIPTION
I have just realized this as I was sharing a link to https://mui.com/blog/2021-developer-survey-results/#which-of-the-following-best-describes-your-current-job-role, the scroll is broken.

The regression is coming from #32844. `docs/src/modules/components/AppLayoutDocs.js` component adds the CSS variables but it's not used by the blog.

https://deploy-preview-32994--material-ui.netlify.app/material-ui/react-button-group/#button-variants