### PR TITLE
[Masonry] Fix flickering when used with React 18

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -1,4 +1,5 @@
 import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { flushSync } from 'react-dom';
 import { styled, useThemeProps } from '@mui/material/styles';
 import {
   createUnarySpacing,
@@ -245,9 +246,13 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
       }
     });
     if (!skip) {
-      setMaxColumnHeight(Math.max(...columnHeights));
-      const numOfLineBreaks = currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0;
-      setNumberOfLineBreaks(numOfLineBreaks);
+      // In React 18, state updates in a ResizeObserver's callback are happening after the paint which causes flickering
+      // when doing some visual updates in it. Using flushSync ensures that the dom will be painted after the states updates happen
+      // Related issue - https://github.com/facebook/react/issues/24331
+      flushSync(() => {
+        setMaxColumnHeight(Math.max(...columnHeights));
+        setNumberOfLineBreaks(currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0);
+      });
     }
   };
 


### PR DESCRIPTION
When used in React 18, there is a visible flickering in the Masonry component. See https://github.com/mui/material-ui/issues/32518's reproduction: https://codesandbox.io/s/b83ug2 (try to open/close some of the accordions and notice the flickering).

I could find one relevant issue on React's repo https://github.com/facebook/react/issues/24331 where the suggestion is to batch the states updates in the `ResizeObserver`'s callback together.

Codesandbox using the packages from this PR
- [Masonry with React 18 codesandbox](https://codesandbox.io/s/masonrywithvariableheightitems-material-demo-forked-vx4vmb?file=/demo.tsx)
- [Masonry with React 17 codesandbox](https://codesandbox.io/s/masonrywithvariableheightitems-material-demo-forked-jmjtsz?file=/index.tsx) - no regressions using React 17

Fixes https://github.com/mui/material-ui/issues/32518

---------

If this is the right fix for this issue, we are likely going to go through all usages of `ResizeObserver` and ensure that there are no more bugs similar to this one.