### PR TITLE
[core] Remove outdated Next.js options

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -33,10 +33,8 @@ module.exports = {
   },
   typescript: {
     // Motivated by https://github.com/vercel/next.js/issues/7687
-    ignoreDevErrors: true,
     ignoreBuildErrors: true,
   },
-  webpack5: true,
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
 


### PR DESCRIPTION
I wanted to check the logs server side, and here is what I got, too much noise for my taste 😁:

<img width="696" alt="Screenshot 2022-08-07 at 22 00 49" src="https://user-images.githubusercontent.com/3165635/183309177-b5fe4e92-72b7-4a59-8141-4d6f96e5d146.png">

It comes from https://github.com/mui/material-ui/pull/33626