### PR TITLE
[Masonry] Support `rem`/`em` values for `spacing` prop

### DIFF
--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -105,7 +105,7 @@ export const getStyle = ({ ownerState, theme }) => {
     }
 
     return {
-      margin: `-calc(${spacing} / 2)`,
+      margin: `calc(0px - (${spacing} / 2))`,
       '& > *': {
         margin: `calc(${spacing} / 2)`,
       },

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -17,18 +17,6 @@ export const parseToNumber = (val) => {
   return Number(val.replace('px', ''));
 };
 
-export const divideStringFontSize = (val, divisor = 2) => {
-  let result = val;
-  if (val.includes('rem')) {
-    const endIndex = val.indexOf('rem');
-    result = `${Number(val.slice(0, endIndex)) / divisor}rem`;
-  } else if (val.includes('em')) {
-    const endIndex = val.indexOf('em');
-    result = `${Number(val.slice(0, endIndex)) / divisor}em`;
-  }
-  return result;
-};
-
 const lineBreakStyle = {
   flexBasis: '100%',
   width: 0,

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -100,22 +100,20 @@ export const getStyle = ({ ownerState, theme }) => {
       typeof propValue === 'number'
     ) {
       const themeSpacingValue = Number(propValue);
-      spacing = parseToNumber(getValue(transformer, themeSpacingValue));
-      halfSpacing = spacing / 2;
+      spacing = getValue(transformer, themeSpacingValue);
     } else {
       spacing = propValue;
-      halfSpacing = divideStringFontSize(propValue);
     }
 
     return {
-      margin: -halfSpacing,
+      margin: `-calc(${spacing} / 2)`,
       '& > *': {
-        margin: halfSpacing,
+        margin: `calc(${spacing} / 2)`,
       },
       ...(ownerState.maxColumnHeight && {
         height:
           typeof spacing === 'number'
-            ? Math.ceil(ownerState.maxColumnHeight + spacing)
+            ? Math.ceil(ownerState.maxColumnHeight + parseToNumber(spacing))
             : `calc(${ownerState.maxColumnHeight}px + ${spacing})`,
       }),
     };

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -93,7 +93,6 @@ export const getStyle = ({ ownerState, theme }) => {
   const transformer = createUnarySpacing(theme);
   const spacingStyleFromPropValue = (propValue) => {
     let spacing;
-    let halfSpacing;
     // in case of string/number value
     if (
       (typeof propValue === 'string' && !Number.isNaN(Number(propValue))) ||

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -42,8 +42,8 @@ describe('<Masonry />', () => {
           </Masonry>
         </div>,
       );
-      const containerMargin = `calc(0px - (${theme.spacing(spacing)} / 2))`;
-      const childMargin = `calc(${theme.spacing(spacing)} / 2)`;
+      const containerMargin = `-${parseToNumber(theme.spacing(spacing)) / 2}px`;
+      const childMargin = `${parseToNumber(theme.spacing(spacing)) / 2}px`;
       expect(getByTestId('container')).toHaveComputedStyle({
         width: `${width}px`,
         display: 'flex',

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -42,7 +42,7 @@ describe('<Masonry />', () => {
           </Masonry>
         </div>,
       );
-      const containerMargin = `-calc(${theme.spacing(spacing)} / 2)`;
+      const containerMargin = `calc(0px - (${theme.spacing(spacing)} / 2))`;
       const childMargin = `calc(${theme.spacing(spacing)} / 2)`;
       expect(getByTestId('container')).toHaveComputedStyle({
         width: `${width}px`,
@@ -141,7 +141,7 @@ describe('<Masonry />', () => {
           margin: `calc(${theme.spacing(spacing)} / 2)`,
           width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing)})`,
         },
-        margin: `-calc(${theme.spacing(spacing)} / 2)`,
+        margin: `calc(0px - (${theme.spacing(spacing)} / 2))`,
         height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing)})`,
       });
     });
@@ -173,7 +173,7 @@ describe('<Masonry />', () => {
             margin: `calc(${theme.spacing(spacing.xs)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.xs)})`,
           },
-          margin: `-calc(${theme.spacing(spacing.xs)} / 2)`,
+          margin: `calc(0px - (${theme.spacing(spacing.xs)} / 2))`,
           height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.xs)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
@@ -181,7 +181,7 @@ describe('<Masonry />', () => {
             margin: `calc(${theme.spacing(spacing.sm)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.sm)})`,
           },
-          margin: `-calc(${theme.spacing(spacing.sm)} / 2)`,
+          margin: `calc(0px - (${theme.spacing(spacing.sm)} / 2))`,
           height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.sm)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
@@ -189,7 +189,7 @@ describe('<Masonry />', () => {
             margin: `calc(${theme.spacing(spacing.md)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.md)})`,
           },
-          margin: `-calc(${theme.spacing(spacing.md)} / 2)`,
+          margin: `calc(0px - (${theme.spacing(spacing.md)} / 2))`,
           height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.md)})`,
         },
       });
@@ -217,7 +217,7 @@ describe('<Masonry />', () => {
           boxSizing: 'border-box',
           margin: `calc(${theme.spacing(spacing)} / 2)`,
         },
-        margin: `-calc(${theme.spacing(spacing)} / 2)`,
+        margin: `calc(0px - (${theme.spacing(spacing)} / 2))`,
         height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing)})`,
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
           '& > *': {
@@ -297,7 +297,7 @@ describe('<Masonry />', () => {
           boxSizing: 'border-box',
           margin: `calc(${theme.spacing(spacing)} / 2)`,
         },
-        margin: `-calc(${theme.spacing(spacing)} / 2)`,
+        margin: `calc(0px - (${theme.spacing(spacing)} / 2))`,
         height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing)})`,
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
           '& > *': {
@@ -346,7 +346,7 @@ describe('<Masonry />', () => {
             margin: `calc(${theme.spacing(spacing.xs)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.xs)})`,
           },
-          margin: `-calc(${theme.spacing(spacing.xs)} / 2)`,
+          margin: `calc(0px - (${theme.spacing(spacing.xs)} / 2))`,
           height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.xs)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
@@ -354,7 +354,7 @@ describe('<Masonry />', () => {
             margin: `calc(${theme.spacing(spacing.sm)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.sm)})`,
           },
-          margin: `-calc(${theme.spacing(spacing.sm)} / 2)`,
+          margin: `calc(0px - (${theme.spacing(spacing.sm)} / 2))`,
           height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.sm)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
@@ -362,7 +362,7 @@ describe('<Masonry />', () => {
             margin: `calc(${theme.spacing(spacing.md)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.md)})`,
           },
-          margin: `-calc(${theme.spacing(spacing.md)} / 2)`,
+          margin: `calc(0px - (${theme.spacing(spacing.md)} / 2))`,
           height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.md)})`,
         },
       });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -49,17 +49,17 @@ describe('<Masonry />', () => {
         flexWrap: 'wrap',
         alignContent: 'flex-start',
         boxSizing: 'border-box',
-        marginTop: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
-        marginRight: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
-        marginBottom: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
-        marginLeft: `${-(parseToNumber(theme.spacing(spacing)) / 2)}px`,
+        marginTop: `-calc(${theme.spacing(spacing)} / 2)`,
+        marginRight: `-calc(${theme.spacing(spacing)} / 2)`,
+        marginBottom: `-calc(${theme.spacing(spacing)} / 2)`,
+        marginLeft: `-calc(${theme.spacing(spacing)} / 2)`,
       });
       expect(getByTestId('child')).toHaveComputedStyle({
         boxSizing: 'border-box',
-        marginTop: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
-        marginRight: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
-        marginBottom: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
-        marginLeft: `${parseToNumber(theme.spacing(spacing)) / 2}px`,
+        marginTop: `calc(${theme.spacing(spacing)} / 2)`,
+        marginRight: `calc(${theme.spacing(spacing)} / 2)`,
+        marginBottom: `calc(${theme.spacing(spacing)} / 2)`,
+        marginLeft: `calc(${theme.spacing(spacing)} / 2)`,
         width: `${width / columns - parseToNumber(theme.spacing(spacing))}px`,
       });
     });
