### PR TITLE
[docs] Fix a typo in `InputUnstyled` docs

### DIFF
--- a/docs/data/base/components/input/input.md
+++ b/docs/data/base/components/input/input.md
@@ -41,7 +41,7 @@ The `multiline` prop transforms the `<input>` field into a `<textarea>` element.
 {{"demo": "InputMultiline.js"}}
 
 If you want the `<textarea>` to grow with the content, you can use the [`TextareaAutosize`](/base/react-textarea-autosize/) component.
-When using `TextareaAutosize`, the height of the `<textarea>` element dynamically matches its content, unless the `row` prop is set.
+When using `TextareaAutosize`, the height of the `<textarea>` element dynamically matches its content, unless the `rows` prop is set.
 To set minimum and maximum sizes, add the `minRows` and `maxRows` props.
 
 {{"demo": "InputMultilineAutosize.js"}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a small typo I noticed while reading the docs.

**Preview:** https://deploy-preview-33077--material-ui.netlify.app/base/react-input/#multiline