### PR TITLE
[internal] Enforce 70 as the max width on the title on the docs

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -394,6 +394,16 @@ function prepareMarkdown(config) {
         throw new Error(`Missing title in the page: ${location}`);
       }
 
+      if (title.length > 60) {
+        throw new Error(
+          [
+            `The title "${title}" is too long (${title.length} characters).`,
+            'It needs to have fewer than 60 characters, see for more details:',
+            'https://developers.google.com/search/docs/advanced/appearance/title-link',
+          ].join('\n'),
+        );
+      }
+
       if (description == null || description === '') {
         throw new Error(`Missing description in the page: ${location}`);
       }

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -398,7 +398,7 @@ function prepareMarkdown(config) {
         throw new Error(
           [
             `The title "${title}" is too long (${title.length} characters).`,
-            'It needs to have fewer than 70 characters, ideally less than 60, see for more details:',
+            'It needs to have fewer than 70 characters—ideally less than 60. For more details, see:',
             'https://developers.google.com/search/docs/advanced/appearance/title-link',
           ].join('\n'),
         );

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -394,11 +394,11 @@ function prepareMarkdown(config) {
         throw new Error(`Missing title in the page: ${location}`);
       }
 
-      if (title.length > 60) {
+      if (title.length > 70) {
         throw new Error(
           [
             `The title "${title}" is too long (${title.length} characters).`,
-            'It needs to have fewer than 60 characters, see for more details:',
+            'It needs to have fewer than 70 characters, ideally less than 60, see for more details:',
             'https://developers.google.com/search/docs/advanced/appearance/title-link',
           ].join('\n'),
         );

--- a/docs/pages/blog/lab-date-pickers-to-mui-x.md
+++ b/docs/pages/blog/lab-date-pickers-to-mui-x.md
@@ -1,6 +1,6 @@
 ---
-title: MUI X expands its product line with advanced date and time picker components
-description: Migrate to the new package to start building with our powerful date and time pickers, now part of MUI X.
+title: Date and time pickers are moving to MUI X
+description: Migrate to the new package to start building with our powerful date and time pickers, now part of MUI X. Previously released MIT components stayed MIT.
 date: 2022-04-03T00:00:00.000Z
 authors: ['flaviendelangle']
 tags: ['MUI X', 'News']
@@ -13,7 +13,7 @@ This means we'll be dedicating even more time and effort to these complex compon
 ## TL;DR
 
 - The date pickers are one step closer to a stable release.
-- **No surprise licenses changes**. We are staying true to [our promises](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd). What's MIT stays MIT, and what was [announced](https://v5-0-6.mui.com/components/date-range-picker/) over 12 months ago to move to a commercial license move.
+- **No surprise licenses changes**. We are staying true to [our promises](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd). What's MIT stays MIT, and what was [announced](https://v5-0-6.mui.com/components/date-range-picker/) over 12 months ago to move to a commercial license for the range feature.
 - Follow the [migration steps](/x/react-date-pickers/migration-lab/)
 
 ## What are date and time pickers?
@@ -32,7 +32,7 @@ The user may need to select an individual date/time, or a range.
 
 [MUI X](/x/) is a collection of advanced components built for complex use cases.
 
-As opposed to the Core library, which leans on the open-source community for support, MUI X components require several full-time developers dedicated to engineering and ongoing maintenance.
+As opposed to the MUI Core library, which leans on the open-source community for support, MUI X components require several full-time developers dedicated to engineering and ongoing maintenance.
 
 MUI X components are available under two licenses:
 

--- a/docs/pages/blog/lab-date-pickers-to-mui-x.md
+++ b/docs/pages/blog/lab-date-pickers-to-mui-x.md
@@ -1,6 +1,6 @@
 ---
 title: Date and time pickers are moving to MUI X
-description: Migrate to the new package to start building with our powerful date and time pickers, now part of MUI X. Previously released MIT components stayed MIT.
+description: Migrate to the new package to start building with our powerful date and time pickers, now part of MUI X. Previously released MIT components will stay MIT.
 date: 2022-04-03T00:00:00.000Z
 authors: ['flaviendelangle']
 tags: ['MUI X', 'News']
@@ -13,7 +13,7 @@ This means we'll be dedicating even more time and effort to these complex compon
 ## TL;DR
 
 - The date pickers are one step closer to a stable release.
-- **No surprise licenses changes**. We are staying true to [our promises](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd). What's MIT stays MIT, and what was [announced](https://v5-0-6.mui.com/components/date-range-picker/) over 12 months ago to move to a commercial license for the range feature.
+- **No surprise licenses changes**. We are staying true to [our promises](https://mui-org.notion.site/Stewardship-542a2226043d4f4a96dfb429d16cf5bd). What's MIT stays MIT, and we're going forward with our [plan announced over a year ago](https://v5-0-6.mui.com/components/date-range-picker/) to move the date range picker to the commercial license.
 - Follow the [migration steps](/x/react-date-pickers/migration-lab/)
 
 ## What are date and time pickers?


### PR DESCRIPTION
A title too long issue was reported in https://app.ahrefs.com/site-audit/3524616/24/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2Cdepth%2Ctitle%2CtitlesLength%2CnrTitles%2Ccompliant&filterCollapsed=true&filterId=0f7e22d4a95d6f7840cd16096f4006c1&issueId=c64dac3a-d0f4-11e7-8ed1-001e67ed4656 

<img width="1215" alt="Screenshot 2022-08-06 at 14 06 19" src="https://user-images.githubusercontent.com/3165635/183248257-8722f9e7-ae85-4f8d-9e58-43fce371e785.png">

<img width="378" alt="Screenshot 2022-08-11 at 18 54 41" src="https://user-images.githubusercontent.com/3165635/184190528-2eb3c12a-3132-4815-b06b-19604ae20835.png">

At first, I was reluctant to enforce it, but in this example, it feels too long. I have proposed a new title that I feel goes quicker to the important message. While ahrefs recommends 60 characters, I have found blog posts that can hardly be shorter, e.g. https://blog.logrocket.com/build-type-safe-version-tailwind-css-sprinkles/ hence 70

The error message feels like this:

<img width="983" alt="Screenshot 2022-08-06 at 14 10 25" src="https://user-images.githubusercontent.com/3165635/183248382-01ecebcc-c2cc-4e70-a304-f0fd05513883.png">