### PR TITLE
[core] Remove thenify version override from package.json resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,8 +212,7 @@
     "**/@types/react": "^18.0.9",
     "**/@types/react-is": "^17.0.3",
     "**/cross-fetch": "^3.1.5",
-    "**/react-is": "^18.2.0",
-    "**/thenify": "^3.3.1"
+    "**/react-is": "^18.2.0"
   },
   "nyc": {
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -15327,7 +15327,7 @@ thenify-all@^1.0.0:
   dependencies:
     thenify ">= 3.1.0 < 4"
 
-thenify@3.3.1, "thenify@>= 3.1.0 < 4", thenify@^3.3.1:
+thenify@3.3.1, "thenify@>= 3.1.0 < 4":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==


### PR DESCRIPTION
A follow-up to #33612
There's no need to have version override in package.json dependencies. yarn.lock is enough for this case.