### PR TITLE
[docs] Simplify "Upload button" demo

### DIFF
--- a/docs/data/material/components/buttons/UploadButtons.js
+++ b/docs/data/material/components/buttons/UploadButtons.js
@@ -1,29 +1,20 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import PhotoCamera from '@mui/icons-material/PhotoCamera';
 import Stack from '@mui/material/Stack';
 
-const Input = styled('input')({
-  display: 'none',
-});
-
 export default function UploadButtons() {
   return (
     <Stack direction="row" alignItems="center" spacing={2}>
-      <label htmlFor="contained-button-file">
-        <Input accept="image/*" id="contained-button-file" multiple type="file" />
-        <Button variant="contained" component="span">
-          Upload
-        </Button>
-      </label>
-      <label htmlFor="icon-button-file">
-        <Input accept="image/*" id="icon-button-file" type="file" />
-        <IconButton color="primary" aria-label="upload picture" component="span">
-          <PhotoCamera />
-        </IconButton>
-      </label>
+      <Button variant="contained" component="label">
+        Upload
+        <input hidden accept="image/*" multiple type="file" />
+      </Button>
+      <IconButton color="primary" aria-label="upload picture" component="label">
+        <input hidden accept="image/*" type="file" />
+        <PhotoCamera />
+      </IconButton>
     </Stack>
   );
 }

--- a/docs/data/material/components/buttons/UploadButtons.tsx
+++ b/docs/data/material/components/buttons/UploadButtons.tsx
@@ -1,29 +1,20 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import PhotoCamera from '@mui/icons-material/PhotoCamera';
 import Stack from '@mui/material/Stack';
 
-const Input = styled('input')({
-  display: 'none',
-});
-
 export default function UploadButtons() {
   return (
     <Stack direction="row" alignItems="center" spacing={2}>
-      <label htmlFor="contained-button-file">
-        <Input accept="image/*" id="contained-button-file" multiple type="file" />
-        <Button variant="contained" component="span">
-          Upload
-        </Button>
-      </label>
-      <label htmlFor="icon-button-file">
-        <Input accept="image/*" id="icon-button-file" type="file" />
-        <IconButton color="primary" aria-label="upload picture" component="span">
-          <PhotoCamera />
-        </IconButton>
-      </label>
+      <Button variant="contained" component="label">
+        Upload
+        <input hidden accept="image/*" multiple type="file" />
+      </Button>
+      <IconButton color="primary" aria-label="upload picture" component="label">
+        <input hidden accept="image/*" type="file" />
+        <PhotoCamera />
+      </IconButton>
     </Stack>
   );
 }

--- a/docs/data/material/components/buttons/UploadButtons.tsx.preview
+++ b/docs/data/material/components/buttons/UploadButtons.tsx.preview
@@ -1,12 +1,8 @@
-<label htmlFor="contained-button-file">
-  <Input accept="image/*" id="contained-button-file" multiple type="file" />
-  <Button variant="contained" component="span">
-    Upload
-  </Button>
-</label>
-<label htmlFor="icon-button-file">
-  <Input accept="image/*" id="icon-button-file" type="file" />
-  <IconButton color="primary" aria-label="upload picture" component="span">
-    <PhotoCamera />
-  </IconButton>
-</label>
+<Button variant="contained" component="label">
+  Upload
+  <input hidden accept="image/*" multiple type="file" />
+</Button>
+<IconButton color="primary" aria-label="upload picture" component="label">
+  <input hidden accept="image/*" type="file" />
+  <PhotoCamera />
+</IconButton>


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

# This PR simplifies the [Upload Button Demo Docs](https://mui.com/material-ui/react-button/#upload-button)

- Use MUI Component Composition API to get rid of HTML `label` element.
- Use `hidden` attribute on the HTML `input` to further simplify the code.

We can add the following `onChange` code block for a more declarative example:
```tsx
onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
  console.log(e.currentTarget.files);  //Access file(s) selected for upload
}}
```

Here's a live [CodeSandbox](https://codesandbox.io/s/uploadbuttons-demo-material-ui-forked-r3o14c?file=/demo.tsx) of the new changes.