### PR TITLE
[Select][base] Fix type issues that appeared with TS 4.8

### DIFF
--- a/docs/data/base/components/select/UnstyledSelectSimple.tsx
+++ b/docs/data/base/components/select/UnstyledSelectSimple.tsx
@@ -130,7 +130,7 @@ const StyledPopper = styled(PopperUnstyled)`
   z-index: 1;
 `;
 
-const CustomSelect = React.forwardRef(function CustomSelect<TValue>(
+const CustomSelect = React.forwardRef(function CustomSelect<TValue extends {}>(
   props: SelectUnstyledProps<TValue>,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
@@ -142,7 +142,7 @@ const CustomSelect = React.forwardRef(function CustomSelect<TValue>(
   };
 
   return <SelectUnstyled {...props} ref={ref} components={components} />;
-}) as <TValue>(
+}) as <TValue extends {}>(
   props: SelectUnstyledProps<TValue> & React.RefAttributes<HTMLButtonElement>,
 ) => JSX.Element;
 

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.spec.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.spec.tsx
@@ -27,12 +27,12 @@ const MultiSelectUnstyledComponentsPropsOverridesTest = (
   />
 );
 
-function CustomRoot<TValue>(props: MultiSelectUnstyledRootSlotProps<TValue>) {
+function CustomRoot<TValue extends {}>(props: MultiSelectUnstyledRootSlotProps<TValue>) {
   const { ownerState, ...other } = props;
   return <div {...other} />;
 }
 
-function CustomPopper<TValue>(props: MultiSelectUnstyledPopperSlotProps<TValue>) {
+function CustomPopper<TValue extends {}>(props: MultiSelectUnstyledPopperSlotProps<TValue>) {
   const { ownerState, ...other } = props;
   return <PopperUnstyled {...other} />;
 }

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -75,7 +75,7 @@ function useUtilityClasses(ownerState: MultiSelectUnstyledOwnerState<any>) {
  *
  * - [MultiSelectUnstyled API](https://mui.com/base/api/multi-select-unstyled/)
  */
-const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue>(
+const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue extends {}>(
   props: MultiSelectUnstyledProps<TValue>,
   forwardedRef: React.ForwardedRef<any>,
 ) {

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
@@ -112,14 +112,15 @@ export interface MultiSelectUnstyledType {
   propTypes?: any;
 }
 
-export interface MultiSelectUnstyledOwnerState<TValue> extends MultiSelectUnstyledProps<TValue> {
+export interface MultiSelectUnstyledOwnerState<TValue extends {}>
+  extends MultiSelectUnstyledProps<TValue> {
   active: boolean;
   disabled: boolean;
   open: boolean;
   focusVisible: boolean;
 }
 
-export type MultiSelectUnstyledRootSlotProps<TValue> = Simplify<
+export type MultiSelectUnstyledRootSlotProps<TValue extends {}> = Simplify<
   UseSelectButtonSlotProps & {
     className?: string;
     children?: React.ReactNode;
@@ -127,7 +128,7 @@ export type MultiSelectUnstyledRootSlotProps<TValue> = Simplify<
   }
 >;
 
-export type MultiSelectUnstyledListboxSlotProps<TValue> = Simplify<
+export type MultiSelectUnstyledListboxSlotProps<TValue extends {}> = Simplify<
   UseSelectListboxSlotProps & {
     className?: string;
     children?: React.ReactNode;
@@ -135,7 +136,7 @@ export type MultiSelectUnstyledListboxSlotProps<TValue> = Simplify<
   }
 >;
 
-export type MultiSelectUnstyledPopperSlotProps<TValue> = {
+export type MultiSelectUnstyledPopperSlotProps<TValue extends {}> = {
   anchorEl: PopperUnstyledProps['anchorEl'];
   children?: PopperUnstyledProps['children'];
   className?: string;

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.spec.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.spec.tsx
@@ -27,12 +27,12 @@ const SelectUnstyledComponentsPropsOverridesTest = (
   />
 );
 
-function CustomRoot<TValue>(props: SelectUnstyledRootSlotProps<TValue>) {
+function CustomRoot<TValue extends {}>(props: SelectUnstyledRootSlotProps<TValue>) {
   const { ownerState, ...other } = props;
   return <div {...other} />;
 }
 
-function CustomPopper<TValue>(props: SelectUnstyledPopperSlotProps<TValue>) {
+function CustomPopper<TValue extends {}>(props: SelectUnstyledPopperSlotProps<TValue>) {
   const { ownerState, ...other } = props;
   return <PopperUnstyled {...other} />;
 }

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -67,7 +67,7 @@ function useUtilityClasses(ownerState: SelectUnstyledOwnerState<any>) {
  *
  * - [SelectUnstyled API](https://mui.com/base/api/select-unstyled/)
  */
-const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue>(
+const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {}>(
   props: SelectUnstyledProps<TValue>,
   forwardedRef: React.ForwardedRef<any>,
 ) {

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
@@ -150,14 +150,15 @@ export interface SelectUnstyledType {
   propTypes?: any;
 }
 
-export interface SelectUnstyledOwnerState<TValue> extends SelectUnstyledOwnProps<TValue> {
+export interface SelectUnstyledOwnerState<TValue extends {}>
+  extends SelectUnstyledOwnProps<TValue> {
   active: boolean;
   disabled: boolean;
   focusVisible: boolean;
   open: boolean;
 }
 
-export type SelectUnstyledRootSlotProps<TValue> = Simplify<
+export type SelectUnstyledRootSlotProps<TValue extends {}> = Simplify<
   UseSelectButtonSlotProps & {
     className?: string;
     children?: React.ReactNode;
@@ -165,7 +166,7 @@ export type SelectUnstyledRootSlotProps<TValue> = Simplify<
   }
 >;
 
-export type SelectUnstyledListboxSlotProps<TValue> = Simplify<
+export type SelectUnstyledListboxSlotProps<TValue extends {}> = Simplify<
   UseSelectListboxSlotProps & {
     className?: string;
     children?: React.ReactNode;
@@ -173,7 +174,7 @@ export type SelectUnstyledListboxSlotProps<TValue> = Simplify<
   }
 >;
 
-export type SelectUnstyledPopperSlotProps<TValue> = {
+export type SelectUnstyledPopperSlotProps<TValue extends {}> = {
   anchorEl: PopperUnstyledProps['anchorEl'];
   children?: PopperUnstyledProps['children'];
   className?: string;

--- a/packages/mui-base/src/utils/useSlotProps.test.tsx
+++ b/packages/mui-base/src/utils/useSlotProps.test.tsx
@@ -11,7 +11,7 @@ function callUseSlotProps<
   ElementType extends React.ElementType,
   SlotProps,
   ExternalForwardedProps,
-  ExternalSlotProps,
+  ExternalSlotProps extends Record<string, unknown>,
   AdditionalProps,
   OwnerState,
 >(


### PR DESCRIPTION
TypeScript 4.8 introduced stricter type checks for generics (https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to). This causes issues in our codebase.

This PR addresses a part of the problem that affects MUI Base. There are a few issues in other packages that prevent us from updating the TS version globally. They will be fixed in a separate PR.

Fixes #34126
