### PR TITLE
[Grow] Limit CSS transition bug workaround to Safari 15.4 only

### DIFF
--- a/packages/mui-material/src/Grow/Grow.js
+++ b/packages/mui-material/src/Grow/Grow.js
@@ -24,12 +24,11 @@ const styles = {
 /*
  TODO v6: remove
  Conditionally apply a workaround for the CSS transition bug in Safari 15.4 / WebKit browsers.
- Remove this workaround once the WebKit bug fix is released.
  */
 const isWebKit154 =
   typeof navigator !== 'undefined' &&
   /^((?!chrome|android).)*(safari|mobile)/i.test(navigator.userAgent) &&
-  /(os |version\/)15(.|_)[4-9]/i.test(navigator.userAgent);
+  /(os |version\/)15(.|_)4/i.test(navigator.userAgent);
 
 /**
  * The Grow transition is used by the [Tooltip](/material-ui/react-tooltip/) and


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Limiting Grow CSS transition bug workaround to Safari 15.4 as per https://github.com/mui/material-ui/issues/31380#issuecomment-1144515973

Preview: https://deploy-preview-32996--material-ui.netlify.app/material-ui/react-menu/#main-content