### PR TITLE
Add name to workspace root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@mui/monorepo",
   "version": "5.8.4",
   "private": true,
   "scripts": {


### PR DESCRIPTION
We're installing the workspace root as a package in MUI X and in Toolpad. Getting too many conflicting dependency issues due to package hoisting and the webpack aliases. Would like to be able to experiment with pnpm as a package manager for Toolpad as that will enable us a non-hoisted setup without sacrificing install size/time. 
pnpm currently errors when trying to install unnamed packages.