### PR TITLE
Add MenuPropsVariantOverrides to Menu

### DIFF
--- a/packages/mui-material/src/Menu/Menu.d.ts
+++ b/packages/mui-material/src/Menu/Menu.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
+import { OverridableStringUnion } from '@mui/types';
 import { InternalStandardProps as StandardProps } from '..';
 import { PopoverProps } from '../Popover';
 import { MenuListProps } from '../MenuList';

--- a/packages/mui-material/src/Menu/Menu.d.ts
+++ b/packages/mui-material/src/Menu/Menu.d.ts
@@ -7,6 +7,8 @@ import { Theme } from '../styles';
 import { TransitionProps } from '../transitions/transition';
 import { MenuClasses } from './menuClasses';
 
+export interface MenuPropsVariantOverrides {}
+
 export interface MenuProps extends StandardProps<PopoverProps> {
   /**
    * An HTML element, or a function that returns one.
@@ -76,7 +78,7 @@ export interface MenuProps extends StandardProps<PopoverProps> {
    * The variant to use. Use `menu` to prevent selected items from impacting the initial focus.
    * @default 'selectedMenu'
    */
-  variant?: 'menu' | 'selectedMenu';
+  variant?: OverridableStringUnion<'menu' | 'selectedMenu', MenuPropsVariantOverrides>;
 }
 
 /**


### PR DESCRIPTION
Adding a custom variant seems to have no effect because there is no option to override it.

```
// Update the  Menu's variant prop options
declare module '@mui/material/Menu' {
  interface MenuPropsVariantOverrides {
    myAwesomeVariant: true
  }
}
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
