### PR TITLE
[TypeScript] Fix theme options components types to use `Theme`

### DIFF
--- a/packages/mui-material/src/styles/createTheme.d.ts
+++ b/packages/mui-material/src/styles/createTheme.d.ts
@@ -9,7 +9,7 @@ import { Components } from './components';
 
 export interface ThemeOptions extends Omit<SystemThemeOptions, 'zIndex'> {
   mixins?: MixinsOptions;
-  components?: Components<BaseTheme>;
+  components?: Components<Omit<Theme, 'components'>>;
   palette?: PaletteOptions;
   shadows?: Shadows;
   transitions?: TransitionsOptions;

--- a/packages/mui-material/test/typescript/moduleAugmentation/themeCustomNode.spec.tsx
+++ b/packages/mui-material/test/typescript/moduleAugmentation/themeCustomNode.spec.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { createTheme, styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+
+interface CustomNode {
+  background: string;
+  color: string;
+}
+
+declare module '@mui/material/styles' {
+  interface ThemeOptions {
+    customNode: CustomNode;
+  }
+
+  interface Theme {
+    customNode: CustomNode;
+  }
+}
+
+const customTheme = createTheme({
+  customNode: {
+    background: '#000',
+    color: '#fff',
+  },
+});
+
+const StyledComponent = styled('div')(({ theme }) => ({
+  background: theme.customNode.background,
+  color: theme.customNode.color,
+}));
+
+<Box
+  sx={(theme) => ({
+    background: theme.customNode.background,
+    color: theme.customNode.color,
+  })}
+/>;

--- a/packages/mui-material/test/typescript/moduleAugmentation/themeCustomNode.tsconfig.json
+++ b/packages/mui-material/test/typescript/moduleAugmentation/themeCustomNode.tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../../tsconfig",
+  "files": ["themeCustomNode.spec.tsx"]
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

Currently, you can't use the custom node that augment from the theme in `components` style overrides:

```ts
import * as React from 'react';
import { createTheme, styled } from '@mui/material/styles';
import Box from '@mui/material/Box';

interface CustomNode {
  background: string;
  color: string;
}

declare module '@mui/material/styles' {
  interface ThemeOptions {
    customNode: CustomNode;
  }

  interface Theme {
    customNode: CustomNode;
  }
}

const customTheme = createTheme({
  customNode: {
    background: '#000',
    color: '#fff',
  },
  components: {
    MuiAppBar: {
      stylesOverrides: {
        root: ({ theme }) => ({
          // @ts-expect-error: this should work!
          backgroundColor: theme.customNode.background,
        })
      }
    }
  }
});
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
