### PR TITLE
[blog] Update date on date pickers v5 release blog post

### DIFF
--- a/docs/pages/blog/date-pickers-stable-v5.md
+++ b/docs/pages/blog/date-pickers-stable-v5.md
@@ -1,7 +1,7 @@
 ---
 title: The MUI X Date and Time Pickers get a stable v5 release
 description: Migrate to the latest version for improved DX, customizability, and API consistency.
-date: 2022-09-05T00:00:00.000Z
+date: 2022-09-19T00:00:00.000Z
 authors: ['alexfauquette', 'josefreitas']
 tags: ['MUI X', 'News']
 card: true


### PR DESCRIPTION
# Summary

I realized when adding the notification to the blog post, that it was shipped with an old date (Sep 5th).

The PR updates with the correct date of blog post release
