### PR TITLE
[docs] Fix the reopening menu problem in MenuUnstyled demo

### DIFF
--- a/docs/data/base/components/menu/MenuSimple.js
+++ b/docs/data/base/components/menu/MenuSimple.js
@@ -108,12 +108,27 @@ export default function UnstyledMenuSimple() {
   const isOpen = Boolean(anchorEl);
   const buttonRef = React.useRef(null);
   const menuActions = React.useRef(null);
+  const preventReopen = React.useRef(false);
 
   const handleButtonClick = (event) => {
+    if (preventReopen.current) {
+      event.preventDefault();
+      preventReopen.current = false;
+      return;
+    }
+
     if (isOpen) {
       setAnchorEl(null);
     } else {
       setAnchorEl(event.currentTarget);
+    }
+  };
+
+  const handleButtonMouseDown = () => {
+    if (isOpen) {
+      // Prevents the menu from reopening right after closing
+      // when clicking the button.
+      preventReopen.current = true;
     }
   };
 
@@ -145,6 +160,7 @@ export default function UnstyledMenuSimple() {
         type="button"
         onClick={handleButtonClick}
         onKeyDown={handleButtonKeyDown}
+        onMouseDown={handleButtonMouseDown}
         ref={buttonRef}
         aria-controls={isOpen ? 'simple-menu' : undefined}
         aria-expanded={isOpen || undefined}

--- a/docs/data/base/components/menu/MenuSimple.tsx
+++ b/docs/data/base/components/menu/MenuSimple.tsx
@@ -108,12 +108,27 @@ export default function UnstyledMenuSimple() {
   const isOpen = Boolean(anchorEl);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const menuActions = React.useRef<MenuUnstyledActions>(null);
+  const preventReopen = React.useRef(false);
 
   const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (preventReopen.current) {
+      event.preventDefault();
+      preventReopen.current = false;
+      return;
+    }
+
     if (isOpen) {
       setAnchorEl(null);
     } else {
       setAnchorEl(event.currentTarget);
+    }
+  };
+
+  const handleButtonMouseDown = () => {
+    if (isOpen) {
+      // Prevents the menu from reopening right after closing
+      // when clicking the button.
+      preventReopen.current = true;
     }
   };
 
@@ -145,6 +160,7 @@ export default function UnstyledMenuSimple() {
         type="button"
         onClick={handleButtonClick}
         onKeyDown={handleButtonKeyDown}
+        onMouseDown={handleButtonMouseDown}
         ref={buttonRef}
         aria-controls={isOpen ? 'simple-menu' : undefined}
         aria-expanded={isOpen || undefined}

--- a/docs/data/base/components/menu/WrappedMenuItems.js
+++ b/docs/data/base/components/menu/WrappedMenuItems.js
@@ -146,12 +146,27 @@ export default function WrappedMenuItems() {
   const isOpen = Boolean(anchorEl);
   const buttonRef = React.useRef(null);
   const menuActions = React.useRef(null);
+  const preventReopen = React.useRef(false);
 
   const handleButtonClick = (event) => {
+    if (preventReopen.current) {
+      event.preventDefault();
+      preventReopen.current = false;
+      return;
+    }
+
     if (isOpen) {
       setAnchorEl(null);
     } else {
       setAnchorEl(event.currentTarget);
+    }
+  };
+
+  const handleButtonMouseDown = () => {
+    if (isOpen) {
+      // Prevents the menu from reopening right after closing
+      // when clicking the button.
+      preventReopen.current = true;
     }
   };
 
@@ -183,6 +198,7 @@ export default function WrappedMenuItems() {
         type="button"
         onClick={handleButtonClick}
         onKeyDown={handleButtonKeyDown}
+        onMouseDown={handleButtonMouseDown}
         ref={buttonRef}
         aria-controls={isOpen ? 'wrapped-menu' : undefined}
         aria-expanded={isOpen || undefined}

--- a/docs/data/base/components/menu/WrappedMenuItems.tsx
+++ b/docs/data/base/components/menu/WrappedMenuItems.tsx
@@ -145,12 +145,27 @@ export default function WrappedMenuItems() {
   const isOpen = Boolean(anchorEl);
   const buttonRef = React.useRef<HTMLButtonElement>(null);
   const menuActions = React.useRef<MenuUnstyledActions>(null);
+  const preventReopen = React.useRef(false);
 
   const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (preventReopen.current) {
+      event.preventDefault();
+      preventReopen.current = false;
+      return;
+    }
+
     if (isOpen) {
       setAnchorEl(null);
     } else {
       setAnchorEl(event.currentTarget);
+    }
+  };
+
+  const handleButtonMouseDown = () => {
+    if (isOpen) {
+      // Prevents the menu from reopening right after closing
+      // when clicking the button.
+      preventReopen.current = true;
     }
   };
 
@@ -182,6 +197,7 @@ export default function WrappedMenuItems() {
         type="button"
         onClick={handleButtonClick}
         onKeyDown={handleButtonKeyDown}
+        onMouseDown={handleButtonMouseDown}
         ref={buttonRef}
         aria-controls={isOpen ? 'wrapped-menu' : undefined}
         aria-expanded={isOpen || undefined}


### PR DESCRIPTION
Added code to prevent reopening a menu after a trigger button is pressed when the menu is already open.
This was caused by the menu closing due to losing focus, then immediately showing up again when the button's onClick handler was fired.

In the future, when we have the MenuButton component, this will be handled internally by the component. For now, such a workaround in user code is needed.

Fixes #33498