### PR TITLE
[system] Add `Stack` component

### DIFF
--- a/docs/data/system/components/stack/BasicStack.js
+++ b/docs/data/system/components/stack/BasicStack.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { styled, Box, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function BasicStack() {
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Stack spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </Box>
+  );
+}

--- a/docs/data/system/components/stack/BasicStack.js
+++ b/docs/data/system/components/stack/BasicStack.js
@@ -4,10 +4,8 @@ import { styled, Box, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function BasicStack() {

--- a/docs/data/system/components/stack/BasicStack.tsx
+++ b/docs/data/system/components/stack/BasicStack.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { styled, Box, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function BasicStack() {
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Stack spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </Box>
+  );
+}

--- a/docs/data/system/components/stack/BasicStack.tsx
+++ b/docs/data/system/components/stack/BasicStack.tsx
@@ -4,10 +4,8 @@ import { styled, Box, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function BasicStack() {

--- a/docs/data/system/components/stack/BasicStack.tsx.preview
+++ b/docs/data/system/components/stack/BasicStack.tsx.preview
@@ -1,0 +1,5 @@
+<Stack spacing={2}>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/system/components/stack/DirectionStack.js
+++ b/docs/data/system/components/stack/DirectionStack.js
@@ -4,10 +4,8 @@ import { styled, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function DirectionStack() {

--- a/docs/data/system/components/stack/DirectionStack.js
+++ b/docs/data/system/components/stack/DirectionStack.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { styled, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function DirectionStack() {
+  return (
+    <div>
+      <Stack direction="row" spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
+  );
+}

--- a/docs/data/system/components/stack/DirectionStack.tsx
+++ b/docs/data/system/components/stack/DirectionStack.tsx
@@ -4,10 +4,8 @@ import { styled, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function DirectionStack() {

--- a/docs/data/system/components/stack/DirectionStack.tsx
+++ b/docs/data/system/components/stack/DirectionStack.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { styled, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function DirectionStack() {
+  return (
+    <div>
+      <Stack direction="row" spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
+  );
+}

--- a/docs/data/system/components/stack/DirectionStack.tsx.preview
+++ b/docs/data/system/components/stack/DirectionStack.tsx.preview
@@ -1,0 +1,5 @@
+<Stack direction="row" spacing={2}>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/system/components/stack/DividerStack.js
+++ b/docs/data/system/components/stack/DividerStack.js
@@ -5,10 +5,8 @@ import { styled, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function DividerStack() {

--- a/docs/data/system/components/stack/DividerStack.js
+++ b/docs/data/system/components/stack/DividerStack.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import Divider from '@mui/material/Divider';
+import { styled, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function DividerStack() {
+  return (
+    <div>
+      <Stack
+        direction="row"
+        divider={<Divider orientation="vertical" flexItem />}
+        spacing={2}
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
+  );
+}

--- a/docs/data/system/components/stack/DividerStack.tsx
+++ b/docs/data/system/components/stack/DividerStack.tsx
@@ -5,10 +5,8 @@ import { styled, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function DividerStack() {

--- a/docs/data/system/components/stack/DividerStack.tsx
+++ b/docs/data/system/components/stack/DividerStack.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import Divider from '@mui/material/Divider';
+import { styled, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function DividerStack() {
+  return (
+    <div>
+      <Stack
+        direction="row"
+        divider={<Divider orientation="vertical" flexItem />}
+        spacing={2}
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
+  );
+}

--- a/docs/data/system/components/stack/DividerStack.tsx.preview
+++ b/docs/data/system/components/stack/DividerStack.tsx.preview
@@ -1,0 +1,9 @@
+<Stack
+  direction="row"
+  divider={<Divider orientation="vertical" flexItem />}
+  spacing={2}
+>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/system/components/stack/InteractiveStack.js
+++ b/docs/data/system/components/stack/InteractiveStack.js
@@ -1,0 +1,198 @@
+import * as React from 'react';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+import Paper from '@mui/material/Paper';
+import RadioGroup from '@mui/material/RadioGroup';
+import Radio from '@mui/material/Radio';
+import { Stack, Unstable_Grid as Grid } from '@mui/system';
+
+export default function InteractiveStack() {
+  const [direction, setDirection] = React.useState('row');
+  const [justifyContent, setJustifyContent] = React.useState('center');
+  const [alignItems, setAlignItems] = React.useState('center');
+  const [spacing, setSpacing] = React.useState(2);
+
+  const jsx = `
+<Stack
+  direction="${direction}"
+  justifyContent="${justifyContent}"
+  alignItems="${alignItems}"
+  spacing={${spacing}}
+>
+`;
+
+  return (
+    <Stack sx={{ flexGrow: 1 }}>
+      <Stack
+        direction={direction}
+        justifyContent={justifyContent}
+        alignItems={alignItems}
+        spacing={spacing}
+        sx={{ height: 240 }}
+      >
+        {[0, 1, 2].map((value) => (
+          <Paper
+            key={value}
+            sx={{
+              p: 2,
+              pt: value + 1,
+              pb: value + 1,
+              color: 'text.secondary',
+              typography: 'body2',
+              backgroundColor: (theme) =>
+                theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+            }}
+          >
+            {`Item ${value + 1}`}
+          </Paper>
+        ))}
+      </Stack>
+      <Paper sx={{ p: 2 }}>
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">direction</FormLabel>
+              <RadioGroup
+                row
+                name="direction"
+                aria-label="direction"
+                value={direction}
+                onChange={(event) => {
+                  setDirection(event.target.value);
+                }}
+              >
+                <FormControlLabel value="row" control={<Radio />} label="row" />
+                <FormControlLabel
+                  value="row-reverse"
+                  control={<Radio />}
+                  label="row-reverse"
+                />
+                <FormControlLabel
+                  value="column"
+                  control={<Radio />}
+                  label="column"
+                />
+                <FormControlLabel
+                  value="column-reverse"
+                  control={<Radio />}
+                  label="column-reverse"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">alignItems</FormLabel>
+              <RadioGroup
+                row
+                name="alignItems"
+                aria-label="align items"
+                value={alignItems}
+                onChange={(event) => {
+                  setAlignItems(event.target.value);
+                }}
+              >
+                <FormControlLabel
+                  value="flex-start"
+                  control={<Radio />}
+                  label="flex-start"
+                />
+                <FormControlLabel
+                  value="center"
+                  control={<Radio />}
+                  label="center"
+                />
+                <FormControlLabel
+                  value="flex-end"
+                  control={<Radio />}
+                  label="flex-end"
+                />
+                <FormControlLabel
+                  value="stretch"
+                  control={<Radio />}
+                  label="stretch"
+                />
+                <FormControlLabel
+                  value="baseline"
+                  control={<Radio />}
+                  label="baseline"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">justifyContent</FormLabel>
+              <RadioGroup
+                row
+                name="justifyContent"
+                aria-label="justifyContent"
+                value={justifyContent}
+                onChange={(event) => {
+                  setJustifyContent(event.target.value);
+                }}
+              >
+                <FormControlLabel
+                  value="flex-start"
+                  control={<Radio />}
+                  label="flex-start"
+                />
+                <FormControlLabel
+                  value="center"
+                  control={<Radio />}
+                  label="center"
+                />
+                <FormControlLabel
+                  value="flex-end"
+                  control={<Radio />}
+                  label="flex-end"
+                />
+                <FormControlLabel
+                  value="space-between"
+                  control={<Radio />}
+                  label="space-between"
+                />
+                <FormControlLabel
+                  value="space-around"
+                  control={<Radio />}
+                  label="space-around"
+                />
+                <FormControlLabel
+                  value="space-evenly"
+                  control={<Radio />}
+                  label="space-evenly"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">spacing</FormLabel>
+              <RadioGroup
+                row
+                name="spacing"
+                aria-label="spacing"
+                value={spacing.toString()}
+                onChange={(event) => {
+                  setSpacing(Number(event.target.value));
+                }}
+              >
+                {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
+                  <FormControlLabel
+                    key={value}
+                    value={value.toString()}
+                    control={<Radio />}
+                    label={value}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+        </Grid>
+      </Paper>
+      <HighlightedCode code={jsx} language="jsx" />
+    </Stack>
+  );
+}

--- a/docs/data/system/components/stack/InteractiveStack.js
+++ b/docs/data/system/components/stack/InteractiveStack.js
@@ -51,7 +51,7 @@ export default function InteractiveStack() {
       </Stack>
       <Paper sx={{ p: 2 }}>
         <Grid container spacing={3}>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">direction</FormLabel>
               <RadioGroup
@@ -82,7 +82,7 @@ export default function InteractiveStack() {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">alignItems</FormLabel>
               <RadioGroup
@@ -122,7 +122,7 @@ export default function InteractiveStack() {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">justifyContent</FormLabel>
               <RadioGroup
@@ -167,7 +167,7 @@ export default function InteractiveStack() {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">spacing</FormLabel>
               <RadioGroup

--- a/docs/data/system/components/stack/InteractiveStack.tsx
+++ b/docs/data/system/components/stack/InteractiveStack.tsx
@@ -1,0 +1,198 @@
+import * as React from 'react';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+import Paper from '@mui/material/Paper';
+import RadioGroup from '@mui/material/RadioGroup';
+import Radio from '@mui/material/Radio';
+import { Stack, Unstable_Grid as Grid, StackProps } from '@mui/system';
+
+export default function InteractiveStack() {
+  const [direction, setDirection] = React.useState<StackProps['direction']>('row');
+  const [justifyContent, setJustifyContent] = React.useState('center');
+  const [alignItems, setAlignItems] = React.useState('center');
+  const [spacing, setSpacing] = React.useState(2);
+
+  const jsx = `
+<Stack
+  direction="${direction}"
+  justifyContent="${justifyContent}"
+  alignItems="${alignItems}"
+  spacing={${spacing}}
+>
+`;
+
+  return (
+    <Stack sx={{ flexGrow: 1 }}>
+      <Stack
+        direction={direction}
+        justifyContent={justifyContent}
+        alignItems={alignItems}
+        spacing={spacing}
+        sx={{ height: 240 }}
+      >
+        {[0, 1, 2].map((value) => (
+          <Paper
+            key={value}
+            sx={{
+              p: 2,
+              pt: value + 1,
+              pb: value + 1,
+              color: 'text.secondary',
+              typography: 'body2',
+              backgroundColor: (theme) =>
+                theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+            }}
+          >
+            {`Item ${value + 1}`}
+          </Paper>
+        ))}
+      </Stack>
+      <Paper sx={{ p: 2 }}>
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">direction</FormLabel>
+              <RadioGroup
+                row
+                name="direction"
+                aria-label="direction"
+                value={direction}
+                onChange={(event) => {
+                  setDirection(event.target.value as StackProps['direction']);
+                }}
+              >
+                <FormControlLabel value="row" control={<Radio />} label="row" />
+                <FormControlLabel
+                  value="row-reverse"
+                  control={<Radio />}
+                  label="row-reverse"
+                />
+                <FormControlLabel
+                  value="column"
+                  control={<Radio />}
+                  label="column"
+                />
+                <FormControlLabel
+                  value="column-reverse"
+                  control={<Radio />}
+                  label="column-reverse"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">alignItems</FormLabel>
+              <RadioGroup
+                row
+                name="alignItems"
+                aria-label="align items"
+                value={alignItems}
+                onChange={(event) => {
+                  setAlignItems(event.target.value);
+                }}
+              >
+                <FormControlLabel
+                  value="flex-start"
+                  control={<Radio />}
+                  label="flex-start"
+                />
+                <FormControlLabel
+                  value="center"
+                  control={<Radio />}
+                  label="center"
+                />
+                <FormControlLabel
+                  value="flex-end"
+                  control={<Radio />}
+                  label="flex-end"
+                />
+                <FormControlLabel
+                  value="stretch"
+                  control={<Radio />}
+                  label="stretch"
+                />
+                <FormControlLabel
+                  value="baseline"
+                  control={<Radio />}
+                  label="baseline"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">justifyContent</FormLabel>
+              <RadioGroup
+                row
+                name="justifyContent"
+                aria-label="justifyContent"
+                value={justifyContent}
+                onChange={(event) => {
+                  setJustifyContent(event.target.value);
+                }}
+              >
+                <FormControlLabel
+                  value="flex-start"
+                  control={<Radio />}
+                  label="flex-start"
+                />
+                <FormControlLabel
+                  value="center"
+                  control={<Radio />}
+                  label="center"
+                />
+                <FormControlLabel
+                  value="flex-end"
+                  control={<Radio />}
+                  label="flex-end"
+                />
+                <FormControlLabel
+                  value="space-between"
+                  control={<Radio />}
+                  label="space-between"
+                />
+                <FormControlLabel
+                  value="space-around"
+                  control={<Radio />}
+                  label="space-around"
+                />
+                <FormControlLabel
+                  value="space-evenly"
+                  control={<Radio />}
+                  label="space-evenly"
+                />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">spacing</FormLabel>
+              <RadioGroup
+                row
+                name="spacing"
+                aria-label="spacing"
+                value={spacing.toString()}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  setSpacing(Number((event.target as HTMLInputElement).value));
+                }}
+              >
+                {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (
+                  <FormControlLabel
+                    key={value}
+                    value={value.toString()}
+                    control={<Radio />}
+                    label={value}
+                  />
+                ))}
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+        </Grid>
+      </Paper>
+      <HighlightedCode code={jsx} language="jsx" />
+    </Stack>
+  );
+}

--- a/docs/data/system/components/stack/InteractiveStack.tsx
+++ b/docs/data/system/components/stack/InteractiveStack.tsx
@@ -51,7 +51,7 @@ export default function InteractiveStack() {
       </Stack>
       <Paper sx={{ p: 2 }}>
         <Grid container spacing={3}>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">direction</FormLabel>
               <RadioGroup
@@ -82,7 +82,7 @@ export default function InteractiveStack() {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">alignItems</FormLabel>
               <RadioGroup
@@ -122,7 +122,7 @@ export default function InteractiveStack() {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">justifyContent</FormLabel>
               <RadioGroup
@@ -167,7 +167,7 @@ export default function InteractiveStack() {
               </RadioGroup>
             </FormControl>
           </Grid>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <FormControl component="fieldset">
               <FormLabel component="legend">spacing</FormLabel>
               <RadioGroup

--- a/docs/data/system/components/stack/ResponsiveStack.js
+++ b/docs/data/system/components/stack/ResponsiveStack.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { styled, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function ResponsiveStack() {
+  return (
+    <div>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={{ xs: 1, sm: 2, md: 4 }}
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
+  );
+}

--- a/docs/data/system/components/stack/ResponsiveStack.js
+++ b/docs/data/system/components/stack/ResponsiveStack.js
@@ -4,10 +4,8 @@ import { styled, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function ResponsiveStack() {

--- a/docs/data/system/components/stack/ResponsiveStack.tsx
+++ b/docs/data/system/components/stack/ResponsiveStack.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import { styled, Stack } from '@mui/system';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function ResponsiveStack() {
+  return (
+    <div>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={{ xs: 1, sm: 2, md: 4 }}
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
+  );
+}

--- a/docs/data/system/components/stack/ResponsiveStack.tsx
+++ b/docs/data/system/components/stack/ResponsiveStack.tsx
@@ -4,10 +4,8 @@ import { styled, Stack } from '@mui/system';
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
-  ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.palette.text.secondary,
 }));
 
 export default function ResponsiveStack() {

--- a/docs/data/system/components/stack/ResponsiveStack.tsx.preview
+++ b/docs/data/system/components/stack/ResponsiveStack.tsx.preview
@@ -1,0 +1,8 @@
+<Stack
+  direction={{ xs: 'column', sm: 'row' }}
+  spacing={{ xs: 1, sm: 2, md: 4 }}
+>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/system/components/stack/stack.md
+++ b/docs/data/system/components/stack/stack.md
@@ -1,0 +1,56 @@
+---
+product: system
+title: React Stack component
+githubLabel: 'component: Stack'
+packageName: '@mui/system'
+---
+
+# Stack
+
+<p class="description">The Stack component manages layout of immediate children along the vertical or horizontal axis with optional spacing and/or dividers between each child.</p>
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
+## Usage
+
+`Stack` is concerned with one-dimensional layouts, while [Grid](/system/react-grid/) handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
+
+{{"demo": "BasicStack.js", "bg": true}}
+
+To control space between children, use the `spacing` prop.
+The spacing value can be any number, including decimals and any string.
+The prop is converted into a CSS property using the [`theme.spacing()`](/material-ui/customization/spacing/) helper.
+
+## Direction
+
+By default, `Stack` arranges items vertically in a `column`.
+However, the `direction` prop can be used to position items horizontally in a `row` as well.
+
+{{"demo": "DirectionStack.js", "bg": true}}
+
+## Dividers
+
+Use the `divider` prop to insert an element between each child. This works particularly well with the [Divider](/material-ui/react-divider/) component.
+
+{{"demo": "DividerStack.js", "bg": true}}
+
+## Responsive values
+
+You can switch the `direction` or `spacing` values based on the active breakpoint.
+
+{{"demo": "ResponsiveStack.js", "bg": true}}
+
+## Interactive
+
+Below is an interactive demo that lets you explore the visual results of the different settings:
+
+{{"demo": "InteractiveStack.js", "hideToolbar": true, "bg": true}}
+
+## System props
+
+As a CSS utility component, the `Stack` supports all [`system`](/system/properties/) properties. You can use them as props directly on the component.
+For instance, a margin-top:
+
+```jsx
+<Stack mt={2}>
+```

--- a/docs/data/system/pages.ts
+++ b/docs/data/system/pages.ts
@@ -49,6 +49,7 @@ const pages = [
       { pathname: '/system/react-box', title: 'Box' },
       { pathname: '/system/react-container', title: 'Container' },
       { pathname: '/system/react-grid', title: 'Grid' },
+      { pathname: '/system/react-stack', title: 'Stack' },
     ],
   },
   {

--- a/docs/data/system/pagesApi.js
+++ b/docs/data/system/pagesApi.js
@@ -2,4 +2,5 @@ module.exports = [
   { pathname: '/system/api/box' },
   { pathname: '/system/api/container' },
   { pathname: '/system/api/grid' },
+  { pathname: '/system/api/stack' },
 ];

--- a/docs/pages/system/api/stack.js
+++ b/docs/pages/system/api/stack.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './stack.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+export function getStaticProps() {
+  const req = require.context('docs/translations/api-docs/stack', false, /stack.*.json$/);
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    props: {
+      descriptions,
+      pageContent: jsonPageContent,
+    },
+  };
+}

--- a/docs/pages/system/api/stack.json
+++ b/docs/pages/system/api/stack.json
@@ -1,0 +1,32 @@
+{
+  "props": {
+    "children": { "type": { "name": "node" } },
+    "direction": {
+      "type": {
+        "name": "union",
+        "description": "'column-reverse'<br>&#124;&nbsp;'column'<br>&#124;&nbsp;'row-reverse'<br>&#124;&nbsp;'row'<br>&#124;&nbsp;Array&lt;'column-reverse'<br>&#124;&nbsp;'column'<br>&#124;&nbsp;'row-reverse'<br>&#124;&nbsp;'row'&gt;<br>&#124;&nbsp;object"
+      }
+    },
+    "divider": { "type": { "name": "node" } },
+    "spacing": {
+      "type": {
+        "name": "union",
+        "description": "Array&lt;number<br>&#124;&nbsp;string&gt;<br>&#124;&nbsp;number<br>&#124;&nbsp;object<br>&#124;&nbsp;string"
+      }
+    },
+    "sx": {
+      "type": {
+        "name": "union",
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+      }
+    }
+  },
+  "name": "Stack",
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
+  "spread": true,
+  "forwardsRefTo": "HTMLDivElement",
+  "filename": "/packages/mui-system/src/Stack/Stack.tsx",
+  "inheritance": null,
+  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack (Material UI)</a></li></ul>",
+  "cssComponent": true
+}

--- a/docs/pages/system/react-stack.js
+++ b/docs/pages/system/react-stack.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import {
+  demos,
+  docs,
+  demoComponents,
+} from 'docs/data/system/components/stack/stack.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
+}

--- a/docs/translations/api-docs/stack/stack.json
+++ b/docs/translations/api-docs/stack/stack.json
@@ -2,7 +2,6 @@
   "componentDescription": "",
   "propDescriptions": {
     "children": "The content of the component.",
-    "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "direction": "Defines the <code>flex-direction</code> style property. It is applied for all screen sizes.",
     "divider": "Add an element between each child.",
     "spacing": "Defines the space between immediate children.",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -181,6 +181,7 @@
     "/system/react-box": "Box",
     "/system/react-container": "Container",
     "/system/react-grid": "Grid",
+    "/system/react-stack": "Stack",
     "/system/styles": "Styles",
     "/system/styles/basics": "Basics",
     "/system/styles/advanced": "Advanced",

--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -1,0 +1,465 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from 'test/utils';
+import Stack from '@mui/system/Stack';
+import { createTheme } from '@mui/system';
+import { style } from './createStack';
+
+describe('<Stack />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Stack />, () => ({
+    render,
+    inheritComponent: 'div',
+    refInstanceof: window.HTMLDivElement,
+    muiName: 'MuiStack',
+    skip: ['componentProp', 'componentsProp', 'rootClass', 'themeVariants', 'themeStyleOverrides'],
+  }));
+
+  const theme = createTheme();
+
+  it('should handle breakpoints with a missing key', () => {
+    expect(
+      style({
+        ownerState: {
+          direction: { xs: 'column', sm: 'row' },
+          spacing: { xs: 1, sm: 2, md: 4 },
+        },
+        theme,
+      }),
+    ).to.deep.equal({
+      '@media (min-width:0px)': {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '8px',
+        },
+        flexDirection: 'column',
+      },
+      [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginLeft: '16px',
+        },
+        flexDirection: 'row',
+      },
+      [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginLeft: '32px',
+        },
+      },
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  it('should handle direction with multiple keys and spacing with one', () => {
+    expect(
+      style({
+        ownerState: {
+          direction: { sm: 'column', md: 'row' },
+          spacing: 2,
+        },
+        theme,
+      }),
+    ).to.deep.equal({
+      [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '16px',
+        },
+        flexDirection: 'column',
+      },
+      [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginLeft: '16px',
+        },
+        flexDirection: 'row',
+      },
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  it('should handle spacing with multiple keys and direction with one', () => {
+    expect(
+      style({
+        ownerState: {
+          direction: 'column',
+          spacing: { sm: 2, md: 4 },
+        },
+        theme,
+      }),
+    ).to.deep.equal({
+      [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '16px',
+        },
+      },
+      [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '32px',
+        },
+      },
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  it('should handle spacing with multiple keys and null values', () => {
+    expect(
+      style({
+        ownerState: {
+          direction: 'column',
+          spacing: { sm: 2, md: 0, lg: 4 },
+        },
+        theme,
+      }),
+    ).to.deep.equal({
+      [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '16px',
+        },
+      },
+      [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '0px',
+        },
+      },
+      [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '32px',
+        },
+      },
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  it('should handle flat params', () => {
+    expect(
+      style({
+        ownerState: {
+          direction: 'row',
+          spacing: 3,
+        },
+        theme,
+      }),
+    ).to.deep.equal({
+      '& > :not(style) + :not(style)': {
+        margin: 0,
+        marginLeft: '24px',
+      },
+      display: 'flex',
+      flexDirection: 'row',
+    });
+  });
+
+  it('should respect the theme breakpoints order', () => {
+    expect(
+      style({
+        ownerState: {
+          direction: { xs: 'column' },
+          spacing: { lg: 2, xs: 1 },
+        },
+        theme,
+      }),
+    ).to.deep.equal({
+      '@media (min-width:0px)': {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '8px',
+        },
+        flexDirection: 'column',
+      },
+      [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '16px',
+        },
+      },
+      display: 'flex',
+      flexDirection: 'column',
+    });
+  });
+
+  describe('prop: direction', () => {
+    it('should generate correct direction given string values', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: 'column-reverse',
+            spacing: 1,
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginBottom: '8px',
+        },
+        display: 'flex',
+        flexDirection: 'column-reverse',
+      });
+    });
+
+    it('should generate correct responsive styles regardless of breakpoints order', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: { sm: 'row', xs: 'column' },
+            spacing: { xs: 1, sm: 2, md: 3 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        '@media (min-width:0px)': {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '8px',
+          },
+          flexDirection: 'column',
+        },
+        [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '16px',
+          },
+          flexDirection: 'row',
+        },
+        [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '24px',
+          },
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+    });
+
+    it('should generate correct direction even though breakpoints are not fully provided', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: { lg: 'row' },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+          flexDirection: 'row',
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+    });
+
+    it('should place correct margin direction even though breakpoints are not fully provided', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: { lg: 'row' },
+            spacing: { xs: 0, md: 2, xl: 4 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '0px',
+          },
+        },
+        [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '16px',
+          },
+        },
+        [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '16px',
+          },
+          flexDirection: 'row',
+        },
+        [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '32px',
+          },
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+
+      expect(
+        style({
+          ownerState: {
+            direction: { lg: 'column', sm: 'row' },
+            spacing: { md: 2, xl: 4, xs: 0 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '0px',
+          },
+        },
+        [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '0px',
+          },
+          flexDirection: 'row',
+        },
+        [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginLeft: '16px',
+          },
+        },
+        [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '16px',
+          },
+          flexDirection: 'column',
+        },
+        [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '32px',
+          },
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+    });
+  });
+
+  describe('prop: spacing', () => {
+    it('should generate correct responsive styles regardless of breakpoints order', () => {
+      expect(
+        style({
+          ownerState: {
+            direction: 'column',
+            spacing: { sm: 2, md: 3, xs: 1 },
+          },
+          theme,
+        }),
+      ).to.deep.equal({
+        '@media (min-width:0px)': {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '8px',
+          },
+        },
+        [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '16px',
+          },
+        },
+        [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '24px',
+          },
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+    });
+
+    it('should generate correct styles if custom breakpoints are provided in theme', () => {
+      const customTheme = createTheme({
+        breakpoints: {
+          values: {
+            smallest: 0,
+            small: 375,
+            mobile: 600,
+            tablet: 992,
+            desktop: 1200,
+          },
+        },
+      });
+
+      expect(
+        style({
+          ownerState: {
+            direction: 'column',
+            spacing: 4,
+          },
+          theme: customTheme,
+        }),
+      ).to.deep.equal({
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          marginTop: '32px',
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+    });
+
+    it('should generate correct responsive styles if custom responsive spacing values are provided', () => {
+      const customTheme = createTheme({
+        breakpoints: {
+          values: {
+            smallest: 0,
+            small: 375,
+            mobile: 600,
+            tablet: 992,
+            desktop: 1200,
+          },
+        },
+      });
+
+      expect(
+        style({
+          ownerState: {
+            direction: 'column',
+            spacing: { small: 4 },
+          },
+          theme: customTheme,
+        }),
+      ).to.deep.equal({
+        [`@media (min-width:${customTheme.breakpoints.values.small}px)`]: {
+          '& > :not(style) + :not(style)': {
+            margin: 0,
+            marginTop: '32px',
+          },
+        },
+        display: 'flex',
+        flexDirection: 'column',
+      });
+    });
+
+    it('should list responsive styles in correct order', () => {
+      const styles = style({
+        ownerState: {
+          direction: { xs: 'column', lg: 'row' },
+          spacing: { xs: 0, md: 2, xl: 4 },
+        },
+        theme,
+      });
+      const keysForResponsiveStyles = Object.keys(styles).filter((prop) => prop.includes('@media'));
+      expect(keysForResponsiveStyles).to.deep.equal([
+        '@media (min-width:0px)',
+        '@media (min-width:900px)',
+        '@media (min-width:1200px)',
+        '@media (min-width:1536px)',
+      ]);
+    });
+  });
+});

--- a/packages/mui-system/src/Stack/Stack.tsx
+++ b/packages/mui-system/src/Stack/Stack.tsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import createStack from './createStack';
+/**
+ *
+ * Demos:
+ *
+ * - [Stack (Material UI)](https://mui.com/material-ui/react-stack/)
+ *
+ * API:
+ *
+ * - [Stack API](https://mui.com/system/api/stack/)
+ */
+const Stack = createStack();
+
+Stack.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Defines the `flex-direction` style property.
+   * It is applied for all screen sizes.
+   * @default 'column'
+   */
+  direction: PropTypes.oneOfType([
+    PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
+    PropTypes.arrayOf(PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row'])),
+    PropTypes.object,
+  ]),
+  /**
+   * Add an element between each child.
+   */
+  divider: PropTypes.node,
+  /**
+   * Defines the space between immediate children.
+   * @default 0
+   */
+  spacing: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop, which allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+} as any;
+
+export default Stack;

--- a/packages/mui-system/src/Stack/StackProps.ts
+++ b/packages/mui-system/src/Stack/StackProps.ts
@@ -4,34 +4,35 @@ import { ResponsiveStyleValue, SxProps } from '../styleFunctionSx';
 import { SystemProps } from '../Box';
 import { Theme } from '../createTheme';
 
+export interface StackBaseProps {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
+   * Defines the `flex-direction` style property.
+   * It is applied for all screen sizes.
+   * @default 'column'
+   */
+  direction?: ResponsiveStyleValue<'row' | 'row-reverse' | 'column' | 'column-reverse'>;
+  /**
+   * Defines the space between immediate children.
+   * @default 0
+   */
+  spacing?: ResponsiveStyleValue<number | string>;
+  /**
+   * Add an element between each child.
+   */
+  divider?: React.ReactNode;
+}
 export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
   props: P &
-    SystemProps<Theme> & {
-      ref?: React.Ref<unknown>;
-      /**
-       * The content of the component.
-       */
-      children?: React.ReactNode;
-      /**
-       * Defines the `flex-direction` style property.
-       * It is applied for all screen sizes.
-       * @default 'column'
-       */
-      direction?: ResponsiveStyleValue<'row' | 'row-reverse' | 'column' | 'column-reverse'>;
-      /**
-       * Defines the space between immediate children.
-       * @default 0
-       */
-      spacing?: ResponsiveStyleValue<number | string>;
-      /**
-       * Add an element between each child.
-       */
-      divider?: React.ReactNode;
+    StackBaseProps & {
       /**
        * The system prop, which allows defining system overrides as well as additional CSS styles.
        */
       sx?: SxProps<Theme>;
-    };
+    } & SystemProps<Theme>;
   defaultComponent: D;
 }
 

--- a/packages/mui-system/src/Stack/StackProps.ts
+++ b/packages/mui-system/src/Stack/StackProps.ts
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { OverrideProps } from '@mui/types';
+import { ResponsiveStyleValue, SxProps } from '../styleFunctionSx';
+import { SystemProps } from '../Box';
+import { Theme } from '../createTheme';
+
+export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P &
+    SystemProps<Theme> & {
+      ref?: React.Ref<unknown>;
+      /**
+       * The content of the component.
+       */
+      children?: React.ReactNode;
+      /**
+       * Defines the `flex-direction` style property.
+       * It is applied for all screen sizes.
+       * @default 'column'
+       */
+      direction?: ResponsiveStyleValue<'row' | 'row-reverse' | 'column' | 'column-reverse'>;
+      /**
+       * Defines the space between immediate children.
+       * @default 0
+       */
+      spacing?: ResponsiveStyleValue<number | string>;
+      /**
+       * Add an element between each child.
+       */
+      divider?: React.ReactNode;
+      /**
+       * The system prop, which allows defining system overrides as well as additional CSS styles.
+       */
+      sx?: SxProps<Theme>;
+    };
+  defaultComponent: D;
+}
+
+export type StackProps<
+  D extends React.ElementType = StackTypeMap['defaultComponent'],
+  P = {
+    component?: React.ElementType;
+  },
+> = OverrideProps<StackTypeMap<P, D>, D>;
+
+export interface StackOwnerState {
+  direction: StackProps['direction'];
+  spacing: StackProps['spacing'];
+}

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -71,8 +71,7 @@ const getSideFromDirection = (direction: StackOwnerState['direction']) => {
     'row-reverse': 'Right',
     column: 'Top',
     'column-reverse': 'Bottom',
-    // @ts-ignore
-  }[direction];
+  }[direction as string];
 };
 
 export const style = ({ ownerState, theme }: StyleFunctionProps) => {
@@ -81,7 +80,6 @@ export const style = ({ ownerState, theme }: StyleFunctionProps) => {
     flexDirection: 'column',
     ...handleBreakpoints(
       { theme },
-      // @ts-ignore TODO: add types for resolveBreakpointValues
       resolveBreakpointValues({
         values: ownerState.direction,
         breakpoints: theme.breakpoints.values,
@@ -95,26 +93,26 @@ export const style = ({ ownerState, theme }: StyleFunctionProps) => {
   if (ownerState.spacing) {
     const transformer = createUnarySpacing(theme);
 
-    const base = Object.keys(theme.breakpoints.values).reduce((acc, breakpoint) => {
-      if (
-        // @ts-ignore
-        (typeof ownerState.spacing === 'object' && ownerState.spacing[breakpoint] != null) ||
-        // @ts-ignore
-        (typeof ownerState.direction === 'object' && ownerState.direction[breakpoint] != null)
-      ) {
-        // @ts-ignore
-        acc[breakpoint] = true;
-      }
-      return acc;
-    }, {});
+    const base = Object.keys(theme.breakpoints.values).reduce<Record<string, boolean>>(
+      (acc, breakpoint) => {
+        if (
+          (typeof ownerState.spacing === 'object' &&
+            (ownerState.spacing as any)[breakpoint] != null) ||
+          (typeof ownerState.direction === 'object' &&
+            (ownerState.direction as any)[breakpoint] != null)
+        ) {
+          acc[breakpoint] = true;
+        }
+        return acc;
+      },
+      {},
+    );
 
-    // @ts-ignore TODO: add types for resolveBreakpointValues
     const directionValues = resolveBreakpointValues({
       values: ownerState.direction,
       base,
     });
 
-    // @ts-ignore TODO: add types for resolveBreakpointValues
     const spacingValues = resolveBreakpointValues({
       values: ownerState.spacing,
       base,
@@ -131,7 +129,7 @@ export const style = ({ ownerState, theme }: StyleFunctionProps) => {
       });
     }
 
-    const styleFromPropValue = (propValue: string | number | null, breakpoint: Breakpoint) => {
+    const styleFromPropValue = (propValue: string | number | null, breakpoint?: Breakpoint) => {
       return {
         '& > :not(style) + :not(style)': {
           margin: 0,

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import {
   deepmerge,
@@ -161,8 +162,7 @@ export default function createStack(
     componentName = 'MuiStack',
   } = options;
 
-  // TODO: Why the Stack in Material UI didn't have any utility classes?
-  const useUtilityClasses = (ownerState: StackOwnerState, theme: typeof defaultTheme) => {
+  const useUtilityClasses = () => {
     const slots = {
       root: ['root'],
     };
@@ -183,6 +183,7 @@ export default function createStack(
       spacing = 0,
       divider,
       children,
+      className,
       ...other
     } = props;
 
@@ -191,8 +192,16 @@ export default function createStack(
       spacing,
     };
 
+    const classes = useUtilityClasses();
+
     return (
-      <StackRoot as={component} ownerState={ownerState} ref={ref} {...other}>
+      <StackRoot
+        as={component}
+        ownerState={ownerState}
+        ref={ref}
+        className={clsx(classes.root, className)}
+        {...other}
+      >
         {divider ? joinChildren(children, divider as React.ReactElement) : children}
       </StackRoot>
     );

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -176,7 +176,7 @@ export default function createStack(
 
   const Stack = React.forwardRef(function Grid(inProps, ref) {
     const themeProps = useThemeProps<typeof inProps & { component?: React.ElementType }>(inProps);
-    const props = extendSxProp(themeProps);
+    const props = extendSxProp(themeProps) as Omit<typeof themeProps, 'color'>; // `color` type conflicts with html color attribute.
     const {
       component = 'div',
       direction = 'column',
@@ -192,7 +192,6 @@ export default function createStack(
     };
 
     return (
-      // @ts-ignore ref type mismatch
       <StackRoot as={component} ownerState={ownerState} ref={ref} {...other}>
         {divider ? joinChildren(children, divider as React.ReactElement) : children}
       </StackRoot>

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -1,0 +1,226 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { OverridableComponent } from '@mui/types';
+import {
+  deepmerge,
+  unstable_composeClasses as composeClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+import systemStyled from '../styled';
+import useThemePropsSystem from '../useThemeProps';
+import { extendSxProp } from '../styleFunctionSx';
+import createTheme from '../createTheme';
+import { CreateMUIStyled } from '../createStyled';
+import { StackTypeMap, StackOwnerState } from './StackProps';
+import type { Breakpoint } from '../createTheme';
+import { Breakpoints } from '../createTheme/createBreakpoints';
+import {
+  handleBreakpoints,
+  mergeBreakpointsInOrder,
+  resolveBreakpointValues,
+} from '../breakpoints';
+import { createUnarySpacing, getValue } from '../spacing';
+import { Spacing } from '../createTheme/createSpacing';
+
+const defaultTheme = createTheme();
+
+interface StyleFunctionProps {
+  theme: { breakpoints: Breakpoints; spacing: Spacing };
+  ownerState: StackOwnerState;
+}
+
+// widening Theme to any so that the consumer can own the theme structure.
+const defaultCreateStyledComponent = (systemStyled as CreateMUIStyled<any>)('div', {
+  name: 'MuiStack',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+});
+
+function useThemePropsDefault<T>(props: T) {
+  return useThemePropsSystem({
+    props,
+    name: 'MuiStack',
+    defaultTheme,
+  });
+}
+
+/**
+ * Return an array with the separator React element interspersed between
+ * each React node of the input children.
+ *
+ * > joinChildren([1,2,3], 0)
+ * [1,0,2,0,3]
+ */
+function joinChildren(children: React.ReactNode, separator: React.ReactElement) {
+  const childrenArray = React.Children.toArray(children).filter(Boolean);
+
+  return childrenArray.reduce<React.ReactNode[]>((output, child, index) => {
+    output.push(child);
+
+    if (index < childrenArray.length - 1) {
+      output.push(React.cloneElement(separator, { key: `separator-${index}` }));
+    }
+
+    return output;
+  }, []);
+}
+
+const getSideFromDirection = (direction: StackOwnerState['direction']) => {
+  return {
+    row: 'Left',
+    'row-reverse': 'Right',
+    column: 'Top',
+    'column-reverse': 'Bottom',
+    // @ts-ignore
+  }[direction];
+};
+
+export const style = ({ ownerState, theme }: StyleFunctionProps) => {
+  let styles = {
+    display: 'flex',
+    flexDirection: 'column',
+    ...handleBreakpoints(
+      { theme },
+      // @ts-ignore TODO: add types for resolveBreakpointValues
+      resolveBreakpointValues({
+        values: ownerState.direction,
+        breakpoints: theme.breakpoints.values,
+      }),
+      (propValue: string) => ({
+        flexDirection: propValue,
+      }),
+    ),
+  };
+
+  if (ownerState.spacing) {
+    const transformer = createUnarySpacing(theme);
+
+    const base = Object.keys(theme.breakpoints.values).reduce((acc, breakpoint) => {
+      if (
+        // @ts-ignore
+        (typeof ownerState.spacing === 'object' && ownerState.spacing[breakpoint] != null) ||
+        // @ts-ignore
+        (typeof ownerState.direction === 'object' && ownerState.direction[breakpoint] != null)
+      ) {
+        // @ts-ignore
+        acc[breakpoint] = true;
+      }
+      return acc;
+    }, {});
+
+    // @ts-ignore TODO: add types for resolveBreakpointValues
+    const directionValues = resolveBreakpointValues({
+      values: ownerState.direction,
+      base,
+    });
+
+    // @ts-ignore TODO: add types for resolveBreakpointValues
+    const spacingValues = resolveBreakpointValues({
+      values: ownerState.spacing,
+      base,
+    });
+
+    if (typeof directionValues === 'object') {
+      Object.keys(directionValues).forEach((breakpoint, index, breakpoints) => {
+        const directionValue = directionValues[breakpoint];
+        if (!directionValue) {
+          const previousDirectionValue =
+            index > 0 ? directionValues[breakpoints[index - 1]] : 'column';
+          directionValues[breakpoint] = previousDirectionValue;
+        }
+      });
+    }
+
+    const styleFromPropValue = (propValue: string | number | null, breakpoint: Breakpoint) => {
+      return {
+        '& > :not(style) + :not(style)': {
+          margin: 0,
+          [`margin${getSideFromDirection(
+            breakpoint ? directionValues[breakpoint] : ownerState.direction,
+          )}`]: getValue(transformer, propValue),
+        },
+      };
+    };
+    styles = deepmerge(styles, handleBreakpoints({ theme }, spacingValues, styleFromPropValue));
+  }
+
+  styles = mergeBreakpointsInOrder(theme.breakpoints, styles);
+
+  return styles;
+};
+
+export default function createStack(
+  options: {
+    createStyledComponent?: typeof defaultCreateStyledComponent;
+    useThemeProps?: typeof useThemePropsDefault;
+    componentName?: string;
+  } = {},
+) {
+  const {
+    // This will allow adding custom styled fn (for example for custom sx style function)
+    createStyledComponent = defaultCreateStyledComponent,
+    useThemeProps = useThemePropsDefault,
+    componentName = 'MuiStack',
+  } = options;
+
+  // TODO: Why the Stack in Material UI didn't have any utility classes?
+  const useUtilityClasses = (ownerState: StackOwnerState, theme: typeof defaultTheme) => {
+    const slots = {
+      root: ['root'],
+    };
+
+    return composeClasses(slots, (slot) => generateUtilityClass(componentName, slot), {});
+  };
+
+  const StackRoot = createStyledComponent<{
+    ownerState: StackOwnerState;
+  }>(style);
+
+  const Stack = React.forwardRef(function Grid(inProps, ref) {
+    const themeProps = useThemeProps<typeof inProps & { component?: React.ElementType }>(inProps);
+    const props = extendSxProp(themeProps);
+    const {
+      component = 'div',
+      direction = 'column',
+      spacing = 0,
+      divider,
+      children,
+      ...other
+    } = props;
+
+    const ownerState = {
+      direction,
+      spacing,
+    };
+
+    return (
+      // @ts-ignore ref type mismatch
+      <StackRoot as={component} ownerState={ownerState} ref={ref} {...other}>
+        {divider ? joinChildren(children, divider as React.ReactElement) : children}
+      </StackRoot>
+    );
+  }) as OverridableComponent<StackTypeMap>;
+
+  Stack.propTypes /* remove-proptypes */ = {
+    children: PropTypes.node,
+    direction: PropTypes.oneOfType([
+      PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
+      PropTypes.arrayOf(PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row'])),
+      PropTypes.object,
+    ]),
+    divider: PropTypes.node,
+    spacing: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+      PropTypes.number,
+      PropTypes.object,
+      PropTypes.string,
+    ]),
+    sx: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+      PropTypes.func,
+      PropTypes.object,
+    ]),
+  };
+
+  return Stack;
+}

--- a/packages/mui-system/src/Stack/index.ts
+++ b/packages/mui-system/src/Stack/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Stack';
+export { default as createStack } from './createStack';
+export * from './StackProps';

--- a/packages/mui-system/src/Stack/index.ts
+++ b/packages/mui-system/src/Stack/index.ts
@@ -1,3 +1,6 @@
 export { default } from './Stack';
 export { default as createStack } from './createStack';
 export * from './StackProps';
+
+export { default as stackClasses } from './stackClasses';
+export * from './stackClasses';

--- a/packages/mui-system/src/Stack/stackClasses.ts
+++ b/packages/mui-system/src/Stack/stackClasses.ts
@@ -1,0 +1,19 @@
+import {
+  unstable_generateUtilityClass as generateUtilityClass,
+  unstable_generateUtilityClasses as generateUtilityClasses,
+} from '@mui/utils';
+
+export interface StackClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type StackClassKey = keyof StackClasses;
+
+export function getStackUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiStack', slot);
+}
+
+const stackClasses: StackClasses = generateUtilityClasses('MuiStack', ['root']);
+
+export default stackClasses;

--- a/packages/mui-system/src/breakpoints.d.ts
+++ b/packages/mui-system/src/breakpoints.d.ts
@@ -1,0 +1,21 @@
+import { CSSObject } from '@mui/styled-engine';
+import { Breakpoints } from './createTheme/createBreakpoints';
+import type { Breakpoint } from './createTheme';
+import { ResponsiveStyleValue } from './styleFunctionSx';
+
+export interface ResolveBreakpointValuesOptions<T> {
+  values: ResponsiveStyleValue<T>;
+  breakpoints?: Breakpoints['values'];
+  base?: Record<string, boolean>;
+}
+export function resolveBreakpointValues<T>(
+  options: ResolveBreakpointValuesOptions<T>,
+): Record<string, T>;
+
+export function mergeBreakpointsInOrder(breakpoints: Breakpoints, styles: CSSObject[]): CSSObject;
+
+export function handleBreakpoints<Props>(
+  props: Props,
+  propValue: any,
+  styleFromPropValue: (value: any, breakpoint?: Breakpoint) => any,
+): any;

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -32,12 +32,7 @@ export type BordersProps = PropsFor<typeof borders>;
 
 // breakpoints.js
 type DefaultBreakPoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-
-export function handleBreakpoints<Props>(
-  props: Props,
-  propValue: any,
-  styleFromPropValue: (value: any) => any,
-): any;
+export { handleBreakpoints } from './breakpoints';
 
 /**
  * @returns An enhanced stylefunction that considers breakpoints

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -178,3 +178,6 @@ export * from './Container';
 
 export { default as Unstable_Grid } from './Unstable_Grid';
 export * from './Unstable_Grid';
+
+export { default as Stack } from './Stack';
+export * from './Stack';

--- a/packages/mui-system/src/index.js
+++ b/packages/mui-system/src/index.js
@@ -57,3 +57,6 @@ export * from './Container';
 
 export { default as Unstable_Grid } from './Unstable_Grid/Grid';
 export * from './Unstable_Grid';
+
+export { default as Stack } from './Stack/Stack';
+export * from './Stack';

--- a/packages/mui-system/src/spacing.d.ts
+++ b/packages/mui-system/src/spacing.d.ts
@@ -58,10 +58,10 @@ export const padding: SimpleStyleFunction<
   | 'paddingBlockEnd'
 >;
 
-type SpacingValue = string | number | null | undefined;
+export type SpacingValueType = string | number | null | undefined;
 export function getValue(
-  transformer: (prop: SpacingValue) => SpacingValue,
-  propValue: SpacingValue,
-): SpacingValue;
+  transformer: (prop: SpacingValueType) => SpacingValueType,
+  propValue: SpacingValueType,
+): SpacingValueType;
 
 export type PaddingProps = PropsFor<typeof padding>;

--- a/packages/mui-system/src/spacing.d.ts
+++ b/packages/mui-system/src/spacing.d.ts
@@ -1,4 +1,3 @@
-import { string } from 'prop-types';
 import { SimpleStyleFunction, spacing, PropsFor } from './Box';
 
 export type SpacingProps = PropsFor<typeof spacing>;

--- a/packages/mui-system/src/spacing.d.ts
+++ b/packages/mui-system/src/spacing.d.ts
@@ -1,3 +1,4 @@
+import { string } from 'prop-types';
 import { SimpleStyleFunction, spacing, PropsFor } from './Box';
 
 export type SpacingProps = PropsFor<typeof spacing>;
@@ -57,5 +58,11 @@ export const padding: SimpleStyleFunction<
   | 'paddingBlockStart'
   | 'paddingBlockEnd'
 >;
+
+type SpacingValue = string | number | null | undefined;
+export function getValue(
+  transformer: (prop: SpacingValue) => SpacingValue,
+  propValue: SpacingValue,
+): SpacingValue;
 
 export type PaddingProps = PropsFor<typeof padding>;


### PR DESCRIPTION
The PR creates `createStack` util in the @mui/system and exports a `Stack component`. The demos used on the system's Stack page are idential with the one for Material UI.

Preview: https://deploy-preview-33760--material-ui.netlify.app/system/react-stack/

I will replace the Material UI's Stack & create Joy UI Stack component in follow up PRs.
Material UI - replace the Stack component with `createStack` https://github.com/mnajdova/material-ui/pull/34