### PR TITLE
[ModalManager] Lock body scroll when container is inside shadow DOM

### DIFF
--- a/packages/mui-base/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalManager.test.js
@@ -167,6 +167,39 @@ describe('ModalManager', () => {
       expect(fixedNode.style.paddingRight).to.equal('');
     });
 
+    describe('shadow dom', () => {
+      let shadowContainer;
+      let container2;
+
+      beforeEach(() => {
+        shadowContainer = document.createElement('div');
+        const shadowRoot = shadowContainer.attachShadow({ mode: 'open' })
+        container2 = document.createElement('div');
+        shadowRoot.appendChild(container2)
+      });
+
+      afterEach(() => {
+        document.body.removeChild(shadowContainer);
+      });
+
+      it('should scroll body when parent is shadow root', () => {
+        const modal = {};
+
+        container2.style.overflow = 'scroll';
+
+        document.body.appendChild(shadowContainer);
+        modalManager.add(modal, container2);
+        modalManager.mount(modal, {});
+
+        expect(container2.style.overflow).to.equal('scroll');
+        expect(document.body.style.overflow).to.equal('hidden');
+        modalManager.remove(modal);
+
+        expect(container2.style.overflow).to.equal('scroll');
+        expect(document.body.style.overflow).to.equal('');
+      });
+    });
+
     describe('restore styles', () => {
       let container2;
 

--- a/packages/mui-base/src/ModalUnstyled/ModalManager.test.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalManager.test.js
@@ -173,9 +173,9 @@ describe('ModalManager', () => {
 
       beforeEach(() => {
         shadowContainer = document.createElement('div');
-        const shadowRoot = shadowContainer.attachShadow({ mode: 'open' })
+        const shadowRoot = shadowContainer.attachShadow({ mode: 'open' });
         container2 = document.createElement('div');
-        shadowRoot.appendChild(container2)
+        shadowRoot.appendChild(container2);
       });
 
       afterEach(() => {

--- a/packages/mui-base/src/ModalUnstyled/ModalManager.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalManager.ts
@@ -122,14 +122,21 @@ function handleContainer(containerInfo: Container, props: ManagedModalProps) {
       });
     }
 
-    // Improve Gatsby support
-    // https://css-tricks.com/snippets/css/force-vertical-scrollbar/
-    const parent = container.parentElement;
-    const containerWindow = ownerWindow(container);
-    const scrollContainer =
-      parent?.nodeName === 'HTML' && containerWindow.getComputedStyle(parent).overflowY === 'scroll'
-        ? parent
-        : container;
+    let scrollContainer: HTMLElement;
+
+    if (container.parentNode instanceof DocumentFragment) {
+      scrollContainer = ownerDocument(container).body;
+    } else {
+      // Improve Gatsby support
+      // https://css-tricks.com/snippets/css/force-vertical-scrollbar/
+      const parent = container.parentElement;
+      const containerWindow = ownerWindow(container);
+      scrollContainer =
+        parent?.nodeName === 'HTML' &&
+        containerWindow.getComputedStyle(parent).overflowY === 'scroll'
+          ? parent
+          : container;
+    }
 
     // Block the scroll even if no scrollbar is visible to account for mobile keyboard
     // screensize shrink.

--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -16,6 +16,7 @@ const whitelist = [
   'Node',
   'Performance',
   'document',
+  'DocumentFragment'
 ];
 const blacklist = ['sessionStorage', 'localStorage'];
 

--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -16,7 +16,7 @@ const whitelist = [
   'Node',
   'Performance',
   'document',
-  'DocumentFragment'
+  'DocumentFragment',
 ];
 const blacklist = ['sessionStorage', 'localStorage'];
 


### PR DESCRIPTION
https://github.com/mui/material-ui/issues/17473#issuecomment-1156251054

If you set a modal's container to an element inside a shadow DOM, MUI will try to lock scrolling on the container, rather than document.body.

This locks document.body, only in the case where the modal container's immediate parent is the shadow root. This works for the example in [the guide](https://mui.com/material-ui/guides/shadow-dom/), where the modal container `shadowRootElement` is a child of `shadowContainer`.


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
