### PR TITLE
Revert "[core] Replace `getInitialProps` with `getStaticProps`"

### DIFF
--- a/docs/pages/base/api/badge-unstyled.js
+++ b/docs/pages/base/api/badge-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/badge-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/button-unstyled.js
+++ b/docs/pages/base/api/button-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/button-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/click-away-listener.js
+++ b/docs/pages/base/api/click-away-listener.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/click-away-listener',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/form-control-unstyled.js
+++ b/docs/pages/base/api/form-control-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/form-control-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/input-unstyled.js
+++ b/docs/pages/base/api/input-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/input-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/menu-item-unstyled.js
+++ b/docs/pages/base/api/menu-item-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/menu-item-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/menu-unstyled.js
+++ b/docs/pages/base/api/menu-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/menu-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/modal-unstyled.js
+++ b/docs/pages/base/api/modal-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/modal-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/multi-select-unstyled.js
+++ b/docs/pages/base/api/multi-select-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/multi-select-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/no-ssr.js
+++ b/docs/pages/base/api/no-ssr.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/no-ssr', false, /no-ssr.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/option-group-unstyled.js
+++ b/docs/pages/base/api/option-group-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/option-group-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/option-unstyled.js
+++ b/docs/pages/base/api/option-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/option-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/popper-unstyled.js
+++ b/docs/pages/base/api/popper-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/popper-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/portal.js
+++ b/docs/pages/base/api/portal.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/portal', false, /portal.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/select-unstyled.js
+++ b/docs/pages/base/api/select-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/select-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/slider-unstyled.js
+++ b/docs/pages/base/api/slider-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/slider-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/switch-unstyled.js
+++ b/docs/pages/base/api/switch-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/switch-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/tab-panel-unstyled.js
+++ b/docs/pages/base/api/tab-panel-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/tab-panel-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/tab-unstyled.js
+++ b/docs/pages/base/api/tab-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/tab-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/table-pagination-unstyled.js
+++ b/docs/pages/base/api/table-pagination-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/table-pagination-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/tabs-list-unstyled.js
+++ b/docs/pages/base/api/tabs-list-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/tabs-list-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/tabs-unstyled.js
+++ b/docs/pages/base/api/tabs-unstyled.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/tabs-unstyled',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/textarea-autosize.js
+++ b/docs/pages/base/api/textarea-autosize.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/textarea-autosize',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/base/api/trap-focus.js
+++ b/docs/pages/base/api/trap-focus.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/trap-focus', false, /trap-focus.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -142,7 +142,7 @@ export default function Experiments({ experiments }) {
   );
 }
 
-export function getStaticProps() {
+Experiments.getInitialProps = () => {
   const experiments = [];
   const req = require.context('./', true, /^\.\/.*(?<!index)\.(js|tsx)$/);
 
@@ -151,8 +151,6 @@ export function getStaticProps() {
   });
 
   return {
-    props: {
-      experiments,
-    },
+    experiments,
   };
-}
+};

