### PR TITLE
[docs] Fix 404 link from Joy to React Router

### DIFF
--- a/docs/data/joy/components/link/link.md
+++ b/docs/data/joy/components/link/link.md
@@ -87,28 +87,28 @@ Here's how you can use the link component with libraries that also provide their
 
 ### Next.js
 
-Based on the [Links API reference documentation](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag).
+Here is an example with the [Link component](https://nextjs.org/docs/api-reference/next/link) of Next.js:
 
 ```js
 import NextLink from 'next/link';
-import JoyLink from '@mui/joy/Link';
+import Link from '@mui/joy/Link';
 
 <NextLink href="/docs" passHref>
-  <JoyLink>Read doc</JoyLink>
+  <Link>Read doc</Link>
 </NextLink>;
 ```
 
-### React router
+### React Router
 
-Based on the [Link found in React router's latets version](https://reactrouter.com/docs/en/v6/components/link).
+Here is an example with the [Link component](https://reactrouter.com/en/main/components/link) of React Router:
 
 ```js
 import { Link as RouterLink } from 'react-router-dom';
-import JoyLink from '@mui/joy/Link';
+import Link from '@mui/joy/Link';
 
-<JoyLink component={RouterLink} to="/docs">
+<Link component={RouterLink} to="/docs">
   Read doc
-</JoyLink>;
+</Link>;
 ```
 
 ## Common examples

--- a/docs/data/material/guides/routing/routing.md
+++ b/docs/data/material/guides/routing/routing.md
@@ -99,8 +99,7 @@ const LinkBehavior = React.forwardRef((props, ref) => (
 
 ### Next.js
 
-Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
-The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript) provides adapters for usage with MUI.
+The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/api-reference/next/link) with MUI.
 
 - The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/blob/HEAD/examples/nextjs-with-typescript/src/Link.tsx) component.
   This component is unstyled and only responsible for handling the navigation.

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -33,8 +33,7 @@ It includes `@mui/material` and its peer dependencies, including `emotion`, the 
 
 ## The link component
 
-Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
-The example folder provides adapters for usage with MUI.
+The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/api-reference/next/link) with MUI.
 More information [in the documentation](https://mui.com/material-ui/guides/routing/#next-js).
 
 ## What's next?

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -34,8 +34,7 @@ If you prefer, you can [use styled-components instead](https://mui.com/material-
 
 ## The link component
 
-Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link).
-The example folder provides adapters for usage with MUI.
+The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/api-reference/next/link) with MUI.
 More information [in the documentation](https://mui.com/material-ui/guides/routing/#next-js).
 
 ## What's next?


### PR DESCRIPTION
The link in the docs of Joy UI (https://reactrouter.com/docs/en/v6/components/link) leads to a 404.