### PR TITLE
[system] Minimize color scheme script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,6 +240,11 @@ jobs:
           command: |
             yarn extract-error-codes
             git diff --exit-code
+      - run:
+          name: '`yarn system:minify-color-scheme-script` changes committed?'
+          command: |
+            yarn system:minify-color-scheme-script
+            git diff --exit-code
   test_types:
     <<: *defaults
     resource_class: 'medium+'

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "size:snapshot": "node --max-old-space-size=4096 ./scripts/sizeSnapshot/create",
     "size:why": "yarn size:snapshot --analyze",
     "start": "yarn && yarn docs:dev",
+    "system:minify-color-scheme-script": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" ./packages/mui-system/scripts/minify-color-scheme-script",
     "t": "node test/cli.js",
     "test": "yarn lint && yarn typescript && yarn test:coverage",
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=text mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",

--- a/packages/mui-system/scripts/colorSchemeScript.js
+++ b/packages/mui-system/scripts/colorSchemeScript.js
@@ -1,0 +1,46 @@
+// This file should be testable.
+/* eslint-disable prefer-template */
+export default function getInitColorSchemeScript(options) {
+  // remove-start: this part is not needed in the minification
+  const {
+    enableColorScheme = true,
+    enableSystem = false,
+    defaultLightColorScheme = 'light',
+    defaultDarkColorScheme = 'dark',
+    modeStorageKey,
+    colorSchemeStorageKey,
+    attribute,
+  } = options || {};
+  // remove-end
+
+  const getStorageItem = localStorage.getItem;
+  // Code-golfing the amount of characters in the script
+  const mode = getStorageItem(modeStorageKey);
+  const c = colorSchemeStorageKey;
+  const lightColorScheme = getStorageItem(c + 'light') || defaultLightColorScheme;
+  const darkColorScheme = getStorageItem(c + 'dark') || defaultDarkColorScheme;
+  let cssColorScheme = mode;
+  let colorScheme = '';
+  if (mode === 'system' || (!mode && enableSystem)) {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    if (mql.matches) {
+      cssColorScheme = 'dark';
+      colorScheme = darkColorScheme;
+    } else {
+      cssColorScheme = 'light';
+      colorScheme = lightColorScheme;
+    }
+  }
+  if (mode === 'light') {
+    colorScheme = lightColorScheme;
+  }
+  if (mode === 'dark') {
+    colorScheme = darkColorScheme;
+  }
+  if (colorScheme) {
+    document.documentElement.setAttribute(attribute, colorScheme);
+  }
+  if (enableColorScheme && !!cssColorScheme) {
+    document.documentElement.style.setProperty('color-scheme', cssColorScheme);
+  }
+}

