### PR TITLE
Adding functionality for custom color use on IconButton.

### DIFF
--- a/docs/data/material/components/buttons/IconButtonCustomColor.js
+++ b/docs/data/material/components/buttons/IconButtonCustomColor.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import IconButton from '@mui/material/IconButton';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AlarmIcon from '@mui/icons-material/Alarm';
+
+export default function IconButtonColors() {
+  return (
+    <Stack direction="row" spacing={1}>
+      <IconButton aria-label="delete" style={{ color: 'red' }}>
+        <DeleteIcon />
+      </IconButton>
+      <IconButton aria-label="alarm" style={{ color: '#1A086C' }}>
+        <AlarmIcon />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/buttons/IconButtonCustomColor.tsx
+++ b/docs/data/material/components/buttons/IconButtonCustomColor.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import IconButton from '@mui/material/IconButton';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AlarmIcon from '@mui/icons-material/Alarm';
+
+export default function IconButtonColors() {
+  return (
+    <Stack direction="row" spacing={1}>
+      <IconButton aria-label="delete" style={{ color: 'red' }}>
+        <DeleteIcon />
+      </IconButton>
+      <IconButton aria-label="alarm" style={{ color: '#1A086C' }}>
+        <AlarmIcon />
+      </IconButton>
+    </Stack>
+  );
+}

--- a/docs/data/material/components/buttons/IconButtonCustomColor.tsx.preview
+++ b/docs/data/material/components/buttons/IconButtonCustomColor.tsx.preview
@@ -1,0 +1,6 @@
+<IconButton aria-label="delete" style={{ color: "red"}}>
+  <DeleteIcon />
+</IconButton>
+<IconButton aria-label="alarm" style={{ color: "#1A086C"}}>
+  <AlarmIcon />
+</IconButton>

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -116,6 +116,10 @@ Use `color` prop to apply theme color palette to component.
 
 {{"demo": "IconButtonColors.js"}}
 
+> Note: You can only use 8 colors with color attribute `inherit | default | primary | secondary | error | info | success | warning`, which gives limited usability of colors. To bring more customization to color we can use `style` attribute.
+
+{{"demo": "IconButtonCustomColor.js"}}
+
 ## Customization
 
 Here are some examples of customizing the component.


### PR DESCRIPTION

Color customizarion for IconButton could only use 8 ( like primary, secondary, danger, etc...). With this we can use numerous colors with the help of HEX code. Also edited the documentation for this.