### PR TITLE
[core] Redirect to X in dev mode

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -242,7 +242,7 @@ module.exports = {
   reactStrictMode,
   trailingSlash: true,
   // rewrites has no effect when run `next export` for production
-  async rewrites() {
+  rewrites: async () => {
     return [
       { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
       // Make sure to include the trailing slash if `trailingSlash` option is set
@@ -250,6 +250,14 @@ module.exports = {
       { source: `/static/x/:rest*`, destination: 'http://0.0.0.0:3001/static/x/:rest*' },
     ];
   },
+  // redirects only take effect in the development, not production (because of `next export`).
+  redirects: async () => [
+    {
+      source: '/x/:path(.{1,})',
+      destination: 'http://0.0.0:3001/x/:path',
+      permanent: false,
+    },
+  ],
   // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
   optimizeFonts: false,
 };


### PR DESCRIPTION
It makes it easier to work across the product. I can click on MUI X and it will direct me to the right localhost URL.

<img width="578" alt="Screenshot 2022-08-07 at 21 58 01" src="https://user-images.githubusercontent.com/3165635/183308970-af21dd0a-835a-4faa-8950-0be0016d316a.png">

