### PR TITLE
[base] Removes invisible tabbable elements from TrapFocus component

### DIFF
--- a/docs/data/base/components/trap-focus/ContainedToggleTrappedFocus.js
+++ b/docs/data/base/components/trap-focus/ContainedToggleTrappedFocus.js
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import TrapFocus from '@mui/base/TrapFocus';
+
+export default function BasicTrapFocus() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+      }}
+    >
+      <TrapFocus open={open} disableRestoreFocus disableAutoFocus>
+        <Stack>
+          <Stack alignItems="center">
+            <button type="button" onClick={() => setOpen(!open)}>
+              {open ? 'Close' : 'Open'}
+            </button>
+          </Stack>
+          {open && (
+            <label>
+              First name: <input type="text" />
+            </label>
+          )}
+        </Stack>
+      </TrapFocus>
+    </Box>
+  );
+}

--- a/docs/data/base/components/trap-focus/ContainedToggleTrappedFocus.tsx
+++ b/docs/data/base/components/trap-focus/ContainedToggleTrappedFocus.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import TrapFocus from '@mui/base/TrapFocus';
+
+export default function BasicTrapFocus() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+      }}
+    >
+      <TrapFocus open={open} disableRestoreFocus disableAutoFocus>
+        <Stack>
+          <Stack alignItems="center">
+            <button type="button" onClick={() => setOpen(!open)}>
+              {open ? 'Close' : 'Open'}
+            </button>
+          </Stack>
+          {open && (
+            <label>
+              First name: <input type="text" />
+            </label>
+          )}
+        </Stack>
+      </TrapFocus>
+    </Box>
+  );
+}

--- a/docs/data/base/components/trap-focus/ContainedToggleTrappedFocus.tsx.preview
+++ b/docs/data/base/components/trap-focus/ContainedToggleTrappedFocus.tsx.preview
@@ -1,0 +1,14 @@
+<TrapFocus open={open} disableRestoreFocus disableAutoFocus>
+  <Stack>
+    <Stack alignItems="center">
+      <button type="button" onClick={() => setOpen(!open)}>
+        {open ? 'Close' : 'Open'}
+      </button>
+    </Stack>
+    {open && (
+      <label>
+        First name: <input type="text" />
+      </label>
+    )}
+  </Stack>
+</TrapFocus>

--- a/docs/data/base/components/trap-focus/trap-focus.md
+++ b/docs/data/base/components/trap-focus/trap-focus.md
@@ -84,3 +84,10 @@ When auto focus is disabled—as in the demo below—the component only traps th
 The following demo uses the [`Portal`](/base/react-portal/) component to render a subset of the `TrapFocus` children into a new "subtree" outside of the current DOM hierarchy, so they are no longer part of the focus loop:
 
 {{"demo": "PortalTrapFocus.js"}}
+
+## Using a toggle inside the trap
+
+The most common use case for the `TrapFocus` component is to maintain focus within a [`Modal`](/base/react-modal/) component which is entire separete from the element which would open the modal. However, there are use cases where you may want to have a toggle button for the `open` prop of the `TrapFocus` component which is stored inside that component.
+
+{{"demo": "ContainedToggleTrappedFocus.js"}}
+

--- a/packages/mui-base/src/TrapFocus/TrapFocus.js
+++ b/packages/mui-base/src/TrapFocus/TrapFocus.js
@@ -325,13 +325,18 @@ function TrapFocus(props) {
   return (
     <React.Fragment>
       <div
-        tabIndex={0}
+        tabIndex={open ? 0 : -1}
         onFocus={handleFocusSentinel}
         ref={sentinelStart}
-        data-test="sentinelStart"
+        data-testid="sentinelStart"
       />
       {React.cloneElement(children, { ref: handleRef, onFocus })}
-      <div tabIndex={0} onFocus={handleFocusSentinel} ref={sentinelEnd} data-test="sentinelEnd" />
+      <div
+        tabIndex={open ? 0 : -1}
+        onFocus={handleFocusSentinel}
+        ref={sentinelEnd}
+        data-testid="sentinelEnd"
+      />
     </React.Fragment>
   );
 }

--- a/packages/mui-base/src/TrapFocus/TrapFocus.test.js
+++ b/packages/mui-base/src/TrapFocus/TrapFocus.test.js
@@ -283,6 +283,28 @@ describe('<TrapFocus />', () => {
     expect(screen.getByTestId('root')).toHaveFocus();
   });
 
+  it('does not allow sentinelStart or sentinelEnd to be tabbable until open={true}', () => {
+    function Test(props) {
+      return (
+        <TrapFocus open {...props}>
+          <div tabIndex={-1}>
+            <button>Test</button>
+          </div>
+        </TrapFocus>
+      );
+    }
+
+    const { setProps } = render(<Test />);
+
+    setProps({ open: false });
+    expect(screen.getByTestId('sentinelStart').getAttribute('tabindex')).to.eq('-1');
+    expect(screen.getByTestId('sentinelEnd').getAttribute('tabindex')).to.eq('-1');
+
+    setProps({ open: true });
+    expect(screen.getByTestId('sentinelStart').getAttribute('tabindex')).to.eq('0');
+    expect(screen.getByTestId('sentinelEnd').getAttribute('tabindex')).to.eq('0');
+  });
+
   describe('interval', () => {
     clock.withFakeTimers();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Problem description

Described in issue #33380 

## Solution

Setting `tabIndex={open ? 0 : -1}` on `sentinelStart` and `sentinelEnd` elements so that they're only tabbable when the `TrapFocus` `open` prop is `true`. Thus removing the awkward experience where there are invisible tabbable elements.

## Whoops

This is a replacement for [this PR](https://github.com/mui/material-ui/pull/33543) which was based off a fork of `master`. When I tried to sync my fork from upstream the PR autoclosed 🤦 