### PR TITLE
[docs] Add caveat about class components with Tooltip

### DIFF
--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -59,6 +59,29 @@ const MyComponent = React.forwardRef(function MyComponent(props, ref) {
 
 You can find a similar concept in the [wrapping components](/material-ui/guides/composition/#wrapping-components) guide.
 
+If using a class component as a child, you'll also need to ensure that the ref is forwarded to the underlying DOM element. (A ref to the class component itself will not work.)
+
+```jsx
+class MyComponent extends React.Component {
+  render() {
+    const { innerRef, ...props } = this.props;
+    //  Spread the props to the underlying DOM element.
+    return <div {...props} ref={innerRef}>Bin</div>
+  }
+};
+
+// Wrap MyComponent to forward the ref as expected by Tooltip
+const WrappedMyComponent = React.forwardRef(function WrappedMyComponent(props, ref) {
+  return <MyComponent {...props} innerRef={ref} />;
+});
+
+// ...
+
+<Tooltip title="Delete">
+  <WrappedMyComponent>
+</Tooltip>
+```
+
 ## Triggers
 
 You can define the types of events that cause a tooltip to show.


### PR DESCRIPTION
Fixes #33152. If any of this doesn't meet MUI's preferred documentation style, edits/corrections/requests for change are welcome.

I wondered if https://mui.com/material-ui/guides/composition/#caveat-with-refs should also reference this (or if this added section should instead be added to https://mui.com/material-ui/guides/composition/#caveat-with-refs, and the Tooltip docs link there).

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
