### PR TITLE
[core] Remove unnecessary packageName attribute from pages

### DIFF
--- a/docs/data/base/components/badge/badge-pt.md
+++ b/docs/data/base/components/badge/badge-pt.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React badge
 components: BadgeUnstyled
 githubLabel: 'component: badge'
-packageName: '@mui/base'
 ---
 
 # Unstyled badge

--- a/docs/data/base/components/badge/badge-zh.md
+++ b/docs/data/base/components/badge/badge-zh.md
@@ -3,7 +3,6 @@ product: base
 title: 无样式的 React 徽章
 components: BadgeUnstyled
 githubLabel: 'component: badge'
-packageName: '@mui/base'
 ---
 
 # 无样式的徽章

--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React Badge component
 components: BadgeUnstyled
 githubLabel: 'component: badge'
-packageName: '@mui/base'
 ---
 
 # Unstyled badge

--- a/docs/data/base/components/click-away-listener/click-away-listener-pt.md
+++ b/docs/data/base/components/click-away-listener/click-away-listener-pt.md
@@ -1,9 +1,8 @@
 ---
-product: material-ui
+product: base
 title: Componente React para Detectar clique fora
 components: ClickAwayListener
 githubLabel: 'component: ClickAwayListener'
-packageName: '@mui/base'
 ---
 
 # Observador de Clique (ClickAwayListener)

--- a/docs/data/base/components/click-away-listener/click-away-listener-zh.md
+++ b/docs/data/base/components/click-away-listener/click-away-listener-zh.md
@@ -1,9 +1,8 @@
 ---
-product: material-ui
+product: base
 title: React Detect click outside（它处点击监听器）组件
 components: ClickAwayListener
 githubLabel: 'component: ClickAwayListener'
-packageName: '@mui/base'
 ---
 
 # Click away listener 它处点击监听器

--- a/docs/data/base/components/click-away-listener/click-away-listener.md
+++ b/docs/data/base/components/click-away-listener/click-away-listener.md
@@ -3,7 +3,6 @@ product: base
 title: React ClickAwayListener component
 components: ClickAwayListener
 githubLabel: 'component: ClickAwayListener'
-packageName: '@mui/base'
 ---
 
 # Click-away listener

--- a/docs/data/base/components/form-control/form-control-pt.md
+++ b/docs/data/base/components/form-control/form-control-pt.md
@@ -2,7 +2,6 @@
 product: base
 title: React form control
 components: FormControlUnstyled
-packageName: '@mui/base'
 ---
 
 # Unstyled form control

--- a/docs/data/base/components/form-control/form-control-zh.md
+++ b/docs/data/base/components/form-control/form-control-zh.md
@@ -2,7 +2,6 @@
 product: base
 title: React form control
 components: FormControlUnstyled
-packageName: '@mui/base'
 ---
 
 # Unstyled form control

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React Form Control component and hook
 components: FormControlUnstyled
 githubLabel: 'component: FormControl'
-packageName: '@mui/base'
 ---
 
 # Unstyled form control

--- a/docs/data/base/components/input/input-pt.md
+++ b/docs/data/base/components/input/input-pt.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React Input component and hook
 components: InputUnstyled
 githubLabel: 'component: input'
-packageName: '@mui/base'
 ---
 
 # Unstyled input

--- a/docs/data/base/components/input/input-zh.md
+++ b/docs/data/base/components/input/input-zh.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React Input component and hook
 components: InputUnstyled
 githubLabel: 'component: input'
-packageName: '@mui/base'
 ---
 
 # Unstyled input

--- a/docs/data/base/components/input/input.md
+++ b/docs/data/base/components/input/input.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React Input component and hook
 components: InputUnstyled
 githubLabel: 'component: input'
-packageName: '@mui/base'
 ---
 
 # Unstyled input

--- a/docs/data/base/components/menu/menu-pt.md
+++ b/docs/data/base/components/menu/menu-pt.md
@@ -4,7 +4,6 @@ title: Unstyled React Menu components and hooks
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#menu'
-packageName: '@mui/base'
 ---
 
 # Unstyled menu

--- a/docs/data/base/components/menu/menu-zh.md
+++ b/docs/data/base/components/menu/menu-zh.md
@@ -4,7 +4,6 @@ title: Unstyled React Menu components and hooks
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#menu'
-packageName: '@mui/base'
 ---
 
 # Unstyled menu

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -4,7 +4,6 @@ title: Unstyled React Menu components and hooks
 components: MenuUnstyled, MenuItemUnstyled
 githubLabel: 'component: menu'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
-packageName: '@mui/base'
 ---
 
 # Unstyled menu

