### PR TITLE
[test] Allow to pass options to `mousePress` function

### DIFF
--- a/test/utils/fireDiscreteEvent.js
+++ b/test/utils/fireDiscreteEvent.js
@@ -45,9 +45,9 @@ function withMissingActWarningsIgnored(callback) {
 // Note that using `fireEvent` from `@testing-library/dom` would not work since /react configures both `fireEvent` to use `act` as a wrapper.
 // -----------------------------------------
 
-export function click(element) {
+export function click(element, options) {
   return withMissingActWarningsIgnored(() => {
-    fireEvent.click(element);
+    fireEvent.click(element, options);
   });
 }
 
@@ -74,7 +74,7 @@ export function keyUp(element, options) {
 }
 
 /**
- * @param {Element} element
+ * @param {Element | Node | Document | Window} element
  * @param {{}} [options]
  * @returns {void}
  */
@@ -85,7 +85,7 @@ export function mouseDown(element, options) {
 }
 
 /**
- * @param {Element} element
+ * @param {Element | Node | Document | Window} element
  * @param {{}} [options]
  * @returns {void}
  */

--- a/test/utils/userEvent.ts
+++ b/test/utils/userEvent.ts
@@ -1,24 +1,24 @@
 import * as React from 'react';
 import { click, mouseDown, mouseUp, keyDown, keyUp } from './fireDiscreteEvent';
-import { act, fireEvent } from './createRenderer';
+import { act, fireEvent, FireFunction } from './createRenderer';
 
 export function touch(target: Element): void {
   fireEvent.touchStart(target);
   fireEvent.touchEnd(target);
 }
 
-export function mousePress(target: Element): void {
+export const mousePress: (...args: Parameters<FireFunction>) => void = (target, options) => {
   if (React.version.startsWith('18')) {
-    fireEvent.mouseDown(target);
-    fireEvent.mouseUp(target);
-    fireEvent.click(target);
+    fireEvent.mouseDown(target, options);
+    fireEvent.mouseUp(target, options);
+    fireEvent.click(target, options);
   } else {
-    mouseDown(target);
-    mouseUp(target);
-    click(target);
+    mouseDown(target, options);
+    mouseUp(target, options);
+    click(target, options);
     act(() => {});
   }
-}
+};
 
 export function keyPress(target: Element, options: { key: string }): void {
   if (React.version.startsWith('18')) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In MUI X we have a use case where we need to pass `{ shiftKey: true }` to it:
https://github.com/mui/mui-x/pull/5920/files#diff-e91c750c30b576a9db65a896c989b9f3bca7e43c74d3b42f40bd538ff92bf8bbR358-R361