### PR TITLE
[docs] Improve link to the security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ This project is licensed under the terms of the
 
 ## Security
 
-For details of supported versions and contact details for reporting security issues, please refer to the [security policy](https://github.com/mui/material-ui/blob/master/SECURITY.md).
+For details of supported versions and contact details for reporting security issues, please refer to the [security policy](https://github.com/mui/material-ui/security/policy).
 
 ## Sponsoring services
 


### PR DESCRIPTION
These two links are similar but the latter:

- Is always up to date.
- Feels more dedicated, there are extra context pages about security.
