### PR TITLE
[Stack] Responsive styles based on breakpoints should be in the correct order

### DIFF
--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -4,6 +4,7 @@ import {
   createUnarySpacing,
   getValue,
   handleBreakpoints,
+  mergeBreakpointsInOrder,
   unstable_extendSxProp as extendSxProp,
   unstable_resolveBreakpointValues as resolveBreakpointValues,
 } from '@mui/system';
@@ -91,6 +92,8 @@ export const style = ({ ownerState, theme }) => {
     };
     styles = deepmerge(styles, handleBreakpoints({ theme }, spacingValues, styleFromPropValue));
   }
+
+  styles = mergeBreakpointsInOrder(theme.breakpoints, styles);
 
   return styles;
 };

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -320,5 +320,22 @@ describe('<Stack />', () => {
         flexDirection: 'column',
       });
     });
+
+    it('should list responsive styles in correct order', () => {
+      const styles = style({
+        ownerState: {
+          direction: { xs: 'column', lg: 'row' },
+          spacing: { xs: 0, md: 2, xl: 4 },
+        },
+        theme,
+      });
+      const keysForResponsiveStyles = Object.keys(styles).filter((prop) => prop.includes('@media'));
+      expect(keysForResponsiveStyles).to.deep.equal([
+        '@media (min-width:0px)',
+        '@media (min-width:900px)',
+        '@media (min-width:1200px)',
+        '@media (min-width:1536px)',
+      ]);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/32999

**Problem**:
- When providing responsive values to both `direction` and `spacing`, the CSS styling could result in such that responsive styles are listed in incorrect order (e.g., lower resolution overwriting the higher one, while the correct behaviour is the opposite).
- Example where `900px` resolution's style is overwriting the style of `1200px`.
<img width="512" alt="Screen Shot 2022-06-02 at 18 58 05" src="https://user-images.githubusercontent.com/5411244/171673192-05ec8f6b-5388-4707-9b1e-d467931dd017.png">

**Solution**:
- Use the utility function [mergeBreakpointsInOrder](https://github.com/mui/material-ui/blob/master/packages/mui-system/src/breakpoints.js#L107) from `@mui/system`.
- Same example used above:
<img width="373" alt="Screenshot 2022-07-17 at 20 12 15" src="https://user-images.githubusercontent.com/32841130/179421260-860228fa-0863-4981-9b4a-acb9cca877ef.png">

**Codesandboxes**:
- [Before](https://codesandbox.io/s/friendly-haze-m7s2mn)
- [After](https://codesandbox.io/s/objective-keldysh-b7ktn6)