### PR TITLE
[docs] Improve CollapsibleList demo in Joy UI List docs

### DIFF
--- a/docs/data/joy/components/list/ExampleCollapsibleList.js
+++ b/docs/data/joy/components/list/ExampleCollapsibleList.js
@@ -85,7 +85,7 @@ export default function ExampleCollapsibleList() {
             </IconButton>
           }
         >
-          <ListItemButton>
+          <ListItemButton onClick={() => setOpen(!open)}>
             <Typography
               level="inherit"
               sx={{
@@ -136,7 +136,7 @@ export default function ExampleCollapsibleList() {
             </IconButton>
           }
         >
-          <ListItemButton>
+          <ListItemButton onClick={() => setOpen2((bool) => !bool)}>
             <Typography
               level="inherit"
               sx={{


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Since we show pointer cursor, when clicked it should toggle the collapse like in [Gatsby documentation](https://www.gatsbyjs.com/docs/).

Before: https://mui.com/joy-ui/react-list/#collapsible-list

After: 