### PR TITLE
[core] Swallow ad blocker fetch fail

### DIFF
--- a/docs/src/modules/components/AdCarbon.js
+++ b/docs/src/modules/components/AdCarbon.js
@@ -61,7 +61,14 @@ export function AdCarbonInline(props) {
         }
 
         attempt += 1;
-        const response = await fetch('https://srv.buysellads.com/ads/CE7DC23W.json');
+        let response;
+        try {
+          response = await fetch('https://srv.buysellads.com/ads/CE7DC23W.json');
+        } catch (err) {
+          // Ad blocker crashes this request
+          return null;
+        }
+
         const data = await response.json();
         // Inspired by https://github.com/Semantic-Org/Semantic-UI-React/blob/2c7134128925dd831de85011e3eb0ec382ba7f73/docs/src/components/CarbonAd/CarbonAdNative.js#L9
         const sanitizedAd = data.ads


### PR DESCRIPTION
I'm using uBlock Origin, which blocks this request. I suspect it's the case for more of our contributors:

**Before**

https://user-images.githubusercontent.com/3165635/180577135-d11172f7-0201-4edc-b001-60c99f952a5c.mov

**After**

No error popup that interrupts the contribution workflow unnecessarily in development mode.