--- a/packages/mui-system/scripts/colorSchemeScript.js
+++ b/packages/mui-system/scripts/colorSchemeScript.js
@@ -17,8 +17,8 @@ export default function getInitColorSchemeScript(options) {
   // Code-golfing the amount of characters in the script
   const mode = getStorageItem(modeStorageKey);
   const c = colorSchemeStorageKey;
-  const lightColorScheme = getStorageItem(c + 'light') || defaultLightColorScheme;
-  const darkColorScheme = getStorageItem(c + 'dark') || defaultDarkColorScheme;
+  const lightColorScheme = getStorageItem(c + '-light') || defaultLightColorScheme;
+  const darkColorScheme = getStorageItem(c + '-dark') || defaultDarkColorScheme;
   let cssColorScheme = mode;
   let colorScheme = '';
   if (mode === 'system' || (!mode && enableSystem)) {

--- a/packages/mui-system/scripts/minify-color-scheme-script.js
+++ b/packages/mui-system/scripts/minify-color-scheme-script.js
@@ -20,19 +20,18 @@ import TerserPlugin from 'terser-webpack-plugin';
     // 1.1 Remove variable declaration section
     code = code.replace(/remove-start.*remove-end/s, '');
 
-    const vars = [
-      'enableColorScheme',
-      'enableSystem',
+    const stringVars = [
       'defaultLightColorScheme',
       'defaultDarkColorScheme',
       'modeStorageKey',
       'colorSchemeStorageKey',
       'attribute',
     ];
+    const booleanVars = ['enableColorScheme', 'enableSystem'];
 
     // 2. Minify the code
     const result = await TerserPlugin.terserMinify({ file: code }, undefined, {
-      mangle: { reserved: vars },
+      mangle: { reserved: [...stringVars, ...booleanVars] },
     });
 
     // 2.1 only the content of the function is needed for the minification.
@@ -42,7 +41,10 @@ import TerserPlugin from 'terser-webpack-plugin';
     );
 
     // 2.2 Turn string into variables after the minification
-    vars.forEach((variable) => {
+    stringVars.forEach((variable) => {
+      code = code.replace(new RegExp(variable, 'g'), `'\${${variable}}'`);
+    });
+    booleanVars.forEach((variable) => {
       code = code.replace(new RegExp(variable, 'g'), `\${${variable}}`);
     });
     // replace `document.documentElement` with `colorSchemeNode`

--- a/packages/mui-system/scripts/minify-color-scheme-script.js
+++ b/packages/mui-system/scripts/minify-color-scheme-script.js
@@ -1,6 +1,8 @@
-import fs from 'fs/promises';
+import fs from 'fs';
 import path from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
+
+const fsp = fs.promises;
 
 /**
  * ```sh
@@ -13,7 +15,7 @@ import TerserPlugin from 'terser-webpack-plugin';
 (async function run() {
   try {
     // 1. Read the testable file
-    let code = await fs.readFile(
+    let code = await fsp.readFile(
       path.join(process.cwd(), 'packages/mui-system/scripts/colorSchemeScript.js'),
       { encoding: 'utf-8' },
     );
@@ -56,7 +58,7 @@ import TerserPlugin from 'terser-webpack-plugin';
       process.cwd(),
       'packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx',
     );
-    let productionCode = await fs.readFile(getInitColorSchemeScriptPath, { encoding: 'utf-8' });
+    let productionCode = await fsp.readFile(getInitColorSchemeScriptPath, { encoding: 'utf-8' });
 
     productionCode = productionCode.replace(
       /__html: `.*`/s,
@@ -64,7 +66,7 @@ import TerserPlugin from 'terser-webpack-plugin';
     );
 
     // 4. Replace the file
-    await fs.writeFile(getInitColorSchemeScriptPath, productionCode);
+    await fsp.writeFile(getInitColorSchemeScriptPath, productionCode);
   } catch (error) {
     console.error(error);
   }

--- a/packages/mui-system/scripts/minify-color-scheme-script.js
+++ b/packages/mui-system/scripts/minify-color-scheme-script.js
@@ -1,0 +1,65 @@
+import fs from 'fs/promises';
+import path from 'path';
+import TerserPlugin from 'terser-webpack-plugin';
+
+/**
+ * This script reads `./colorSchemeScript.js` and minified using terser.
+ * Some variables are not minified so that they can be mapped with the production code `getInitColorSchemeScript.tsx`
+ */
+(async function run() {
+  try {
+    // 1. Read the testable file
+    let code = await fs.readFile(
+      path.join(process.cwd(), 'packages/mui-system/scripts/colorSchemeScript.js'),
+      { encoding: 'utf-8' },
+    );
+    // 1.1 Remove variable declaration section
+    code = code.replace(/remove-start.*remove-end/s, '');
+
+    const vars = [
+      'enableColorScheme',
+      'enableSystem',
+      'defaultLightColorScheme',
+      'defaultDarkColorScheme',
+      'modeStorageKey',
+      'colorSchemeStorageKey',
+      'attribute',
+    ];
+
+    // 2. Minify the code
+    const result = await TerserPlugin.terserMinify({ file: code }, undefined, {
+      mangle: { reserved: vars },
+    });
+
+    // 2.1 only the content of the function is needed for the minification.
+    code = result.code.replace(
+      /^export default function getInitColorSchemeScript\([a-zA-Z]+\){(.*)}$/,
+      '$1',
+    );
+
+    // 2.2 Turn string into variables after the minification
+    vars.forEach((variable) => {
+      code = code.replace(new RegExp(variable, 'g'), `\${${variable}}`);
+    });
+    // replace `document.documentElement` with `colorSchemeNode`
+    // eslint-disable-next-line no-template-curly-in-string
+    code = code.replace(/document\.documentElement/gm, '${colorSchemeNode}');
+
+    // 3. Read the production code and replace the __html: script
+    const getInitColorSchemeScriptPath = path.join(
+      process.cwd(),
+      'packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx',
+    );
+    let productionCode = await fs.readFile(getInitColorSchemeScriptPath, { encoding: 'utf-8' });
+
+    productionCode = productionCode.replace(
+      /__html: `.*`/s,
+      `__html: \`(function(){try{${code}}catch(e){}})();\``,
+    );
+
+    // 4. Replace the file
+    await fs.writeFile(getInitColorSchemeScriptPath, productionCode);
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/packages/mui-system/scripts/minify-color-scheme-script.js
+++ b/packages/mui-system/scripts/minify-color-scheme-script.js
@@ -3,6 +3,10 @@ import path from 'path';
 import TerserPlugin from 'terser-webpack-plugin';
 
 /**
+ * ```sh
+ * yarn system:minify-color-scheme-script
+ * ```
+ *
  * This script reads `./colorSchemeScript.js` and minified using terser.
  * Some variables are not minified so that they can be mapped with the production code `getInitColorSchemeScript.tsx`
  */

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -305,6 +305,7 @@ export default function createCssVarsProvider(options) {
       attribute: defaultAttribute,
       colorSchemeStorageKey: defaultColorSchemeStorageKey,
       modeStorageKey: defaultModeStorageKey,
+      enableColorScheme: designSystemEnableColorScheme,
       ...params,
     });
 

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.test.js
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.test.js
@@ -35,7 +35,7 @@ describe('getInitColorSchemeScript', () => {
     window.matchMedia = originalMatchmedia;
   });
 
-  it('should set `light` color scheme to body', () => {
+  it('should set `light` color scheme to document', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'light';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'foo';
 
@@ -44,7 +44,7 @@ describe('getInitColorSchemeScript', () => {
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('foo');
   });
 
-  it('should set custom color scheme to body with custom attribute', () => {
+  it('should set custom color scheme to document with custom attribute', () => {
     storage['mui-foo-mode'] = 'light';
     storage[`mui-bar-color-scheme-light`] = 'flash';
 
@@ -59,7 +59,7 @@ describe('getInitColorSchemeScript', () => {
     expect(document.documentElement.getAttribute('data-mui-baz-scheme')).to.equal('flash');
   });
 
-  it('should set `dark` color scheme to body', () => {
+  it('should set `dark` color scheme to document', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'dark';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'bar';
 
@@ -68,7 +68,7 @@ describe('getInitColorSchemeScript', () => {
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('bar');
   });
 
-  it('should set dark color scheme to body, given prefers-color-scheme is `dark`', () => {
+  it('should set dark color scheme to document, given prefers-color-scheme is `dark`', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'system';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-dark`] = 'dim';
     window.matchMedia = createMatchMedia(true);
@@ -78,7 +78,7 @@ describe('getInitColorSchemeScript', () => {
     expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('dim');
   });
 
-  it('should set light color scheme to body, given prefers-color-scheme is NOT `dark`', () => {
+  it('should set light color scheme to document, given prefers-color-scheme is NOT `dark`', () => {
     storage[DEFAULT_MODE_STORAGE_KEY] = 'system';
     storage[`${DEFAULT_COLOR_SCHEME_STORAGE_KEY}-light`] = 'bright';
     window.matchMedia = createMatchMedia(false);
@@ -89,7 +89,7 @@ describe('getInitColorSchemeScript', () => {
   });
 
   describe('[option: `enableSystem`]', () => {
-    it('should set dark color scheme to body, given `enableSystem` is true and prefers-color-scheme is `dark`', () => {
+    it('should set dark color scheme to document, given `enableSystem` is true and prefers-color-scheme is `dark`', () => {
       window.matchMedia = createMatchMedia(true);
 
       const { container } = render(
@@ -102,7 +102,7 @@ describe('getInitColorSchemeScript', () => {
       expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('trueDark');
     });
 
-    it('should set light color scheme to body, given `enableSystem` is true and prefers-color-scheme is NOT `dark`', () => {
+    it('should set light color scheme to document, given `enableSystem` is true and prefers-color-scheme is NOT `dark`', () => {
       window.matchMedia = createMatchMedia(false);
 
       const { container } = render(
@@ -113,6 +113,37 @@ describe('getInitColorSchemeScript', () => {
       );
       eval(container.firstChild.textContent);
       expect(document.documentElement.getAttribute(DEFAULT_ATTRIBUTE)).to.equal('yellow');
+    });
+  });
+
+  describe('[option: `enableColorScheme`]', () => {
+    it('should set dark color scheme to document, given `enableColorScheme` & `enableSystem` is true and prefers-color-scheme is `dark`', () => {
+      // simulate 1st visit where `mode` does not exist yet
+      window.matchMedia = createMatchMedia(true);
+
+      const { container } = render(
+        getInitColorSchemeScript({
+          enableSystem: true,
+          enableColorScheme: true,
+          defaultDarkColorScheme: 'trueDark',
+        }),
+      );
+      eval(container.firstChild.textContent);
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).to.equal('dark');
+    });
+
+    it('should set light color scheme to document, if mode exists in the storage', () => {
+      storage[DEFAULT_MODE_STORAGE_KEY] = 'light';
+      window.matchMedia = createMatchMedia(false);
+
+      const { container } = render(
+        getInitColorSchemeScript({
+          enableColorScheme: true,
+          defaultLightColorScheme: 'yellow',
+        }),
+      );
+      eval(container.firstChild.textContent);
+      expect(document.documentElement.style.getPropertyValue('color-scheme')).to.equal('light');
     });
   });
 });

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -6,6 +6,11 @@ export const DEFAULT_ATTRIBUTE = 'data-color-scheme';
 
 export interface GetInitColorSchemeScriptOptions {
   /**
+   * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
+   * @default true
+   */
+  enableColorScheme?: boolean;
+  /**
    * If `true`, the initial color scheme is set to the user's prefers-color-scheme mode
    * @default false
    */
@@ -42,6 +47,7 @@ export interface GetInitColorSchemeScriptOptions {
 
 export default function getInitColorSchemeScript(options?: GetInitColorSchemeScriptOptions) {
   const {
+    enableColorScheme = true,
     enableSystem = false,
     defaultLightColorScheme = 'light',
     defaultDarkColorScheme = 'dark',
@@ -56,13 +62,16 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
       dangerouslySetInnerHTML={{
         __html: `(function() { try {
         var mode = localStorage.getItem('${modeStorageKey}');
+        var cssColorScheme = mode;
         var colorScheme = '';
         if (mode === 'system' || (!mode && !!${enableSystem})) {
           // handle system mode
           var mql = window.matchMedia('(prefers-color-scheme: dark)');
           if (mql.matches) {
+            cssColorScheme = 'dark';
             colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
           } else {
+            cssColorScheme = 'light';
             colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
           }
         }
@@ -74,6 +83,9 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
         }
         if (colorScheme) {
           ${colorSchemeNode}.setAttribute('${attribute}', colorScheme);
+        }
+        if (${enableColorScheme} && !!cssColorScheme) {
+          ${colorSchemeNode}.style.setProperty('color-scheme', cssColorScheme);
         }
       } catch (e) {} })();`,
       }}

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -47,7 +47,7 @@ export interface GetInitColorSchemeScriptOptions {
 
 export default function getInitColorSchemeScript(options?: GetInitColorSchemeScriptOptions) {
   const {
-    enableColorScheme = true,
+    enableColorScheme = false,
     enableSystem = false,
     defaultLightColorScheme = 'light',
     defaultDarkColorScheme = 'dark',
@@ -61,7 +61,7 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
       // DO NOT EDIT HERE, auto-generated from `packages/mui-system/scripts/minify-color-scheme-script.js`
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{
-        __html: `(function(){try{const t=localStorage.getItem,o=t(${modeStorageKey}),r=${colorSchemeStorageKey},l=t(r+"light")||${defaultLightColorScheme},c=t(r+"dark")||${defaultDarkColorScheme};let m=o,a="";if("system"===o||!o&&${enableSystem}){window.matchMedia("(prefers-color-scheme: dark)").matches?(m="dark",a=c):(m="light",a=l)}"light"===o&&(a=l),"dark"===o&&(a=c),a&&${colorSchemeNode}.setAttribute(${attribute},a),${enableColorScheme}&&m&&${colorSchemeNode}.style.setProperty("color-scheme",m)}catch(e){}})();`,
+        __html: `(function(){try{const t=localStorage.getItem,o=t('${modeStorageKey}'),r='${colorSchemeStorageKey}',l=t(r+"-light")||'${defaultLightColorScheme}',c=t(r+"-dark")||'${defaultDarkColorScheme}';let m=o,a="";if("system"===o||!o&&${enableSystem}){window.matchMedia("(prefers-color-scheme: dark)").matches?(m="dark",a=c):(m="light",a=l)}"light"===o&&(a=l),"dark"===o&&(a=c),a&&${colorSchemeNode}.setAttribute('${attribute}',a),${enableColorScheme}&&m&&${colorSchemeNode}.style.setProperty("color-scheme",m)}catch(e){}})();`,
       }}
     />
   );

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -58,36 +58,10 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
   } = options || {};
   return (
     <script
+      // DO NOT EDIT HERE, auto-generated from `packages/mui-system/scripts/minify-color-scheme-script.js`
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{
-        __html: `(function() { try {
-        var mode = localStorage.getItem('${modeStorageKey}');
-        var cssColorScheme = mode;
-        var colorScheme = '';
-        if (mode === 'system' || (!mode && !!${enableSystem})) {
-          // handle system mode
-          var mql = window.matchMedia('(prefers-color-scheme: dark)');
-          if (mql.matches) {
-            cssColorScheme = 'dark';
-            colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
-          } else {
-            cssColorScheme = 'light';
-            colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
-          }
-        }
-        if (mode === 'light') {
-          colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
-        }
-        if (mode === 'dark') {
-          colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
-        }
-        if (colorScheme) {
-          ${colorSchemeNode}.setAttribute('${attribute}', colorScheme);
-        }
-        if (${enableColorScheme} && !!cssColorScheme) {
-          ${colorSchemeNode}.style.setProperty('color-scheme', cssColorScheme);
-        }
-      } catch (e) {} })();`,
+        __html: `(function(){try{const t=localStorage.getItem,o=t(${modeStorageKey}),r=${colorSchemeStorageKey},l=t(r+"light")||${defaultLightColorScheme},c=t(r+"dark")||${defaultDarkColorScheme};let m=o,a="";if("system"===o||!o&&${enableSystem}){window.matchMedia("(prefers-color-scheme: dark)").matches?(m="dark",a=c):(m="light",a=l)}"light"===o&&(a=l),"dark"===o&&(a=c),a&&${colorSchemeNode}.setAttribute(${attribute},a),${enableColorScheme}&&m&&${colorSchemeNode}.style.setProperty("color-scheme",m)}catch(e){}})();`,
       }}
     />
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

To reduce HTML size, the script returns from `getInitColorSchemeScript` should be minified.

This PR:

- Move the logic to `scripts/colorSchemeScript` (source of truth)
- Run `yarn system:minify-color-scheme-script` to read the source and minify via terser
- Put the minified code back to `src/cssVars/getInitColorSchemeScript`

All the tests are passed, so I believe that the minification is done correctly.  

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