--- a/docs/data/base/components/modal/modal-pt.md
+++ b/docs/data/base/components/modal/modal-pt.md
@@ -4,7 +4,6 @@ title: Unstyled React Modal component
 components: ModalUnstyled
 githubLabel: 'component: modal'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#dialog_modal'
-packageName: '@mui/base'
 ---
 
 # Unstyled modal
@@ -24,7 +23,7 @@ Features:
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 > **Note:** the term "modal" is sometimes used interchangeably with "dialog," but this is incorrect. A dialog may be _modal_ or _nonmodal (modeless)_.
-> 
+>
 > A modal [blocks interaction with the rest of the application](https://en.wikipedia.org/wiki/Modal_window), forcing the user to take action. As such, it should be used sparingly—only when the app _requires_ user input before it can continue.
 
 <!-- Uncomment the next line, once an unstyled dialog component is added in @mui/base -->

--- a/docs/data/base/components/modal/modal-zh.md
+++ b/docs/data/base/components/modal/modal-zh.md
@@ -4,7 +4,6 @@ title: Unstyled React Modal component
 components: ModalUnstyled
 githubLabel: 'component: modal'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#dialog_modal'
-packageName: '@mui/base'
 ---
 
 # Unstyled modal
@@ -24,7 +23,7 @@ Features:
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 > **Note:** the term "modal" is sometimes used interchangeably with "dialog," but this is incorrect. A dialog may be _modal_ or _nonmodal (modeless)_.
-> 
+>
 > A modal [blocks interaction with the rest of the application](https://en.wikipedia.org/wiki/Modal_window), forcing the user to take action. As such, it should be used sparingly—only when the app _requires_ user input before it can continue.
 
 <!-- Uncomment the next line, once an unstyled dialog component is added in @mui/base -->

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -4,7 +4,6 @@ title: Unstyled React Modal component
 components: ModalUnstyled
 githubLabel: 'component: modal'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
-packageName: '@mui/base'
 ---
 
 # Unstyled modal

--- a/docs/data/base/components/no-ssr/no-ssr-pt.md
+++ b/docs/data/base/components/no-ssr/no-ssr-pt.md
@@ -1,8 +1,7 @@
 ---
-product: material-ui
+product: base
 title: Componente React Sem SSR
 components: NoSsr
-packageName: '@mui/base'
 ---
 
 # Sem SSR

--- a/docs/data/base/components/no-ssr/no-ssr-zh.md
+++ b/docs/data/base/components/no-ssr/no-ssr-zh.md
@@ -1,8 +1,7 @@
 ---
-product: material-ui
+product: base
 title: React No SSR（非服务端渲染）的组件
 components: NoSsr
-packageName: '@mui/base'
 ---
 
 # 非服务端渲染（SSR）

--- a/docs/data/base/components/no-ssr/no-ssr.md
+++ b/docs/data/base/components/no-ssr/no-ssr.md
@@ -2,7 +2,6 @@
 product: base
 title: No SSR React component
 components: NoSsr
-packageName: '@mui/base'
 ---
 
 # No SSR

--- a/docs/data/base/components/popper/popper.md
+++ b/docs/data/base/components/popper/popper.md
@@ -4,7 +4,6 @@ title: Unstyled React Popper component
 components: PopperUnstyled
 githubLabel: 'component: Popper'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
-packageName: '@mui/base'
 ---
 
 # Unstyled popper

--- a/docs/data/base/components/portal/portal-pt.md
+++ b/docs/data/base/components/portal/portal-pt.md
@@ -1,9 +1,8 @@
 ---
-product: material-ui
+product: base
 title: Componente React Portal
 components: Portal
 githubLabel: 'component: Portal'
-packageName: '@mui/base'
 ---
 
 # Portal

--- a/docs/data/base/components/portal/portal-zh.md
+++ b/docs/data/base/components/portal/portal-zh.md
@@ -1,9 +1,8 @@
 ---
-product: material-ui
+product: base
 title: React Portal（传送门）组件
 components: Portal
 githubLabel: 'component: Portal'
-packageName: '@mui/base'
 ---
 
 # Portal

--- a/docs/data/base/components/portal/portal.md
+++ b/docs/data/base/components/portal/portal.md
@@ -3,7 +3,6 @@ product: base
 title: React Portal component
 components: Portal
 githubLabel: 'component: Portal'
-packageName: '@mui/base'
 ---
 
 # Portal

--- a/docs/data/base/components/select/select-pt.md
+++ b/docs/data/base/components/select/select-pt.md
@@ -4,7 +4,6 @@ title: Unstyled React Select components and hook
 components: SelectUnstyled, MultiSelectUnstyled, OptionUnstyled, OptionGroupUnstyled
 githubLabel: 'component: select'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#combobox'
-packageName: '@mui/base'
 ---
 
 # Unstyled select

--- a/docs/data/base/components/select/select-zh.md
+++ b/docs/data/base/components/select/select-zh.md
@@ -4,7 +4,6 @@ title: Unstyled React Select components and hook
 components: SelectUnstyled, MultiSelectUnstyled, OptionUnstyled, OptionGroupUnstyled
 githubLabel: 'component: select'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#combobox'
-packageName: '@mui/base'
 ---
 
 # Unstyled select

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -4,7 +4,6 @@ title: Unstyled React Select components and hook
 components: SelectUnstyled, MultiSelectUnstyled, OptionUnstyled, OptionGroupUnstyled
 githubLabel: 'component: select'
 waiAria: https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html
-packageName: '@mui/base'
 ---
 
 # Unstyled select

--- a/docs/data/base/components/slider/slider-pt.md
+++ b/docs/data/base/components/slider/slider-pt.md
@@ -4,7 +4,6 @@ title: Unstyled React Slider component and hook
 components: SliderUnstyled
 githubLabel: 'component: slider'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#slider'
-packageName: '@mui/base'
 ---
 
 # Unstyled slider
@@ -23,7 +22,7 @@ import SliderUnstyled from '@mui/base/SliderUnstyled';
 
 ## Discrete sliders
 
-O controle deslizante mais básico é _contínuo_, o que significa que não tem valores pré-definidos  para o usuário selecionar. Isso é adequado para situações em que um valor aproximado é bom o suficiente para o usuário, como brilho ou volume.
+O controle deslizante mais básico é _contínuo_, o que significa que não tem valores pré-definidos para o usuário selecionar. Isso é adequado para situações em que um valor aproximado é bom o suficiente para o usuário, como brilho ou volume.
 
 But if your users need more precise options, you can create a discrete slider that snaps the thumb to pre-defined stops along the bar.
 

--- a/docs/data/base/components/slider/slider-zh.md
+++ b/docs/data/base/components/slider/slider-zh.md
@@ -4,7 +4,6 @@ title: Unstyled React Slider component and hook
 components: SliderUnstyled
 githubLabel: 'component: slider'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#slider'
-packageName: '@mui/base'
 ---
 
 # Unstyled slider

--- a/docs/data/base/components/slider/slider.md
+++ b/docs/data/base/components/slider/slider.md
@@ -4,7 +4,6 @@ title: Unstyled React Slider component and hook
 components: SliderUnstyled
 githubLabel: 'component: slider'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/
-packageName: '@mui/base'
 ---
 
 # Unstyled slider

--- a/docs/data/base/components/switch/switch-pt.md
+++ b/docs/data/base/components/switch/switch-pt.md
@@ -4,7 +4,6 @@ title: React Switch component
 components: SwitchUnstyled
 githubLabel: 'component: switch'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#switch'
-packageName: '@mui/base'
 ---
 
 # Switch

--- a/docs/data/base/components/switch/switch-zh.md
+++ b/docs/data/base/components/switch/switch-zh.md
@@ -4,7 +4,6 @@ title: React Switch component
 components: SwitchUnstyled
 githubLabel: 'component: switch'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#switch'
-packageName: '@mui/base'
 ---
 
 # Switch

--- a/docs/data/base/components/switch/switch.md
+++ b/docs/data/base/components/switch/switch.md
@@ -4,7 +4,6 @@ title: Unstyled React Switch component and hook
 components: SwitchUnstyled
 githubLabel: 'component: switch'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/switch/
-packageName: '@mui/base'
 ---
 
 # Unstyled switch

--- a/docs/data/base/components/table-pagination/table-pagination-pt.md
+++ b/docs/data/base/components/table-pagination/table-pagination-pt.md
@@ -3,7 +3,6 @@ product: base
 title: React Table pagination component
 components: TablePaginationUnstyled
 githubLabel: 'component: TablePagination'
-packageName: '@mui/base'
 ---
 
 # Unstyled table pagination

--- a/docs/data/base/components/table-pagination/table-pagination-zh.md
+++ b/docs/data/base/components/table-pagination/table-pagination-zh.md
@@ -3,7 +3,6 @@ product: base
 title: React Table pagination component
 components: TablePaginationUnstyled
 githubLabel: 'component: TablePagination'
-packageName: '@mui/base'
 ---
 
 # Unstyled table pagination

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -3,7 +3,6 @@ product: base
 title: Unstyled React Table Pagination component
 components: TablePaginationUnstyled
 githubLabel: 'component: TablePagination'
-packageName: '@mui/base'
 ---
 
 # Unstyled table pagination

--- a/docs/data/base/components/tabs/tabs-pt.md
+++ b/docs/data/base/components/tabs/tabs-pt.md
@@ -4,7 +4,6 @@ title: React Tabs component
 components: TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
 githubLabel: 'component: tabs'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#tabpanel'
-packageName: '@mui/base'
 ---
 
 # Tabs

--- a/docs/data/base/components/tabs/tabs-zh.md
+++ b/docs/data/base/components/tabs/tabs-zh.md
@@ -4,7 +4,6 @@ title: React Tabs component
 components: TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
 githubLabel: 'component: tabs'
 waiAria: 'https://www.w3.org/TR/wai-aria-practices/#tabpanel'
-packageName: '@mui/base'
 ---
 
 # Tabs

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -4,7 +4,6 @@ title: Unstyled React Tabs components
 components: TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
 githubLabel: 'component: tabs'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
-packageName: '@mui/base'
 ---
 
 # Tabs

--- a/docs/data/base/components/textarea-autosize/textarea-autosize-pt.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize-pt.md
@@ -1,9 +1,8 @@
 ---
-product: material-ui
+product: base
 title: Componente React de texto autoajustável
 components: TextareaAutosize
 githubLabel: 'component: TextareaAutosize'
-packageName: '@mui/base'
 ---
 
 # Texto autoajustável

--- a/docs/data/base/components/textarea-autosize/textarea-autosize-zh.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize-zh.md
@@ -1,9 +1,8 @@
 ---
-product: material-ui
+product: base
 title: React Textarea Autosize（自适应文本框）组件
 components: TextareaAutosize
 githubLabel: 'component: TextareaAutosize'
-packageName: '@mui/base'
 ---
 
 # Textarea Autosize 自适应文本框

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -3,7 +3,6 @@ product: base
 title: Textarea Autosize React component
 components: TextareaAutosize
 githubLabel: 'component: TextareaAutosize'
-packageName: '@mui/base'
 ---
 
 # Textarea autosize

--- a/docs/data/base/components/trap-focus/trap-focus-pt.md
+++ b/docs/data/base/components/trap-focus/trap-focus-pt.md
@@ -3,7 +3,6 @@ product: base
 title: Componente React para capturar foco
 components: TrapFocus
 githubLabel: 'component: TrapFocus'
-packageName: '@mui/base'
 ---
 
 # Capturar foco

--- a/docs/data/base/components/trap-focus/trap-focus-zh.md
+++ b/docs/data/base/components/trap-focus/trap-focus-zh.md
@@ -3,7 +3,6 @@ product: base
 title: React Trap Focus（容器焦点）组件
 components: TrapFocus
 githubLabel: 'component: TrapFocus'
-packageName: '@mui/base'
 ---
 
 # Trap Focus 容器焦点

--- a/docs/data/base/components/trap-focus/trap-focus.md
+++ b/docs/data/base/components/trap-focus/trap-focus.md
@@ -3,7 +3,6 @@ product: base
 title: React Trap Focus component
 components: TrapFocus
 githubLabel: 'component: TrapFocus'
-packageName: '@mui/base'
 ---
 
 # Trap focus

--- a/docs/data/material/components/popper/popper-pt.md
+++ b/docs/data/material/components/popper/popper-pt.md
@@ -4,7 +4,6 @@ title: Componente React Popper
 components: Popper
 githubLabel: 'component: Popper'
 unstyled: /base/react-popper/
-packageName: '@mui/base'
 ---
 
 # Popper

--- a/docs/data/material/components/popper/popper-zh.md
+++ b/docs/data/material/components/popper/popper-zh.md
@@ -4,7 +4,6 @@ title: React Popper（弹出提示）组件
 components: Popper, PopperUnstyled
 githubLabel: 'component: Popper'
 unstyled: /base/react-popper/
-packageName: '@mui/base'
 ---
 
 # Popper 弹出提示

--- a/docs/data/system/components/grid/grid.md
+++ b/docs/data/system/components/grid/grid.md
@@ -2,7 +2,6 @@
 product: system
 title: React Grid component
 githubLabel: 'component: Grid'
-packageName: '@mui/system'
 ---
 
 # Grid


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow up on https://github.com/mui/material-ui/pull/33439
Since `ComponentLinkHeader` now has default `packageName` for each `product`, it's safe to remove most of `packageName` usage in pages:
https://github.com/mui/material-ui/blob/88ad7d4e623183b8e20702e7961ef9c8de330dc7/docs/src/modules/components/ComponentLinkHeader.js#L30-L35

Now `packageName` in only used on few pages that need to override it (`@mui/lab` and `@mui/icons-material` in `material-ui` product)

https://deploy-preview-33488--material-ui.netlify.app/base/react-badge/