### PR TITLE
[docs] Enforce description for all pages

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -129,8 +129,8 @@ function getContents(markdown) {
 function getTitle(markdown) {
   const matches = markdown.match(titleRegExp);
 
-  if (!matches || !matches[1]) {
-    throw new Error('Missing title in the page');
+  if (matches === null) {
+    return undefined;
   }
 
   return matches[1].replace(/`/g, '');
@@ -386,8 +386,18 @@ function prepareMarkdown(config) {
     .forEach((translation) => {
       const { filename, markdown, userLanguage } = translation;
       const headers = getHeaders(markdown);
+      const location = headers.filename || `/docs${pageFilename}/${filename}`;
       const title = headers.title || getTitle(markdown);
       const description = headers.description || getDescription(markdown);
+
+      if (title == null || title === '') {
+        throw new Error(`Missing title in the page: ${location}`);
+      }
+
+      if (description == null || description === '') {
+        throw new Error(`Missing description in the page: ${location}`);
+      }
+
       const contents = getContents(markdown);
 
       if (headers.unstyled) {
@@ -416,7 +426,6 @@ ${headers.components
   `);
       }
 
-      const location = headers.filename || `/docs${pageFilename}/${filename}`;
       const toc = [];
       const render = createRender({ headingHashes, toc, userLanguage, location });
 

--- a/docs/packages/markdown/parseMarkdown.test.js
+++ b/docs/packages/markdown/parseMarkdown.test.js
@@ -153,6 +153,9 @@ authors:
     it('returns the table of contents with html and emojis stripped', () => {
       const markdown = `
 # Support
+
+<p class="description">Foo</p>
+
 ## Community help (free)
 ### GitHub <img src="/static/images/logos/github.svg" width="24" height="24" alt="GitHub logo" loading="lazy" />
 ### Unofficial 👍
@@ -185,6 +188,9 @@ authors:
     it('enables word-break for function signatures', () => {
       const markdown = `
 # Theming
+
+<p class="description">Foo</p>
+
 ## API
 ### responsiveFontSizes(theme, options) => theme
 ### createTheme(options, ...args) => theme
@@ -223,6 +229,9 @@ authors:
     it('use english hash for different locales', () => {
       const markdownEn = `
 # Localization
+
+<p class="description">Foo</p>
+
 ## Locales
 ### Example
 ### Use same hash
@@ -230,6 +239,9 @@ authors:
 
       const markdownPt = `
 # Localização
+
+<p class="description">Foo</p>
+
 ## Idiomas
 ### Exemplo
 ### Usar o mesmo hash
@@ -237,6 +249,9 @@ authors:
 
       const markdownZh = `
 # 所在位置
+
+<p class="description">Foo</p>
+
 ## 语言环境
 ### 例
 ### 使用相同的哈希
@@ -320,6 +335,9 @@ authors:
     it('use translated hash for translations are not synced', () => {
       const markdownEn = `
 # Localization
+
+<p class="description">Foo</p>
+
 ## Locales
 ### Example
 ### Use same hash
@@ -327,6 +345,9 @@ authors:
 
       const markdownPt = `
 # Localização
+
+<p class="description">Foo</p>
+
 ## Idiomas
 ### Exemplo
 ### Usar o mesmo hash
@@ -395,6 +416,8 @@ authors:
     it('should report missing trailing splashes', () => {
       const markdown = `
 # Localization
+
+<p class="description">Foo</p>
 
 [bar](/bar/)
 [foo](/foo)


### PR DESCRIPTION
https://mui.com/x/api/data-grid/grid-export-state-params/ is the only page of on mui.com that doesn't have a description. See [ahrefs explanation](https://help.ahrefs.com/en/articles/2630975-meta-description-tag-missing-or-empty-error-in-site-audit) for why we probably want to have one on all the pages. I'm fixing the problem on the surface with: https://github.com/mui/mui-x/pull/5654. It surfaced in [an SEO crawl](https://app.ahrefs.com/site-audit/3523498/21/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2CmetaDescription%2CmetaDescriptionLength%2CnrMetaDescription%2Ccompliant&filterCollapsed=true&filterId=c2374462d9d0ef63ad879d0f2dd819fc&issueId=c64d31f0-d0f4-11e7-8ed1-001e67ed4656).

But the main reason why I worked on this is that it seems to be a quick-win opportunity. With this PR we should be able to solve the problem at the root, to have https://github.com/mui/mui-x/pull/5390's CI fail, it's easy to miss.

<img width="981" alt="Screenshot 2022-07-29 at 16 47 27" src="https://user-images.githubusercontent.com/3165635/181807560-28d39df8-7351-4c2a-a09e-a06547c6b5d6.png">

A shorter feedback loop and one less thing to think about :). 

---

Soon or later, I would need to delegate my ownership of the SEO execution quality of mui.com. It's increasingly harder for me to find time to work on this.