### PR TITLE
[pickers] Fix broken ref forwarding

### DIFF
--- a/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -33,10 +33,11 @@ type CalendarPickerComponent = (<TDate>(
  */
 const CalendarPicker = React.forwardRef(function DeprecatedCalendarPicker<TDate>(
   props: CalendarPickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XCalendarPicker {...props} />;
+  return <XCalendarPicker ref={ref} {...props} />;
 }) as CalendarPickerComponent;
 
 export default CalendarPicker;

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -34,10 +34,11 @@ type CalendarPickerSkeletonComponent = ((
  */
 const CalendarPickerSkeleton = React.forwardRef(function DeprecatedCalendarPickerSkeleton(
   props: CalendarPickerSkeletonProps,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XCalendarPickerSkeleton {...props} />;
+  return <XCalendarPickerSkeleton ref={ref} {...props} />;
 }) as CalendarPickerSkeletonComponent;
 
 CalendarPickerSkeleton.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
@@ -30,10 +30,11 @@ type ClockPickerComponent = (<TDate>(
  */
 const ClockPicker = React.forwardRef(function DeprecatedClockPicker<TDate>(
   props: ClockPickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XClockPicker {...props} />;
+  return <XClockPicker ref={ref} {...props} />;
 }) as ClockPickerComponent;
 
 export default ClockPicker;

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -34,10 +34,11 @@ type DateTimePickerComponent = (<TDate>(
  */
 const DateTimePicker = React.forwardRef(function DeprecatedDateTimePicker<TDate>(
   props: DateTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XDateTimePicker {...props} />;
+  return <XDateTimePicker ref={ref} {...props} />;
 }) as DateTimePickerComponent;
 
 DateTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -34,10 +34,11 @@ type DesktopDatePickerComponent = (<TDate>(
  */
 const DesktopDatePicker = React.forwardRef(function DeprecatedDesktopDatePicker<TDate>(
   props: DesktopDatePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XDesktopDatePicker {...props} />;
+  return <XDesktopDatePicker ref={ref} {...props} />;
 }) as DesktopDatePickerComponent;
 
 DesktopDatePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -34,10 +34,11 @@ type DesktopDateTimePickerComponent = (<TDate>(
  */
 const DesktopDateTimePicker = React.forwardRef(function DeprecatedDesktopDateTimePicker<TDate>(
   props: DesktopDateTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XDesktopDateTimePicker {...props} />;
+  return <XDesktopDateTimePicker ref={ref} {...props} />;
 }) as DesktopDateTimePickerComponent;
 
 DesktopDateTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -34,10 +34,11 @@ type DesktopTimePickerComponent = (<TDate>(
  */
 const DesktopTimePicker = React.forwardRef(function DeprecatedDesktopTimePicker<TDate>(
   props: DesktopTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XDesktopTimePicker {...props} />;
+  return <XDesktopTimePicker ref={ref} {...props} />;
 }) as DesktopTimePickerComponent;
 
 DesktopTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -34,10 +34,11 @@ type LocalizationProviderComponent = ((
  */
 const LocalizationProvider = React.forwardRef(function DeprecatedLocalizationProvider(
   props: LocalizationProviderProps,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XLocalizationProvider {...props} />;
+  return <XLocalizationProvider ref={ref} {...props} />;
 }) as LocalizationProviderComponent;
 
 LocalizationProvider.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -34,10 +34,11 @@ type MobileDatePickerComponent = (<TDate>(
  */
 const MobileDatePicker = React.forwardRef(function DeprecatedMobileDatePicker<TDate>(
   props: MobileDatePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XMobileDatePicker {...props} />;
+  return <XMobileDatePicker ref={ref} {...props} />;
 }) as MobileDatePickerComponent;
 
 MobileDatePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -34,10 +34,11 @@ type MobileDateTimePickerComponent = (<TDate>(
  */
 const MobileDateTimePicker = React.forwardRef(function DeprecatedMobileDateTimePicker<TDate>(
   props: MobileDateTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XMobileDateTimePicker {...props} />;
+  return <XMobileDateTimePicker ref={ref} {...props} />;
 }) as MobileDateTimePickerComponent;
 
 MobileDateTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -34,10 +34,11 @@ type MobileTimePickerComponent = (<TDate>(
  */
 const MobileTimePicker = React.forwardRef(function DeprecatedMobileTimePicker<TDate>(
   props: MobileTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XMobileTimePicker {...props} />;
+  return <XMobileTimePicker ref={ref} {...props} />;
 }) as MobileTimePickerComponent;
 
 MobileTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -30,10 +30,11 @@ type MonthPickerComponent = (<TDate>(
  */
 const MonthPicker = React.forwardRef(function DeprecatedMonthPicker<TDate>(
   props: MonthPickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XMonthPicker {...props} />;
+  return <XMonthPicker ref={ref} {...props} />;
 }) as MonthPickerComponent;
 
 export default MonthPicker;

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -31,10 +31,11 @@ type PickersDayComponent = (<TDate>(
  */
 const PickersDay = React.forwardRef(function DeprecatedPickersDay<TDate>(
   props: PickersDayProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XPickersDay {...props} />;
+  return <XPickersDay ref={ref} {...props} />;
 }) as PickersDayComponent;
 
 PickersDay.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -34,10 +34,11 @@ type StaticDatePickerComponent = (<TDate>(
  */
 const StaticDatePicker = React.forwardRef(function DeprecatedStaticDatePicker<TDate>(
   props: StaticDatePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XStaticDatePicker {...props} />;
+  return <XStaticDatePicker ref={ref} {...props} />;
 }) as StaticDatePickerComponent;
 
 StaticDatePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -34,10 +34,11 @@ type StaticDateTimePickerComponent = (<TDate>(
  */
 const StaticDateTimePicker = React.forwardRef(function DeprecatedStaticDateTimePicker<TDate>(
   props: StaticDateTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XStaticDateTimePicker {...props} />;
+  return <XStaticDateTimePicker ref={ref} {...props} />;
 }) as StaticDateTimePickerComponent;
 
 StaticDateTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -34,10 +34,11 @@ type StaticTimePickerComponent = (<TDate>(
  */
 const StaticTimePicker = React.forwardRef(function DeprecatedStaticTimePicker<TDate>(
   props: StaticTimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XStaticTimePicker {...props} />;
+  return <XStaticTimePicker ref={ref} {...props} />;
 }) as StaticTimePickerComponent;
 
 StaticTimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -31,10 +31,11 @@ type TimePickerComponent = (<TDate>(
  */
 const TimePicker = React.forwardRef(function DeprecatedTimePicker<TDate>(
   props: TimePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XTimePicker {...props} />;
+  return <XTimePicker ref={ref} {...props} />;
 }) as TimePickerComponent;
 
 TimePicker.propTypes /* remove-proptypes */ = {

--- a/packages/mui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/mui-lab/src/YearPicker/YearPicker.tsx
@@ -28,12 +28,10 @@ type YearPickerComponent = (<TDate>(
 /**
  * @ignore - do not document.
  */
-const YearPicker = React.forwardRef(function DeprecatedYearPicker<TDate>(
-  props: YearPickerProps<TDate>,
-) {
+const YearPicker = function DeprecatedYearPicker<TDate>(props: YearPickerProps<TDate>) {
   warn();
 
   return <XYearPicker {...props} />;
-}) as YearPickerComponent;
+} as YearPickerComponent;
 
 export default YearPicker;


### PR DESCRIPTION
So developers get less noise, so they can focus on the important messages. We didn't test #32950 in depth.

Sample test:

```jsx
import * as React from 'react';
import TextField from '@mui/material/TextField';
import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
import LocalizationProvider from '@mui/lab/LocalizationProvider';
import DatePicker from '@mui/lab/DatePicker';

export default function BasicDatePicker() {
  const [value, setValue] = React.useState<Date | null>(null);

  return (
    <LocalizationProvider dateAdapter={AdapterDateFns}>
      <DatePicker
        label="Basic example"
        value={value}
        onChange={(newValue) => {
          setValue(newValue);
        }}
        renderInput={(params) => <TextField {...params} />}
      />
    </LocalizationProvider>
  );
}
```

**Before**

<img width="587" alt="Screenshot 2022-06-11 at 19 54 55" src="https://user-images.githubusercontent.com/3165635/173199358-1a86fb4c-ad36-4dfb-99b9-b3ae516428fb.png">

**After**

<img width="517" alt="Screenshot 2022-06-11 at 19 54 36" src="https://user-images.githubusercontent.com/3165635/173199361-76d96f7e-98bc-48e6-8f49-299002e50cc7.png">
