### PR TITLE
[docs] Fix internal link in Box page

### DIFF
--- a/docs/data/material/components/box/box.md
+++ b/docs/data/material/components/box/box.md
@@ -9,7 +9,7 @@ githubLabel: 'component: Box'
 
 <p class="description">The Box component serves as a wrapper component for most of the CSS utility needs.</p>
 
-The Box component packages [all the style functions](/system/basics/#all-inclusive) that are exposed in `@mui/system`.
+The Box component packages [all the style functions](/system/properties/) that are exposed in `@mui/system`.
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 


### PR DESCRIPTION
This PR is to fix https://github.com/mui/material-ui/issues/33062 updated the internal link in the Box page