### PR TITLE
[core] Sanitize input in icon synonyms update script

### DIFF
--- a/docs/scripts/updateIconSynonyms.js
+++ b/docs/scripts/updateIconSynonyms.js
@@ -21,8 +21,23 @@ async function run() {
     const data = JSON.parse(text.replace(")]}'", ''));
 
     const materialIcons = data.icons.reduce((acc, icon) => {
-      // remove the icon name strings from the tags
-      icon.tags = not(icon.tags, icon.name.replace('_'));
+      icon.tags = not(icon.tags, icon.name.replace('_')) // remove the icon name strings from the tags
+        .filter((t) => {
+          // remove invalid tags
+          if (
+            t.includes('Remove') ||
+            t.includes('Duplicate') ||
+            t.includes('Same as') ||
+            t.includes('remove others')
+          ) {
+            console.log(`Skipping invalid tag (${t}) in ${icon.name}`);
+            return false;
+          }
+
+          return true;
+        })
+        .map((t) => t.replace(/'/g, ''));
+
       // Fix names that can't be exported as ES modules.
       icon.name = myDestRewriter({ base: icon.name });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "docs:typescript": "yarn docs:typescript:formatted --watch",
     "docs:typescript:check": "yarn workspace docs typescript",
     "docs:typescript:formatted": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/formattedTSDemos",
-    "docs:mdicons:synonyms": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/updateIconSynonyms",
+    "docs:mdicons:synonyms": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/updateIconSynonyms && yarn prettier",
     "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true lerna run --parallel build:modern",
     "template:screenshot": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" ./docs/scripts/generateTemplateScreenshots",
     "install:codesandbox": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn install --ignore-engines",


### PR DESCRIPTION
The icon metadata from https://fonts.google.com/metadata/icons contain tags that cause our script to produce invalid JS. Specifically, a few tags are surrounded by apostrophes. This fix removes any apostrophes found in the tags.
Additionally, it skips tags that are clearly invalid - ones that contain "Remove", "Duplicate", "Same as", "remove others", so these strings don't appear as synonyms.