### PR TITLE
[TablePagination] Fix to allow custom next/back button icons on the TablePagination component 

### DIFF
--- a/packages/mui-material/src/TablePagination/TablePaginationActions.js
+++ b/packages/mui-material/src/TablePagination/TablePaginationActions.js
@@ -62,7 +62,8 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions(
         title={getItemAriaLabel('previous', page)}
         {...backIconButtonProps}
       >
-        {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+        {backIconButtonProps?.children ||
+          (theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />)}
       </IconButton>
       <IconButton
         onClick={handleNextButtonClick}
@@ -72,7 +73,8 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions(
         title={getItemAriaLabel('next', page)}
         {...nextIconButtonProps}
       >
-        {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+        {nextIconButtonProps?.children ||
+          (theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />)}
       </IconButton>
       {showLastButton && (
         <IconButton


### PR DESCRIPTION
Currently the [docs](https://mui.com/material-ui/api/table-pagination/) suggest all [props of IconButton](https://mui.com/material-ui/api/icon-button/) are supported in nextIconButtonProps & backIconButtonProps on the TablePagination component.

Passing in icon component overrides are not currently supported and as such the 'children' prop is ignored when passed into nextIconButtonProps and backIconButtonProps.

Signed-off-by: Sam Fenwick <45273188+samfenwick@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
