### PR TITLE
[core] Download tracker rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "deduplicate": "node scripts/deduplicate.js",
     "benchmark:browser": "yarn workspace benchmark browser",
     "build:codesandbox": "lerna run --parallel --scope \"@mui/*\" build",
-    "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --force-publish=@mui/core-internal-download-tracker",
+    "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --force-publish=@mui/core-downloads-tracker",
     "release:build": "lerna run --parallel --scope \"@mui/*\" build",
     "release:changelog": "node scripts/releaseChangelog",
     "release:publish": "lerna publish from-package --dist-tag latest --contents build",

--- a/packages/mui-core-downloads-tracker/README.md
+++ b/packages/mui-core-downloads-tracker/README.md
@@ -1,4 +1,4 @@
-# @mui/core-internal-download-tracker
+# @mui/core-downloads-tracker
 
 This package does not contain any code.
 It is used solely to track number of downloads of @mui/material and @mui/joy (the only packages that depend on it) and help us determine the number of users of @mui/base.

--- a/packages/mui-core-downloads-tracker/package.json
+++ b/packages/mui-core-downloads-tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mui/core-internal-download-tracker",
+  "name": "@mui/core-downloads-tracker",
   "version": "5.10.1",
   "private": false,
   "author": "MUI Team",
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/mui/material-ui.git",
-    "directory": "packages/mui-core-internal-download-tracker"
+    "directory": "packages/core-downloads-tracker"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/mui-core-internal-download-tracker/index.js
+++ b/packages/mui-core-internal-download-tracker/index.js
@@ -1,1 +1,0 @@
-export default null;

--- a/packages/mui-core-internal-download-tracker/package.json
+++ b/packages/mui-core-internal-download-tracker/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "author": "MUI Team",
   "description": "Internal package to track number of downloads of our design system libraries",
-  "main": "./index.js",
+  "files": [],
   "repository": {
     "type": "git",
     "url": "https://github.com/mui/material-ui.git",
@@ -20,7 +20,7 @@
     "url": "https://opencollective.com/mui"
   },
   "scripts": {
-    "build": "mkdir build && cpy index.js build/ && yarn build:copy-files",
+    "build": "mkdir build && yarn build:copy-files",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build"

--- a/packages/mui-core-internal-download-tracker/package.json
+++ b/packages/mui-core-internal-download-tracker/package.json
@@ -23,7 +23,7 @@
     "build": "mkdir build && cpy index.js build/ && yarn build:copy-files",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
-    "release": "npm publish ."
+    "release": "yarn build && npm publish build"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@mui/base": "5.0.0-alpha.93",
-    "@mui/core-internal-download-tracker": "^5.10.1",
+    "@mui/core-downloads-tracker": "^5.10.1",
     "@mui/system": "^5.10.1",
     "@mui/types": "^7.1.5",
     "@mui/utils": "^5.9.3",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@mui/base": "5.0.0-alpha.93",
-    "@mui/core-internal-download-tracker": "^5.10.1",
+    "@mui/core-downloads-tracker": "^5.10.1",
     "@mui/system": "^5.10.1",
     "@mui/types": "^7.1.5",
     "@mui/utils": "^5.9.3",


### PR DESCRIPTION
Renamed the downloads tracker to remove the `internal` from its name as it apparently prevents the package from being published.

Also removed the unnecessary index.js file.