### PR TITLE
[Showcase][ThemeDatePicker] Added overflow:hidden to showcase ThemeDatePicker component

### DIFF
--- a/docs/src/components/showcase/ThemeDatePicker.tsx
+++ b/docs/src/components/showcase/ThemeDatePicker.tsx
@@ -142,6 +142,7 @@ export default function ThemeDatePicker() {
                 border: '1px solid',
                 borderColor: mode === 'dark' ? primaryDark[500] : grey[200],
                 borderRadius: 1,
+                overflow: 'hidden',
               },
               '& > div > div > div': {
                 width: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
There has been an overflow for showcase ThemeDatePicker component in [mui.com](https://www.mui.com) 

|Before|After|
|-|-|
|<img width="840" alt="Screenshot 2022-08-24 at 18 43 52" src="https://user-images.githubusercontent.com/26146760/186428117-5bf26909-3c48-42d2-98a1-2950910fce83.png">|<img width="943" alt="Screenshot 2022-08-24 at 18 44 04" src="https://user-images.githubusercontent.com/26146760/186428003-91d57966-1437-42e9-b423-add11dcc2eb3.png">|

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