@@ -85,13 +85,13 @@ describe('<Masonry />', () => {
 
       const topAndBottomMargin = parseToNumber(defaultTheme.spacing(spacingProp)) * 2;
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `${secondChildInitialHeight + topAndBottomMargin}px`,
+        `calc(${secondChildInitialHeight}px + ${topAndBottomMargin}px)`,
       );
 
       secondItem.style.height = `${secondChildNewHeight}px`;
 
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `${secondChildNewHeight + topAndBottomMargin}px`,
+        `calc(${secondChildNewHeight}px + ${topAndBottomMargin}px)`,
       );
     });
 
@@ -136,11 +136,11 @@ describe('<Masonry />', () => {
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
-          margin: parseToNumber(theme.spacing(spacing)) / 2,
+          margin: `calc(${theme.spacing(spacing)} / 2)`,
           width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing)})`,
         },
-        margin: -(parseToNumber(theme.spacing(spacing)) / 2),
-        height: maxColumnHeight + parseToNumber(theme.spacing(spacing)),
+        margin: `-calc(${theme.spacing(spacing)} / 2)`,
+        height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing)})`,
       });
     });
 
@@ -168,27 +168,27 @@ describe('<Masonry />', () => {
         },
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
           '& > *': {
-            margin: parseToNumber(theme.spacing(spacing.xs)) / 2,
+            margin: `calc(${theme.spacing(spacing.xs)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.xs)})`,
           },
-          margin: -(parseToNumber(theme.spacing(spacing.xs)) / 2),
-          height: maxColumnHeight + parseToNumber(theme.spacing(spacing.xs)),
+          margin: `-calc(${theme.spacing(spacing.xs)} / 2)`,
+          height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.xs)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
           '& > *': {
-            margin: parseToNumber(theme.spacing(spacing.sm)) / 2,
+            margin: `calc(${theme.spacing(spacing.sm)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.sm)})`,
           },
