### PR TITLE
[website] Optimize meta description length

### DIFF
--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -827,7 +827,7 @@ export default function About() {
     <BrandingProvider>
       <Head
         title="About us - MUI"
-        description="MUI (formerly Material UI) started back in 2014 to unify React and Material Design. Today, MUI has grown to become one of the world's most popular React libraries – used by a vibrant community of more than 2M developers in over 180 countries."
+        description="Our mission is to empower anyone to build UIs, faster. We're reducing the entry barrier, making design skills accessible."
       />
       <AppHeaderBanner />
       <AppHeader />

--- a/docs/pages/blog/material-ui-v1-is-out.md
+++ b/docs/pages/blog/material-ui-v1-is-out.md
@@ -1,6 +1,6 @@
 ---
 title: Material UI v1 is out 🎉
-description: Material UI v1 is out 🎉
+description: It has taken us two years to do it, but Material UI v1 has finally arrived!
 date: 2018-05-18T00:00:00.000Z
 authors: ['oliviertassinari', 'mbrookes']
 tags: ['Company']

--- a/docs/pages/blog/material-ui-v4-is-out.md
+++ b/docs/pages/blog/material-ui-v4-is-out.md
@@ -1,6 +1,6 @@
 ---
 title: Material UI v4 is out 🎉
-description: Material UI v4 is out 🎉
+description: Material UI v4 has finally arrived. We are so excited about this release, as it defines better foundations for the UI components.
 date: 2019-05-23T00:00:00.000Z
 authors: ['oliviertassinari', 'mbrookes', 'eps1lon']
 tags: ['Company']

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -286,8 +286,8 @@ function CareersContent() {
               minHeight: 48, // a hack to reduce CLS (layout shift)
             }}
           >
-            Our mission is to empower anyone to build UIs, faster. We&apos;re reducing the entry
-            barrier, making design skills accessible.
+            Our mission is to enable developers at every level of ability to build great UIs,
+            faster.
           </Typography>
         </Box>
       </Container>

--- a/docs/pages/core.tsx
+++ b/docs/pages/core.tsx
@@ -16,7 +16,7 @@ export default function Home() {
     <BrandingProvider>
       <Head
         title="MUI Core: Ready to use components, free forever"
-        description="Get a growing list of components, ready-to-use, free forever and with accessibility always in mind. We've built the foundational UI blocks for your design system so you don't have to."
+        description="Get a growing list of components, ready-to-use, free forever and with accessibility always in mind."
         card="/static/social-previews/core-preview.jpg"
       />
       <AppHeaderBanner />

--- a/docs/pages/material-ui.tsx
+++ b/docs/pages/material-ui.tsx
@@ -55,7 +55,7 @@ export default function Components() {
     <BrandingProvider>
       <Head
         title="React Components - Material UI"
-        description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design. You will develop React applications faster."
+        description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design."
       />
       <AppHeader />
       <main id="main-content">


### PR DESCRIPTION
Meta descriptions are recommended to be between 110 and 160 characters. I have used the opportunity to update the about us description to exactly match the mission statement: https://www.notion.so/mui-org/Direction-d8b8c142a6a44e3aa963f26edf4e03db#c3479698694645ff906efae69d442be2.