### PR TITLE
[docs] Fix `/system/getting-started/advanced/` does not exist

### DIFF
--- a/docs/data/system/getting-started/overview/overview.md
+++ b/docs/data/system/getting-started/overview/overview.md
@@ -27,4 +27,4 @@ Learn more on [the `sx` prop page](/system/getting-started/the-sx-prop/).
 [MUI Base](/base/getting-started/overview/) is a library of "unstyled" React components, while MUI System is a set of utilities for quickly applying styles to those components (as well as other MUI component libraries like Material UI and Joy UI).
 
 MUI Base is a standalone component library, whereas the System is _supplemental_ in that it's designed to be paired with Base and other MUI components, as well as third-party components.
-See [Advanced](/system/getting-started/advanced/) for details on how to use MUI System with non-MUI components.
+See the [Custom components page](/system/getting-started/custom-components/) for details on how to use MUI System with non-MUI components.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Literally https://github.com/mui/material-ui/issues/33865#issuecomment-1208966004

Fixes #33865 

Preview: https://deploy-preview-33867--material-ui.netlify.app/system/getting-started/overview/#mui-system-vs-mui-base