### PR TITLE
[Theme] add `ownerState` to variants style function arguments

### DIFF
--- a/packages/mui-material/src/styles/variants.d.ts
+++ b/packages/mui-material/src/styles/variants.d.ts
@@ -5,6 +5,6 @@ import { ComponentsPropsList } from './props';
 export type ComponentsVariants = {
   [Name in keyof ComponentsPropsList]?: Array<{
     props: Partial<ComponentsPropsList[Name]>;
-    style: Interpolation<{ theme: Theme }>;
+    style: Interpolation<{ theme: Theme; ownerState: Partial<ComponentsPropsList[Name]> }>;
   }>;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`ownerState` was missing in the `style` function arguments, so it wasn't possible to query for state in style variant overrides when using TypeScript

```typescript
  MuiButton: {
    variants: [
      {
        props: { color: 'primary' },
        style: ({ theme, ownerState: { startIcon } }) =>
                         ^ error TS2339: Property 'ownerState' does not exist on type '{ theme: Theme; }'.

```