### PR TITLE
[system] Show type error for invalid properties in sx prop

### DIFF
--- a/docs/src/components/footer/EmailSubscribe.tsx
+++ b/docs/src/components/footer/EmailSubscribe.tsx
@@ -137,12 +137,12 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
             },
 
             [`&.${inputBaseClasses.focused}`]: {
-              borderColor: (theme) =>
+              borderColor: (theme: Theme) =>
                 theme.palette.mode === 'dark'
                   ? theme.palette.primaryDark[300]
                   : theme.palette.primary[500],
               outline: '3px solid',
-              outlineColor: (theme) =>
+              outlineColor: (theme: Theme) =>
                 theme.palette.mode === 'dark'
                   ? theme.palette.primaryDark[500]
                   : theme.palette.primary[200],

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -26,11 +26,13 @@ export interface CSSSelectorObject<Theme extends object = {}> {
 
 type CssVariableType = string | number;
 
+type AllowedKeys = `--${string}` | `&${string}`;
+
 /**
  * Map all nested selectors and CSS variables.
  */
 export interface CSSSelectorObjectOrCssVariables<Theme extends object = {}> {
-  [cssSelectorOrVariable: string]:
+  [cssSelectorOrVariable: AllowedKeys]:
     | ((theme: Theme) => SystemStyleObject<Theme> | string | number)
     | SystemStyleObject<Theme>
     | CssVariableType;

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.d.ts
@@ -26,7 +26,12 @@ export interface CSSSelectorObject<Theme extends object = {}> {
 
 type CssVariableType = string | number;
 
-type AllowedKeys = `--${string}` | `&${string}`;
+type AllowedKeys =
+  | `--${string}`
+  | `&${string}`
+  | `${CSS.AtRules}${string}`
+  | `::${string}`
+  | `${number}%`;
 
 /**
  * Map all nested selectors and CSS variables.

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.spec.tsx
@@ -21,3 +21,6 @@ const Text = (props: { sx?: SxProps<Theme> }) => null;
 
 // array contains boolean
 <Text sx={[false && { p: 2 }, { m: 2 }]} />;
+
+// @ts-expect-error invalid property 'lm'
+<Text sx={{ mt: 1, lm: 2 }} />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #33794 

Detailed explanation in https://github.com/mui/material-ui/issues/33794#issuecomment-1210177761.

I believe this is not a robust solution. I opened this PR to discuss if there's a better solution.

---

Before: https://codesandbox.io/s/jovial-glitter-kt9uvc?file=/demo.tsx

After: https://codesandbox.io/s/agitated-brattain-3dv74i?file=/demo.tsx

[Works for me with TypeScript version 3.5.3](https://codesandbox.io/s/upbeat-jones-srmh5y?file=/demo.tsx)