### PR TITLE
[docs] Fix typo in the ClickAwayListerner name

### DIFF
--- a/docs/data/material/components/click-away-listener/click-away-listener.md
+++ b/docs/data/material/components/click-away-listener/click-away-listener.md
@@ -53,7 +53,7 @@ In order to prevent screen readers from marking non-interactive children as "cli
   <div role="presentation">
     <h1>non-interactive heading</h1>
   </div>
-</ClickAwayListern>
+</ClickAwayListener>
 ```
 
 This is also required to fix a quirk in NVDA when using Firefox that prevents announcement of alert messages (see [mui/material-ui#29080](https://github.com/mui/material-ui/issues/29080)).


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
