### PR TITLE
[BadgeUnstyled] Export BadgeUnstyledOwnProps interface to fix typescript compiler error

### DIFF
--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
@@ -11,7 +11,7 @@ export type BadgeUnstyledOwnerState = BadgeUnstyledProps & {
   showZero: boolean;
 };
 
-interface BadgeUnstyledOwnProps {
+export interface BadgeUnstyledOwnProps {
   /**
    * The components used for each slot inside the Badge.
    * Either a string to use a HTML element or a component.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Problem
@michaldudak's #33176 introduced changes that moved some `BadgeUnstyled` props out of the public `BadgeUnstyledTypeMap` interface, and into a new _private_ `BadgeUnstyledOwnProps` interface.

This causes a typescript error for consumers who try to extend from `BadgeProps` or `BadgeUnstyledProps` in a library that has `declaration: true` set in their tsconfig. The error occurs because the typescript compiler is unable to determine the exact shape of the custom interface / type because it does not know the shape of `BadgeUnstyledOwnProps`:

```tsx
import {
  Badge,
  BadgeProps,
  BadgeTypeMap
} from "@mui/material";
import * as React from "react";

export type CustomBadgeProps<
  D extends React.ElementType = BadgeTypeMap['defaultComponent'],
  P = unknown
> = BadgeProps<D, P> & {
  /* some custom props */
};

export const CustomBadge = React.forwardRef<HTMLSpanElement, CustomBadgeProps>(/*...*/);

export default CustomBadge;
```

<img width="1101" alt="Screen Shot 2022-06-27 at 11 20 20 AM" src="https://user-images.githubusercontent.com/1750797/176009313-b9653898-76e2-43f2-8769-e40777a4be49.png">

[This is similar to this issue found on StackOverflow](https://stackoverflow.com/questions/43900035/ts4023-exported-variable-x-has-or-is-using-name-y-from-external-module-but)


### Solution
Export `BadgeUnstyledOwnProps`