--- a/docs/pages/material-ui/api/accordion-actions.js
+++ b/docs/pages/material-ui/api/accordion-actions.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/accordion-actions',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/accordion-details.js
+++ b/docs/pages/material-ui/api/accordion-details.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/accordion-details',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/accordion-summary.js
+++ b/docs/pages/material-ui/api/accordion-summary.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/accordion-summary',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/accordion.js
+++ b/docs/pages/material-ui/api/accordion.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/accordion', false, /accordion.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/alert-title.js
+++ b/docs/pages/material-ui/api/alert-title.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/alert-title',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/alert.js
+++ b/docs/pages/material-ui/api/alert.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/alert', false, /alert.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/app-bar.js
+++ b/docs/pages/material-ui/api/app-bar.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/app-bar', false, /app-bar.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/autocomplete.js
+++ b/docs/pages/material-ui/api/autocomplete.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/autocomplete',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/avatar-group.js
+++ b/docs/pages/material-ui/api/avatar-group.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/avatar-group',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/avatar.js
+++ b/docs/pages/material-ui/api/avatar.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/avatar', false, /avatar.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/backdrop.js
+++ b/docs/pages/material-ui/api/backdrop.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/backdrop', false, /backdrop.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/badge.js
+++ b/docs/pages/material-ui/api/badge.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/badge', false, /badge.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/bottom-navigation-action.js
+++ b/docs/pages/material-ui/api/bottom-navigation-action.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/bottom-navigation-action',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/bottom-navigation.js
+++ b/docs/pages/material-ui/api/bottom-navigation.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/bottom-navigation',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/box.js
+++ b/docs/pages/material-ui/api/box.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/box', false, /box.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/breadcrumbs.js
+++ b/docs/pages/material-ui/api/breadcrumbs.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/breadcrumbs',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/button-base.js
+++ b/docs/pages/material-ui/api/button-base.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/button-base',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/button-group.js
+++ b/docs/pages/material-ui/api/button-group.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/button-group',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/button.js
+++ b/docs/pages/material-ui/api/button.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/button', false, /button.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/card-action-area.js
+++ b/docs/pages/material-ui/api/card-action-area.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/card-action-area',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/card-actions.js
+++ b/docs/pages/material-ui/api/card-actions.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/card-actions',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/card-content.js
+++ b/docs/pages/material-ui/api/card-content.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/card-content',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/card-header.js
+++ b/docs/pages/material-ui/api/card-header.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/card-header',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/card-media.js
+++ b/docs/pages/material-ui/api/card-media.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/card-media', false, /card-media.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/card.js
+++ b/docs/pages/material-ui/api/card.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/card', false, /card.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/checkbox.js
+++ b/docs/pages/material-ui/api/checkbox.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/checkbox', false, /checkbox.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/chip.js
+++ b/docs/pages/material-ui/api/chip.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/chip', false, /chip.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/circular-progress.js
+++ b/docs/pages/material-ui/api/circular-progress.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/circular-progress',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/collapse.js
+++ b/docs/pages/material-ui/api/collapse.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/collapse', false, /collapse.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/container.js
+++ b/docs/pages/material-ui/api/container.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/container', false, /container.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/css-baseline.js
+++ b/docs/pages/material-ui/api/css-baseline.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/css-baseline',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/dialog-actions.js
+++ b/docs/pages/material-ui/api/dialog-actions.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/dialog-actions',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/dialog-content-text.js
+++ b/docs/pages/material-ui/api/dialog-content-text.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/dialog-content-text',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/dialog-content.js
+++ b/docs/pages/material-ui/api/dialog-content.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/dialog-content',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/dialog-title.js
+++ b/docs/pages/material-ui/api/dialog-title.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/dialog-title',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/dialog.js
+++ b/docs/pages/material-ui/api/dialog.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/dialog', false, /dialog.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/divider.js
+++ b/docs/pages/material-ui/api/divider.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/divider', false, /divider.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/drawer.js
+++ b/docs/pages/material-ui/api/drawer.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/drawer', false, /drawer.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/fab.js
+++ b/docs/pages/material-ui/api/fab.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/fab', false, /fab.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/fade.js
+++ b/docs/pages/material-ui/api/fade.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/fade', false, /fade.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/filled-input.js
+++ b/docs/pages/material-ui/api/filled-input.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/filled-input',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/form-control-label.js
+++ b/docs/pages/material-ui/api/form-control-label.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/form-control-label',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/form-control.js
+++ b/docs/pages/material-ui/api/form-control.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/form-control',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/form-group.js
+++ b/docs/pages/material-ui/api/form-group.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/form-group', false, /form-group.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/form-helper-text.js
+++ b/docs/pages/material-ui/api/form-helper-text.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/form-helper-text',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/form-label.js
+++ b/docs/pages/material-ui/api/form-label.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/form-label', false, /form-label.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/global-styles.js
+++ b/docs/pages/material-ui/api/global-styles.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/global-styles',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/grid.js
+++ b/docs/pages/material-ui/api/grid.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/grid', false, /grid.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/grow.js
+++ b/docs/pages/material-ui/api/grow.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/grow', false, /grow.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/hidden.js
+++ b/docs/pages/material-ui/api/hidden.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/hidden', false, /hidden.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/icon-button.js
+++ b/docs/pages/material-ui/api/icon-button.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/icon-button',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/icon.js
+++ b/docs/pages/material-ui/api/icon.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/icon', false, /icon.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/image-list-item-bar.js
+++ b/docs/pages/material-ui/api/image-list-item-bar.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/image-list-item-bar',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/image-list-item.js
+++ b/docs/pages/material-ui/api/image-list-item.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/image-list-item',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/image-list.js
+++ b/docs/pages/material-ui/api/image-list.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/image-list', false, /image-list.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/input-adornment.js
+++ b/docs/pages/material-ui/api/input-adornment.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/input-adornment',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/input-base.js
+++ b/docs/pages/material-ui/api/input-base.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/input-base', false, /input-base.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/input-label.js
+++ b/docs/pages/material-ui/api/input-label.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/input-label',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/input.js
+++ b/docs/pages/material-ui/api/input.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/input', false, /input.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/linear-progress.js
+++ b/docs/pages/material-ui/api/linear-progress.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/linear-progress',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/link.js
+++ b/docs/pages/material-ui/api/link.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/link', false, /link.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-item-avatar.js
+++ b/docs/pages/material-ui/api/list-item-avatar.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/list-item-avatar',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-item-button.js
+++ b/docs/pages/material-ui/api/list-item-button.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/list-item-button',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-item-icon.js
+++ b/docs/pages/material-ui/api/list-item-icon.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/list-item-icon',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-item-secondary-action.js
+++ b/docs/pages/material-ui/api/list-item-secondary-action.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/list-item-secondary-action',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-item-text.js
+++ b/docs/pages/material-ui/api/list-item-text.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/list-item-text',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-item.js
+++ b/docs/pages/material-ui/api/list-item.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/list-item', false, /list-item.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list-subheader.js
+++ b/docs/pages/material-ui/api/list-subheader.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/list-subheader',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/list.js
+++ b/docs/pages/material-ui/api/list.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/list', false, /list.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/loading-button.js
+++ b/docs/pages/material-ui/api/loading-button.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/loading-button',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/masonry.js
+++ b/docs/pages/material-ui/api/masonry.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/masonry', false, /masonry.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/menu-item.js
+++ b/docs/pages/material-ui/api/menu-item.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/menu-item', false, /menu-item.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/menu-list.js
+++ b/docs/pages/material-ui/api/menu-list.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/menu-list', false, /menu-list.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/menu.js
+++ b/docs/pages/material-ui/api/menu.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/menu', false, /menu.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/mobile-stepper.js
+++ b/docs/pages/material-ui/api/mobile-stepper.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/mobile-stepper',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/modal.js
+++ b/docs/pages/material-ui/api/modal.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/modal', false, /modal.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/native-select.js
+++ b/docs/pages/material-ui/api/native-select.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/native-select',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/outlined-input.js
+++ b/docs/pages/material-ui/api/outlined-input.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/outlined-input',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/pagination-item.js
+++ b/docs/pages/material-ui/api/pagination-item.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/pagination-item',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/pagination.js
+++ b/docs/pages/material-ui/api/pagination.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/pagination', false, /pagination.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/paper.js
+++ b/docs/pages/material-ui/api/paper.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/paper', false, /paper.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/popover.js
+++ b/docs/pages/material-ui/api/popover.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/popover', false, /popover.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/popper.js
+++ b/docs/pages/material-ui/api/popper.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/popper', false, /popper.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/radio-group.js
+++ b/docs/pages/material-ui/api/radio-group.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/radio-group',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/radio.js
+++ b/docs/pages/material-ui/api/radio.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/radio', false, /radio.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/rating.js
+++ b/docs/pages/material-ui/api/rating.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/rating', false, /rating.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/scoped-css-baseline.js
+++ b/docs/pages/material-ui/api/scoped-css-baseline.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/scoped-css-baseline',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/select.js
+++ b/docs/pages/material-ui/api/select.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/select', false, /select.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/skeleton.js
+++ b/docs/pages/material-ui/api/skeleton.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/skeleton', false, /skeleton.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/slide.js
+++ b/docs/pages/material-ui/api/slide.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/slide', false, /slide.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/slider.js
+++ b/docs/pages/material-ui/api/slider.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/slider', false, /slider.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/snackbar-content.js
+++ b/docs/pages/material-ui/api/snackbar-content.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/snackbar-content',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/snackbar.js
+++ b/docs/pages/material-ui/api/snackbar.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/snackbar', false, /snackbar.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/speed-dial-action.js
+++ b/docs/pages/material-ui/api/speed-dial-action.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/speed-dial-action',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/speed-dial-icon.js
+++ b/docs/pages/material-ui/api/speed-dial-icon.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/speed-dial-icon',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/speed-dial.js
+++ b/docs/pages/material-ui/api/speed-dial.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/speed-dial', false, /speed-dial.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/stack.js
+++ b/docs/pages/material-ui/api/stack.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/stack', false, /stack.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/step-button.js
+++ b/docs/pages/material-ui/api/step-button.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/step-button',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/step-connector.js
+++ b/docs/pages/material-ui/api/step-connector.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/step-connector',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/step-content.js
+++ b/docs/pages/material-ui/api/step-content.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/step-content',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/step-icon.js
+++ b/docs/pages/material-ui/api/step-icon.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/step-icon', false, /step-icon.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/step-label.js
+++ b/docs/pages/material-ui/api/step-label.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/step-label', false, /step-label.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/step.js
+++ b/docs/pages/material-ui/api/step.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/step', false, /step.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/stepper.js
+++ b/docs/pages/material-ui/api/stepper.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/stepper', false, /stepper.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/svg-icon.js
+++ b/docs/pages/material-ui/api/svg-icon.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/svg-icon', false, /svg-icon.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/swipeable-drawer.js
+++ b/docs/pages/material-ui/api/swipeable-drawer.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/swipeable-drawer',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/switch.js
+++ b/docs/pages/material-ui/api/switch.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/switch', false, /switch.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tab-context.js
+++ b/docs/pages/material-ui/api/tab-context.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/tab-context',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tab-list.js
+++ b/docs/pages/material-ui/api/tab-list.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tab-list', false, /tab-list.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tab-panel.js
+++ b/docs/pages/material-ui/api/tab-panel.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tab-panel', false, /tab-panel.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tab-scroll-button.js
+++ b/docs/pages/material-ui/api/tab-scroll-button.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/tab-scroll-button',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tab.js
+++ b/docs/pages/material-ui/api/tab.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tab', false, /tab.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-body.js
+++ b/docs/pages/material-ui/api/table-body.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/table-body', false, /table-body.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-cell.js
+++ b/docs/pages/material-ui/api/table-cell.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/table-cell', false, /table-cell.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-container.js
+++ b/docs/pages/material-ui/api/table-container.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/table-container',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-footer.js
+++ b/docs/pages/material-ui/api/table-footer.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/table-footer',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-head.js
+++ b/docs/pages/material-ui/api/table-head.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/table-head', false, /table-head.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-pagination.js
+++ b/docs/pages/material-ui/api/table-pagination.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/table-pagination',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-row.js
+++ b/docs/pages/material-ui/api/table-row.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/table-row', false, /table-row.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table-sort-label.js
+++ b/docs/pages/material-ui/api/table-sort-label.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/table-sort-label',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/table.js
+++ b/docs/pages/material-ui/api/table.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/table', false, /table.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tabs.js
+++ b/docs/pages/material-ui/api/tabs.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tabs', false, /tabs.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/text-field.js
+++ b/docs/pages/material-ui/api/text-field.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/text-field', false, /text-field.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline-connector.js
+++ b/docs/pages/material-ui/api/timeline-connector.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/timeline-connector',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline-content.js
+++ b/docs/pages/material-ui/api/timeline-content.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/timeline-content',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline-dot.js
+++ b/docs/pages/material-ui/api/timeline-dot.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/timeline-dot',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline-item.js
+++ b/docs/pages/material-ui/api/timeline-item.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/timeline-item',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline-opposite-content.js
+++ b/docs/pages/material-ui/api/timeline-opposite-content.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/timeline-opposite-content',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline-separator.js
+++ b/docs/pages/material-ui/api/timeline-separator.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/timeline-separator',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/timeline.js
+++ b/docs/pages/material-ui/api/timeline.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/timeline', false, /timeline.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/toggle-button-group.js
+++ b/docs/pages/material-ui/api/toggle-button-group.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/toggle-button-group',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/toggle-button.js
+++ b/docs/pages/material-ui/api/toggle-button.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/toggle-button',
     false,
