### PR TITLE
[IconButton][Joy] Fix large IconButton scaling

### DIFF
--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -52,7 +52,7 @@ const IconButtonRoot = styled('button', {
         fontSize: theme.vars.fontSize.md,
       }),
       ...(ownerState.size === 'lg' && {
-        '--Icon-fontSize': 'calc(var(--IconButton-size, 3rem) - 1.714)', // 1.75rem by default
+        '--Icon-fontSize': 'calc(var(--IconButton-size, 3rem) / 1.714)', // 1.75rem by default
         minWidth: 'var(--IconButton-size, 3rem)',
         minHeight: 'var(--IconButton-size, 3rem)',
         fontSize: theme.vars.fontSize.lg,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This was probably a typo in https://github.com/mui/material-ui/pull/33750

### Before
![before](https://user-images.githubusercontent.com/230597/184027139-8c1983c3-268f-4f7d-909a-1db009463e94.gif)

### After
![after](https://user-images.githubusercontent.com/230597/184027157-93d2fdea-a20b-4ed7-908d-9232bf398d4f.gif)

