### PR TITLE
[Select] Annotate empty string as valid value prop

### DIFF
--- a/docs/pages/material-ui/api/select.json
+++ b/docs/pages/material-ui/api/select.json
@@ -27,7 +27,7 @@
         "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
-    "value": { "type": { "name": "any" } },
+    "value": { "type": { "name": "union", "description": "''<br>&#124;&nbsp;any" } },
     "variant": {
       "type": {
         "name": "enum",

--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -144,7 +144,7 @@ export interface SelectProps<T = unknown>
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    */
-  value?: T;
+  value?: T | '';
   /**
    * The variant to use.
    * @default 'outlined'

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -263,7 +263,7 @@ Select.propTypes /* remove-proptypes */ = {
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    */
-  value: PropTypes.any,
+  value: PropTypes.oneOfType([PropTypes.oneOf(['']), PropTypes.any]),
   /**
    * The variant to use.
    * @default 'outlined'


### PR DESCRIPTION
Include the empty string `''` as a valid value for the `value` prop of the `Select` component, including when the component's inferred parametric type does not overlap with `string`.

This is necessary because the docs state that `''` is a symbol for "no selection". `undefined` is *not* a valid substitute because this is a symbol for "uncontrolled component" and using it in this way will trigger a warning. Therefore `''` must always be a valid option no matter the type of the available selections.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
