### PR TITLE
[OutlinedInput] Fix `ownerState` undefined in theme style overrides

### DIFF
--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -154,12 +154,26 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
     muiFormControl,
     states: ['required'],
   });
+  const ownerState = {
+    ...props,
+    color: fcs.color || 'primary',
+    disabled: fcs.disabled,
+    error: fcs.error,
+    focused: fcs.focused,
+    formControl: muiFormControl,
+    fullWidth,
+    hiddenLabel: fcs.hiddenLabel,
+    multiline,
+    size: fcs.size,
+    type,
+  };
 
   return (
     <InputBase
       components={{ Root: OutlinedInputRoot, Input: OutlinedInputInput, ...components }}
       renderSuffix={(state) => (
         <NotchedOutlineRoot
+          ownerState={ownerState}
           className={classes.notchedOutline}
           label={
             label != null && label !== '' && fcs.required ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #31982

**Root cause**

No `ownerState` is provided to `NotchedOutlineRoot`. This is strange at first because the `NotchedOutlinedRoot` slot is not `root` but why the ownerState is logged.

```js
const theme = createTheme({
  components: {
    MuiOutlinedInput: {
      styleOverrides: {
        root: ({ ownerState }) => {
          console.log('MuiOutlinedInput ownerState', ownerState);
          return {};
        },
      },
    },
  },
});
```

Each slot traverses the `styleOverrides` and passes props if the value is a function. In the end, the slot picks the resolved styles. That's why the callback is called multiple times even though it is declared on the root slot style overrides.

We can't use @oliviertassinari 's [fix](https://github.com/mui/material-ui/issues/31982#issuecomment-1093514995) at this point because it will be breaking changes. This is one example from InputBase:

```js
export const InputBaseRoot = styled('div', {
  name: 'MuiInputBase',
  slot: 'Root',
  overridesResolver: (props, styles) => {
    const { ownerState } = props;
    return [
      styles.root,
      ownerState.formControl && styles.formControl,
      ownerState.startAdornment && styles.adornedStart,
      ownerState.endAdornment && styles.adornedEnd,
      ownerState.error && styles.error,
      ownerState.size === 'small' && styles.sizeSmall,
      ownerState.multiline && styles.multiline,
      ownerState.color && styles[`color${capitalize(ownerState.color)}`],
      ownerState.fullWidth && styles.fullWidth,
      ownerState.hiddenLabel && styles.hiddenLabel,
    ];
  },
})
```

Here is the InputBase root slot which looks for other various keys.

We could do the fix in v6 as breaking changes.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
