### PR TITLE
[SnackbarContent] fix message text color with css var provider

### DIFF
--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.js
@@ -31,7 +31,7 @@ const SnackbarContentRoot = styled(Paper, {
   return {
     ...theme.typography.body2,
     color: theme.vars
-      ? theme.vars.palette.text.primary
+      ? theme.vars.palette.SnackbarContent.text
       : theme.palette.getContrastText(backgroundColor),
     backgroundColor: theme.vars ? theme.vars.palette.SnackbarContent.bg : backgroundColor,
     display: 'flex',

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.js
@@ -31,7 +31,7 @@ const SnackbarContentRoot = styled(Paper, {
   return {
     ...theme.typography.body2,
     color: theme.vars
-      ? theme.vars.palette.SnackbarContent.text
+      ? theme.vars.palette.SnackbarContent.color
       : theme.palette.getContrastText(backgroundColor),
     backgroundColor: theme.vars ? theme.vars.palette.SnackbarContent.bg : backgroundColor,
     display: 'flex',

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -145,11 +145,12 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Slider, 'infoTrack', lighten(palette.info.main, 0.62));
       setColor(palette.Slider, 'successTrack', lighten(palette.success.main, 0.62));
       setColor(palette.Slider, 'warningTrack', lighten(palette.warning.main, 0.62));
-      setColor(palette.SnackbarContent, 'bg', emphasize(palette.background.default, 0.8));
+      const snackbarContentBackground = emphasize(palette.background.default, 0.8);
+      setColor(palette.SnackbarContent, 'bg', snackbarContentBackground);
       setColor(
         palette.SnackbarContent,
         'text',
-        lightPalette.getContrastText(emphasize(palette.background.default, 0.8)),
+        lightPalette.getContrastText(snackbarContentBackground),
       );
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
       setColor(palette.StepConnector, 'border', 'var(--mui-palette-grey-400)');
@@ -216,11 +217,12 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Slider, 'infoTrack', darken(palette.info.main, 0.5));
       setColor(palette.Slider, 'successTrack', darken(palette.success.main, 0.5));
       setColor(palette.Slider, 'warningTrack', darken(palette.warning.main, 0.5));
-      setColor(palette.SnackbarContent, 'bg', emphasize(palette.background.default, 0.98));
+      const snackbarContentBackground = emphasize(palette.background.default, 0.98);
+      setColor(palette.SnackbarContent, 'bg', snackbarContentBackground);
       setColor(
         palette.SnackbarContent,
         'text',
-        darkPalette.getContrastText(emphasize(palette.background.default, 0.98)),
+        darkPalette.getContrastText(snackbarContentBackground),
       );
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
       setColor(palette.StepConnector, 'border', 'var(--mui-palette-grey-600)');

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -146,6 +146,11 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Slider, 'successTrack', lighten(palette.success.main, 0.62));
       setColor(palette.Slider, 'warningTrack', lighten(palette.warning.main, 0.62));
       setColor(palette.SnackbarContent, 'bg', emphasize(palette.background.default, 0.8));
+      setColor(
+        palette.SnackbarContent,
+        'text',
+        lightPalette.getContrastText(emphasize(palette.background.default, 0.8)),
+      );
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
       setColor(palette.StepConnector, 'border', 'var(--mui-palette-grey-400)');
       setColor(palette.StepContent, 'border', 'var(--mui-palette-grey-400)');
@@ -212,6 +217,11 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Slider, 'successTrack', darken(palette.success.main, 0.5));
       setColor(palette.Slider, 'warningTrack', darken(palette.warning.main, 0.5));
       setColor(palette.SnackbarContent, 'bg', emphasize(palette.background.default, 0.98));
+      setColor(
+        palette.SnackbarContent,
+        'text',
+        darkPalette.getContrastText(emphasize(palette.background.default, 0.98)),
+      );
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
       setColor(palette.StepConnector, 'border', 'var(--mui-palette-grey-600)');
       setColor(palette.StepContent, 'border', 'var(--mui-palette-grey-600)');

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -149,7 +149,7 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.SnackbarContent, 'bg', snackbarContentBackground);
       setColor(
         palette.SnackbarContent,
-        'text',
+        'color',
         lightPalette.getContrastText(snackbarContentBackground),
       );
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
@@ -221,7 +221,7 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.SnackbarContent, 'bg', snackbarContentBackground);
       setColor(
         palette.SnackbarContent,
-        'text',
+        'color',
         darkPalette.getContrastText(snackbarContentBackground),
       );
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://github.com/mui/material-ui/issues/32049#issuecomment-1165572329

This PR fixes the SnackbarContent message text color to use the contrast text color instead of the primary text color.
