### PR TITLE
[examples] Fix error in Next.js example with @mui/styles

### DIFF
--- a/examples/nextjs-with-typescript-v4-migration/package.json
+++ b/examples/nextjs-with-typescript-v4-migration/package.json
@@ -17,7 +17,10 @@
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/styles": "latest",
+    "autoprefixer": "^10.4.7",
+    "clean-css": "^5.3.0",
     "next": "12.1.5",
+    "postcss": "^8.4.14",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/nextjs-with-typescript-v4-migration/package.json
+++ b/examples/nextjs-with-typescript-v4-migration/package.json
@@ -17,10 +17,10 @@
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/styles": "latest",
-    "autoprefixer": "^10.4.7",
-    "clean-css": "^5.3.0",
+    "autoprefixer": "latest",
+    "clean-css": "latest",
     "next": "latest",
-    "postcss": "^8.4.14",
+    "postcss": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/nextjs-with-typescript-v4-migration/package.json
+++ b/examples/nextjs-with-typescript-v4-migration/package.json
@@ -19,7 +19,7 @@
     "@mui/styles": "latest",
     "autoprefixer": "^10.4.7",
     "clean-css": "^5.3.0",
-    "next": "12.1.5",
+    "next": "latest",
     "postcss": "^8.4.14",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

When I tried to deploy this to production I got the following errors.
<img width="1208" alt="Screen Shot 2022-07-09 at 10 56 24 PM" src="https://user-images.githubusercontent.com/1796066/178133214-d9263097-7f94-4e2c-a9b5-e49d0dfd32d7.png">


**Root cause:** https://github.com/mui/material-ui/blob/9c7cce753f2313452c0fb268d47364b1121a6253/examples/nextjs-with-typescript-v4-migration/pages/_document.tsx#L43-L45

**Solution:** We need to add these packages in package.json

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
