### PR TITLE
[core] Update @mui/styles peer dependencies to support React 18

### DIFF
--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -38,8 +38,8 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.0",
-    "react": "^17.0.0"
+    "@types/react": "^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hello,

I suggest this change to make upgrading my React 18 project smother :

```bash
PS D:\workspace\yt_gaming_library> npm outdated
Package           Current   Wanted   Latest  Location                       Depended by      
@mui/styles         5.8.0    5.8.3    5.8.3  node_modules/@mui/styles       yt_gaming_library
@mui/x-data-grid   5.12.0   5.12.1   5.12.1  node_modules/@mui/x-data-grid  yt_gaming_library
@types/react      18.0.10  18.0.12  18.0.12  node_modules/@types/react      yt_gaming_library
PS D:\workspace\yt_gaming_library> npm update @mui/styles @mui/x-data-grid
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: yt_gaming_library@0.1.0
npm ERR! Found: react@18.1.0
npm ERR! node_modules/react
npm ERR!   react@"^18.1.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0" from @mui/styles@5.8.3
npm ERR! node_modules/@mui/styles
npm ERR!   @mui/styles@"^5.8.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See C:\Users\jy95\AppData\Local\npm-cache\eresolve-report.txt for a full report.    

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\jy95\AppData\Local\npm-cache\_logs\2022-06-12T10_51_21_456Z-debug-0.log
```