### PR TITLE
[base] Add missing `TablePaginationUnstyled` export from root

### DIFF
--- a/packages/mui-base/src/index.d.ts
+++ b/packages/mui-base/src/index.d.ts
@@ -75,6 +75,9 @@ export * from './TabsUnstyled';
 export { default as TabUnstyled } from './TabUnstyled';
 export * from './TabUnstyled';
 
+export { default as TablePaginationUnstyled } from './TablePaginationUnstyled';
+export * from './TablePaginationUnstyled';
+
 export { default as TextareaAutosize } from './TextareaAutosize';
 export * from './TextareaAutosize';
 

--- a/packages/mui-base/src/index.d.ts
+++ b/packages/mui-base/src/index.d.ts
@@ -63,6 +63,9 @@ export * from './SliderUnstyled';
 export { default as SwitchUnstyled } from './SwitchUnstyled';
 export * from './SwitchUnstyled';
 
+export { default as TablePaginationUnstyled } from './TablePaginationUnstyled';
+export * from './TablePaginationUnstyled';
+
 export { default as TabPanelUnstyled } from './TabPanelUnstyled';
 export * from './TabPanelUnstyled';
 
@@ -74,9 +77,6 @@ export * from './TabsUnstyled';
 
 export { default as TabUnstyled } from './TabUnstyled';
 export * from './TabUnstyled';
-
-export { default as TablePaginationUnstyled } from './TablePaginationUnstyled';
-export * from './TablePaginationUnstyled';
 
 export { default as TextareaAutosize } from './TextareaAutosize';
 export * from './TextareaAutosize';

--- a/packages/mui-base/src/index.js
+++ b/packages/mui-base/src/index.js
@@ -58,6 +58,9 @@ export * from './SliderUnstyled';
 export { default as SwitchUnstyled } from './SwitchUnstyled';
 export * from './SwitchUnstyled';
 
+export { default as TablePaginationUnstyled } from './TablePaginationUnstyled';
+export * from './TablePaginationUnstyled';
+
 export { default as TabPanelUnstyled } from './TabPanelUnstyled';
 export * from './TabPanelUnstyled';
 
@@ -69,9 +72,6 @@ export * from './TabsUnstyled';
 
 export { default as TabUnstyled } from './TabUnstyled';
 export * from './TabUnstyled';
-
-export { default as TablePaginationUnstyled } from './TablePaginationUnstyled';
-export * from './TablePaginationUnstyled';
 
 export { default as TextareaAutosize } from './TextareaAutosize';
 

--- a/packages/mui-base/src/index.js
+++ b/packages/mui-base/src/index.js
@@ -70,6 +70,9 @@ export * from './TabsUnstyled';
 export { default as TabUnstyled } from './TabUnstyled';
 export * from './TabUnstyled';
 
+export { default as TablePaginationUnstyled } from './TablePaginationUnstyled';
+export * from './TablePaginationUnstyled';
+
 export { default as TextareaAutosize } from './TextareaAutosize';
 
 export { default as TrapFocus } from './TrapFocus';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes #33694

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I added the export statement snippets for TablePaginationUnstyled, in the base/index.js and base/index.d.ts. 

I followed the name ordering (see image below )you get when you default import MUI using NPM on Mac

<img width="214" alt="table" src="https://user-images.githubusercontent.com/83738282/182929240-698c4af5-1f18-4f2a-949d-97b61271be1f.png">

Ran this locally and it seems to fix it up :). I also checked if any other exports were missing but this seemed to be the only one. 
