### PR TITLE
Fixes emotion compat, className overwriting more specific classes

### DIFF
--- a/packages/mui-material/src/Tab/Tab.js
+++ b/packages/mui-material/src/Tab/Tab.js
@@ -10,11 +10,13 @@ import unsupportedProp from '../utils/unsupportedProp';
 import tabClasses, { getTabUtilityClass } from './tabClasses';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, textColor, fullWidth, wrapped, icon, label, selected, disabled } = ownerState;
+  const { classes, className, textColor, fullWidth, wrapped, icon, label, selected, disabled } =
+    ownerState;
 
   const slots = {
     root: [
       'root',
+      'className',
       icon && label && 'labelIcon',
       `textColor${capitalize(textColor)}`,
       fullWidth && 'fullWidth',
@@ -25,7 +27,7 @@ const useUtilityClasses = (ownerState) => {
     iconWrapper: ['iconWrapper'],
   };
 
-  return composeClasses(slots, getTabUtilityClass, classes);
+  return composeClasses(slots, getTabUtilityClass, { ...classes, className });
 };
 
 const TabRoot = styled(ButtonBase, {
@@ -187,7 +189,7 @@ const Tab = React.forwardRef(function Tab(inProps, ref) {
   return (
     <TabRoot
       focusRipple={!disableFocusRipple}
-      className={clsx(classes.root, className)}
+      className={classes.root}
       ref={ref}
       role="tab"
       aria-selected={selected}

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -4,6 +4,8 @@ import { expect } from 'chai';
 import * as React from 'react';
 import { spy } from 'sinon';
 import { act, createRenderer, describeConformance, fireEvent } from 'test/utils';
+import { ClassNames } from '@emotion/react';
+import PhoneIcon from '@mui/icons-material/Phone';
 
 describe('<Tab />', () => {
   const { render } = createRenderer();
@@ -164,6 +166,29 @@ describe('<Tab />', () => {
       expect(style).to.have.property('width', '80%');
       expect(style).to.have.property('color', 'red');
       expect(style).to.have.property('alignText', 'center');
+    });
+  });
+
+  describe('Emotion compatibility', () => {
+    it('className should not overwrite the the more specific classes that applies to root', () => {
+      // This is pink
+      const colorPink = 'rgb(255, 192, 204)';
+
+      const { getByRole } = render(
+        <ClassNames>
+          {({ css }) => (
+            <Tab
+              icon={<PhoneIcon />}
+              label="Background should be pink"
+              className={css({ backgroundColor: 'red' })}
+              classes={{ labelIcon: css({ backgroundColor: colorPink }) }}
+            />
+          )}
+        </ClassNames>,
+      );
+      const tab = getByRole('tab');
+
+      expect(getComputedStyle(tab).backgroundColor).to.equal(colorPink);
     });
   });
 });

--- a/test/regressions/fixtures/Table/EmotionCompat.js
+++ b/test/regressions/fixtures/Table/EmotionCompat.js
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { ClassNames } from '@emotion/react';
+import Tab from '@mui/material/Tab';
+import PhoneIcon from '@mui/icons-material/Phone';
+
+export default function EmotionCompat() {
+  return (
+    <ClassNames>
+      {({ css }) => (
+        <React.Fragment>
+          <Tab
+            icon={<PhoneIcon />}
+            label="Background should be green"
+            classes={{
+              root: css({
+                backgroundColor: 'red',
+              }),
+              labelIcon: css({ backgroundColor: 'green' }),
+            }}
+          />
+          <Tab
+            icon={<PhoneIcon />}
+            label="Background should be green"
+            className={css({ backgroundColor: 'red' })}
+            classes={{
+              labelIcon: css({
+                backgroundColor: 'green',
+              }),
+            }}
+          />
+        </React.Fragment>
+      )}
+    </ClassNames>
+  );
+}


### PR DESCRIPTION
Hi,  
This PR is related to #33205.  

What is happening is that `classNames` overwrites the `classes` that applies to the root component.  
I have implemented a fix for the `Tab` component. If you are fine with it I can generalize it.  

   
[The visual test case](https://github.com/garronej/material-ui/blob/classes_ordering/test/regressions/fixtures/Table/EmotionCompat.js) can be run with:  
```bash
yarn test:regressions:dev
```  
Then accessing: http://localhost:3000/regression-Table/EmotionCompat#no-dev  

With this branch you'll get:  
![image](https://user-images.githubusercontent.com/6702424/183566313-1b97dd05-aad5-4b7f-95eb-c1cecc20945b.png)

With `mui/material-ui#master`:  
![image](https://user-images.githubusercontent.com/6702424/183566375-5ca9d930-d66a-4ca0-af65-1aaaf55f85f7.png)  


Best regard,  