### PR TITLE
[SvgIcon] Fix passing an ownerState to SvgIcon changes the font size 

### DIFF
--- a/docs/pages/material-ui/api/svg-icon.json
+++ b/docs/pages/material-ui/api/svg-icon.json
@@ -40,6 +40,7 @@
       "colorDisabled",
       "fontSizeInherit",
       "fontSizeSmall",
+      "fontSizeMedium",
       "fontSizeLarge"
     ],
     "globalClasses": {},

--- a/docs/translations/api-docs/svg-icon/svg-icon.json
+++ b/docs/translations/api-docs/svg-icon/svg-icon.json
@@ -50,6 +50,11 @@
       "nodeName": "the root element",
       "conditions": "<code>fontSize=\"small\"</code>"
     },
+    "fontSizeMedium": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>fontSize=\"medium\"</code>"
+    },
     "fontSizeLarge": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-joy/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-joy/src/SvgIcon/SvgIcon.test.js
@@ -129,4 +129,13 @@ describe('<SvgIcon />', () => {
       expect(container.firstChild).to.have.attribute('viewBox', '-4 -4 24 24');
     });
   });
+
+  it('should not override internal ownerState with the ownerState passed to the icon', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const { container } = render(<SvgIcon ownerState={{ fontSize: 'sm' }}>{path}</SvgIcon>);
+    expect(container.firstChild).toHaveComputedStyle({ fontSize: '20px' }); // fontSize: xl -> 1.25rem = 20px
+  });
 });

--- a/packages/mui-joy/src/SvgIcon/SvgIcon.tsx
+++ b/packages/mui-joy/src/SvgIcon/SvgIcon.tsx
@@ -89,7 +89,6 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
     <SvgIconRoot
       as={component}
       className={clsx(classes.root, className)}
-      ownerState={ownerState}
       focusable="false"
       color={htmlColor}
       aria-hidden={titleAccess ? undefined : true}
@@ -97,6 +96,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
       ref={ref}
       {...other}
       {...(!inheritViewBox && { viewBox })}
+      ownerState={ownerState}
     >
       {children}
       {titleAccess ? <title>{titleAccess}</title> : null}

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -47,7 +47,7 @@ const SvgIconRoot = styled('svg', {
     inherit: 'inherit',
     small: theme.typography?.pxToRem?.(20) || '1.25rem',
     medium: theme.typography?.pxToRem?.(24) || '1.5rem',
-    large: theme.typography?.pxToRem?.(35) || '2.1875',
+    large: theme.typography?.pxToRem?.(35) || '2.1875rem',
   }[ownerState.fontSize],
   // TODO v5 deprecate, v6 remove for sx
   color:

--- a/packages/mui-material/src/SvgIcon/SvgIcon.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.js
@@ -96,7 +96,6 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
     <SvgIconRoot
       as={component}
       className={clsx(classes.root, className)}
-      ownerState={ownerState}
       focusable="false"
       color={htmlColor}
       aria-hidden={titleAccess ? undefined : true}
@@ -104,6 +103,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(inProps, ref) {
       ref={ref}
       {...more}
       {...other}
+      ownerState={ownerState}
     >
       {children}
       {titleAccess ? <title>{titleAccess}</title> : null}

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -119,4 +119,13 @@ describe('<SvgIcon />', () => {
       expect(container.firstChild).to.have.attribute('viewBox', '-4 -4 24 24');
     });
   });
+
+  it('should not override internal ownerState with the ownerState passed to the icon', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const { container } = render(<SvgIcon ownerState={{ fontSize: 'large' }}>{path}</SvgIcon>);
+    expect(container.firstChild).toHaveComputedStyle({ fontSize: '24px' }); // fontSize: medium -> 1.5rem = 24px
+  });
 });

--- a/packages/mui-material/src/SvgIcon/svgIconClasses.ts
+++ b/packages/mui-material/src/SvgIcon/svgIconClasses.ts
@@ -17,6 +17,8 @@ export interface SvgIconClasses {
   fontSizeInherit: string;
   /** Styles applied to the root element if `fontSize="small"`. */
   fontSizeSmall: string;
+  /** Styles applied to the root element if `fontSize="medium"`. */
+  fontSizeMedium: string;
   /** Styles applied to the root element if `fontSize="large"`. */
   fontSizeLarge: string;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #34056 

When a custom SVG icon is provided in components slot and the slot's `componentsProps` is defined with the `useSlotProps` hook, it should not override the `ownerState` of the internal SvgIcon.

The `styled` API does prevent forwarding `ownerState` of the hook, but if customizing components by other methods, the ownerState passed to the hook overrides the internal one of the SVG Icon.

Even if custom icon component is not provided, the `ownerState` passed to the hook is causing changes in the svgicon default styling.

---

Before: https://codesandbox.io/s/data-grid-community-forked-5hnr7p?file=/src/App.tsx

After: https://codesandbox.io/s/data-grid-community-forked-p1d7rr