### PR TITLE
[Rating] Fix precision rating

### DIFF
--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -165,6 +165,7 @@ const RatingDecimal = styled('span', {
     return [styles.decimal, iconActive && styles.iconActive];
   },
 })(({ iconActive }) => ({
+  display: 'flex',
   position: 'relative',
   ...(iconActive && {
     transform: 'scale(1.2)',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #32557.

This fixes the issue of precision rating, the star doesn't become full when we click on the second part, the issue was in the click event. By adding `display: flex`, the click event works as expected.

Note:
I tested only on Brave, we need to test also on Google Chrome & Microsoft Edge, I didn't find the specific versions!