### PR TITLE
[docs] Add yarn command for Roboto font in Material UI's typography.md

### DIFF
--- a/docs/data/material/components/typography/typography.md
+++ b/docs/data/material/components/typography/typography.md
@@ -35,7 +35,7 @@ Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 ## Install with npm
 
-You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by typing the command below in your terminal using **npm**:
+You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by running one of the following commands in your terminal:
 
 `npm install @fontsource/roboto`
 

--- a/docs/data/material/components/typography/typography.md
+++ b/docs/data/material/components/typography/typography.md
@@ -35,9 +35,13 @@ Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 ## Install with npm
 
-You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by typing the below command in your terminal:
+You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by typing the command below in your terminal using **npm**:
 
 `npm install @fontsource/roboto`
+
+Or **yarn**:
+
+`yarn add @fontsource/roboto`
 
 Then, you can import it in your entry-point.
 

--- a/docs/data/material/components/typography/typography.md
+++ b/docs/data/material/components/typography/typography.md
@@ -37,6 +37,8 @@ Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 You can [install it](https://www.npmjs.com/package/@fontsource/roboto) by running one of the following commands in your terminal:
 
+With **npm**:
+
 `npm install @fontsource/roboto`
 
 Or **yarn**:


### PR DESCRIPTION
A Yarn command for installing the Roboto font has been added for convenience and consistency across the docs.
