### PR TITLE
[TimelineDot] Add TimelineDotPropsColorOverrides interface to extend color options

### DIFF
--- a/docs/pages/material-ui/api/timeline-dot.json
+++ b/docs/pages/material-ui/api/timeline-dot.json
@@ -4,8 +4,8 @@
     "classes": { "type": { "name": "object" } },
     "color": {
       "type": {
-        "name": "enum",
-        "description": "'error'<br>&#124;&nbsp;'grey'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'"
+        "name": "union",
+        "description": "'error'<br>&#124;&nbsp;'grey'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
       },
       "default": "'grey'"
     },

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.d.ts
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.d.ts
@@ -7,6 +7,8 @@ import { TimelineDotClasses } from './timelineDotClasses';
 
 export interface TimelineDotPropsVariantOverrides {}
 
+export interface TimelineDotPropsColorOverrides {}
+
 export interface TimelineDotProps extends StandardProps<React.HTMLAttributes<HTMLSpanElement>> {
   /**
    * The content of the component.
@@ -20,7 +22,10 @@ export interface TimelineDotProps extends StandardProps<React.HTMLAttributes<HTM
    * The dot can have a different colors.
    * @default 'grey'
    */
-  color?: 'inherit' | 'grey' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+  color?: OverridableStringUnion<
+    'inherit' | 'grey' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+    TimelineDotPropsColorOverrides
+  >;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.js
@@ -111,15 +111,18 @@ TimelineDot.propTypes /* remove-proptypes */ = {
    * The dot can have a different colors.
    * @default 'grey'
    */
-  color: PropTypes.oneOf([
-    'error',
-    'grey',
-    'info',
-    'inherit',
-    'primary',
-    'secondary',
-    'success',
-    'warning',
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf([
+      'error',
+      'grey',
+      'info',
+      'inherit',
+      'primary',
+      'secondary',
+      'success',
+      'warning',
+    ]),
+    PropTypes.string,
   ]),
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.


### PR DESCRIPTION
Hi there!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Current behaviour:**
Extension of color property in TimelineDot interface is not available with module augmentation. 

**Expected behaviour:**
Color property can accept custom color palette properties

Fixes #33492 