### PR TITLE
[TimelineConnector] Add support for CSS variables

### DIFF
--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
@@ -22,7 +22,7 @@ const TimelineConnectorRoot = styled('span', {
 })(({ theme }) => {
   return {
     width: 2,
-    backgroundColor: theme.palette.grey[400],
+    backgroundColor: (theme.vars || theme).palette.grey[400],
     flexGrow: 1,
   };
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #33959 

CodeSandbox to test in - https://codesandbox.io/s/create-react-app-with-typescript-forked-1ixyq3

If I inspect the classNames on this component with or without CSS vars I don't see any difference, the classNames are not changed without CSS vars. But I guess, there is something of benefit after we added this support. Perhaps a good DX about knowing the design tokens being used instead of hex values?