### PR TITLE
[docs] Improve social sharing of docs pages

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -109,7 +109,12 @@ function AppLayoutDocs(props) {
         }}
       />
       <AdManager>
-        <Head title={`${title} - ${productName}`} description={description} />
+        <Head
+          title={`${title} - ${productName}`}
+          description={description}
+          largeCard={false}
+          card="https://mui.com/static/logo.png"
+        />
         {disableAd ? null : (
           <AdGuest>
             <Ad />

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -34,7 +34,7 @@ JoyModeObserver.propTypes = {
   mode: PropTypes.oneOf(['light', 'dark']),
 };
 
-function MarkdownDocs(props) {
+export default function MarkdownDocs(props) {
   const theme = useTheme();
   const router = useRouter();
   const asPathWithoutLang = router.asPath.replace(/^\/[a-zA-Z]{2}\//, '/');
@@ -144,5 +144,3 @@ MarkdownDocs.propTypes = {
 if (process.env.NODE_ENV !== 'production') {
   MarkdownDocs.propTypes = exactProp(MarkdownDocs.propTypes);
 }
-
-export default MarkdownDocs;

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -214,10 +214,11 @@ function TopLayoutBlog(props) {
   const { description, rendered, title, headers } = docs.en;
   const finalTitle = title || headers.title;
   const router = useRouter();
+  const slug = router.pathname.replace(/\/blog\//, '');
   const { canonicalAs } = pathnameToLanguage(router.asPath);
   const card =
     headers.card === 'true'
-      ? `https://mui.com/static${router.pathname}/card.png`
+      ? `https://mui.com/static/blog/${slug}/card.png`
       : 'https://mui.com/static/logo.png';
 
   return (


### PR DESCRIPTION
Same rationale as #32536. When sharing a page to a specific docs page, the social image creates confusion https://twitter.com/olivtassinari/status/1571093885644046339.

Going forward, I think that we have two opportunities to improve, by increasing effort & outcome:

1. Something like https://github.com/mui/material-ui/pull/32536#issuecomment-1120263622, one very low distraction illustration, like "Material UI", one per product
2. Something custom for each page https://www.notion.so/mui-org/Page-image-generator-75bc177fefe64c0b899a42a6f919a907

A bit related to #32181