### PR TITLE
Enable Joy and Material UI compatibility

### DIFF
--- a/docs/data/joy/customization/approaches/ButtonThemes.js
+++ b/docs/data/joy/customization/approaches/ButtonThemes.js
@@ -17,6 +17,7 @@ const Select = styled('select')(({ theme }) => ({
 }));
 
 const githubTheme = extendTheme({
+  cssVarPrefix: 'gh',
   colorSchemes: {
     light: {
       palette: {
@@ -138,6 +139,7 @@ const githubCode = `const githubTheme = extendTheme({
 });`;
 
 const fluentTheme = extendTheme({
+  cssVarPrefix: 'fluent',
   colorSchemes: {
     light: {
       palette: {
@@ -269,6 +271,7 @@ const fluentCode = `const fluentTheme = extendTheme({
 });`;
 
 const chakraTheme = extendTheme({
+  cssVarPrefix: 'chakra',
   colorSchemes: {
     light: {
       palette: {
@@ -352,6 +355,7 @@ const chakraCode = `const chakraTheme = extendTheme({
 });`;
 
 const mantineTheme = extendTheme({
+  cssVarPrefix: 'mantine',
   colorSchemes: {
     light: {
       palette: {
@@ -466,9 +470,6 @@ const codes = {
   chakra: chakraCode,
   mantine: mantineCode,
 };
-const prefixes = {
-  github: 'gh',
-};
 
 const useEnhancedEffect =
   typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
@@ -483,7 +484,6 @@ export default function ButtonThemes() {
   const [design, setDesign] = React.useState('github');
   return (
     <CssVarsProvider
-      prefix={prefixes[design] || design}
       theme={themes[design]}
       colorSchemeNode={node || null}
       colorSchemeSelector="#button-themes-demo"

--- a/docs/data/joy/customization/theme-tokens/BootstrapVariantTokens.js
+++ b/docs/data/joy/customization/theme-tokens/BootstrapVariantTokens.js
@@ -79,6 +79,7 @@ const palette = {
 };
 
 const bootstrapTheme = extendTheme({
+  cssVarPrefix: 'bs',
   colorSchemes: {
     light: { palette },
     dark: { palette },
@@ -116,7 +117,6 @@ export default function BootstrapVariantTokens() {
 
   return (
     <CssVarsProvider
-      prefix="bs"
       theme={bootstrapTheme}
       colorSchemeNode={node || null}
       colorSchemeSelector="#bootstrap-buttons-demo"

--- a/docs/data/joy/customization/theme-tokens/theme-tokens.md
+++ b/docs/data/joy/customization/theme-tokens/theme-tokens.md
@@ -133,7 +133,7 @@ function App() {
 ```
 
 :::info
-**Note**: Joy will add the prefix (default as `joy`) to all CSS variables. If you want to change that, do `<CssVarsProvider prefix="myproduct">`.
+**Note**: Joy will add the prefix (default as `joy`) to all CSS variables. If you want to change that, do `<CssVarsProvider theme={extendTheme({ cssVarPrefix: 'myproduct' })}>`.
 The generated CSS variables will then be:
 
 ```diff

--- a/docs/data/joy/customization/using-css-variables/using-css-variables.md
+++ b/docs/data/joy/customization/using-css-variables/using-css-variables.md
@@ -112,13 +112,17 @@ You can use the `.` notation to get the value of an object.
 ## Custom prefix
 
 By default, the generated CSS variables are prefixed with `joy`.
-If you want to change the prefix to something else, provide the `prefix` prop to the `CssVarsProvider`:
+If you want to change the prefix to something else, provide the `cssVarPrefix` to the `extendTheme`:
 
 ```jsx
-import { CssVarsProvider } from '@mui/joy/styles';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 
 function App() {
-  return <CssVarsProvider prefix="company">...</CssVarsProvider>;
+  return (
+    <CssVarsProvider theme={extendTheme({ cssVarPrefix: 'company' })}>
+      ...
+    </CssVarsProvider>
+  );
 }
 ```
 
@@ -131,7 +135,7 @@ The generated CSS variables will be:
 
 ### Remove the prefix
 
-Specify `""` as a value to `<CssVarsProvider prefix="">`.
+Specify `""` as a value to `extendTheme({ cssVarPrefix: '' })`.
 
 The generated CSS variables will be:
 

--- a/docs/pages/experiments/joy/variant.tsx
+++ b/docs/pages/experiments/joy/variant.tsx
@@ -146,8 +146,8 @@ export default function JoyVariant() {
         </Box>
       </CssVarsProvider>
       <CssVarsProvider
-        prefix="strapi"
         theme={extendTheme({
+          cssVarPrefix: 'strapi',
           colorSchemes: {
             light: {
               palette: {
@@ -337,8 +337,8 @@ declare module '@mui/joy/styles' {
 }
 
 <CssVarsProvider
-  prefix="strapi"
   theme={extendTheme({
+    cssVarPrefix: 'strapi',
     colorSchemes: {
       light: {
         palette: {
@@ -416,8 +416,8 @@ declare module '@mui/joy/styles' {
 }
 
 <CssVarsProvider
-  prefix="strapi"
   theme={extendTheme({
+    cssVarPrefix: 'strapi',
     colorSchemes: {
       light: {
         palette: {
@@ -604,8 +604,8 @@ declare module '@mui/joy/styles' {
               component={MarkdownElement}
               code={`
 <CssVarsProvider
-  prefix="strapi"
   theme={extendTheme({
+    cssVarPrefix: 'strapi',
     colorSchemes: {
       // ...
     },
@@ -700,8 +700,8 @@ declare module '@mui/joy/styles' {
 }
 
 <CssVarsProvider
-  prefix="strapi"
   theme={extendTheme({
+    cssVarPrefix: 'strapi',
     colorSchemes: {
       light: {
         palette: {

--- a/packages/mui-joy/src/styles/CssVarsProvider.test.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.test.tsx
@@ -513,10 +513,6 @@ describe('[Joy] CssVarsProvider', () => {
 
       expect(container.firstChild?.textContent).to.equal(
         [
-          'plainOverrides',
-          'outlinedOverrides',
-          'softOverrides',
-          'solidOverrides',
           'plain',
           'plainHover',
           'plainActive',
@@ -533,6 +529,10 @@ describe('[Joy] CssVarsProvider', () => {
           'solidHover',
           'solidActive',
           'solidDisabled',
+          'plainOverrides',
+          'outlinedOverrides',
+          'softOverrides',
+          'solidOverrides',
         ].join(','),
       );
     });

--- a/packages/mui-joy/src/styles/CssVarsProvider.test.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.test.tsx
@@ -513,6 +513,10 @@ describe('[Joy] CssVarsProvider', () => {
 
       expect(container.firstChild?.textContent).to.equal(
         [
+          'plainOverrides',
+          'outlinedOverrides',
+          'softOverrides',
+          'solidOverrides',
           'plain',
           'plainHover',
           'plainActive',
@@ -529,10 +533,6 @@ describe('[Joy] CssVarsProvider', () => {
           'solidHover',
           'solidActive',
           'solidDisabled',
-          'plainOverrides',
-          'outlinedOverrides',
-          'softOverrides',
-          'solidOverrides',
         ].join(','),
       );
     });

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -1,7 +1,7 @@
 import { deepmerge } from '@mui/utils';
 import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/system';
 import extendTheme from './extendTheme';
-import { createVariant, createTextOverrides, createContainedOverrides } from './variantUtils';
+import { createTextOverrides, createContainedOverrides } from './variantUtils';
 import type { Theme, DefaultColorScheme, ExtendedColorScheme } from './types';
 
 const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
@@ -20,23 +20,6 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
   resolveTheme: (mergedTheme: Theme) => {
     mergedTheme.variants = deepmerge(
       {
-        plain: createVariant('plain', mergedTheme),
-        plainHover: createVariant('plainHover', mergedTheme),
-        plainActive: createVariant('plainActive', mergedTheme),
-        plainDisabled: createVariant('plainDisabled', mergedTheme),
-        outlined: createVariant('outlined', mergedTheme),
-        outlinedHover: createVariant('outlinedHover', mergedTheme),
-        outlinedActive: createVariant('outlinedActive', mergedTheme),
-        outlinedDisabled: createVariant('outlinedDisabled', mergedTheme),
-        soft: createVariant('soft', mergedTheme),
-        softHover: createVariant('softHover', mergedTheme),
-        softActive: createVariant('softActive', mergedTheme),
-        softDisabled: createVariant('softDisabled', mergedTheme),
-        solid: createVariant('solid', mergedTheme),
-        solidHover: createVariant('solidHover', mergedTheme),
-        solidActive: createVariant('solidActive', mergedTheme),
-        solidDisabled: createVariant('solidDisabled', mergedTheme),
-
         // variant overrides
         plainOverrides: createTextOverrides(mergedTheme),
         outlinedOverrides: createTextOverrides(mergedTheme),

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -2,6 +2,9 @@ import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/sy
 import extendTheme from './extendTheme';
 import type { Theme, DefaultColorScheme, ExtendedColorScheme } from './types';
 
+const shouldSkipGeneratingVar = (keys: string[]) =>
+  !!keys[0].match(/(typography|variants|focus|breakpoints)/);
+
 const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
   DefaultColorScheme | ExtendedColorScheme,
   Theme
@@ -14,12 +17,7 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
     light: 'light',
     dark: 'dark',
   },
-  prefix: 'joy',
-  shouldSkipGeneratingVar: (keys) =>
-    keys[0] === 'typography' ||
-    keys[0] === 'variants' ||
-    keys[0] === 'focus' ||
-    keys[0] === 'breakpoints',
+  shouldSkipGeneratingVar,
 });
 
-export { CssVarsProvider, useColorScheme, getInitColorSchemeScript };
+export { CssVarsProvider, useColorScheme, getInitColorSchemeScript, shouldSkipGeneratingVar };

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -1,7 +1,5 @@
-import { deepmerge } from '@mui/utils';
 import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/system';
 import extendTheme from './extendTheme';
-import { createTextOverrides, createContainedOverrides } from './variantUtils';
 import type { Theme, DefaultColorScheme, ExtendedColorScheme } from './types';
 
 const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
@@ -17,20 +15,6 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
     dark: 'dark',
   },
   prefix: 'joy',
-  resolveTheme: (mergedTheme: Theme) => {
-    mergedTheme.variants = deepmerge(
-      {
-        // variant overrides
-        plainOverrides: createTextOverrides(mergedTheme),
-        outlinedOverrides: createTextOverrides(mergedTheme),
-        softOverrides: createTextOverrides(mergedTheme),
-        solidOverrides: createContainedOverrides(mergedTheme),
-      } as typeof mergedTheme.variants,
-      mergedTheme.variants,
-      { clone: false },
-    );
-    return mergedTheme;
-  },
   shouldSkipGeneratingVar: (keys) =>
     keys[0] === 'typography' ||
     keys[0] === 'variants' ||

--- a/packages/mui-joy/src/styles/defaultTheme.test.js
+++ b/packages/mui-joy/src/styles/defaultTheme.test.js
@@ -25,6 +25,7 @@ describe('extendTheme', () => {
         'typography',
         'variants',
         'vars',
+        'cssVarPrefix',
       ]).to.includes(field);
     });
   });

--- a/packages/mui-joy/src/styles/defaultTheme.ts
+++ b/packages/mui-joy/src/styles/defaultTheme.ts
@@ -2,7 +2,6 @@ import { deepmerge } from '@mui/utils';
 import extendTheme from './extendTheme';
 import type { ThemeInput, ColorSystemInput } from './extendTheme';
 import type { Theme, RuntimeColorSystem } from './types';
-import { createVariant, createTextOverrides, createContainedOverrides } from './variantUtils';
 
 export const getThemeWithVars = (
   themeInput?: Omit<ThemeInput, 'colorSchemes'> & ColorSystemInput,
@@ -29,7 +28,7 @@ export const getThemeWithVars = (
     ...palette
   } = colorSchemePalette as RuntimeColorSystem['palette'];
 
-  const defaultTheme = {
+  return {
     fontFamily,
     fontSize,
     fontWeight,
@@ -49,35 +48,6 @@ export const getThemeWithVars = (
     },
     vars: { fontFamily, fontSize, fontWeight, letterSpacing, lineHeight, radius, shadow, palette },
   } as unknown as Theme;
-
-  defaultTheme.variants = deepmerge(
-    {
-      plain: createVariant('plain', defaultTheme),
-      plainHover: createVariant('plainHover', defaultTheme),
-      plainActive: createVariant('plainActive', defaultTheme),
-      plainDisabled: createVariant('plainDisabled', defaultTheme),
-      outlined: createVariant('outlined', defaultTheme),
-      outlinedHover: createVariant('outlinedHover', defaultTheme),
-      outlinedActive: createVariant('outlinedActive', defaultTheme),
-      outlinedDisabled: createVariant('outlinedDisabled', defaultTheme),
-      soft: createVariant('soft', defaultTheme),
-      softHover: createVariant('softHover', defaultTheme),
-      softActive: createVariant('softActive', defaultTheme),
-      softDisabled: createVariant('softDisabled', defaultTheme),
-      solid: createVariant('solid', defaultTheme),
-      solidHover: createVariant('solidHover', defaultTheme),
-      solidActive: createVariant('solidActive', defaultTheme),
-      solidDisabled: createVariant('solidDisabled', defaultTheme),
-
-      // variant overrides
-      plainOverrides: createTextOverrides(defaultTheme),
-      outlinedOverrides: createTextOverrides(defaultTheme),
-      softOverrides: createTextOverrides(defaultTheme),
-      solidOverrides: createContainedOverrides(defaultTheme),
-    },
-    defaultTheme.variants,
-  );
-  return defaultTheme;
 };
 
 const defaultTheme = getThemeWithVars();

--- a/packages/mui-joy/src/styles/extendTheme.test.js
+++ b/packages/mui-joy/src/styles/extendTheme.test.js
@@ -21,7 +21,26 @@ describe('extendTheme', () => {
         'shadow',
         'typography',
         'variants',
+        'cssVarPrefix',
       ]).to.includes(field);
     });
+  });
+
+  it('should have joy default css var prefix', () => {
+    const theme = extendTheme();
+    expect(theme.cssVarPrefix).to.equal('joy');
+    expect(theme.typography.body1.fontSize).to.equal('var(--joy-fontSize-md)');
+  });
+
+  it('should have custom css var prefix', () => {
+    const theme = extendTheme({ cssVarPrefix: 'foo' });
+    expect(theme.cssVarPrefix).to.equal('foo');
+    expect(theme.typography.body1.fontSize).to.equal('var(--foo-fontSize-md)');
+  });
+
+  it('should have no css var prefix', () => {
+    const theme = extendTheme({ cssVarPrefix: '' });
+    expect(theme.cssVarPrefix).to.equal('');
+    expect(theme.typography.body1.fontSize).to.equal('var(--fontSize-md)');
   });
 });

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -40,7 +40,7 @@ export interface ColorSystemInput extends Partial3Level<ColorSystem> {}
 
 // Use Partial2Level instead of PartialDeep because nested value type is CSSObject which does not work with PartialDeep.
 export interface ThemeInput extends Partial2Level<ThemeScales> {
-  prefix?: string;
+  cssVarPrefix?: string;
   focus?: Partial<Focus>;
   typography?: Partial<TypographySystem>;
   variants?: Partial2Level<Variants>;
@@ -50,18 +50,19 @@ export interface ThemeInput extends Partial2Level<ThemeScales> {
   colorSchemes?: Partial<Record<DefaultColorScheme | ExtendedColorScheme, ColorSystemInput>>;
 }
 
-export const createGetCssVar = (prefix = 'joy') => systemCreateGetCssVar<ThemeCSSVar>(prefix);
+export const createGetCssVar = (cssVarPrefix = 'joy') =>
+  systemCreateGetCssVar<ThemeCSSVar>(cssVarPrefix);
 
 export default function extendTheme(themeInput?: ThemeInput): Theme {
   const {
-    prefix = 'joy',
+    cssVarPrefix = 'joy',
     breakpoints,
     spacing,
     components: componentsInput,
     variants: variantsInput,
     ...scalesInput
   } = themeInput || {};
-  const getCssVar = createGetCssVar(prefix);
+  const getCssVar = createGetCssVar(cssVarPrefix);
 
   const createLightModeVariantVariables = (color: ColorPaletteProp) => ({
     plainColor: getCssVar(`palette-${color}-600`),
@@ -594,6 +595,7 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       },
       variantsInput,
     ),
+    cssVarPrefix,
     getCssVar,
     spacing: createSpacing(spacing),
   } as unknown as Theme; // Need type casting due to module augmentation inside the repo

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -606,7 +606,6 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       variantsInput,
     ),
     cssVarPrefix,
-    getCssVar,
     spacing: createSpacing(spacing),
   } as unknown as Theme; // Need type casting due to module augmentation inside the repo
 

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -606,6 +606,7 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       variantsInput,
     ),
     cssVarPrefix,
+    getCssVar,
     spacing: createSpacing(spacing),
   } as unknown as Theme; // Need type casting due to module augmentation inside the repo
 

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -16,7 +16,7 @@ import { Variants } from './types/variants';
 import { Theme, ThemeCSSVar, ThemeScales } from './types';
 import { Components } from './components';
 import { generateUtilityClass } from '../className';
-import { createVariant } from './variantUtils';
+import { createVariant, createTextOverrides, createContainedOverrides } from './variantUtils';
 
 type Partial2Level<T> = {
   [K in keyof T]?: T[K] extends Record<any, any>
@@ -586,6 +586,11 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
         solidHover: createVariant('solidHover', variantInput),
         solidActive: createVariant('solidActive', variantInput),
         solidDisabled: createVariant('solidDisabled', variantInput),
+        // variant overrides
+        plainOverrides: createTextOverrides(variantInput),
+        outlinedOverrides: createTextOverrides(variantInput),
+        softOverrides: createTextOverrides(variantInput),
+        solidOverrides: createContainedOverrides(variantInput),
       },
       variantsInput,
     ),

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -40,6 +40,16 @@ export interface ColorSystemInput extends Partial3Level<ColorSystem> {}
 
 // Use Partial2Level instead of PartialDeep because nested value type is CSSObject which does not work with PartialDeep.
 export interface ThemeInput extends Partial2Level<ThemeScales> {
+  /**
+   * Prefix of the generated CSS variables
+   * @default 'joy'
+   * @example extendTheme({ cssVarPrefix: 'foo-bar' })
+   * // { ..., typography: { body1: { fontSize: 'var(--foo-bar-fontSize-md)' } }, ... }
+   *
+   * @example <caption>Provides empty string ('') to remove the prefix</caption>
+   * extendTheme({ cssVarPrefix: 'foo-bar' })
+   * // { ..., typography: { body1: { fontSize: 'var(--fontSize-md)' } }, ... }
+   */
   cssVarPrefix?: string;
   focus?: Partial<Focus>;
   typography?: Partial<TypographySystem>;
@@ -531,7 +541,7 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
     : defaultScales;
 
   const { palette: firstColorSchemePalette } = Object.entries(colorSchemes)[0][1];
-  const variantInput = { getCssVar, palette: firstColorSchemePalette };
+  const variantInput = { palette: firstColorSchemePalette, prefix: cssVarPrefix, getCssVar };
 
   const theme = {
     colorSchemes,

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -1,4 +1,3 @@
-import * as CSS from 'csstype';
 import { deepmerge } from '@mui/utils';
 import {
   BreakpointsOptions,
@@ -17,8 +16,7 @@ import { Variants } from './types/variants';
 import { Theme, ThemeCSSVar, ThemeScales } from './types';
 import { Components } from './components';
 import { generateUtilityClass } from '../className';
-
-type CSSProperties = CSS.Properties<number | string>;
+import { createVariant } from './variantUtils';
 
 type Partial2Level<T> = {
   [K in keyof T]?: T[K] extends Record<any, any>
@@ -42,6 +40,7 @@ export interface ColorSystemInput extends Partial3Level<ColorSystem> {}
 
 // Use Partial2Level instead of PartialDeep because nested value type is CSSObject which does not work with PartialDeep.
 export interface ThemeInput extends Partial2Level<ThemeScales> {
+  prefix?: string;
   focus?: Partial<Focus>;
   typography?: Partial<TypographySystem>;
   variants?: Partial2Level<Variants>;
@@ -53,74 +52,83 @@ export interface ThemeInput extends Partial2Level<ThemeScales> {
 
 export const createGetCssVar = (prefix = 'joy') => systemCreateGetCssVar<ThemeCSSVar>(prefix);
 
-const createLightModeVariantVariables = (color: ColorPaletteProp) => ({
-  plainColor: `var(--joy-palette-${color}-600)`,
-  plainHoverBg: `var(--joy-palette-${color}-100)`,
-  plainActiveBg: `var(--joy-palette-${color}-200)`,
-  plainDisabledColor: `var(--joy-palette-${color}-200)`,
-
-  outlinedColor: `var(--joy-palette-${color}-500)`,
-  outlinedBorder: `var(--joy-palette-${color}-200)`,
-  outlinedHoverBg: `var(--joy-palette-${color}-100)`,
-  outlinedHoverBorder: `var(--joy-palette-${color}-300)`,
-  outlinedActiveBg: `var(--joy-palette-${color}-200)`,
-  outlinedDisabledColor: `var(--joy-palette-${color}-100)`,
-  outlinedDisabledBorder: `var(--joy-palette-${color}-100)`,
-
-  softColor: `var(--joy-palette-${color}-600)`,
-  softBg: `var(--joy-palette-${color}-100)`,
-  softHoverBg: `var(--joy-palette-${color}-200)`,
-  softActiveBg: `var(--joy-palette-${color}-300)`,
-  softDisabledColor: `var(--joy-palette-${color}-300)`,
-  softDisabledBg: `var(--joy-palette-${color}-50)`,
-
-  solidColor: '#fff',
-  solidBg: `var(--joy-palette-${color}-500)`,
-  solidHoverBg: `var(--joy-palette-${color}-600)`,
-  solidActiveBg: `var(--joy-palette-${color}-700)`,
-  solidDisabledColor: `#fff`,
-  solidDisabledBg: `var(--joy-palette-${color}-200)`,
-
-  overrideTextPrimary: `var(--joy-palette-${color}-700)`,
-  overrideTextSecondary: `var(--joy-palette-${color}-500)`,
-  overrideTextTertiary: `var(--joy-palette-${color}-400)`,
-});
-
-const createDarkModeVariantVariables = (color: ColorPaletteProp) => ({
-  plainColor: `var(--joy-palette-${color}-300)`,
-  plainHoverBg: `var(--joy-palette-${color}-800)`,
-  plainActiveBg: `var(--joy-palette-${color}-700)`,
-  plainDisabledColor: `var(--joy-palette-${color}-800)`,
-
-  outlinedColor: `var(--joy-palette-${color}-200)`,
-  outlinedBorder: `var(--joy-palette-${color}-700)`,
-  outlinedHoverBg: `var(--joy-palette-${color}-800)`,
-  outlinedHoverBorder: `var(--joy-palette-${color}-600)`,
-  outlinedActiveBg: `var(--joy-palette-${color}-900)`,
-  outlinedDisabledColor: `var(--joy-palette-${color}-800)`,
-  outlinedDisabledBorder: `var(--joy-palette-${color}-800)`,
-
-  softColor: `var(--joy-palette-${color}-200)`,
-  softBg: `var(--joy-palette-${color}-900)`,
-  softHoverBg: `var(--joy-palette-${color}-800)`,
-  softActiveBg: `var(--joy-palette-${color}-700)`,
-  softDisabledColor: `var(--joy-palette-${color}-800)`,
-  softDisabledBg: `var(--joy-palette-${color}-900)`,
-
-  solidColor: `#fff`,
-  solidBg: `var(--joy-palette-${color}-600)`,
-  solidHoverBg: `var(--joy-palette-${color}-700)`,
-  solidActiveBg: `var(--joy-palette-${color}-800)`,
-  solidDisabledColor: `#fff`,
-  solidDisabledBg: `var(--joy-palette-${color}-300)`,
-
-  overrideTextPrimary: `var(--joy-palette-${color}-200)`,
-  overrideTextSecondary: `var(--joy-palette-${color}-400)`,
-  overrideTextTertiary: `var(--joy-palette-${color}-500)`,
-});
-
 export default function extendTheme(themeInput?: ThemeInput): Theme {
-  const { breakpoints, spacing, components: componentsInput, ...scalesInput } = themeInput || {};
+  const {
+    prefix = 'joy',
+    breakpoints,
+    spacing,
+    components: componentsInput,
+    variants: variantsInput,
+    ...scalesInput
+  } = themeInput || {};
+  const getCssVar = createGetCssVar(prefix);
+
+  const createLightModeVariantVariables = (color: ColorPaletteProp) => ({
+    plainColor: getCssVar(`palette-${color}-600`),
+    plainHoverBg: getCssVar(`palette-${color}-100`),
+    plainActiveBg: getCssVar(`palette-${color}-200`),
+    plainDisabledColor: getCssVar(`palette-${color}-200`),
+
+    outlinedColor: getCssVar(`palette-${color}-500`),
+    outlinedBorder: getCssVar(`palette-${color}-200`),
+    outlinedHoverBg: getCssVar(`palette-${color}-100`),
+    outlinedHoverBorder: getCssVar(`palette-${color}-300`),
+    outlinedActiveBg: getCssVar(`palette-${color}-200`),
+    outlinedDisabledColor: getCssVar(`palette-${color}-100`),
+    outlinedDisabledBorder: getCssVar(`palette-${color}-100`),
+
+    softColor: getCssVar(`palette-${color}-600`),
+    softBg: getCssVar(`palette-${color}-100`),
+    softHoverBg: getCssVar(`palette-${color}-200`),
+    softActiveBg: getCssVar(`palette-${color}-300`),
+    softDisabledColor: getCssVar(`palette-${color}-300`),
+    softDisabledBg: getCssVar(`palette-${color}-50`),
+
+    solidColor: '#fff',
+    solidBg: getCssVar(`palette-${color}-500`),
+    solidHoverBg: getCssVar(`palette-${color}-600`),
+    solidActiveBg: getCssVar(`palette-${color}-700`),
+    solidDisabledColor: `#fff`,
+    solidDisabledBg: getCssVar(`palette-${color}-200`),
+
+    overrideTextPrimary: getCssVar(`palette-${color}-700`),
+    overrideTextSecondary: getCssVar(`palette-${color}-500`),
+    overrideTextTertiary: getCssVar(`palette-${color}-400`),
+  });
+
+  const createDarkModeVariantVariables = (color: ColorPaletteProp) => ({
+    plainColor: getCssVar(`palette-${color}-300`),
+    plainHoverBg: getCssVar(`palette-${color}-800`),
+    plainActiveBg: getCssVar(`palette-${color}-700`),
+    plainDisabledColor: getCssVar(`palette-${color}-800`),
+
+    outlinedColor: getCssVar(`palette-${color}-200`),
+    outlinedBorder: getCssVar(`palette-${color}-700`),
+    outlinedHoverBg: getCssVar(`palette-${color}-800`),
+    outlinedHoverBorder: getCssVar(`palette-${color}-600`),
+    outlinedActiveBg: getCssVar(`palette-${color}-900`),
+    outlinedDisabledColor: getCssVar(`palette-${color}-800`),
+    outlinedDisabledBorder: getCssVar(`palette-${color}-800`),
+
+    softColor: getCssVar(`palette-${color}-200`),
+    softBg: getCssVar(`palette-${color}-900`),
+    softHoverBg: getCssVar(`palette-${color}-800`),
+    softActiveBg: getCssVar(`palette-${color}-700`),
+    softDisabledColor: getCssVar(`palette-${color}-800`),
+    softDisabledBg: getCssVar(`palette-${color}-900`),
+
+    solidColor: `#fff`,
+    solidBg: getCssVar(`palette-${color}-600`),
+    solidHoverBg: getCssVar(`palette-${color}-700`),
+    solidActiveBg: getCssVar(`palette-${color}-800`),
+    solidDisabledColor: `#fff`,
+    solidDisabledBg: getCssVar(`palette-${color}-300`),
+
+    overrideTextPrimary: getCssVar(`palette-${color}-200`),
+    overrideTextSecondary: getCssVar(`palette-${color}-400`),
+    overrideTextTertiary: getCssVar(`palette-${color}-500`),
+  });
+
   const lightColorSystem = {
     palette: {
       primary: {
@@ -129,39 +137,39 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       },
       neutral: {
         ...colors.grey,
-        plainColor: `var(--joy-palette-neutral-700)`,
-        plainHoverColor: `var(--joy-palette-neutral-900)`,
-        plainHoverBg: `var(--joy-palette-neutral-100)`,
-        plainActiveBg: `var(--joy-palette-neutral-200)`,
-        plainDisabledColor: `var(--joy-palette-neutral-400)`,
+        plainColor: getCssVar(`palette-neutral-700`),
+        plainHoverColor: getCssVar(`palette-neutral-900`),
+        plainHoverBg: getCssVar(`palette-neutral-100`),
+        plainActiveBg: getCssVar(`palette-neutral-200`),
+        plainDisabledColor: getCssVar(`palette-neutral-400`),
 
-        outlinedColor: `var(--joy-palette-neutral-700)`,
-        outlinedBorder: `var(--joy-palette-neutral-200)`,
-        outlinedHoverColor: `var(--joy-palette-neutral-900)`,
-        outlinedHoverBg: `var(--joy-palette-neutral-100)`,
-        outlinedHoverBorder: `var(--joy-palette-neutral-300)`,
-        outlinedActiveBg: `var(--joy-palette-neutral-200)`,
-        outlinedDisabledColor: `var(--joy-palette-neutral-400)`,
-        outlinedDisabledBorder: `var(--joy-palette-neutral-100)`,
+        outlinedColor: getCssVar(`palette-neutral-700`),
+        outlinedBorder: getCssVar(`palette-neutral-200`),
+        outlinedHoverColor: getCssVar(`palette-neutral-900`),
+        outlinedHoverBg: getCssVar(`palette-neutral-100`),
+        outlinedHoverBorder: getCssVar(`palette-neutral-300`),
+        outlinedActiveBg: getCssVar(`palette-neutral-200`),
+        outlinedDisabledColor: getCssVar(`palette-neutral-400`),
+        outlinedDisabledBorder: getCssVar(`palette-neutral-100`),
 
-        softColor: `var(--joy-palette-neutral-700)`,
-        softBg: `var(--joy-palette-neutral-100)`,
-        softHoverColor: `var(--joy-palette-neutral-900)`,
-        softHoverBg: `var(--joy-palette-neutral-200)`,
-        softActiveBg: `var(--joy-palette-neutral-300)`,
-        softDisabledColor: `var(--joy-palette-neutral-500)`,
-        softDisabledBg: `var(--joy-palette-neutral-50)`,
+        softColor: getCssVar(`palette-neutral-700`),
+        softBg: getCssVar(`palette-neutral-100`),
+        softHoverColor: getCssVar(`palette-neutral-900`),
+        softHoverBg: getCssVar(`palette-neutral-200`),
+        softActiveBg: getCssVar(`palette-neutral-300`),
+        softDisabledColor: getCssVar(`palette-neutral-500`),
+        softDisabledBg: getCssVar(`palette-neutral-50`),
 
         solidColor: '#fff',
-        solidBg: `var(--joy-palette-neutral-700)`,
-        solidHoverBg: `var(--joy-palette-neutral-800)`,
-        solidActiveBg: `var(--joy-palette-neutral-700)`,
-        solidDisabledColor: `var(--joy-palette-neutral-50)`,
-        solidDisabledBg: `var(--joy-palette-neutral-300)`,
+        solidBg: getCssVar(`palette-neutral-700`),
+        solidHoverBg: getCssVar(`palette-neutral-800`),
+        solidActiveBg: getCssVar(`palette-neutral-700`),
+        solidDisabledColor: getCssVar(`palette-neutral-50`),
+        solidDisabledBg: getCssVar(`palette-neutral-300`),
 
-        overrideTextPrimary: `var(--joy-palette-neutral-700)`,
-        overrideTextSecondary: `var(--joy-palette-neutral-500)`,
-        overrideTextTertiary: `var(--joy-palette-neutral-400)`,
+        overrideTextPrimary: getCssVar(`palette-neutral-700`),
+        overrideTextSecondary: getCssVar(`palette-neutral-500`),
+        overrideTextTertiary: getCssVar(`palette-neutral-400`),
       },
       danger: {
         ...colors.red,
@@ -175,57 +183,57 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
         ...colors.green,
         ...createLightModeVariantVariables('success'),
         solidColor: '#fff',
-        solidBg: `var(--joy-palette-success-600)`,
-        solidHoverBg: `var(--joy-palette-success-700)`,
-        solidActiveBg: `var(--joy-palette-success-800)`,
-        solidDisabledColor: `var(--joy-palette-success-50)`,
-        solidDisabledBg: `var(--joy-palette-success-300)`,
+        solidBg: getCssVar(`palette-success-600`),
+        solidHoverBg: getCssVar(`palette-success-700`),
+        solidActiveBg: getCssVar(`palette-success-800`),
+        solidDisabledColor: getCssVar(`palette-success-50`),
+        solidDisabledBg: getCssVar(`palette-success-300`),
 
-        softColor: `var(--joy-palette-success-700)`,
+        softColor: getCssVar(`palette-success-700`),
 
-        outlinedColor: `var(--joy-palette-success-800)`,
-        outlinedBorder: `var(--joy-palette-success-300)`,
-        outlinedHoverBorder: `var(--joy-palette-success-400)`,
+        outlinedColor: getCssVar(`palette-success-800`),
+        outlinedBorder: getCssVar(`palette-success-300`),
+        outlinedHoverBorder: getCssVar(`palette-success-400`),
 
-        plainColor: `var(--joy-palette-success-900)`,
+        plainColor: getCssVar(`palette-success-900`),
       },
       warning: {
         ...colors.yellow,
         ...createLightModeVariantVariables('warning'),
-        solidColor: `var(--joy-palette-common-black)`,
-        solidBg: `var(--joy-palette-warning-500)`,
-        solidHoverBg: `var(--joy-palette-warning-600)`,
-        solidActiveBg: `var(--joy-palette-warning-700)`,
-        solidDisabledColor: `var(--joy-palette-warning-50)`,
-        solidDisabledBg: `var(--joy-palette-warning-300)`,
+        solidColor: getCssVar(`palette-common-black`),
+        solidBg: getCssVar(`palette-warning-500`),
+        solidHoverBg: getCssVar(`palette-warning-600`),
+        solidActiveBg: getCssVar(`palette-warning-700`),
+        solidDisabledColor: getCssVar(`palette-warning-50`),
+        solidDisabledBg: getCssVar(`palette-warning-300`),
 
-        softColor: `var(--joy-palette-warning-800)`,
+        softColor: getCssVar(`palette-warning-800`),
 
-        outlinedColor: `var(--joy-palette-warning-800)`,
-        outlinedBorder: `var(--joy-palette-warning-500)`,
-        outlinedHoverBorder: `var(--joy-palette-warning-600)`,
+        outlinedColor: getCssVar(`palette-warning-800`),
+        outlinedBorder: getCssVar(`palette-warning-500`),
+        outlinedHoverBorder: getCssVar(`palette-warning-600`),
 
-        plainColor: `var(--joy-palette-warning-800)`,
+        plainColor: getCssVar(`palette-warning-800`),
       },
       common: {
         white: '#FFF',
         black: '#0F0F0F',
       },
       text: {
-        primary: 'var(--joy-palette-neutral-800)',
-        secondary: 'var(--joy-palette-neutral-600)',
-        tertiary: 'var(--joy-palette-neutral-500)',
+        primary: getCssVar('palette-neutral-800'),
+        secondary: getCssVar('palette-neutral-600'),
+        tertiary: getCssVar('palette-neutral-500'),
       },
       background: {
-        body: 'var(--joy-palette-common-white)',
-        surface: 'var(--joy-palette-common-white)',
-        level1: 'var(--joy-palette-neutral-50)',
-        level2: 'var(--joy-palette-neutral-100)',
-        level3: 'var(--joy-palette-neutral-200)',
-        tooltip: 'var(--joy-palette-neutral-800)',
+        body: getCssVar('palette-common-white'),
+        surface: getCssVar('palette-common-white'),
+        level1: getCssVar('palette-neutral-50'),
+        level2: getCssVar('palette-neutral-100'),
+        level3: getCssVar('palette-neutral-200'),
+        tooltip: getCssVar('palette-neutral-800'),
       },
-      divider: 'var(--joy-palette-neutral-200)',
-      focusVisible: 'var(--joy-palette-primary-200)',
+      divider: getCssVar('palette-neutral-200'),
+      focusVisible: getCssVar('palette-primary-200'),
     },
     shadowRing: '0 0 #000',
     shadowChannel: '187 187 187',
@@ -238,39 +246,39 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       },
       neutral: {
         ...colors.grey,
-        plainColor: `var(--joy-palette-neutral-200)`,
-        plainHoverColor: `var(--joy-palette-neutral-50)`,
-        plainHoverBg: `var(--joy-palette-neutral-800)`,
-        plainActiveBg: `var(--joy-palette-neutral-700)`,
-        plainDisabledColor: `var(--joy-palette-neutral-600)`,
+        plainColor: getCssVar(`palette-neutral-200`),
+        plainHoverColor: getCssVar(`palette-neutral-50`),
+        plainHoverBg: getCssVar(`palette-neutral-800`),
+        plainActiveBg: getCssVar(`palette-neutral-700`),
+        plainDisabledColor: getCssVar(`palette-neutral-600`),
 
-        outlinedColor: `var(--joy-palette-neutral-200)`,
-        outlinedBorder: `var(--joy-palette-neutral-800)`,
-        outlinedHoverColor: `var(--joy-palette-neutral-50)`,
-        outlinedHoverBg: `var(--joy-palette-neutral-800)`,
-        outlinedHoverBorder: `var(--joy-palette-neutral-700)`,
-        outlinedActiveBg: `var(--joy-palette-neutral-800)`,
-        outlinedDisabledColor: `var(--joy-palette-neutral-600)`,
-        outlinedDisabledBorder: `var(--joy-palette-neutral-800)`,
+        outlinedColor: getCssVar(`palette-neutral-200`),
+        outlinedBorder: getCssVar(`palette-neutral-800`),
+        outlinedHoverColor: getCssVar(`palette-neutral-50`),
+        outlinedHoverBg: getCssVar(`palette-neutral-800`),
+        outlinedHoverBorder: getCssVar(`palette-neutral-700`),
+        outlinedActiveBg: getCssVar(`palette-neutral-800`),
+        outlinedDisabledColor: getCssVar(`palette-neutral-600`),
+        outlinedDisabledBorder: getCssVar(`palette-neutral-800`),
 
-        softColor: `var(--joy-palette-neutral-200)`,
-        softBg: `var(--joy-palette-neutral-900)`,
-        softHoverColor: `var(--joy-palette-neutral-50)`,
-        softHoverBg: `var(--joy-palette-neutral-800)`,
-        softActiveBg: `var(--joy-palette-neutral-700)`,
-        softDisabledColor: `var(--joy-palette-neutral-600)`,
-        softDisabledBg: `var(--joy-palette-neutral-900)`,
+        softColor: getCssVar(`palette-neutral-200`),
+        softBg: getCssVar(`palette-neutral-900`),
+        softHoverColor: getCssVar(`palette-neutral-50`),
+        softHoverBg: getCssVar(`palette-neutral-800`),
+        softActiveBg: getCssVar(`palette-neutral-700`),
+        softDisabledColor: getCssVar(`palette-neutral-600`),
+        softDisabledBg: getCssVar(`palette-neutral-900`),
 
         solidColor: `#fff`,
-        solidBg: `var(--joy-palette-neutral-600)`,
-        solidHoverBg: `var(--joy-palette-neutral-700)`,
-        solidActiveBg: `var(--joy-palette-neutral-800)`,
-        solidDisabledColor: `var(--joy-palette-neutral-400)`,
-        solidDisabledBg: `var(--joy-palette-neutral-800)`,
+        solidBg: getCssVar(`palette-neutral-600`),
+        solidHoverBg: getCssVar(`palette-neutral-700`),
+        solidActiveBg: getCssVar(`palette-neutral-800`),
+        solidDisabledColor: getCssVar(`palette-neutral-400`),
+        solidDisabledBg: getCssVar(`palette-neutral-800`),
 
-        overrideTextPrimary: `var(--joy-palette-neutral-200)`,
-        overrideTextSecondary: `var(--joy-palette-neutral-400)`,
-        overrideTextTertiary: `var(--joy-palette-neutral-500)`,
+        overrideTextPrimary: getCssVar(`palette-neutral-200`),
+        overrideTextSecondary: getCssVar(`palette-neutral-400`),
+        overrideTextTertiary: getCssVar(`palette-neutral-500`),
       },
       danger: {
         ...colors.red,
@@ -284,41 +292,41 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
         ...colors.green,
         ...createDarkModeVariantVariables('success'),
         solidColor: '#fff',
-        solidBg: `var(--joy-palette-success-600)`,
-        solidHoverBg: `var(--joy-palette-success-700)`,
-        solidActiveBg: `var(--joy-palette-success-800)`,
-        solidDisabledColor: `var(--joy-palette-success-50)`,
-        solidDisabledBg: `var(--joy-palette-success-300)`,
+        solidBg: getCssVar(`palette-success-600`),
+        solidHoverBg: getCssVar(`palette-success-700`),
+        solidActiveBg: getCssVar(`palette-success-800`),
+        solidDisabledColor: getCssVar(`palette-success-50`),
+        solidDisabledBg: getCssVar(`palette-success-300`),
       },
       warning: {
         ...colors.yellow,
         ...createDarkModeVariantVariables('warning'),
-        solidColor: `var(--joy-palette-common-black)`,
-        solidBg: `var(--joy-palette-warning-500)`,
-        solidHoverBg: `var(--joy-palette-warning-600)`,
-        solidActiveBg: `var(--joy-palette-warning-700)`,
-        solidDisabledColor: `var(--joy-palette-warning-50)`,
-        solidDisabledBg: `var(--joy-palette-warning-300)`,
+        solidColor: getCssVar(`palette-common-black`),
+        solidBg: getCssVar(`palette-warning-500`),
+        solidHoverBg: getCssVar(`palette-warning-600`),
+        solidActiveBg: getCssVar(`palette-warning-700`),
+        solidDisabledColor: getCssVar(`palette-warning-50`),
+        solidDisabledBg: getCssVar(`palette-warning-300`),
       },
       common: {
         white: '#FFF',
         black: '#0F0F0F',
       },
       text: {
-        primary: 'var(--joy-palette-neutral-100)',
-        secondary: 'var(--joy-palette-neutral-300)',
-        tertiary: 'var(--joy-palette-neutral-400)',
+        primary: getCssVar('palette-neutral-100'),
+        secondary: getCssVar('palette-neutral-300'),
+        tertiary: getCssVar('palette-neutral-400'),
       },
       background: {
-        body: 'var(--joy-palette-neutral-900)',
-        surface: 'var(--joy-palette-common-black)',
-        level1: 'var(--joy-palette-neutral-800)',
-        level2: 'var(--joy-palette-neutral-700)',
-        level3: 'var(--joy-palette-neutral-600)',
-        tooltip: 'var(--joy-palette-neutral-600)',
+        body: getCssVar('palette-neutral-900'),
+        surface: getCssVar('palette-common-black'),
+        level1: getCssVar('palette-neutral-800'),
+        level2: getCssVar('palette-neutral-700'),
+        level3: getCssVar('palette-neutral-600'),
+        tooltip: getCssVar('palette-neutral-600'),
       },
-      divider: 'var(--joy-palette-neutral-800)',
-      focusVisible: 'var(--joy-palette-primary-500)',
+      divider: getCssVar('palette-neutral-800'),
+      focusVisible: getCssVar('palette-primary-500'),
     },
     shadowRing: '0 0 #000',
     shadowChannel: '0 0 0',
@@ -345,8 +353,8 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       xl7: '4.5rem',
     },
     fontFamily: {
-      body: '"Public Sans", var(--joy-fontFamily-fallback)',
-      display: '"Public Sans", var(--joy-fontFamily-fallback)',
+      body: `"Public Sans", ${getCssVar('fontFamily-fallback')}`,
+      display: `"Public Sans", ${getCssVar('fontFamily-fallback')}`,
       code: 'Source Code Pro,ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace',
       fallback:
         '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
@@ -363,8 +371,8 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
     focus: {
       selector: `&.${generateUtilityClass('', 'focusVisible')}, &:focus-visible`,
       default: {
-        outlineOffset: 'var(--joy-focus-outlineOffset, 0px)', // reset user agent stylesheet
-        outline: '4px solid var(--joy-palette-focusVisible)',
+        outlineOffset: getCssVar('focus-outlineOffset', '0px'), // reset user agent stylesheet
+        outline: `4px solid ${getCssVar('palette-focusVisible')}`,
       },
     },
     lineHeight: {
@@ -385,102 +393,134 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       xl: '20px',
     },
     shadow: {
-      xs: 'var(--joy-shadowRing), 0 1px 2px 0 rgba(var(--joy-shadowChannel) / 0.12)',
-      sm: 'var(--joy-shadowRing), 0.3px 0.8px 1.1px rgba(var(--joy-shadowChannel) / 0.11), 0.5px 1.3px 1.8px -0.6px rgba(var(--joy-shadowChannel) / 0.18), 1.1px 2.7px 3.8px -1.2px rgba(var(--joy-shadowChannel) / 0.26)',
-      md: 'var(--joy-shadowRing), 0.3px 0.8px 1.1px rgba(var(--joy-shadowChannel) / 0.12), 1.1px 2.8px 3.9px -0.4px rgba(var(--joy-shadowChannel) / 0.17), 2.4px 6.1px 8.6px -0.8px rgba(var(--joy-shadowChannel) / 0.23), 5.3px 13.3px 18.8px -1.2px rgba(var(--joy-shadowChannel) / 0.29)',
-      lg: 'var(--joy-shadowRing), 0.3px 0.8px 1.1px rgba(var(--joy-shadowChannel) / 0.11), 1.8px 4.5px 6.4px -0.2px rgba(var(--joy-shadowChannel) / 0.13), 3.2px 7.9px 11.2px -0.4px rgba(var(--joy-shadowChannel) / 0.16), 4.8px 12px 17px -0.5px rgba(var(--joy-shadowChannel) / 0.19), 7px 17.5px 24.7px -0.7px rgba(var(--joy-shadowChannel) / 0.21)',
-      xl: 'var(--joy-shadowRing), 0.3px 0.8px 1.1px rgba(var(--joy-shadowChannel) / 0.11), 1.8px 4.5px 6.4px -0.2px rgba(var(--joy-shadowChannel) / 0.13), 3.2px 7.9px 11.2px -0.4px rgba(var(--joy-shadowChannel) / 0.16), 4.8px 12px 17px -0.5px rgba(var(--joy-shadowChannel) / 0.19), 7px 17.5px 24.7px -0.7px rgba(var(--joy-shadowChannel) / 0.21), 10.2px 25.5px 36px -0.9px rgba(var(--joy-shadowChannel) / 0.24), 14.8px 36.8px 52.1px -1.1px rgba(var(--joy-shadowChannel) / 0.27), 21px 52.3px 74px -1.2px rgba(var(--joy-shadowChannel) / 0.29)',
+      xs: `${getCssVar('shadowRing')}, 0 1px 2px 0 rgba(${getCssVar('shadowChannel')} / 0.12)`,
+      sm: `${getCssVar('shadowRing')}, 0.3px 0.8px 1.1px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.11), 0.5px 1.3px 1.8px -0.6px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.18), 1.1px 2.7px 3.8px -1.2px rgba(${getCssVar('shadowChannel')} / 0.26)`,
+      md: `${getCssVar('shadowRing')}, 0.3px 0.8px 1.1px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.12), 1.1px 2.8px 3.9px -0.4px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.17), 2.4px 6.1px 8.6px -0.8px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.23), 5.3px 13.3px 18.8px -1.2px rgba(${getCssVar('shadowChannel')} / 0.29)`,
+      lg: `${getCssVar('shadowRing')}, 0.3px 0.8px 1.1px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.11), 1.8px 4.5px 6.4px -0.2px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.13), 3.2px 7.9px 11.2px -0.4px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.16), 4.8px 12px 17px -0.5px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.19), 7px 17.5px 24.7px -0.7px rgba(${getCssVar('shadowChannel')} / 0.21)`,
+      xl: `${getCssVar('shadowRing')}, 0.3px 0.8px 1.1px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.11), 1.8px 4.5px 6.4px -0.2px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.13), 3.2px 7.9px 11.2px -0.4px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.16), 4.8px 12px 17px -0.5px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.19), 7px 17.5px 24.7px -0.7px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.21), 10.2px 25.5px 36px -0.9px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.24), 14.8px 36.8px 52.1px -1.1px rgba(${getCssVar(
+        'shadowChannel',
+      )} / 0.27), 21px 52.3px 74px -1.2px rgba(${getCssVar('shadowChannel')} / 0.29)`,
     },
     typography: {
       display1: {
-        fontFamily: 'var(--joy-fontFamily-display)',
-        fontWeight: 'var(--joy-fontWeight-xl)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl7)',
-        lineHeight: 'var(--joy-lineHeight-sm)',
-        letterSpacing: 'var(--joy-letterSpacing-sm)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-display'),
+        fontWeight: getCssVar('fontWeight-xl'),
+        fontSize: getCssVar('fontSize-xl7'),
+        lineHeight: getCssVar('lineHeight-sm'),
+        letterSpacing: getCssVar('letterSpacing-sm'),
+        color: getCssVar('palette-text-primary'),
       },
       display2: {
-        fontFamily: 'var(--joy-fontFamily-display)',
-        fontWeight: 'var(--joy-fontWeight-xl)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl6)',
-        lineHeight: 'var(--joy-lineHeight-sm)',
-        letterSpacing: 'var(--joy-letterSpacing-sm)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-display'),
+        fontWeight: getCssVar('fontWeight-xl'),
+        fontSize: getCssVar('fontSize-xl6'),
+        lineHeight: getCssVar('lineHeight-sm'),
+        letterSpacing: getCssVar('letterSpacing-sm'),
+        color: getCssVar('palette-text-primary'),
       },
       h1: {
-        fontFamily: 'var(--joy-fontFamily-display)',
-        fontWeight: 'var(--joy-fontWeight-lg)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl5)',
-        lineHeight: 'var(--joy-lineHeight-sm)',
-        letterSpacing: 'var(--joy-letterSpacing-sm)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-display'),
+        fontWeight: getCssVar('fontWeight-lg'),
+        fontSize: getCssVar('fontSize-xl5'),
+        lineHeight: getCssVar('lineHeight-sm'),
+        letterSpacing: getCssVar('letterSpacing-sm'),
+        color: getCssVar('palette-text-primary'),
       },
       h2: {
-        fontFamily: 'var(--joy-fontFamily-display)',
-        fontWeight: 'var(--joy-fontWeight-lg)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl4)',
-        lineHeight: 'var(--joy-lineHeight-sm)',
-        letterSpacing: 'var(--joy-letterSpacing-sm)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-display'),
+        fontWeight: getCssVar('fontWeight-lg'),
+        fontSize: getCssVar('fontSize-xl4'),
+        lineHeight: getCssVar('lineHeight-sm'),
+        letterSpacing: getCssVar('letterSpacing-sm'),
+        color: getCssVar('palette-text-primary'),
       },
       h3: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontWeight: 'var(--joy-fontWeight-md)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl3)',
-        lineHeight: 'var(--joy-lineHeight-sm)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontWeight: getCssVar('fontWeight-md'),
+        fontSize: getCssVar('fontSize-xl3'),
+        lineHeight: getCssVar('lineHeight-sm'),
+        color: getCssVar('palette-text-primary'),
       },
       h4: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontWeight: 'var(--joy-fontWeight-md)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl2)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontWeight: getCssVar('fontWeight-md'),
+        fontSize: getCssVar('fontSize-xl2'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-primary'),
       },
       h5: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontWeight: 'var(--joy-fontWeight-md)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-xl)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontWeight: getCssVar('fontWeight-md'),
+        fontSize: getCssVar('fontSize-xl'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-primary'),
       },
       h6: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontWeight: 'var(--joy-fontWeight-md)' as CSSProperties['fontWeight'],
-        fontSize: 'var(--joy-fontSize-lg)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontWeight: getCssVar('fontWeight-md'),
+        fontSize: getCssVar('fontSize-lg'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-primary'),
       },
       body1: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontSize: 'var(--joy-fontSize-md)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-primary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontSize: getCssVar('fontSize-md'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-primary'),
       },
       body2: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontSize: 'var(--joy-fontSize-sm)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-secondary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontSize: getCssVar('fontSize-sm'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-secondary'),
       },
       body3: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontSize: 'var(--joy-fontSize-xs)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-tertiary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontSize: getCssVar('fontSize-xs'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-tertiary'),
       },
       body4: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontSize: 'var(--joy-fontSize-xs2)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-tertiary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontSize: getCssVar('fontSize-xs2'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-tertiary'),
       },
       body5: {
-        fontFamily: 'var(--joy-fontFamily-body)',
-        fontSize: 'var(--joy-fontSize-xs3)',
-        lineHeight: 'var(--joy-lineHeight-md)',
-        color: 'var(--joy-palette-text-tertiary)',
+        fontFamily: getCssVar('fontFamily-body'),
+        fontSize: getCssVar('fontSize-xs3'),
+        lineHeight: getCssVar('lineHeight-md'),
+        color: getCssVar('palette-text-tertiary'),
       },
     },
   };
@@ -488,6 +528,9 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
   const { colorSchemes, ...mergedScales } = scalesInput
     ? deepmerge(defaultScales, scalesInput)
     : defaultScales;
+
+  const { palette: firstColorSchemePalette } = Object.entries(colorSchemes)[0][1];
+  const variantInput = { getCssVar, palette: firstColorSchemePalette };
 
   const theme = {
     colorSchemes,
@@ -525,7 +568,28 @@ export default function extendTheme(themeInput?: ThemeInput): Theme {
       } as Components<Theme>,
       componentsInput,
     ),
-    getCssVar: createGetCssVar('joy'),
+    variants: deepmerge(
+      {
+        plain: createVariant('plain', variantInput),
+        plainHover: createVariant('plainHover', variantInput),
+        plainActive: createVariant('plainActive', variantInput),
+        plainDisabled: createVariant('plainDisabled', variantInput),
+        outlined: createVariant('outlined', variantInput),
+        outlinedHover: createVariant('outlinedHover', variantInput),
+        outlinedActive: createVariant('outlinedActive', variantInput),
+        outlinedDisabled: createVariant('outlinedDisabled', variantInput),
+        soft: createVariant('soft', variantInput),
+        softHover: createVariant('softHover', variantInput),
+        softActive: createVariant('softActive', variantInput),
+        softDisabled: createVariant('softDisabled', variantInput),
+        solid: createVariant('solid', variantInput),
+        solidHover: createVariant('solidHover', variantInput),
+        solidActive: createVariant('solidActive', variantInput),
+        solidDisabled: createVariant('solidDisabled', variantInput),
+      },
+      variantsInput,
+    ),
+    getCssVar,
     spacing: createSpacing(spacing),
   } as unknown as Theme; // Need type casting due to module augmentation inside the repo
 

--- a/packages/mui-joy/src/styles/index.ts
+++ b/packages/mui-joy/src/styles/index.ts
@@ -51,7 +51,12 @@ export type {
   VariantProp,
 } from './types/variants';
 export type { Theme } from './types/theme';
-export { CssVarsProvider, useColorScheme, getInitColorSchemeScript } from './CssVarsProvider';
+export {
+  CssVarsProvider,
+  useColorScheme,
+  getInitColorSchemeScript,
+  shouldSkipGeneratingVar,
+} from './CssVarsProvider';
 export { default as styled } from './styled';
 export { default as ThemeProvider } from './ThemeProvider';
 export * from './ThemeProvider';

--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -63,7 +63,7 @@ export interface Theme extends ThemeScales, RuntimeColorSystem {
   variants: Variants;
   spacing: Spacing;
   breakpoints: Breakpoints;
-  prefix: string;
+  cssVarPrefix: string;
   vars: ThemeVars;
   getCssVar: <CustomVar extends string = never>(
     field: ThemeCSSVar | CustomVar,

--- a/packages/mui-joy/src/styles/variantUtils.test.js
+++ b/packages/mui-joy/src/styles/variantUtils.test.js
@@ -364,6 +364,7 @@ describe('variant utils', () => {
     it('automatically create solid overrides if the variable is in the correct format', () => {
       const result = createContainedOverrides({
         prefix: 'foo',
+        getCssVar: createGetCssVar('foo'),
         palette: {
           primary: {
             plainColor: '',

--- a/packages/mui-joy/src/styles/variantUtils.test.js
+++ b/packages/mui-joy/src/styles/variantUtils.test.js
@@ -6,6 +6,7 @@ import {
   createVariant,
   createContainedOverrides,
 } from './variantUtils';
+import { createGetCssVar } from './extendTheme';
 
 describe('variant utils', () => {
   it('isVariantPalette', () => {
@@ -302,28 +303,22 @@ describe('variant utils', () => {
   describe('createVariant', () => {
     it('should only create style with properties from palette variables', () => {
       const result = createVariant('outlinedActive', {
+        getCssVar: createGetCssVar('joy'),
         palette: {
           primary: {
             outlinedActiveBorder: 'some-color',
             outlinedActiveBg: null, // background-color will not be created
           },
         },
-        vars: {
-          palette: {
-            primary: {
-              outlinedActiveBorder: 'var(--any-token)',
-              outlinedActiveBg: 'var(--any-token)',
-            },
-          },
-        },
       });
       expect(result.primary).to.deep.include({
-        borderColor: 'var(--any-token)',
+        borderColor: 'var(--joy-palette-primary-outlinedActiveBorder)',
       });
     });
 
     it('automatically create variant style if the variable is in the correct format', () => {
       const theme = {
+        getCssVar: createGetCssVar('joy'),
         palette: {
           customColor: {
             softColor: 'some-color',
@@ -331,26 +326,17 @@ describe('variant utils', () => {
             softHoverColor: 'some-color',
           },
         },
-        vars: {
-          palette: {
-            customColor: {
-              softColor: 'var(--any-token)',
-              softBg: 'var(--any-token)',
-              softHoverColor: 'var(--any-token)',
-            },
-          },
-        },
       };
       const softResult = createVariant('soft', theme);
       expect(softResult.customColor).to.deep.include({
-        color: 'var(--any-token)',
-        backgroundColor: 'var(--any-token)',
+        color: 'var(--joy-palette-customColor-softColor)',
+        backgroundColor: 'var(--joy-palette-customColor-softBg)',
       });
 
       const softHoverResult = createVariant('softHover', theme);
       expect(softHoverResult.customColor).to.deep.include({
         cursor: 'pointer',
-        color: 'var(--any-token)',
+        color: 'var(--joy-palette-customColor-softHoverColor)',
       });
     });
 

--- a/packages/mui-joy/src/styles/variantUtils.ts
+++ b/packages/mui-joy/src/styles/variantUtils.ts
@@ -1,4 +1,4 @@
-import { CSSObject, unstable_createGetCssVar as createGetCssVar } from '@mui/system';
+import { CSSObject } from '@mui/system';
 import { DefaultColorPalette, PaletteVariant, PaletteRange } from './types/colorSystem';
 import { VariantKey } from './types/variants';
 
@@ -101,8 +101,8 @@ interface ThemeFragment {
 }
 
 export const createTextOverrides = (theme: ThemeFragment) => {
-  const getCssVar = createGetCssVar(theme.prefix);
-  const prefixVar = createPrefixVar(theme.prefix);
+  const { prefix, getCssVar } = theme;
+  const prefixVar = createPrefixVar(prefix);
   let result = {} as Record<DefaultColorPalette, CSSObject>;
   Object.entries(theme.palette).forEach((entry) => {
     const [color, colorPalette] = entry as [
@@ -128,8 +128,8 @@ export const createTextOverrides = (theme: ThemeFragment) => {
 };
 
 export const createContainedOverrides = (theme: ThemeFragment) => {
-  const getCssVar = createGetCssVar(theme.prefix);
-  const prefixVar = createPrefixVar(theme.prefix);
+  const { prefix, getCssVar } = theme;
+  const prefixVar = createPrefixVar(prefix);
   let result = {} as Record<DefaultColorPalette, CSSObject>;
   Object.entries(theme.palette).forEach((entry) => {
     const [color, colorPalette] = entry as [

--- a/packages/mui-joy/src/styles/variantUtils.ts
+++ b/packages/mui-joy/src/styles/variantUtils.ts
@@ -94,13 +94,13 @@ export const createVariantStyle = (
   return result;
 };
 
-interface Theme {
+interface ThemeFragment {
   prefix?: string;
-  palette: Record<DefaultColorPalette, PaletteRange>;
-  vars: { palette: Record<DefaultColorPalette, PaletteRange> };
+  getCssVar: (...args: string[]) => string;
+  palette: Record<string, any>;
 }
 
-export const createTextOverrides = (theme: Theme) => {
+export const createTextOverrides = (theme: ThemeFragment) => {
   const getCssVar = createGetCssVar(theme.prefix);
   const prefixVar = createPrefixVar(theme.prefix);
   let result = {} as Record<DefaultColorPalette, CSSObject>;
@@ -127,7 +127,7 @@ export const createTextOverrides = (theme: Theme) => {
   return result;
 };
 
-export const createContainedOverrides = (theme: Theme) => {
+export const createContainedOverrides = (theme: ThemeFragment) => {
   const getCssVar = createGetCssVar(theme.prefix);
   const prefixVar = createPrefixVar(theme.prefix);
   let result = {} as Record<DefaultColorPalette, CSSObject>;
@@ -179,25 +179,20 @@ export const createContainedOverrides = (theme: Theme) => {
   return result;
 };
 
-export const createVariant = (variant: VariantKey, theme?: Theme) => {
+export const createVariant = (variant: VariantKey, theme?: ThemeFragment) => {
   let result = {} as Record<DefaultColorPalette | 'context', CSSObject>;
-
   if (theme) {
-    Object.entries(theme.palette).forEach((entry) => {
+    const { getCssVar, palette } = theme;
+    Object.entries(palette).forEach((entry) => {
       const [color, colorPalette] = entry as [
         Exclude<DefaultColorPalette, 'context'>,
         string | number | Record<string, any>,
       ];
-      if (isVariantPalette(colorPalette)) {
+      if (isVariantPalette(colorPalette) && typeof colorPalette === 'object') {
         result = {
           ...result,
-          [color]: createVariantStyle(
-            variant,
-            // cannot use theme.vars because it is created from all color schemes.
-            // @example developer provides `primary.outlinedActiveBorder` to only dark mode.
-            //          theme.vars.palette.primary.outlinedActiveBorder always exists regardless of the current color scheme.
-            theme.palette[color],
-            (variantVar) => theme.vars.palette[color][variantVar],
+          [color]: createVariantStyle(variant, colorPalette, (variantVar) =>
+            getCssVar(`palette-${color}-${variantVar}`),
           ),
         };
       }

--- a/packages/mui-material/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-material/src/styles/CssVarsProvider.tsx
@@ -6,6 +6,10 @@ import experimental_extendTheme, {
 } from './experimental_extendTheme';
 import createTypography from './createTypography';
 
+const shouldSkipGeneratingVar = (keys: string[]) =>
+  !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
+  (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/));
+
 const defaultTheme = experimental_extendTheme();
 
 const {
@@ -30,9 +34,12 @@ const {
 
     return newTheme;
   },
-  shouldSkipGeneratingVar: (keys) =>
-    !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
-    (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/)),
+  shouldSkipGeneratingVar,
 });
 
-export { useColorScheme, getInitColorSchemeScript, Experimental_CssVarsProvider };
+export {
+  useColorScheme,
+  getInitColorSchemeScript,
+  Experimental_CssVarsProvider,
+  shouldSkipGeneratingVar,
+};

--- a/packages/mui-material/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-material/src/styles/CssVarsProvider.tsx
@@ -25,7 +25,6 @@ const {
     light: 'light',
     dark: 'dark',
   },
-  prefix: 'mui',
   resolveTheme: (theme) => {
     const newTheme = {
       ...theme,

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -256,6 +256,10 @@ export interface ColorSystem {
 }
 
 export interface CssVarsThemeOptions extends Omit<ThemeOptions, 'palette' | 'components'> {
+  /**
+   * Prefix of the generated CSS variables
+   * @default 'mui'
+   */
   cssVarPrefix?: string;
   components?: Components<Omit<CssVarsTheme, 'components'>>;
   colorSchemes?: Partial<Record<SupportedColorScheme, ColorSystemOptions>>;

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -256,6 +256,7 @@ export interface ColorSystem {
 }
 
 export interface CssVarsThemeOptions extends Omit<ThemeOptions, 'palette' | 'components'> {
+  cssVarPrefix?: string;
   components?: Components<Omit<CssVarsTheme, 'components'>>;
   colorSchemes?: Partial<Record<SupportedColorScheme, ColorSystemOptions>>;
 }
@@ -284,7 +285,7 @@ export {};
 export interface CssVarsTheme extends Omit<Theme, 'palette' | 'components'>, ColorSystem {
   components?: Components<Omit<CssVarsTheme, 'components'>>;
   colorSchemes: Record<SupportedColorScheme, ColorSystem>;
-  prefix: string;
+  cssVarPrefix: string;
   vars: ThemeVars;
   getCssVar: <CustomVar extends string = never>(
     field: string | CustomVar,

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -1,5 +1,12 @@
 import { deepmerge } from '@mui/utils';
-import { colorChannel, alpha, darken, lighten, emphasize } from '@mui/system';
+import {
+  colorChannel,
+  alpha,
+  darken,
+  lighten,
+  emphasize,
+  unstable_createGetCssVar as systemCreateGetCssVar,
+} from '@mui/system';
 import createThemeWithoutVars from './createTheme';
 import { getOverlayAlpha } from '../Paper/Paper';
 
@@ -23,8 +30,11 @@ function setColor(obj, key, defaultValue) {
   obj[key] = obj[key] || defaultValue;
 }
 
+export const createGetCssVar = (cssVarPrefix = 'mui') => systemCreateGetCssVar(cssVarPrefix);
+
 export default function extendTheme(options = {}, ...args) {
-  const { colorSchemes: colorSchemesInput = {}, ...input } = options;
+  const { colorSchemes: colorSchemesInput = {}, cssVarPrefix = 'mui', ...input } = options;
+  const getCssVar = createGetCssVar(cssVarPrefix);
 
   const { palette: lightPalette, ...muiTheme } = createThemeWithoutVars({
     ...input,
@@ -36,6 +46,7 @@ export default function extendTheme(options = {}, ...args) {
 
   let theme = {
     ...muiTheme,
+    cssVarPrefix,
     colorSchemes: {
       ...colorSchemesInput,
       light: {
@@ -100,10 +111,10 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Alert, 'infoColor', darken(palette.info.light, 0.6));
       setColor(palette.Alert, 'successColor', darken(palette.success.light, 0.6));
       setColor(palette.Alert, 'warningColor', darken(palette.warning.light, 0.6));
-      setColor(palette.Alert, 'errorFilledBg', 'var(--mui-palette-error-main)');
-      setColor(palette.Alert, 'infoFilledBg', 'var(--mui-palette-info-main)');
-      setColor(palette.Alert, 'successFilledBg', 'var(--mui-palette-success-main)');
-      setColor(palette.Alert, 'warningFilledBg', 'var(--mui-palette-warning-main)');
+      setColor(palette.Alert, 'errorFilledBg', getCssVar('palette-error-main'));
+      setColor(palette.Alert, 'infoFilledBg', getCssVar('palette-info-main'));
+      setColor(palette.Alert, 'successFilledBg', getCssVar('palette-success-main'));
+      setColor(palette.Alert, 'warningFilledBg', getCssVar('palette-warning-main'));
       setColor(palette.Alert, 'errorFilledColor', lightPalette.getContrastText(palette.error.main));
       setColor(palette.Alert, 'infoFilledColor', lightPalette.getContrastText(palette.info.main));
       setColor(
@@ -120,15 +131,15 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Alert, 'infoStandardBg', lighten(palette.info.light, 0.9));
       setColor(palette.Alert, 'successStandardBg', lighten(palette.success.light, 0.9));
       setColor(palette.Alert, 'warningStandardBg', lighten(palette.warning.light, 0.9));
-      setColor(palette.Alert, 'errorIconColor', 'var(--mui-palette-error-light)');
-      setColor(palette.Alert, 'infoIconColor', 'var(--mui-palette-info-light)');
-      setColor(palette.Alert, 'successIconColor', 'var(--mui-palette-success-light)');
-      setColor(palette.Alert, 'warningIconColor', 'var(--mui-palette-warning-light)');
-      setColor(palette.AppBar, 'defaultBg', 'var(--mui-palette-grey-100)');
-      setColor(palette.Avatar, 'defaultBg', 'var(--mui-palette-grey-400)');
-      setColor(palette.Chip, 'defaultBorder', 'var(--mui-palette-grey-400)');
-      setColor(palette.Chip, 'defaultAvatarColor', 'var(--mui-palette-grey-700)');
-      setColor(palette.Chip, 'defaultIconColor', 'var(--mui-palette-grey-700)');
+      setColor(palette.Alert, 'errorIconColor', getCssVar('palette-error-light'));
+      setColor(palette.Alert, 'infoIconColor', getCssVar('palette-info-light'));
+      setColor(palette.Alert, 'successIconColor', getCssVar('palette-success-light'));
+      setColor(palette.Alert, 'warningIconColor', getCssVar('palette-warning-light'));
+      setColor(palette.AppBar, 'defaultBg', getCssVar('palette-grey-100'));
+      setColor(palette.Avatar, 'defaultBg', getCssVar('palette-grey-400'));
+      setColor(palette.Chip, 'defaultBorder', getCssVar('palette-grey-400'));
+      setColor(palette.Chip, 'defaultAvatarColor', getCssVar('palette-grey-700'));
+      setColor(palette.Chip, 'defaultIconColor', getCssVar('palette-grey-700'));
       setColor(palette.FilledInput, 'bg', 'rgba(0, 0, 0, 0.06)');
       setColor(palette.FilledInput, 'hoverBg', 'rgba(0, 0, 0, 0.09)');
       setColor(palette.FilledInput, 'disabledBg', 'rgba(0, 0, 0, 0.12)');
@@ -147,10 +158,10 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Slider, 'warningTrack', lighten(palette.warning.main, 0.62));
       setColor(palette.SnackbarContent, 'bg', emphasize(palette.background.default, 0.8));
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
-      setColor(palette.StepConnector, 'border', 'var(--mui-palette-grey-400)');
-      setColor(palette.StepContent, 'border', 'var(--mui-palette-grey-400)');
-      setColor(palette.Switch, 'defaultColor', 'var(--mui-palette-common-white)');
-      setColor(palette.Switch, 'defaultDisabledColor', 'var(--mui-palette-grey-100)');
+      setColor(palette.StepConnector, 'border', getCssVar('palette-grey-400'));
+      setColor(palette.StepContent, 'border', getCssVar('palette-grey-400'));
+      setColor(palette.Switch, 'defaultColor', getCssVar('palette-common-white'));
+      setColor(palette.Switch, 'defaultDisabledColor', getCssVar('palette-grey-100'));
       setColor(palette.Switch, 'primaryDisabledColor', lighten(palette.primary.main, 0.62));
       setColor(palette.Switch, 'secondaryDisabledColor', lighten(palette.secondary.main, 0.62));
       setColor(palette.Switch, 'errorDisabledColor', lighten(palette.error.main, 0.62));
@@ -164,10 +175,10 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Alert, 'infoColor', lighten(palette.info.light, 0.6));
       setColor(palette.Alert, 'successColor', lighten(palette.success.light, 0.6));
       setColor(palette.Alert, 'warningColor', lighten(palette.warning.light, 0.6));
-      setColor(palette.Alert, 'errorFilledBg', 'var(--mui-palette-error-dark)');
-      setColor(palette.Alert, 'infoFilledBg', 'var(--mui-palette-info-dark)');
-      setColor(palette.Alert, 'successFilledBg', 'var(--mui-palette-success-dark)');
-      setColor(palette.Alert, 'warningFilledBg', 'var(--mui-palette-warning-dark)');
+      setColor(palette.Alert, 'errorFilledBg', getCssVar('palette-error-dark'));
+      setColor(palette.Alert, 'infoFilledBg', getCssVar('palette-info-dark'));
+      setColor(palette.Alert, 'successFilledBg', getCssVar('palette-success-dark'));
+      setColor(palette.Alert, 'warningFilledBg', getCssVar('palette-warning-dark'));
       setColor(palette.Alert, 'errorFilledColor', darkPalette.getContrastText(palette.error.dark));
       setColor(palette.Alert, 'infoFilledColor', darkPalette.getContrastText(palette.info.dark));
       setColor(
@@ -184,17 +195,17 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Alert, 'infoStandardBg', darken(palette.info.light, 0.9));
       setColor(palette.Alert, 'successStandardBg', darken(palette.success.light, 0.9));
       setColor(palette.Alert, 'warningStandardBg', darken(palette.warning.light, 0.9));
-      setColor(palette.Alert, 'errorIconColor', 'var(--mui-palette-error-main)');
-      setColor(palette.Alert, 'infoIconColor', 'var(--mui-palette-info-main)');
-      setColor(palette.Alert, 'successIconColor', 'var(--mui-palette-success-main)');
-      setColor(palette.Alert, 'warningIconColor', 'var(--mui-palette-warning-main)');
-      setColor(palette.AppBar, 'defaultBg', 'var(--mui-palette-grey-900)');
-      setColor(palette.AppBar, 'darkBg', 'var(--mui-palette-background-paper)'); // specific for dark mode
-      setColor(palette.AppBar, 'darkColor', 'var(--mui-palette-text-primary)'); // specific for dark mode
-      setColor(palette.Avatar, 'defaultBg', 'var(--mui-palette-grey-600)');
-      setColor(palette.Chip, 'defaultBorder', 'var(--mui-palette-grey-700)');
-      setColor(palette.Chip, 'defaultAvatarColor', 'var(--mui-palette-grey-300)');
-      setColor(palette.Chip, 'defaultIconColor', 'var(--mui-palette-grey-300)');
+      setColor(palette.Alert, 'errorIconColor', getCssVar('palette-error-main'));
+      setColor(palette.Alert, 'infoIconColor', getCssVar('palette-info-main'));
+      setColor(palette.Alert, 'successIconColor', getCssVar('palette-success-main'));
+      setColor(palette.Alert, 'warningIconColor', getCssVar('palette-warning-main'));
+      setColor(palette.AppBar, 'defaultBg', getCssVar('palette-grey-900'));
+      setColor(palette.AppBar, 'darkBg', getCssVar('palette-background-paper')); // specific for dark mode
+      setColor(palette.AppBar, 'darkColor', getCssVar('palette-text-primary')); // specific for dark mode
+      setColor(palette.Avatar, 'defaultBg', getCssVar('palette-grey-600'));
+      setColor(palette.Chip, 'defaultBorder', getCssVar('palette-grey-700'));
+      setColor(palette.Chip, 'defaultAvatarColor', getCssVar('palette-grey-300'));
+      setColor(palette.Chip, 'defaultIconColor', getCssVar('palette-grey-300'));
       setColor(palette.FilledInput, 'bg', 'rgba(255, 255, 255, 0.09)');
       setColor(palette.FilledInput, 'hoverBg', 'rgba(255, 255, 255, 0.13)');
       setColor(palette.FilledInput, 'disabledBg', 'rgba(255, 255, 255, 0.12)');
@@ -213,10 +224,10 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.Slider, 'warningTrack', darken(palette.warning.main, 0.5));
       setColor(palette.SnackbarContent, 'bg', emphasize(palette.background.default, 0.98));
       setColor(palette.SpeedDialAction, 'fabHoverBg', emphasize(palette.background.paper, 0.15));
-      setColor(palette.StepConnector, 'border', 'var(--mui-palette-grey-600)');
-      setColor(palette.StepContent, 'border', 'var(--mui-palette-grey-600)');
-      setColor(palette.Switch, 'defaultColor', 'var(--mui-palette-grey-300)');
-      setColor(palette.Switch, 'defaultDisabledColor', 'var(--mui-palette-grey-600)');
+      setColor(palette.StepConnector, 'border', getCssVar('palette-grey-600'));
+      setColor(palette.StepContent, 'border', getCssVar('palette-grey-600'));
+      setColor(palette.Switch, 'defaultColor', getCssVar('palette-grey-300'));
+      setColor(palette.Switch, 'defaultDisabledColor', getCssVar('palette-grey-600'));
       setColor(palette.Switch, 'primaryDisabledColor', darken(palette.primary.main, 0.55));
       setColor(palette.Switch, 'secondaryDisabledColor', darken(palette.secondary.main, 0.55));
       setColor(palette.Switch, 'errorDisabledColor', darken(palette.error.main, 0.55));

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -149,7 +149,7 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.LinearProgress, 'infoBg', lighten(palette.info.main, 0.62));
       setColor(palette.LinearProgress, 'successBg', lighten(palette.success.main, 0.62));
       setColor(palette.LinearProgress, 'warningBg', lighten(palette.warning.main, 0.62));
-      setColor(palette.Skeleton, 'bg', 'rgba(var(--mui-palette-text-primaryChannel) / 0.11)');
+      setColor(palette.Skeleton, 'bg', `rgba(${getCssVar('palette-text-primaryChannel')} / 0.11)`);
       setColor(palette.Slider, 'primaryTrack', lighten(palette.primary.main, 0.62));
       setColor(palette.Slider, 'secondaryTrack', lighten(palette.secondary.main, 0.62));
       setColor(palette.Slider, 'errorTrack', lighten(palette.error.main, 0.62));
@@ -215,7 +215,7 @@ export default function extendTheme(options = {}, ...args) {
       setColor(palette.LinearProgress, 'infoBg', darken(palette.info.main, 0.5));
       setColor(palette.LinearProgress, 'successBg', darken(palette.success.main, 0.5));
       setColor(palette.LinearProgress, 'warningBg', darken(palette.warning.main, 0.5));
-      setColor(palette.Skeleton, 'bg', 'rgba(var(--mui-palette-text-primaryChannel) / 0.13)');
+      setColor(palette.Skeleton, 'bg', `rgba(${getCssVar('palette-text-primaryChannel')} / 0.13)`);
       setColor(palette.Slider, 'primaryTrack', darken(palette.primary.main, 0.5));
       setColor(palette.Slider, 'secondaryTrack', darken(palette.secondary.main, 0.5));
       setColor(palette.Slider, 'errorTrack', darken(palette.error.main, 0.5));

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -47,6 +47,7 @@ export default function extendTheme(options = {}, ...args) {
   let theme = {
     ...muiTheme,
     cssVarPrefix,
+    getCssVar,
     colorSchemes: {
       ...colorSchemesInput,
       light: {

--- a/packages/mui-material/src/styles/experimental_extendTheme.test.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.test.js
@@ -393,4 +393,16 @@ describe('experimental_extendTheme', () => {
     );
     expect(container.firstChild).toHaveComputedStyle({ fontFamily: 'cursive' });
   });
+
+  describe('css var prefix', () => {
+    it('has mui as default css var prefix', () => {
+      const theme = extendTheme();
+      expect(theme.cssVarPrefix).to.equal('mui');
+    });
+
+    it('custom css var prefix', () => {
+      const theme = extendTheme({ cssVarPrefix: 'foo' });
+      expect(theme.cssVarPrefix).to.equal('foo');
+    });
+  });
 });

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -92,11 +92,6 @@ export default function createCssVarsProvider<
 >(
   options: CssVarsProviderConfig<ColorScheme> & {
     /**
-     * CSS variable prefix
-     * @default ''
-     */
-    prefix?: string;
-    /**
      * Design system default theme
      *
      * The structure inside `theme.colorSchemes[colorScheme]` should be exactly the same in all color schemes because

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -45,10 +45,13 @@ export interface CssVarsProviderConfig<ColorScheme extends string> {
    */
   enableColorScheme?: boolean;
   /**
-   * CSS variable prefix
-   * @default ''
+   * A function to determine if the key, value should be attached as CSS Variable
+   * `keys` is an array that represents the object path keys.
+   *  Ex, if the theme is { foo: { bar: 'var(--test)' } }
+   *  then, keys = ['foo', 'bar']
+   *        value = 'var(--test)'
    */
-  prefix?: string;
+  shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
 }
 
 export interface CreateCssVarsProviderResult<ColorScheme extends string, ThemeInput> {
@@ -89,6 +92,11 @@ export default function createCssVarsProvider<
 >(
   options: CssVarsProviderConfig<ColorScheme> & {
     /**
+     * CSS variable prefix
+     * @default ''
+     */
+    prefix?: string;
+    /**
      * Design system default theme
      *
      * The structure inside `theme.colorSchemes[colorScheme]` should be exactly the same in all color schemes because
@@ -114,14 +122,6 @@ export default function createCssVarsProvider<
      *  }
      */
     theme: any;
-    /**
-     * A function to determine if the key, value should be attached as CSS Variable
-     * `keys` is an array that represents the object path keys.
-     *  Ex, if the theme is { foo: { bar: 'var(--test)' } }
-     *  then, keys = ['foo', 'bar']
-     *        value = 'var(--test)'
-     */
-    shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
     /**
      * A function to be called after the CSS variables are attached. The result of this function will be the final theme pass to ThemeProvider.
      *

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -27,7 +27,7 @@ export default function createCssVarsProvider(options) {
     disableTransitionOnChange: designSystemTransitionOnChange = false,
     enableColorScheme: designSystemEnableColorScheme = true,
     prefix: designSystemPrefix = '',
-    shouldSkipGeneratingVar,
+    shouldSkipGeneratingVar: designSystemShouldSkipGeneratingVar,
     resolveTheme,
   } = options;
 
@@ -55,7 +55,6 @@ export default function createCssVarsProvider(options) {
   function CssVarsProvider({
     children,
     theme: themeProp = defaultTheme,
-    prefix = designSystemPrefix,
     modeStorageKey = defaultModeStorageKey,
     colorSchemeStorageKey = defaultColorSchemeStorageKey,
     attribute = defaultAttribute,
@@ -67,10 +66,16 @@ export default function createCssVarsProvider(options) {
     documentNode = typeof document === 'undefined' ? undefined : document,
     colorSchemeNode = typeof document === 'undefined' ? undefined : document.documentElement,
     colorSchemeSelector = ':root',
+    shouldSkipGeneratingVar = designSystemShouldSkipGeneratingVar,
   }) {
     const hasMounted = React.useRef(false);
 
-    const { colorSchemes = {}, components = {}, ...restThemeProp } = themeProp;
+    const {
+      colorSchemes = {},
+      components = {},
+      cssVarPrefix = designSystemPrefix,
+      ...restThemeProp
+    } = themeProp;
     const allColorSchemes = Object.keys(colorSchemes);
     const defaultLightColorScheme =
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.light;
@@ -111,7 +116,7 @@ export default function createCssVarsProvider(options) {
       vars: rootVars,
       parsedTheme,
     } = cssVarsParser(theme, {
-      prefix,
+      prefix: cssVarPrefix,
       basePrefix: designSystemPrefix,
       shouldSkipGeneratingVar,
     });
@@ -120,9 +125,9 @@ export default function createCssVarsProvider(options) {
       ...parsedTheme,
       components,
       colorSchemes,
-      prefix,
+      cssVarPrefix,
       vars: rootVars,
-      getCssVar: createGetCssVar(prefix),
+      getCssVar: createGetCssVar(cssVarPrefix),
       getColorSchemeSelector: (targetColorScheme) => `[${attribute}="${targetColorScheme}"] &`,
     };
 
@@ -135,7 +140,7 @@ export default function createCssVarsProvider(options) {
         vars,
         parsedTheme: parsedScheme,
       } = cssVarsParser(scheme, {
-        prefix,
+        prefix: cssVarPrefix,
         basePrefix: designSystemPrefix,
         shouldSkipGeneratingVar,
       });
@@ -286,9 +291,9 @@ export default function createCssVarsProvider(options) {
      */
     modeStorageKey: PropTypes.string,
     /**
-     * CSS variable prefix.
+     * A function to determine if the key, value should be attached as CSS Variable
      */
-    prefix: PropTypes.string,
+    shouldSkipGeneratingVar: PropTypes.func,
     /**
      * The window that attaches the 'storage' event listener
      * @default window

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -11,7 +11,6 @@ import systemGetInitColorSchemeScript, {
   DEFAULT_MODE_STORAGE_KEY,
 } from './getInitColorSchemeScript';
 import useCurrentColorScheme from './useCurrentColorScheme';
-import createGetCssVar from './createGetCssVar';
 
 export const DISABLE_CSS_TRANSITION =
   '*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}';
@@ -120,7 +119,6 @@ export default function createCssVarsProvider(options) {
       colorSchemes,
       cssVarPrefix,
       vars: rootVars,
-      getCssVar: createGetCssVar(cssVarPrefix),
       getColorSchemeSelector: (targetColorScheme) => `[${attribute}="${targetColorScheme}"] &`,
     };
 

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -26,7 +26,6 @@ export default function createCssVarsProvider(options) {
     defaultColorScheme: designSystemColorScheme,
     disableTransitionOnChange: designSystemTransitionOnChange = false,
     enableColorScheme: designSystemEnableColorScheme = true,
-    prefix: designSystemPrefix = '',
     shouldSkipGeneratingVar: designSystemShouldSkipGeneratingVar,
     resolveTheme,
   } = options;
@@ -70,12 +69,7 @@ export default function createCssVarsProvider(options) {
   }) {
     const hasMounted = React.useRef(false);
 
-    const {
-      colorSchemes = {},
-      components = {},
-      cssVarPrefix = designSystemPrefix,
-      ...restThemeProp
-    } = themeProp;
+    const { colorSchemes = {}, components = {}, cssVarPrefix, ...restThemeProp } = themeProp;
     const allColorSchemes = Object.keys(colorSchemes);
     const defaultLightColorScheme =
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.light;
@@ -117,7 +111,6 @@ export default function createCssVarsProvider(options) {
       parsedTheme,
     } = cssVarsParser(theme, {
       prefix: cssVarPrefix,
-      basePrefix: designSystemPrefix,
       shouldSkipGeneratingVar,
     });
 
@@ -141,7 +134,6 @@ export default function createCssVarsProvider(options) {
         parsedTheme: parsedScheme,
       } = cssVarsParser(scheme, {
         prefix: cssVarPrefix,
-        basePrefix: designSystemPrefix,
         shouldSkipGeneratingVar,
       });
       theme.vars = deepmerge(theme.vars, vars);

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -74,48 +74,6 @@ describe('createCssVarsProvider', () => {
       expect(screen.getByTestId('current-color-scheme').textContent).to.equal('light');
     });
 
-    it('has CSS variable prefix', () => {
-      const { CssVarsProvider } = createCssVarsProvider({
-        theme: {
-          colorSchemes: { light: { fontSize: 16 } },
-        },
-        defaultColorScheme: 'light',
-        prefix: 'mui',
-      });
-      const Text = () => {
-        const theme = useTheme();
-        return <div data-testid={`text`}>{theme.vars.fontSize}</div>;
-      };
-      render(
-        <CssVarsProvider>
-          <Text />
-        </CssVarsProvider>,
-      );
-
-      expect(screen.getByTestId('text').textContent).to.equal('var(--mui-fontSize)');
-    });
-
-    it('provide getCssVar util', () => {
-      const { CssVarsProvider } = createCssVarsProvider({
-        theme: {
-          colorSchemes: { light: { palette: { primary: { 500: '#ff5252' } } } },
-        },
-        defaultColorScheme: 'light',
-        prefix: 'mui',
-      });
-      const Text = () => {
-        const theme = useTheme();
-        return <div data-testid={`text`}>{theme.getCssVar('palette-primary-500')}</div>;
-      };
-      render(
-        <CssVarsProvider>
-          <Text />
-        </CssVarsProvider>,
-      );
-
-      expect(screen.getByTestId('text').textContent).to.equal('var(--mui-palette-primary-500)');
-    });
-
     it('provide getColorSchemeSelector util', () => {
       const { CssVarsProvider } = createCssVarsProvider({
         theme: {
@@ -851,7 +809,6 @@ describe('createCssVarsProvider', () => {
           colorSchemes: { light: { fontSize: 16 } },
         },
         defaultColorScheme: 'light',
-        prefix: 'mui',
       });
       const Text = () => {
         const theme = useTheme();

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -858,7 +858,12 @@ describe('createCssVarsProvider', () => {
         return <div data-testid={`text`}>{theme.vars.fontSize}</div>;
       };
       render(
-        <CssVarsProvider prefix="foo-bar">
+        <CssVarsProvider
+          theme={{
+            cssVarPrefix: 'foo-bar',
+            colorSchemes: { light: { fontSize: 16 } },
+          }}
+        >
           <Text />
         </CssVarsProvider>,
       );

--- a/packages/mui-system/src/cssVars/createGetCssVar.ts
+++ b/packages/mui-system/src/cssVars/createGetCssVar.ts
@@ -20,9 +20,9 @@ export default function createGetCssVar<T extends string = string>(prefix: strin
   // AdditionalVars makes `getCssVar` less strict, so it can be use like this `getCssVar('non-mui-variable')` without type error.
   const getCssVar = <AdditionalVars extends string = never>(
     field: T | AdditionalVars,
-    ...vars: (T | AdditionalVars)[]
+    ...fallbacks: (T | AdditionalVars)[]
   ) => {
-    return `var(--${prefix ? `${prefix}-` : ''}${field}${appendVar(...vars)})`;
+    return `var(--${prefix ? `${prefix}-` : ''}${field}${appendVar(...fallbacks)})`;
   };
   return getCssVar;
 }

--- a/packages/mui-system/src/cssVars/cssVarsParser.test.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.test.ts
@@ -162,61 +162,8 @@ describe('cssVarsParser', () => {
         prefix: 'foo-bar',
       });
       expect(css).to.deep.equal({
-        '--foo-bar-bg': 'var(--foo-bar-palette-neutral-50)',
-        '--foo-bar-text-heading':
-          'var(--foo-bar-palette-primary-500, var(--foo-bar-palette-neutral-500))',
-      });
-    });
-
-    it('replace default prefix if provided', () => {
-      const theme = {
-        fontFamily: {
-          body: '"Public Sans", var( --joy-fontFamily-fallback)',
-          display: '"Public Sans", var(    --joy-fontFamily-fallback)',
-        },
-      };
-      const { css } = cssVarsParser(theme, {
-        prefix: 'foo-bar',
-        basePrefix: 'joy',
-      });
-      expect(css).to.deep.equal({
-        '--foo-bar-fontFamily-body': '"Public Sans", var(--foo-bar-fontFamily-fallback)',
-        '--foo-bar-fontFamily-display': '"Public Sans", var(--foo-bar-fontFamily-fallback)',
-      });
-    });
-
-    it('replace value starts with `var` if basePrefix, prefix are different', () => {
-      const theme = {
-        bg: 'var(--joy-palette-neutral-50)',
-        text: {
-          heading: 'var(--joy-palette-primary-500, var(--joy-palette-neutral-500))',
-        },
-      };
-      const { css } = cssVarsParser(theme, {
-        basePrefix: 'joy',
-        prefix: 'custom',
-      });
-      expect(css).to.deep.equal({
-        '--custom-bg': 'var(--custom-palette-neutral-50)',
-        '--custom-text-heading':
-          'var(--custom-palette-primary-500, var(--custom-palette-neutral-500))',
-      });
-    });
-
-    it('basePrefix in the value is removed if prefix is ""', () => {
-      const theme = {
-        bg: 'var(--joy-palette-neutral-50, var(--joy-colors-white))',
-        text: {
-          heading: 'var(--joy-palette-primary-500)',
-        },
-      };
-      const { css } = cssVarsParser(theme, {
-        basePrefix: 'joy',
-        prefix: '',
-      });
-      expect(css).to.deep.equal({
-        '--bg': 'var(--palette-neutral-50, var(--colors-white))',
-        '--text-heading': 'var(--palette-primary-500)',
+        '--foo-bar-bg': 'var(--palette-neutral-50)',
+        '--foo-bar-text-heading': 'var(--palette-primary-500, var(--palette-neutral-500))',
       });
     });
 
@@ -426,16 +373,16 @@ describe('cssVarsParser', () => {
       expect(parsedTheme).to.deep.equal({
         primary: {
           500: '#ffffff',
-          main: 'var(--foo-palette-500)',
+          main: 'var(--palette-500)',
         },
       });
       expect(parsedTheme2).to.deep.equal({
         primary: {
           500: '#ffffff',
-          main: 'var(--bar-palette-500)',
+          main: 'var(--palette-500)',
         },
       });
-      expect(parsedTheme).not.to.deep.equal(parsedTheme2);
+      expect(parsedTheme).not.to.equal(parsedTheme2);
     });
 
     it('preserve array even if the key is listed in `shouldSkipGeneratingVar`', () => {
@@ -462,58 +409,6 @@ describe('cssVarsParser', () => {
       expect(parsedTheme.pxToRem(16)).to.equal('1rem');
     });
 
-    it('apply prefix to CSS variable value', () => {
-      const { parsedTheme } = cssVarsParser(
-        {
-          palette: {
-            primary: {
-              main: 'var(--palette-token)',
-            },
-            secondary: {
-              main: 'var(--palette-token, var(--palette-token))',
-            },
-          },
-        },
-        { prefix: 'foo' },
-      );
-      expect(parsedTheme).to.deep.equal({
-        palette: {
-          primary: {
-            main: 'var(--foo-palette-token)',
-          },
-          secondary: {
-            main: 'var(--foo-palette-token, var(--foo-palette-token))',
-          },
-        },
-      });
-    });
-
-    it('replace basePrefix with prefix', () => {
-      const { parsedTheme } = cssVarsParser(
-        {
-          palette: {
-            primary: {
-              main: 'var(--foo-palette-token)',
-            },
-            secondary: {
-              main: 'var(--foo-palette-token, var(--foo-palette-token))',
-            },
-          },
-        },
-        { prefix: 'joy', basePrefix: 'foo' },
-      );
-      expect(parsedTheme).to.deep.equal({
-        palette: {
-          primary: {
-            main: 'var(--joy-palette-token)',
-          },
-          secondary: {
-            main: 'var(--joy-palette-token, var(--joy-palette-token))',
-          },
-        },
-      });
-    });
-
     it('all key,values remains in parsedTheme even shouldSkipGeneratingVar is provided', () => {
       const { parsedTheme } = cssVarsParser(
         {
@@ -530,8 +425,8 @@ describe('cssVarsParser', () => {
       expect(parsedTheme.pxToRem(14)).to.equal('0.875rem');
       expect(parsedTheme.typography).to.deep.equal({
         body: {
-          fontSize: 'var(--foo-fontSize-md)',
-          fontFamily: 'Roboto, var(--foo-fontFamily-fallback)',
+          fontSize: 'var(--fontSize-md)',
+          fontFamily: 'Roboto, var(--fontFamily-fallback)',
         },
       });
     });

--- a/test/regressions/fixtures/CssVarsProvider/CssVarsProviderJoy.js
+++ b/test/regressions/fixtures/CssVarsProvider/CssVarsProviderJoy.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CssVarsProvider } from '@mui/joy/styles';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 
@@ -10,10 +10,10 @@ export default function VariantColorJoy() {
       <CssVarsProvider>
         <Button>Button</Button>
       </CssVarsProvider>
-      <CssVarsProvider prefix="foo">
+      <CssVarsProvider theme={extendTheme({ cssVarPrefix: 'foo' })}>
         <Button>Button</Button>
       </CssVarsProvider>
-      <CssVarsProvider prefix="bar">
+      <CssVarsProvider theme={extendTheme({ cssVarPrefix: 'bar' })}>
         <Button>Button</Button>
       </CssVarsProvider>
     </Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Sandbox**: https://codesandbox.io/s/joy-cra-typescript-forked-c9csds?file=/src/App.tsx

## Motivation

From #33275, the community is interested in trying Joy but given the small number of components, Material UI is a backup. This PR simplifies the theme for Joy so that it can be used with Material UI (only for the short term).

## Changes

- **Joy**: Move variants generation to `extendTheme` so that the theme can be combined with Material UI.
- **Joy, Material UI**: Move CSS var prefix to `extendTheme`. This reduces complexity in `CssVarsProvider` and allows theme to be combined.
- **System**: remove `prefix` prop at `CssVarsProvider` given the prefix is handled by `extendTheme`.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
