### PR TITLE
[core] Add CI check to prevent merging if `PR: needs test` label is present (draft)

### DIFF
--- a/.github/workflows/check-if-pr-has-label.yml
+++ b/.github/workflows/check-if-pr-has-label.yml
@@ -14,3 +14,12 @@ jobs:
           mode: minimum
           count: 1
           labels: ""
+  # Prevent merging if 'PR: needs test' label is present
+  test-prevent-merging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mnajdova/github-action-required-labels@v2.0
+        with:
+          mode: exactly
+          count: 0
+          labels: "PR: needs test"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
