### PR TITLE
[styled-engine-sc] Add missing @babel/runtime dependency

### DIFF
--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -38,7 +38,8 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },
   "dependencies": {
-    "prop-types": "^15.8.1"
+    "prop-types": "^15.8.1",
+    "@babel/runtime": "^7.18.9"
   },
   "peerDependencies": {
     "@types/styled-components": "^5.1.14",

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -38,8 +38,8 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json"
   },
   "dependencies": {
-    "prop-types": "^15.8.1",
-    "@babel/runtime": "^7.18.9"
+    "@babel/runtime": "^7.17.2",
+    "prop-types": "^15.8.1"
   },
   "peerDependencies": {
     "@types/styled-components": "^5.1.14",


### PR DESCRIPTION
Fixes #33690 

Signed-off-by: Arseny Garelyshev <monstrag@gmail.com>

I tried to find anything in CONTRIBUTING in relation to running `yarn build` or dedupe or whatever to update lockfiles but did not find anything.

Running yarn build anyway did not produce any changes.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
