### PR TITLE
[system] Export required types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - run: yarn release:changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn validate-declarations
       - name: yarn release:tag
         run: |
           git remote -v

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}' 'scripts/**/*.test.{js,ts,tsx}' 'test/utils/**/*.test.{js,ts,tsx}'",
     "test:argos": "node ./scripts/pushArgos.js",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript"
+    "typescript:ci": "lerna run --concurrency 7 --no-bail --no-sort typescript",
+    "validate-declarations": "babel-node --extensions \".ts\" scripts/validateTypescriptDeclarations.ts"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",

--- a/packages/mui-material/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-material/src/styles/CssVarsProvider.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/system';
 import experimental_extendTheme, {
   SupportedColorScheme,
@@ -8,11 +7,10 @@ import createTypography from './createTypography';
 
 const defaultTheme = experimental_extendTheme();
 
-const {
-  CssVarsProvider: Experimental_CssVarsProvider,
-  useColorScheme,
-  getInitColorSchemeScript,
-} = createCssVarsProvider<SupportedColorScheme, CssVarsTheme>({
+const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
+  SupportedColorScheme,
+  CssVarsTheme
+>({
   theme: defaultTheme,
   attribute: 'data-mui-color-scheme',
   modeStorageKey: 'mui-mode',
@@ -35,4 +33,8 @@ const {
     (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/)),
 });
 
-export { useColorScheme, getInitColorSchemeScript, Experimental_CssVarsProvider };
+export {
+  useColorScheme,
+  getInitColorSchemeScript,
+  CssVarsProvider as Experimental_CssVarsProvider,
+};

--- a/packages/mui-system/src/cssVars/index.ts
+++ b/packages/mui-system/src/cssVars/index.ts
@@ -1,2 +1,8 @@
 export { default } from './createCssVarsProvider';
-export type { CreateCssVarsProviderResult } from './createCssVarsProvider';
+export type {
+  CreateCssVarsProviderResult,
+  CssVarsProviderConfig,
+  ColorSchemeContextValue,
+} from './createCssVarsProvider';
+
+export { default as getInitColorSchemeScript } from './getInitColorSchemeScript';

--- a/scripts/validateTypescriptDeclarations.ts
+++ b/scripts/validateTypescriptDeclarations.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+import globby from 'globby';
+import fs from 'fs';
+
+/**
+ * Validates if there are no missing exports from TS files that would
+ * result in an import from a local file.
+ */
+function validateFiles() {
+  const declarationFiles = globby.sync(['packages/*/build/**/*.d.ts']);
+  const invalidFiles = declarationFiles.filter((file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    const regex = /import\(["']packages\//gm;
+    return regex.test(content);
+  });
+
+  if (invalidFiles.length > 0) {
+    console.error('Found invalid imports in the following files:');
+    invalidFiles.forEach((file) => console.error(file));
+    process.exit(1);
+  }
+
+  console.log('Found no invalid import statements in built declaration files.');
+}
+
+validateFiles();


### PR DESCRIPTION
Exports system types used in Material UI. Without these, the Typescript compiler throws errors in built .d.ts files.

Fixes #33321