### PR TITLE
Issue template: move reproduction steps to the top

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -24,14 +24,6 @@ body:
           required: true
   - type: textarea
     attributes:
-      label: Current behavior 😯
-      description: Describe what happens instead of the expected behavior.
-  - type: textarea
-    attributes:
-      label: Expected behavior 🤔
-      description: Describe what should happen.
-  - type: textarea
-    attributes:
       label: Steps to reproduce 🕹
       description: |
         Please provide a link to a live example and an unambiguous set of steps to reproduce this bug.
@@ -47,7 +39,14 @@ body:
         1.
         2.
         3.
-        4.
+  - type: textarea
+    attributes:
+      label: Current behavior 😯
+      description: Describe what happens instead of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Expected behavior 🤔
+      description: Describe what should happen.
   - type: textarea
     attributes:
       label: Context 🔦


### PR DESCRIPTION
Following up on https://github.com/mui/mui-toolpad/pull/908 which proposes to experiment with this in the core repo first.

When creating issues an issue I tend to
1. describe the steps that lead me to the situation
2. explain what's buggy about it
3. explain what the correct behavior may be

in that order. However, the issue template puts 1. after 3. Whenever I file a core bug report, it feels like the issue template works against me. 