### PR TITLE
[base] POC: Allow customizing generated class names

### DIFF
--- a/packages/mui-base/src/ClassNameConfigurator/ClassNameConfigurator.test.tsx
+++ b/packages/mui-base/src/ClassNameConfigurator/ClassNameConfigurator.test.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import SwitchUnstyled, { switchUnstyledClasses } from '@mui/base/SwitchUnstyled';
+import ClassNameConfigurator from '@mui/base/ClassNameConfigurator';
+import { createRenderer } from 'test/utils';
+import { expect } from 'chai';
+
+describe('ClassNameConfigurator', () => {
+  const { render } = createRenderer();
+
+  it('should apply default classes when not configured', () => {
+    const { container } = render(<SwitchUnstyled defaultChecked disabled />);
+
+    const switchComponent = container.firstChild!;
+
+    expect(switchComponent).to.have.class(switchUnstyledClasses.root);
+    expect(switchComponent).to.have.class(switchUnstyledClasses.checked);
+    expect(switchComponent).to.have.class(switchUnstyledClasses.disabled);
+
+    expect(switchComponent.childNodes[0]).to.have.class(switchUnstyledClasses.track);
+    expect(switchComponent.childNodes[1]).to.have.class(switchUnstyledClasses.thumb);
+    expect(switchComponent.childNodes[2]).to.have.class(switchUnstyledClasses.input);
+  });
+
+  it('should override the default class names when configured', () => {
+    function classNameGenerator(component: string, slot: string) {
+      return `test:${component.toLowerCase()}/${slot}`;
+    }
+
+    const { container } = render(
+      <ClassNameConfigurator generator={classNameGenerator}>
+        <SwitchUnstyled defaultChecked disabled />
+      </ClassNameConfigurator>,
+    );
+
+    const switchComponent = container.firstChild!;
+
+    expect(switchComponent).to.have.class('test:switch/root');
+    expect(switchComponent).not.to.have.class(switchUnstyledClasses.root);
+    expect(switchComponent).to.have.class('test:switch/checked');
+    expect(switchComponent).not.to.have.class(switchUnstyledClasses.checked);
+    expect(switchComponent).to.have.class('test:switch/disabled');
+    expect(switchComponent).not.to.have.class(switchUnstyledClasses.disabled);
+
+    expect(switchComponent.childNodes[0]).to.have.class('test:switch/track');
+    expect(switchComponent.childNodes[0]).not.to.have.class(switchUnstyledClasses.track);
+    expect(switchComponent.childNodes[1]).to.have.class('test:switch/thumb');
+    expect(switchComponent.childNodes[1]).not.to.have.class(switchUnstyledClasses.thumb);
+    expect(switchComponent.childNodes[2]).to.have.class('test:switch/input');
+    expect(switchComponent.childNodes[2]).not.to.have.class(switchUnstyledClasses.input);
+  });
+
+  it('should not generate any classes when configured as such', () => {
+    const { container } = render(
+      <ClassNameConfigurator disableClasses>
+        <SwitchUnstyled defaultChecked disabled />
+      </ClassNameConfigurator>,
+    );
+
+    const switchComponent = container.firstChild!;
+
+    expect(switchComponent).not.to.have.class(switchUnstyledClasses.root);
+    expect(switchComponent).not.to.have.class(switchUnstyledClasses.checked);
+    expect(switchComponent).not.to.have.class(switchUnstyledClasses.disabled);
+
+    expect(switchComponent.childNodes[0]).not.to.have.class(switchUnstyledClasses.track);
+    expect(switchComponent.childNodes[1]).not.to.have.class(switchUnstyledClasses.thumb);
+    expect(switchComponent.childNodes[2]).not.to.have.class(switchUnstyledClasses.input);
+  });
+
+  it('should not remove custom classes when disableClasses is set', () => {
+    const { container } = render(
+      <ClassNameConfigurator disableClasses>
+        <SwitchUnstyled
+          className="custom-switch"
+          componentsProps={{
+            track: { className: 'custom-track' },
+            thumb: { className: 'custom-thumb' },
+            input: { className: 'custom-input' },
+          }}
+        />
+      </ClassNameConfigurator>,
+    );
+
+    const switchComponent = container.firstChild!;
+
+    expect(switchComponent).to.have.class('custom-switch');
+    expect(switchComponent.childNodes[0]).to.have.class('custom-track');
+    expect(switchComponent.childNodes[1]).to.have.class('custom-thumb');
+    expect(switchComponent.childNodes[2]).to.have.class('custom-input');
+  });
+});