@@ -17,9 +17,7 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/toolbar.js
+++ b/docs/pages/material-ui/api/toolbar.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/toolbar', false, /toolbar.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tooltip.js
+++ b/docs/pages/material-ui/api/tooltip.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tooltip', false, /tooltip.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tree-item.js
+++ b/docs/pages/material-ui/api/tree-item.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tree-item', false, /tree-item.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/tree-view.js
+++ b/docs/pages/material-ui/api/tree-view.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/tree-view', false, /tree-view.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/typography.js
+++ b/docs/pages/material-ui/api/typography.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/typography', false, /typography.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/material-ui/api/zoom.js
+++ b/docs/pages/material-ui/api/zoom.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/zoom', false, /zoom.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/system/api/box.js
+++ b/docs/pages/system/api/box.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/box', false, /box.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/system/api/container.js
+++ b/docs/pages/system/api/container.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/container', false, /container.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/system/api/grid.js
+++ b/docs/pages/system/api/grid.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/grid', false, /grid.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/system/api/stack.js
+++ b/docs/pages/system/api/stack.js
@@ -8,14 +8,12 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context('docs/translations/api-docs/stack', false, /stack.*.json$/);
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
-}
+};

--- a/docs/pages/versions.js
+++ b/docs/pages/versions.js
@@ -38,7 +38,7 @@ async function getBranches() {
   return JSON.parse(text);
 }
 
