### PR TITLE
[website] Fix MUI X subscribe email border style

### DIFF
--- a/docs/src/components/productX/XComponents.tsx
+++ b/docs/src/components/productX/XComponents.tsx
@@ -223,15 +223,7 @@ export default function XComponents() {
                         Subscribe to our newsletter to get first-hand info about the development and
                         release of new components.
                       </Typography>
-                      <EmailSubscribe
-                        sx={{
-                          '& > div': {
-                            maxWidth: 'initial',
-                            border: '1px solid',
-                            borderColor: 'primaryDark.600',
-                          },
-                        }}
-                      />
+                      <EmailSubscribe />
                     </Frame.Info>
                   </ThemeProvider>
                 </Frame>

--- a/docs/src/components/productX/XDateRangeDemo.tsx
+++ b/docs/src/components/productX/XDateRangeDemo.tsx
@@ -102,15 +102,7 @@ export default function XDateRangeDemo() {
             Subscribe to our newsletter to get first-hand info about the development and release of
             new components.
           </Typography>
-          <EmailSubscribe
-            sx={{
-              '& > div': {
-                maxWidth: 'initial',
-                border: '1px solid',
-                borderColor: 'primaryDark.600',
-              },
-            }}
-          />
+          <EmailSubscribe />
         </Frame.Info>
       </ThemeProvider>
     </Frame>

--- a/docs/src/components/productX/XTreeViewDemo.tsx
+++ b/docs/src/components/productX/XTreeViewDemo.tsx
@@ -293,15 +293,7 @@ export default function XDateRangeDemo() {
             Subscribe to our newsletter to get first-hand info about the development and release of
             new components.
           </Typography>
-          <EmailSubscribe
-            sx={{
-              '& > div': {
-                maxWidth: 'initial',
-                border: '1px solid',
-                borderColor: 'primaryDark.600',
-              },
-            }}
-          />
+          <EmailSubscribe />
         </Frame.Info>
       </ThemeProvider>
     </Frame>


### PR DESCRIPTION
We used to see this:

<img width="589" alt="Screenshot 2022-09-16 at 00 23 07" src="https://user-images.githubusercontent.com/3165635/190519133-323a6e0c-302e-4b83-9b4f-ec4321a2bc75.png">

https://62d59767934a0000083cd4e9--material-ui-docs.netlify.app/x/ (v5.9.1)

After #33585, we now have:

<img width="600" alt="Screenshot 2022-09-16 at 00 23 32" src="https://user-images.githubusercontent.com/3165635/190519221-f42fbf55-8f1a-4193-a57c-929ba615e49d.png">

https://62deb307440fcb0008f9665d--material-ui-docs.netlify.app/x/ (v5.9.2)

This PR removes the custom style, to have the same section look like this: 

<img width="602" alt="Screenshot 2022-09-16 at 00 24 18" src="https://user-images.githubusercontent.com/3165635/190519279-78622c17-0e8c-44fc-9a61-009fb9617996.png">

https://deploy-preview-34330--material-ui.netlify.app/x/

I found this by chance while we were talking with MUI X about the need to refresh this marketing page. The page was created a year ago, things are evolving on MUI X.