### PR TITLE
[docs] Fix typo in the Transition docs

### DIFF
--- a/docs/data/material/components/transitions/transitions.md
+++ b/docs/data/material/components/transitions/transitions.md
@@ -85,7 +85,7 @@ const MyComponent = React.forwardRef((props, ref) {
 export default Main() {
   return (
     <Fade>
-      {/* MyComponent must the only child */}
+      {/* MyComponent must be the only child */}
       <MyComponent />
     </Fade>
   );


### PR DESCRIPTION
corrected a simple grammar problem at line  88
-- {/* MyComponent must the only child */}
++{/* MyComponent must be the only child */}


Signed-off-by: alireza <94165013+alirezahekmati@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
