### PR TITLE
[docs] fix bootstrap tooltip docs example 

### DIFF
--- a/docs/data/material/components/tooltips/CustomizedTooltips.js
+++ b/docs/data/material/components/tooltips/CustomizedTooltips.js
@@ -18,8 +18,9 @@ const LightTooltip = styled(({ className, ...props }) => (
 const BootstrapTooltip = styled(({ className, ...props }) => (
   <Tooltip {...props} arrow classes={{ popper: className }} />
 ))(({ theme }) => ({
-  [`& .${tooltipClasses.arrow}`]: {
-    color: theme.palette.common.black,
+  [`& .${tooltipClasses.arrow}::before`]: {
+    backgroundColor: theme.palette.common.black,
+    border: 'none'
   },
   [`& .${tooltipClasses.tooltip}`]: {
     backgroundColor: theme.palette.common.black,

--- a/docs/data/material/components/tooltips/CustomizedTooltips.tsx
+++ b/docs/data/material/components/tooltips/CustomizedTooltips.tsx
@@ -18,8 +18,9 @@ const LightTooltip = styled(({ className, ...props }: TooltipProps) => (
 const BootstrapTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} arrow classes={{ popper: className }} />
 ))(({ theme }) => ({
-  [`& .${tooltipClasses.arrow}`]: {
-    color: theme.palette.common.black,
+  [`& .${tooltipClasses.arrow}::before`]: {
+    backgroundColor: theme.palette.common.black,
+    border: 'none'
   },
   [`& .${tooltipClasses.tooltip}`]: {
     backgroundColor: theme.palette.common.black,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

1. Fix custom tooltip example in Docs (screenshot attached)

<img width="315" alt="Screen Shot 2022-07-27 at 8 54 01 AM" src="https://user-images.githubusercontent.com/4117152/181264729-621feafc-011f-4f29-9da5-6f8cf7d4924f.png">
