### PR TITLE
[docs] Fix copy search false positives

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -412,13 +412,13 @@ const Root = styled('div')(({ theme }) => ({
     position: 'relative',
     '&:hover': {
       '& .MuiCode-copy': {
-        opacity: 1,
+        display: 'block',
       },
     },
   },
   '& .MuiCode-copy': {
     minWidth: 64,
-    opacity: 0,
+    display: 'none',
     backgroundColor: alpha(blueDark[600], 0.5),
     cursor: 'pointer',
     position: 'absolute',


### PR DESCRIPTION
I'm using display: none to remove the content from the content tree. I don't think that we should use opacity for this use case. For context, I was searching for the "copy" feature in https://mui.com/x/react-data-grid/export/#clipboard. It was super confusing.

**Before**

<img width="372" alt="Screenshot 2022-07-08 at 18 34 17" src="https://user-images.githubusercontent.com/3165635/178033590-4b3670bf-24b8-4433-a4d7-21128bac479f.png">

https://mui.com/material-ui/react-alert/

<img width="309" alt="Screenshot 2022-07-08 at 18 39 12" src="https://user-images.githubusercontent.com/3165635/178034324-f3f75b64-0e21-4053-889a-7f557105515c.png">

**After**

<img width="376" alt="Screenshot 2022-07-08 at 18 31 40" src="https://user-images.githubusercontent.com/3165635/178033241-b40eaa09-b6e1-47f8-a28a-3ff7a231eacc.png">

https://deploy-preview-33438--material-ui.netlify.app/material-ui/react-alert/

If the plan was to add a transition effect on the opacity, I guess we would need to use a pseudo-element with the CSS content property https://stackoverflow.com/questions/13296789/is-it-possible-to-make-css-generated-content-searchable-by-a-browser.