-export async function getStaticProps() {
+Page.getInitialProps = async () => {
   const FILTERED_BRANCHES = ['latest', 'l10n', 'next', 'migration', 'material-ui.com'];
 
   const branches = await getBranches();
@@ -78,5 +78,5 @@ export async function getStaticProps() {
     });
   }
 
-  return { props: { versions: sortedUniqBy(versions, 'version') } };
-}
+  return { versions: sortedUniqBy(versions, 'version') };
+};

--- a/docs/scripts/ApiBuilders/ComponentApiBuilder.ts
+++ b/docs/scripts/ApiBuilders/ComponentApiBuilder.ts
@@ -378,7 +378,7 @@ export default function Page(props) {
   return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
 }
 
-export function getStaticProps() {
+Page.getInitialProps = () => {
   const req = require.context(
     'docs/translations/api-docs/${kebabCase(reactApi.name)}',
     false,
@@ -387,10 +387,8 @@ export function getStaticProps() {
   const descriptions = mapApiPageTranslations(req);
 
   return {
-    props: {
-      descriptions,
-      pageContent: jsonPageContent,
-    },
+    descriptions,
+    pageContent: jsonPageContent,
   };
 };
 `.replace(/\r?\n/g, reactApi.EOL),


### PR DESCRIPTION
Reverts mui/material-ui#33684. 

The PR broke the SEO structure when it comes to the translations. For example, the page https://mui.com/material-ui/api/table-pagination/ says:

```html
<link rel="alternate" href="https://mui.com/zh/material-ui/api/table-pagination/" hrefLang="zh"/>
```

But this page is a 404 https://mui.com/zh/material-ui/api/table-pagination/. Chinese users will directly get a 404. The Google Search console started to [raise flags about it](https://search.google.com/search-console/index/drilldown?resource_id=sc-domain:mui.com&item_key=CAMYMiAD&utm_source=wnc_10030322). The root problem might be covered in https://github.com/vercel/next.js/issues/15315#issuecomment-661074532.