### PR TITLE
[docs] Fix warnings related to Next.js' links

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -219,9 +219,10 @@ function AppFrame(props) {
           >
             <SvgHamburgerMenu />
           </NavIconButton>
-          <NextLink href="/" passHref /* onClick={onClose} */>
+          <NextLink href="/" passHref>
             <Box
               component="a"
+              onClick={onClose}
               aria-label={t('goToHome')}
               sx={{ display: { md: 'flex', lg: 'none' }, ml: 2 }}
             >

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -219,10 +219,9 @@ function AppFrame(props) {
           >
             <SvgHamburgerMenu />
           </NavIconButton>
-          <NextLink href="/" passHref>
+          <NextLink href="/" passHref /* onClick={onClose} */>
             <Box
               component="a"
-              onClick={onClose}
               aria-label={t('goToHome')}
               sx={{ display: { md: 'flex', lg: 'none' }, ml: 2 }}
             >

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -371,9 +371,10 @@ export default function AppNavDrawer(props) {
     return (
       <React.Fragment>
         <ToolbarDiv>
-          <NextLink href="/" passHref onClick={onClose}>
+          <NextLink href="/" passHref>
             <Box
               component="a"
+              onClick={onClose}
               aria-label={t('goToHome')}
               sx={{
                 pr: '12px',


### PR DESCRIPTION
Related to https://github.com/mui/material-ui/pull/33196#discussion_r922541351

Fixes the following warning:

![image](https://user-images.githubusercontent.com/4512430/181733528-709d7389-3b17-4358-bc3e-345235609cd6.png)

No need to update the examples, as the correct propagating of props is used there. This was occurrence of direct usage of Next's Link in the docs.