### PR TITLE
[core] Update Node.js version to 14 on CircleCI, CodeSandbox, and Netlify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ defaults: &defaults
     AWS_REGION_ARTIFACTS: eu-central-1
   working_directory: /tmp/material-ui
   docker:
-    - image: cimg/node:12.22
+    - image: cimg/node:14.19
 
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,7 +1,7 @@
 {
   "buildCommand": "build:codesandbox",
   "installCommand": "install:codesandbox",
-  "node": "12",
+  "node": "14",
   "packages": [
     "packages/mui-material",
     "packages/mui-codemod",

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   command = "yarn docs:build && yarn docs:export"
 
 [build.environment]
-  NODE_VERSION = "12"
+  NODE_VERSION = "14"
   # Not using `playwright` when building docs.
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 


### PR DESCRIPTION
Updated the Node.js version used by our CI tools to unblock many dependencies that require version >=14. 

Related to #32546