### PR TITLE
[docs] Add permanent notifications back

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -10,11 +10,6 @@
     "text": "Joy UI is MUI's new starting point for your design system. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"first-look-at-joy/\" href=\"/blog/first-look-at-joy/\">Check out the blog post</a> to see what's in store for this new library."
   },
   {
-    "id": 66,
-    "title": "<b>MUI's company retreat in Tenerife</b> 🏝",
-    "text": "In late June 2022, MUI team members gathered in the Canary Islands for a company retreat. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"2022-tenerife-retreat/\" href=\"/blog/2022-tenerife-retreat/\">Check out the recap here</a>."
-  },
-  {
     "id": 67,
     "title": "<b>Aggregate data like in Excel, but easier!</b>",
     "text": "Aggregation functions and summary rows are now available in the MUI X Premium Data Grid. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"aggregation-functions\" href=\"/blog/aggregation-functions/\">Check out our blog post</a>."


### PR DESCRIPTION
A continuation of #33745

- Remove company category blog posts. I feel that it's off-topic for the docs. AFAIK the purpose of this blog is for curious candidates that browse https://mui.com/blog/?tags=Company.
- Add the notification about how to get notifications back. I have also mentioned the blog.
- Welcome Chinese with notification only for them to signal that we want to translate.

<img width="411" alt="Screenshot 2022-08-07 at 21 12 49" src="https://user-images.githubusercontent.com/3165635/183307277-1dc31af0-9ded-4872-a7a5-e8b2868b256e.png">