### PR TITLE
[docs] Fix the color contrast on optional API methods

### DIFF
--- a/docs/data/material/migration/migration-v4/v5-style-changes-zh.md
+++ b/docs/data/material/migration/migration-v4/v5-style-changes-zh.md
@@ -267,8 +267,8 @@ The `theme.palette.type` key was renamed to `theme.palette.mode`, to better foll
 
 ```diff
  import { createTheme } from '@mui/material/styles';
--const theme = createTheme({palette: { type: 'dark' }}),
-+const theme = createTheme({palette: { mode: 'dark' }}),
+-const theme = createTheme({ palette: { type: 'dark' } }),
++const theme = createTheme({ palette: { mode: 'dark' } }),
 ```
 
 ### Change default theme.palette.info colors
@@ -276,7 +276,7 @@ The `theme.palette.type` key was renamed to `theme.palette.mode`, to better foll
 The default `theme.palette.info` colors were changed to pass the AA accessibility standard contrast ratio in both light and dark modes.
 
 ```diff
-  info = {
+ info = {
 -  main: cyan[500],
 +  main: lightBlue[700], // lightBlue[400] in "dark" mode
 
@@ -285,7 +285,7 @@ The default `theme.palette.info` colors were changed to pass the AA accessibilit
 
 -  dark: cyan[700],
 +  dark: lightBlue[900], // lightBlue[700] in "dark" mode
-  }
+ }
 ```
 
 ### Change default theme.palette.success colors
@@ -293,7 +293,7 @@ The default `theme.palette.info` colors were changed to pass the AA accessibilit
 The default `theme.palette.success` colors were changed to pass the AA accessibility standard contrast ratio in both light and dark modes.
 
 ```diff
-  success = {
+ success = {
 -  main: green[500],
 +  main: green[800], // green[400] in "dark" mode
 
@@ -302,7 +302,7 @@ The default `theme.palette.success` colors were changed to pass the AA accessibi
 
 -  dark: green[700],
 +  dark: green[900], // green[700] in "dark" mode
-  }
+ }
 ```
 
 ### Change default theme.palette.warning colors
@@ -310,7 +310,7 @@ The default `theme.palette.success` colors were changed to pass the AA accessibi
 The default `theme.palette.warning` colors were changed to pass the AA accesibility standard contrast ratio in both light and dark modes.
 
 ```diff
-  warning = {
+ warning = {
 -  main: orange[500],
 +  main: '#ED6C02', // orange[400] in "dark" mode
 
@@ -319,7 +319,7 @@ The default `theme.palette.warning` colors were changed to pass the AA accesibil
 
 -  dark: orange[700],
 +  dark: orange[900], // orange[700] in "dark" mode
-  }
+ }
 ```
 
 ### Restore theme.palette.text.hint key (if needed)
@@ -327,7 +327,7 @@ The default `theme.palette.warning` colors were changed to pass the AA accesibil
 The `theme.palette.text.hint` key was unused in Material UI components, and has been removed. If you depend on it, you can add it back:
 
 ```diff
-  import { createTheme } from '@mui/material/styles';
+ import { createTheme } from '@mui/material/styles';
 
 -const theme = createTheme(),
 +const theme = createTheme({

--- a/docs/data/material/migration/migration-v4/v5-style-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-style-changes.md
@@ -276,8 +276,8 @@ The `theme.palette.type` key was renamed to `theme.palette.mode`, to better foll
 
 ```diff
  import { createTheme } from '@mui/material/styles';
--const theme = createTheme({palette: { type: 'dark' }}),
-+const theme = createTheme({palette: { mode: 'dark' }}),
+-const theme = createTheme({ palette: { type: 'dark' } }),
++const theme = createTheme({ palette: { mode: 'dark' } }),
 ```
 
 ### Change default theme.palette.info colors

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -173,7 +173,7 @@ const Root = styled('div')(({ theme }) => ({
       color: theme.palette.mode === 'light' ? '#006500' : '#a5ffa5',
     },
     '& .optional': {
-      color: theme.palette.type === 'light' ? '#080065' : '#a5b3ff',
+      color: theme.palette.mode === 'light' ? '#45529f' : '#a5b3ff',
     },
     '& .prop-type': {
       color: theme.palette.mode === 'light' ? '#932981' : '#ffb6ec',

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -993,8 +993,15 @@ npx @mui/codemod v5.0.0/theme-options <path>
 Renames `type` to `mode`.
 
 ```diff
-- { palette: { type: 'dark' } }
-+ { palette: { mode: 'dark' } }
+ {
+   palette: {
+-    type: 'dark',
++    mode: 'dark',
+   },
+ }
+```
+
+```diff
 -theme.palette.type === 'dark'
 +theme.palette.mode === 'dark'
 ```


### PR DESCRIPTION
A quick win. I have noticed the issue here, the text is unreadable:

<img width="763" alt="Screenshot 2022-08-30 at 01 12 42" src="https://user-images.githubusercontent.com/3165635/187314559-3a755d4d-da62-4254-abcc-9d47cbbaab6d.png">

https://mui.com/x/api/data-grid/grid-col-def/.

It fails the contrast ratio thresholds:

<img width="723" alt="Screenshot 2022-08-30 at 01 13 12" src="https://user-images.githubusercontent.com/3165635/187314637-30622959-5356-4b22-9228-f9582f12e84f.png">

https://webaim.org/resources/contrastchecker/?fcolor=A5B3FF&bcolor=FFFFFF

## After

<img width="768" alt="Screenshot 2022-08-30 at 01 14 19" src="https://user-images.githubusercontent.com/3165635/187314723-c7e6f632-934c-48de-9ee0-5e93ad6d98fa.png">

<img width="757" alt="Screenshot 2022-08-30 at 01 14 31" src="https://user-images.githubusercontent.com/3165635/187314748-4a314bce-0725-4cc2-93a0-5b7f3f4a0fae.png">
