### PR TITLE
[docs] Fix Select `onChange` call 

### DIFF
--- a/docs/data/joy/customization/approaches/ButtonThemes.js
+++ b/docs/data/joy/customization/approaches/ButtonThemes.js
@@ -560,7 +560,7 @@ export default function ButtonThemes() {
               }}
               size="sm"
               value={design}
-              onChange={setDesign}
+              onChange={(event, newValue) => setDesign(newValue)}
               sx={{ minWidth: 160 }}
             >
               <Option value="github">GitHub</Option>

--- a/docs/data/joy/main-features/automatic-adjustment/ListThemes.js
+++ b/docs/data/joy/main-features/automatic-adjustment/ListThemes.js
@@ -115,7 +115,7 @@ export default function ButtonThemes() {
               },
             }}
             value={preset}
-            onChange={setPreset}
+            onChange={(event, newValue) => setPreset(newValue)}
             sx={{ minWidth: 160 }}
           >
             <Option value="">Default</Option>

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -438,7 +438,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                       },
                     }}
                     value={(resolvedValue || 'none') as string}
-                    onChange={(val) =>
+                    onChange={(event, val) =>
                       setProps((latestProps) => ({
                         ...latestProps,
                         [propName]: val,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #34398

Some part of the docs does not migrate to the new arguments from #34158 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
