### PR TITLE
[Joy] Fix variants color palette regressions

### DIFF
--- a/docs/data/joy/components/radio/ExampleProductAttributes.js
+++ b/docs/data/joy/components/radio/ExampleProductAttributes.js
@@ -35,7 +35,7 @@ export default function ExampleProductAttributes() {
                 width: 40,
                 height: 40,
                 flexShrink: 0,
-                bgcolor: `${color}.500`,
+                bgcolor: `${color}.solidBg`,
                 borderRadius: '50%',
                 display: 'flex',
                 alignItems: 'center',

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -197,17 +197,24 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
       warning: {
         ...colors.yellow,
         ...createLightModeVariantVariables('warning'),
-        solidColor: getCssVar(`palette-common-black`),
+        solidColor: getCssVar(`palette-warning-800`),
         solidBg: getCssVar(`palette-warning-200`),
         solidHoverBg: getCssVar(`palette-warning-300`),
         solidActiveBg: getCssVar(`palette-warning-400`),
         solidDisabledColor: getCssVar(`palette-warning-200`),
         solidDisabledBg: getCssVar(`palette-warning-50`),
 
-        softColor: getCssVar(`palette-common-black`),
+        softColor: getCssVar(`palette-warning-800`),
+        softBg: getCssVar(`palette-warning-50`),
+        softHoverBg: getCssVar(`palette-warning-100`),
+        softActiveBg: getCssVar(`palette-warning-200`),
+        softDisabledColor: getCssVar(`palette-warning-200`),
+        softDisabledBg: getCssVar(`palette-warning-50`),
 
+        outlinedColor: getCssVar(`palette-warning-800`),
         outlinedHoverBg: getCssVar(`palette-warning-50`),
 
+        plainColor: getCssVar(`palette-warning-800`),
         plainHoverBg: getCssVar(`palette-warning-50`),
       },
       common: {

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -132,8 +132,8 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
     solidBg: getCssVar(`palette-${color}-600`),
     solidHoverBg: getCssVar(`palette-${color}-700`),
     solidActiveBg: getCssVar(`palette-${color}-800`),
-    solidDisabledColor: `#fff`,
-    solidDisabledBg: getCssVar(`palette-${color}-300`),
+    solidDisabledColor: getCssVar(`palette-${color}-700`),
+    solidDisabledBg: getCssVar(`palette-${color}-900`),
 
     overrideTextPrimary: getCssVar(`palette-${color}-200`),
     overrideTextSecondary: getCssVar(`palette-${color}-400`),
@@ -297,8 +297,6 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
         solidBg: getCssVar(`palette-success-600`),
         solidHoverBg: getCssVar(`palette-success-700`),
         solidActiveBg: getCssVar(`palette-success-800`),
-        solidDisabledColor: getCssVar(`palette-success-50`),
-        solidDisabledBg: getCssVar(`palette-success-300`),
       },
       warning: {
         ...colors.yellow,
@@ -307,8 +305,6 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
         solidBg: getCssVar(`palette-warning-300`),
         solidHoverBg: getCssVar(`palette-warning-400`),
         solidActiveBg: getCssVar(`palette-warning-500`),
-        solidDisabledColor: getCssVar(`palette-warning-50`),
-        solidDisabledBg: getCssVar(`palette-warning-300`),
       },
       common: {
         white: '#FFF',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

My previous PR (https://github.com/mui/material-ui/pull/33158) might've introduced a couple of color regressions, somehow.
This now fixes those－mostly regarding the soft variant with the warning palette at light mode and all the dark mode disabled solid variant colors. 


