### PR TITLE
[docs] Fix a typo in the code in `Sorting & selecting` Table demo

### DIFF
--- a/docs/data/material/components/tables/EnhancedTable.js
+++ b/docs/data/material/components/tables/EnhancedTable.js
@@ -237,7 +237,7 @@ export default function EnhancedTable() {
   };
 
   const handleSelectAllClick = (event) => {
-    if (event.target.checked && selected.length === 0) {
+    if (event.target.checked) {
       const newSelected = rows.map((n) => n.name);
       setSelected(newSelected);
       return;

--- a/docs/data/material/components/tables/EnhancedTable.js
+++ b/docs/data/material/components/tables/EnhancedTable.js
@@ -237,9 +237,9 @@ export default function EnhancedTable() {
   };
 
   const handleSelectAllClick = (event) => {
-    if (event.target.checked) {
-      const newSelecteds = rows.map((n) => n.name);
-      setSelected(newSelecteds);
+    if (event.target.checked && selected.length === 0) {
+      const newSelected = rows.map((n) => n.name);
+      setSelected(newSelected);
       return;
     }
     setSelected([]);

--- a/docs/data/material/components/tables/EnhancedTable.tsx
+++ b/docs/data/material/components/tables/EnhancedTable.tsx
@@ -268,9 +268,9 @@ export default function EnhancedTable() {
   };
 
   const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.checked) {
-      const newSelecteds = rows.map((n) => n.name);
-      setSelected(newSelecteds);
+    if (event.target.checked && selected.length === 0) {
+      const newSelected = rows.map((n) => n.name);
+      setSelected(newSelected);
       return;
     }
     setSelected([]);

--- a/docs/data/material/components/tables/EnhancedTable.tsx
+++ b/docs/data/material/components/tables/EnhancedTable.tsx
@@ -268,7 +268,7 @@ export default function EnhancedTable() {
   };
 
   const handleSelectAllClick = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.checked && selected.length === 0) {
+    if (event.target.checked) {
       const newSelected = rows.map((n) => n.name);
       setSelected(newSelected);
       return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Description**

I noticed 2 issues with the current version of the `EnhancedTable` example ([link](https://mui.com/material-ui/react-table/#sorting-amp-selecting))
- There seems to be a typo: `newSelecteds` -> `newSelected` ?
- Clicking the select all checkbox when it has an `indeterminate` state should _deselect_ all rows, like in the [data table example](https://mui.com/material-ui/react-table/#data-table). Currently, it _selects_ all rows.

Both of these issues are addressed here. I think the changes are self explanatory but I am happy to answer any questions. Thanks for taking a look.