### PR TITLE
[docs] Update links to MUI X Overview and Introduction pages

### DIFF
--- a/docs/data/material/guides/understand-mui-packages/understand-mui-packages.md
+++ b/docs/data/material/guides/understand-mui-packages/understand-mui-packages.md
@@ -34,7 +34,7 @@ The following chart illustrates how MUI's packages are related to one another:
 <img src="/static/images/packages/mui-packages.png" style="width: 796px; margin-top: 4px; margin-bottom: 8px;" alt="The first half of the image shows @mui/material and @mui/base as component libraries, and @mui/system and styled engines as styling solutions, both under the MUI Core umbrella. The second half shows @mui/x-data-grid and @mui/x-date-pickers as components from MUI X."/>
 
 In this article, we'll only cover the MUI Core packages.
-Check the [MUI X overview](/x/advanced-components/) for more information about our collection of advanced components.
+Visit the [MUI X Overview](/x/introduction/) for more information about our collection of advanced components.
 
 ## Component libraries
 

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -90,8 +90,8 @@ const faqData = [
       <React.Fragment>
         After you purchase a license, you'll receive a license key by email. Once you have the
         license key, you need to follow the{' '}
-        <Link href="/x/advanced-components/#license-key-installation">instructions</Link> necessary
-        to set it up.
+        <Link href="/x/introduction/licensing/#license-key-installation">instructions</Link>{' '}
+        necessary to set it up.
       </React.Fragment>
     ),
   },

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -80,9 +80,7 @@ export default function WhatToExpect() {
             <Typography variant="body2" color="text.secondary">
               With your purchase you receive support and access to new versions for the duration of
               your subscription. You can{' '}
-              <Link href="https://mui.com/x/advanced-components/#support">
-                learn more about support
-              </Link>{' '}
+              <Link href="https://mui.com/x/introduction/support/">learn more about support</Link>{' '}
               in the docs. Note that, except for critical issues, e.g. security, we release bug
               fixes, and other improvements on top of the latest version, instead of patching older
               versions.

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -471,13 +471,9 @@ export default function AppNavDrawer(props) {
               ])}
             />
           )}
-          {
-            // TODO: remove first condition when https://github.com/mui/mui-x/pull/4692 is released
-            (asPathWithoutLang.startsWith('/x/advanced-components') ||
-              asPathWithoutLang.startsWith('/x/introduction')) && (
-              <ProductIdentifier name="Advanced components" metadata="MUI X" />
-            )
-          }
+          {asPathWithoutLang.startsWith('/x/introduction') && (
+            <ProductIdentifier name="Advanced components" metadata="MUI X" />
+          )}
           {(asPathWithoutLang.startsWith('/x/react-data-grid') ||
             asPathWithoutLang.startsWith('/x/api/data-grid')) && (
             <ProductIdentifier

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -52,7 +52,7 @@ const ROUTES = {
     ? '/material-ui/discover-more/backers/#gold'
     : '/discover-more/backers/#gold/',
   store: 'https://mui.com/store/',
-  advancedComponents: '/x/advanced-components/',
+  advancedComponents: '/x/introduction/',
   dataGridSpace: '/x/react-data-grid/getting-started/',
   dataGridDocs: FEATURE_TOGGLE.enable_redirects
     ? '/x/react-data-grid/getting-started/'

--- a/test/e2e-website/products-drawer.spec.ts
+++ b/test/e2e-website/products-drawer.spec.ts
@@ -24,7 +24,7 @@ test('able to navigate between products', async ({ page }) => {
     '/system/basics/',
   );
 
-  await expect(page.locator('#mui-product-menu a[href="/x/advanced-components/"]')).toBeVisible();
+  await expect(page.locator('#mui-product-menu a[href="/x/introduction/"]')).toBeVisible();
 
   if (FEATURE_TOGGLE.enable_mui_base_scope) {
     await expect(


### PR DESCRIPTION
This PR is connected to https://github.com/mui/mui-x/pull/4692. It updates links pointing to the X Overview page to match the new structure of that PR.

This should only be merged after its sister on the X side is **released** in production 👯‍♀️