### PR TITLE
[docs] Fix Gatsby sample config in CSS variables

### DIFF
--- a/docs/data/material/experimental-api/css-variables/css-variables.md
+++ b/docs/data/material/experimental-api/css-variables/css-variables.md
@@ -187,7 +187,7 @@ export default class MyDocument extends Document {
 
 #### Gatsby
 
-To use the API with a Gatsby project, add the following code to the custom [`gatsby-ssr.jsx`](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/) file:
+To use the API with a Gatsby project, add the following code to the custom [`gatsby-ssr.js`](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/) file:
 
 ```jsx
 import React from 'react';

--- a/docs/data/material/experimental-api/css-variables/css-variables.md
+++ b/docs/data/material/experimental-api/css-variables/css-variables.md
@@ -194,7 +194,11 @@ import React from 'react';
 import { getInitColorSchemeScript } from '@mui/material/styles';
 
 export function onRenderBody({ setPreBodyComponents }) {
-  setPreBodyComponents([getInitColorSchemeScript()]);
+  setPreBodyComponents([
+    <React.Fragment key="mui-init-color-scheme-script">
+      {getInitColorSchemeScript()}
+    </React.Fragment>,
+  ]);
 }
 ```
 

--- a/docs/data/material/experimental-api/css-variables/css-variables.md
+++ b/docs/data/material/experimental-api/css-variables/css-variables.md
@@ -187,7 +187,7 @@ export default class MyDocument extends Document {
 
 #### Gatsby
 
-To use the API with a Gatsby project, add the following code to the custom [`gatsby-ssr.js`](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/) file:
+To use the API with a Gatsby project, add the following code to the custom [`gatsby-ssr.jsx`](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/) file:
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
---
- [CSS variables - Server-side rendering](https://mui.com/material-ui/experimental-api/css-variables/#server-side-rendering)
- The array key is not set and react will cause a warning.
- `<Fragment>` add to the Gatsby config sample.

```txt
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <body>. See https://reactjs.org/link/warning-keys for more information.
```