### PR TITLE
[lab][deps] Move @mui/types to dependencies

### DIFF
--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -63,13 +63,11 @@
     "@babel/runtime": "^7.19.0",
     "@mui/base": "5.0.0-alpha.98",
     "@mui/system": "^5.10.6",
+    "@mui/types": "^7.2.0",
     "@mui/utils": "^5.10.6",
     "clsx": "^1.2.1",
     "prop-types": "^15.8.1",
     "react-is": "^18.2.0"
-  },
-  "devDependencies": {
-    "@mui/types": "^7.2.0"
   },
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `@mui/lab` package imports `@mui/types` package in its declaration files, so `@mui/types` should be a regular dependency instead of a devDependency.

```
ERROR in ../../.yarn/__virtual__/@mui-lab-virtual-b4b85e650c/0/cache/@mui-lab-npm-5.0.0-alpha.99-abf77ae8d8-db54edffbd.zip/node_modules/@mui/lab/TabList/TabList.d.ts:3:34
TS2307: Cannot find module '@mui/types' or its corresponding type declarations.
    1 | import * as React from 'react';
    2 | import { TabsTypeMap } from '@mui/material/Tabs';
  > 3 | import { DistributiveOmit } from '@mui/types';
      |                                  ^^^^^^^^^^^^
    4 | import { OverridableComponent, OverrideProps } from '@mui/material/OverridableComponent';
    5 |
    6 | export interface TabListTypeMap<

ERROR in ../../.yarn/__virtual__/@mui-lab-virtual-b4b85e650c/0/cache/@mui-lab-npm-5.0.0-alpha.99-abf77ae8d8-db54edffbd.zip/node_modules/@mui/lab/TimelineDot/TimelineDot.d.ts:2:40
TS2307: Cannot find module '@mui/types' or its corresponding type declarations.
    1 | import * as React from 'react';
  > 2 | import { OverridableStringUnion } from '@mui/types';
      |                                        ^^^^^^^^^^^^
    3 | import { SxProps } from '@mui/system';
    4 | import { Theme } from '@mui/material/styles';
    5 | import { InternalStandardProps as StandardProps } from '@mui/material';
```