### PR TITLE
[SwitchUnstyled] Use useSlotProps

### DIFF
--- a/docs/pages/base/api/switch-unstyled.json
+++ b/docs/pages/base/api/switch-unstyled.json
@@ -1,7 +1,6 @@
 {
   "props": {
     "checked": { "type": { "name": "bool" } },
-    "className": { "type": { "name": "string" } },
     "component": { "type": { "name": "elementType" } },
     "components": {
       "type": {

--- a/docs/translations/api-docs/switch-unstyled/switch-unstyled.json
+++ b/docs/translations/api-docs/switch-unstyled/switch-unstyled.json
@@ -2,7 +2,6 @@
   "componentDescription": "The foundation for building custom-styled switches.",
   "propDescriptions": {
     "checked": "If <code>true</code>, the component is checked.",
-    "className": "Class name applied to the root element.",
     "component": "The component used for the Root slot. Either a string to use a HTML element or a component. This is equivalent to <code>components.Root</code>. If both are provided, the <code>component</code> is used.",
     "components": "The components used for each slot inside the Switch. Either a string to use a HTML element or a component.",
     "componentsProps": "The props used for each slot inside the Switch.",

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.tsx
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.tsx
@@ -43,7 +43,6 @@ const ButtonUnstyled = React.forwardRef(function ButtonUnstyled<
   const {
     action,
     children,
-    className,
     component,
     components = {},
     componentsProps = {},
@@ -96,7 +95,7 @@ const ButtonUnstyled = React.forwardRef(function ButtonUnstyled<
       ref: forwardedRef,
     },
     ownerState,
-    className: [classes.root, className],
+    className: classes.root,
   });
 
   return <Root {...rootProps}>{children}</Root>;
@@ -122,10 +121,6 @@ ButtonUnstyled.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
   /**
    * The component used for the Root slot.
    * Either a string to use a HTML element or a component.

--- a/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.tsx
+++ b/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.tsx
@@ -32,7 +32,6 @@ const MenuItemUnstyled = React.forwardRef(function MenuItemUnstyled(
 ) {
   const {
     children,
-    className,
     disabled: disabledProp = false,
     component,
     components = {},
@@ -57,7 +56,7 @@ const MenuItemUnstyled = React.forwardRef(function MenuItemUnstyled(
     getSlotProps: getRootProps,
     externalSlotProps: componentsProps.root,
     externalForwardedProps: other,
-    className: [classes.root, className],
+    className: classes.root,
     ownerState,
   });
 
@@ -73,10 +72,6 @@ MenuItemUnstyled.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
   /**
    * @ignore
    */

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.tsx
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { HTMLElementType, refType } from '@mui/utils';
 import MenuUnstyledContext, { MenuUnstyledContextType } from './MenuUnstyledContext';
 import {
@@ -41,7 +40,6 @@ const MenuUnstyled = React.forwardRef(function MenuUnstyled(
     actions,
     anchorEl,
     children,
-    className,
     component,
     components = {},
     componentsProps = {},
@@ -94,7 +92,7 @@ const MenuUnstyled = React.forwardRef(function MenuUnstyled(
       role: undefined,
       ref: forwardedRef,
     },
-    className: clsx(classes.root, className),
+    className: classes.root,
     ownerState,
   }) as MenuUnstyledRootSlotProps;
 
@@ -148,10 +146,6 @@ MenuUnstyled.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   children: PropTypes.node,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
   /**
    * @ignore
    */

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import composeClasses from '../composeClasses';
 import useSwitch from './useSwitch';
-import classes from './switchUnstyledClasses';
+import { getSwitchUnstyledUtilityClass } from './switchUnstyledClasses';
 import {
   SwitchUnstyledProps,
   SwitchUnstyledOwnerState,
@@ -11,6 +12,25 @@ import {
   SwitchUnstyledTrackSlotProps,
 } from './SwitchUnstyled.types';
 import { useSlotProps, WithOptionalOwnerState } from '../utils';
+
+const useUtilityClasses = (ownerState: SwitchUnstyledOwnerState) => {
+  const { checked, disabled, focusVisible, readOnly } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      checked && 'checked',
+      disabled && 'disabled',
+      focusVisible && 'focusVisible',
+      readOnly && 'readOnly',
+    ],
+    thumb: ['thumb'],
+    input: ['input'],
+    track: ['track'],
+  };
+
+  return composeClasses(slots, getSwitchUnstyledUtilityClass, {});
+};
 
 /**
  * The foundation for building custom-styled switches.
@@ -29,7 +49,6 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled(
 ) {
   const {
     checked: checkedProp,
-    className,
     component,
     components = {},
     componentsProps = {},
@@ -41,7 +60,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled(
     onFocusVisible,
     readOnly: readOnlyProp,
     required,
-    ...otherProps
+    ...other
   } = props;
 
   const useSwitchProps = {
@@ -65,23 +84,18 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled(
     readOnly,
   };
 
-  const stateClasses = {
-    [classes.checked]: checked,
-    [classes.disabled]: disabled,
-    [classes.focusVisible]: focusVisible,
-    [classes.readOnly]: readOnly,
-  };
+  const classes = useUtilityClasses(ownerState);
 
   const Root: React.ElementType = component ?? components.Root ?? 'span';
   const rootProps: WithOptionalOwnerState<SwitchUnstyledRootSlotProps> = useSlotProps({
     elementType: Root,
     externalSlotProps: componentsProps.root,
-    externalForwardedProps: otherProps,
+    externalForwardedProps: other,
     additionalProps: {
       ref,
     },
     ownerState,
-    className: [classes.root, stateClasses, className],
+    className: classes.root,
   });
 
   const Thumb: React.ElementType = components.Thumb ?? 'span';
@@ -128,10 +142,6 @@ SwitchUnstyled.propTypes /* remove-proptypes */ = {
    * If `true`, the component is checked.
    */
   checked: PropTypes.bool,
-  /**
-   * Class name applied to the root element.
-   */
-  className: PropTypes.string,
   /**
    * The component used for the Root slot.
    * Either a string to use a HTML element or a component.

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import useSwitch from './useSwitch';
 import classes from './switchUnstyledClasses';
-import appendOwnerState from '../utils/appendOwnerState';
 import {
   SwitchUnstyledProps,
   SwitchUnstyledOwnerState,
@@ -12,8 +10,7 @@ import {
   SwitchUnstyledThumbSlotProps,
   SwitchUnstyledTrackSlotProps,
 } from './SwitchUnstyled.types';
-import { WithOptionalOwnerState } from '../utils';
-import resolveComponentProps from '../utils/resolveComponentProps';
+import { useSlotProps, WithOptionalOwnerState } from '../utils';
 
 /**
  * The foundation for building custom-styled switches.
@@ -76,48 +73,45 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled(
   };
 
   const Root: React.ElementType = component ?? components.Root ?? 'span';
-  const rootComponentProps = resolveComponentProps(componentsProps.root, ownerState);
-  const rootProps: WithOptionalOwnerState<SwitchUnstyledRootSlotProps> = appendOwnerState(
-    Root,
-    {
-      ...otherProps,
-      ...rootComponentProps,
-      className: clsx(classes.root, stateClasses, className, rootComponentProps?.className),
+  const rootProps: WithOptionalOwnerState<SwitchUnstyledRootSlotProps> = useSlotProps({
+    elementType: Root,
+    externalSlotProps: componentsProps.root,
+    externalForwardedProps: otherProps,
+    additionalProps: {
+      ref,
     },
     ownerState,
-  );
+    className: [classes.root, stateClasses, className],
+  });
 
   const Thumb: React.ElementType = components.Thumb ?? 'span';
-  const thumbComponentProps = resolveComponentProps(componentsProps.thumb, ownerState);
-  const thumbProps: WithOptionalOwnerState<SwitchUnstyledThumbSlotProps> = appendOwnerState(
-    Thumb,
-    { ...thumbComponentProps, className: clsx(classes.thumb, thumbComponentProps?.className) },
+  const thumbProps: WithOptionalOwnerState<SwitchUnstyledThumbSlotProps> = useSlotProps({
+    elementType: Thumb,
+    externalSlotProps: componentsProps.thumb,
     ownerState,
-  );
+    className: classes.thumb,
+  });
 
   const Input: React.ElementType = components.Input ?? 'input';
-  const inputComponentProps = resolveComponentProps(componentsProps.input, ownerState);
-  const inputProps: WithOptionalOwnerState<SwitchUnstyledInputSlotProps> = appendOwnerState(
-    Input,
-    {
-      ...getInputProps(),
-      ...inputComponentProps,
-      className: clsx(classes.input, inputComponentProps?.className),
-    },
+  const inputProps: WithOptionalOwnerState<SwitchUnstyledInputSlotProps> = useSlotProps({
+    elementType: Input,
+    getSlotProps: getInputProps,
+    externalSlotProps: componentsProps.input,
     ownerState,
-  );
+    className: classes.input,
+  });
 
   const Track: React.ElementType =
     components.Track === null ? () => null : components.Track ?? 'span';
-  const trackComponentProps = resolveComponentProps(componentsProps.track, ownerState);
-  const trackProps: WithOptionalOwnerState<SwitchUnstyledTrackSlotProps> = appendOwnerState(
-    Track,
-    { ...trackComponentProps, className: clsx(classes.track, trackComponentProps?.className) },
+  const trackProps: WithOptionalOwnerState<SwitchUnstyledTrackSlotProps> = useSlotProps({
+    elementType: Track,
+    externalSlotProps: componentsProps.track,
     ownerState,
-  );
+    className: classes.track,
+  });
 
   return (
-    <Root ref={ref} {...rootProps}>
+    <Root {...rootProps}>
       <Track {...trackProps} />
       <Thumb {...thumbProps} />
       <Input {...inputProps} />

--- a/packages/mui-base/src/utils/mergeSlotProps.ts
+++ b/packages/mui-base/src/utils/mergeSlotProps.ts
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import clsx, { ClassValue } from 'clsx';
 import { Simplify } from '@mui/types';
 import { EventHandlers } from './types';
 import extractEventHandlers from './extractEventHandlers';
@@ -40,7 +40,7 @@ export interface MergeSlotPropsParameters<
   /**
    * Extra class name(s) to be placed on the slot.
    */
-  className?: string | (string | undefined)[] | undefined;
+  className?: ClassValue | ClassValue[];
 }
 
 export type MergeSlotPropsResult<


### PR DESCRIPTION
Prepare slots' props with the useSlotProps hook.

Also improved the consistency of the codebase by introducing the useUtilityClasses function, as in other components.