-          margin: -(parseToNumber(theme.spacing(spacing.sm)) / 2),
-          height: maxColumnHeight + parseToNumber(theme.spacing(spacing.sm)),
+          margin: `-calc(${theme.spacing(spacing.sm)} / 2)`,
+          height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.sm)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
           '& > *': {
-            margin: parseToNumber(theme.spacing(spacing.md)) / 2,
+            margin: `calc(${theme.spacing(spacing.md)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.md)})`,
           },
-          margin: -(parseToNumber(theme.spacing(spacing.md)) / 2),
-          height: maxColumnHeight + parseToNumber(theme.spacing(spacing.md)),
+          margin: `-calc(${theme.spacing(spacing.md)} / 2)`,
+          height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.md)})`,
         },
       });
     });
@@ -213,10 +213,10 @@ describe('<Masonry />', () => {
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
-          margin: parseToNumber(theme.spacing(spacing)) / 2,
+          margin: `calc(${theme.spacing(spacing)} / 2)`,
         },
-        margin: -(parseToNumber(theme.spacing(spacing)) / 2),
-        height: maxColumnHeight + parseToNumber(theme.spacing(spacing)),
+        margin: `-calc(${theme.spacing(spacing)} / 2)`,
+        height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing)})`,
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
           '& > *': {
             width: `calc(${(100 / columns.xs).toFixed(2)}% - ${theme.spacing(spacing)})`,
@@ -293,10 +293,10 @@ describe('<Masonry />', () => {
         boxSizing: 'border-box',
         '& > *': {
           boxSizing: 'border-box',
-          margin: parseToNumber(theme.spacing(spacing)) / 2,
+          margin: `calc(${theme.spacing(spacing)} / 2)`,
         },
-        margin: -(parseToNumber(theme.spacing(spacing)) / 2),
-        height: maxColumnHeight + parseToNumber(theme.spacing(spacing)),
+        margin: `-calc(${theme.spacing(spacing)} / 2)`,
+        height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing)})`,
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
           '& > *': {
             width: `calc(${(100 / columns.xs).toFixed(2)}% - ${theme.spacing(spacing)})`,
@@ -341,27 +341,27 @@ describe('<Masonry />', () => {
         },
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
           '& > *': {
-            margin: parseToNumber(theme.spacing(spacing.xs)) / 2,
+            margin: `calc(${theme.spacing(spacing.xs)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.xs)})`,
           },
-          margin: -(parseToNumber(theme.spacing(spacing.xs)) / 2),
-          height: maxColumnHeight + parseToNumber(theme.spacing(spacing.xs)),
+          margin: `-calc(${theme.spacing(spacing.xs)} / 2)`,
+          height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.xs)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
           '& > *': {
-            margin: parseToNumber(theme.spacing(spacing.sm)) / 2,
+            margin: `calc(${theme.spacing(spacing.sm)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.sm)})`,
           },
-          margin: -(parseToNumber(theme.spacing(spacing.sm)) / 2),
-          height: maxColumnHeight + parseToNumber(theme.spacing(spacing.sm)),
+          margin: `-calc(${theme.spacing(spacing.sm)} / 2)`,
+          height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.sm)})`,
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
           '& > *': {
-            margin: parseToNumber(theme.spacing(spacing.md)) / 2,
+            margin: `calc(${theme.spacing(spacing.md)} / 2)`,
             width: `calc(${(100 / columns).toFixed(2)}% - ${theme.spacing(spacing.md)})`,
           },
