### PR TITLE
[docs] Improve the `useTheme` documentation

### DIFF
--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -88,8 +88,6 @@ function DeepChild() {
 }
 ```
 
-{{"demo": "UseTheme.js"}}
-
 ## Nesting the theme
 
 [You can nest](/system/styles/advanced/#theme-nesting) multiple theme providers.

--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -77,7 +77,18 @@ The community has built great tools to build a theme:
 
 ## Accessing the theme in a component
 
-You [can access](/system/styles/advanced/#accessing-the-theme-in-a-component) the theme variables inside your React components.
+You [can access](/system/styles/advanced/#accessing-the-theme-in-a-component) the theme variables inside your functional React components using the `useTheme` hook:
+
+```jsx
+import { useTheme } from '@mui/styles';
+
+function DeepChild() {
+  const theme = useTheme();
+  return <span>{`spacing ${theme.spacing}`}</span>;
+}
+```
+
+{{"demo": "UseTheme.js"}}
 
 ## Nesting the theme
 

--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -77,7 +77,7 @@ The community has built great tools to build a theme:
 
 ## Accessing the theme in a component
 
-You [can access](/system/styles/advanced/#accessing-the-theme-in-a-component) the theme variables inside your functional React components using the `useTheme` hook:
+You can access the theme variables inside your functional React components using the `useTheme` hook:
 
 ```jsx
 import { useTheme } from '@mui/styles';

--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -80,7 +80,7 @@ The community has built great tools to build a theme:
 You can access the theme variables inside your functional React components using the `useTheme` hook:
 
 ```jsx
-import { useTheme } from '@mui/styles';
+import { useTheme } from '@mui/material/styles';
 
 function DeepChild() {
   const theme = useTheme();


### PR DESCRIPTION
This PR moves the useTheme documentation from the advanced(legacy)section to the theming section. This was done to prevent confusion about deprecating the `useTheme` hook (see #32173).