### PR TITLE
[Hidden] Remove dependency on hoist-non-react-statics

### DIFF
--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -63,7 +63,6 @@
     "@mui/utils": "^5.8.0",
     "clsx": "^1.1.1",
     "csstype": "^3.1.0",
-    "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.8.1",
     "react-is": "^17.0.2"
   },

--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -68,7 +68,6 @@
     "@types/react-transition-group": "^4.4.4",
     "clsx": "^1.1.1",
     "csstype": "^3.1.0",
-    "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.8.1",
     "react-is": "^17.0.2",
     "react-transition-group": "^4.4.2"

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -68,7 +68,6 @@
     "@types/react-transition-group": "^4.4.4",
     "clsx": "^1.1.1",
     "csstype": "^3.1.0",
-    "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.8.1",
     "react-is": "^17.0.2",
     "react-transition-group": "^4.4.2"

--- a/packages/mui-material/src/Hidden/withWidth.js
+++ b/packages/mui-material/src/Hidden/withWidth.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { getDisplayName } from '@mui/utils';
 import { getThemeProps } from '@mui/system';
-import hoistNonReactStatics from 'hoist-non-react-statics';
 import useTheme from '../styles/useTheme';
 import useEnhancedEffect from '../utils/useEnhancedEffect';
 import useMediaQuery from '../useMediaQuery';
@@ -107,8 +106,6 @@ const withWidth =
     if (process.env.NODE_ENV !== 'production') {
       WithWidth.displayName = `WithWidth(${getDisplayName(Component)})`;
     }
-
-    hoistNonReactStatics(WithWidth, Component);
 
     return WithWidth;
   };


### PR DESCRIPTION
The API was removed in #26136 but we forgot to remove this dead logic. I found it thanks to https://npm.anvaka.com/#/view/2d/%2540mui%252Fmaterial, one of the few licenses that is not MIT:

<img width="604" alt="Screenshot 2022-06-04 at 16 30 05" src="https://user-images.githubusercontent.com/3165635/172006955-3b089bd2-1ebd-4153-aa34-6b6e9e8642ac.png">