### PR TITLE
[MultiSelect][base] Require a single tap to select an item on mobile Chrome

### DIFF
--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -135,9 +135,9 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       });
     };
 
-  const createHandleOptionMouseOver =
+  const createHandleOptionPointerOver =
     (option: TOption, other: Record<string, React.EventHandler<any>>) =>
-    (event: React.MouseEvent) => {
+    (event: React.PointerEvent) => {
       other.onMouseOver?.(event);
       if (event.defaultPrevented) {
         return;
@@ -294,11 +294,11 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       ...otherHandlers,
       'aria-disabled': optionState.disabled || undefined,
       'aria-selected': optionState.selected,
-      tabIndex: getOptionTabIndex(optionState),
       id: optionIdGenerator(option, index),
       onClick: createHandleOptionClick(option, otherHandlers),
-      onMouseOver: createHandleOptionMouseOver(option, otherHandlers),
+      onPointerOver: createHandleOptionPointerOver(option, otherHandlers),
       role: 'option',
+      tabIndex: getOptionTabIndex(optionState),
     };
   };
 

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -228,7 +228,9 @@ interface UseListboxOptionSlotOwnProps {
   'aria-selected': React.AriaAttributes['aria-selected'];
   id?: string;
   onClick: React.MouseEventHandler;
+  onPointerOver: React.PointerEventHandler;
   role: React.AriaRole;
+  tabIndex?: number;
 }
 
 export type UseListboxOptionSlotProps<TOther = {}> = Omit<

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
@@ -14,6 +14,7 @@ const dummyGetOptionProps = () => ({
   'aria-selected': false,
   label: '',
   onClick: () => {},
+  onPointerOver: () => {},
   role: 'option',
   value: '',
 });


### PR DESCRIPTION
Mobile Chrome emulates onMouseOver when an option is tapped. This causes both mouseover and click actions to be dispatched next to each other. The MultiSelect behavior is broken in such case. This PR changes the mouseover to pointerover (which is not emulated when tapping on an element), preventing the problem.

Fixes #34151