### PR TITLE
[website] Fix the scroll-top for all the website

### DIFF
--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -271,6 +271,9 @@ export const getDesignTokens = (mode: 'light' | 'dark') =>
         letterSpacing: 0,
         fontWeight: 700,
       },
+      allVariants: {
+        scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
+      },
     },
   } as ThemeOptions);
 

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -230,7 +230,6 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
             <ReplayRoundedIcon />
           </IconButton>
         </Box>
-
         <Box
           sx={{
             display: 'flex',

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -102,7 +102,6 @@ const Root = styled('div')(({ theme }) => ({
     }),
   },
   '& h1, & h2, & h3, & h4': {
-    scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
     '& code': {
       fontSize: 'inherit',
       lineHeight: 'inherit',


### PR DESCRIPTION
Fix the scroll position in https://mui.com/careers/#open-roles. This fix is moving one step toward making the configuration a global one. Maybe even to consider as part of the default design system in v6.

I found this bug while I was working on adding a link to our job board from https://angel.co/company/mui/jobs.

- https://deploy-preview-33215--material-ui.netlify.app/material-ui/react-radio-button/#color
- https://deploy-preview-33215--material-ui.netlify.app/careers/#open-roles