### PR TITLE
Standardizing Darken Function To Output HSL

### DIFF
--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -17,6 +17,36 @@ function clamp(value, min = 0, max = 1) {
   return Math.min(Math.max(min, value), max);
 }
 
+
+/**
+ * Converts a color from CSS RGB format to CSS HSL format.
+ * Calculations from https://www.30secondsofcode.org/js/s/rgb-to-hsl
+ * @param {string} color - A CSS RGB color string i.e. rgb(0,0,0)
+ * @returns {string} A CSS HSL color string i.e. hsl(0,0%,0%)
+ */
+ function rgbToHsl(color) {
+  let rgb = color.replace(/[^\d,]/g, '').split(',')
+  let r= parseInt(rgb[0]) / 255
+  let g= parseInt(rgb[1]) /255
+  let b= parseInt(rgb[2]) / 255
+  const l = Math.max(r, g, b);
+  const s = l - Math.min(r, g, b);
+  const h = s
+    ? l === r
+      ? (g - b) / s
+      : l === g
+      ? 2 + (b - r) / s
+      : 4 + (r - g) / s
+    : 0;
+  
+    let hFinal = Math.round(60 * h < 0 ? 60 * h + 360 : 60 * h);
+    let sFinal = Math.round(100 * (s ? (l <= 0.5 ? s / (2 * l - s) : s / (2 - (2 * l - s))) : 0))
+    let lFinal = Math.round((100 * (2 * l - s)) / 2)
+
+  return `hsl(${hFinal}, ${sFinal}%, ${lFinal}%)` ;
+}
+
+
 /**
  * Converts a color from CSS hex format to CSS rgb format.
  * @param {string} color - Hex color, i.e. #nnn or #nnnnnn
@@ -61,6 +91,10 @@ export function decomposeColor(color) {
 
   if (color.charAt(0) === '#') {
     return decomposeColor(hexToRgb(color));
+  }
+  
+   if (color.charAt(0) === 'r') {
+    return decomposeColor(rgbToHsl(color));
   }
 
   const marker = color.indexOf('(');

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -26,21 +26,36 @@ function clamp(value, min = 0, max = 1) {
  */
  function rgbToHsl(color) {
   const rgb = color.replace(/[^\d,]/g, '').split(',')
-  const r= parseInt(rgb[0]) / 255
-  const g= parseInt(rgb[1]) /255
-  const b= parseInt(rgb[2]) / 255
+  const r= parseInt(rgb[0],10) / 255
+  const g= parseInt(rgb[1],10) /255
+  const b= parseInt(rgb[2],10) / 255
   const l = Math.max(r, g, b);
   const s = l - Math.min(r, g, b);
-  const h = s
-    ? l === r
-      ? (g - b) / s
-      : l === g
-      ? 2 + (b - r) / s
-      : 4 + (r - g) / s
-    : 0;
+  let h
+
+  if (s) {
+    if (l === r){
+      h=(g - b) / s
+    } else if (l === g) {
+      h=2 + (b - r) / s
+    } else{
+      h=4 + (r - g) / s
+    }} else {
+    h=0
+   }
+  
+    let sFinal
+    if (s){
+      if (l <= 0.5){
+        sFinal =Math.round(100 *  s / (2 * l - s))
+      } else {
+        sFinal =Math.round(100 * s / (2 - (2 * l - s)))
+      }
+    } else {
+      sFinal = 0
+    }
   
     const hFinal = Math.round(60 * h < 0 ? 60 * h + 360 : 60 * h);
-    const sFinal = Math.round(100 * (s ? (l <= 0.5 ? s / (2 * l - s) : s / (2 - (2 * l - s))) : 0))
     const lFinal = Math.round((100 * (2 * l - s)) / 2)
 
   return `hsl(${hFinal}, ${sFinal}%, ${lFinal}%)` ;

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -25,10 +25,10 @@ function clamp(value, min = 0, max = 1) {
  * @returns {string} A CSS HSL color string i.e. hsl(0,0%,0%)
  */
  function rgbToHsl(color) {
-  let rgb = color.replace(/[^\d,]/g, '').split(',')
-  let r= parseInt(rgb[0]) / 255
-  let g= parseInt(rgb[1]) /255
-  let b= parseInt(rgb[2]) / 255
+  const rgb = color.replace(/[^\d,]/g, '').split(',')
+  const r= parseInt(rgb[0]) / 255
+  const g= parseInt(rgb[1]) /255
+  const b= parseInt(rgb[2]) / 255
   const l = Math.max(r, g, b);
   const s = l - Math.min(r, g, b);
   const h = s
@@ -39,9 +39,9 @@ function clamp(value, min = 0, max = 1) {
       : 4 + (r - g) / s
     : 0;
   
-    let hFinal = Math.round(60 * h < 0 ? 60 * h + 360 : 60 * h);
-    let sFinal = Math.round(100 * (s ? (l <= 0.5 ? s / (2 * l - s) : s / (2 - (2 * l - s))) : 0))
-    let lFinal = Math.round((100 * (2 * l - s)) / 2)
+    const hFinal = Math.round(60 * h < 0 ? 60 * h + 360 : 60 * h);
+    const sFinal = Math.round(100 * (s ? (l <= 0.5 ? s / (2 * l - s) : s / (2 - (2 * l - s))) : 0))
+    const lFinal = Math.round((100 * (2 * l - s)) / 2)
 
   return `hsl(${hFinal}, ${sFinal}%, ${lFinal}%)` ;
 }

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -108,9 +108,6 @@ export function decomposeColor(color) {
     return decomposeColor(hexToRgb(color));
   }
   
-   if (color.charAt(0) === 'r') {
-    return decomposeColor(rgbToHsl(color));
-  }
 
   const marker = color.indexOf('(');
   const type = color.substring(0, marker);
@@ -294,7 +291,16 @@ export function alpha(color, value) {
  * @returns {string} A CSS color string. Hex input values are returned as rgb
  */
 export function darken(color, coefficient) {
-  color = decomposeColor(color);
+  
+  if (color.charAt(0) === 'r') {
+    //Standardize darken to HSL
+    color = decomposeColor(rgbToHsl(color));
+  } else if (color.charAt(0) === '#'){
+    color = decomposeColor(decomposeColor(rgbToHsl(hexToRgb(color))))
+  } else {
+    color = decomposeColor(color);
+  }
+   
   coefficient = clamp(coefficient);
 
   if (color.type.indexOf('hsl') !== -1) {
@@ -314,15 +320,18 @@ export function darken(color, coefficient) {
  * @returns {string} A CSS color string. Hex input values are returned as rgb
  */
 export function lighten(color, coefficient) {
-  color = decomposeColor(color);
+  if (color.charAt(0) === 'r') {
+    //Standardize darken to HSL
+    color = decomposeColor(rgbToHsl(color));
+  } else if (color.charAt(0) === '#'){
+    color = decomposeColor(decomposeColor(rgbToHsl(hexToRgb(color))))
+  } else {
+    color = decomposeColor(color);
+  }
   coefficient = clamp(coefficient);
 
   if (color.type.indexOf('hsl') !== -1) {
     color.values[2] += (100 - color.values[2]) * coefficient;
-  } else if (color.type.indexOf('rgb') !== -1) {
-    for (let i = 0; i < 3; i += 1) {
-      color.values[i] += (255 - color.values[i]) * coefficient;
-    }
   } else if (color.type.indexOf('color') !== -1) {
     for (let i = 0; i < 3; i += 1) {
       color.values[i] += (1 - color.values[i]) * coefficient;

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -295,7 +295,7 @@ export function darken(color, coefficient) {
   if (color.charAt(0) === 'r') {
     color = decomposeColor(rgbToHsl(color));
   } else if (color.charAt(0) === '#'){
-    color = decomposeColor(decomposeColor(rgbToHsl(hexToRgb(color))))
+    color = decomposeColor(rgbToHsl(hexToRgb(color)))
   } else {
     color = decomposeColor(color);
   }
@@ -322,7 +322,7 @@ export function lighten(color, coefficient) {
   if (color.charAt(0) === 'r') {
     color = decomposeColor(rgbToHsl(color));
   } else if (color.charAt(0) === '#'){
-    color = decomposeColor(decomposeColor(rgbToHsl(hexToRgb(color))))
+    color = decomposeColor(rgbToHsl(hexToRgb(color)))
   } else {
     color = decomposeColor(color);
   }

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -291,7 +291,6 @@ export function alpha(color, value) {
  * @returns {string} A CSS color string. Hex input values are returned as rgb
  */
 export function darken(color, coefficient) {
-  
   if (color.charAt(0) === 'r') {
     color = decomposeColor(rgbToHsl(color));
   } else if (color.charAt(0) === '#'){
@@ -309,6 +308,7 @@ export function darken(color, coefficient) {
       color.values[i] *= 1 - coefficient;
     }
   }
+
   return recomposeColor(color);
 }
 
@@ -326,6 +326,7 @@ export function lighten(color, coefficient) {
   } else {
     color = decomposeColor(color);
   }
+
   coefficient = clamp(coefficient);
 
   if (color.type.indexOf('hsl') !== -1) {

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -293,7 +293,6 @@ export function alpha(color, value) {
 export function darken(color, coefficient) {
   
   if (color.charAt(0) === 'r') {
-    //Standardize darken to HSL
     color = decomposeColor(rgbToHsl(color));
   } else if (color.charAt(0) === '#'){
     color = decomposeColor(decomposeColor(rgbToHsl(hexToRgb(color))))
@@ -321,7 +320,6 @@ export function darken(color, coefficient) {
  */
 export function lighten(color, coefficient) {
   if (color.charAt(0) === 'r') {
-    //Standardize darken to HSL
     color = decomposeColor(rgbToHsl(color));
   } else if (color.charAt(0) === '#'){
     color = decomposeColor(decomposeColor(rgbToHsl(hexToRgb(color))))


### PR DESCRIPTION
Fixes #34136

I've added an `rgbToHsl` function and modified decompose colors to output HSL to standardize the `darken` function, I tested `lighten` as well and it works fine.

<img width="620" alt="Screen Shot 2022-09-06 at 9 00 39 PM" src="https://user-images.githubusercontent.com/83738282/188765942-9724106b-0ddb-43ca-b3ad-2b7cf1af770a.png">
<img width="1149" alt="Screen Shot 2022-09-06 at 8 38 18 PM" src="https://user-images.githubusercontent.com/83738282/188766223-b1ad4a79-6acd-4e5f-9669-f963beff5f91.png">

I tried to follow the existing code format as best I could. I think the next step would be to add exports and tests if this is an acceptable fix. I can also refactor a bit of the `decompose` function that checks for RGB later on

Signed-off-by: Mark Daniel <83738282+Mark-777-0@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
