### PR TITLE
[Grid] Avoid scrollbar in demo

### DIFF
--- a/docs/data/system/components/grid/grid.md
+++ b/docs/data/system/components/grid/grid.md
@@ -128,8 +128,8 @@ If you specify custom breakpoints to the theme, you can use those names as grid 
 The custom breakpoints affect both the size and offset props:
 
 ```diff
-- <Grid xs={6} xsOffset={2} sm={4} smOffset={2} md={3} mdOffset={3}>
-+ <Grid mobile={6} mobileOffset={2} tablet={4} tabletOffset={2} laptop={3} laptopOffset={3}>
+-<Grid xs={6} xsOffset={2} sm={4} smOffset={2}>
++<Grid mobile={6} mobileOffset={2} tablet={4} tabletOffset={2}>
 ```
 
 :::

--- a/docs/data/system/components/grid/grid.md
+++ b/docs/data/system/components/grid/grid.md
@@ -128,8 +128,8 @@ If you specify custom breakpoints to the theme, you can use those names as grid 
 The custom breakpoints affect both the size and offset props:
 
 ```diff
--<Grid xs={6} xsOffset={2} sm={4} smOffset={2}>
-+<Grid mobile={6} mobileOffset={2} tablet={4} tabletOffset={2}>
+-<Grid xs={6} xsOffset={2}>
++<Grid mobile={6} mobileOffset={2}>
 ```
 
 :::


### PR DESCRIPTION
A small polish. Avoid the need to scroll, and make it less overwhelming to understand what's going on. It took me some time to understand the message we were trying to communicate.

### Before:

<img width="773" alt="Screenshot 2022-07-15 at 23 45 53" src="https://user-images.githubusercontent.com/3165635/179315261-c54b38b3-9059-4cf0-bdcb-031648427ffe.png">

https://mui.com/system/react-grid/#custom-breakpoints

### After:

<img width="778" alt="Screenshot 2022-07-15 at 23 45 57" src="https://user-images.githubusercontent.com/3165635/179315258-d7eb1f96-0097-41ad-816b-0db26e9f5e09.png">

https://deploy-preview-33527--material-ui.netlify.app/system/react-grid/#custom-breakpoints