### PR TITLE
[docs] Fix typo in Joy UI's List Component docs

### DIFF
--- a/docs/data/joy/components/list/list.md
+++ b/docs/data/joy/components/list/list.md
@@ -14,7 +14,7 @@ Joy UI provides four list-related components:
 
 - [`List`](#basic-usage): A wrapper for list items (defaulting as `ul`).
 - [`ListItem`](#basic-usage): A common list item (default as `li`).
-- [`ListItemButton`](#actionable): Ans action element to be used inside a list item.
+- [`ListItemButton`](#actionable): An action element to be used inside a list item.
 - [`ListItemDecorator`](#decorator): A decorator of a list item, usually used to display an icon.
 - [`ListItemContent`](#ellipsis-content): A container inside a list item, used to display text content.
 - [`ListDivider`](#divider): A separator between list items.


### PR DESCRIPTION
Fixed typo in Joy UI's List Component docs

I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).