### PR TITLE
[typography] apply font properties to typography inherit variant

### DIFF
--- a/packages/mui-material/src/styles/createTypography.js
+++ b/packages/mui-material/src/styles/createTypography.js
@@ -72,6 +72,13 @@ export default function createTypography(palette, typography) {
     button: buildVariant(fontWeightMedium, 14, 1.75, 0.4, caseAllCaps),
     caption: buildVariant(fontWeightRegular, 12, 1.66, 0.4),
     overline: buildVariant(fontWeightRegular, 12, 2.66, 1, caseAllCaps),
+    inherit: {
+      fontFamily: 'inherit',
+      fontWeight: 'inherit',
+      fontSize: 'inherit',
+      lineHeight: 'inherit',
+      letterSpacing: 'inherit',
+    }
   };
 
   return deepmerge(

--- a/packages/mui-material/src/styles/createTypography.test.js
+++ b/packages/mui-material/src/styles/createTypography.test.js
@@ -74,6 +74,21 @@ describe('createTypography', () => {
     );
   });
 
+  it('should apply font CSS properties to inherit variant', () => {
+    const typography = createTypography(palette, {});
+    const fontProperties = [
+      'fontFamily',
+      'fontWeight',
+      'fontSize',
+      'lineHeight',
+      'letterSpacing',
+    ];
+
+    fontProperties.forEach((prop) => {
+      expect(typography.inherit[prop]).to.equal('inherit');
+    });
+  });
+
   describe('warnings', () => {
     it('logs an error if `fontSize` is not of type number', () => {
       expect(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Ensure that `Typography` components actually inherit font properties when inherit variant is used.
Since the `Link` component is built on top of the `Typography` component, this also fixes #32942.

```js
const theme = createTheme({
  typography: {
    fontFamily: "Inconsolata, Arial"
  }
});
```

Prior:

```jsx
<ThemeProvider theme={theme}>
    <Typography variant="body1">
      <Link>This is good (it's Inconsolata)</Link>
      <br />
      <Link component="button">This is not good (it's Arial)</Link>
    </Typography>
</ThemeProvider>
```

Now:

```jsx
<ThemeProvider theme={theme}>
    <Typography variant="body1">
      <Link>This is good (it's Inconsolata)</Link>
      <br />
      <Link component="button">This is good too (it's Inconsolata)</Link>
    </Typography>
</ThemeProvider>
```

Fixes #32942
