### PR TITLE
[styled-engine] Add missing type dependency on csstype

### DIFF
--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@emotion/cache": "^11.7.1",
+    "csstype": "^3.1.0",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The TypeScript declaration files for `@mui/styled-engine` import from `csstype`, so `csstype` should be added as a dependency of `@mui/styled-engine`.

```
TS2307: Cannot find module 'csstype' or its corresponding type declarations.
  > 1 | import * as CSS from 'csstype';
      |                      ^^^^^^^^^
    2 | import { StyledComponent, StyledOptions } from '@emotion/styled';
    3 | import { PropsOf } from '@emotion/react';
    4 |
```