### PR TITLE
[base] Change the order of class names merged in useSlotProps

### DIFF
--- a/packages/mui-base/src/utils/mergeSlotProps.test.ts
+++ b/packages/mui-base/src/utils/mergeSlotProps.test.ts
@@ -40,7 +40,7 @@ describe('mergeSlotProps', () => {
     expect(merged.props.prop4).to.equal('internal');
   });
 
-  it('joins all the class names', () => {
+  it('joins all the class names in order from internal to external', () => {
     const getSlotProps = () => ({
       className: 'internal',
     });
@@ -67,12 +67,9 @@ describe('mergeSlotProps', () => {
       className,
     });
 
-    expect(merged.props.className).to.contain('class1');
-    expect(merged.props.className).to.contain('class2');
-    expect(merged.props.className).to.contain('internal');
-    expect(merged.props.className).to.contain('additional');
-    expect(merged.props.className).to.contain('externalForwarded');
-    expect(merged.props.className).to.contain('externalSlot');
+    expect(merged.props.className).to.equal(
+      'internal additional class1 class2 externalForwarded externalSlot',
+    );
   });
 
   it('merges the style props', () => {

--- a/packages/mui-base/src/utils/mergeSlotProps.ts
+++ b/packages/mui-base/src/utils/mergeSlotProps.ts
@@ -135,11 +135,11 @@ export default function mergeSlotProps<
 
   const internalSlotProps = getSlotProps(eventHandlers);
   const joinedClasses = clsx(
+    internalSlotProps?.className,
+    additionalProps?.className,
+    className,
     externalForwardedProps?.className,
     externalSlotProps?.className,
-    className,
-    additionalProps?.className,
-    internalSlotProps?.className,
   );
 
   const mergedStyle = {

--- a/packages/mui-base/src/utils/useSlotProps.test.tsx
+++ b/packages/mui-base/src/utils/useSlotProps.test.tsx
@@ -246,7 +246,7 @@ describe('useSlotProps', () => {
     // class names are concatenated
     expect(result).to.haveOwnProperty(
       'className',
-      'externalForwarded externalComponentsProps another-class yet-another-class additional internal',
+      'internal additional another-class yet-another-class externalForwarded externalComponentsProps',
     );
 
     // `data-test` from componentProps overrides the one from forwardedProps


### PR DESCRIPTION
This PR sets the order of classes returned from useSlotProps to be internal-first, external-last. This was discussed in https://github.com/mui/material-ui/pull/33205#discussion_r903713447

cc @garronej 