-          margin: -(parseToNumber(theme.spacing(spacing.md)) / 2),
-          height: maxColumnHeight + parseToNumber(theme.spacing(spacing.md)),
+          margin: `-calc(${theme.spacing(spacing.md)} / 2)`,
+          height: `calc(${maxColumnHeight}px + ${theme.spacing(spacing.md)})`,
         },
       });
     });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -42,6 +42,8 @@ describe('<Masonry />', () => {
           </Masonry>
         </div>,
       );
+      const containerMargin = `-calc(${theme.spacing(spacing)} / 2)`;
+      const childMargin = `calc(${theme.spacing(spacing)} / 2)`;
       expect(getByTestId('container')).toHaveComputedStyle({
         width: `${width}px`,
         display: 'flex',
@@ -49,17 +51,17 @@ describe('<Masonry />', () => {
         flexWrap: 'wrap',
         alignContent: 'flex-start',
         boxSizing: 'border-box',
-        marginTop: `-calc(${theme.spacing(spacing)} / 2)`,
-        marginRight: `-calc(${theme.spacing(spacing)} / 2)`,
-        marginBottom: `-calc(${theme.spacing(spacing)} / 2)`,
-        marginLeft: `-calc(${theme.spacing(spacing)} / 2)`,
+        marginTop: containerMargin,
+        marginRight: containerMargin,
+        marginBottom: containerMargin,
+        marginLeft: containerMargin,
       });
       expect(getByTestId('child')).toHaveComputedStyle({
         boxSizing: 'border-box',
-        marginTop: `calc(${theme.spacing(spacing)} / 2)`,
-        marginRight: `calc(${theme.spacing(spacing)} / 2)`,
-        marginBottom: `calc(${theme.spacing(spacing)} / 2)`,
-        marginLeft: `calc(${theme.spacing(spacing)} / 2)`,
+        marginTop: childMargin,
+        marginRight: childMargin,
+        marginBottom: childMargin,
+        marginLeft: childMargin,
         width: `${width / columns - parseToNumber(theme.spacing(spacing))}px`,
       });
     });
@@ -85,13 +87,13 @@ describe('<Masonry />', () => {
 
       const topAndBottomMargin = parseToNumber(defaultTheme.spacing(spacingProp)) * 2;
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `calc(${secondChildInitialHeight}px + ${topAndBottomMargin}px)`,
+        `${secondChildInitialHeight + topAndBottomMargin}px)`,
       );
 
       secondItem.style.height = `${secondChildNewHeight}px`;
 
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `calc(${secondChildNewHeight}px + ${topAndBottomMargin}px)`,
+        `${secondChildNewHeight + topAndBottomMargin}px)`,
       );
     });
 

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -87,13 +87,13 @@ describe('<Masonry />', () => {
 
       const topAndBottomMargin = parseToNumber(defaultTheme.spacing(spacingProp)) * 2;
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `${secondChildInitialHeight + topAndBottomMargin}px)`,
+        `${secondChildInitialHeight + topAndBottomMargin}px`,
       );
 
       secondItem.style.height = `${secondChildNewHeight}px`;
 
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `${secondChildNewHeight + topAndBottomMargin}px)`,
+        `${secondChildNewHeight + topAndBottomMargin}px`,
       );
     });
 

--- a/test/regressions/fixtures/Masonry/EmSpacingValue.js
+++ b/test/regressions/fixtures/Masonry/EmSpacingValue.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
+import Masonry from '@mui/lab/Masonry';
+
+const heights = [150, 30, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(0.5),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function EmSpacingValue() {
+  return (
+    <Box sx={{ width: 500, minHeight: 393 }}>
+      <Masonry columns={4} spacing={'2rem'}>
+        {heights.map((height, index) => (
+          <Item key={index} sx={{ height }}>
+            {index + 1}
+          </Item>
+        ))}
+      </Masonry>
+    </Box>
+  );
+}

--- a/test/regressions/fixtures/Masonry/RemSpacingValue.js
+++ b/test/regressions/fixtures/Masonry/RemSpacingValue.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
+import Masonry from '@mui/lab/Masonry';
+
+const heights = [150, 30, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(0.5),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function RemSpacingValue() {
+  return (
+    <Box sx={{ width: 500, minHeight: 393 }}>
+      <Masonry columns={4} spacing={'2rem'}>
+        {heights.map((height, index) => (
+          <Item key={index} sx={{ height }}>
+            {index + 1}
+          </Item>
+        ))}
+      </Masonry>
+    </Box>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/33141

- [x] Support `rem` value for `spacing`
- [x] Add regression test for using `rem` for `spacing`
- [x] Support `em` value for `spacing`
- [x] Add regression test for using `em` for `spacing`

Code sandboxes:
- [Before](https://codesandbox.io/s/basicmasonry-demo-material-ui-forked-4n3912?file=/demo.tsx)
- [After](https://codesandbox.io/s/basicmasonry-demo-material-ui-forked-ez4e01?file=/demo.tsx)