### PR TITLE
[core] Use proper external build id for Argos uploads

### DIFF
--- a/scripts/pushArgos.js
+++ b/scripts/pushArgos.js
@@ -45,7 +45,7 @@ async function run() {
       '--batchCount',
       chunks.length,
       '--external-build-id',
-      process.env.CIRCLE_SHA1,
+      process.env.CIRCLE_BUILD_NUM,
     ]);
     // eslint-disable-next-line no-console -- pipe stdout
     console.log(argosResults.stdout);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In MUI X sometimes we have false negative regressions like https://app.argos-ci.com/mui/mui-x/builds/3071
Currently, we have to push new commit (or rebase) to trigger whole CI pipeline and upload new screenshot to Argos.
But ideally we would like to restart a single step in the pipeline.

Turned out, we used wrong external build id as pointed out in https://github.com/argos-ci/argos/issues/457#issuecomment-1213308341