### PR TITLE
[core] Add the download tracker build script

### DIFF
--- a/packages/mui-core-internal-download-tracker/package.json
+++ b/packages/mui-core-internal-download-tracker/package.json
@@ -20,6 +20,9 @@
     "url": "https://opencollective.com/mui"
   },
   "scripts": {
+    "build": "mkdir build && cpy index.js build/ && yarn build:copy-files",
+    "build:copy-files": "node ../../scripts/copy-files.js",
+    "prebuild": "rimraf build",
     "release": "npm publish ."
   }
 }


### PR DESCRIPTION
Add a script to copy the source into the build folder (as required by convention).

Adapted from the mui-types package.