### PR TITLE
[website] Fix notifications not being marked as read in production

### DIFF
--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -79,7 +79,7 @@ export default function Notifications() {
     setOpen((prevOpen) => !prevOpen);
     setTooltipOpen(false);
 
-    if (process.env.NODE_ENV !== 'development') {
+    if (process.env.NODE_ENV === 'development') {
       // Skip last seen logic in dev to make editing noti easier.
       return;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I've noticed that on mui.com notifications badge doesn't disappear after opening notifications popup:

https://user-images.githubusercontent.com/13808724/182340755-352dec3a-0a6d-47ce-ac8e-ae519689ddbb.mov

This PR fixes this regression from https://github.com/mui/material-ui/pull/32728/files#diff-0c46f5931a115b3f0c7fe7cbecebb058b5acf6b36f0bf82f57a1ef999c9f412aR82
