### PR TITLE
[system] Add enableColorScheme option to getInitColorSchemeScript

### DIFF
--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -305,6 +305,7 @@ export default function createCssVarsProvider(options) {
       attribute: defaultAttribute,
       colorSchemeStorageKey: defaultColorSchemeStorageKey,
       modeStorageKey: defaultModeStorageKey,
+      enableColorScheme: designSystemEnableColorScheme,
       ...params,
     });
 

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -6,6 +6,11 @@ export const DEFAULT_ATTRIBUTE = 'data-color-scheme';
 
 export interface GetInitColorSchemeScriptOptions {
   /**
+   * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
+   * @default true
+   */
+  enableColorScheme?: boolean;
+  /**
    * If `true`, the initial color scheme is set to the user's prefers-color-scheme mode
    * @default false
    */
@@ -42,6 +47,7 @@ export interface GetInitColorSchemeScriptOptions {
 
 export default function getInitColorSchemeScript(options?: GetInitColorSchemeScriptOptions) {
   const {
+    enableColorScheme = true,
     enableSystem = false,
     defaultLightColorScheme = 'light',
     defaultDarkColorScheme = 'dark',
@@ -56,13 +62,16 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
       dangerouslySetInnerHTML={{
         __html: `(function() { try {
         var mode = localStorage.getItem('${modeStorageKey}');
+        var cssColorScheme = mode;
         var colorScheme = '';
         if (mode === 'system' || (!mode && !!${enableSystem})) {
           // handle system mode
           var mql = window.matchMedia('(prefers-color-scheme: dark)');
           if (mql.matches) {
+            cssColorScheme = 'dark';
             colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
           } else {
+            cssColorScheme = 'light';
             colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
           }
         }
@@ -74,6 +83,9 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
         }
         if (colorScheme) {
           ${colorSchemeNode}.setAttribute('${attribute}', colorScheme);
+        }
+        if (${enableColorScheme} && !!cssColorScheme) {
+          ${colorSchemeNode}.style.setProperty('color-scheme', cssColorScheme);
         }
       } catch (e) {} })();`,
       }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The `enableColorScheme` option did not pass to `getInitColorSchemeScript`. By adding this option, the script attaches the [color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) before the application is rendered on the screen.

Next step: I will add a script to minimize via [terser](https://terser.org/docs/cli-usage).

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
