### PR TITLE
[website] Link EULA in the license quantity section

### DIFF
--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -88,7 +88,7 @@ const faqData = [
     summary: 'How to remove the "unlicensed" watermark?',
     detail: (
       <React.Fragment>
-        After you purchase a license, you'll receive a license key by email Once you have the
+        After you purchase a license, you'll receive a license key by email. Once you have the
         license key, you need to follow the{' '}
         <Link href="/x/advanced-components/#license-key-installation">instructions</Link> necessary
         to set it up.

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -30,22 +30,11 @@ const faqData = [
     ),
   },
   {
-    summary: 'Why are you calling it "early access"?',
-    detail: (
-      <React.Fragment>
-        We think you'll love the features we've built so far, but we're planning to release more. We
-        opened it up as soon as we had something useful so that you can start getting value from it
-        right away, and we'll be adding new features and components based on our own ideas, and on
-        suggestions from early access customers.
-      </React.Fragment>
-    ),
-  },
-  {
     summary: 'How many developer seats do I need?',
     detail: (
       <React.Fragment>
         The number of seats purchased on your license must correspond to the number of concurrent
-        developers contributing changes to the front-end code of a project that uses MUI X Pro or
+        developers contributing changes to the front-end code of the projects that uses MUI X Pro or
         Premium.
         <br />
         <br />
@@ -62,6 +51,36 @@ const faqData = [
         the new library and so does the team working on 'AppB'. 'AppA' has 5 front-end developers
         and 'AppB' has 3. There are 2 front-end developers on the UI development team. Company 'B'
         purchases 10 licenses.
+        <br />
+        <br />
+        <Link
+          target="_blank"
+          rel="noopener"
+          href="https://mui.com/store/legal/mui-x-eula/#required-quantity-of-licenses"
+        >
+          The clause in the EULA.
+        </Link>
+      </React.Fragment>
+    ),
+  },
+  {
+    summary: 'Do developers have to be named?',
+    detail: (
+      <React.Fragment>
+        <strong>No.</strong> We trust that you will not go over the number of licensed developers.
+        Developers moving on and off projects is expected occasionally, and the license can be
+        transferred between developers at that time.
+      </React.Fragment>
+    ),
+  },
+  {
+    summary: 'Why are you calling it "early access"?',
+    detail: (
+      <React.Fragment>
+        We think you'll love the features we've built so far, but we're planning to release more. We
+        opened it up as soon as we had something useful so that you can start getting value from it
+        right away, and we'll be adding new features and components based on our own ideas, and on
+        suggestions from early access customers.
       </React.Fragment>
     ),
   },
@@ -73,16 +92,6 @@ const faqData = [
         license key, you need to follow the{' '}
         <Link href="/x/advanced-components/#license-key-installation">instructions</Link> necessary
         to set it up.
-      </React.Fragment>
-    ),
-  },
-  {
-    summary: 'Do developers have to be named?',
-    detail: (
-      <React.Fragment>
-        No. We trust that you will not go over the number of licensed developers. Developers moving
-        on and off projects is expected occasionally, and the license can be transferred between
-        developers at that time.
       </React.Fragment>
     ),
   },

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -107,7 +107,15 @@ export default function WhatToExpect() {
               Developers contributing changes to the front-end code of a project that include the
               software need an active license. You will need to renew your subscription if you wish
               to continue active development after the end of your subscription. You can learn more
-              about it in <Link href="https://mui.com/store/legal/mui-x-eula/">the EULA</Link>.
+              about it in{' '}
+              <Link
+                target="_blank"
+                rel="noopener"
+                href="https://mui.com/store/legal/mui-x-eula/#perpetual-in-production"
+              >
+                the EULA
+              </Link>
+              .
             </Typography>
           </Paper>
         </Grid>


### PR DESCRIPTION
Nothing major, I have tried to:

- Link more
- Group the related FAQ questions together.

https://deploy-preview-33292--material-ui.netlify.app/pricing/