### PR TITLE
[docs][system] Throw an informative error when `theme.vars` is used in `createTheme` and mention this in the theming docs

### DIFF
--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -44,6 +44,14 @@ const theme = createTheme({
 });
 ```
 
+**WARNING**: `vars` is a private field used for CSS variables support. It will throw an error if you try to use it:
+
+```jsx
+createTheme({
+  vars: { ... },
+})
+```
+
 If you are using TypeScript, you would also need to use [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) for the theme to accept the above values.
 
 ```tsx
@@ -173,7 +181,7 @@ theme = createTheme(theme, {
 
 Think of creating a theme as a two-step composition process: first, you define the basic design options; then, you'll use these design options to compose other options.
 
-**WARNING**: `theme.vars` is a private object used for CSS variables support. Please use another name for a custom object.
+**WARNING**: `theme.vars` is a private field used for CSS variables support. Please use another name for a custom object.
 
 ### `responsiveFontSizes(theme, options) => theme`
 

--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -173,6 +173,8 @@ theme = createTheme(theme, {
 
 Think of creating a theme as a two-step composition process: first, you define the basic design options; then, you'll use these design options to compose other options.
 
+**WARNING**: `theme.vars` is a private object used for CSS variables support. Please use another name for a custom object.
+
 ### `responsiveFontSizes(theme, options) => theme`
 
 Generate responsive typography settings based on the options received.

--- a/docs/public/static/error-codes.json
+++ b/docs/public/static/error-codes.json
@@ -16,5 +16,6 @@
   "15": "MUI: withStyles is no longer exported from @mui/material/styles.\nYou have to import it from @mui/styles.\nSee https://mui.com/r/migration-v4/#mui-material-styles for more details.",
   "16": "MUI: withTheme is no longer exported from @mui/material/styles.\nYou have to import it from @mui/styles.\nSee https://mui.com/r/migration-v4/#mui-material-styles for more details.",
   "17": "MUI: Expected valid input target. Did you use a custom `components.Input` and forget to forward refs? See https://mui.com/r/input-component-ref-interface for more info.",
+  "18": "MUI: `vars` is a private field used for CSS variables support.\nPlease use another name.",
   "19": "MUI: `useColorScheme` must be called under <CssVarsProvider />"
 }

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -20,6 +20,16 @@ function createTheme(options = {}, ...args) {
     ...other
   } = options;
 
+  if (other.vars) {
+    console.warn(
+      [
+        'MUI: `vars` is a private field used for CSS variables support.',
+        '',
+        'Please use another name.',
+      ].join('\n'),
+    );
+  }
+
   const palette = createPalette(paletteInput);
   const systemTheme = systemCreateTheme(options);
 

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -21,7 +21,7 @@ function createTheme(options = {}, ...args) {
   } = options;
 
   if (other.vars) {
-    console.warn(
+    console.error(
       [
         'MUI: `vars` is a private field used for CSS variables support.',
         '',

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -20,7 +20,7 @@ function createTheme(options = {}, ...args) {
     ...other
   } = options;
 
-  if (other.vars) {
+  if (options.vars) {
     console.error(
       [
         'MUI: `vars` is a private field used for CSS variables support.',

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -1,6 +1,7 @@
 import { deepmerge } from '@mui/utils';
 import { generateUtilityClass } from '@mui/base';
 import { createTheme as systemCreateTheme } from '@mui/system';
+import MuiError from '@mui/utils/macros/MuiError.macro';
 import createMixins from './createMixins';
 import createPalette from './createPalette';
 import createTypography from './createTypography';
@@ -21,12 +22,9 @@ function createTheme(options = {}, ...args) {
   } = options;
 
   if (options.vars) {
-    console.error(
-      [
-        'MUI: `vars` is a private field used for CSS variables support.',
-        '',
+    throw new MuiError(
+      'MUI: `vars` is a private field used for CSS variables support.\n' +
         'Please use another name.',
-      ].join('\n'),
     );
   }
 

--- a/packages/mui-material/src/styles/createTheme.test.js
+++ b/packages/mui-material/src/styles/createTheme.test.js
@@ -250,4 +250,19 @@ describe('createTheme', () => {
       borderBottomRightRadius: '0px',
     });
   });
+
+  it('Throw an informative error when the key `vars` is passed as part of `options` passed', () => {
+    try {
+      createTheme({
+        vars: {
+          primary: '#EF14E2',
+        },
+      });
+    } catch (e) {
+      expect(e.message).to.equal(
+        'MUI: `vars` is a private field used for CSS variables support.\n' +
+          'Please use another name.',
+      );
+    }
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/33544

**Problem**:
- Passing `vars` property to `createTheme` results in error, because `theme.vars` is a private field used for CSS variables support.

**Preview**: https://deploy-preview-33619--material-ui.netlify.app/material-ui/customization/theming/#createtheme-options-args-theme

**Codesandboxes**:
- [Before](https://codesandbox.io/s/styled-components-forked-theme-provider-broken-o8jff6)
- [After](https://codesandbox.io/s/styled-components-forked-theme-provider-broken-8ong34)