### PR TITLE
[docs] Fix `CssBaseline` import in example code

### DIFF
--- a/docs/data/material/customization/dark-mode/dark-mode.md
+++ b/docs/data/material/customization/dark-mode/dark-mode.md
@@ -7,7 +7,8 @@
 You can make your application use the dark theme as the default—regardless of the user's preference—by adding `mode: 'dark'` to the `createTheme` helper:
 
 ```js
-import { ThemeProvider, createTheme, CssBaseline } from '@mui/material/styles';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
 
 const darkTheme = createTheme({
   palette: {


### PR DESCRIPTION
First code example on page uses
  `import { ThemeProvider, createTheme, CssBaseline } from '@mui/material/styles';`
which fails with
  `export 'CssBaseline' (imported as 'CssBaseline') was not found in '@mui/material/styles' ... `.

Presumably, `CssBaseline` was moved recently and the first code example was not updated correspondingly; last code example on page is fine.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-33614--material-ui.netlify.app/material-ui/customization/dark-mode/#dark-mode-by-default