### PR TITLE
[envinfo] copy output to OS clipboard

### DIFF
--- a/packages/mui-envinfo/README.md
+++ b/packages/mui-envinfo/README.md
@@ -1,6 +1,6 @@
 # @mui/envinfo
 
-Prints information about the current environment relevant to MUI packages to the console and clipboard.
+Prints information about the current environment relevant to MUI packages to the console.
 Please use this package if you report [issues to MUI](https://github.com/mui/material-ui/issues).
 
 ## Usage
@@ -44,4 +44,4 @@ $ npx @mui/envinfo
 
 `--json` - writes output as JSON
 
-`--skipClipboard` - doesn't copy information to clipboard
+`--clipboard` - copies env information to clipboard

--- a/packages/mui-envinfo/README.md
+++ b/packages/mui-envinfo/README.md
@@ -1,6 +1,6 @@
 # @mui/envinfo
 
-Prints information about the current environment relevant to MUI packages to the console.
+Prints information about the current environment relevant to MUI packages to the console and clipboard.
 Please use this package if you report [issues to MUI](https://github.com/mui/material-ui/issues).
 
 ## Usage
@@ -39,3 +39,9 @@ $ npx @mui/envinfo
     styled-components:  5.2.1
     typescript: ^4.0.2 => 4.0.5
 ```
+
+## Options
+
+`--json` - writes output as JSON
+
+`--skipClipboard` - doesn't copy information to clipboard

--- a/packages/mui-envinfo/envinfo.js
+++ b/packages/mui-envinfo/envinfo.js
@@ -4,7 +4,7 @@ const envinfo = require('envinfo');
 const clipboard = require('clipboardy');
 
 const json = process.argv.indexOf('--json') !== -1;
-const skipClipboard = process.argv.indexOf('--skipClipboard') !== -1;
+const copyToClipboard = process.argv.indexOf('--clipboard') !== -1;
 
 envinfo
   .run(
@@ -38,7 +38,7 @@ envinfo
   .then((output) => {
     console.log(output);
 
-    if (!skipClipboard) {
+    if (copyToClipboard) {
       try {
         // write to OS clipboard
         clipboard.writeSync(output);

--- a/packages/mui-envinfo/envinfo.js
+++ b/packages/mui-envinfo/envinfo.js
@@ -42,9 +42,9 @@ envinfo
       try {
         // write to OS clipboard
         clipboard.writeSync(output);
-        console.log('\x1b[33m%s\x1b[0m', '\nOutput copied to clipboard', '\x1b[0m');
+        console.log('\x1b[33m%s\x1b[0m', 'Output copied to clipboard', '\x1b[0m');
       } catch (e) {
-        console.log('\x1b[31m%s\x1b[0m', '\nFailed to copy to clipboard', '\x1b[0m');
+        console.log('\x1b[31m%s\x1b[0m', 'Failed to copy to clipboard', '\x1b[0m');
         console.log(e);
       }
     }

--- a/packages/mui-envinfo/envinfo.js
+++ b/packages/mui-envinfo/envinfo.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
+const console = require('console');
 const envinfo = require('envinfo');
+const clipboard = require('clipboardy');
 
 const json = process.argv.indexOf('--json') !== -1;
 envinfo
@@ -32,6 +34,9 @@ envinfo
     },
   )
   .then((output) => {
-    // eslint-disable-next-line no-console
     console.log(output);
+
+    // write to memory
+    console.log('\x1b[33m%s\x1b[0m', '\nOutput copied to clipboard');
+    clipboard.writeSync(output);
   });

--- a/packages/mui-envinfo/envinfo.js
+++ b/packages/mui-envinfo/envinfo.js
@@ -39,8 +39,13 @@ envinfo
     console.log(output);
 
     if (!skipClipboard) {
-      // write to memory
-      console.log('\x1b[33m%s\x1b[0m', '\nOutput copied to clipboard');
-      clipboard.writeSync(output);
+      try {
+        // write to OS clipboard
+        clipboard.writeSync(output);
+        console.log('\x1b[33m%s\x1b[0m', '\nOutput copied to clipboard', '\x1b[0m');
+      } catch (e) {
+        console.log('\x1b[31m%s\x1b[0m', '\nFailed to copy to clipboard', '\x1b[0m');
+        console.log(e);
+      }
     }
   });

--- a/packages/mui-envinfo/envinfo.js
+++ b/packages/mui-envinfo/envinfo.js
@@ -4,6 +4,8 @@ const envinfo = require('envinfo');
 const clipboard = require('clipboardy');
 
 const json = process.argv.indexOf('--json') !== -1;
+const skipClipboard = process.argv.indexOf('--skipClipboard') !== -1;
+
 envinfo
   .run(
     {
@@ -36,7 +38,9 @@ envinfo
   .then((output) => {
     console.log(output);
 
-    // write to memory
-    console.log('\x1b[33m%s\x1b[0m', '\nOutput copied to clipboard');
-    clipboard.writeSync(output);
+    if (!skipClipboard) {
+      // write to memory
+      console.log('\x1b[33m%s\x1b[0m', '\nOutput copied to clipboard');
+      clipboard.writeSync(output);
+    }
   });

--- a/packages/mui-envinfo/envinfo.test.js
+++ b/packages/mui-envinfo/envinfo.test.js
@@ -13,7 +13,6 @@ describe('@mui/envinfo', () => {
     try {
       clipboard.writeSync('');
     } catch (e) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       isClipboardAvailable = false;
     }
   });

--- a/packages/mui-envinfo/envinfo.test.js
+++ b/packages/mui-envinfo/envinfo.test.js
@@ -60,7 +60,7 @@ describe('@mui/envinfo', () => {
     // Need more time to download packages
     this.timeout(10000);
 
-    const envinfoJSON = execEnvinfo(['--json', '--skipClipboard']);
+    const envinfoJSON = execEnvinfo(['--json']);
 
     const envinfo = JSON.parse(envinfoJSON);
 
@@ -83,7 +83,38 @@ describe('@mui/envinfo', () => {
     expect(envinfo).to.have.nested.property('npmPackages.typescript');
   });
 
-  it('copies env information to the clipboard', function test() {
+  it('with --clipboard flag, copies env information to the clipboard', function test() {
+    if (!isClipboardAvailable) {
+      this.skip();
+    }
+
+    // Need more time to download packages
+    this.timeout(10000);
+
+    const info = 'Output copied to clipboard';
+
+    const consoleOutput = execEnvinfo(['--clipboard']);
+    const envFromClipboard = clipboard.readSync();
+
+    expect(consoleOutput).to.include(info);
+    expect(consoleOutput).to.include(envFromClipboard);
+
+    expect(envFromClipboard).to.include('@mui/material');
+    expect(envFromClipboard).to.include('typescript');
+    expect(envFromClipboard).to.not.include(info);
+  });
+
+  it('when copy to clipboard fails, adds error message at the end', function test() {
+    if (isClipboardAvailable) {
+      this.skip();
+    }
+
+    const consoleOutput = execEnvinfo(['--clipboard']).toLocaleLowerCase();
+
+    expect(consoleOutput).to.include('failed to copy to clipboard');
+  });
+
+  it("without --clipboard flag, doesn't copy to clipboard", function test() {
     if (!isClipboardAvailable) {
       this.skip();
     }
@@ -96,38 +127,7 @@ describe('@mui/envinfo', () => {
     const consoleOutput = execEnvinfo();
     const envFromClipboard = clipboard.readSync();
 
-    expect(consoleOutput).to.include(info);
-    expect(consoleOutput).to.include(envFromClipboard);
-
-    expect(envFromClipboard).to.include('@mui/material');
-    expect(envFromClipboard).to.include('typescript');
-    expect(envFromClipboard).to.not.include(info);
-  });
-
-  it("doesn't copy to clipboard with --skipClipboard flag", function test() {
-    if (!isClipboardAvailable) {
-      this.skip();
-    }
-
-    // Need more time to download packages
-    this.timeout(10000);
-
-    const info = 'Output copied to clipboard';
-
-    const consoleOutput = execEnvinfo(['--skipClipboard']);
-    const envFromClipboard = clipboard.readSync();
-
     expect(consoleOutput).to.not.include(info);
     expect(envFromClipboard).to.be.equal('');
-  });
-
-  it('when copy to clipboard fails, adds error message at the end', function test() {
-    if (isClipboardAvailable) {
-      this.skip();
-    }
-
-    const consoleOutput = execEnvinfo().toLocaleLowerCase();
-
-    expect(consoleOutput).to.include('failed to copy to clipboard');
   });
 });

--- a/packages/mui-envinfo/envinfo.test.js
+++ b/packages/mui-envinfo/envinfo.test.js
@@ -6,6 +6,7 @@ const isRunningOnWindows = process.platform === 'win32';
 
 describe('@mui/envinfo', () => {
   const packagePath = __dirname;
+
   before(function beforeHook() {
     // only run in node
     if (!/jsdom/.test(window.navigator.userAgent)) {
@@ -20,7 +21,7 @@ describe('@mui/envinfo', () => {
     });
   });
 
-  function execEnvinfo(args) {
+  function execEnvinfo(args = []) {
     const buildPath = path.resolve(packagePath, 'build');
     return execFileSync(
       isRunningOnWindows ? 'npx.cmd' : 'npx',
@@ -36,8 +37,9 @@ describe('@mui/envinfo', () => {
     // Need more time to download packages
     this.timeout(10000);
 
-    const envinfoJSON = execEnvinfo(['--json']);
+    const envinfoJSON = execEnvinfo(['--json', '--skipClipboard']);
 
+    // eslint-disable-next-line no-console
     const envinfo = JSON.parse(envinfoJSON);
 
     // chai doesn't have expect.any(String) like jest so we have to use what's available

--- a/packages/mui-envinfo/package.json
+++ b/packages/mui-envinfo/package.json
@@ -9,6 +9,7 @@
   "version": "2.0.6",
   "bin": "./envinfo.js",
   "dependencies": {
+    "clipboardy": "^2.3.0",
     "envinfo": "^7.8.1"
   },
   "author": "MUI Team",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5466,7 +5466,7 @@ clipboard-copy@^4.0.1:
   resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-4.0.1.tgz#326ef9726d4ffe72d9a82a7bbe19379de692017d"
   integrity sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==
 
-clipboardy@2.3.0:
+clipboardy@2.3.0, clipboardy@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
   integrity sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

#### Background:
Copying the output from `npx @mui/envinfo` can be cumbersome in some terminals, esp. if the output is large.

#### Changes:
- [x] using [clipboardy@2.x](https://www.npmjs.com/package/clipboardy) to copy envinfo output to the OS clipboard

#### Usage

```bash
npx @mui/envinfo --clipboard
```

<img width="473" alt="Screenshot 2022-06-15 at 19 15 32" src="https://user-images.githubusercontent.com/2707029/173886798-22d9e873-b0ae-4acf-90b7-900d7d2884eb.png">

