### PR TITLE
[docs] Update module reference for `usePagination`

### DIFF
--- a/docs/data/material/components/pagination/pagination.md
+++ b/docs/data/material/components/pagination/pagination.md
@@ -61,7 +61,7 @@ related to the rendering of JSX.
 The Pagination component is built on this hook.
 
 ```jsx
-import { usePagination } from '@mui/material/Pagination';
+import { usePagination } from '@mui/material/usePagination';
 ```
 
 {{"demo": "UsePagination.js"}}

--- a/docs/data/material/components/pagination/pagination.md
+++ b/docs/data/material/components/pagination/pagination.md
@@ -61,7 +61,7 @@ related to the rendering of JSX.
 The Pagination component is built on this hook.
 
 ```jsx
-import { usePagination } from '@mui/material/usePagination';
+import usePagination from '@mui/material/usePagination';
 ```
 
 {{"demo": "UsePagination.js"}}


### PR DESCRIPTION
While migrating to Material UI v5, we found the reference to [the docs here](https://mui.com/material-ui/react-pagination/#usepagination) were incorrectly referring to `Pagination`, but it should actually be `usePagination`, and `usePagination` should be a default import

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-33675--material-ui.netlify.app/material-ui/react-pagination/#usepagination