### PR TITLE
[system] Remove needless optional chaining check in `createEmptyBreakpointObject` method

### DIFF
--- a/packages/mui-system/src/breakpoints.js
+++ b/packages/mui-system/src/breakpoints.js
@@ -85,7 +85,7 @@ function breakpoints(styleFunction) {
 }
 
 export function createEmptyBreakpointObject(breakpointsInput = {}) {
-  const breakpointsInOrder = breakpointsInput?.keys?.reduce((acc, key) => {
+  const breakpointsInOrder = breakpointsInput.keys?.reduce((acc, key) => {
     const breakpointStyleKey = breakpointsInput.up(key);
     acc[breakpointStyleKey] = {};
     return acc;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

A small improvement that optional chaining operator is not needed if a default parameter is present. This method is used within `sx`. 
