### PR TITLE
[core] Remove old babel resolve rule

### DIFF
--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -1,17 +1,7 @@
-const bpmr = require('babel-plugin-module-resolver');
 const fse = require('fs-extra');
 const path = require('path');
 
 const errorCodesPath = path.resolve(__dirname, './public/static/error-codes.json');
-
-function resolvePath(sourcePath, currentFile, opts) {
-  if (sourcePath === 'markdown') {
-    const base = currentFile.substring(__dirname.length).slice(0, -3);
-    return `${__dirname}/docs/src/${base}/`;
-  }
-
-  return bpmr.resolvePath(sourcePath, currentFile, opts);
-}
 
 const alias = {
   '@mui/material': '../packages/mui-material/src',
@@ -70,7 +60,6 @@ module.exports = {
       {
         alias,
         transformFunctions: ['require', 'require.context'],
-        resolvePath,
       },
     ],
   ],


### PR DESCRIPTION
The logic was added in #13066. We now fix the same problem with a webpack plugin, we don't need this logic.

This was found working on https://github.com/mui/mui-toolpad/pull/542.