### PR TITLE
[system] catch localStorage errors

### DIFF
--- a/packages/mui-system/src/cssVars/useCurrentColorScheme.ts
+++ b/packages/mui-system/src/cssVars/useCurrentColorScheme.ts
@@ -147,8 +147,10 @@ export default function useCurrentColorScheme<SupportedColorScheme extends strin
         if (mode === currentState.mode) {
           return currentState;
         }
-        if (typeof localStorage !== 'undefined') {
+        try {
           localStorage.setItem(modeStorageKey, newMode);
+        } catch (e) {
+          // Unsupported
         }
         return {
           ...currentState,
@@ -175,7 +177,11 @@ export default function useCurrentColorScheme<SupportedColorScheme extends strin
               return newState;
             }
             processState(currentState, (mode) => {
-              localStorage.setItem(`${colorSchemeStorageKey}-${mode}`, value);
+              try {
+                localStorage.setItem(`${colorSchemeStorageKey}-${mode}`, value);
+              } catch (e) {
+                // Unsupported
+              }
               if (mode === 'light') {
                 newState.lightColorScheme = value;
               }
@@ -203,11 +209,15 @@ export default function useCurrentColorScheme<SupportedColorScheme extends strin
           }
           return newState;
         });
-        if (value.light) {
-          localStorage.setItem(`${colorSchemeStorageKey}-light`, value.light);
-        }
-        if (value.dark) {
-          localStorage.setItem(`${colorSchemeStorageKey}-dark`, value.dark);
+        try {
+          if (value.light) {
+            localStorage.setItem(`${colorSchemeStorageKey}-light`, value.light);
+          }
+          if (value.dark) {
+            localStorage.setItem(`${colorSchemeStorageKey}-dark`, value.dark);
+          }
+        } catch (e) {
+          // Unsupported
         }
       }
     },
@@ -245,17 +255,21 @@ export default function useCurrentColorScheme<SupportedColorScheme extends strin
 
   // Save mode, lightColorScheme & darkColorScheme to localStorage
   React.useEffect(() => {
-    if (state.mode) {
-      localStorage.setItem(modeStorageKey, state.mode);
+    try {
+      if (state.mode) {
+        localStorage.setItem(modeStorageKey, state.mode);
+      }
+      processState(state, (mode) => {
+        if (mode === 'light') {
+          localStorage.setItem(`${colorSchemeStorageKey}-light`, state.lightColorScheme);
+        }
+        if (mode === 'dark') {
+          localStorage.setItem(`${colorSchemeStorageKey}-dark`, state.darkColorScheme);
+        }
+      });
+    } catch (e) {
+      // Unsupported
     }
-    processState(state, (mode) => {
-      if (mode === 'light') {
-        localStorage.setItem(`${colorSchemeStorageKey}-light`, state.lightColorScheme);
-      }
-      if (mode === 'dark') {
-        localStorage.setItem(`${colorSchemeStorageKey}-dark`, state.darkColorScheme);
-      }
-    });
   }, [state, colorSchemeStorageKey, modeStorageKey]);
 
   // Handle when localStorage has changed


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I was trying to use Joy UI to build a Figma plugin, but localStorage is not available in this environment and so the library could not be used. This would also be the case for private mode as mentioned in https://github.com/mui/material-ui/issues/33853

This PR just wraps all of the calls in a try / catch, which was how one call was already handled. 

Another solution might be to create our own class, similar to a polyfill, that wraps localStorage and proxies commands with a try catch, so the code calling localStorage becomes smaller and potentially more readable.

I didn't not want to make too many assumptions about how MUI team wants to resolve the bug so let me know what you think and I will update if needed.

closes https://github.com/mui/material-ui/issues/33853