### PR TITLE
[codemod] Preserve comments within jss-to-tss-react

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-from-material-ui-core.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-from-material-ui-core.js
@@ -1,5 +1,13 @@
 import React from "react";
+
+/*
+Test makeStyles comment
+ */
 import { makeStyles } from "@material-ui/core";
+/*
+clsx comment that will not be preserved since the import is being removed (not just replaced)
+and is not at the beginning of the file.
+ */
 import clsx from "clsx";
 
 const useStyles = makeStyles(() => ({

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-mixins-pattern.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-mixins-pattern.js
@@ -1,6 +1,7 @@
+// Comment on first node where the first node will be removed and we should preserve this comment.
+import clsx from "clsx";
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import clsx from "clsx";
 
 function mixins() {
   return {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-todo-comments.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-todo-comments.js
@@ -1,6 +1,13 @@
+/*
+Comments to be preserved when clsx import is removed. These comments should come before
+and comments that they get combined with.
+ */
+import clsx from "clsx";
+/*
+Comments that should not be lost when the clsx import comments are preserved.
+ */
 import React from "react";
 import { makeStyles } from "@material-ui/core";
-import clsx from "clsx";
 
 const useStyles = makeStyles(() => ({
   test: {

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-todo-comments.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/actual-todo-comments.js
@@ -1,6 +1,6 @@
 /*
 Comments to be preserved when clsx import is removed. These comments should come before
-and comments that they get combined with.
+any comments that they get combined with.
  */
 import clsx from "clsx";
 /*

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-from-material-ui-core.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-from-material-ui-core.js
@@ -1,4 +1,8 @@
 import React from "react";
+
+/*
+Test makeStyles comment
+ */
 import { makeStyles } from 'tss-react/mui';
 
 const useStyles = makeStyles()((_theme, _params, classes) => ({

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-mixins-pattern.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-mixins-pattern.js
@@ -1,3 +1,4 @@
+// Comment on first node where the first node will be removed and we should preserve this comment.
 import React from "react";
 import { makeStyles } from 'tss-react/mui';
 

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-todo-comments.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-todo-comments.js
@@ -1,6 +1,6 @@
 /*
 Comments to be preserved when clsx import is removed. These comments should come before
-and comments that they get combined with.
+any comments that they get combined with.
  */
 /*
 Comments that should not be lost when the clsx import comments are preserved.

--- a/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-todo-comments.js
+++ b/packages/mui-codemod/src/v5.0.0/jss-to-tss-react.test/expected-todo-comments.js
@@ -1,3 +1,10 @@
+/*
+Comments to be preserved when clsx import is removed. These comments should come before
+and comments that they get combined with.
+ */
+/*
+Comments that should not be lost when the clsx import comments are preserved.
+ */
 import React from "react";
 import { makeStyles } from 'tss-react/mui';
 


### PR DESCRIPTION
- Preserve comments for imports that get replaced
- Preserve comments for an import that gets removed if it was the first import in the file (otherwise the comment is probably no longer relevant)
- When preserving the initial comment in a file, avoid wiping out comments for the next import in the file

This is a replacement implementation for the issue brought up in #32964.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
