### PR TITLE
[docs] Fix 404 from old URLs we forgot to redirect

### DIFF
--- a/docs/pages/careers/fullstack-engineer.js
+++ b/docs/pages/careers/fullstack-engineer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/careers/full-stack-engineer.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/careers/people-operations-manager.js
+++ b/docs/pages/careers/people-operations-manager.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/careers/people-operation-manager.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/careers/product-engineer.js
+++ b/docs/pages/careers/product-engineer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/careers/product-engineer.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/careers/react-engineer-core.js
+++ b/docs/pages/careers/react-engineer-core.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/careers/react-engineer-core.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/careers/react-engineer-x.js
+++ b/docs/pages/careers/react-engineer-x.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/careers/react-engineer-x.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/careers/react-support-engineer.js
+++ b/docs/pages/careers/react-support-engineer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/careers/react-support-engineer.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/careers/support-agent.js
+++ b/docs/pages/careers/support-agent.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import { demos, docs, demoComponents } from 'docs/src/pages/careers/support-agent.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/pages/company/contact.js
+++ b/docs/pages/company/contact.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import TopLayoutCompany from 'docs/src/modules/components/TopLayoutCompany';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
 import {
   demos,
   docs,
@@ -7,5 +7,5 @@ import {
 } from 'docs/src/pages/company/contact/contact.md?@mui/markdown';
 
 export default function Page() {
-  return <TopLayoutCompany demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <TopLayoutCareers demos={demos} docs={docs} demoComponents={demoComponents} />;
 }

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -52,9 +52,13 @@
 /api/mui-theme-provider/ /system/styles/api/ 301
 /components/expansion-panels/ /material-ui/react-accordion/ 301
 /api/expansion-panel/ /material-ui/api/accordion/ 301
+/:lang/api/expansion-panel/ /:lang/material-ui/api/accordion/ 301
 /api/expansion-panel-actions/ /material-ui/api/accordion-actions/ 301
+/:lang/api/expansion-panel-actions/ /:lang/material-ui/api/accordion-actions/ 301
 /api/expansion-panel-details/ /material-ui/api/accordion-details/ 301
+/:lang/api/expansion-panel-details/ /:lang/material-ui/api/accordion-details/ 301
 /api/expansion-panel-summary/ /material-ui/api/accordion-summary/ 301
+/:lang/api/expansion-panel-summary/ /:lang/material-ui/api/accordion-summary/ 301
 # 2020
 /premium-themes* https://mui.com/store/ 301
 /customization/themes/ /material-ui/customization/theming/ 301
@@ -62,17 +66,22 @@ https://v1-5-0.mui.com/* https://v1.mui.com/:splat 301!
 https://v3-9-0.mui.com/* https://v3.mui.com/:splat 301!
 /components/grid-list/ /material-ui/react-image-list/ 301
 /api/grid-list/ /material-ui/api/image-list/ 301
+/:lang/api/grid-list/ /:lang/material-ui/api/image-list/ 301
 /api/grid-list-tile/ /material-ui/api/image-list-item/ 301
+/:lang/api/grid-list-tile/ /:lang/material-ui/api/image-list-item/ 301
 /api/grid-list-tile-bar/ /material-ui/api/image-list-item-bar/ 301
+/:lang/api/grid-list-tile-bar/ /:lang/material-ui/api/image-list-item-bar/ 301
 /customization/components/ /material-ui/customization/how-to-customize/ 301
 /:lang/customization/components/ /:lang/material-ui/customization/how-to-customize/ 301
 /customization/globals/ /material-ui/customization/theme-components/ 301
+/:lang/customization/globals/ /:lang/material-ui/customization/theme-components/ 301
 # 2021
 /api/root-ref/ https://v4.mui.com/api/root-ref/ 301
 /:lang/api/root-ref/ https://v4.mui.com/:lang/api/root-ref/ 301
 /components/slider-styled/ /material-ui/react-slider/ 301
 /customization/styled/ /system/styled/ 301
 /api/data-grid/x-grid/ /x/api/data-grid/data-grid-pro/ 301
+/api/x-grid/ /x/api/data-grid/data-grid-pro/ 301
 https://next.material-ui.com/* https://mui.com/:splat 301!
 https://v0.material-ui.com/* https://v0.mui.com/:splat 301!
 https://v1.material-ui.com/* https://v1.mui.com/:splat 301!
@@ -81,6 +90,7 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /company/careers/ /careers/ 301
 /:lang/company/careers/ /:lang/careers/ 301
 /discover-more/team/ /about/ 301
+/:lang/discover-more/team/ /:lang/about/ 301
 /api/data-grid/grid-export-csv-options/ /x/api/data-grid/grid-csv-export-options/ 301
 /fr/* /:splat 301
 /de/* /:splat 301
@@ -318,20 +328,42 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /api/modal-unstyled/ /base/api/modal-unstyled/ 301
 /pt/api/modal-unstyled/ /pt/base/api/modal-unstyled/ 301
 /zh/api/modal-unstyled/ /zh/base/api/modal-unstyled/ 301
+/api/option-group-unstyled/ /base/api/option-group-unstyled/ 301
+/:lang/api/option-group-unstyled/ /:lang/base/api/option-group-unstyled/ 301
+/api/portal/ /base/api/portal/ 301
+/:lang/api/portal/ /:lang/base/api/portal/ 301
+/api/menu-item-unstyled/ /base/api/menu-item-unstyled/ 301
+/:lang/api/menu-item-unstyled/ /:lang/base/api/menu-item-unstyled/ 301
+/api/tabs-list-unstyled/ /base/api/tabs-list-unstyled/ 301
+/:lang/api/tabs-list-unstyled/ /:lang/base/api/tabs-list-unstyled/ 301
+/api/api/menu-unstyled/ /base/api/api/menu-unstyled/ 301
+/:lang/api/api/menu-unstyled/ /:lang/base/api/api/menu-unstyled/ 301
 /api/* /material-ui/api/:splat 301
 /zh/api/* /zh/material-ui/api/:splat 301
 /pt/api/* /pt/material-ui/api/:splat 301
 /company/about/ /about/ 301
 /company/jobs/ /careers/ 301
 /material-ui/customization/unstyled-components/ /base/getting-started/overview/ 301
+/:lang/material-ui/customization/unstyled-components/ /:lang/base/getting-started/overview/ 301
 /material-ui/guides/migration-v4/ /material-ui/migration/migration-v4/ 301
+/:lang/material-ui/guides/migration-v4/ /:lang/material-ui/migration/migration-v4/ 301
 /material-ui/guides/migration-v3/ /material-ui/migration/migration-v3/ 301
+/:lang/material-ui/guides/migration-v3/ /:lang/material-ui/migration/migration-v3/ 301
 /material-ui/guides/migration-v0x/ /material-ui/migration/migration-v0x/ 301
+/:lang/material-ui/guides/migration-v0x/ /:lang/material-ui/migration/migration-v0x/ 301
 /material/* /material-ui/:splat 301
 /zh/material/* /zh/material-ui/:splat 301
 /pt/material/* /pt/material-ui/:splat 301
 /zh/blog/* /blog/:splat 301
 /pt/blog/* /blog/:splat 301
+/legal/mui-x-eula/ /store/legal/mui-x-eula/ 301
+/:lang/size-snapshot/ /size-snapshot/ 301
+/joy-ui/customization/themed-tokens/ /joy-ui/customization/themed-components/ 301
+/joy-ui/customization/one-off-styling/ /joy-ui/customization/approaches/#one-off-customization 301
+/joy-ui/customization/theme-components/ /joy-ui/customization/themed-components/ 301
+/base/react-chip/ /material-ui/react-chip/ 301
+/system/api/ /system/properties/ 301
+/:lang/system/api/ /:lang/system/properties/ 301
 # 2023
 
 # Proxies

--- a/docs/src/modules/components/TopLayoutCareers.js
+++ b/docs/src/modules/components/TopLayoutCareers.js
@@ -22,14 +22,16 @@ const StyledAppContainer = styled(AppContainer)(({ theme }) => ({
   },
 }));
 
-function TopLayoutCompany(props) {
+function TopLayoutCareers(props) {
   const { docs } = props;
   const { description, rendered, title } = docs.en;
 
   return (
     <BrandingProvider>
       <AppHeader />
-      <Head title={`${title} - MUI`} description={description} />
+      <Head title={`${title} - MUI`} description={description}>
+        <meta name="robots" content="noindex,nofollow" />
+      </Head>
       <StyledDiv>
         <StyledAppContainer component="main" sx={{ py: { xs: 3, sm: 4, md: 8 } }}>
           <Link
@@ -52,8 +54,8 @@ function TopLayoutCompany(props) {
   );
 }
 
-TopLayoutCompany.propTypes = {
+TopLayoutCareers.propTypes = {
   docs: PropTypes.object.isRequired,
 };
 
-export default TopLayoutCompany;
+export default TopLayoutCareers;


### PR DESCRIPTION
I'm fixing https://search.google.com/search-console/index?resource_id=sc-domain%3Amui.com. There are currently 3,703 URLs that are linked on external domains, that we used to have pages against, etc. that Google is aware of and tries to index. In reality, the number of real 404 pages we have should be in the order of 300, an order of magnitude less. For example: older open jobs that are now closed.

<img width="950" alt="Screenshot 2022-06-18 at 20 44 09" src="https://user-images.githubusercontent.com/3165635/174452213-749fd33c-b6ee-49f9-9c36-b312fd155130.png">

One example a bug this fix:

- https://mui.com/api/portal/
- https://deploy-preview-33206--material-ui.netlify.app/api/portal/