### PR TITLE
[Joy] Adjust the `Input` and `Textarea` styles

### DIFF
--- a/docs/data/joy/components/text-field/TextFieldUsage.js
+++ b/docs/data/joy/components/text-field/TextFieldUsage.js
@@ -15,6 +15,11 @@ export default function TextFieldUsage() {
           options: ['plain', 'outlined', 'soft', 'solid'],
         },
         {
+          propName: 'color',
+          knob: 'color',
+          defaultValue: 'neutral',
+        },
+        {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],

--- a/docs/data/joy/components/textarea/TextareaUsage.js
+++ b/docs/data/joy/components/textarea/TextareaUsage.js
@@ -14,6 +14,11 @@ export default function TextareaUsage() {
           options: ['plain', 'outlined', 'soft', 'solid'],
         },
         {
+          propName: 'color',
+          knob: 'color',
+          defaultValue: 'neutral',
+        },
+        {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -115,7 +115,6 @@ const InputRoot = styled('div', {
       // variant styles
       ...variantStyle,
       '&:hover': {
-        ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
         cursor: 'text',
       },
       [`&.${inputClasses.disabled}`]:

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -85,9 +85,6 @@ const InputRoot = styled('div', {
       alignItems: 'center',
       paddingInline: `var(--Input-paddingInline)`,
       borderRadius: 'var(--Input-radius)',
-      ...(!variantStyle?.backgroundColor && {
-        backgroundColor: theme.vars.palette.background.surface,
-      }),
       fontFamily: theme.vars.fontFamily.body,
       fontSize: theme.vars.fontSize.md,
       ...(ownerState.size === 'sm' && {
@@ -114,16 +111,16 @@ const InputRoot = styled('div', {
     {
       // variant styles
       ...variantStyle,
-      '&:hover': {
+      backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
+      [`&:hover:not(.${inputClasses.focused})`]: {
+        ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
+        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
         cursor: 'text',
       },
       [`&.${inputClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-    },
-    // This style has to come after the global variant to set the background to surface
-    ownerState.variant !== 'solid' && {
       [`&.${inputClasses.focused}`]: {
-        backgroundColor: theme.vars.palette.background.surface,
+        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
         '&:before': {
           boxShadow: `inset 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
         },
@@ -173,6 +170,7 @@ const InputStartDecorator = styled('span', {
   alignItems: 'center',
   marginInlineEnd: 'var(--Input-gap)',
   color: theme.vars.palette.text.tertiary,
+  cursor: 'initial',
   ...(ownerState.focused && {
     color: theme.vars.palette[ownerState.color!]?.[`${ownerState.variant!}Color`],
   }),
@@ -190,6 +188,7 @@ const InputEndDecorator = styled('span', {
   alignItems: 'center',
   marginInlineStart: 'var(--Input-gap)',
   color: theme.vars.palette[ownerState.color!]?.[`${ownerState.variant!}Color`],
+  cursor: 'initial',
 }));
 
 const Input = React.forwardRef(function Input(inProps, ref) {

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -92,7 +92,7 @@ const InputRoot = styled('div', {
       }),
       // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
       transition:
-        'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+        'border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
       '&:before': {
         boxSizing: 'border-box',
         content: '""',
@@ -114,13 +114,13 @@ const InputRoot = styled('div', {
       backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
       [`&:hover:not(.${inputClasses.focused})`]: {
         ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
+        backgroundColor: variantStyle?.backgroundColor,
         cursor: 'text',
       },
       [`&.${inputClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
       [`&.${inputClasses.focused}`]: {
-        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
+        backgroundColor: variantStyle?.backgroundColor,
         '&:before': {
           boxShadow: `inset 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
         },

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -114,13 +114,12 @@ const InputRoot = styled('div', {
       backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
       [`&:hover:not(.${inputClasses.focused})`]: {
         ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-        backgroundColor: variantStyle?.backgroundColor,
+        backgroundColor: null, // it is not common to change background on hover for Input
         cursor: 'text',
       },
       [`&.${inputClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
       [`&.${inputClasses.focused}`]: {
-        backgroundColor: variantStyle?.backgroundColor,
         '&:before': {
           boxShadow: `inset 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
         },

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -115,13 +115,12 @@ const TextareaRoot = styled('div', {
       backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
       [`&:hover:not(.${textareaClasses.focused})`]: {
         ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-        backgroundColor: variantStyle?.backgroundColor,
+        backgroundColor: null, // it is not common to change background on hover for Input
         cursor: 'text',
       },
       [`&.${textareaClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
       [`&.${textareaClasses.focused}`]: {
-        backgroundColor: variantStyle?.backgroundColor,
         '&:before': {
           boxShadow: `inset 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
         },

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -116,7 +116,6 @@ const TextareaRoot = styled('div', {
       // variant styles
       ...variantStyle,
       '&:hover': {
-        ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
         cursor: 'text',
       },
       [`&.${textareaClasses.disabled}`]:

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -84,9 +84,6 @@ const TextareaRoot = styled('div', {
       paddingInlineStart: `var(--Textarea-paddingInline)`, // the paddingInlineEnd is added to the textarea. It looks better when the scrollbar appears.
       paddingBlock: 'var(--Textarea-paddingBlock)',
       borderRadius: 'var(--Textarea-radius)',
-      ...(!variantStyle?.backgroundColor && {
-        backgroundColor: theme.vars.palette.background.surface,
-      }),
       fontFamily: theme.vars.fontFamily.body,
       fontSize: theme.vars.fontSize.md,
       lineHeight: theme.vars.lineHeight.md,
@@ -115,16 +112,16 @@ const TextareaRoot = styled('div', {
     {
       // variant styles
       ...variantStyle,
-      '&:hover': {
+      backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
+      [`&:hover:not(.${textareaClasses.focused})`]: {
+        ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
+        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
         cursor: 'text',
       },
       [`&.${textareaClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-    },
-    // This style has to come after the global variant to set the background to surface
-    ownerState.variant !== 'solid' && {
       [`&.${textareaClasses.focused}`]: {
-        backgroundColor: theme.vars.palette.background.surface,
+        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
         '&:before': {
           boxShadow: `inset 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
         },
@@ -176,6 +173,7 @@ const TextareaStartDecorator = styled('div', {
   marginInlineEnd: 'var(--Textarea-paddingBlock)',
   marginBlockEnd: 'var(--Textarea-gap)',
   color: theme.vars.palette.text.tertiary,
+  cursor: 'initial',
 }));
 
 const TextareaEndDecorator = styled('div', {
@@ -188,6 +186,7 @@ const TextareaEndDecorator = styled('div', {
   marginInlineEnd: 'var(--Textarea-paddingBlock)',
   marginBlockStart: 'var(--Textarea-gap)',
   color: theme.vars.palette.text.tertiary,
+  cursor: 'initial',
 }));
 
 const Textarea = React.forwardRef(function Textarea(inProps, ref) {

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -93,7 +93,7 @@ const TextareaRoot = styled('div', {
       }),
       // TODO: discuss the transition approach in a separate PR. This value is copied from mui-material Button.
       transition:
-        'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+        'border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
       '&:before': {
         boxSizing: 'border-box',
         content: '""',
@@ -115,13 +115,13 @@ const TextareaRoot = styled('div', {
       backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
       [`&:hover:not(.${textareaClasses.focused})`]: {
         ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
+        backgroundColor: variantStyle?.backgroundColor,
         cursor: 'text',
       },
       [`&.${textareaClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
       [`&.${textareaClasses.focused}`]: {
-        backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
+        backgroundColor: variantStyle?.backgroundColor,
         '&:before': {
           boxShadow: `inset 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR preserves the same background when hovering on the `Input` or `Textarea`.

## Benchmarks

From the benchmarks, all the popular libraries don't have hovered background:
- https://developer.microsoft.com/en-us/fluentui#/controls/web/textfield
- https://mantine.dev/core/input/
- https://design-system-git-main-strapijs.vercel.app/?path=/story/design-system-components-field--base
- https://getbootstrap.com/docs/5.0/forms/form-control/
- https://chakra-ui.com/docs/components/input/usage
- https://react-spectrum.adobe.com/react-spectrum/TextField.html
- https://ant.design/components/input/#header

## Changes

[**Before**](https://mui.com/joy-ui/react-textarea/):

https://user-images.githubusercontent.com/18292247/189567090-1932d084-021d-446c-9270-b58251fbcaf8.mov

When the decorators are actionable, the hovered background makes actions harder to perceive.

[**After**](https://deploy-preview-34281--material-ui.netlify.app/joy-ui/react-textarea/):

https://user-images.githubusercontent.com/18292247/189567283-f039ba3d-48db-4ea5-bed6-04dbc3ff17b3.mov




- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
