### PR TITLE
[Divider] Able to pass `undefined` to remove role

### DIFF
--- a/docs/data/material/components/dividers/dividers.md
+++ b/docs/data/material/components/dividers/dividers.md
@@ -44,6 +44,20 @@ You can also render a divider with content.
 
 {{"demo": "DividerText.js"}}
 
+:::info
+**♿️ Tips**: If you use the `Divider` for visual decoration of your content (eg. a heading), you should do this to make sure that screen readers can announce your content to the users:
+
+- specify an appropriate `component` prop (eg. `div`)
+- explicitly specify `role={undefined}` to the divider
+
+```js
+<Divider component="div" role={undefined}>
+  <Typography variant="h2">My Heading</Typography>
+</Divider>
+```
+
+:::
+
 ## Vertical divider
 
 You can also render a divider vertically using the `orientation` prop.

--- a/docs/data/material/components/dividers/dividers.md
+++ b/docs/data/material/components/dividers/dividers.md
@@ -45,9 +45,9 @@ You can also render a divider with content.
 {{"demo": "DividerText.js"}}
 
 :::info
-**♿️ Tips**: If you use the `Divider` for visual decoration of your content (eg. a heading), you should do this to make sure that screen readers can announce your content to the users:
+**Accessibility tips**: When using the `Divider component for visual decoration, such as in a heading, follow the tips below to make sure screen readers can announce your app's content to users correctly:
 
-- specify an appropriate `component` prop (eg. `div`)
+- specify an appropriate `component` prop (e.g. `div`)
 - explicitly specify `role={undefined}` to the divider
 
 ```js

--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -175,11 +175,16 @@ const Divider = React.forwardRef(function Divider(inProps, ref) {
     flexItem = false,
     light = false,
     orientation = 'horizontal',
-    role = component !== 'hr' ? 'separator' : undefined,
+    role: roleProp = component !== 'hr' ? 'separator' : undefined,
     textAlign = 'center',
     variant = 'fullWidth',
     ...other
   } = props;
+
+  let role = roleProp;
+  if ('role' in inProps) {
+    role = inProps.role;
+  }
 
   const ownerState = {
     ...props,

--- a/packages/mui-material/src/Divider/Divider.test.js
+++ b/packages/mui-material/src/Divider/Divider.test.js
@@ -143,5 +143,10 @@ describe('<Divider />', () => {
       const { container } = render(<Divider role="presentation" />);
       expect(container.firstChild).to.have.attribute('role', 'presentation');
     });
+
+    it('should not have role if `undefined` is provided', () => {
+      const { container } = render(<Divider component="div" role={undefined} />);
+      expect(container.firstChild).not.to.have.attribute('role');
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #33351

Previously, there is no way to remove `role` from the Divider if `component` prop is provided.

@Fox32 raised a valid use case where Divider is used as a visual decoration (without role). This PR lets developers explicitly specify `role={undefined}` to remove the role.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
