### PR TITLE
Tree Item "disabled" styling does not update immediately

### DIFF
--- a/packages/mui-lab/src/TreeView/TreeView.js
+++ b/packages/mui-lab/src/TreeView/TreeView.js
@@ -591,10 +591,13 @@ const TreeView = React.forwardRef(function TreeView(inProps, ref) {
   /*
    * Mapping Helpers
    */
+  const [allDisabledState, setAllDisabledState] = React.useState({});
+
   const registerNode = React.useCallback((node) => {
     const { id, index, parentId, expandable, idAttribute, disabled } = node;
 
     nodeMap.current[id] = { id, index, parentId, expandable, idAttribute, disabled };
+    setAllDisabledState((prev) => ({ ...prev, [id]: disabled }));
   }, []);
 
   const unregisterNode = React.useCallback((id) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
ISSUE LINK: https://github.com/mui/material-ui/issues/33011

The issue is caused by the useRef nature of the nodeMap in TreeView component. 
I think the issue arises due to the following flow. 

1. disabled prop is updated to true
2. Entire Component tree is rendered. The TreeItemContent uses the old value from the nodeMap.
3. useEffect is then run where it ReRegisters the component.
4. No state update happens after that. The TreeItemContent never rerenders to disabled state

Proposed Fix: Force rerender on disabled state update

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
