### PR TITLE
[Base] Add missing type definitions in useControllableReducer

### DIFF
--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
@@ -110,7 +110,7 @@ export default function useControllableReducer<TOption>(
   };
 
   const combinedReducer = React.useCallback(
-    (state, action) => {
+    (state: ListboxState<TOption>, action: ListboxAction<TOption>) => {
       if (externalReducer) {
         return externalReducer(getControlledState(state, propsRef.current), action);
       }


### PR DESCRIPTION
After merging #33408 the build on master started failing because of untyped parameters of useCallback. This PR fixes the problem.