### PR TITLE
[Joy] Add missing global exports

### DIFF
--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -7,23 +7,41 @@ export * from './Avatar';
 export { default as AvatarGroup } from './AvatarGroup';
 export * from './AvatarGroup';
 
-export { default as Button } from './Button';
-export * from './Button';
+export { default as Badge } from './Badge';
+export * from './Badge';
+
+export { default as Box } from './Box';
+export * from './Box';
 
 export { default as Breadcrumbs } from './Breadcrumbs';
 export * from './Breadcrumbs';
 
-export { default as Typography } from './Typography';
-export * from './Typography';
+export { default as Button } from './Button';
+export * from './Button';
 
-export { default as Switch } from './Switch';
-export * from './Switch';
+export { default as Checkbox } from './Checkbox';
+export * from './Checkbox';
 
-export { default as SvgIcon } from './SvgIcon';
-export * from './SvgIcon';
+export { default as Chip } from './Chip';
+export * from './Chip';
 
-export { default as Slider } from './Slider';
-export * from './Slider';
+export { default as ChipDelete } from './ChipDelete';
+export * from './ChipDelete';
+
+export { default as Container } from './Container';
+export * from './Container';
+
+export { default as FormHelperText } from './FormHelperText';
+export * from './FormHelperText';
+
+export { default as FormLabel } from './FormLabel';
+export * from './FormLabel';
+
+export { default as Grid } from './Grid';
+export * from './Grid';
+
+export { default as Input } from './Input';
+export * from './Input';
 
 export { default as Link } from './Link';
 export * from './Link';
@@ -37,56 +55,14 @@ export * from './ListDivider';
 export { default as ListItem } from './ListItem';
 export * from './ListItem';
 
-export { default as ListItemDecorator } from './ListItemDecorator';
-export * from './ListItemDecorator';
-
 export { default as ListItemButton } from './ListItemButton';
 export * from './ListItemButton';
 
 export { default as ListItemContent } from './ListItemContent';
 export * from './ListItemContent';
 
-export { default as Input } from './Input';
-export * from './Input';
-
-export { default as Sheet } from './Sheet';
-export * from './Sheet';
-
-export { default as Checkbox } from './Checkbox';
-export * from './Checkbox';
-
-export { default as Chip } from './Chip';
-export * from './Chip';
-
-export { default as ChipDelete } from './ChipDelete';
-export * from './ChipDelete';
-
-export { default as FormLabel } from './FormLabel';
-export * from './FormLabel';
-
-export { default as FormHelperText } from './FormHelperText';
-export * from './FormHelperText';
-
-export { default as TextField } from './TextField';
-export * from './TextField';
-
-export { default as Box } from './Box';
-export * from './Box';
-
-export { default as Container } from './Container';
-export * from './Container';
-
-export { default as Badge } from './Badge';
-export * from './Badge';
-
-export { default as Radio } from './Radio';
-export * from './Radio';
-
-export { default as RadioGroup } from './RadioGroup';
-export * from './RadioGroup';
-
-export { default as Grid } from './Grid';
-export * from './Grid';
+export { default as ListItemDecorator } from './ListItemDecorator';
+export * from './ListItemDecorator';
 
 export { default as Menu } from './Menu';
 export * from './Menu';
@@ -97,17 +73,41 @@ export * from './MenuItem';
 export { default as MenuList } from './MenuList';
 export * from './MenuList';
 
+export { default as Radio } from './Radio';
+export * from './Radio';
+
+export { default as RadioGroup } from './RadioGroup';
+export * from './RadioGroup';
+
+export { default as Sheet } from './Sheet';
+export * from './Sheet';
+
+export { default as Slider } from './Slider';
+export * from './Slider';
+
 export { default as Stack } from './Stack';
 export * from './Stack';
 
-export { default as Tabs } from './Tabs';
-export * from './Tabs';
+export { default as SvgIcon } from './SvgIcon';
+export * from './SvgIcon';
 
-export { default as TabList } from './TabList';
-export * from './TabList';
+export { default as Switch } from './Switch';
+export * from './Switch';
 
 export { default as Tab } from './Tab';
 export * from './Tab';
 
+export { default as TabList } from './TabList';
+export * from './TabList';
+
 export { default as TabPanel } from './TabPanel';
 export * from './TabPanel';
+
+export { default as Tabs } from './Tabs';
+export * from './Tabs';
+
+export { default as TextField } from './TextField';
+export * from './TextField';
+
+export { default as Typography } from './Typography';
+export * from './Typography';

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -1,6 +1,9 @@
 export { default as colors } from './colors';
 export * from './styles';
 
+export { default as AspectRatio } from './AspectRatio';
+export * from './AspectRatio';
+
 export { default as Avatar } from './Avatar';
 export * from './Avatar';
 
@@ -18,6 +21,18 @@ export * from './Breadcrumbs';
 
 export { default as Button } from './Button';
 export * from './Button';
+
+export { default as Card } from './Card';
+export * from './Card';
+
+export { default as CardContent } from './CardContent';
+export * from './CardContent';
+
+export { default as CardCover } from './CardCover';
+export * from './CardCover';
+
+export { default as CardOverflow } from './CardOverflow';
+export * from './CardOverflow';
 
 export { default as Checkbox } from './Checkbox';
 export * from './Checkbox';
@@ -39,6 +54,9 @@ export * from './FormLabel';
 
 export { default as Grid } from './Grid';
 export * from './Grid';
+
+export { default as IconButton } from './IconButton';
+export * from './IconButton';
 
 export { default as Input } from './Input';
 export * from './Input';
@@ -73,11 +91,17 @@ export * from './MenuItem';
 export { default as MenuList } from './MenuList';
 export * from './MenuList';
 
+export { default as Option } from './Option';
+export * from './Option';
+
 export { default as Radio } from './Radio';
 export * from './Radio';
 
 export { default as RadioGroup } from './RadioGroup';
 export * from './RadioGroup';
+
+export { default as Select } from './Select';
+export * from './Select';
 
 export { default as Sheet } from './Sheet';
 export * from './Sheet';


### PR DESCRIPTION
I noticed that some of the Components are not re-exported from `@mui/joy`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
