### PR TITLE
[docs] Fix typo in Joy UI's `AspectRatio` docs

### DIFF
--- a/docs/data/joy/components/aspect-ratio/aspect-ratio.md
+++ b/docs/data/joy/components/aspect-ratio/aspect-ratio.md
@@ -13,8 +13,8 @@ title: React Aspect Ratio component
 Its default implementation combines `height: 0px` with percentage `padding-bottom` to properly accomodate the content.
 
 :::info
-**Note:** A [native CSS `aspect-ratio`property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) already exists but we're not using it yet due to limited browser support.
-Once that increases significantly, we'll switch over to it.
+**Note:** A [native CSS `aspect-ratio` property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) already exists but MUI is not using it yet due to limited browser support.
+Once the support increases significantly, MUI will switch over to it.
 :::
 
 ## Component

--- a/docs/data/joy/components/aspect-ratio/aspect-ratio.md
+++ b/docs/data/joy/components/aspect-ratio/aspect-ratio.md
@@ -13,7 +13,7 @@ title: React Aspect Ratio component
 Its default implementation combines `height: 0px` with percentage `padding-bottom` to properly accomodate the content.
 
 :::info
-**Note:** A [native CSS `aspect-radio`property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) already exists but we're not using it yet due to limited browser support.
+**Note:** A [native CSS `aspect-ratio`property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) already exists but we're not using it yet due to limited browser support.
 Once that increases significantly, we'll switch over to it.
 :::
 


### PR DESCRIPTION
Signed-off-by: IsaacInsoll <30609296+IsaacInsoll@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-33895--material-ui.netlify.app/joy-ui/react-aspect-ratio/
