### PR TITLE
[Tooltip] Fix tooltip arrow css var background

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -198,9 +198,7 @@ const TooltipArrow = styled('span', {
   width: '1em',
   height: '0.71em' /* = width / sqrt(2) = (length of the hypotenuse) */,
   boxSizing: 'border-box',
-  color: theme.vars
-    ? theme.vars.palette.Tooltip.bg
-    : alpha(theme.palette.grey[700], 0.9),
+  color: theme.vars ? theme.vars.palette.Tooltip.bg : alpha(theme.palette.grey[700], 0.9),
   '&::before': {
     content: '""',
     margin: 'auto',

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -199,7 +199,7 @@ const TooltipArrow = styled('span', {
   height: '0.71em' /* = width / sqrt(2) = (length of the hypotenuse) */,
   boxSizing: 'border-box',
   color: theme.vars
-    ? `rgba(${theme.vars.palette.grey.darkChannel} / 0.9)`
+    ? theme.vars.palette.Tooltip.bg
     : alpha(theme.palette.grey[700], 0.9),
   '&::before': {
     content: '""',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes the Tooltip arrow background color, to use the same color as the tooltip if CSS variables are used.