### PR TITLE
[lab] Fix React's `forwardRef` warning when importing from the index

### DIFF
--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -31,10 +31,11 @@ type DatePickerComponent = (<TDate>(
  */
 const DatePicker = React.forwardRef(function DeprecatedDatePicker<TDate>(
   props: DatePickerProps<TDate>,
+  ref: React.Ref<any>,
 ) {
   warn();
 
-  return <XDatePicker {...props} />;
+  return <XDatePicker ref={ref} {...props} />;
 }) as DatePickerComponent;
 
 DatePicker.propTypes /* remove-proptypes */ = {


### PR DESCRIPTION
Follow up on https://github.com/mui/material-ui/pull/33107

Fixes https://github.com/mui/material-ui/issues/33085
Fixes https://github.com/mui/material-ui/issues/33080