### PR TITLE
[core] In `typescript-to-proptypes`, respect the value pass to the generic

### DIFF
--- a/docs/data/base/components/select/UnstyledSelectIntroduction.js
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction.js
@@ -56,7 +56,7 @@ Button.propTypes = {
       root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     }),
     defaultListboxOpen: PropTypes.bool,
-    defaultValue: PropTypes.object,
+    defaultValue: PropTypes.any,
     disabled: PropTypes.bool.isRequired,
     focusVisible: PropTypes.bool.isRequired,
     getSerializedValue: PropTypes.func,
@@ -68,7 +68,7 @@ Button.propTypes = {
     open: PropTypes.bool.isRequired,
     optionStringifier: PropTypes.func,
     renderValue: PropTypes.func,
-    value: PropTypes.object,
+    value: PropTypes.any,
   }).isRequired,
 };
 

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -278,7 +278,7 @@ SelectUnstyled.propTypes /* remove-proptypes */ = {
   /**
    * The default selected value. Use when the component is not controlled.
    */
-  defaultValue: PropTypes /* @typescript-to-proptypes-ignore */.any,
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the select is disabled.
    * @default false
@@ -330,7 +330,7 @@ SelectUnstyled.propTypes /* remove-proptypes */ = {
    * The selected value.
    * Set to `null` to deselect all options.
    */
-  value: PropTypes /* @typescript-to-proptypes-ignore */.any,
+  value: PropTypes.any,
 } as any;
 
 export default SelectUnstyled;

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -610,7 +610,7 @@ Select.propTypes /* remove-proptypes */ = {
   /**
    * The default selected value. Use when the component is not controlled.
    */
-  defaultValue: PropTypes /* @typescript-to-proptypes-ignore */.any,
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the component is disabled.
    * @default false
@@ -666,7 +666,7 @@ Select.propTypes /* remove-proptypes */ = {
    * The selected value.
    * Set to `null` to deselect all options.
    */
-  value: PropTypes /* @typescript-to-proptypes-ignore */.any,
+  value: PropTypes.any,
   /**
    * The variant to use.
    * @default 'solid'

--- a/packages/mui-material/src/CardHeader/CardHeader.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.js
@@ -176,7 +176,7 @@ CardHeader.propTypes /* remove-proptypes */ = {
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
    */
-  component: PropTypes /* @typescript-to-proptypes-ignore */.elementType,
+  component: PropTypes.elementType,
   /**
    * If `true`, `subheader` and `title` won't be wrapped by a Typography component.
    * This can be useful to render an alternative Typography variant by wrapping

--- a/packages/typescript-to-proptypes/src/parser.ts
+++ b/packages/typescript-to-proptypes/src/parser.ts
@@ -186,12 +186,6 @@ export function parseFromProgram(
       return t.createObjectType({ jsDoc: undefined });
     }
 
-    const defaultGenericType = type.getDefault();
-    // This is generic type – use default type <T = SomeDefaultType>
-    if (defaultGenericType) {
-      return checkType(defaultGenericType, location, typeStack, name);
-    }
-
     {
       const typeNode = type as any;
 
@@ -267,6 +261,21 @@ export function parseFromProgram(
       });
 
       return node.types.length === 1 ? node.types[0] : node;
+    }
+
+    if (type.flags & ts.TypeFlags.TypeParameter) {
+      const baseConstraintOfType = checker.getBaseConstraintOfType(type);
+
+      if (baseConstraintOfType) {
+        if (
+          baseConstraintOfType.flags & ts.TypeFlags.Object &&
+          baseConstraintOfType.symbol.members?.size === 0
+        ) {
+          return t.createAnyType({ jsDoc: getDocumentation(type.symbol) });
+        }
+
+        return checkType(baseConstraintOfType!, location, typeStack, name);
+      }
     }
 
     if (type.flags & ts.TypeFlags.String) {
@@ -421,15 +430,24 @@ export function parseFromProgram(
         // so we just pick the first and ignore the rest
         checker.getTypeOfSymbolAtLocation(symbol, declaration)
       : checker.getTypeOfSymbolAtLocation(symbol, location);
-    // get `React.ElementType` from `C extends React.ElementType`
-    const declaredType =
-      declaration !== undefined ? checker.getTypeAtLocation(declaration) : undefined;
-    const baseConstraintOfType =
-      declaredType !== undefined ? checker.getBaseConstraintOfType(declaredType) : undefined;
-    const type =
-      baseConstraintOfType !== undefined && baseConstraintOfType !== declaredType
-        ? baseConstraintOfType
-        : symbolType;
+
+    let type: ts.Type;
+    if (declaration === undefined) {
+      type = symbolType;
+    } else {
+      const declaredType = checker.getTypeAtLocation(declaration);
+      const baseConstraintOfType = checker.getBaseConstraintOfType(declaredType);
+
+      if (baseConstraintOfType === undefined || baseConstraintOfType === declaredType) {
+        type = symbolType;
+      }
+      // get `React.ElementType` from `C extends React.ElementType`
+      else if (baseConstraintOfType.aliasSymbol?.escapedName === 'ElementType') {
+        type = baseConstraintOfType;
+      } else {
+        type = symbolType;
+      }
+    }
 
     if (!type) {
       throw new Error('No types found');

--- a/packages/typescript-to-proptypes/test/generic/input.d.ts
+++ b/packages/typescript-to-proptypes/test/generic/input.d.ts
@@ -1,0 +1,10 @@
+type Type = 'one' | 'two' | 'three'
+
+interface ParentProps<T extends Type> {
+  optionalType?: T;
+  requiredType: T
+}
+
+interface ChildProps extends ParentProps<'one' | 'two'> {}
+
+export function Foo(props: ChildProps): JSX.Element;

--- a/packages/typescript-to-proptypes/test/generic/output.js
+++ b/packages/typescript-to-proptypes/test/generic/output.js
@@ -1,0 +1,4 @@
+Foo.propTypes = {
+  optionalType: PropTypes.oneOf(['one', 'two']),
+  requiredType: PropTypes.oneOf(['one', 'two']).isRequired,
+};


### PR DESCRIPTION
While working on X, I noticed that the generation of the proptypes does not work well in the following scenario:

```tsx
type Type = 'one' | 'two' | 'three'

interface ParentProps<T extends Type> {
  A: T;
}

interface ChildProps extends ParentProps<'one' | 'two'> {}

export function Foo(props: ChildProps): JSX.Element;

// Should output:
Foo.propTypes = {
  A: PropTypes.oneOf(['one', 'two']).isRequired,
};

// But outputs:
Foo.propTypes = {
  A: PropTypes.oneOf(['one', 'two', 'three']).isRequired,
};
```

We even looses the optional in the following scenario:

```tsx
type Type = 'one' | 'two' | 'three'

interface ParentProps<T extends Type> {
  A: T;
}

interface ChildProps extends Partial<ParentProps<'one' | 'two'>> {}

export function Foo(props: ChildProps): JSX.Element;

// Should output:
Foo.propTypes = {
  A: PropTypes.oneOf(['one', 'two']),
};

// But outputs:
Foo.propTypes = {
  A: PropTypes.oneOf(['one', 'two', 'three']).isRequired,
};
```

The issue is that, when we have a prop that equals a generic value, then we apply its base constraints (in `<A extends B>`, we apply B).
From what I understand, it was purely done to avoid weird behaviors for scenario like `<A extends React.ElementType>`, where TTP was considering `A` as a union.

____

My solution is simply to only keep this custom behavior for `React.ElementType`.
It is not 100% safe, if you have a better idea I am open of course.

There was one issue on the `AutoComplete` component with the generics that have `undefined` by default.
Before, ttp generated the type from there constrain (`boolean | undefined`), but now it generates the type from the whole type. And the behavior in that situation was to apply the default value.
But you can't create a proptype for something always undefined.
I think it's better to apply the constraint in this scenario rather than the default value.

```tsx
export interface AutocompleteProps<
  DisableClearable extends boolean | undefined = undefined,
> {
  disableClearable?: DisableClearable;
}
```