### PR TITLE
[website] Add new FAQ to pricing page

### DIFF
--- a/docs/pages/blog/premium-plan-release.md
+++ b/docs/pages/blog/premium-plan-release.md
@@ -90,7 +90,7 @@ Here is a list of everything that has changed:
 
 - **Removing volume and renewal discounts**
 
-  We aim to give a more transparent price based on the number of developer seats while providing more predictable revenue for MUI X in the long term.
+  We aim to give a more transparent price based on the number of developer licenses while providing more predictable revenue for MUI X in the long term.
   We believe that’s best for both our long-standing customers and us as a company.
 
 - **Perpetual in production**

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -71,12 +71,13 @@ const faqData = [
         <strong>and indirectly</strong>.
         <br />
         <br />
-        We are including indirect developers in the pricing model
-        to help reduce the creation of silos in your engineering organization. If only direct
-        developers needed a license, then only a handful of engineers would be allowed to use MUI X.
+        We are including indirect developers in the pricing model to help reduce the creation of
+        silos in your engineering organization. If only direct developers needed a license, then
+        only a handful of engineers would be allowed to use MUI X.
         <br />
         <br />
-        In exchange, the price point per developer is lower than it would be if only direct developers needed a seat.
+        In exchange, the price point per developer is lower than it would be if only direct
+        developers needed a seat.
       </React.Fragment>
     ),
   },

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -74,8 +74,8 @@ const faqData = [
         supported.
         <br />
         <br />
-        The price point per developer is adjusted to be lower than if only direct
-        use needed a license.{' '}
+        The price point per developer is adjusted to be lower than if only direct use needed a
+        license.{' '}
         <Link
           target="_blank"
           rel="noopener"

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -63,16 +63,16 @@ const faqData = [
     summary: 'Why do we must license developers not using the software directly?',
     detail: (
       <React.Fragment>
-        Our pricing model requires all developers working on a project using MUI X to be licensed. 
-        This is designed to make it easier for your engineers to use MUI X components
-        without having to constantly verify if they have the right number of seats. It aims
-        to replicate one of the great properties open-source licenses have: simplicity.
+        Our pricing model requires all developers working on a project using MUI X to be licensed.
+        This is designed to make it easier for your engineers to use MUI X components without having
+        to constantly verify if they have the right number of seats. It aims to replicate one of the
+        great properties open-source licenses have: simplicity.
         <br />
         <br />
-        Our pricing model also requires developers indirectly using MUI X to be licensed,
-        e.g. through a wrapper library. This is because the more developers in your organization
-        using the software, the more they need comprehensive documentation, and the more hedge cases
-        they will ask to be supported.
+        Our pricing model also requires developers indirectly using MUI X to be licensed, e.g.
+        through a wrapper library. This is because the more developers in your organization using
+        the software, the more they need comprehensive documentation, and the more hedge cases they
+        will ask to be supported.
         <br />
         <br />
         The price point per developer was adjusted to be much lower than what it would be if only

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -64,14 +64,11 @@ const faqData = [
       <React.Fragment>
         Our pricing model requires all developers working on a project using MUI X Pro or Premium to
         be licensed. This is intended to make it easier for you and your team to know if the right
-        number of developers are licensed. It tries to emulate the simplicity of the open-source
-        licenses.
+        number of developers are licensed.
         <br />
         <br />
         Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g.
-        through a wrapper library) to be licensed. The more developers in your organization using
-        the software, the more they need documentation, and the more hedge cases they need to be
-        supported.
+        through a wrapper library) to be licensed.
         <br />
         <br />
         The price point per developer is adjusted to be lower than if only direct use needed a

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -69,9 +69,9 @@ const faqData = [
         <br />
         <br />
         Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g.
-        through a wrapper library) to be licensed. This is because the more developers in your
-        organization using the software, the more they need comprehensive documentation, and the
-        more hedge cases they will ask to be supported.
+        through a wrapper library) to be licensed. The more developers in your organization using
+        the software, the more they need documentation, and the more hedge cases they need to be
+        supported.
         <br />
         <br />
         The price point per developer was adjusted to be lower than what it would be if only direct

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -26,12 +26,11 @@ const faqData = [
     ),
   },
   {
-    summary: 'How many developer seats do I need?',
+    summary: 'How many developer licenses do I need?',
     detail: (
       <React.Fragment>
-        The number of seats purchased on your license must correspond to the number of concurrent
-        developers contributing changes to the front-end code of the projects that uses MUI X Pro or
-        Premium.
+        The number of licenses purchased must correspond to the number of concurrent developers
+        contributing changes to the front-end code of the projects that uses MUI X Pro or Premium.
         <br />
         <br />
         <b>Example 1.</b> Company 'A' is developing an application named 'AppA'. The app needs to

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -30,7 +30,7 @@ const faqData = [
     detail: (
       <React.Fragment>
         The number of licenses purchased must correspond to the number of concurrent developers
-        contributing changes to the front-end code of the projects that uses MUI X Pro or Premium.
+        contributing changes to the front-end code of projects that use MUI X Pro or Premium.
         <br />
         <br />
         <b>Example 1.</b> Company 'A' is developing an application named 'AppA'. The app needs to
@@ -59,11 +59,11 @@ const faqData = [
     ),
   },
   {
-    summary: 'Why do we must license developers not using the software directly?',
+    summary: 'Why must we license developers not using the software directly?',
     detail: (
       <React.Fragment>
         Our pricing model requires all developers working on a project using MUI X Pro or Premium to
-        be licensed. This is intended to make it easier for you and your team to know if right
+        be licensed. This is intended to make it easier for you and your team to know if the right
         number of developers are licensed. It tries to emulate the simplicity of the open-source
         licenses.
         <br />
@@ -74,14 +74,14 @@ const faqData = [
         supported.
         <br />
         <br />
-        The price point per developer was adjusted to be lower than what it would be if only direct
+        The price point per developer is adjusted to be lower than if only direct
         use needed a license.{' '}
         <Link
           target="_blank"
           rel="noopener"
           href="https://mui.com/store/legal/mui-x-eula/#required-quantity-of-licenses"
         >
-          The clause in the EULA.
+          The relevant EULA clause.
         </Link>
       </React.Fragment>
     ),

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -63,13 +63,13 @@ const faqData = [
     summary: 'Why do we must license developers not using the software directly?',
     detail: (
       <React.Fragment>
-        Our pricing model requires all developers working on the same project that the software is
-        used into to be licensed. This is designed to make it easier for your engineers to use the
-        software without having to constantly verify if they have the right number of seats. It aims
+        Our pricing model requires all developers working on a project using MUI X to be licensed. 
+        This is designed to make it easier for your engineers to use MUI X components
+        without having to constantly verify if they have the right number of seats. It aims
         to replicate one of the great properties open-source licenses have: simplicity.
         <br />
         <br />
-        Our pricing model also requires developers using the software indirectly to be licensed,
+        Our pricing model also requires developers indirectly using MUI X to be licensed,
         e.g. through a wrapper library. This is because the more developers in your organization
         using the software, the more they need comprehensive documentation, and the more hedge cases
         they will ask to be supported.

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -63,13 +63,13 @@ const faqData = [
     detail: (
       <React.Fragment>
         Our pricing model requires all developers working on a project using MUI X Pro or Premium to
-        be licensed. This is designed to make it easier for your engineers to use the software
+        be licensed. This is intended to make it easier for your engineers to use the software
         without having to constantly verify if they have the right number of seats. It aims to
         replicate one of the great properties open-source licenses have: simplicity.
         <br />
         <br />
-        Our pricing model also requires developers indirectly using MUI X Pro or Premium to be
-        licensed, e.g. through a wrapper library. This is because the more developers in your
+        Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g. through a wrapper library) to be
+        licensed. This is because the more developers in your
         organization using the software, the more they need comprehensive documentation, and the
         more hedge cases they will ask to be supported.
         <br />

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -64,6 +64,23 @@ const faqData = [
     ),
   },
   {
+    summary: 'Why does developers using MUI X indirectly needs to be licensed?',
+    detail: (
+      <React.Fragment>
+        The number of seats purchased must include developers using MUI X Pro or Premium directly{' '}
+        <strong>and indirectly</strong>.
+        <br />
+        <br />
+        We are including indirect developers in the pricing model
+        to help reduce the creation of silos in your engineering organization. If only direct
+        developers needed a license, then only a handful of engineers would be allowed to use MUI X.
+        <br />
+        <br />
+        In exchange, the price point per developer is lower than it would be if only direct developers needed a seat.
+      </React.Fragment>
+    ),
+  },
+  {
     summary: 'Do developers have to be named?',
     detail: (
       <React.Fragment>
@@ -246,14 +263,15 @@ export default function FAQ() {
           {renderItem(0)}
           {renderItem(1)}
           {renderItem(2)}
+          {renderItem(3)}
         </Grid>
         <Grid item xs={12} md={4}>
-          {renderItem(3)}
           {renderItem(4)}
           {renderItem(5)}
+          {renderItem(6)}
         </Grid>
         <Grid item xs={12} md={4}>
-          {renderItem(6)}
+          {renderItem(7)}
           <Paper
             variant="outlined"
             sx={{

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -63,9 +63,9 @@ const faqData = [
     detail: (
       <React.Fragment>
         Our pricing model requires all developers working on a project using MUI X Pro or Premium to
-        be licensed. This is intended to make it easier for your engineers to use the software
-        without having to constantly verify if they have the right number of seats. It aims to
-        replicate one of the great properties open-source licenses have: simplicity.
+        be licensed. This is intended to make it easier for you and your team to know if right
+        number of developers are licensed to use the software. It tries to emulate the simplicity of
+        the open-source licenses.
         <br />
         <br />
         Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g.

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -17,15 +17,11 @@ const faqData = [
     summary: 'How do I know if I need to buy a license?',
     detail: (
       <React.Fragment>
-        If you are in doubt, check the license file of the npm package you're installing.
-        <br />
-        <br />
-        For instance <Link href="https://unpkg.com/@mui/x-data-grid/LICENSE">
-          @mui/x-data-grid
-        </Link>{' '}
-        is MIT while{' '}
-        <Link href="https://unpkg.com/@mui/x-data-grid-pro/LICENSE">@mui/x-data-grid-pro</Link> is
-        commercial.
+        If you are in doubt, check the license file of the npm package you're installing. For
+        instance <Link href="https://unpkg.com/@mui/x-data-grid/LICENSE">@mui/x-data-grid</Link> is
+        an MIT License (free) while{' '}
+        <Link href="https://unpkg.com/@mui/x-data-grid-pro/LICENSE">@mui/x-data-grid-pro</Link> is a
+        Commercial License.
       </React.Fragment>
     ),
   },
@@ -64,20 +60,30 @@ const faqData = [
     ),
   },
   {
-    summary: 'Why does developers using MUI X indirectly needs to be licensed?',
+    summary: 'Why do we must license developers not using the software directly?',
     detail: (
       <React.Fragment>
-        The number of seats purchased must include developers using MUI X Pro or Premium directly{' '}
-        <strong>and indirectly</strong>.
+        Our pricing model requires all developers working on the same project that the software is
+        used into to be licensed. This is designed to make it easier for your engineers to use the
+        software without having to constantly verify if they have the right number of seats. It aims
+        to replicate one of the great properties open-source licenses have: simplicity.
         <br />
         <br />
-        We are including indirect developers in the pricing model to help reduce the creation of
-        silos in your engineering organization. If only direct developers needed a license, then
-        only a handful of engineers would be allowed to use MUI X.
+        Our pricing model also requires developers using the software indirectly to be licensed,
+        e.g. through a wrapper library. This is because the more developers in your organization
+        using the software, the more they need comprehensive documentation, and the more hedge cases
+        they will ask to be supported.
         <br />
         <br />
-        In exchange, the price point per developer is lower than it would be if only direct
-        developers needed a seat.
+        The price point per developer was adjusted to be much lower than what it would be if only
+        direct use needed a license.{' '}
+        <Link
+          target="_blank"
+          rel="noopener"
+          href="https://mui.com/store/legal/mui-x-eula/#required-quantity-of-licenses"
+        >
+          The clause in the EULA.
+        </Link>
       </React.Fragment>
     ),
   },

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -75,8 +75,8 @@ const faqData = [
         more hedge cases they will ask to be supported.
         <br />
         <br />
-        The price point per developer was adjusted to be much lower than what it would be if only
-        direct use needed a license.{' '}
+        The price point per developer was adjusted to be lower than what it would be if only direct
+        use needed a license.{' '}
         <Link
           target="_blank"
           rel="noopener"

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -68,8 +68,8 @@ const faqData = [
         replicate one of the great properties open-source licenses have: simplicity.
         <br />
         <br />
-        Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g. through a wrapper library) to be
-        licensed. This is because the more developers in your
+        Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g.
+        through a wrapper library) to be licensed. This is because the more developers in your
         organization using the software, the more they need comprehensive documentation, and the
         more hedge cases they will ask to be supported.
         <br />

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -64,8 +64,8 @@ const faqData = [
       <React.Fragment>
         Our pricing model requires all developers working on a project using MUI X Pro or Premium to
         be licensed. This is intended to make it easier for you and your team to know if right
-        number of developers are licensed to use the software. It tries to emulate the simplicity of
-        the open-source licenses.
+        number of developers are licensed. It tries to emulate the simplicity of the open-source
+        licenses.
         <br />
         <br />
         Our licensing model also requires developers indirectly using MUI X Pro or Premium (e.g.

--- a/docs/src/components/pricing/FAQ.tsx
+++ b/docs/src/components/pricing/FAQ.tsx
@@ -63,16 +63,16 @@ const faqData = [
     summary: 'Why do we must license developers not using the software directly?',
     detail: (
       <React.Fragment>
-        Our pricing model requires all developers working on a project using MUI X to be licensed.
-        This is designed to make it easier for your engineers to use MUI X components without having
-        to constantly verify if they have the right number of seats. It aims to replicate one of the
-        great properties open-source licenses have: simplicity.
+        Our pricing model requires all developers working on a project using MUI X Pro or Premium to
+        be licensed. This is designed to make it easier for your engineers to use the software
+        without having to constantly verify if they have the right number of seats. It aims to
+        replicate one of the great properties open-source licenses have: simplicity.
         <br />
         <br />
-        Our pricing model also requires developers indirectly using MUI X to be licensed, e.g.
-        through a wrapper library. This is because the more developers in your organization using
-        the software, the more they need comprehensive documentation, and the more hedge cases they
-        will ask to be supported.
+        Our pricing model also requires developers indirectly using MUI X Pro or Premium to be
+        licensed, e.g. through a wrapper library. This is because the more developers in your
+        organization using the software, the more they need comprehensive documentation, and the
+        more hedge cases they will ask to be supported.
         <br />
         <br />
         The price point per developer was adjusted to be much lower than what it would be if only

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -59,8 +59,9 @@ export default function WhatToExpect() {
             <Typography variant="body2" color="text.secondary">
               The licenses are sold on a per-developer basis, using the software directly or
               indirectly. The Pro plan includes a cap at 10 developers, extra developers do not need
-              to pay for their seats. You can contact <Link href="mailto:sales@mui.com">sales</Link>{' '}
-              for a volume discount when licensing over 50 developers under the Premium plan.
+              to pay for their license. You can contact{' '}
+              <Link href="mailto:sales@mui.com">sales</Link> for a volume discount when licensing
+              over 50 developers under the Premium plan.
             </Typography>
           </Paper>
         </Grid>

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -35,8 +35,8 @@ export default function WhatToExpect() {
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary">
-              You can use the software in a production environment forever. All the versions of the
-              software released until the end of your subscription are available in perpetuity.
+              You can use the software in a production environment forever. Any version of the
+              software released prior to the end of your subscription are available in perpetuity.
               There are no further charges unless you choose to continue development. See the
               &quot;Development license&quot; section of this page for more details.
             </Typography>
@@ -57,9 +57,9 @@ export default function WhatToExpect() {
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary">
-              The licenses are sold on a per-developer basis, using the software directly or
-              indirectly. The Pro plan includes a cap at 10 developers, extra developers do not need
-              to pay for their license. You can contact{' '}
+              The licenses are sold on a per front-end developer basis.
+              The Pro plan includes is capped at ten licenses; you do not need to pay for additional licenses for more than ten developers.
+              You can contact{' '}
               <Link href="mailto:sales@mui.com">sales</Link> for a volume discount when licensing
               over 50 developers under the Premium plan.
             </Typography>
@@ -85,8 +85,8 @@ export default function WhatToExpect() {
               <Link href="https://mui.com/x/introduction/support/#technical-support">
                 learn more about support
               </Link>{' '}
-              in the docs. Note that, except for critical issues, e.g. security, we release bug
-              fixes, and other improvements on top of the latest version, instead of patching older
+              in the docs. Note that, except for critical issues, such as security flaws, we release bug
+              fixes and other improvements on top of the latest version, instead of patching older
               versions.
             </Typography>
           </Paper>

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -59,8 +59,8 @@ export default function WhatToExpect() {
             <Typography variant="body2" color="text.secondary">
               The licenses are sold on a per-developer basis, using the software directly or
               indirectly. The Pro plan includes a cap at 10 developers, extra developers do not need
-              to pay for their seats. You can contact <Link href="mailto:sales@mui.com">sales</Link> for a
-              volume discount when licensing over 50 developers under the Premium plan.
+              to pay for their seats. You can contact <Link href="mailto:sales@mui.com">sales</Link>{' '}
+              for a volume discount when licensing over 50 developers under the Premium plan.
             </Typography>
           </Paper>
         </Grid>

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -59,7 +59,7 @@ export default function WhatToExpect() {
             <Typography variant="body2" color="text.secondary">
               The licenses are sold on a per-developer basis, using the software directly or
               indirectly. The Pro plan includes a cap at 10 developers, extra developers do not need
-              to be licensed. You can contact <Link href="mailto:sales@mui.com">sales</Link> for a
+              to pay for their seats. You can contact <Link href="mailto:sales@mui.com">sales</Link> for a
               volume discount when licensing over 50 developers under the Premium plan.
             </Typography>
           </Paper>

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -57,11 +57,10 @@ export default function WhatToExpect() {
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary">
-              The licenses are sold on a per front-end developer basis.
-              The Pro plan includes is capped at ten licenses; you do not need to pay for additional licenses for more than ten developers.
-              You can contact{' '}
-              <Link href="mailto:sales@mui.com">sales</Link> for a volume discount when licensing
-              over 50 developers under the Premium plan.
+              The licenses are sold on a per front-end developer basis. The Pro plan includes is
+              capped at ten licenses; you do not need to pay for additional licenses for more than
+              ten developers. You can contact <Link href="mailto:sales@mui.com">sales</Link> for a
+              volume discount when licensing over 50 developers under the Premium plan.
             </Typography>
           </Paper>
         </Grid>
@@ -85,9 +84,9 @@ export default function WhatToExpect() {
               <Link href="https://mui.com/x/introduction/support/#technical-support">
                 learn more about support
               </Link>{' '}
-              in the docs. Note that, except for critical issues, such as security flaws, we release bug
-              fixes and other improvements on top of the latest version, instead of patching older
-              versions.
+              in the docs. Note that, except for critical issues, such as security flaws, we release
+              bug fixes and other improvements on top of the latest version, instead of patching
+              older versions.
             </Typography>
           </Paper>
         </Grid>

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -38,7 +38,7 @@ export default function WhatToExpect() {
               You can use the software in a production environment forever. Any version of the
               software released prior to the end of your subscription are available in perpetuity.
               There are no further charges unless you choose to continue development. See the
-              &quot;Development license&quot; section of this page for more details.
+              &quot;Development license&quot; section for more details.
             </Typography>
           </Paper>
         </Grid>

--- a/docs/src/components/pricing/WhatToExpect.tsx
+++ b/docs/src/components/pricing/WhatToExpect.tsx
@@ -36,8 +36,9 @@ export default function WhatToExpect() {
             </Box>
             <Typography variant="body2" color="text.secondary">
               You can use the software in a production environment forever. All the versions of the
-              software released until the end of your subscription are available. There are no
-              further charges unless you choose to continue development.
+              software released until the end of your subscription are available in perpetuity.
+              There are no further charges unless you choose to continue development. See the
+              &quot;Development license&quot; section of this page for more details.
             </Typography>
           </Paper>
         </Grid>
@@ -56,10 +57,10 @@ export default function WhatToExpect() {
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary">
-              The licenses are sold on a per-developer basis. The Pro plan includes a cap at 10
-              developers, extra developers do not need to be licensed. You can contact{' '}
-              <Link href="mailto:sales@mui.com">sales</Link> for a volume discount when licensing
-              over 50 developers under the Premium plan.
+              The licenses are sold on a per-developer basis, using the software directly or
+              indirectly. The Pro plan includes a cap at 10 developers, extra developers do not need
+              to be licensed. You can contact <Link href="mailto:sales@mui.com">sales</Link> for a
+              volume discount when licensing over 50 developers under the Premium plan.
             </Typography>
           </Paper>
         </Grid>
@@ -78,9 +79,11 @@ export default function WhatToExpect() {
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary">
-              With your purchase you are entitled to technical support (for MUI X components) and
-              access to new versions for the duration of your subscription. You can{' '}
-              <Link href="https://mui.com/x/introduction/support/">learn more about support</Link>{' '}
+              With your purchase you receive support and access to new versions for the duration of
+              your subscription. You can{' '}
+              <Link href="https://mui.com/x/introduction/support/#technical-support">
+                learn more about support
+              </Link>{' '}
               in the docs. Note that, except for critical issues, e.g. security, we release bug
               fixes, and other improvements on top of the latest version, instead of patching older
               versions.


### PR DESCRIPTION
Per https://www.notion.so/mui-org/MUI-X-Pricing-changes-2022-f17df701bf10406884a3204dcb8a3a3f#f50eb9adbc33495b8876d69cc69350d1 and per @joserodolfofreitas's point on how this point is confusing based on the sales analytics on the number of licenses sold. This effort is part of https://github.com/mui/mui-store/issues/136.

Preview: https://deploy-preview-33553--material-ui.netlify.app/pricing/

### User questions

- https://mui.zendesk.com/agent/tickets/4208

  <img width="697" alt="Screenshot 2022-07-23 at 13 16 10" src="https://user-images.githubusercontent.com/3165635/180602776-2eeda455-17c2-4ec3-9db2-302a7f940334.png">