### PR TITLE
[blog] Correct 2021 survey data interpretation

### DIFF
--- a/docs/pages/blog/2021-developer-survey-results.md
+++ b/docs/pages/blog/2021-developer-survey-results.md
@@ -462,7 +462,7 @@ It's crucial for our docs—and even the code itself—to be easily understood b
 
 <p class="blog-description">1051 out of 1589 answered.</p>
 
-Roughly half—47%—of those who responded to this question shipped one app or simply maintained an existing app.
+Roughly half (47%) of those who responded to this question shipped one app or simply maintained an existing app.
 Impressively, 5% of respondents delivered six or more apps, and more than half of those surpassed 10!
 
 ### Which MUI products do you use in your application?

--- a/docs/pages/blog/2021-developer-survey-results.md
+++ b/docs/pages/blog/2021-developer-survey-results.md
@@ -462,7 +462,8 @@ It's crucial for our docs—and even the code itself—to be easily understood b
 
 <p class="blog-description">1051 out of 1589 answered.</p>
 
-It might be a possible interpration that MUI could be one of the enablers of this high-speed development, which is very encouraging. Shipping 28 apps in a year is already a huge accomplishment but 122 to 494 is just wild!
+Roughly half—47%—of those who responded to this question shipped one app or simply maintained an existing app.
+Impressively, 5% of respondents delivered 6 or more apps, and more than half of those surpassed 10!
 
 ### Which MUI products do you use in your application?
 

--- a/docs/pages/blog/2021-developer-survey-results.md
+++ b/docs/pages/blog/2021-developer-survey-results.md
@@ -463,7 +463,7 @@ It's crucial for our docs—and even the code itself—to be easily understood b
 <p class="blog-description">1051 out of 1589 answered.</p>
 
 Roughly half—47%—of those who responded to this question shipped one app or simply maintained an existing app.
-Impressively, 5% of respondents delivered 6 or more apps, and more than half of those surpassed 10!
+Impressively, 5% of respondents delivered six or more apps, and more than half of those surpassed 10!
 
 ### Which MUI products do you use in your application?
 


### PR DESCRIPTION
This PR addresses some user feedback regarding the [2021 developer survey results post](https://mui.com/blog/2021-developer-survey-results/).

The original draft misinterpreted the data from the question "How many web applications did you or your team deliver using MUI this year?" by mixing up the x and y axes. I've rewritten the text there to correct this.

https://deploy-preview-34291--material-ui.netlify.app/blog/2021-developer-survey-results/