### PR TITLE
[core] Fix scroll restoration

### DIFF
--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -13558,7 +13558,7 @@ _May 24, 2015_
 
 ### Breaking Changes
 
-- Refactored all CSS into Javascript (#30, #316)
+- Refactored all CSS into JavaScript (#30, #316)
   - All Material UI components now have their styles defined inline. This solves
     many problems with CSS as mentions in [@vjeux's presentation](https://speakerdeck.com/vjeux/react-css-in-js)
     such as polluting the global namespace with classes that really should be

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -35,6 +35,9 @@ module.exports = {
     // Motivated by https://github.com/vercel/next.js/issues/7687
     ignoreBuildErrors: true,
   },
+  experimental: {
+    scrollRestoration: true,
+  },
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -27,7 +27,10 @@ if (staging) {
   console.log(`Staging deploy of ${process.env.REPOSITORY_URL || 'local repository'}`);
 }
 
-module.exports = {
+const baseline = {
+  experimental: {
+    scrollRestoration: true,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },
@@ -35,9 +38,14 @@ module.exports = {
     // Motivated by https://github.com/vercel/next.js/issues/7687
     ignoreBuildErrors: true,
   },
-  experimental: {
-    scrollRestoration: true,
-  },
+  trailingSlash: true,
+  // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
+  optimizeFonts: false,
+};
+
+module.exports = {
+  ...baseline,
+  baseline, // Exported so the other projects can use this configuration directly.
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
 
@@ -182,7 +190,6 @@ module.exports = {
     NETLIFY_DEPLOY_URL: process.env.DEPLOY_URL || 'http://localhost:3000',
     NETLIFY_SITE_NAME: process.env.SITE_NAME || 'material-ui',
     PULL_REQUEST: process.env.PULL_REQUEST === 'true',
-    REACT_STRICT_MODE: reactStrictMode,
     FEEDBACK_URL: process.env.FEEDBACK_URL,
     // #default-branch-switch
     SOURCE_CODE_ROOT_URL: 'https://github.com/mui/material-ui/blob/master',
@@ -241,9 +248,8 @@ module.exports = {
     return map;
   },
   reactStrictMode,
-  trailingSlash: true,
   // rewrites has no effect when run `next export` for production
-  async rewrites() {
+  rewrites: async () => {
     return [
       { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
       // Make sure to include the trailing slash if `trailingSlash` option is set
@@ -251,6 +257,4 @@ module.exports = {
       { source: `/static/x/:rest*`, destination: 'http://0.0.0.0:3001/static/x/:rest*' },
     ];
   },
-  // Can be turned on when https://github.com/vercel/next.js/issues/24640 is fixed
-  optimizeFonts: false,
 };

--- a/docs/pages/blog/2019-developer-survey-results.md
+++ b/docs/pages/blog/2019-developer-survey-results.md
@@ -215,7 +215,7 @@ designers to give it a bespoke look and feel for their organization.
 
 <img src="/static/blog/2019-survey/9.png" style="display: block; margin: 0 auto;" alt="Bar chart: 26 x I'm just getting started!, 43 x 6 months +, 150 x 1 year +, 179 x 3 years +, 155 x 5 years, 82 x 10 years +, 47 x 15 years +" />
 
-A nice bell curve, with the majority of developers having 1 to 5 years experience with Javascript.
+A nice bell curve, with the majority of developers having 1 to 5 years experience with JavaScript.
 
 ### 10. How long have you been developing with React?
 

--- a/docs/src/components/showcase/ThemeChip.tsx
+++ b/docs/src/components/showcase/ThemeChip.tsx
@@ -89,7 +89,7 @@ export default function ThemeChip() {
     <ThemeProvider theme={theme}>
       <Stack direction="row" spacing={2}>
         <Chip label="React" color="primary" onDelete={() => {}} />
-        <Chip label="Javascript" onDelete={() => {}} />
+        <Chip label="JavaScript" onDelete={() => {}} />
       </Stack>
     </ThemeProvider>
   );

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {
-  ThemeProvider as MuiThemeProvider,
-  createTheme as createLegacyModeTheme,
-  unstable_createMuiStrictModeTheme as createStrictModeTheme,
-} from '@mui/material/styles';
+import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
 import { deepmerge } from '@mui/utils';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { enUS, zhCN, faIR, ruRU, ptBR, esES, frFR, deDE, jaJP } from '@mui/material/locale';
@@ -114,13 +110,6 @@ export const DispatchContext = React.createContext(() => {
 
 if (process.env.NODE_ENV !== 'production') {
   DispatchContext.displayName = 'ThemeDispatchContext';
-}
-
-let createTheme;
-if (process.env.REACT_STRICT_MODE) {
-  createTheme = createStrictModeTheme;
-} else {
-  createTheme = createLegacyModeTheme;
 }
 
 export function ThemeProvider(props) {


### PR DESCRIPTION
Fix https://github.com/mui/material-ui/pull/33196#discussion_r928753221 using https://github.com/vercel/next.js/issues/37893#issuecomment-1221335543

Before: http://mui.com/
After: https://deploy-preview-34037--material-ui.netlify.app/

---

I have also made a change so that MUI X and MUI Toolpad can do:

```diff
diff --git a/docs/next.config.js b/docs/next.config.js
index 3467a20a..e99f6bb1 100644
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const nextConfig = require('@mui/monorepo/docs/next.config');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 // const withTM = require('next-transpile-modules')(['@mui/monorepo']);
 const pkg = require('../package.json');
@@ -27,15 +28,9 @@ if (reactStrictMode) {
 const isDeployment = process.env.NETLIFY === 'true';

 module.exports = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
+  ...nextConfig.baseline,
   // Avoid conflicts with the other Next.js apps hosted under https://mui.com/
   assetPrefix: isDeployment ? '/x' : undefined,
-  typescript: {
-    // Motivated by https://github.com/zeit/next.js/issues/7687
-    ignoreBuildErrors: true,
-  },
   env: {
     COMMIT_REF: process.env.COMMIT_REF,
     CONTEXT: process.env.CONTEXT,
@@ -108,7 +103,6 @@ module.exports = {
       },
     };
   },
-  trailingSlash: true,
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
   exportPathMap: () => {
```

They should get this bug fix for free, not have to apply it again.