### PR TITLE
[docs] Fix broken Joy UI codesandbox export

### DIFF
--- a/docs/data/joy/components/text-field/text-field.md
+++ b/docs/data/joy/components/text-field/text-field.md
@@ -14,7 +14,7 @@ unstyled: /base/react-input/
 Text fields allow users to enter text into a UI.
 They typically appear in forms and dialogs.
 
-{{"demo": "TextFieldUsage.js"}}
+{{"demo": "TextFieldUsage.js", "hideToolbar": true}}
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 


### PR DESCRIPTION
I was looking into a bug in https://mui.com/joy-ui/react-text-field/, so wanted to export a codesandbox with the first button that I could click on. The first one opened https://codesandbox.io/s/30i7kf?file=/demo.tsx which crash

<img width="537" alt="Screenshot 2022-08-21 at 01 35 54" src="https://user-images.githubusercontent.com/3165635/185769454-6abe54b8-2233-4b52-a7f8-5facda900298.png">

