### PR TITLE
[Grid] Export interface `RegularBreakpoints` to fix type error

### DIFF
--- a/packages/mui-material/src/Grid/Grid.d.ts
+++ b/packages/mui-material/src/Grid/Grid.d.ts
@@ -19,7 +19,7 @@ export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
 export type GridSize = 'auto' | number;
 
-interface RegularBreakpoints {
+export interface RegularBreakpoints {
   /**
    * If a number, it sets the number of columns the grid item uses.
    * It can't be greater than the total number of columns of the container (12 by default).


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #33165 

This issue occurs only for library apps where it is needed to generate declaration files (`.d.ts`) with `declaration: true` set in it's tsconfig.

Explained well in https://github.com/mui/material-ui/issues/33165#issuecomment-1161445846

Discussion about this in TypeScript repo: https://github.com/Microsoft/TypeScript/issues/5711

----

Before: https://codesandbox.io/s/trusting-water-wxupl4?file=/src/App.tsx

After: https://codesandbox.io/s/create-react-app-with-typescript-forked-iupbvd?file=/src/App.tsx