### PR TITLE
[docs] Miscellaneous fixes in `MUI Base` docs

### DIFF
--- a/docs/data/base/components/input/UseInput.js
+++ b/docs/data/base/components/input/UseInput.js
@@ -52,7 +52,7 @@ const CustomInput = React.forwardRef(function CustomInput(props, ref) {
 
   const inputProps = getInputProps();
 
-  // Make sure that both the forwarded ref and the ref returned from the are applied on the input element
+  // Make sure that both the forwarded ref and the ref returned from the getInputProps are applied on the input element
   inputProps.ref = useForkRef(inputProps.ref, ref);
 
   return (

--- a/docs/data/base/components/input/UseInput.tsx
+++ b/docs/data/base/components/input/UseInput.tsx
@@ -55,7 +55,7 @@ const CustomInput = React.forwardRef(function CustomInput(
 
   const inputProps = getInputProps();
 
-  // Make sure that both the forwarded ref and the ref returned from the are applied on the input element
+  // Make sure that both the forwarded ref and the ref returned from the getInputProps are applied on the input element
   inputProps.ref = useForkRef(inputProps.ref, ref);
 
   return (

--- a/docs/data/base/getting-started/usage/usage.md
+++ b/docs/data/base/getting-started/usage/usage.md
@@ -68,10 +68,10 @@ The code snippet below shows how to override the `Root` element of the [`BadgeUn
 The `componentsProps` prop is an object that contains the props for all slots within a component.
 You can use it to define additional custom props for a component's interior elements.
 
-For example, the code snippet below shows how to add a custom CSS class to the `input` slot of the `BadgeUnstyled` component:
+For example, the code snippet below shows how to add a custom CSS class to the `badge` slot of the `BadgeUnstyled` component:
 
 ```jsx
-<BadgeUnstyled componentsProps={{ input: { className: 'my-badge' } }} />
+<BadgeUnstyled componentsProps={{ badge: { className: 'my-badge' } }} />
 ```
 
 All additional props placed on the primary component are also propagated into the `Root` slot (just as if they were placed in `componentsProps.root`).


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I am working on `SnackbarUnstyled` component and thus noticed the following while reading the docs:
1. It should be `badge` props slot, not `input` in the usage section.
2. Code comment in `useInput` demo.
