### PR TITLE
[docs] z-index added in popper when used by split button

### DIFF
--- a/docs/data/material/components/button-group/SplitButton.js
+++ b/docs/data/material/components/button-group/SplitButton.js
@@ -54,7 +54,7 @@ export default function SplitButton() {
       </ButtonGroup>
       <Popper
         sx={{
-          zIndex: 1
+          zIndex: 1,
         }}
         open={open}
         anchorEl={anchorRef.current}

--- a/docs/data/material/components/button-group/SplitButton.js
+++ b/docs/data/material/components/button-group/SplitButton.js
@@ -53,6 +53,9 @@ export default function SplitButton() {
         </Button>
       </ButtonGroup>
       <Popper
+        sx={{
+          zIndex: 1
+        }}
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}

--- a/docs/data/material/components/button-group/SplitButton.tsx
+++ b/docs/data/material/components/button-group/SplitButton.tsx
@@ -60,7 +60,7 @@ export default function SplitButton() {
       </ButtonGroup>
       <Popper
         sx={{
-          zIndex: 1
+          zIndex: 1,
         }}
         open={open}
         anchorEl={anchorRef.current}

--- a/docs/data/material/components/button-group/SplitButton.tsx
+++ b/docs/data/material/components/button-group/SplitButton.tsx
@@ -59,6 +59,9 @@ export default function SplitButton() {
         </Button>
       </ButtonGroup>
       <Popper
+        sx={{
+          zIndex: 1
+        }}
         open={open}
         anchorEl={anchorRef.current}
         role={undefined}


### PR DESCRIPTION
resolves #33762

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
