### PR TITLE
InputBase: change onInvalid handler to use HTMLInputElement | HTMLTextAreaElement Element type

### DIFF
--- a/docs/pages/material-ui/api/input-base.json
+++ b/docs/pages/material-ui/api/input-base.json
@@ -37,6 +37,7 @@
     "name": { "type": { "name": "string" } },
     "onBlur": { "type": { "name": "func" } },
     "onChange": { "type": { "name": "func" } },
+    "onInvalid": { "type": { "name": "func" } },
     "placeholder": { "type": { "name": "string" } },
     "readOnly": { "type": { "name": "bool" } },
     "required": { "type": { "name": "bool" } },

--- a/docs/translations/api-docs/input-base/input-base.json
+++ b/docs/translations/api-docs/input-base/input-base.json
@@ -24,6 +24,7 @@
     "name": "Name attribute of the <code>input</code> element.",
     "onBlur": "Callback fired when the <code>input</code> is blurred.<br>Notice that the first argument (event) might be undefined.",
     "onChange": "Callback fired when the value is changed.<br><br><strong>Signature:</strong><br><code>function(event: React.ChangeEvent&lt;HTMLTextAreaElement | HTMLInputElement&gt;) =&gt; void</code><br><em>event:</em> The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string).",
+    "onInvalid": "Callback fired when the <code>input</code> doesn&#39;t satisfy its constraints.",
     "placeholder": "The short hint displayed in the <code>input</code> before the user enters a value.",
     "readOnly": "It prevents the user from changing the value of the field (not from interacting with the field).",
     "required": "If <code>true</code>, the <code>input</code> element is required. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component.",

--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -15,11 +15,18 @@ export interface InputBaseProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement>,
     /*
-     * `onChange`, `onKeyUp`, `onKeyDown`, `onBlur`, `onFocus` are applied to the inner `InputComponent`,
+     * `onBlur`, `onChange`, `onFocus`, `onInvalid`, `onKeyDown`, `onKeyUp` are applied to the inner `InputComponent`,
      * which by default is an input or textarea. Since these handlers differ from the
      * ones inherited by `React.HTMLAttributes<HTMLDivElement>` we need to omit them.
      */
-    'children' | 'onChange' | 'onKeyUp' | 'onKeyDown' | 'onBlur' | 'onFocus' | 'defaultValue'
+    | 'children'
+    | 'defaultValue'
+    | 'onBlur'
+    | 'onChange'
+    | 'onFocus'
+    | 'onInvalid'
+    | 'onKeyDown'
+    | 'onKeyUp'
   > {
   'aria-describedby'?: string;
   /**
@@ -142,6 +149,10 @@ export interface InputBaseProps
   onFocus?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  /**
+   * Callback fired when the `input` doesn't satisfy its constraints.
+   */
+  onInvalid?: React.FormEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   /**
    * The short hint displayed in the `input` before the user enters a value.
    */

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -712,6 +712,10 @@ InputBase.propTypes /* remove-proptypes */ = {
    */
   onFocus: PropTypes.func,
   /**
+   * Callback fired when the `input` doesn't satisfy its constraints.
+   */
+  onInvalid: PropTypes.func,
+  /**
    * @ignore
    */
   onKeyDown: PropTypes.func,

--- a/packages/mui-material/src/InputBase/InputBase.spec.tsx
+++ b/packages/mui-material/src/InputBase/InputBase.spec.tsx
@@ -1,0 +1,9 @@
+import InputBase from '@mui/material/InputBase';
+import { expectType } from '@mui/types';
+import React from 'react';
+
+<InputBase
+  onInvalid={(event) => {
+    expectType<React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, typeof event>(event);
+  }}
+/>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Hi, I was forced to cast `onInvalid` handler to `React.FormEventHandler<HTMLDivElement>` to please tsc.
This shouldn't be the case as it is applied to the inner `InputComponent`

regards,
Nicolas Le Cam

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
