### PR TITLE
[Stack] Ensure that `marginundefined` doesn't occur in styling 

### DIFF
--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -79,6 +79,17 @@ export const style = ({ ownerState, theme }) => {
       base,
     });
 
+    if (typeof directionValues === 'object') {
+      Object.keys(directionValues).forEach((breakpoint, index, breakpoints) => {
+        const directionValue = directionValues[breakpoint];
+        if (!directionValue) {
+          const previousDirectionValue =
+            index > 0 ? directionValues[breakpoints[index - 1]] : 'column';
+          directionValues[breakpoint] = previousDirectionValue;
+        }
+      });
+    }
+
     const styleFromPropValue = (propValue, breakpoint) => {
       return {
         '& > :not(style) + :not(style)': {
@@ -91,6 +102,7 @@ export const style = ({ ownerState, theme }) => {
     };
     styles = deepmerge(styles, handleBreakpoints({ theme }, spacingValues, styleFromPropValue));
   }
+  console.log(styles);
 
   return styles;
 };

--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -102,7 +102,6 @@ export const style = ({ ownerState, theme }) => {
     };
     styles = deepmerge(styles, handleBreakpoints({ theme }, spacingValues, styleFromPropValue));
   }
-  console.log(styles);
 
   return styles;
 };

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -222,7 +222,7 @@ describe('<Stack />', () => {
       });
     });
 
-    it('handles responsive `direction` prop when it does not start with the smallest breakpoint', () => {
+    it('should place correct margin direction even though breakpoints are not fully provided', () => {
       expect(
         style({
           ownerState: {

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -222,7 +222,7 @@ describe('<Stack />', () => {
       });
     });
 
-    it.only('should place correct margin direction even though breakpoints are not fully provided', () => {
+    it('should place correct margin direction even though breakpoints are not fully provided', () => {
       expect(
         style({
           ownerState: {

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -222,7 +222,7 @@ describe('<Stack />', () => {
       });
     });
 
-    it('should place correct margin direction even though breakpoints are not fully provided', () => {
+    it.only('should place correct margin direction even though breakpoints are not fully provided', () => {
       expect(
         style({
           ownerState: {
@@ -255,6 +255,50 @@ describe('<Stack />', () => {
           '& > :not(style) + :not(style)': {
             margin: 0,
             marginLeft: '32px',
+          },
+        },
+        display: 'flex',
+      });
+
+      expect(
+        style({
+          ownerState: {
+            direction: { lg: 'column', sm: 'row' },
+            spacing: { md: 2, xl: 4, xs: 0 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${defaultTheme.breakpoints.values.xs}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '0px',
+          },
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.sm}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '0px',
+          },
+          flexDirection: 'row',
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '16px',
+          },
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.lg}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '16px',
+          },
+          flexDirection: 'column',
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.xl}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '32px',
           },
         },
         display: 'flex',

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -320,5 +320,44 @@ describe('<Stack />', () => {
         flexDirection: 'column',
       });
     });
+
+    it('handles responsive `direction` prop when it does not start with the smallest breakpoint', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: { lg: 'row' },
+            spacing: { xs: 0, md: 2, xl: 4 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${defaultTheme.breakpoints.values.xs}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '0px',
+          },
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '16px',
+          },
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.lg}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '16px',
+          },
+          flexDirection: 'row',
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.xl}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '32px',
+          },
+        },
+        display: 'flex',
+      });
+    });
   });
 });

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -221,6 +221,45 @@ describe('<Stack />', () => {
         display: 'flex',
       });
     });
+
+    it('handles responsive `direction` prop when it does not start with the smallest breakpoint', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: { lg: 'row' },
+            spacing: { xs: 0, md: 2, xl: 4 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${defaultTheme.breakpoints.values.xs}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '0px',
+          },
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '16px',
+          },
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.lg}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '16px',
+          },
+          flexDirection: 'row',
+        },
+        [`@media (min-width:${defaultTheme.breakpoints.values.xl}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '32px',
+          },
+        },
+        display: 'flex',
+      });
+    });
   });
 
   describe('prop: spacing', () => {
@@ -318,45 +357,6 @@ describe('<Stack />', () => {
         },
         display: 'flex',
         flexDirection: 'column',
-      });
-    });
-
-    it('handles responsive `direction` prop when it does not start with the smallest breakpoint', () => {
-      expect(
-        style({
-          ownerState: {
-            direction: { lg: 'row' },
-            spacing: { xs: 0, md: 2, xl: 4 },
-          },
-          theme,
-        }),
-      ).to.deep.equal({
-        [`@media (min-width:${defaultTheme.breakpoints.values.xs}px)`]: {
-          '& > :not(style) + :not(style)': {
-            margin: 0,
-            marginTop: '0px',
-          },
-        },
-        [`@media (min-width:${defaultTheme.breakpoints.values.md}px)`]: {
-          '& > :not(style) + :not(style)': {
-            margin: 0,
-            marginTop: '16px',
-          },
-        },
-        [`@media (min-width:${defaultTheme.breakpoints.values.lg}px)`]: {
-          '& > :not(style) + :not(style)': {
-            margin: 0,
-            marginLeft: '16px',
-          },
-          flexDirection: 'row',
-        },
-        [`@media (min-width:${defaultTheme.breakpoints.values.xl}px)`]: {
-          '& > :not(style) + :not(style)': {
-            margin: 0,
-            marginLeft: '32px',
-          },
-        },
-        display: 'flex',
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/32196

**Problem**:
- If `direction` prop receives a responsive value such that it doesn't start with the smallest breakpoint, such as `direction={{ lg: 'row' }}`, for the breakpoints below `lg`, `"marginundefined": "0px"`is being used in styling instead of `"marginLeft": "0px"` (for `row` direction) or `"marginTop": "0px"` (for `column` direction).
- [This function in line 86](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Stack/Stack.js#L86) results in `undefined` because `directionValues[breakpoint]` in the next line, [line 87](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Stack/Stack.js#L87),  is `undefined`.

**Solution**:
- Ensure that [this function in line 86](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Stack/Stack.js#L86) never results in `undefined`, by ensuring that `directionValues[breakpoint]` in the next line, [line 87](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Stack/Stack.js#L87),  is not `undefined`.

**Codesandboxes**:
- [Before](https://codesandbox.io/s/jovial-bouman-qd3b7m)
- <img width="285" alt="Screenshot 2022-07-17 at 13 16 28" src="https://user-images.githubusercontent.com/32841130/179397843-8006fc02-229f-45ec-b0de-a0b49e27df94.png">

- [After](https://codesandbox.io/s/charming-lumiere-9qud9p)
- <img width="265" alt="Screenshot 2022-07-17 at 13 18 15" src="https://user-images.githubusercontent.com/32841130/179397904-dabd740a-c627-4843-b345-10cc502b5b2d.png">