### PR TITLE
[Divider] Add `aria-hidden={true}` attribute

### DIFF
--- a/packages/mui-material/src/Divider/Divider.js
+++ b/packages/mui-material/src/Divider/Divider.js
@@ -199,6 +199,7 @@ const Divider = React.forwardRef(function Divider(inProps, ref) {
     <DividerRoot
       as={component}
       className={clsx(classes.root, className)}
+      aria-hidden
       role={role}
       ref={ref}
       ownerState={ownerState}


### PR DESCRIPTION
Add aria-hidden attribute to Divider so dividers are not announced by screen readers.

Fixes #34248.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