--- a/packages/mui-base/src/ClassNameConfigurator/ClassNameConfigurator.tsx
+++ b/packages/mui-base/src/ClassNameConfigurator/ClassNameConfigurator.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { unstable_generateUtilityClass as generalGenerateUtilityClass } from '@mui/utils';
+import baseGenerateUtilityClass from '../generateUtilityClass';
+
+type Product = 'Material UI' | 'Joy UI' | 'MUI Base';
+
+export type ClassNameGenerator = (
+  componentName: string,
+  className: string,
+  product: Product,
+) => string;
+
+const ClassNameConfiguratorContext = React.createContext<ClassNameGenerator | undefined>(undefined);
+
+type ClassNameConfiguratorProps =
+  | {
+      children?: React.ReactNode;
+      disableClasses?: undefined | false;
+      generator: ClassNameGenerator;
+    }
+  | {
+      children?: React.ReactNode;
+      disableClasses: true;
+      generator?: undefined;
+    };
+
+function defaultClassNameGenerator(componentName: string, className: string, product: Product) {
+  if (product === 'MUI Base') {
+    return baseGenerateUtilityClass(`Mui${componentName}`, className);
+  }
+
+  return generalGenerateUtilityClass(`Mui${componentName}`, className);
+}
+
+function voidClassNameGenerator() {
+  return '';
+}
+
+export function useClassNameGenerator() {
+  const customGenerator = React.useContext(ClassNameConfiguratorContext);
+  if (customGenerator === undefined) {
+    return defaultClassNameGenerator;
+  }
+
+  return customGenerator;
+}
+
+export default function ClassNameConfigurator(props: ClassNameConfiguratorProps) {
+  const { generator, disableClasses, children } = props;
+
+  return (
+    <ClassNameConfiguratorContext.Provider
+      value={disableClasses ? voidClassNameGenerator : generator}
+    >
+      {children}
+    </ClassNameConfiguratorContext.Provider>
+  );
+}

--- a/packages/mui-base/src/ClassNameConfigurator/index.ts
+++ b/packages/mui-base/src/ClassNameConfigurator/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ClassNameConfigurator';
+export * from './ClassNameConfigurator';

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { OverridableComponent } from '@mui/types';
 import composeClasses from '../composeClasses';
 import useSwitch from './useSwitch';
-import { getSwitchUnstyledUtilityClass } from './switchUnstyledClasses';
 import {
   SwitchUnstyledProps,
   SwitchUnstyledOwnerState,
@@ -14,9 +13,11 @@ import {
   SwitchUnstyledTypeMap,
 } from './SwitchUnstyled.types';
 import { useSlotProps, WithOptionalOwnerState } from '../utils';
+import { useClassNameGenerator } from '../ClassNameConfigurator';
 
 const useUtilityClasses = (ownerState: SwitchUnstyledOwnerState) => {
   const { checked, disabled, focusVisible, readOnly } = ownerState;
+  const generateClassName = useClassNameGenerator();
 
   const slots = {
     root: [
@@ -31,7 +32,7 @@ const useUtilityClasses = (ownerState: SwitchUnstyledOwnerState) => {
     track: ['track'],
   };
 
-  return composeClasses(slots, getSwitchUnstyledUtilityClass, {});
+  return composeClasses(slots, (slot: string) => generateClassName('Switch', slot, 'MUI Base'));
 };
 
 /**

--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -1,7 +1,7 @@
 export default function composeClasses<ClassKey extends string>(
   slots: Record<ClassKey, ReadonlyArray<string | false | undefined | null>>,
   getUtilityClass: (slot: string) => string,
-  classes: Record<string, string> | undefined,
+  classes: Record<string, string> | undefined = undefined,
 ): Record<ClassKey, string> {
   const output: Record<ClassKey, string> = {} as any;
 
@@ -12,7 +12,10 @@ export default function composeClasses<ClassKey extends string>(
       output[slot] = slots[slot]
         .reduce((acc, key) => {
           if (key) {
-            acc.push(getUtilityClass(key));
+            const utilityClass = getUtilityClass(key);
+            if (utilityClass !== '') {
+              acc.push(utilityClass);
+            }
             if (classes && classes[key]) {
               acc.push(classes[key]);
             }


### PR DESCRIPTION
This PR introduces the ClassNameConfigurator - a utility that lets developers change the pattern of generated class names (or even disable them at all).

Closes #30820