### PR TITLE
[system] Fix ContainerProps export

### DIFF
--- a/packages/mui-system/src/Container/index.d.ts
+++ b/packages/mui-system/src/Container/index.d.ts
@@ -1,5 +1,5 @@
 export { default } from './Container';
-export * from './Container';
+export * from './ContainerProps';
 
 export { default as containerClasses } from './containerClasses';
 export * from './containerClasses';


### PR DESCRIPTION
Container.ts only exports a default component.  ContainerProps contains definitions for Container Props and it should be exported.

Signed-off-by: Jack Zhao <bugzpodder@hotmail.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
