### PR TITLE
[Joy][Textarea] Pass `textarea` props from `componentsProps`

### DIFF
--- a/packages/mui-joy/src/Textarea/Textarea.test.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.test.tsx
@@ -35,6 +35,21 @@ describe('Joy <Textarea />', () => {
     expect(screen.getByTestId('end')).toBeVisible();
   });
 
+  it('should pass props to Textarea', () => {
+    const { container } = render(
+      <Textarea
+        componentsProps={{
+          textarea: {
+            maxLength: 5,
+          },
+        }}
+      />,
+    );
+
+    const textarea = container.querySelector('textarea')!;
+    expect(textarea).to.have.attr('maxlength', '5');
+  });
+
   describe('prop: disabled', () => {
     it('should have disabled classes', () => {
       const { container } = render(<Textarea disabled />);

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -247,12 +247,12 @@ const Textarea = React.forwardRef(function Textarea(inProps, ref) {
 
   const textareaProps = useSlotProps({
     elementType: TextareaInput,
-    externalSlotProps: componentsProps.textarea,
     getSlotProps: (otherHandlers: EventHandlers) =>
       getInputProps({ ...otherHandlers, ...propsToForward }),
     externalSlotProps: {
       minRows,
       maxRows,
+      ...componentsProps.textarea,
     },
     ownerState,
     className: [classes.textarea, inputStateClasses],

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -247,6 +247,7 @@ const Textarea = React.forwardRef(function Textarea(inProps, ref) {
 
   const textareaProps = useSlotProps({
     elementType: TextareaInput,
+    externalSlotProps: componentsProps.textarea,
     getSlotProps: (otherHandlers: EventHandlers) =>
       getInputProps({ ...otherHandlers, ...propsToForward }),
     externalSlotProps: {


### PR DESCRIPTION
Signed-off-by: VelociRaptor <77036902+HexM7@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes textarea props (minLength, maxLength, etc) not being passed to the native element.