### PR TITLE
[system] Fix duplicated styles in Box

### DIFF
--- a/packages/mui-system/src/createBox.js
+++ b/packages/mui-system/src/createBox.js
@@ -12,8 +12,7 @@ export default function createBox(options = {}) {
     styleFunctionSx = defaultStyleFunctionSx,
   } = options;
   const BoxRoot = styled('div', {
-    shouldForwardProp: (prop) =>
-      prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as',
+    shouldForwardProp: (prop) => prop !== 'theme' && prop !== 'sx' && prop !== 'as',
   })(styleFunctionSx);
 
   const Box = React.forwardRef(function Box(inProps, ref) {

--- a/packages/mui-system/src/createBox.js
+++ b/packages/mui-system/src/createBox.js
@@ -11,7 +11,10 @@ export default function createBox(options = {}) {
     generateClassName,
     styleFunctionSx = defaultStyleFunctionSx,
   } = options;
-  const BoxRoot = styled('div')(styleFunctionSx);
+  const BoxRoot = styled('div', {
+    shouldForwardProp: (prop) =>
+      prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as',
+  })(styleFunctionSx);
 
   const Box = React.forwardRef(function Box(inProps, ref) {
     const theme = useTheme(defaultTheme);

--- a/packages/mui-system/src/createBox.test.js
+++ b/packages/mui-system/src/createBox.test.js
@@ -64,19 +64,34 @@ describe('createBox', () => {
 
   it('should call styleFunctionSx once', () => {
     const Box = createBox();
-    const sypSx = spy();
-    render(<Box sx={sypSx}>Content</Box>);
-    expect(sypSx.callCount).to.equal(2); // React 18 renders twice in strict mode.
+    const spySx = spy();
+    render(<Box sx={spySx}>Content</Box>);
+    expect(spySx.callCount).to.equal(2); // React 18 renders twice in strict mode.
   });
 
   it('should still call styleFunctionSx once', () => {
     const Box = createBox();
-    const sypSx = spy();
+    const spySx = spy();
     render(
-      <Box component={Box} sx={sypSx}>
+      <Box component={Box} sx={spySx}>
         Content
       </Box>,
     );
-    expect(sypSx.callCount).to.equal(2); // React 18 renders twice in strict mode.
+    expect(spySx.callCount).to.equal(2); // React 18 renders twice in strict mode.
+  });
+
+  it('overridable via `component` prop', () => {
+    const Box = createBox();
+
+    const { container } = render(<Box component="span" />);
+    expect(container.firstChild).to.have.tagName('span');
+  });
+
+  it('should not have `as` and `theme` attribute spread to DOM', () => {
+    const Box = createBox();
+
+    const { container } = render(<Box component="span" />);
+    expect(container.firstChild).not.to.have.attribute('as');
+    expect(container.firstChild).not.to.have.attribute('theme');
   });
 });

--- a/packages/mui-system/src/createBox.test.js
+++ b/packages/mui-system/src/createBox.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { createRenderer } from 'test/utils';
 import { createBox, ThemeProvider } from '@mui/system';
 
@@ -53,5 +54,29 @@ describe('createBox', () => {
 
     const { container } = render(<Box />);
     expect(container.firstChild).to.have.class('Box');
+  });
+
+  it('should accept sx prop', () => {
+    const Box = createBox();
+    const { container } = render(<Box sx={{ color: 'rgb(255, 0, 0)' }}>Content</Box>);
+    expect(container.firstChild).toHaveComputedStyle({ color: 'rgb(255, 0, 0)' });
+  });
+
+  it('should call styleFunctionSx once', () => {
+    const Box = createBox();
+    const sypSx = spy();
+    render(<Box sx={sypSx}>Content</Box>);
+    expect(sypSx.callCount).to.equal(2); // React 18 renders twice in strict mode.
+  });
+
+  it('should still call styleFunctionSx once', () => {
+    const Box = createBox();
+    const sypSx = spy();
+    render(
+      <Box component={Box} sx={sypSx}>
+        Content
+      </Box>,
+    );
+    expect(sypSx.callCount).to.equal(2); // React 18 renders twice in strict mode.
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
fixes #33443 

The `Box` should not forward the `sx` prop to the override component. We can overwrite the `shouldForwardProp`  function of the `@mui/styled-engine` to solve the problem.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
