### PR TITLE
[Joy] Use `orientation` prop for consistency

### DIFF
--- a/docs/data/joy/components/aspect-ratio/CarouselRatio.js
+++ b/docs/data/joy/components/aspect-ratio/CarouselRatio.js
@@ -40,7 +40,7 @@ export default function CarouselRatio() {
     >
       {data.map((item) => (
         <Card
-          row
+          orientation="horizontal"
           key={item.title}
           variant="outlined"
           sx={{

--- a/docs/data/joy/components/aspect-ratio/CarouselRatio.tsx
+++ b/docs/data/joy/components/aspect-ratio/CarouselRatio.tsx
@@ -40,7 +40,7 @@ export default function CarouselRatio() {
     >
       {data.map((item) => (
         <Card
-          row
+          orientation="horizontal"
           key={item.title}
           variant="outlined"
           sx={{

--- a/docs/data/joy/components/card/InteractiveCard.js
+++ b/docs/data/joy/components/card/InteractiveCard.js
@@ -10,7 +10,7 @@ export default function InteractiveCard() {
   return (
     <Card
       variant="outlined"
-      row
+      orientation="horizontal"
       sx={{
         minWidth: '320px',
         gap: 2,

--- a/docs/data/joy/components/card/InteractiveCard.tsx
+++ b/docs/data/joy/components/card/InteractiveCard.tsx
@@ -10,7 +10,7 @@ export default function InteractiveCard() {
   return (
     <Card
       variant="outlined"
-      row
+      orientation="horizontal"
       sx={{
         minWidth: '320px',
         gap: 2,

--- a/docs/data/joy/components/card/RowCard.js
+++ b/docs/data/joy/components/card/RowCard.js
@@ -8,7 +8,7 @@ import Typography from '@mui/joy/Typography';
 export default function InteractiveCard() {
   return (
     <Card
-      row
+      orientation="horizontal"
       variant="outlined"
       sx={{
         minWidth: '260px',

--- a/docs/data/joy/components/card/RowCard.tsx
+++ b/docs/data/joy/components/card/RowCard.tsx
@@ -8,7 +8,7 @@ import Typography from '@mui/joy/Typography';
 export default function InteractiveCard() {
   return (
     <Card
-      row
+      orientation="horizontal"
       variant="outlined"
       sx={{
         minWidth: '260px',

--- a/docs/data/joy/components/checkbox/ExampleButtonCheckbox.js
+++ b/docs/data/joy/components/checkbox/ExampleButtonCheckbox.js
@@ -14,7 +14,7 @@ export default function ExampleButtonCheckbox() {
       variant="soft"
       aria-label="Screens"
       role="group"
-      row
+      orientation="horizontal"
       sx={{
         flexGrow: 0,
         '--List-gap': '8px',

--- a/docs/data/joy/components/checkbox/ExampleChoiceChipCheckbox.js
+++ b/docs/data/joy/components/checkbox/ExampleChoiceChipCheckbox.js
@@ -16,7 +16,7 @@ export default function ExampleChoiceChipCheckbox() {
       </Typography>
       <Box role="group" aria-labelledby="rank">
         <List
-          row
+          orientation="horizontal"
           wrap
           sx={{
             '--List-gap': '8px',

--- a/docs/data/joy/components/checkbox/IconlessCheckbox.js
+++ b/docs/data/joy/components/checkbox/IconlessCheckbox.js
@@ -13,7 +13,7 @@ export default function IconlessCheckbox() {
       </Typography>
       <Box role="group" aria-labelledby="topping">
         <List
-          row
+          orientation="horizontal"
           wrap
           sx={{
             '--List-gap': '8px',

--- a/docs/data/joy/components/chip/RadioChip.js
+++ b/docs/data/joy/components/chip/RadioChip.js
@@ -18,7 +18,7 @@ export default function RadioChip() {
         <RadioGroup
           name="best-movie"
           aria-labelledby="best-movie"
-          row
+          orientation="horizontal"
           sx={{ flexWrap: 'wrap', gap: 1 }}
         >
           {[

--- a/docs/data/joy/components/chip/RadioChip.tsx
+++ b/docs/data/joy/components/chip/RadioChip.tsx
@@ -18,7 +18,7 @@ export default function RadioChip() {
         <RadioGroup
           name="best-movie"
           aria-labelledby="best-movie"
-          row
+          orientation="horizontal"
           sx={{ flexWrap: 'wrap', gap: 1 }}
         >
           {[

--- a/docs/data/joy/components/list/ExampleNavigationMenu.js
+++ b/docs/data/joy/components/list/ExampleNavigationMenu.js
@@ -303,7 +303,7 @@ export default function ExampleNavigationMenu() {
     <Box sx={{ minHeight: 190 }}>
       <List
         role="menubar"
-        row
+        orientation="horizontal"
         sx={{
           '--List-radius': '8px',
           '--List-padding': '4px',

--- a/docs/data/joy/components/list/HorizontalDividedList.js
+++ b/docs/data/joy/components/list/HorizontalDividedList.js
@@ -8,7 +8,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 export default function HorizontalDividedList() {
   return (
     <List
-      row
+      orientation="horizontal"
       variant="outlined"
       sx={{
         borderRadius: 'sm',

--- a/docs/data/joy/components/list/HorizontalList.js
+++ b/docs/data/joy/components/list/HorizontalList.js
@@ -10,7 +10,7 @@ import Person from '@mui/icons-material/Person';
 export default function HorizontalList() {
   return (
     <Box component="nav" aria-label="My site" sx={{ flexGrow: 1 }}>
-      <List role="menubar" row>
+      <List role="menubar" orientation="horizontal">
         <ListItem role="none">
           <ListItemButton
             role="menuitem"

--- a/docs/data/joy/components/menu/MenuToolbarExample.js
+++ b/docs/data/joy/components/menu/MenuToolbarExample.js
@@ -144,7 +144,7 @@ export default function MenuToolbarExample() {
 
   return (
     <List
-      row
+      orientation="horizontal"
       aria-label="Example application menu bar"
       role="menubar"
       data-joy-color-scheme="dark"

--- a/docs/data/joy/components/radio/ExampleAlignmentButtons.js
+++ b/docs/data/joy/components/radio/ExampleAlignmentButtons.js
@@ -11,7 +11,7 @@ export default function RadioButtonsGroup() {
   const [alignment, setAlignment] = React.useState('left');
   return (
     <RadioGroup
-      row
+      orientation="horizontal"
       aria-label="Alignment"
       name="alignment"
       variant="outlined"

--- a/docs/data/joy/components/radio/ExamplePaymentChannels.js
+++ b/docs/data/joy/components/radio/ExamplePaymentChannels.js
@@ -50,7 +50,7 @@ export default function ExamplePaymentChannels() {
       >
         <List
           variant="outlined"
-          row={row}
+          orientation={row ? 'horizontal' : 'vertical'}
           sx={{
             borderRadius: 'sm',
             boxShadow: 'sm',

--- a/docs/data/joy/components/radio/OverlayRadio.js
+++ b/docs/data/joy/components/radio/OverlayRadio.js
@@ -25,7 +25,7 @@ export default function OverlayRadio() {
         name="member"
         aria-labelledby="member"
         defaultValue="person1"
-        row
+        orientation="horizontal"
         sx={{ gap: 2 }}
       >
         {[1, 2, 3].map((num) => (

--- a/docs/data/joy/components/radio/RadioUsage.js
+++ b/docs/data/joy/components/radio/RadioUsage.js
@@ -36,7 +36,9 @@ export default function RadioUsage() {
           codeBlockDisplay: false,
         },
       ]}
-      getCodeBlock={(code, props) => `<RadioGroup${props.row ? ` row` : ''}>
+      getCodeBlock={(code, props) => `<RadioGroup${
+        props.row ? ` orientation="horizontal"` : ''
+      }>
 ${prependLinesSpace(code, 2)}
 </RadioGroup>`}
       renderDemo={({ orientation, ...props }) => (

--- a/docs/data/joy/components/radio/RadioUsage.js
+++ b/docs/data/joy/components/radio/RadioUsage.js
@@ -29,16 +29,17 @@ export default function RadioUsage() {
           defaultValue: 'md',
         },
         {
-          propName: 'row',
-          knob: 'switch',
-          defaultValue: false,
+          propName: 'orientation',
+          knob: 'radio',
+          options: ['vertical', 'horizontal'],
+          defaultValue: 'vertical',
           codeBlockDisplay: false,
         },
       ]}
       getCodeBlock={(code, props) => `<RadioGroup${props.row ? ` row` : ''}>
 ${prependLinesSpace(code, 2)}
 </RadioGroup>`}
-      renderDemo={({ row, ...props }) => (
+      renderDemo={({ orientation, ...props }) => (
         <div>
           <FormLabel
             id="radio-button-usage-label"
@@ -54,7 +55,7 @@ ${prependLinesSpace(code, 2)}
             Pizza crust
           </FormLabel>
           <RadioGroup
-            row={row}
+            orientation={orientation}
             defaultValue="1"
             name="radio-button-usage"
             aria-labelledby="radio-button-usage-label"

--- a/docs/data/joy/getting-started/templates/email/components/EmailContent.tsx
+++ b/docs/data/joy/getting-started/templates/email/components/EmailContent.tsx
@@ -173,7 +173,7 @@ export default function EmailContent() {
             />
           </AspectRatio>
         </Card>
-        <Card variant="outlined" row>
+        <Card variant="outlined" orientation="horizontal">
           <CardOverflow>
             <AspectRatio ratio="1" sx={{ minWidth: 80 }}>
               <Box

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -298,7 +298,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                     {propName}
                   </Typography>
                   <RadioGroup
-                    row
+                    orientation="horizontal"
                     name={labelId}
                     aria-labelledby={labelId}
                     value={resolvedValue}
@@ -343,7 +343,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                     Color
                   </Typography>
                   <RadioGroup
-                    row
+                    orientation="horizontal"
                     name={`${componentName}-color`}
                     aria-labelledby={`${componentName}-color`}
                     value={resolvedValue || ''}

--- a/packages/mui-joy/src/Card/Card.tsx
+++ b/packages/mui-joy/src/Card/Card.tsx
@@ -9,18 +9,18 @@ import styled from '../styles/styled';
 import { getCardUtilityClass } from './cardClasses';
 import { CardProps, CardTypeMap } from './CardProps';
 import { resolveSxValue } from '../styles/styleUtils';
-import { CardRowContext } from './CardContext';
+import { CardOrientationContext } from './CardContext';
 
 const useUtilityClasses = (ownerState: CardProps) => {
-  const { size, variant, color, row } = ownerState;
+  const { size, variant, color, orientation } = ownerState;
 
   const slots = {
     root: [
       'root',
+      orientation,
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
-      row && 'row',
     ],
   };
 
@@ -74,7 +74,7 @@ const CardRoot = styled('div', {
     transition: 'box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
     position: 'relative',
     display: 'flex',
-    flexDirection: ownerState.row ? 'row' : 'column',
+    flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
   },
   theme.variants[ownerState.variant!]?.[ownerState.color!],
 ]);
@@ -92,7 +92,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
     size = 'md',
     variant = 'plain',
     children,
-    row = false,
+    orientation = 'vertical',
     ...other
   } = props;
 
@@ -100,7 +100,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
     ...props,
     color,
     component,
-    row,
+    orientation,
     size,
     variant,
   };
@@ -108,7 +108,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   return (
-    <CardRowContext.Provider value={row}>
+    <CardOrientationContext.Provider value={orientation}>
       <CardRoot
         as={component}
         ownerState={ownerState}
@@ -129,7 +129,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
           return child;
         })}
       </CardRoot>
-    </CardRowContext.Provider>
+    </CardOrientationContext.Provider>
   );
 }) as OverridableComponent<CardTypeMap>;
 
@@ -161,10 +161,10 @@ Card.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
-   * If `true`, flex direction is set to 'row'.
-   * @default false
+   * The flow direction of the content.
+   * @default 'vertical'
    */
-  row: PropTypes.bool,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   /**
    * The size of the component.
    * It accepts theme values between 'xs' and 'xl'.

--- a/packages/mui-joy/src/Card/CardContext.ts
+++ b/packages/mui-joy/src/Card/CardContext.ts
@@ -2,4 +2,4 @@ import * as React from 'react';
 
 // internal logic
 // eslint-disable-next-line import/prefer-default-export
-export const CardRowContext = React.createContext<boolean>(false);
+export const CardOrientationContext = React.createContext<'vertical' | 'horizontal'>('vertical');

--- a/packages/mui-joy/src/Card/CardProps.ts
+++ b/packages/mui-joy/src/Card/CardProps.ts
@@ -21,10 +21,10 @@ export interface CardTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     color?: OverridableStringUnion<ColorPaletteProp, CardPropsColorOverrides>;
     /**
-     * If `true`, flex direction is set to 'row'.
-     * @default false
+     * The flow direction of the content.
+     * @default 'vertical'
      */
-    row?: boolean;
+    orientation?: 'vertical' | 'horizontal';
     /**
      * The size of the component.
      * It accepts theme values between 'xs' and 'xl'.

--- a/packages/mui-joy/src/Card/cardClasses.ts
+++ b/packages/mui-joy/src/Card/cardClasses.ts
@@ -29,8 +29,10 @@ export interface CardClasses {
   sizeMd: string;
   /** Styles applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Styles applied to the root element if `row={true}`. */
-  row: string;
+  /** Styles applied to the root element, if `orientation="vertical"`. */
+  vertical: string;
+  /** Styles applied to the root element, if `orientation="horizontal"`. */
+  horizontal: string;
 }
 
 export type CardClassKey = keyof CardClasses;
@@ -54,7 +56,8 @@ const cardClasses: CardClasses = generateUtilityClasses('JoyCard', [
   'sizeSm',
   'sizeMd',
   'sizeLg',
-  'row',
+  'vertical',
+  'horizontal',
 ]);
 
 export default cardClasses;

--- a/packages/mui-joy/src/CardOverflow/CardOverflow.tsx
+++ b/packages/mui-joy/src/CardOverflow/CardOverflow.tsx
@@ -8,7 +8,7 @@ import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
 import { getCardOverflowUtilityClass } from './cardOverflowClasses';
 import { CardOverflowProps, CardOverflowTypeMap } from './CardOverflowProps';
-import { CardRowContext } from '../Card/CardContext';
+import { CardOrientationContext } from '../Card/CardContext';
 
 const useUtilityClasses = (ownerState: CardOverflowProps) => {
   const { variant, color } = ownerState;
@@ -29,14 +29,14 @@ const CardOverflowRoot = styled('div', {
   overridesResolver: (props, styles) => styles.root,
 })<{
   ownerState: CardOverflowProps & {
-    row: boolean;
+    orientation: 'horizontal' | 'vertical';
     'data-first-child'?: string;
     'data-last-child'?: string;
   };
 }>(({ theme, ownerState }) => {
   const childRadius = 'calc(var(--CardOverflow-radius) - var(--variant-borderWidth))';
   return [
-    ownerState.row
+    ownerState.orientation === 'horizontal'
       ? {
           '--AspectRatio-margin': 'calc(-1 * var(--Card-padding)) 0px',
           marginTop: 'var(--CardOverflow-offset)',
@@ -89,7 +89,7 @@ const CardOverflow = React.forwardRef(function CardOverflow(inProps, ref) {
     name: 'JoyCardOverflow',
   });
 
-  const row = React.useContext(CardRowContext);
+  const orientation = React.useContext(CardOrientationContext);
 
   const {
     className,
@@ -105,7 +105,7 @@ const CardOverflow = React.forwardRef(function CardOverflow(inProps, ref) {
     component,
     color,
     variant,
-    row,
+    orientation,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/List/List.test.js
+++ b/packages/mui-joy/src/List/List.test.js
@@ -51,9 +51,12 @@ describe('Joy <List />', () => {
     expect(getByRole('list')).to.have.class(classes.nesting);
   });
 
-  it('should have row classes', () => {
-    const { getByRole } = render(<List row />);
-    expect(getByRole('list')).to.have.class(classes.row);
+  it('should have orientation classes', () => {
+    const { getByRole, rerender } = render(<List />);
+    expect(getByRole('list')).to.have.class(classes.vertical);
+
+    rerender(<List orientation="horizontal" />);
+    expect(getByRole('list')).to.have.class(classes.horizontal);
   });
 
   describe('MenuList - integration', () => {

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -16,16 +16,16 @@ import ListProvider from './ListProvider';
 const useUtilityClasses = (
   ownerState: ListProps & { nesting: boolean; instanceSize: ListProps['size'] },
 ) => {
-  const { variant, color, size, nesting, row, instanceSize } = ownerState;
+  const { variant, color, size, nesting, orientation, instanceSize } = ownerState;
   const slots = {
     root: [
       'root',
+      orientation,
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       !instanceSize && !nesting && size && `size${capitalize(size)}`,
       instanceSize && `size${capitalize(instanceSize)}`,
       nesting && 'nesting',
-      row && 'row',
     ],
   };
 
@@ -46,7 +46,7 @@ export const ListRoot = styled('ul', {
           '--List-item-paddingY': '0.25rem',
           '--List-item-paddingX': '0.5rem',
           '--List-item-fontSize': theme.vars.fontSize.sm,
-          '--List-decorator-width': ownerState.row ? '1.5rem' : '2rem',
+          '--List-decorator-width': ownerState.orientation === 'horizontal' ? '1.5rem' : '2rem',
           '--Icon-fontSize': '1.125rem',
         };
       }
@@ -57,7 +57,7 @@ export const ListRoot = styled('ul', {
           '--List-item-paddingY': '0.375rem',
           '--List-item-paddingX': '0.75rem',
           '--List-item-fontSize': theme.vars.fontSize.md,
-          '--List-decorator-width': ownerState.row ? '1.75rem' : '2.5rem',
+          '--List-decorator-width': ownerState.orientation === 'horizontal' ? '1.75rem' : '2.5rem',
           '--Icon-fontSize': '1.25rem',
         };
       }
@@ -68,7 +68,7 @@ export const ListRoot = styled('ul', {
           '--List-item-paddingY': '0.5rem',
           '--List-item-paddingX': '1rem',
           '--List-item-fontSize': theme.vars.fontSize.md,
-          '--List-decorator-width': ownerState.row ? '2.25rem' : '3rem',
+          '--List-decorator-width': ownerState.orientation === 'horizontal' ? '2.25rem' : '3rem',
           '--Icon-fontSize': '1.5rem',
         };
       }
@@ -107,7 +107,7 @@ export const ListRoot = styled('ul', {
         '--List-item-endActionTranslateX': 'calc(-0.5 * var(--List-item-paddingRight))',
         margin: 'initial',
         // --List-padding is not declared to let list uses --List-divider-gap by default.
-        ...(ownerState.row
+        ...(ownerState.orientation === 'horizontal'
           ? {
               ...(ownerState.wrap
                 ? {
@@ -129,7 +129,7 @@ export const ListRoot = styled('ul', {
         borderRadius: 'var(--List-radius)',
         listStyle: 'none',
         display: 'flex',
-        flexDirection: ownerState.row ? 'row' : 'column',
+        flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
         ...(ownerState.wrap && {
           flexWrap: 'wrap',
         }),
@@ -155,7 +155,7 @@ const List = React.forwardRef(function List(inProps, ref) {
     className,
     children,
     size = 'md',
-    row = false,
+    orientation = 'vertical',
     wrap = false,
     variant = 'plain',
     color = 'neutral',
@@ -167,7 +167,7 @@ const List = React.forwardRef(function List(inProps, ref) {
     instanceSize: inProps.size,
     size,
     nesting,
-    row,
+    orientation,
     wrap,
     variant,
     color,
@@ -189,7 +189,7 @@ const List = React.forwardRef(function List(inProps, ref) {
       <ComponentListContext.Provider
         value={`${typeof component === 'string' ? component : ''}:${role || ''}`}
       >
-        <ListProvider row={row} wrap={wrap}>
+        <ListProvider orientation={orientation} wrap={wrap}>
           {children}
         </ListProvider>
       </ComponentListContext.Provider>
@@ -224,14 +224,14 @@ List.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
+   * The flow direction of the content.
+   * @default 'vertical'
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
    * @ignore
    */
   role: PropTypes /* @typescript-to-proptypes-ignore */.string,
-  /**
-   * If `true`, display the list in horizontal direction.
-   * @default false
-   */
-  row: PropTypes.bool,
   /**
    * The size of the component (affect other nested list* components).
    * @default 'md'

--- a/packages/mui-joy/src/List/ListOrientationContext.ts
+++ b/packages/mui-joy/src/List/ListOrientationContext.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+const ListOrientationContext = React.createContext<'vertical' | 'horizontal'>('vertical');
+
+export default ListOrientationContext;

--- a/packages/mui-joy/src/List/ListProps.ts
+++ b/packages/mui-joy/src/List/ListProps.ts
@@ -22,10 +22,10 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      */
     color?: OverridableStringUnion<ColorPaletteProp, ListPropsColorOverrides>;
     /**
-     * If `true`, display the list in horizontal direction.
-     * @default false
+     * The flow direction of the content.
+     * @default 'vertical'
      */
-    row?: boolean;
+    orientation?: 'vertical' | 'horizontal';
     /**
      * The size of the component (affect other nested list* components).
      * @default 'md'

--- a/packages/mui-joy/src/List/ListProvider.tsx
+++ b/packages/mui-joy/src/List/ListProvider.tsx
@@ -33,10 +33,10 @@ export interface ListProviderProps {
    */
   nested?: boolean;
   /**
-   * If `true`, display the list in horizontal direction.
-   * @default false
+   * The flow direction of the content.
+   * @default 'vertical'
    */
-  row?: boolean;
+  orientation?: 'vertical' | 'horizontal';
   /**
    * Only for horizontal list.
    * If `true`, the list sets the flex-wrap to "wrap" and adjust margin to have gap-like behavior (will move to `gap` in the future).
@@ -50,11 +50,11 @@ export interface ListProviderProps {
 const ListProvider = ({
   children,
   nested,
-  row = false,
+  orientation,
   wrap = false,
 }: React.PropsWithChildren<ListProviderProps>) => {
   const baseProviders = (
-    <RowListContext.Provider value={row}>
+    <RowListContext.Provider value={orientation === 'horizontal'}>
       <WrapListContext.Provider value={wrap}>
         {React.Children.map(children, (child, index) =>
           React.isValidElement(child)

--- a/packages/mui-joy/src/List/ListProvider.tsx
+++ b/packages/mui-joy/src/List/ListProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import RowListContext from './RowListContext';
+import ListOrientationContext from './ListOrientationContext';
 import WrapListContext from './WrapListContext';
 import NestedListContext from './NestedListContext';
 
@@ -50,11 +50,11 @@ export interface ListProviderProps {
 const ListProvider = ({
   children,
   nested,
-  orientation,
+  orientation = 'vertical',
   wrap = false,
 }: React.PropsWithChildren<ListProviderProps>) => {
   const baseProviders = (
-    <RowListContext.Provider value={orientation === 'horizontal'}>
+    <ListOrientationContext.Provider value={orientation}>
       <WrapListContext.Provider value={wrap}>
         {React.Children.map(children, (child, index) =>
           React.isValidElement(child)
@@ -65,7 +65,7 @@ const ListProvider = ({
             : child,
         )}
       </WrapListContext.Provider>
-    </RowListContext.Provider>
+    </ListOrientationContext.Provider>
   );
   if (nested === undefined) {
     return baseProviders;

--- a/packages/mui-joy/src/List/RowListContext.ts
+++ b/packages/mui-joy/src/List/RowListContext.ts
@@ -1,5 +1,0 @@
-import * as React from 'react';
-
-const RowListContext = React.createContext(false);
-
-export default RowListContext;

--- a/packages/mui-joy/src/List/listClasses.ts
+++ b/packages/mui-joy/src/List/listClasses.ts
@@ -5,8 +5,10 @@ export interface ListClasses {
   root: string;
   /** Classname applied to the root element if wrapped with nested context. */
   nesting: string;
-  /** Classname applied to the root element if `row` is true. */
-  row: string;
+  /** Styles applied to the root element, if `orientation="vertical"`. */
+  vertical: string;
+  /** Styles applied to the root element, if `orientation="horizontal"`. */
+  horizontal: string;
   /** Classname applied to the root element if `scoped` is true. */
   scoped: string;
   /** Classname applied to the root element if `size="sm"`. */
@@ -46,7 +48,8 @@ export function getListUtilityClass(slot: string): string {
 const listClasses: ListClasses = generateUtilityClasses('JoyList', [
   'root',
   'nesting',
-  'row',
+  'vertical',
+  'horizontal',
   'scoped',
   'sizeSm',
   'sizeMd',

--- a/packages/mui-joy/src/ListDivider/ListDivider.test.js
+++ b/packages/mui-joy/src/ListDivider/ListDivider.test.js
@@ -38,7 +38,7 @@ describe('Joy <ListDivider />', () => {
 
     it('should have aria-orientation set to vertical', () => {
       render(
-        <List row>
+        <List orientation="horizontal">
           <ListDivider />
         </List>,
       );
@@ -47,7 +47,7 @@ describe('Joy <ListDivider />', () => {
 
     it('should not add aria-orientation if role is custom', () => {
       render(
-        <List row>
+        <List orientation="horizontal">
           <ListDivider role="presentation" />
         </List>,
       );

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -7,7 +7,7 @@ import composeClasses from '@mui/base/composeClasses';
 import { styled, useThemeProps } from '../styles';
 import { ListDividerProps, ListDividerTypeMap } from './ListDividerProps';
 import { getListDividerUtilityClass } from './listDividerClasses';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 
 const useUtilityClasses = (ownerState: ListDividerProps) => {
   const slots = {
@@ -21,43 +21,46 @@ const ListDividerRoot = styled('li', {
   name: 'JoyListDivider',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: ListDividerProps & { row: boolean; 'data-first-child'?: boolean } }>(
-  ({ theme, ownerState }) => ({
-    border: 'none', // reset the border for `hr` tag
-    ...(ownerState.row && {
-      borderInlineStart: '1px solid',
-      marginBlock: ownerState.inset === 'gutter' ? 'var(--List-item-paddingY)' : 0,
-      marginInline: 'var(--List-divider-gap)',
-      ...(ownerState['data-first-child'] === undefined && {
-        // combine --List-gap and --List-divider-gap to replicate flexbox gap behavior
-        marginInlineStart: 'calc(var(--List-gap) + var(--List-divider-gap))',
-      }),
+})<{
+  ownerState: ListDividerProps & {
+    orientation: 'horizontal' | 'vertical';
+    'data-first-child'?: boolean;
+  };
+}>(({ theme, ownerState }) => ({
+  border: 'none', // reset the border for `hr` tag
+  ...(ownerState.orientation === 'horizontal' && {
+    borderInlineStart: '1px solid',
+    marginBlock: ownerState.inset === 'gutter' ? 'var(--List-item-paddingY)' : 0,
+    marginInline: 'var(--List-divider-gap)',
+    ...(ownerState['data-first-child'] === undefined && {
+      // combine --List-gap and --List-divider-gap to replicate flexbox gap behavior
+      marginInlineStart: 'calc(var(--List-gap) + var(--List-divider-gap))',
     }),
-    ...(!ownerState.row && {
-      // by default, the divider line is stretched from edge-to-edge of the List
-      // spacing between ListItem can be controlled by `--List-divider-gap` on the List
-      ...(ownerState['data-first-child'] === undefined && {
-        // combine --List-gap and --List-divider-gap to replicate flexbox gap behavior
-        marginBlockStart: 'calc(var(--List-gap) + var(--List-divider-gap))',
-      }),
-      marginBlockEnd: 'var(--List-divider-gap)',
-      marginInline: 'calc(-1 * var(--List-padding))',
-      ...(ownerState.inset === 'gutter' && {
-        marginInlineStart: 'var(--List-item-paddingLeft)',
-        marginInlineEnd: 'var(--List-item-paddingRight)',
-      }),
-      ...(ownerState.inset === 'startDecorator' && {
-        marginInlineStart: 'var(--List-item-paddingLeft)',
-      }),
-      ...(ownerState.inset === 'startContent' && {
-        marginInlineStart: 'calc(var(--List-item-paddingLeft) + var(--List-decorator-width))',
-      }),
-      borderBlockEnd: '1px solid',
-    }),
-    borderColor: theme.vars.palette.divider,
-    listStyle: 'none',
   }),
-);
+  ...(ownerState.orientation !== 'horizontal' && {
+    // by default, the divider line is stretched from edge-to-edge of the List
+    // spacing between ListItem can be controlled by `--List-divider-gap` on the List
+    ...(ownerState['data-first-child'] === undefined && {
+      // combine --List-gap and --List-divider-gap to replicate flexbox gap behavior
+      marginBlockStart: 'calc(var(--List-gap) + var(--List-divider-gap))',
+    }),
+    marginBlockEnd: 'var(--List-divider-gap)',
+    marginInline: 'calc(-1 * var(--List-padding))',
+    ...(ownerState.inset === 'gutter' && {
+      marginInlineStart: 'var(--List-item-paddingLeft)',
+      marginInlineEnd: 'var(--List-item-paddingRight)',
+    }),
+    ...(ownerState.inset === 'startDecorator' && {
+      marginInlineStart: 'var(--List-item-paddingLeft)',
+    }),
+    ...(ownerState.inset === 'startContent' && {
+      marginInlineStart: 'calc(var(--List-item-paddingLeft) + var(--List-decorator-width))',
+    }),
+    borderBlockEnd: '1px solid',
+  }),
+  borderColor: theme.vars.palette.divider,
+  listStyle: 'none',
+}));
 
 const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
   const props = useThemeProps<typeof inProps & { component?: React.ElementType }>({
@@ -65,13 +68,13 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
     name: 'JoyListDivider',
   });
 
-  const row = React.useContext(RowListContext);
+  const orientation = React.useContext(ListOrientationContext);
 
   const { component, className, children, inset, role = 'separator', ...other } = props;
 
   const ownerState = {
     inset,
-    row,
+    orientation,
     ...props,
   };
 
@@ -85,7 +88,7 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
       ownerState={ownerState}
       role={role}
       {...(role === 'separator' &&
-        row && {
+        orientation === 'horizontal' && {
           // The implicit aria-orientation of separator is 'horizontal'
           // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
           'aria-orientation': 'vertical',
@@ -122,7 +125,7 @@ ListDivider.propTypes /* remove-proptypes */ = {
   /**
    * The empty space on the side(s) of the divider in a vertical list.
    *
-   * For horizontal list (the nearest parent List has `row` prop set to `true`), only `inset="gutter"` affects the list divider.
+   * For horizontal list (the nearest parent List has `horizontal` orientation), only `inset="gutter"` affects the list divider.
    */
   inset: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['gutter', 'startDecorator', 'startContent']),

--- a/packages/mui-joy/src/ListDivider/ListDividerProps.ts
+++ b/packages/mui-joy/src/ListDivider/ListDividerProps.ts
@@ -20,7 +20,7 @@ export interface ListDividerTypeMap<P = {}, D extends React.ElementType = 'li'> 
     /**
      * The empty space on the side(s) of the divider in a vertical list.
      *
-     * For horizontal list (the nearest parent List has `row` prop set to `true`), only `inset="gutter"` affects the list divider.
+     * For horizontal list (the nearest parent List has `horizontal` orientation), only `inset="gutter"` affects the list divider.
      */
     inset?: OverridableStringUnion<
       'gutter' | 'startDecorator' | 'startContent',

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -12,7 +12,7 @@ import { styled, useThemeProps } from '../styles';
 import { ListItemProps, ListItemTypeMap } from './ListItemProps';
 import { getListItemUtilityClass } from './listItemClasses';
 import NestedListContext from '../List/NestedListContext';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 import WrapListContext from '../List/WrapListContext';
 import ComponentListContext from '../List/ComponentListContext';
 
@@ -39,7 +39,11 @@ const ListItemRoot = styled('li', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })<{
-  ownerState: ListItemProps & { row: boolean; wrap: boolean; 'data-first-child'?: string };
+  ownerState: ListItemProps & {
+    orientation: 'horizontal' | 'vertical';
+    wrap: boolean;
+    'data-first-child'?: string;
+  };
 }>(({ theme, ownerState }) => [
   !ownerState.nested && {
     // add negative margin to ListItemButton equal to this ListItem padding
@@ -80,7 +84,7 @@ const ListItemRoot = styled('li', {
     paddingInlineStart: 'var(--List-item-paddingLeft)',
     paddingInlineEnd: 'var(--List-item-paddingRight)',
     ...(ownerState['data-first-child'] === undefined && {
-      ...(ownerState.row
+      ...(ownerState.orientation === 'horizontal'
         ? {
             marginInlineStart: 'var(--List-gap)',
           }
@@ -88,7 +92,7 @@ const ListItemRoot = styled('li', {
             marginBlockStart: 'var(--List-gap)',
           }),
     }),
-    ...(ownerState.row &&
+    ...(ownerState.orientation === 'horizontal' &&
       ownerState.wrap && {
         marginInlineStart: 'var(--List-gap)',
         marginBlockStart: 'var(--List-gap)',
@@ -140,7 +144,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
   const menuContext = React.useContext(MenuUnstyledContext);
 
   const listComponent = React.useContext(ComponentListContext);
-  const row = React.useContext(RowListContext);
+  const orientation = React.useContext(ListOrientationContext);
   const wrap = React.useContext(WrapListContext);
   const nesting = React.useContext(NestedListContext);
 
@@ -161,7 +165,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     sticky,
     startAction,
     endAction,
-    row,
+    orientation,
     wrap,
     variant,
     color,

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -11,7 +11,7 @@ import {
   ListItemButtonTypeMap,
 } from './ListItemButtonProps';
 import listItemButtonClasses, { getListItemButtonUtilityClass } from './listItemButtonClasses';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 
 const useUtilityClasses = (ownerState: ListItemButtonProps & { focusVisible: boolean }) => {
   const { color, disabled, focusVisible, focusVisibleClassName, selected, variant } = ownerState;
@@ -42,7 +42,10 @@ export const ListItemButtonRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })<{
-  ownerState: ListItemButtonProps & { row: boolean; 'data-first-child'?: string };
+  ownerState: ListItemButtonProps & {
+    orientation: 'horizontal' | 'vertical';
+    'data-first-child'?: string;
+  };
 }>(({ theme, ownerState }) => [
   {
     ...(ownerState.selected && {
@@ -59,8 +62,8 @@ export const ListItemButtonRoot = styled('div', {
     marginInline: 'var(--List-itemButton-marginInline)',
     marginBlock: 'var(--List-itemButton-marginBlock)',
     ...(ownerState['data-first-child'] === undefined && {
-      marginInlineStart: ownerState.row ? 'var(--List-gap)' : undefined,
-      marginBlockStart: ownerState.row ? undefined : 'var(--List-gap)',
+      marginInlineStart: ownerState.orientation === 'horizontal' ? 'var(--List-gap)' : undefined,
+      marginBlockStart: ownerState.orientation === 'horizontal' ? undefined : 'var(--List-gap)',
     }),
     // account for the border width, so that all of the ListItemButtons content aligned horizontally
     paddingBlock: 'calc(var(--List-item-paddingY) - var(--variant-borderWidth))',
@@ -72,7 +75,7 @@ export const ListItemButtonRoot = styled('div', {
     minBlockSize: 'var(--List-item-minHeight)',
     border: 'none',
     borderRadius: 'var(--List-item-radius)',
-    flex: ownerState.row ? 'none' : 1,
+    flex: ownerState.orientation === 'horizontal' ? 'none' : 1,
     minInlineSize: 0,
     // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
     transition:
@@ -99,7 +102,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     name: 'JoyListItemButton',
   });
 
-  const row = React.useContext(RowListContext);
+  const orientation = React.useContext(ListOrientationContext);
 
   const {
     children,
@@ -137,7 +140,7 @@ const ListItemButton = React.forwardRef(function ListItemButton(inProps, ref) {
     component,
     color,
     focusVisible,
-    row,
+    orientation,
     selected,
     variant,
   };

--- a/packages/mui-joy/src/Menu/Menu.tsx
+++ b/packages/mui-joy/src/Menu/Menu.tsx
@@ -119,7 +119,7 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
     modifiers,
     open,
     nesting: false,
-    row: false,
+    orientation: 'vertical',
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -7,7 +7,7 @@ import { ListItemButtonRoot } from '../ListItemButton/ListItemButton';
 import { styled, useThemeProps } from '../styles';
 import { getMenuItemUtilityClass } from './menuItemClasses';
 import { MenuItemProps, ExtendMenuItem, MenuItemTypeMap } from './MenuItemProps';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 
 const useUtilityClasses = (ownerState: MenuItemProps & { focusVisible: boolean }) => {
   const { focusVisible, disabled, selected } = ownerState;
@@ -34,7 +34,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     name: 'JoyMenuItem',
   });
 
-  const row = React.useContext(RowListContext);
+  const orientation = React.useContext(ListOrientationContext);
 
   const {
     children,
@@ -58,7 +58,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     disabled,
     focusVisible,
     selected,
-    row,
+    orientation,
     variant,
   };
 

--- a/packages/mui-joy/src/MenuList/MenuList.tsx
+++ b/packages/mui-joy/src/MenuList/MenuList.tsx
@@ -92,7 +92,7 @@ const MenuList = React.forwardRef(function MenuList(inProps, ref) {
     size,
     instanceSize: size,
     nesting: false,
-    row: false,
+    orientation: 'vertical' as const,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/Option/Option.tsx
+++ b/packages/mui-joy/src/Option/Option.tsx
@@ -10,7 +10,7 @@ import { styled, useThemeProps } from '../styles';
 import { ColorPaletteProp } from '../styles/types';
 import { OptionProps, ExtendOption, OptionTypeMap } from './OptionProps';
 import optionClasses, { getOptionUtilityClass } from './optionClasses';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 
 const useUtilityClasses = (ownerState: OptionProps & OptionState) => {
   const { disabled, highlighted, selected } = ownerState;
@@ -49,7 +49,7 @@ const Option = React.forwardRef(function Option(inProps, ref) {
     ...other
   } = props;
 
-  const row = React.useContext(RowListContext);
+  const orientation = React.useContext(ListOrientationContext);
   const selectContext = React.useContext(SelectUnstyledContext) as SelectUnstyledContextType & {
     color: ColorPaletteProp;
   };
@@ -81,7 +81,7 @@ const Option = React.forwardRef(function Option(inProps, ref) {
     component,
     variant,
     color,
-    row,
+    orientation,
   };
 
   const optionRef = React.useRef<HTMLLIElement>(null);

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -47,7 +47,11 @@ const RadioRoot = styled('span', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })<{
-  ownerState: RadioProps & { 'data-first-child'?: string; 'data-parent'?: string; row?: boolean };
+  ownerState: RadioProps & {
+    'data-first-child'?: string;
+    'data-parent'?: string;
+    orientation?: 'horizontal' | 'vertical';
+  };
 }>(({ ownerState, theme }) => {
   return [
     {
@@ -85,8 +89,10 @@ const RadioRoot = styled('span', {
       }),
       ...(ownerState['data-parent'] === 'RadioGroup' &&
         ownerState['data-first-child'] === undefined && {
-          marginInlineStart: ownerState.row ? 'var(--RadioGroup-gap)' : undefined,
-          marginBlockStart: ownerState.row ? undefined : 'var(--RadioGroup-gap)',
+          marginInlineStart:
+            ownerState.orientation === 'horizontal' ? 'var(--RadioGroup-gap)' : undefined,
+          marginBlockStart:
+            ownerState.orientation === 'horizontal' ? undefined : 'var(--RadioGroup-gap)',
         }),
     },
   ];
@@ -275,7 +281,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
     size,
     disableIcon,
     overlay,
-    row: radioGroup.row,
+    orientation: radioGroup.orientation,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/Radio/RadioProps.ts
+++ b/packages/mui-joy/src/Radio/RadioProps.ts
@@ -33,10 +33,10 @@ export interface RadioTypeMap<P = {}, D extends React.ElementType = 'span'> {
        */
       componentsProps?: {
         root?: React.ComponentPropsWithRef<'span'>;
-        radio?: React.ComponentPropsWithRef<'span'>;
-        action?: React.ComponentPropsWithRef<'span'>;
-        input?: React.ComponentPropsWithRef<'input'>;
-        label?: React.ComponentPropsWithRef<'label'>;
+        radio?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
+        action?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
+        input?: React.ComponentPropsWithRef<'input'> & { sx?: SxProps };
+        label?: React.ComponentPropsWithRef<'label'> & { sx?: SxProps };
       };
       /**
        * The color of the component. It supports those theme colors that make sense for this component.

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.test.js
@@ -16,14 +16,16 @@ describe('<RadioGroup />', () => {
     ThemeProvider,
     muiName: 'JoyRadioGroup',
     refInstanceof: window.HTMLDivElement,
-    testVariantProps: { row: true },
+    testVariantProps: { orientation: 'horizontal' },
     skip: ['componentProp', 'componentsProp', 'classesRoot', 'propsSpread'],
   }));
 
-  it('should have row class if `row` is true', () => {
-    const { getByRole } = render(<RadioGroup value="" row />);
+  it('should have orientation class', () => {
+    const { getByRole, rerender } = render(<RadioGroup value="" />);
+    expect(getByRole('radiogroup')).to.have.class(classes.vertical);
 
-    expect(getByRole('radiogroup')).to.have.class(classes.row);
+    rerender(<RadioGroup value="" orientation="horizontal" />);
+    expect(getByRole('radiogroup')).to.have.class(classes.horizontal);
   });
 
   it('the root component has the radiogroup role', () => {

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.tsx
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.tsx
@@ -14,11 +14,11 @@ import { RadioGroupProps, RadioGroupTypeMap } from './RadioGroupProps';
 import RadioGroupContext from './RadioGroupContext';
 
 const useUtilityClasses = (ownerState: RadioGroupProps) => {
-  const { row, size, variant, color } = ownerState;
+  const { orientation, size, variant, color } = ownerState;
   const slots = {
     root: [
       'root',
-      row && 'row',
+      orientation,
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
@@ -43,7 +43,7 @@ const RadioGroupRoot = styled('div', {
     '--RadioGroup-gap': '1.25rem',
   }),
   display: 'flex',
-  flexDirection: ownerState.row ? 'row' : 'column',
+  flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
   borderRadius: theme.vars.radius.sm,
   ...theme.variants[ownerState.variant!]?.[ownerState.color!],
 }));
@@ -67,7 +67,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
     color = 'neutral',
     variant = 'plain',
     size = 'md',
-    row = false,
+    orientation = 'vertical',
     ...otherProps
   } = props;
 
@@ -78,7 +78,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
   });
 
   const ownerState = {
-    row,
+    orientation,
     size,
     variant,
     color,
@@ -102,7 +102,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
       value={{
         disableIcon,
         overlay,
-        row,
+        orientation,
         size,
         name,
         value,
@@ -178,14 +178,14 @@ RadioGroup.propTypes /* remove-proptypes */ = {
    */
   onChange: PropTypes.func,
   /**
+   * The direction of the radio buttons.
+   * @default 'vertical'
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
    * The radio's `overlay` prop. If specified, the value is passed down to every radios under this element.
    */
   overlay: PropTypes.bool,
-  /**
-   * If `true`, flex direction is set to 'row'.
-   * @default false
-   */
-  row: PropTypes.bool,
   /**
    * The size of the component.
    * @default 'md'

--- a/packages/mui-joy/src/RadioGroup/RadioGroupContext.ts
+++ b/packages/mui-joy/src/RadioGroup/RadioGroupContext.ts
@@ -3,13 +3,13 @@ import { RadioProps } from '../Radio/RadioProps';
 
 const RadioGroupContext = React.createContext<
   Pick<RadioProps, 'size' | 'disableIcon' | 'overlay'> & {
-    row?: boolean;
+    orientation?: 'vertical' | 'horizontal';
     name?: string;
     value?: unknown;
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
   }
 >({
-  row: undefined,
+  orientation: undefined,
   size: undefined,
   name: undefined,
   value: undefined,

--- a/packages/mui-joy/src/RadioGroup/RadioGroupProps.ts
+++ b/packages/mui-joy/src/RadioGroup/RadioGroupProps.ts
@@ -45,10 +45,10 @@ export interface RadioGroupTypeMap<P = {}, D extends React.ElementType = 'div'> 
      */
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
     /**
-     * If `true`, flex direction is set to 'row'.
-     * @default false
+     * The direction of the radio buttons.
+     * @default 'vertical'
      */
-    row?: boolean;
+    orientation?: 'vertical' | 'horizontal';
     /**
      * The size of the component.
      * @default 'md'

--- a/packages/mui-joy/src/RadioGroup/radioGroupClasses.ts
+++ b/packages/mui-joy/src/RadioGroup/radioGroupClasses.ts
@@ -3,8 +3,10 @@ import { generateUtilityClass, generateUtilityClasses } from '../className';
 export interface RadioGroupClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element, if `row` is true. */
-  row: string;
+  /** Styles applied to the root element, if `orientation="vertical"`. */
+  vertical: string;
+  /** Styles applied to the root element, if `orientation="horizontal"`. */
+  horizontal: string;
   /** Styles applied to the root element if `size="sm"`. */
   sizeSm: string;
   /** Styles applied to the root element if `size="md"`. */
@@ -41,7 +43,8 @@ export function getRadioGroupUtilityClass(slot: string): string {
 
 const radioGroupClasses: RadioGroupClasses = generateUtilityClasses('JoyRadioGroup', [
   'root',
-  'row',
+  'vertical',
+  'horizontal',
   'colorPrimary',
   'colorNeutral',
   'colorDanger',

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -464,7 +464,7 @@ const Select = React.forwardRef(function Select<TValue>(
     ownerState: {
       ...ownerState,
       nesting: false,
-      row: false,
+      orientation: 'vertical',
     },
     className: classes.listbox,
   });

--- a/packages/mui-joy/src/Tab/Tab.tsx
+++ b/packages/mui-joy/src/Tab/Tab.tsx
@@ -10,7 +10,7 @@ import { useThemeProps } from '../styles';
 import styled from '../styles/styled';
 import { getTabUtilityClass } from './tabClasses';
 import { TabOwnerState, TabTypeMap } from './TabProps';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 
 const useUtilityClasses = (ownerState: TabOwnerState) => {
   const { selected, disabled, focusVisible, variant, color } = ownerState;
@@ -57,7 +57,7 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
     name: 'JoyTab',
   });
 
-  const row = React.useContext(RowListContext);
+  const orientation = React.useContext(ListOrientationContext);
 
   const {
     action,
@@ -94,7 +94,7 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
 
   const ownerState = {
     ...props,
-    row,
+    orientation,
     active,
     focusVisible,
     disabled,

--- a/packages/mui-joy/src/TabList/TabList.test.tsx
+++ b/packages/mui-joy/src/TabList/TabList.test.tsx
@@ -5,7 +5,7 @@ import { TabsContext, useTabs, TabsUnstyledProps } from '@mui/base/TabsUnstyled'
 import { ThemeProvider } from '@mui/joy/styles';
 import Tabs from '@mui/joy/Tabs';
 import TabList, { tabListClasses as classes } from '@mui/joy/TabList';
-import RowListContext from '../List/RowListContext';
+import ListOrientationContext from '../List/ListOrientationContext';
 
 const TabsProvider = ({ children, ...props }: TabsUnstyledProps) => {
   const { tabsContextValue } = useTabs(props);
@@ -79,8 +79,8 @@ describe('Joy <TabList />', () => {
 
   it('provides the correct value to RowListContext', () => {
     const TabItem = () => {
-      const row = React.useContext(RowListContext);
-      return <div>{row ? 'horizontal' : 'vertical'}</div>;
+      const orientation = React.useContext(ListOrientationContext);
+      return <div>{orientation}</div>;
     };
     render(
       <Tabs orientation="vertical">

--- a/packages/mui-joy/src/TabList/TabList.tsx
+++ b/packages/mui-joy/src/TabList/TabList.tsx
@@ -60,7 +60,6 @@ const TabList = React.forwardRef(function TabList(inProps, ref) {
 
   const { isRtl, orientation, getRootProps, processChildren } = useTabsList({ ...props, ref });
 
-  const row = orientation === 'horizontal';
   const size = sizeProp ?? tabsSize;
 
   const ownerState = {
@@ -70,7 +69,6 @@ const TabList = React.forwardRef(function TabList(inProps, ref) {
     variant,
     color,
     size,
-    row,
     nesting: false,
   };
 
@@ -93,7 +91,7 @@ const TabList = React.forwardRef(function TabList(inProps, ref) {
   return (
     // @ts-ignore conflicted ref types
     <TabListRoot {...tabsListRootProps}>
-      <ListProvider row={row} nested>
+      <ListProvider orientation={orientation} nested>
         {processedChildren}
       </ListProvider>
     </TabListRoot>

--- a/packages/mui-joy/src/Tabs/Tabs.tsx
+++ b/packages/mui-joy/src/Tabs/Tabs.tsx
@@ -43,10 +43,7 @@ const TabsRoot = styled(SheetRoot, {
   }),
   '--List-radius': theme.vars.radius.md, // targets TabList which reuses styles from List.
   display: 'flex',
-  flexDirection: 'column',
-  ...(ownerState.orientation === 'vertical' && {
-    flexDirection: 'row',
-  }),
+  flexDirection: ownerState.orientation === 'vertical' ? 'row' : 'column',
 }));
 
 const Tabs = React.forwardRef(function Tabs(inProps, ref) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Replace `row` prop with `orientation`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
