### PR TITLE
[docs] Fix invalid `createStyles` example code

### DIFF
--- a/docs/data/styles/api/api.md
+++ b/docs/data/styles/api/api.md
@@ -96,10 +96,11 @@ Link a style sheet with a function component using the **hook** pattern.
 ### Returns
 
 `hook`: A hook. This hook can be used in a function component. The documentation often calls this returned hook `useStyles`.
+
 #### `useStyles([props]) => classes`
-* It accepts one argument: the props that will be used for "interpolation" in
-the style sheet.
-* It returns a dictionary object containing the generated class names. The keys of this object match the keys of the style rules provided to `makeStyles`.
+
+- It accepts one argument: the props that will be used for "interpolation" in the style sheet.
+- It returns a dictionary object containing the generated class names. The keys of this object match the keys of the style rules provided to `makeStyles`.
 
 When using the function syntax of `styles` to access the `Theme` object, the hook must be called in a component which is inside your app's [`ThemeProvider`](#themeprovider).
 

--- a/docs/data/styles/api/api.md
+++ b/docs/data/styles/api/api.md
@@ -66,20 +66,14 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      backgroundColor: theme.palette.red,
+      backgroundColor: theme.palette.success.light,
     },
   }),
 );
 
-const theme = createTheme();
-
 export default function MyComponent() {
   const classes = useStyles();
-  return (
-    <ThemeProvider theme={theme}>
-      <div className={classes.root} />
-    </ThemeProvider>
-  );
+  return <div className={classes.root} />;
 }
 ```
 
@@ -102,8 +96,12 @@ Link a style sheet with a function component using the **hook** pattern.
 ### Returns
 
 `hook`: A hook. This hook can be used in a function component. The documentation often calls this returned hook `useStyles`.
-It accepts one argument: the props that will be used for "interpolation" in
+#### `useStyles([props]) => classes`
+* It accepts one argument: the props that will be used for "interpolation" in
 the style sheet.
+* It returns a dictionary object containing the generated class names. The keys of this object match the keys of the style rules provided to `makeStyles`.
+
+When using the function syntax of `styles` to access the `Theme` object, the hook must be called in a component which is inside your app's [`ThemeProvider`](#themeprovider).
 
 ### Examples
 


### PR DESCRIPTION
fixes #33494 

As explained in [this comment](https://github.com/mui/material-ui/issues/33494#issuecomment-1186235457), the current code block in the `createStyles` section will not work.  I have removed the invalid `<ThemeProvider>` code from that example and added a note to the `makeStyles` section explaining that components which call `useStyles` must be inside of a provider.

I also changed `theme.palette.red` to `theme.palette.success.light` because I think it's more user-friendly to use standard/built-in theme properties in examples.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
