### PR TITLE
[blog] Fix horizontal scrollbar with code snippets

### DIFF
--- a/docs/pages/blog/mui-x-v5.md
+++ b/docs/pages/blog/mui-x-v5.md
@@ -129,7 +129,9 @@ const GridToolbarContainerStyled = styled(GridToolbarContainer)({
 });
 
 function MyCustomToolbar() {
-  return <GridToolbarContainerStyled>My custom toolbar</GridToolbarContainerStyled>;
+  return (
+    <GridToolbarContainerStyled>My custom toolbar</GridToolbarContainerStyled>
+  );
 }
 
 export default function App() {

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -47,6 +47,7 @@ const Root = styled('div')(({ theme }) => ({
   // block code
   '& code[class*="language-"]': {
     color: '#fff',
+    padding: 0,
     backgroundColor: blueDark[800],
   },
   '& h1': {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -7,7 +7,16 @@ module.exports = {
       files: ['docs/**/*.md', 'docs/src/pages/**/*.{js,tsx}', 'docs/data/**/*.{js,tsx}'],
       options: {
         // otherwise code blocks overflow on the docs website
+        // The container is 751px
         printWidth: 85,
+      },
+    },
+    {
+      files: ['docs/pages/blog/**/*.md'],
+      options: {
+        // otherwise code blocks overflow on the blog website
+        // The container is 676px
+        printWidth: 82,
       },
     },
   ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

# Summary
The print container width on blog pages needs to be smaller to avoid horizontal scrolling.

This PR adds a new rule to address this issue and prettify blog pages.

more context: https://github.com/mui/material-ui/pull/33595/files#r929087645

Before: https://mui.com/blog/mui-x-v5/#simplified-style-customization
After: https://deploy-preview-33648--material-ui.netlify.app/blog/mui-x-v5/#simplified-style-customization