### PR TITLE
[Divider] Avoid adding aria semantics if the divider has children

### DIFF
--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -175,7 +175,7 @@ const Divider = React.forwardRef(function Divider(inProps, ref) {
     flexItem = false,
     light = false,
     orientation = 'horizontal',
-    role = component !== 'hr' ? 'separator' : undefined,
+    role = component !== 'hr' && !children ? 'separator' : undefined,
     textAlign = 'center',
     variant = 'fullWidth',
     ...other

--- a/packages/mui-material/src/Divider/Divider.test.js
+++ b/packages/mui-material/src/Divider/Divider.test.js
@@ -133,6 +133,17 @@ describe('<Divider />', () => {
       expect(container.firstChild).not.to.have.attribute('role');
     });
 
+    it('avoids adding aria semantics if children are present', () => {
+      // giving an aria semantic would make the children non-accessible as the
+      // separator role can not have children.
+      const { container } = render(
+        <Divider>
+          <h2>content</h2>
+        </Divider>,
+      );
+      expect(container.firstChild).not.to.have.attribute('role');
+    });
+
     it('adds a proper role if none is specified', () => {
       const { container } = render(<Divider component="div" />);
       expect(container.firstChild).to.have.attribute('role', 'separator');


### PR DESCRIPTION
Elements with role=separator can only have children of role=presentational (or all children are converted automatically to role=presentational). This means that placing a heading as a children doesn't work. Right now there is no way of removing the role afterwards, because it is always applied too dividers with children.

With this change it is not applied automatically if children are present, but can still be applied manually.

Closes #33351

---

I'm not 100% percent sure if this is the best solution. An alternative could be an explicit opt-out of setting a role for the divider. I'm open for a discussion here.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
