### PR TITLE
[docs] Fix missing JSX closing tag in Tooltip docs

### DIFF
--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -53,7 +53,7 @@ const MyComponent = React.forwardRef(function MyComponent(props, ref) {
 // ...
 
 <Tooltip title="Delete">
-  <MyComponent>
+  <MyComponent />
 </Tooltip>
 ```
 
@@ -78,7 +78,7 @@ const WrappedMyComponent = React.forwardRef(function WrappedMyComponent(props, r
 // ...
 
 <Tooltip title="Delete">
-  <WrappedMyComponent>
+  <WrappedMyComponent />
 </Tooltip>
 ```
 

--- a/docs/data/material/components/tooltips/tooltips.md
+++ b/docs/data/material/components/tooltips/tooltips.md
@@ -47,14 +47,18 @@ If the child is a custom React element, you need to make sure that it spreads it
 ```jsx
 const MyComponent = React.forwardRef(function MyComponent(props, ref) {
   //  Spread the props to the underlying DOM element.
-  return <div {...props} ref={ref}>Bin</div>
+  return (
+    <div {...props} ref={ref}>
+      Bin
+    </div>
+  );
 });
 
 // ...
 
 <Tooltip title="Delete">
   <MyComponent />
-</Tooltip>
+</Tooltip>;
 ```
 
 You can find a similar concept in the [wrapping components](/material-ui/guides/composition/#wrapping-components) guide.
@@ -66,9 +70,13 @@ class MyComponent extends React.Component {
   render() {
     const { innerRef, ...props } = this.props;
     //  Spread the props to the underlying DOM element.
-    return <div {...props} ref={innerRef}>Bin</div>
+    return (
+      <div {...props} ref={innerRef}>
+        Bin
+      </div>
+    );
   }
-};
+}
 
 // Wrap MyComponent to forward the ref as expected by Tooltip
 const WrappedMyComponent = React.forwardRef(function WrappedMyComponent(props, ref) {
@@ -79,7 +87,7 @@ const WrappedMyComponent = React.forwardRef(function WrappedMyComponent(props, r
 
 <Tooltip title="Delete">
   <WrappedMyComponent />
-</Tooltip>
+</Tooltip>;
 ```
 
 ## Triggers


### PR DESCRIPTION
Signed-off-by: Snêu <39024711+hoangph271@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-34064--material-ui.netlify.app/material-ui/react-tooltip/#custom-child-element