### PR TITLE
[docs] remove react import from nextjs-typescript example

### DIFF
--- a/examples/nextjs-with-typescript/pages/_app.tsx
+++ b/examples/nextjs-with-typescript/pages/_app.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Head from 'next/head';
 import { AppProps } from 'next/app';
 import { ThemeProvider } from '@mui/material/styles';

--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
 import theme from '../src/theme';

--- a/examples/nextjs-with-typescript/pages/about.tsx
+++ b/examples/nextjs-with-typescript/pages/about.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { NextPage } from 'next';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';

--- a/examples/nextjs-with-typescript/pages/index.tsx
+++ b/examples/nextjs-with-typescript/pages/index.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { NextPage } from 'next';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';

--- a/examples/nextjs-with-typescript/src/Copyright.tsx
+++ b/examples/nextjs-with-typescript/src/Copyright.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import MuiLink from '@mui/material/Link';
 

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';

--- a/examples/nextjs-with-typescript/src/ProTip.tsx
+++ b/examples/nextjs-with-typescript/src/ProTip.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import Link from '@mui/material/Link';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import Typography from '@mui/material/Typography';


### PR DESCRIPTION
Remove unnecesary `import ... from 'react'` that is unnecessary on new versions.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

