### PR TITLE
[docs] Fix production deploy of codesandboxes

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -29,7 +29,6 @@ describe('CodeSandbox', () => {
     expect(result.files).to.deep.equal({
       'package.json': {
         content: {
-          name: 'BasicButtons Material Demo',
           description:
             'https://github.com/mui/material-ui/blob/v5.7.0/docs/data/material/components/buttons/BasicButtons.js',
           dependencies: {
@@ -71,7 +70,6 @@ describe('CodeSandbox', () => {
     expect(result.files).to.deep.equal({
       'package.json': {
         content: {
-          name: 'BasicButtons Material Demo',
           description:
             'https://github.com/mui/material-ui/blob/v5.7.0/docs/data/material/components/buttons/BasicButtons.tsx',
           dependencies: {

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -36,7 +36,6 @@ const createReactApp = (demo: {
 
   files['package.json'] = {
     content: {
-      name: title,
       description,
       dependencies,
       devDependencies,
@@ -108,7 +107,6 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
 
   files['package.json'] = {
     content: {
-      name: title,
       description,
       dependencies,
       devDependencies,


### PR DESCRIPTION
The `name` is usally something like "ContinuousSlider demo — Material UI" which is not allowed:

> The "name" field contains your package's name, and must be lowercase and one word, and may contain hyphens and underscores.

https://docs.npmjs.com/creating-a-package-json-file. In practice, it breaks the deployment of codesandboxes to production with yarn:

<img width="310" alt="Screenshot 2022-07-21 at 18 52 47" src="https://user-images.githubusercontent.com/3165635/180270247-b4ca0e0d-cd44-4226-8ddb-94c60fe896f2.png">

<img width="722" alt="Screenshot 2022-07-21 at 18 49 23" src="https://user-images.githubusercontent.com/3165635/180269629-8991ff69-f9e0-4a58-932b-2eaa9e3c9099.png">

https://codesandbox.io/s/continuousslider-demo-material-ui-forked-69rumd?file=/package.json:518-553

It used to work before the last factorization of the explore to codesandbox/stackblitz. What's the value? Sometimes a change in a PR only impacts the behavior in production. I needed this for https://github.com/mui/mui-x/issues/5557#issuecomment-1191764448.