### PR TITLE
[SelectUnstyled] Do not call onChange unnecessarily

### DIFF
--- a/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   ListboxState,
-  UseListboxStrictProps,
+  UseListboxPropsWithDefaults,
   ListboxAction,
   ActionTypes,
 } from './useListbox.types';
@@ -108,12 +108,12 @@ function getNewHighlightedOption<TOption>(
 function handleOptionSelection<TOption>(
   option: TOption,
   state: ListboxState<TOption>,
-  props: UseListboxStrictProps<TOption>,
+  props: UseListboxPropsWithDefaults<TOption>,
 ): ListboxState<TOption> {
   const { multiple, optionComparer = (o, v) => o === v, isOptionDisabled = () => false } = props;
   const { selectedValue } = state;
 
-  const optionIndex = props.options.indexOf(option);
+  const optionIndex = props.options.findIndex((o) => props.optionComparer(option, o));
 
   if (isOptionDisabled(option, optionIndex)) {
     return state;
@@ -145,7 +145,7 @@ function handleOptionSelection<TOption>(
 function handleKeyDown<TOption>(
   event: React.KeyboardEvent,
   state: Readonly<ListboxState<TOption>>,
-  props: UseListboxStrictProps<TOption>,
+  props: UseListboxPropsWithDefaults<TOption>,
 ): ListboxState<TOption> {
   const { options, isOptionDisabled, disableListWrap, disabledItemsFocusable, optionComparer } =
     props;
@@ -246,7 +246,7 @@ const textCriteriaMatches = <TOption>(
 function handleTextNavigation<TOption>(
   state: ListboxState<TOption>,
   searchString: string,
-  props: UseListboxStrictProps<TOption>,
+  props: UseListboxPropsWithDefaults<TOption>,
 ): ListboxState<TOption> {
   const {
     options,
@@ -305,7 +305,7 @@ function handleOptionsChange<TOption>(
   options: TOption[],
   previousOptions: TOption[],
   state: ListboxState<TOption>,
-  props: UseListboxStrictProps<TOption>,
+  props: UseListboxPropsWithDefaults<TOption>,
 ): ListboxState<TOption> {
   const { multiple, optionComparer } = props;
 

--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
@@ -52,30 +52,26 @@ function useStateChangeDetection<TOption>(
     }
 
     const previousState = getControlledState(internalPreviousState, propsRef.current);
-    const { multiple, optionComparer, onChange } = propsRef.current;
+    const { multiple, optionComparer } = propsRef.current;
 
     if (multiple) {
-      if (
-        !areArraysEqual(
-          nextState.selectedValue as TOption[],
-          (previousState?.selectedValue ?? []) as TOption[],
-          optionComparer,
-        )
-      ) {
-        // TODO: type this properly
-        onChange?.(nextState.selectedValue as any);
+      const previousSelectedValues = (previousState?.selectedValue ?? []) as TOption[];
+      const nextSelectedValues = nextState.selectedValue as TOption[];
+      const onChange = propsRef.current.onChange as ((value: TOption[]) => void) | undefined;
+
+      if (!areArraysEqual(nextSelectedValues, previousSelectedValues, optionComparer)) {
+        onChange?.(nextSelectedValues);
       }
-    } else if (
-      !areOptionsEqual(
-        nextState.selectedValue as TOption,
-        previousState?.selectedValue as TOption,
-        propsRef.current.optionComparer,
-      )
-    ) {
-      // TODO: type this properly
-      onChange?.(nextState.selectedValue as any);
+    } else {
+      const previousSelectedValue = previousState?.selectedValue as TOption | null;
+      const nextSelectedValue = nextState.selectedValue as TOption | null;
+      const onChange = propsRef.current.onChange as ((value: TOption | null) => void) | undefined;
+
+      if (!areOptionsEqual(nextSelectedValue, previousSelectedValue, optionComparer)) {
+        onChange?.(nextSelectedValue);
+      }
     }
-  }, [nextState, internalPreviousState, propsRef]);
+  }, [nextState.selectedValue, internalPreviousState, propsRef]);
 
   React.useEffect(() => {
     if (!propsRef.current) {
@@ -90,7 +86,6 @@ function useStateChangeDetection<TOption>(
         propsRef.current.optionComparer,
       )
     ) {
-      // TODO: test this
       propsRef.current?.onHighlightChange?.(nextState.highlightedValue);
     }
   }, [nextState.highlightedValue, internalPreviousState.highlightedValue, propsRef]);
@@ -125,7 +120,6 @@ export default function useControllableReducer<TOption>(
     [externalReducer, internalReducer, propsRef],
   );
 
-  // TODO: augment dispatch with props
   const [nextState, dispatch] = React.useReducer(combinedReducer, initalState);
 
   const previousState = React.useRef<ListboxState<TOption>>(initalState);

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { unstable_useForkRef as useForkRef, unstable_useId as useId } from '@mui/utils';
 import {
   UseListboxParameters,
-  UseListboxStrictProps,
+  UseListboxPropsWithDefaults,
   ActionTypes,
   OptionState,
   UseListboxOptionSlotProps,
@@ -43,7 +43,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
 
   const optionIdGenerator = props.optionIdGenerator ?? defaultIdGenerator;
 
-  const propsWithDefaults: UseListboxStrictProps<TOption> = {
+  const propsWithDefaults: UseListboxPropsWithDefaults<TOption> = {
     ...props,
     disabledItemsFocusable,
     disableListWrap,
@@ -181,7 +181,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       });
 
       // Handle text navigation
-      if (event.key.length === 1) {
+      if (event.key.length === 1 && event.key !== ' ') {
         const textCriteria = textCriteriaRef.current;
         const lowerKey = event.key.toLowerCase();
         const currentTime = performance.now();

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -8,7 +8,7 @@ type UseListboxStrictPropsRequiredKeys =
   | 'optionStringifier'
   | 'multiple';
 
-export type UseListboxStrictProps<TOption> = Omit<
+export type UseListboxPropsWithDefaults<TOption> = Omit<
   UseListboxParameters<TOption>,
   UseListboxStrictPropsRequiredKeys
 > &
@@ -35,32 +35,32 @@ interface OptionClickAction<TOption> {
   type: ActionTypes.optionClick;
   option: TOption;
   event: React.MouseEvent;
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface OptionHoverAction<TOption> {
   type: ActionTypes.optionHover;
   option: TOption;
   event: React.MouseEvent;
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface FocusAction<TOption> {
   type: ActionTypes.focus;
   event: React.FocusEvent;
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface BlurAction<TOption> {
   type: ActionTypes.blur;
   event: React.FocusEvent;
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface KeyDownAction<TOption> {
   type: ActionTypes.keyDown;
   event: React.KeyboardEvent;
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface SetValueAction<TOption> {
@@ -76,14 +76,14 @@ interface SetHighlightAction<TOption> {
 interface TextNavigationAction<TOption> {
   type: ActionTypes.textNavigation;
   searchString: string;
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface OptionsChangeAction<TOption> {
   type: ActionTypes.optionsChange;
   options: TOption[];
   previousOptions: TOption[];
-  props: UseListboxStrictProps<TOption>;
+  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 export type ListboxAction<TOption> =

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -14,12 +14,6 @@ import {
   fireEvent,
 } from 'test/utils';
 
-declare module '@mui/base/MultiSelectUnstyled' {
-  interface MultiSelectUnstyledComponentsPropsOverrides {
-    'data-testid'?: string;
-  }
-}
-
 describe('MultiSelectUnstyled', () => {
   const mount = createMount();
   const { render } = createRenderer();
@@ -177,7 +171,7 @@ describe('MultiSelectUnstyled', () => {
             componentsProps={{
               root: {
                 'data-testid': 'select',
-              },
+              } as any,
             }}
           >
             <OptionUnstyled value={1}>1</OptionUnstyled>

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -14,6 +14,12 @@ import {
   fireEvent,
 } from 'test/utils';
 
+declare module '@mui/base/MultiSelectUnstyled' {
+  interface MultiSelectUnstyledComponentsPropsOverrides {
+    'data-testid'?: string;
+  }
+}
+
 describe('MultiSelectUnstyled', () => {
   const mount = createMount();
   const { render } = createRenderer();
@@ -154,6 +160,44 @@ describe('MultiSelectUnstyled', () => {
     const button = getByText('Update value');
     act(() => button.click());
     expect(onChange.notCalled).to.equal(true);
+  });
+
+  it('sets a value correctly when interacted by a user and external code', () => {
+    function TestComponent() {
+      const [value, setValue] = React.useState<number[]>([]);
+
+      return (
+        <div>
+          <button data-testid="update-externally" onClick={() => setValue([1])}>
+            Update value
+          </button>
+          <MultiSelectUnstyled
+            value={value}
+            onChange={setValue}
+            componentsProps={{
+              root: {
+                'data-testid': 'select',
+              },
+            }}
+          >
+            <OptionUnstyled value={1}>1</OptionUnstyled>
+            <OptionUnstyled value={2}>2</OptionUnstyled>
+          </MultiSelectUnstyled>
+        </div>
+      );
+    }
+
+    const { getByTestId, getByText } = render(<TestComponent />);
+    const updateButton = getByTestId('update-externally');
+    const selectButton = getByTestId('select');
+
+    act(() => updateButton.click());
+    act(() => selectButton.click());
+
+    const option2 = getByText('2');
+    act(() => option2.click());
+
+    expect(selectButton).to.have.text('1, 2');
   });
 
   it('closes the listbox without selecting an option when focus is lost', () => {

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import MultiSelectUnstyled from '@mui/base/MultiSelectUnstyled';
 import { selectUnstyledClasses } from '@mui/base/SelectUnstyled';
 import OptionUnstyled from '@mui/base/OptionUnstyled';
@@ -126,6 +127,33 @@ describe('MultiSelectUnstyled', () => {
       expect(button).to.have.text('1');
       expect(queryByRole('listbox')).to.equal(null);
     });
+  });
+
+  it('does not call onChange if `value` is modified externally', () => {
+    function TestComponent({ onChange }: { onChange: (value: number[]) => void }) {
+      const [value, setValue] = React.useState([1]);
+      const handleChange = (newValue: number[]) => {
+        setValue(newValue);
+        onChange(newValue);
+      };
+
+      return (
+        <div>
+          <button onClick={() => setValue([1, 2])}>Update value</button>
+          <MultiSelectUnstyled value={value} onChange={handleChange}>
+            <OptionUnstyled value={1}>1</OptionUnstyled>
+            <OptionUnstyled value={2}>2</OptionUnstyled>
+          </MultiSelectUnstyled>
+        </div>
+      );
+    }
+
+    const onChange = sinon.spy();
+    const { getByText } = render(<TestComponent onChange={onChange} />);
+
+    const button = getByText('Update value');
+    act(() => button.click());
+    expect(onChange.notCalled).to.equal(true);
   });
 
   it('closes the listbox without selecting an option when focus is lost', () => {

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -58,7 +58,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
   const handleButtonRef = useForkRef(buttonRefProp, buttonRef);
 
   const listboxRef = React.useRef<HTMLElement | null>(null);
-  const intermediaryListboxRef = useForkRef(listboxRefProp, listboxRef);
 
   const [value, setValue] = useControlled({
     controlled: valueProp,
@@ -89,7 +88,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     focusListboxIfRequested();
   };
 
-  const handleListboxRef = useForkRef(intermediaryListboxRef, updateListboxRef);
+  const handleListboxRef = useForkRef(useForkRef(listboxRefProp, listboxRef), updateListboxRef);
 
   React.useEffect(() => {
     focusListboxIfRequested();
@@ -296,9 +295,9 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
   };
 
   React.useDebugValue({
-    selectedOption: listboxSelectedOption as TValue | null,
-    open,
+    selectedOption: listboxSelectedOption,
     highlightedOption,
+    open,
   });
 
   return {

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -227,8 +227,9 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       listboxRef: handleListboxRef,
       multiple: true,
       onChange: (newOptions) => {
-        setValue(newOptions.map((o) => o.value));
-        (onChange as (value: TValue[]) => void)?.(newOptions.map((o) => o.value));
+        const newValues = newOptions.map((o) => o.value);
+        setValue(newValues);
+        (onChange as (value: TValue[]) => void)?.(newValues);
       },
       options,
       optionStringifier,


### PR DESCRIPTION
Revised the logic of the controllable reducer that powers the useSelect hook. The `onChange` callback was incorrectly called when a controlled value was modified externally.

I was able to simplify the useControlledReducer by the way.

Fixes #33286