### PR TITLE
[docs] Update `margin` props demo code for `TextField`

### DIFF
--- a/docs/data/material/components/text-fields/LayoutTextFields.js
+++ b/docs/data/material/components/text-fields/LayoutTextFields.js
@@ -2,11 +2,25 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
-function RedBar() {
+function RedNormalBar() {
   return (
     <Box
       sx={{
         height: 20,
+        backgroundColor: (theme) =>
+          theme.palette.mode === 'light'
+            ? 'rgba(255, 0, 0, 0.1)'
+            : 'rgb(255 132 132 / 25%)',
+      }}
+    />
+  );
+}
+
+function RedDenseBar() {
+  return (
+    <Box
+      sx={{
+        height: 10,
         backgroundColor: (theme) =>
           theme.palette.mode === 'light'
             ? 'rgba(255, 0, 0, 0.1)'
@@ -25,13 +39,19 @@ export default function LayoutTextFields() {
         '& .MuiTextField-root': { width: '25ch' },
       }}
     >
-      <RedBar />
-      <TextField label={'margin="none"'} id="margin-none" />
-      <RedBar />
-      <TextField label={'margin="dense"'} id="margin-dense" margin="dense" />
-      <RedBar />
-      <TextField label={'margin="normal"'} id="margin-normal" margin="normal" />
-      <RedBar />
+      <Box my={1}>
+        <TextField label={'margin="none"'} id="margin-none" />
+      </Box>
+      <Box my={1}>
+        <RedDenseBar />
+        <TextField label={'margin="dense"'} id="margin-dense" margin="dense" />
+        <RedDenseBar />
+      </Box>
+      <Box my={1}>
+        <RedNormalBar />
+        <TextField label={'margin="normal"'} id="margin-normal" margin="normal" />
+        <RedNormalBar />
+      </Box>
     </Box>
   );
 }

--- a/docs/data/material/components/text-fields/LayoutTextFields.tsx
+++ b/docs/data/material/components/text-fields/LayoutTextFields.tsx
@@ -2,11 +2,25 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
-function RedBar() {
+function RedNormalBar() {
   return (
     <Box
       sx={{
         height: 20,
+        backgroundColor: (theme) =>
+          theme.palette.mode === 'light'
+            ? 'rgba(255, 0, 0, 0.1)'
+            : 'rgb(255 132 132 / 25%)',
+      }}
+    />
+  );
+}
+
+function RedDenseBar() {
+  return (
+    <Box
+      sx={{
+        height: 10,
         backgroundColor: (theme) =>
           theme.palette.mode === 'light'
             ? 'rgba(255, 0, 0, 0.1)'
@@ -25,13 +39,19 @@ export default function LayoutTextFields() {
         '& .MuiTextField-root': { width: '25ch' },
       }}
     >
-      <RedBar />
-      <TextField label={'margin="none"'} id="margin-none" />
-      <RedBar />
-      <TextField label={'margin="dense"'} id="margin-dense" margin="dense" />
-      <RedBar />
-      <TextField label={'margin="normal"'} id="margin-normal" margin="normal" />
-      <RedBar />
+      <Box my={1}>
+        <TextField label={'margin="none"'} id="margin-none" />
+      </Box>
+      <Box my={1}>
+        <RedDenseBar />
+        <TextField label={'margin="dense"'} id="margin-dense" margin="dense" />
+        <RedDenseBar />
+      </Box>
+      <Box my={1}>
+        <RedNormalBar />
+        <TextField label={'margin="normal"'} id="margin-normal" margin="normal" />
+        <RedNormalBar />
+      </Box>
     </Box>
   );
 }

--- a/docs/data/material/components/text-fields/LayoutTextFields.tsx.preview
+++ b/docs/data/material/components/text-fields/LayoutTextFields.tsx.preview
@@ -1,7 +1,13 @@
-<RedBar />
-<TextField label={'margin="none"'} id="margin-none" />
-<RedBar />
-<TextField label={'margin="dense"'} id="margin-dense" margin="dense" />
-<RedBar />
-<TextField label={'margin="normal"'} id="margin-normal" margin="normal" />
-<RedBar />
+<Box my={1}>
+  <TextField label={'margin="none"'} id="margin-none" />
+</Box>
+<Box my={1}>
+  <RedDenseBar />
+  <TextField label={'margin="dense"'} id="margin-dense" margin="dense" />
+  <RedDenseBar />
+</Box>
+<Box my={1}>
+  <RedNormalBar />
+  <TextField label={'margin="normal"'} id="margin-normal" margin="normal" />
+  <RedNormalBar />
+</Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Summary

Thank you for developing this wonderful package.
I've fixed this because the following documentation was different from the actual behavior of the `margin` props demo code for the` TextField` component.

https://mui.com/material-ui/react-text-field/#margin

The changes are as follows:

1. If you specify `none` for` margin`, `margin` is` 0`. However, the demo code had red borders drawn at the top and bottom, so I removed this.
2. If `nomal` is specified for` margin`, `margin` will be added. I replaced the existing `RedBar` with the name` RedNormalBar` and placed it above and below.
3. If `dense` is specified for` margin`, `margin` smaller than` nomal` will be given. I created a `RedDenseBar` with a` height` smaller than the existing `RedBar` and placed it above and below.

Could you review if this change is okay?

## Check

For reference, I created a simple code with `TextField` on the　[`codesandbox`](https://codesandbox.io/s/boring-ully-trbsu9) page.
At the same time, we have prepared a [demo code](https://codesandbox.io/s/silly-feather-2cpvtp) page after the change.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

