### PR TITLE
[ButtonBase] Fix focus ripple

### DIFF
--- a/docs/pages/material-ui/api/button-base.json
+++ b/docs/pages/material-ui/api/button-base.json
@@ -22,7 +22,7 @@
     "touchRippleRef": {
       "type": {
         "name": "union",
-        "description": "func<br>&#124;&nbsp;{ current?: { pulsate: func, start: func, stop: func } }"
+        "description": "func<br>&#124;&nbsp;{ current?: { start: func, stop: func } }"
       }
     }
   },

--- a/packages/mui-material-next/src/Button/Button.test.js
+++ b/packages/mui-material-next/src/Button/Button.test.js
@@ -309,7 +309,7 @@ describe('<Button />', () => {
 
   it('should have a focusRipple by default', () => {
     const { getByRole } = render(
-      <Button TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}>
+      <Button TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }}>
         Hello World
       </Button>,
     );
@@ -319,15 +319,14 @@ describe('<Button />', () => {
     act(() => {
       button.focus();
     });
-
-    expect(button.querySelector('.pulsate-focus-visible')).not.to.equal(null);
+    expect(button.querySelector('.ripple-visible')).not.to.equal(null);
   });
 
   it('can disable the focusRipple', () => {
     const { getByRole } = render(
       <Button
         disableFocusRipple
-        TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}
+        TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }}
       >
         Hello World
       </Button>,
@@ -339,7 +338,7 @@ describe('<Button />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).to.equal(null);
+    expect(button.querySelector('.ripple-visible')).to.equal(null);
   });
 
   describe('server-side', () => {

--- a/packages/mui-material-next/src/Tab/Tab.test.js
+++ b/packages/mui-material-next/src/Tab/Tab.test.js
@@ -34,7 +34,7 @@ describe('<Tab />', () => {
 
   it('should have a focusRipple by default', () => {
     const { container, getByRole } = render(
-      <Tab TouchRippleProps={{ classes: { ripplePulsate: 'focus-ripple' } }} />,
+      <Tab TouchRippleProps={{ classes: { rippleVisible: 'focus-ripple' } }} />,
     );
     // simulate pointer device
     fireEvent.pointerDown(document.body);

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -534,7 +534,7 @@ describe('<Button />', () => {
 
   it('should have a focusRipple by default', () => {
     const { getByRole } = render(
-      <Button TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}>
+      <Button TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }}>
         Hello World
       </Button>,
     );
@@ -545,14 +545,14 @@ describe('<Button />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).not.to.equal(null);
+    expect(button.querySelector('.ripple-visible')).not.to.equal(null);
   });
 
   it('can disable the focusRipple', () => {
     const { getByRole } = render(
       <Button
         disableFocusRipple
-        TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}
+        TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }}
       >
         Hello World
       </Button>,
@@ -564,7 +564,7 @@ describe('<Button />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).to.equal(null);
+    expect(button.querySelector('.ripple-visible')).to.equal(null);
   });
 
   describe('server-side', () => {

--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -142,7 +142,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
 
   React.useEffect(() => {
     if (focusVisible && focusRipple && !disableRipple && mountedState) {
-      rippleRef.current.pulsate();
+      rippleRef.current.start();
     }
   }, [disableRipple, focusRipple, focusVisible, mountedState]);
 
@@ -269,7 +269,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
     ) {
       keydownRef.current = false;
       rippleRef.current.stop(event, () => {
-        rippleRef.current.pulsate(event);
+        rippleRef.current.start(event);
       });
     }
     if (onKeyUp) {
@@ -525,7 +525,6 @@ ButtonBase.propTypes /* remove-proptypes */ = {
     PropTypes.func,
     PropTypes.shape({
       current: PropTypes.shape({
-        pulsate: PropTypes.func.isRequired,
         start: PropTypes.func.isRequired,
         stop: PropTypes.func.isRequired,
       }),

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -596,6 +596,53 @@ describe('<ButtonBase />', () => {
       expect(rippleStyle).not.to.have.property('height', '101px');
       expect(rippleStyle).not.to.have.property('width', '101px');
     });
+    it('renders the ripple with the right width and height', () => {
+      const { container, getByRole } = render(
+        <ButtonBase
+          centerRipple
+          TouchRippleProps={{ classes: { root: 'touch-ripple', ripple: 'touch-ripple-ripple' } }}
+        />,
+      );
+      // @ts-ignore
+      stub(container.querySelector('.touch-ripple'), 'getBoundingClientRect').callsFake(() => ({
+        width: 40,
+        height: 50,
+        bottom: 10,
+        left: 20,
+        top: 20,
+      }));
+      fireEvent.mouseDown(getByRole('button'), { clientX: 10, clientY: 10 });
+      const rippleRipple = container.querySelector('.touch-ripple-ripple');
+      expect(rippleRipple).not.to.equal(null);
+      // @ts-ignore
+      const rippleStyle = window.getComputedStyle(rippleRipple);
+      expect(rippleStyle).to.have.property('height', '51px');
+      expect(rippleStyle).to.have.property('width', '51px');
+    });
+
+    it('renders the ripple with the right width and height 2', () => {
+      const { container, getByRole } = render(
+        <ButtonBase
+          centerRipple
+          TouchRippleProps={{ classes: { root: 'touch-ripple', ripple: 'touch-ripple-ripple' } }}
+        />,
+      );
+      // @ts-ignore
+      stub(container.querySelector('.touch-ripple'), 'getBoundingClientRect').callsFake(() => ({
+        width: 100,
+        height: 50,
+        bottom: 10,
+        left: 20,
+        top: 20,
+      }));
+      fireEvent.mouseDown(getByRole('button'), { clientX: 10, clientY: 10 });
+      const rippleRipple = container.querySelector('.touch-ripple-ripple');
+      expect(rippleRipple).not.to.equal(null);
+      // @ts-ignore
+      const rippleStyle = window.getComputedStyle(rippleRipple);
+      expect(rippleStyle).to.have.property('height', '101px');
+      expect(rippleStyle).to.have.property('width', '101px');
+    });
   });
 
   describe('focusRipple', () => {

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -253,7 +253,7 @@ describe('<ButtonBase />', () => {
           <ButtonBase
             TouchRippleProps={{
               classes: {
-                ripplePulsate: 'ripple-pulsate',
+                rippleVisible: 'ripple-visible',
               },
             }}
           />,
@@ -263,7 +263,7 @@ describe('<ButtonBase />', () => {
 
         focusVisible(button);
 
-        expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(0);
+        expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(0);
       });
 
       it('should start the ripple when the mouse is pressed', () => {
@@ -495,7 +495,7 @@ describe('<ButtonBase />', () => {
                 action={buttonRef}
                 TouchRippleProps={{
                   classes: {
-                    ripplePulsate: 'ripple-pulsate',
+                    rippleVisible: 'ripple-visible',
                   },
                 }}
                 focusRipple
@@ -510,7 +510,7 @@ describe('<ButtonBase />', () => {
         const { container, getByTestId } = render(<App />);
 
         fireEvent.click(getByTestId('trigger'));
-        expect(container.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
+        expect(container.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
       });
 
       it('should stop the ripple on blur if disableTouchRipple is set', () => {
@@ -646,32 +646,13 @@ describe('<ButtonBase />', () => {
   });
 
   describe('focusRipple', () => {
-    it('should pulsate the ripple when focusVisible', () => {
-      const { getByRole } = render(
-        <ButtonBase
-          focusRipple
-          TouchRippleProps={{
-            classes: {
-              ripplePulsate: 'ripple-pulsate',
-            },
-          }}
-        />,
-      );
-      const button = getByRole('button');
-
-      simulatePointerDevice();
-      focusVisible(button);
-
-      expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
-    });
-
     it('should not stop the ripple when the mouse leaves', () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
           TouchRippleProps={{
             classes: {
-              ripplePulsate: 'ripple-pulsate',
+              rippleVisible: 'ripple-visible',
             },
           }}
         />,
@@ -682,17 +663,15 @@ describe('<ButtonBase />', () => {
       focusVisible(button);
       fireEvent.mouseLeave(button);
 
-      expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
+      expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
     });
-
-    it('should stop pulsate and start a ripple when the space button is pressed', () => {
+    it('should stop and start a ripple when the space button is pressed', () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
           TouchRippleProps={{
             classes: {
               childLeaving: 'child-leaving',
-              ripplePulsate: 'ripple-pulsate',
               rippleVisible: 'rippled-visible',
             },
           }}
@@ -704,18 +683,16 @@ describe('<ButtonBase />', () => {
       focusVisible(button);
       fireEvent.keyDown(button, { key: ' ' });
 
-      expect(button.querySelectorAll('.ripple-pulsate .child-leaving')).to.have.lengthOf(1);
       expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(0);
     });
 
-    it('should stop and re-pulsate when space bar is released', () => {
+    it('should stop and start ripple when space bar is released', () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
           TouchRippleProps={{
             classes: {
               childLeaving: 'child-leaving',
-              ripplePulsate: 'ripple-pulsate',
               rippleVisible: 'ripple-visible',
             },
           }}
@@ -725,11 +702,15 @@ describe('<ButtonBase />', () => {
 
       simulatePointerDevice();
       focusVisible(button);
+      expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(1);
+
       fireEvent.keyDown(button, { key: ' ' });
+      expect(button.querySelectorAll('.child-leaving')).to.have.lengthOf(1);
+      expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(2);
+
       fireEvent.keyUp(button, { key: ' ' });
 
-      expect(button.querySelectorAll('.ripple-pulsate .child-leaving')).to.have.lengthOf(1);
-      expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(2);
+      expect(button.querySelectorAll('.child-leaving')).to.have.lengthOf(2);
       expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(3);
     });
 

--- a/packages/mui-material/src/ButtonBase/Ripple.js
+++ b/packages/mui-material/src/ButtonBase/Ripple.js
@@ -6,22 +6,10 @@ import clsx from 'clsx';
  * @ignore - internal component.
  */
 function Ripple(props) {
-  const {
-    className,
-    classes,
-    pulsate = false,
-    rippleX,
-    rippleY,
-    rippleSize,
-    in: inProp,
-    onExited,
-    timeout,
-  } = props;
+  const { className, classes, rippleX, rippleY, rippleSize, in: inProp, onExited, timeout } = props;
   const [leaving, setLeaving] = React.useState(false);
 
-  const rippleClassName = clsx(className, classes.ripple, classes.rippleVisible, {
-    [classes.ripplePulsate]: pulsate,
-  });
+  const rippleClassName = clsx(className, classes.ripple, classes.rippleVisible);
 
   const rippleStyles = {
     width: rippleSize,
@@ -32,7 +20,6 @@ function Ripple(props) {
 
   const childClassName = clsx(classes.child, {
     [classes.childLeaving]: leaving,
-    [classes.childPulsate]: pulsate,
   });
 
   if (!inProp && !leaving) {
@@ -71,10 +58,6 @@ Ripple.propTypes = {
    * @ignore - injected from TransitionGroup
    */
   onExited: PropTypes.func,
-  /**
-   * If `true`, the ripple pulsates, typically indicating the keyboard focus state of an element.
-   */
-  pulsate: PropTypes.bool,
   /**
    * Diameter of the ripple.
    */

--- a/packages/mui-material/src/ButtonBase/Ripple.test.js
+++ b/packages/mui-material/src/ButtonBase/Ripple.test.js
@@ -17,7 +17,7 @@ describe('<Ripple />', () => {
     expect(ripple).not.to.have.class(classes.fast);
   });
 
-  describe('starting and stopping', () => {
+  describe('starting and stopping ripple', () => {
     it('should start the ripple', () => {
       const { container, setProps } = render(
         <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} />,
@@ -41,45 +41,7 @@ describe('<Ripple />', () => {
     });
   });
 
-  describe('pulsating and stopping 1', () => {
-    it('should render the ripple inside a pulsating Ripple', () => {
-      const { container } = render(
-        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} pulsate />,
-      );
-
-      const ripple = container.querySelector('span');
-      expect(ripple).to.have.class(classes.ripple);
-      expect(ripple).to.have.class(classes.ripplePulsate);
-      const child = container.querySelector('span > span');
-      expect(child).to.have.class(classes.childPulsate);
-    });
-
-    it('should start the ripple', () => {
-      const { container, setProps } = render(
-        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} pulsate />,
-      );
-
-      setProps({ in: true });
-
-      const ripple = container.querySelector('span');
-      expect(ripple).to.have.class(classes.rippleVisible);
-      const child = container.querySelector('span > span');
-      expect(child).to.have.class(classes.childPulsate);
-    });
-
-    it('should stop the ripple', () => {
-      const { container, setProps } = render(
-        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} pulsate />,
-      );
-
-      setProps({ in: true });
-      setProps({ in: false });
-      const child = container.querySelector('span > span');
-      expect(child).to.have.class(classes.childLeaving);
-    });
-  });
-
-  describe('pulsating and stopping 2', () => {
+  describe('starting and stopping ripple 2', () => {
     clock.withFakeTimers();
 
     it('handleExit should trigger a timer', () => {
@@ -93,7 +55,6 @@ describe('<Ripple />', () => {
           rippleX={0}
           rippleY={0}
           rippleSize={11}
-          pulsate
         />,
       );
 
@@ -115,7 +76,6 @@ describe('<Ripple />', () => {
           rippleX={0}
           rippleY={0}
           rippleSize={11}
-          pulsate
         />,
       );
 

--- a/packages/mui-material/src/ButtonBase/TouchRipple.d.ts
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.d.ts
@@ -5,7 +5,6 @@ import { TouchRippleClasses, TouchRippleClassKey } from './touchRippleClasses';
 export { TouchRippleClassKey };
 
 export interface StartActionOptions {
-  pulsate?: boolean;
   center?: boolean;
 }
 
@@ -15,7 +14,6 @@ export interface TouchRippleActions {
     options?: StartActionOptions,
     callback?: () => void,
   ) => void;
-  pulsate: (event?: React.SyntheticEvent) => void;
   stop: (event?: React.SyntheticEvent, callback?: () => void) => void;
 }
 

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -33,20 +33,6 @@ const exitKeyframe = keyframes`
   }
 `;
 
-const pulsateKeyframe = keyframes`
-  0% {
-    transform: scale(1);
-  }
-
-  50% {
-    transform: scale(0.92);
-  }
-
-  100% {
-    transform: scale(1);
-  }
-`;
-
 export const TouchRippleRoot = styled('span', {
   name: 'MuiTouchRipple',
   slot: 'Root',
@@ -79,10 +65,6 @@ export const TouchRippleRipple = styled(Ripple, {
     animation-timing-function: ${({ theme }) => theme.transitions.easing.easeInOut};
   }
 
-  &.${touchRippleClasses.ripplePulsate} {
-    animation-duration: ${({ theme }) => theme.transitions.duration.shorter}ms;
-  }
-
   & .${touchRippleClasses.child} {
     opacity: 1;
     display: block;
@@ -97,18 +79,6 @@ export const TouchRippleRipple = styled(Ripple, {
     animation-name: ${exitKeyframe};
     animation-duration: ${DURATION}ms;
     animation-timing-function: ${({ theme }) => theme.transitions.easing.easeInOut};
-  }
-
-  & .${touchRippleClasses.childPulsate} {
-    position: absolute;
-    /* @noflip */
-    left: 0px;
-    top: 0;
-    animation-name: ${pulsateKeyframe};
-    animation-duration: 2500ms;
-    animation-timing-function: ${({ theme }) => theme.transitions.easing.easeInOut};
-    animation-iteration-count: infinite;
-    animation-delay: 200ms;
   }
 `;
 
@@ -150,7 +120,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
 
   const startCommit = React.useCallback(
     (params) => {
-      const { pulsate, rippleX, rippleY, rippleSize, cb } = params;
+      const { rippleX, rippleY, rippleSize, cb } = params;
 
       setRipples((oldRipples) => [
         ...oldRipples,
@@ -159,13 +129,10 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
           classes={{
             ripple: clsx(classes.ripple, touchRippleClasses.ripple),
             rippleVisible: clsx(classes.rippleVisible, touchRippleClasses.rippleVisible),
-            ripplePulsate: clsx(classes.ripplePulsate, touchRippleClasses.ripplePulsate),
             child: clsx(classes.child, touchRippleClasses.child),
             childLeaving: clsx(classes.childLeaving, touchRippleClasses.childLeaving),
-            childPulsate: clsx(classes.childPulsate, touchRippleClasses.childPulsate),
           }}
           timeout={DURATION}
-          pulsate={pulsate}
           rippleX={rippleX}
           rippleY={rippleY}
           rippleSize={rippleSize}
@@ -180,8 +147,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
   const start = React.useCallback(
     (event = {}, options = {}, cb) => {
       const {
-        pulsate = false,
-        center = centerProp || options.pulsate,
+        center = centerProp,
         fakeElement = false, // For test purposes
       } = options;
 
@@ -247,7 +213,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
         if (startTimerCommit.current === null) {
           // Prepare the ripple effect.
           startTimerCommit.current = () => {
-            startCommit({ pulsate, rippleX, rippleY, rippleSize, cb });
+            startCommit({ rippleX, rippleY, rippleSize, cb });
           };
           // Delay the execution of the ripple effect.
           startTimer.current = setTimeout(() => {
@@ -258,15 +224,11 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
           }, DELAY_RIPPLE); // We have to make a tradeoff with this value.
         }
       } else {
-        startCommit({ pulsate, rippleX, rippleY, rippleSize, cb });
+        startCommit({ rippleX, rippleY, rippleSize, cb });
       }
     },
     [centerProp, startCommit],
   );
-
-  const pulsate = React.useCallback(() => {
-    start({}, { pulsate: true });
-  }, [start]);
 
   const stop = React.useCallback((event, cb) => {
     clearTimeout(startTimer.current);
@@ -296,11 +258,10 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
   React.useImperativeHandle(
     ref,
     () => ({
-      pulsate,
       start,
       stop,
     }),
-    [pulsate, start, stop],
+    [start, stop],
   );
 
   return (

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -225,7 +225,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
       }
 
       if (center) {
-        rippleSize = Math.sqrt((2 * rect.width ** 2 + rect.height ** 2) / 3);
+        rippleSize = Math.max(rect.width, rect.height);
 
         // For some reason the animation is broken on Mobile Chrome if the size is even.
         if (rippleSize % 2 === 0) {

--- a/packages/mui-material/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.test.js
@@ -132,7 +132,6 @@ describe('<TouchRipple />', () => {
         instance.start(
           {},
           {
-            pulsate: true,
             fakeElement: true,
           },
           cb,

--- a/packages/mui-material/src/Fab/Fab.test.js
+++ b/packages/mui-material/src/Fab/Fab.test.js
@@ -103,13 +103,7 @@ describe('<Fab />', () => {
 
   it('should have a focusRipple by default', async () => {
     const { getByRole } = render(
-      <Fab
-        TouchRippleProps={{
-          classes: { ripplePulsate: 'pulsate-focus-visible' },
-        }}
-      >
-        Fab
-      </Fab>,
+      <Fab TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }}>Fab</Fab>,
     );
     const button = getByRole('button');
 
@@ -118,17 +112,12 @@ describe('<Fab />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).not.to.equal(null);
+    expect(button.querySelector('.ripple-visible')).not.to.equal(null);
   });
 
   it('should pass disableFocusRipple to ButtonBase', async () => {
     const { getByRole } = render(
-      <Fab
-        TouchRippleProps={{
-          classes: { ripplePulsate: 'pulsate-focus-visible' },
-        }}
-        disableFocusRipple
-      >
+      <Fab TouchRippleProps={{ classes: { rippleVisible: 'ripple-visible' } }} disableFocusRipple>
         Fab
       </Fab>,
     );
@@ -139,7 +128,7 @@ describe('<Fab />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).to.equal(null);
+    expect(button.querySelector('.ripple-visible')).to.equal(null);
   });
 
   it('should render Icon children with right classes', () => {

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -34,7 +34,7 @@ describe('<Tab />', () => {
 
   it('should have a focusRipple by default', () => {
     const { container, getByRole } = render(
-      <Tab TouchRippleProps={{ classes: { ripplePulsate: 'focus-ripple' } }} />,
+      <Tab TouchRippleProps={{ classes: { rippleVisible: 'focus-ripple' } }} />,
     );
     // simulate pointer device
     fireEvent.pointerDown(document.body);
@@ -50,7 +50,7 @@ describe('<Tab />', () => {
 
   it('can disable the focusRipple', () => {
     const { container, getByRole } = render(
-      <Tab disableFocusRipple TouchRippleProps={{ classes: { ripplePulsate: 'focus-ripple' } }} />,
+      <Tab disableFocusRipple TouchRippleProps={{ classes: { rippleVisible: 'focus-ripple' } }} />,
     );
     // simulate pointer device
     fireEvent.pointerDown(document.body);

--- a/packages/mui-material/src/useTouchRipple/useTouchRipple.ts
+++ b/packages/mui-material/src/useTouchRipple/useTouchRipple.ts
@@ -37,7 +37,7 @@ const useTouchRipple = (props: UseTouchRippleProps) => {
 
   React.useEffect(() => {
     if (focusVisible && !disableFocusRipple && !disableRipple) {
-      rippleRef.current?.pulsate();
+      rippleRef.current?.start();
     }
   }, [rippleRef, focusVisible, disableFocusRipple, disableRipple]);
 
@@ -82,7 +82,7 @@ const useTouchRipple = (props: UseTouchRippleProps) => {
     ) {
       keydownRef.current = false;
       rippleRef.current.stop(event, () => {
-        rippleRef?.current?.pulsate(event);
+        rippleRef?.current?.start(event);
       });
     }
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #33303

**Problem:**
The focus ripple doesn't fit the whole width and height of the button

**Solution:**
Based on the explanations [this comment](https://github.com/mui/material-ui/issues/33303#issuecomment-1242805777), the solution is the removal of this behavior as it's not in accordance with the latest Material Design. Pulsate in the ButtonBase component mainly controlled this effect, so I updated the code and tests based on this removal.
Also, the way the width and height of the ripple were calculated caused additional paddings. I proposed to set it equal to the max of width and height.

The pulsate was shared with different components such as tabs, button, and fab.

Button demo in the doc: https://deploy-preview-34258--material-ui.netlify.app/material-ui/react-button/
Fab demo in the doc: https://deploy-preview-34258--material-ui.netlify.app/material-ui/react-floating-action-button/
Tabs demo in the doc: https://deploy-preview-34258--material-ui.netlify.app/material-ui/react-tabs/