### PR TITLE
[website] Improve visual look of code demos

### DIFF
--- a/docs/src/components/action/Frame.tsx
+++ b/docs/src/components/action/Frame.tsx
@@ -28,6 +28,7 @@ const FrameInfo = React.forwardRef<HTMLDivElement, BoxProps>(function FrameInfo(
         bgcolor: 'primaryDark.800',
         border: '1px solid',
         borderColor: 'primaryDark.700',
+        colorScheme: 'dark',
         ...props.sx,
       }}
     />

--- a/docs/src/components/productCore/CoreStyling.tsx
+++ b/docs/src/components/productCore/CoreStyling.tsx
@@ -56,9 +56,9 @@ const code = `
         borderRadius: 1,
         display: 'flex',
         typography: 'caption',
-        bgcolor: (theme) => 
+        bgcolor: (theme) =>
           theme.palette.mode === 'dark' ? 'primary.900' : 'primary.50',
-        color: (theme) => 
+        color: (theme) =>
           theme.palette.mode === 'dark' ? '#fff' : 'primary.700',
       }}
     >

--- a/docs/src/components/productCore/CoreTheming.tsx
+++ b/docs/src/components/productCore/CoreTheming.tsx
@@ -18,63 +18,70 @@ import MarkdownElement from 'docs/src/components/markdown/MarkdownElement';
 const lightTheme = createTheme();
 const darkTheme = createTheme({ palette: { mode: 'dark' } });
 
-const code = `        <Card
-variant="outlined"
-sx={{
-  p: 1,
-  display: 'flex',
-  flexDirection: { xs: 'column', sm: 'row' },
-}}
->
-<CardMedia
-  component="img"
-  width="124"
-  height="124"
-  alt="Beside Myself album cover"
-  src="/static/images/cards/basement-beside-myself.jpeg"
+const code = `
+<Card
+  variant="outlined"
   sx={{
-    borderRadius: 0.5,
-    width: 'clamp(124px, (304px - 100%) * 999 , 100%)',
+    p: 1,
+    display: 'flex',
+    flexDirection: { xs: 'column', sm: 'row' },
   }}
-/>
-<Box sx={{ alignSelf: 'center', px: { xs: 0, sm: 2 } }}>
-  <Typography
-    variant="body1"
-    color="text.primary"
-    fontWeight={600}
-    sx={{ textAlign: { xs: 'center', sm: 'start' }, mt: { xs: 1.5, sm: 0 } }}
-  >
-    Ultraviolet
-  </Typography>
-  <Typography
-    component="div"
-    variant="caption"
-    color="text.secondary"
-    fontWeight={500}
-    sx={{ textAlign: { xm: 'center', sm: 'start' } }}
-  >
-    Basement • Beside Myself
-  </Typography>
-  <Stack
-    direction="row"
-    spacing={1}
-    sx={{ mt: 2, justifyContent: { xs: 'space-between', sm: 'flex-start' } }}
-  >
-    <IconButton aria-label="fast rewind" disabled>
-      <FastRewindRounded />
-    </IconButton>
-    <IconButton
-      aria-label={paused ? 'play' : 'pause'}
-      sx={{ mx: 1 }}
-      onClick={() => setPaused((val) => !val)}
+>
+  <CardMedia
+    component="img"
+    width="124"
+    height="124"
+    alt="Beside Myself album cover"
+    src="/static/images/cards/basement-beside-myself.jpeg"
+    sx={{
+      borderRadius: 0.5,
+      width: 'clamp(124px, (304px - 100%) * 999 , 100%)',
+    }}
+  />
+  <Box sx={{ alignSelf: 'center', px: { xs: 0, sm: 2 } }}>
+    <Typography
+      variant="body1"
+      color="text.primary"
+      fontWeight={600}
+      sx={{
+        textAlign: { xs: 'center', sm: 'start' },
+        mt: { xs: 1.5, sm: 0 },
+      }}
     >
-      {paused ? <PlayArrowRounded /> : <PauseRounded />}
-    </IconButton>
-    <IconButton aria-label="fast forward" disabled>
-      <FastForwardRounded />
-    </IconButton>
-  </Stack>
-</Box>
+      Ultraviolet
+    </Typography>
+    <Typography
+      component="div"
+      variant="caption"
+      color="text.secondary"
+      fontWeight={500}
+      sx={{ textAlign: { xm: 'center', sm: 'start' } }}
+    >
+      Basement • Beside Myself
+    </Typography>
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{
+        mt: 2,
+        justifyContent: { xs: 'space-between', sm: 'flex-start' },
+      }}
+    >
+      <IconButton aria-label="fast rewind" disabled>
+        <FastRewindRounded />
+      </IconButton>
+      <IconButton
+        aria-label={paused ? 'play' : 'pause'}
+        sx={{ mx: 1 }}
+        onClick={() => setPaused((val) => !val)}
+      >
+        {paused ? <PlayArrowRounded /> : <PauseRounded />}
+      </IconButton>
+      <IconButton aria-label="fast forward" disabled>
+        <FastForwardRounded />
+      </IconButton>
+    </Stack>
+  </Box>
 </Card>`;
 
 export default function CoreTheming() {


### PR DESCRIPTION
A quick opportunity I saw while I updated the link on https://github.com/mui/material-ui from http://mui.com/ to http://mui.com/core/

<img width="322" alt="Screenshot 2022-08-25 at 15 38 33" src="https://user-images.githubusercontent.com/3165635/186679840-e6eb0dd6-1074-4b34-a52e-3eabc1b91936.png">

**Before**

<img width="595" alt="Screenshot 2022-08-25 at 15 37 53" src="https://user-images.githubusercontent.com/3165635/186679869-23f25b13-77bc-4313-ab17-f872b376b9f5.png">

https://mui.com/core/

**After**

<img width="590" alt="Screenshot 2022-08-25 at 15 39 39" src="https://user-images.githubusercontent.com/3165635/186680034-60e7e70e-8c1a-4cea-a30f-7be2bbfacf91.png">

https://deploy-preview-34070--material-ui.netlify.app/core/