### PR TITLE
[ImageList] Remove vertical spacing between items in masonry layout

### DIFF
--- a/packages/mui-material/src/ImageListItem/ImageListItem.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.js
@@ -34,9 +34,8 @@ const ImageListItemRoot = styled('li', {
     ];
   },
 })(({ ownerState }) => ({
-  display: 'inline-block',
+  display: 'block',
   position: 'relative',
-  lineHeight: 0, // 🤷🏻‍♂️Fixes masonry item gap
   ...(ownerState.variant === 'standard' && {
     // For titlebar under list item
     display: 'flex',
@@ -53,6 +52,7 @@ const ImageListItemRoot = styled('li', {
     objectFit: 'cover',
     width: '100%',
     height: '100%',
+    display: 'block',
     ...(ownerState.variant === 'standard' && {
       height: 'auto',
       flexGrow: 1,


### PR DESCRIPTION
Removes the extra vertical whitespace from between images when the ImageList is in masonry mode.

Fixes #33328