### PR TITLE
[utils] fix deepmerge issue with NextJS Edge runtime SSR

### DIFF
--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -1,5 +1,5 @@
 export function isPlainObject(item: unknown): item is Record<keyof any, unknown> {
-  return item !== null && typeof item === 'object' && item.constructor === Object;
+  return item !== null && typeof item === 'object';
 }
 
 export interface DeepmergeOptions {


### PR DESCRIPTION
I made MUI work (more or less) with the new [NextJS 12.2 edge runtime SSR](https://nextjs.org/docs/advanced-features/react-18/switchable-runtime). I found a bunch of issues on the emotion side and only this small but critical one on your side (or Next's side, tbh I am not sure).

Somewhy `({}).constructor === Object` is false on the edge runtime and messes up pretty much everything with MUI via a `deepmerge` internal check.

Minimal repro is this NextJS page:

```
export default () => 'Testy'

const x = {}
console.log(x.constructor, Object, x.constructor === Object)

export const config = {
  runtime: 'experimental-edge'
}
```

It logs `[Function: Object] [Function: Object] false`

I suspect from the tests that part of the check was there to check against prototype pollution, I did not check yet. Please let me know if you are interested and I can put more work into this and maybe the emotion side of things too.




