### PR TITLE
[Joy] Use native html for root slot

### DIFF
--- a/docs/data/joy/components/select/SelectCustomOption.js
+++ b/docs/data/joy/components/select/SelectCustomOption.js
@@ -17,6 +17,7 @@ export default function SelectCustomOption() {
         },
       }}
       sx={{
+        // For the selected option
         '--List-decorator-width': '44px',
         minWidth: 240,
       }}

--- a/docs/data/joy/components/select/SelectFieldDemo.js
+++ b/docs/data/joy/components/select/SelectFieldDemo.js
@@ -11,15 +11,10 @@ export default function SelectFieldDemo() {
     <Box sx={{ width: 240 }}>
       <FormLabel>Favorite pet</FormLabel>
       <Select
-        defaultValue="dog"
-        componentsProps={{
-          button: {
-            // screen readers will announce "Favorite pet, dog selected" when the select is focused.
-            'aria-label': `Favorite pet, ${value} selected.`,
-            // and this in the next sentence.
-            'aria-describedby': 'select-field-demo-helper',
-          },
-        }}
+        // screen readers will announce "Favorite pet, dog selected" when the select is focused.
+        aria-label={`Favorite pet, ${value} selected.`}
+        // and this in the next sentence.
+        aria-describedby="select-field-demo-helper"
         value={value}
         onChange={setValue}
         sx={{ mt: 0.25 }}

--- a/docs/data/joy/components/select/SelectGroupedOptions.js
+++ b/docs/data/joy/components/select/SelectGroupedOptions.js
@@ -39,13 +39,12 @@ export default function SelectGroupedOptions() {
     >
       {Object.entries(group).map(([name, animals], index) => (
         <React.Fragment key={name}>
-          {index !== 0 && <ListDivider role="none" />}
+          {index !== 0 && <ListDivider />}
           <List
-            role="group"
             aria-labelledby={`select-group-${name}`}
             sx={{ '--List-decorator-width': '28px' }}
           >
-            <ListItem role="presentation" id={`select-group-${name}`} sticky>
+            <ListItem id={`select-group-${name}`} sticky>
               <Typography level="body3" textTransform="uppercase" letterSpacing="md">
                 {name} ({animals.length})
               </Typography>

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -433,10 +433,8 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                   <Select
                     size="sm"
                     placeholder="Select a variant..."
+                    aria-labelledby={selectId}
                     componentsProps={{
-                      button: {
-                        'aria-labelledby': selectId,
-                      },
                       listbox: {
                         sx: {
                           '--List-decorator-width': '24px',

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -478,7 +478,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                   key={propName}
                   label={propName}
                   size="sm"
-                  value={resolvedValue || ''}
+                  value={resolvedValue != null ? String(resolvedValue) : ''}
                   onChange={(event) =>
                     setProps((latestProps) => ({
                       ...latestProps,

--- a/packages/mui-joy/src/Input/Input.spec.tsx
+++ b/packages/mui-joy/src/Input/Input.spec.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { expectType } from '@mui/types';
+import Input from '@mui/joy/Input';
+
+<Input
+  placeholder="test"
+  id="test"
+  name="test"
+  defaultValue="hey"
+  autoFocus
+  autoComplete="on"
+  startDecorator="test"
+  endDecorator={<span>hello</span>}
+/>;
+<Input
+  ref={(current) => {
+    expectType<HTMLInputElement | null, typeof current>(current);
+  }}
+  placeholder="test"
+  value="test"
+  onChange={(event) => {
+    expectType<React.ChangeEvent<HTMLInputElement>, typeof event>(event);
+  }}
+/>;
+<Input sx={(theme) => ({ bgcolor: theme.vars.palette.background.surface })} />;
+
+// @ts-expect-error: `rows` is a property of HTMLTextarea
+<Input rows={2} />;
+
+<Input component="textarea" rows={2} cols={3} />; // `rows` and `cols` works!

--- a/packages/mui-joy/src/Input/Input.test.js
+++ b/packages/mui-joy/src/Input/Input.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, screen, act } from 'test/utils';
+import { describeConformance, createRenderer, screen, act, fireEvent } from 'test/utils';
 import Input, { inputClasses as classes } from '@mui/joy/Input';
 import { ThemeProvider } from '@mui/joy/styles';
 
@@ -12,12 +12,25 @@ describe('Joy <Input />', () => {
     render,
     classes,
     ThemeProvider,
-    refInstanceof: window.HTMLDivElement,
+    refInstanceof: window.HTMLInputElement,
     muiName: 'JoyInput',
     testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
     testVariantProps: { variant: 'solid', fullWidth: true },
-    skip: ['propsSpread', 'componentsProp', 'classesRoot'],
+    skip: [
+      'mergeClassName',
+      'classesRoot',
+      'rootClass',
+      'propsSpread',
+      'componentProp',
+      'componentsProp',
+      'themeDefaultProps',
+    ],
   }));
+
+  it('applies the className to the root component', () => {
+    render(<Input className="foo-bar" />);
+    expect(screen.getByRole('textbox')).to.have.class('foo-bar');
+  });
 
   it('should have error classes', () => {
     const { container } = render(<Input error />);
@@ -40,8 +53,15 @@ describe('Joy <Input />', () => {
   });
 
   it('should change to textarea', () => {
-    const { container } = render(<Input componentsProps={{ input: { component: 'textarea' } }} />);
+    const { container } = render(<Input component="textarea" />);
     expect(container.firstChild.firstChild).to.have.tagName('textarea');
+  });
+
+  it('should focus input if wrapper is clicked', () => {
+    const { container } = render(<Input />);
+    fireEvent.click(container.firstChild);
+
+    expect(screen.getByRole('textbox')).toHaveFocus();
   });
 
   describe('prop: disabled', () => {
@@ -64,6 +84,17 @@ describe('Joy <Input />', () => {
       expect(handleBlur.callCount).to.equal(1);
       // check if focus not initiated again
       expect(handleFocus.callCount).to.equal(1);
+    });
+  });
+
+  describe('prop: onClick', () => {
+    it('should handle onClick', () => {
+      const handleClick = spy();
+      render(<Input onClick={handleClick} />);
+
+      fireEvent.click(screen.getByRole('textbox'));
+
+      expect(handleClick.callCount).to.equal(1);
     });
   });
 });

--- a/packages/mui-joy/src/Input/Input.test.js
+++ b/packages/mui-joy/src/Input/Input.test.js
@@ -14,7 +14,8 @@ describe('Joy <Input />', () => {
     ThemeProvider,
     refInstanceof: window.HTMLInputElement,
     muiName: 'JoyInput',
-    testDeepOverrides: { slotName: 'input', slotClassName: classes.input },
+    testRootOverrides: { slotName: 'wrapper', slotClassName: classes.wrapper },
+    testDeepOverrides: { slotName: 'root', slotClassName: classes.root },
     testVariantProps: { variant: 'solid', fullWidth: true },
     skip: [
       'mergeClassName',

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -312,23 +312,9 @@ Input.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
-  'aria-describedby': PropTypes.string,
-  /**
-   * @ignore
-   */
-  'aria-label': PropTypes.string,
-  /**
-   * @ignore
-   */
-  'aria-labelledby': PropTypes.string,
-  /**
-   * This prop helps users to fill forms faster, especially on mobile devices.
-   * The name can be confusing, as it's more like an autofill.
-   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
-   */
   autoComplete: PropTypes.string,
   /**
-   * If `true`, the `input` element is focused during the first mount.
+   * @ignore
    */
   autoFocus: PropTypes.bool,
   /**
@@ -336,11 +322,7 @@ Input.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
-   * Class name applied to the root element.
+   * @ignore
    */
   className: PropTypes.string,
   /**
@@ -365,12 +347,15 @@ Input.propTypes /* remove-proptypes */ = {
     wrapper: PropTypes.object,
   }),
   /**
-   * The default value. Use when the component is not controlled.
+   * @ignore
    */
-  defaultValue: PropTypes.any,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /**
-   * If `true`, the component is disabled.
-   * The prop defaults to the value (`false`) inherited from the parent FormControl component.
+   * @ignore
    */
   disabled: PropTypes.bool,
   /**
@@ -388,11 +373,11 @@ Input.propTypes /* remove-proptypes */ = {
    */
   fullWidth: PropTypes.bool,
   /**
-   * The id of the `input` element.
+   * @ignore
    */
   id: PropTypes.string,
   /**
-   * Name attribute of the `input` element.
+   * @ignore
    */
   name: PropTypes.string,
   /**
@@ -410,23 +395,13 @@ Input.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
-  onKeyDown: PropTypes.func,
+  placeholder: PropTypes.string,
   /**
    * @ignore
    */
-  onKeyUp: PropTypes.func,
-  /**
-   * The short hint displayed in the `input` before the user enters a value.
-   */
-  placeholder: PropTypes.string,
-  /**
-   * It prevents the user from changing the value of the field
-   * (not from interacting with the field).
-   */
   readOnly: PropTypes.bool,
   /**
-   * If `true`, the `input` element is required.
-   * The prop defaults to the value (`false`) inherited from the parent FormControl component.
+   * @ignore
    */
   required: PropTypes.bool,
   /**
@@ -450,14 +425,13 @@ Input.propTypes /* remove-proptypes */ = {
     PropTypes.object,
   ]),
   /**
-   * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
-   * @default 'plain'
+   * @ignore
    */
-  type: PropTypes.string,
-  /**
-   * The value of the `input` element, required for a controlled component.
-   */
-  value: PropTypes.any,
+  value: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /**
    * The variant to use.
    * @default 'outlined'

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -10,7 +10,7 @@ import { InputTypeMap, InputProps } from './InputProps';
 import inputClasses, { getInputUtilityClass } from './inputClasses';
 
 const useUtilityClasses = (ownerState: InputProps) => {
-  const { classes, disabled, fullWidth, variant, color, size } = ownerState;
+  const { disabled, fullWidth, variant, color, size } = ownerState;
 
   const slots = {
     wrapper: [
@@ -26,7 +26,7 @@ const useUtilityClasses = (ownerState: InputProps) => {
     endDecorator: ['endDecorator'],
   };
 
-  return composeClasses(slots, getInputUtilityClass, classes);
+  return composeClasses(slots, getInputUtilityClass, {});
 };
 
 const InputWrapper = styled('div', {
@@ -264,7 +264,7 @@ const Input = React.forwardRef(function Input(inProps, ref) {
   const wrapperProps = useSlotProps({
     elementType: InputWrapper,
     getSlotProps: getRootProps,
-    externalSlotProps: componentsProps.root,
+    externalSlotProps: componentsProps.wrapper,
     additionalProps: {
       as: componentsProps.wrapper?.component,
       sx,

--- a/packages/mui-joy/src/Input/InputProps.ts
+++ b/packages/mui-joy/src/Input/InputProps.ts
@@ -4,7 +4,7 @@ import { UseInputParameters } from '@mui/base/InputUnstyled';
 import { InputClasses } from './inputClasses';
 import { ColorPaletteProp, VariantProp, SxProps } from '../styles/types';
 
-export type InputSlot = 'root' | 'input' | 'startDecorator' | 'endDecorator';
+export type InputSlot = 'wrapper' | 'root' | 'startDecorator' | 'endDecorator';
 
 export interface InputPropsVariantOverrides {}
 
@@ -46,11 +46,11 @@ export interface InputTypeMap<P = {}, D extends React.ElementType = 'div'> {
        * @default {}
        */
       componentsProps?: {
-        root?: React.ComponentPropsWithRef<'div'>;
-        input?: React.ComponentPropsWithRef<'input'> & {
+        wrapper?: React.ComponentPropsWithRef<'div'> & {
           component?: React.ElementType;
           sx?: SxProps;
         };
+        root?: React.ComponentPropsWithRef<'input'>;
       };
       /**
        * Trailing adornment for this input.

--- a/packages/mui-joy/src/Input/InputProps.ts
+++ b/packages/mui-joy/src/Input/InputProps.ts
@@ -1,7 +1,5 @@
 import React from 'react';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
-import { UseInputParameters } from '@mui/base/InputUnstyled';
-import { InputClasses } from './inputClasses';
 import { ColorPaletteProp, VariantProp, SxProps } from '../styles/types';
 
 export type InputSlot = 'wrapper' | 'root' | 'startDecorator' | 'endDecorator';
@@ -12,102 +10,57 @@ export interface InputPropsColorOverrides {}
 
 export interface InputPropsSizeOverrides {}
 
-export interface InputTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
-    Omit<UseInputParameters, 'inputRef'> & {
-      'aria-describedby'?: string;
-      'aria-label'?: string;
-      'aria-labelledby'?: string;
-      /**
-       * This prop helps users to fill forms faster, especially on mobile devices.
-       * The name can be confusing, as it's more like an autofill.
-       * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
-       */
-      autoComplete?: string;
-      /**
-       * If `true`, the `input` element is focused during the first mount.
-       */
-      autoFocus?: boolean;
-      /**
-       * Class name applied to the root element.
-       */
-      className?: string;
-      /**
-       * Override or extend the styles applied to the component.
-       */
-      classes?: Partial<InputClasses>;
-      /**
-       * The color of the component. It supports those theme colors that make sense for this component.
-       * @default 'neutral'
-       */
-      color?: OverridableStringUnion<ColorPaletteProp, InputPropsColorOverrides>;
-      /**
-       * The props used for each slot inside the Input.
-       * @default {}
-       */
-      componentsProps?: {
-        wrapper?: React.ComponentPropsWithRef<'div'> & {
-          component?: React.ElementType;
-          sx?: SxProps;
-        };
-        root?: React.ComponentPropsWithRef<'input'>;
+export interface InputTypeMap<P = {}, D extends React.ElementType = 'input'> {
+  props: P & {
+    /**
+     * The color of the component. It supports those theme colors that make sense for this component.
+     * @default 'neutral'
+     */
+    color?: OverridableStringUnion<ColorPaletteProp, InputPropsColorOverrides>;
+    /**
+     * The props used for each slot inside the Input.
+     * @default {}
+     */
+    componentsProps?: {
+      wrapper?: React.ComponentPropsWithRef<'div'> & {
+        component?: React.ElementType;
+        sx?: SxProps;
       };
-      /**
-       * Trailing adornment for this input.
-       */
-      endDecorator?: React.ReactNode;
-      /**
-       * If `true`, the button will take up the full width of its container.
-       * @default false
-       */
-      fullWidth?: boolean;
-      /**
-       * The id of the `input` element.
-       */
-      id?: string;
-      /**
-       * Name attribute of the `input` element.
-       */
-      name?: string;
-      onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
-      onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>;
-      /**
-       * The short hint displayed in the `input` before the user enters a value.
-       */
-      placeholder?: string;
-      /**
-       * It prevents the user from changing the value of the field
-       * (not from interacting with the field).
-       */
-      readOnly?: boolean;
-      /**
-       * Leading adornment for this input.
-       */
-      startDecorator?: React.ReactNode;
-      /**
-       * The size of the component.
-       * @default 'md'
-       */
-      size?: OverridableStringUnion<'sm' | 'md' | 'lg', InputPropsSizeOverrides>;
-      /**
-       * The system prop that allows defining system overrides as well as additional CSS styles.
-       */
-      sx?: SxProps;
-      /**
-       * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
-       * @default 'plain'
-       */
-      type?: string;
-      /**
-       * The value of the `input` element, required for a controlled component.
-       */
-      value?: unknown;
-      /**
-       * The variant to use.
-       * @default 'outlined'
-       */
-      variant?: OverridableStringUnion<VariantProp, InputPropsVariantOverrides>;
+      root?: React.ComponentPropsWithRef<'input'>;
     };
+    /**
+     * Trailing adornment for this input.
+     */
+    endDecorator?: React.ReactNode;
+    /**
+     * If `true`, the `input` will indicate an error.
+     * The prop defaults to the value (`false`) inherited from the parent FormControl component.
+     */
+    error?: boolean;
+    /**
+     * If `true`, the button will take up the full width of its container.
+     * @default false
+     */
+    fullWidth?: boolean;
+    /**
+     * Leading adornment for this input.
+     */
+    startDecorator?: React.ReactNode;
+    /**
+     * The size of the component.
+     * @default 'md'
+     */
+    size?: OverridableStringUnion<'sm' | 'md' | 'lg', InputPropsSizeOverrides>;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps;
+    /**
+     * The variant to use.
+     * @default 'outlined'
+     */
+    variant?: OverridableStringUnion<VariantProp, InputPropsVariantOverrides>;
+  };
   defaultComponent: D;
 }
 

--- a/packages/mui-joy/src/Input/inputClasses.ts
+++ b/packages/mui-joy/src/Input/inputClasses.ts
@@ -1,10 +1,10 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface InputClasses {
-  /** Styles applied to the root element. */
+  /** Styles applied to the root(html input) element. */
   root: string;
-  /** Styles applied to the input element. */
-  input: string;
+  /** Styles applied to the wrapper element. */
+  wrapper: string;
   /** Styles applied to the root element if the component is a descendant of `FormControl`. */
   formControl: string;
   /** Styles applied to the root element if the component is focused. */
@@ -53,7 +53,7 @@ export function getInputUtilityClass(slot: string): string {
 
 const inputClasses: InputClasses = generateUtilityClasses('JoyInput', [
   'root',
-  'input',
+  'wrapper',
   'formControl',
   'focused',
   'disabled',

--- a/packages/mui-joy/src/Input/inputClasses.ts
+++ b/packages/mui-joy/src/Input/inputClasses.ts
@@ -58,8 +58,6 @@ const inputClasses: InputClasses = generateUtilityClasses('JoyInput', [
   'focused',
   'disabled',
   'error',
-  'adornedStart',
-  'adornedEnd',
   'colorPrimary',
   'colorNeutral',
   'colorDanger',

--- a/packages/mui-joy/src/Select/Select.spec.tsx
+++ b/packages/mui-joy/src/Select/Select.spec.tsx
@@ -36,21 +36,19 @@ interface Value {
 />;
 <Select sx={{ bgcolor: (theme) => theme.vars.palette.background.body }} />;
 <Select
+  aria-labelledby="some-id"
+  aria-describedby="some-id"
+  onClick={() => {}}
   componentsProps={{
-    button: {
-      'aria-labelledby': 'some-id',
-      'aria-describedby': 'some-id',
-      onClick: () => {},
-      sx: {
-        bgcolor: (theme) => theme.vars.palette.background.body,
-      },
-    },
     listbox: {
       component: 'div',
       sx: {
         '--List-padding': '8px',
       },
     },
+  }}
+  sx={{
+    bgcolor: (theme) => theme.vars.palette.background.body,
   }}
 />;
 

--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -18,7 +18,8 @@ describe('Joy <Select />', () => {
     ThemeProvider,
     refInstanceof: window.HTMLButtonElement,
     muiName: 'JoySelect',
-    testDeepOverrides: { slotName: 'wrapper', slotClassName: classes.wrapper },
+    testRootOverrides: { slotName: 'wrapper', slotClassName: classes.wrapper },
+    testDeepOverrides: { slotName: 'indicator', slotClassName: classes.indicator },
     testVariantProps: { variant: 'soft' },
     skip: [
       'mergeClassName',

--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -16,11 +16,19 @@ describe('Joy <Select />', () => {
     render,
     classes,
     ThemeProvider,
-    refInstanceof: window.HTMLDivElement,
+    refInstanceof: window.HTMLButtonElement,
     muiName: 'JoySelect',
-    testDeepOverrides: { slotName: 'button', slotClassName: classes.button },
+    testDeepOverrides: { slotName: 'wrapper', slotClassName: classes.wrapper },
     testVariantProps: { variant: 'soft' },
-    skip: ['classesRoot', 'propsSpread', 'componentProp', 'componentsProp'],
+    skip: [
+      'mergeClassName',
+      'classesRoot',
+      'rootClass',
+      'propsSpread',
+      'componentProp',
+      'componentsProp',
+      'themeDefaultProps',
+    ],
   }));
 
   it('should be able to mount the component', () => {
@@ -60,15 +68,7 @@ describe('Joy <Select />', () => {
   it('should pass "name" as part of the event.target for onBlur', () => {
     const handleBlur = stub().callsFake((event) => event.target.name);
     const { getByRole } = render(
-      <Select
-        name="blur-testing"
-        componentsProps={{
-          button: {
-            onBlur: handleBlur,
-          },
-        }}
-        value=""
-      >
+      <Select name="blur-testing" onBlur={handleBlur} value="">
         <Option value="">none</Option>
       </Select>,
     );

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -239,6 +239,7 @@ const SelectEndDecorator = styled('span', {
 const SelectIndicator = styled('span', {
   name: 'JoySelect',
   slot: 'Indicator',
+  overridesResolver: (props, styles) => styles.indicator,
 })<{ ownerState: SelectOwnerState<any> }>({
   color: 'var(--Select-indicator-color)',
   display: 'inherit',
@@ -415,6 +416,7 @@ const Select = React.forwardRef(function Select<TValue>(
     externalSlotProps: componentsProps.wrapper,
     additionalProps: {
       ref: wrapperRef,
+      as: componentsProps.wrapper?.component,
       sx,
     },
     ownerState,

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -572,7 +572,7 @@ Select.propTypes /* remove-proptypes */ = {
    */
   defaultValue: PropTypes /* @typescript-to-proptypes-ignore */.any,
   /**
-   * If `true`, the component is disabled.
+   * If `true`, the select is disabled.
    * @default false
    */
   disabled: PropTypes.bool,

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -404,13 +404,13 @@ const Select = React.forwardRef(function Select<TValue>(
   const wrapperProps = useSlotProps({
     elementType: SelectWrapper,
     getSlotProps: (handlers) => ({
-      onMouseUp: (event: React.MouseEvent<HTMLDivElement>) => {
+      onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => {
         if (!listboxOpen && event.currentTarget === event.target) {
           // show the popup if user click outside of the button element.
           // the close action is already handled by blur event.
           handleOpenChange(true);
         }
-        handlers.onMouseUp?.(event);
+        handlers.onMouseDown?.(event);
       },
     }),
     externalSlotProps: componentsProps.wrapper,

--- a/packages/mui-joy/src/Select/SelectProps.ts
+++ b/packages/mui-joy/src/Select/SelectProps.ts
@@ -7,7 +7,7 @@ import { ColorPaletteProp, VariantProp, SxProps } from '../styles/types';
 
 export type SelectSlot =
   | 'root'
-  | 'button'
+  | 'wrapper'
   | 'startDecorator'
   | 'endDecorator'
   | 'indicator'

--- a/packages/mui-joy/src/Select/SelectProps.ts
+++ b/packages/mui-joy/src/Select/SelectProps.ts
@@ -36,8 +36,8 @@ export interface SelectStaticProps extends SelectUnstyledCommonProps {
    * @default {}
    */
   componentsProps?: {
-    root?: React.ComponentPropsWithRef<'div'>;
-    button?: React.ComponentPropsWithRef<'button'> & { sx?: SxProps };
+    wrapper?: React.ComponentPropsWithRef<'div'> & { sx?: SxProps; component?: React.ElementType };
+    root?: React.ComponentPropsWithRef<'button'> & { sx?: SxProps };
     listbox?: Omit<PopperUnstyledProps, 'open'> &
       Pick<ListProps, 'variant' | 'color'> & { sx?: SxProps };
   };

--- a/packages/mui-joy/src/Select/SelectProps.ts
+++ b/packages/mui-joy/src/Select/SelectProps.ts
@@ -42,11 +42,6 @@ export interface SelectStaticProps extends SelectUnstyledCommonProps {
       Pick<ListProps, 'variant' | 'color'> & { sx?: SxProps };
   };
   /**
-   * If `true`, the component is disabled.
-   * @default false
-   */
-  disabled?: boolean;
-  /**
    * Trailing adornment for the select.
    */
   endDecorator?: React.ReactNode;

--- a/packages/mui-joy/src/Select/selectClasses.ts
+++ b/packages/mui-joy/src/Select/selectClasses.ts
@@ -1,10 +1,10 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface SelectClasses {
-  /** Styles applied to the root slot. */
+  /** Styles applied to the root(html button) slot. */
   root: string;
-  /** Styles applied to the button slot. */
-  button: string;
+  /** Styles applied to the wrapper slot. */
+  wrapper: string;
   /** Styles applied to the indicator slot. */
   indicator: string;
   /** Styles applied to the startDecorator slot. */
@@ -57,7 +57,7 @@ export function getSelectUtilityClass(slot: string): string {
 
 const selectClasses: SelectClasses = generateUtilityClasses('JoySelect', [
   'root',
-  'button',
+  'wrapper',
   'indicator',
   'startDecorator',
   'endDecorator',

--- a/packages/mui-joy/src/TextField/TextField.test.js
+++ b/packages/mui-joy/src/TextField/TextField.test.js
@@ -48,7 +48,7 @@ describe('Joy <TextField />', () => {
 
     rerender(<TextField variant="soft" />);
     expect(container.firstChild).to.have.class(classes.variantSoft);
-    expect(container.querySelector(`.${inputClasses.root}`)).to.have.class(
+    expect(container.querySelector(`.${inputClasses.wrapper}`)).to.have.class(
       inputClasses.variantSoft,
     );
   });
@@ -59,14 +59,14 @@ describe('Joy <TextField />', () => {
 
     rerender(<TextField size="sm" />);
     expect(container.firstChild).to.have.class(classes.sizeSm);
-    expect(container.querySelector(`.${inputClasses.root}`)).to.have.class(inputClasses.sizeSm);
+    expect(container.querySelector(`.${inputClasses.wrapper}`)).to.have.class(inputClasses.sizeSm);
   });
 
   it('should have configurable color', () => {
     const { container } = render(<TextField color="primary" />);
 
     expect(container.firstChild).to.have.class(classes.colorPrimary);
-    expect(container.querySelector(`.${inputClasses.root}`)).to.have.class(
+    expect(container.querySelector(`.${inputClasses.wrapper}`)).to.have.class(
       inputClasses.colorPrimary,
     );
   });
@@ -87,21 +87,25 @@ describe('Joy <TextField />', () => {
     const { container } = render(<TextField error />);
 
     expect(container.firstChild).to.have.class(classes.error);
-    expect(container.querySelector(`.${inputClasses.root}`)).to.have.class(inputClasses.error);
+    expect(container.querySelector(`.${inputClasses.wrapper}`)).to.have.class(inputClasses.error);
   });
 
   it('should be disabled', () => {
     const { container } = render(<TextField disabled />);
 
     expect(container.firstChild).to.have.class(classes.disabled);
-    expect(container.querySelector(`.${inputClasses.root}`)).to.have.class(inputClasses.disabled);
+    expect(container.querySelector(`.${inputClasses.wrapper}`)).to.have.class(
+      inputClasses.disabled,
+    );
   });
 
   it('should have fullWidth classes', () => {
     const { container } = render(<TextField fullWidth />);
 
     expect(container.firstChild).to.have.class(classes.fullWidth);
-    expect(container.querySelector(`.${inputClasses.root}`)).to.have.class(inputClasses.fullWidth);
+    expect(container.querySelector(`.${inputClasses.wrapper}`)).to.have.class(
+      inputClasses.fullWidth,
+    );
   });
 
   it('should show asterisk if required', () => {

--- a/packages/mui-joy/src/TextField/TextField.tsx
+++ b/packages/mui-joy/src/TextField/TextField.tsx
@@ -182,13 +182,11 @@ TextField.propTypes /* remove-proptypes */ = {
   // |     To update them edit TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
-   * This prop helps users to fill forms faster, especially on mobile devices.
-   * The name can be confusing, as it's more like an autofill.
-   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   * @ignore
    */
   autoComplete: PropTypes.string,
   /**
-   * If `true`, the `input` element is focused during the first mount.
+   * @ignore
    */
   autoFocus: PropTypes.bool,
   /**
@@ -231,12 +229,15 @@ TextField.propTypes /* remove-proptypes */ = {
     root: PropTypes.object,
   }),
   /**
-   * The default value. Use when the component is not controlled.
+   * @ignore
    */
-  defaultValue: PropTypes.any,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /**
-   * If `true`, the component is disabled.
-   * The prop defaults to the value (`false`) inherited from the parent FormControl component.
+   * @ignore
    */
   disabled: PropTypes.bool,
   /**
@@ -287,8 +288,7 @@ TextField.propTypes /* remove-proptypes */ = {
    */
   placeholder: PropTypes.string,
   /**
-   * If `true`, the `input` element is required.
-   * The prop defaults to the value (`false`) inherited from the parent FormControl component.
+   * @ignore
    */
   required: PropTypes.bool,
   /**
@@ -304,14 +304,17 @@ TextField.propTypes /* remove-proptypes */ = {
    */
   startDecorator: PropTypes.node,
   /**
-   * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
-   * @default 'plain'
+   * @ignore
    */
-  type: PropTypes.string,
+  type: PropTypes /* @typescript-to-proptypes-ignore */.string,
   /**
-   * The value of the `input` element, required for a controlled component.
+   * @ignore
    */
-  value: PropTypes.any,
+  value: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /**
    * The variant to use.
    * @default 'outlined'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Motivation

Our `Input` and `Select` requires a `div` for creating the layout because we want to make it easy to add styles and start/end decorators. Conventionally, all the props are spread to the `div` (defined as the `root` element), which makes the DX sometimes really bad:

```js
<Input componentsProps={{ input: { aria-label: 'Search' } }} />
<Input componentsProps={{ input: { component: 'textarea' } }} /> // this makes typescript really hard

// or worse, Input is a slot in TextField
<TextField componentsProps={{ input: { componentsProps: { data-attribute: '' } } }} />
<TextField
    {...inputProps}
    componentsProps={{
      input: { componentsProps: { readOnly: true, input: { ref: inputRef } } },
    }}
  />
  
<Select componentsProps={{ button: { aria-label: '...', id: '...' } }} />
```

**Related issues:**
- #33060
- #11377

## Proposal

I think 99.99% of developers want to pass props/ref to the `input` element, not the `div` so why don't we mark the `input` as the root slot so that it still follows our convention and add a special note that the `root` slot does not need to be the uppermost parent of the component.

This reduces some complexity in the code as well because we don't need to define which prop should be forwarded to `input`.

The result will be like this:

```js
<Input aria-label="Search" />
<Input component="textarea"  /> // typescript just works

<TextField componentsProps={{ input: { data-attribute: '' } }} />
<TextField
    {...inputProps}
    componentsProps={{
      input: { readOnly: true, ref: inputRef },
    }}
  />
  
<Select aria-label="..." id="" />
```

However, the `sx` prop is a special prop. It always goes to the uppermost of the component for styling purposes. (I tried and it gives a lot better experience).

cc @flaviendelangle What do you think?

close #33738 

---

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
