### PR TITLE
[docs] Remove a note about Base components being reexported from Material UI

### DIFF
--- a/docs/data/material/guides/understand-mui-packages/understand-mui-packages.md
+++ b/docs/data/material/guides/understand-mui-packages/understand-mui-packages.md
@@ -42,7 +42,7 @@ Check the [MUI X overview](/x/advanced-components/) for more information about o
 
 Material UI is a comprehensive library of components that features our implementation of Google's Material Design.
 
-Both `@mui/base` and `@mui/system` are included as dependencies, meaning you don't need to install or import them separately—you can import them directly from `@mui/material`.
+`@mui/system` is included as dependency, meaning you don't need to install or import it separately—you can import its components and functions directly from `@mui/material`.
 
 ### MUI Base
 

--- a/docs/data/material/guides/understand-mui-packages/understand-mui-packages.md
+++ b/docs/data/material/guides/understand-mui-packages/understand-mui-packages.md
@@ -6,9 +6,6 @@
 
 - If you want to build a design system based on Material Design, use `@mui/material`.
 - If you want to build with components that give you complete control over your app's CSS, use `@mui/base`.
-  :::info
-  MUI Base components are also included within`@mui/material`—no need to install Base separately if you're using Material UI.
-  :::
 - For CSS utilities to help in laying out custom designs with Material UI or MUI Base, use `@mui/system`.
 
 ### Glossary


### PR DESCRIPTION
As Material UI does not reexport most of the Base components anymore, the docs need to be updated.
