### PR TITLE
[Radio][Joy] support `componentsProps` as a function

### DIFF
--- a/docs/data/joy/components/radio/ExampleAlignmentButtons.js
+++ b/docs/data/joy/components/radio/ExampleAlignmentButtons.js
@@ -56,10 +56,10 @@ export default function RadioButtonsGroup() {
             variant={alignment === item ? 'solid' : 'plain'}
             componentsProps={{
               input: { 'aria-label': item },
-            }}
-            sx={{
-              [`& .${radioClasses.action}`]: { borderRadius: 0, transition: 'none' },
-              [`& .${radioClasses.label}`]: { lineHeight: 0 },
+              action: {
+                sx: { borderRadius: 0, transition: 'none' },
+              },
+              label: { sx: { lineHeight: 0 } },
             }}
           />
         </Box>

--- a/docs/data/joy/components/radio/ExampleProductAttributes.js
+++ b/docs/data/joy/components/radio/ExampleProductAttributes.js
@@ -48,15 +48,19 @@ export default function ExampleProductAttributes() {
                 color={color}
                 checkedIcon={<Done fontSize="xl2" />}
                 value={color}
-                componentsProps={{ input: { 'aria-label': color } }}
+                componentsProps={{
+                  input: { 'aria-label': color },
+                  radio: {
+                    sx: {
+                      display: 'contents',
+                      '--variant-borderWidth': '2px',
+                    },
+                  },
+                }}
                 sx={{
                   '--joy-focus-outlineOffset': '4px',
                   '--joy-palette-focusVisible': (theme) =>
                     theme.vars.palette[color][500],
-                  [`& .${radioClasses.radio}`]: {
-                    display: 'contents',
-                    '--variant-borderWidth': '2px',
-                  },
                   [`& .${radioClasses.action}.${radioClasses.focusVisible}`]: {
                     outlineWidth: '2px',
                   },

--- a/docs/data/joy/components/radio/ExampleSegmentedControls.js
+++ b/docs/data/joy/components/radio/ExampleSegmentedControls.js
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Radio from '@mui/joy/Radio';
+import RadioGroup from '@mui/joy/RadioGroup';
+import Typography from '@mui/joy/Typography';
+
+export default function RadioButtonsGroup() {
+  const [justify, setJustify] = React.useState('flex-start');
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <Typography id="segmented-controls-example" fontWeight="lg" fontSize="sm">
+        Justify:
+      </Typography>
+      <RadioGroup
+        row
+        aria-labelledby="segmented-controls-example"
+        name="justify"
+        value={justify}
+        onChange={(event) => setJustify(event.target.value)}
+        sx={{
+          minHeight: 48,
+          padding: '4px',
+          borderRadius: 'md',
+          bgcolor: 'neutral.softBg',
+          '--RadioGroup-gap': '4px',
+          '--Radio-action-radius': '8px',
+        }}
+      >
+        {['flex-start', 'center', 'flex-end'].map((item) => (
+          <Radio
+            color="neutral"
+            value={item}
+            disableIcon
+            label={item}
+            variant="plain"
+            sx={{
+              px: 2,
+              alignItems: 'center',
+            }}
+            componentsProps={{
+              action: ({ checked }) => ({
+                sx: {
+                  ...(checked && {
+                    bgcolor: 'background.surface',
+                    boxShadow: 'md',
+                    '&:hover': {
+                      bgcolor: 'background.surface',
+                    },
+                  }),
+                },
+              }),
+            }}
+          />
+        ))}
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/radio/IconlessRadio.js
+++ b/docs/data/joy/components/radio/IconlessRadio.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Box from '@mui/joy/Box';
 import FormLabel from '@mui/joy/FormLabel';
-import Radio, { radioClasses } from '@mui/joy/Radio';
+import Radio from '@mui/joy/Radio';
 import RadioGroup from '@mui/joy/RadioGroup';
 import Sheet from '@mui/joy/Sheet';
 
@@ -33,23 +33,26 @@ export default function IconlessRadio() {
               overlay
               disableIcon
               value={value}
-              sx={(theme) => ({
-                '& label': {
-                  fontWeight: 'lg',
-                  fontSize: 'md',
-                  color: 'text.secondary',
-                },
-                [`&.${radioClasses.checked}`]: {
-                  '& label': { color: 'text.primary' },
-                  '--joy-palette-primary-outlinedBorder':
-                    theme.vars.palette.primary[500],
-                  '--joy-palette-primary-outlinedHoverBorder':
-                    theme.vars.palette.primary[500],
-                  [`& .${radioClasses.action}`]: {
-                    '--variant-borderWidth': '2px',
+              componentsProps={{
+                label: ({ checked }) => ({
+                  sx: {
+                    fontWeight: 'lg',
+                    fontSize: 'md',
+                    color: checked ? 'text.primary' : 'text.secondary',
                   },
-                },
-              })}
+                }),
+                action: ({ checked }) => ({
+                  sx: (theme) => ({
+                    ...(checked && {
+                      '--variant-borderWidth': '2px',
+                      '&&': {
+                        // && to increase the specificity to win the base :hover styles
+                        borderColor: theme.vars.palette.primary[500],
+                      },
+                    }),
+                  }),
+                }),
+              }}
             />
           </Sheet>
         ))}

--- a/docs/data/joy/components/radio/RadioPositionEnd.js
+++ b/docs/data/joy/components/radio/RadioPositionEnd.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import List from '@mui/joy/List';
 import ListItem from '@mui/joy/ListItem';
 import ListItemDecorator from '@mui/joy/ListItemDecorator';
-import Radio, { radioClasses } from '@mui/joy/Radio';
+import Radio from '@mui/joy/Radio';
 import RadioGroup from '@mui/joy/RadioGroup';
 import Person from '@mui/icons-material/Person';
 import People from '@mui/icons-material/People';
@@ -10,45 +10,40 @@ import Apartment from '@mui/icons-material/Apartment';
 
 export default function RadioPositionEnd() {
   return (
-    <RadioGroup name="people" overlay defaultValue="person">
+    <RadioGroup name="people" defaultValue="Individual">
       <List
-        sx={(theme) => ({
+        sx={{
           minWidth: 240,
           '--List-gap': '0.5rem',
           '--List-item-paddingY': '1rem',
           '--List-item-radius': '8px',
           '--List-decorator-size': '32px',
-          [`& .${radioClasses.root}`]: {
-            flexGrow: 1,
-            flexDirection: 'row-reverse',
-            [`&.${radioClasses.checked}`]: {
-              [`& .${radioClasses.action}`]: {
-                inset: -1,
-                border: '2px solid',
-                borderColor: theme.vars.palette.primary[500],
-              },
-            },
-          },
-        })}
+        }}
       >
-        <ListItem variant="outlined">
-          <ListItemDecorator>
-            <Person />
-          </ListItemDecorator>
-          <Radio value="person" label="Individual" />
-        </ListItem>
-        <ListItem variant="outlined">
-          <ListItemDecorator>
-            <People />
-          </ListItemDecorator>
-          <Radio value="team" label="Team" />
-        </ListItem>
-        <ListItem variant="outlined">
-          <ListItemDecorator>
-            <Apartment />
-          </ListItemDecorator>
-          <Radio value="interprise" label="Interprise" />
-        </ListItem>
+        {['Individual', 'Team', 'Interprise'].map((item, index) => (
+          <ListItem variant="outlined" key={item}>
+            <ListItemDecorator>
+              {[<Person />, <People />, <Apartment />][index]}
+            </ListItemDecorator>
+            <Radio
+              overlay
+              value={item}
+              label={item}
+              sx={{ flexGrow: 1, flexDirection: 'row-reverse' }}
+              componentsProps={{
+                action: ({ checked }) => ({
+                  sx: (theme) => ({
+                    ...(checked && {
+                      inset: -1,
+                      border: '2px solid',
+                      borderColor: theme.vars.palette.primary[500],
+                    }),
+                  }),
+                }),
+              }}
+            />
+          </ListItem>
+        ))}
       </List>
     </RadioGroup>
   );

--- a/docs/data/joy/components/radio/radio.md
+++ b/docs/data/joy/components/radio/radio.md
@@ -117,9 +117,13 @@ Visit the [WAI-ARIA documentation](https://www.w3.org/WAI/ARIA/apg/patterns/radi
 
 ## Common examples
 
+### Segmented controls
+
+{{"demo": "ExampleSegmentedControls.js"}}
+
 ### Alignment buttons
 
-Simply provide an icon as a label to the `Radio` to make the radio buttons concise. You need to provide `aria-label` to the input slot for users who rely on screen readers.
+Provide an icon as a label to the `Radio` to make the radio buttons concise. You need to provide `aria-label` to the input slot for users who rely on screen readers.
 
 {{"demo": "ExampleAlignmentButtons.js"}}
 

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -401,11 +401,12 @@ Radio.propTypes /* remove-proptypes */ = {
    * @default {}
    */
   componentsProps: PropTypes.shape({
-    action: PropTypes.object,
-    input: PropTypes.object,
-    label: PropTypes.object,
-    radio: PropTypes.object,
-    root: PropTypes.object,
+    action: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    icon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    input: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    label: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    radio: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   }),
   /**
    * The default checked state. Use when the component is not controlled.

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -25,7 +25,12 @@ const useUtilityClasses = (ownerState: RadioProps & { focusVisible: boolean }) =
       size && `size${capitalize(size)}`,
     ],
     radio: ['radio', disabled && 'disabled'], // disabled class is necessary for displaying global variant
-    action: ['action', disableIcon && disabled && 'disabled', focusVisible && 'focusVisible'], // add disabled class to action element for displaying global variant
+    action: [
+      'action',
+      checked && 'checked',
+      disableIcon && disabled && 'disabled', // add disabled class to action element for displaying global variant
+      focusVisible && 'focusVisible',
+    ],
     input: ['input'],
     label: ['label'],
   };

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize, unstable_useId as useId } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { useSlotProps } from '@mui/base/utils';
 import { useSwitch } from '@mui/base/SwitchUnstyled';
 import { styled, useThemeProps } from '../styles';
 import radioClasses, { getRadioUtilityClass } from './radioClasses';
@@ -25,6 +25,7 @@ const useUtilityClasses = (ownerState: RadioProps & { focusVisible: boolean }) =
       size && `size${capitalize(size)}`,
     ],
     radio: ['radio', disabled && 'disabled'], // disabled class is necessary for displaying global variant
+    icon: ['icon'],
     action: [
       'action',
       checked && 'checked',
@@ -223,7 +224,6 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const {
     checked: checkedProp,
     checkedIcon,
-    className,
     component,
     componentsProps = {},
     defaultChecked,
@@ -243,7 +243,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
     size: sizeProp = 'md',
     uncheckedIcon,
     value,
-    ...otherProps
+    ...other
   } = props;
   const id = useId(idOverride);
   const radioGroup = React.useContext(RadioGroupContext);
@@ -285,45 +285,75 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  const rootProps = useSlotProps({
+    elementType: RadioRoot,
+    externalForwardedProps: other,
+    externalSlotProps: componentsProps.root,
+    additionalProps: {
+      as: component,
+      ref,
+    },
+    className: classes.root,
+    ownerState,
+  });
+
+  const radioProps = useSlotProps({
+    elementType: RadioRadio,
+    externalSlotProps: componentsProps.radio,
+    className: classes.radio,
+    ownerState,
+  });
+
+  const radioIconProps = useSlotProps({
+    elementType: RadioIcon,
+    externalSlotProps: componentsProps.icon,
+    className: classes.icon,
+    ownerState,
+  });
+
+  const radioActionProps = useSlotProps({
+    elementType: RadioAction,
+    externalSlotProps: componentsProps.action,
+    className: classes.action,
+    ownerState,
+  });
+
+  const radioInputProps = useSlotProps({
+    elementType: RadioInput,
+    getSlotProps: () => getInputProps({ onChange: radioGroup.onChange }),
+    externalSlotProps: componentsProps.input,
+    className: classes.input,
+    additionalProps: {
+      type: 'radio',
+      id,
+      name,
+      value: String(value),
+    },
+    ownerState,
+  });
+
+  const radioLabelProps = useSlotProps({
+    elementType: RadioLabel,
+    externalSlotProps: componentsProps.label,
+    className: classes.label,
+    ownerState,
+    additionalProps: {
+      htmlFor: id,
+    },
+  });
+
   return (
-    <RadioRoot
-      ref={ref}
-      {...otherProps}
-      as={component}
-      ownerState={ownerState}
-      className={clsx(classes.root, className)}
-    >
-      <RadioRadio
-        {...componentsProps?.radio}
-        ownerState={ownerState}
-        className={clsx(classes.radio, componentsProps?.radio?.className)}
-      >
+    <RadioRoot {...rootProps}>
+      <RadioRadio {...radioProps}>
         {checked && !disableIcon && checkedIcon}
         {!checked && !disableIcon && uncheckedIcon}
-        {!checkedIcon && !uncheckedIcon && !disableIcon && <RadioIcon ownerState={ownerState} />}
-        <RadioAction
-          {...componentsProps?.action}
-          ownerState={ownerState}
-          className={clsx(classes.action, componentsProps?.action?.className)}
-        >
-          <RadioInput
-            ownerState={ownerState}
-            {...getInputProps({ ...componentsProps.input, onChange: radioGroup.onChange })}
-            type="radio"
-            id={id}
-            name={name}
-            value={String(value)}
-            className={clsx(classes.input, componentsProps.input?.className)}
-          />
+        {!checkedIcon && !uncheckedIcon && !disableIcon && <RadioIcon {...radioIconProps} />}
+        <RadioAction {...radioActionProps}>
+          <RadioInput {...radioInputProps} />
         </RadioAction>
       </RadioRadio>
       {label && (
-        <RadioLabel
-          {...componentsProps?.label}
-          htmlFor={id}
-          ownerState={ownerState}
-          className={clsx(classes.label, componentsProps?.label?.className)}
-        >
+        <RadioLabel {...radioLabelProps}>
           {/* Automatically adjust the Typography to render `span` */}
           <TypographyContext.Provider value>{label}</TypographyContext.Provider>
         </RadioLabel>

--- a/packages/mui-joy/src/Radio/RadioProps.ts
+++ b/packages/mui-joy/src/Radio/RadioProps.ts
@@ -1,15 +1,25 @@
 import * as React from 'react';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { UseSwitchParameters } from '@mui/base/SwitchUnstyled';
+import { SlotComponentProps } from '@mui/base/utils';
 import { ColorPaletteProp, VariantProp, SxProps } from '../styles/types';
 
-export type RadioSlot = 'root' | 'radio' | 'action' | 'input' | 'label';
+export type RadioSlot = 'root' | 'radio' | 'icon' | 'action' | 'input' | 'label';
 
 export interface RadioPropsVariantOverrides {}
 
 export interface RadioPropsColorOverrides {}
 
 export interface RadioPropsSizeOverrides {}
+
+interface ComponentsProps {
+  root?: SlotComponentProps<'span', { sx?: SxProps }, RadioOwnerState>;
+  radio?: SlotComponentProps<'span', { sx?: SxProps }, RadioOwnerState>;
+  icon?: SlotComponentProps<'span', { sx?: SxProps }, RadioOwnerState>;
+  action?: SlotComponentProps<'span', { sx?: SxProps }, RadioOwnerState>;
+  input?: SlotComponentProps<'input', { sx?: SxProps }, RadioOwnerState>;
+  label?: SlotComponentProps<'label', { sx?: SxProps }, RadioOwnerState>;
+}
 
 export interface RadioTypeMap<P = {}, D extends React.ElementType = 'span'> {
   props: P &
@@ -31,13 +41,7 @@ export interface RadioTypeMap<P = {}, D extends React.ElementType = 'span'> {
        * The props used for each slot inside the Input.
        * @default {}
        */
-      componentsProps?: {
-        root?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
-        radio?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
-        action?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
-        input?: React.ComponentPropsWithRef<'input'> & { sx?: SxProps };
-        label?: React.ComponentPropsWithRef<'label'> & { sx?: SxProps };
-      };
+      componentsProps?: ComponentsProps;
       /**
        * The color of the component. It supports those theme colors that make sense for this component.
        * @default 'neutral'
@@ -94,3 +98,5 @@ export type RadioProps<
     component?: React.ElementType;
   },
 > = OverrideProps<RadioTypeMap<P, D>, D>;
+
+export type RadioOwnerState = RadioProps;

--- a/packages/mui-joy/src/Radio/RadioProps.ts
+++ b/packages/mui-joy/src/Radio/RadioProps.ts
@@ -32,11 +32,11 @@ export interface RadioTypeMap<P = {}, D extends React.ElementType = 'span'> {
        * @default {}
        */
       componentsProps?: {
-        root?: React.ComponentPropsWithRef<'span'>;
-        radio?: React.ComponentPropsWithRef<'span'>;
-        action?: React.ComponentPropsWithRef<'span'>;
-        input?: React.ComponentPropsWithRef<'input'>;
-        label?: React.ComponentPropsWithRef<'label'>;
+        root?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
+        radio?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
+        action?: React.ComponentPropsWithRef<'span'> & { sx?: SxProps };
+        input?: React.ComponentPropsWithRef<'input'> & { sx?: SxProps };
+        label?: React.ComponentPropsWithRef<'label'> & { sx?: SxProps };
       };
       /**
        * The color of the component. It supports those theme colors that make sense for this component.

--- a/packages/mui-joy/src/Radio/radioClasses.ts
+++ b/packages/mui-joy/src/Radio/radioClasses.ts
@@ -1,45 +1,47 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface RadioClasses {
-  /** Styles applied to the root element. */
+  /** Classname applied to the root element. */
   root: string;
-  /** Styles applied to the input element. */
+  /** Classname applied to the radio element. */
   radio: string;
-  /** Styles applied to the action element. */
+  /** Classname applied to the icon element. */
+  icon: string;
+  /** Classname applied to the action element. */
   action: string;
-  /** Styles applied to the input element. */
+  /** Classname applied to the input element. */
   input: string;
-  /** Styles applied to the input element. */
+  /** Classname applied to the label element. */
   label: string;
-  /** State class applied to the input component's `checked` class. */
+  /** State class applied to the root, action slots if `checked`. */
   checked: string;
-  /** State class applied to the input component's disabled class. */
+  /** State class applied to the root, action slots if `disabled`. */
   disabled: string;
   /** Class applied to the root element if the switch has visible focus */
   focusVisible: string;
-  /** Styles applied to the root element if `color="primary"`. */
+  /** Classname applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Styles applied to the root element if `color="danger"`. */
+  /** Classname applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Styles applied to the root element if `color="info"`. */
+  /** Classname applied to the root element if `color="info"`. */
   colorInfo: string;
-  /** Styles applied to the root element if `color="neutral"`. */
+  /** Classname applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Styles applied to the root element if `color="success"`. */
+  /** Classname applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Styles applied to the root element if `color="warning"`. */
+  /** Classname applied to the root element if `color="warning"`. */
   colorWarning: string;
-  /** Styles applied to the root element if `size="sm"`. */
+  /** Classname applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Styles applied to the root element if `size="md"`. */
+  /** Classname applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Styles applied to the root element if `size="lg"`. */
+  /** Classname applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Styles applied to the root element if `variant="outlined"`. */
+  /** Classname applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Styles applied to the root element if `variant="soft"`. */
+  /** Classname applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Styles applied to the root element if `variant="solid"`. */
+  /** Classname applied to the root element if `variant="solid"`. */
   variantSolid: string;
 }
 
@@ -52,6 +54,7 @@ export function getRadioUtilityClass(slot: string): string {
 const radioClasses: RadioClasses = generateUtilityClasses('JoyRadio', [
   'root',
   'radio',
+  'icon',
   'action',
   'input',
   'label',

--- a/packages/mui-joy/src/Radio/radioClasses.ts
+++ b/packages/mui-joy/src/Radio/radioClasses.ts
@@ -1,17 +1,17 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface RadioClasses {
-  /** Classname applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the radio element. */
+  /** Class name applied to the radio element. */
   radio: string;
-  /** Classname applied to the icon element. */
+  /** Class name applied to the icon element. */
   icon: string;
-  /** Classname applied to the action element. */
+  /** Class name applied to the action element. */
   action: string;
-  /** Classname applied to the input element. */
+  /** Class name applied to the input element. */
   input: string;
-  /** Classname applied to the label element. */
+  /** Class name applied to the label element. */
   label: string;
   /** State class applied to the root, action slots if `checked`. */
   checked: string;
@@ -19,29 +19,29 @@ export interface RadioClasses {
   disabled: string;
   /** Class applied to the root element if the switch has visible focus */
   focusVisible: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="info"`. */
+  /** Class name applied to the root element if `color="info"`. */
   colorInfo: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- follows the MUI Base `componentsProps` pattern (support callback) which remove the need for `classes` to style between states.
- update typings
- update demos to use the callback


**Before**:
```js
<Radio sx={theme => ({
  [`&.${radioClasses.checked}`]: {
    [`& .${radioClasses.action}]: { ... }
  }
}) />
```
**After**:
```js
<Radio componentsProps={{
  action: ({ checked }) => ({
    sx: theme => ({
      ...checked && { ... }
    })
  })
}} />
```


---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
