### PR TITLE
[docs] Fix typo in Joy UI's docs

### DIFF
--- a/docs/data/joy/components/aspect-ratio/aspect-ratio-pt.md
+++ b/docs/data/joy/components/aspect-ratio/aspect-ratio-pt.md
@@ -9,7 +9,7 @@ title: React Aspect Ratio component
 
 ## Introduction
 
-`AspectRatio` is a wrapper component that allows you to rapidly control its content aspect ratio. Its default implementation combines `height: 0px` with percentage `padding-bottom` to properly accomodate the content.
+`AspectRatio` is a wrapper component that allows you to rapidly control its content aspect ratio. Its default implementation combines `height: 0px` with percentage `padding-bottom` to properly accommodate the content.
 
 :::info
 **Note:** A [native CSS `aspect-radio`property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) already exists but we're not using it yet due to limited browser support. Once that increases significantly, we'll switch over to it.


### PR DESCRIPTION
There was a typo in the Joy UI aspect ratio which has been fixed now!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
