### PR TITLE
[Popover] Fix the scrolling issue when a Popover is inside an iframe

### DIFF
--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -120,8 +120,8 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     TransitionProps: { onEntering, ...TransitionProps } = {},
     ...other
   } = props;
+
   const paperRef = React.useRef();
-  const handlePaperRef = useForkRef(paperRef, PaperProps.ref);
 
   const ownerState = {
     ...props,
@@ -295,6 +295,14 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     }
     element.style.transformOrigin = positioning.transformOrigin;
   }, [getPositioningStyle]);
+
+  const handlePaperRefUpdate = (paperElement) => {
+    if (paperElement !== null && open) {
+      setPositioningStyles();
+    }
+  };
+
+  const handlePaperRef = useForkRef(useForkRef(paperRef, handlePaperRefUpdate), PaperProps.ref);
 
   const handleEntering = (element, isAppearing) => {
     if (onEntering) {


### PR DESCRIPTION
This is a partial fix of a problem described in #27584.
With this fix, the page doesn't scroll to the top of the iframe, but it centers the Select in the viewport. It's not a perfect solution but it does improve the UX.