### PR TITLE
[website] Link MUI Toolpad in mui.com

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -368,15 +368,21 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 
 # Proxies
 
-## Store
+## MUI Store
 /store/* https://mui-store.netlify.app/:splat 200
 /store-staging/* https://master--mui-store.netlify.app/:splat 200
 
 ## MUI X
 ## Unlike the store that expect to be hosted under a subfolder,
 ## MUI X is configured to be hosted at the root.
-/_next/* https://docs-v5--material-ui-x.netlify.app/_next/:splat 200
-/static/x/* https://docs-v5--material-ui-x.netlify.app/static/x/:splat 200
-/x/* https://docs-v5--material-ui-x.netlify.app/x/:splat 200
-/r/x-* https://docs-v5--material-ui-x.netlify.app/r/x-:splat 200
-/:lang/x/* https://docs-v5--material-ui-x.netlify.app/:lang/x/:splat 200
+/_next/* https://material-ui-x.netlify.app/_next/:splat 200
+/static/x/* https://material-ui-x.netlify.app/static/x/:splat 200
+/x/* https://material-ui-x.netlify.app/x/:splat 200
+/r/x-* https://material-ui-x.netlify.app/r/x-:splat 200
+/:lang/x/* https://material-ui-x.netlify.app/:lang/x/:splat 200
+
+## MUI Toolpad
+/_next/* https://mui-toolpad-docs.netlify.app/_next/:splat 200
+/static/toolpad/* https://mui-toolpad-docs.netlify.app/static/toolpad/:splat 200
+/toolpad/* https://mui-toolpad-docs.netlify.app/toolpad/:splat 200
+/r/toolpad-* https://mui-toolpad-docs.netlify.app/r/toolpad-:splat 200


### PR DESCRIPTION
Related to https://github.com/mui/mui-toolpad/pull/542, the goal is to get us one step closer to displaying https://deploy-preview-542--mui-toolpad-docs.netlify.app/toolpad/getting-started/ in https://mui.com/toolpad/getting-started/.

Preview: https://deploy-preview-33287--material-ui.netlify.app/toolpad/