### PR TITLE
[system] Fix parsing of hsla colors in getLuminance

### DIFF
--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -189,7 +189,10 @@ export function hslToRgb(color) {
 export function getLuminance(color) {
   color = decomposeColor(color);
 
-  let rgb = color.type === 'hsl' ? decomposeColor(hslToRgb(color)).values : color.values;
+  let rgb =
+    color.type === 'hsl' || color.type === 'hsla'
+      ? decomposeColor(hslToRgb(color)).values
+      : color.values;
   rgb = rgb.map((val) => {
     if (color.type !== 'color') {
       val /= 255; // normalized

--- a/packages/mui-system/src/colorManipulator.test.js
+++ b/packages/mui-system/src/colorManipulator.test.js
@@ -199,6 +199,14 @@ describe('utils/colorManipulator', () => {
       expect(getLuminance('rgb(255, 255, 255)')).to.equal(1);
     });
 
+    it('returns a valid luminance for hsla black', () => {
+      expect(getLuminance('hsla(0, 100%, 0%, 1)')).to.equal(0);
+    });
+
+    it('returns a valid luminance for hsla white', () => {
+      expect(getLuminance('hsla(0, 100%, 100%, 1)')).to.equal(1);
+    });
+
     it('returns a valid luminance for rgb mid-grey', () => {
       expect(getLuminance('rgba(127, 127, 127)')).to.equal(0.212);
       expect(getLuminance('rgb(127, 127, 127)')).to.equal(0.212);
@@ -210,6 +218,10 @@ describe('utils/colorManipulator', () => {
 
     it('returns a valid luminance from an hsl color', () => {
       expect(getLuminance('hsl(100, 100%, 50%)')).to.equal(0.735);
+    });
+
+    it('returns a valid luminance from an hsla color', () => {
+      expect(getLuminance('hsla(100, 100%, 50%, 1)')).to.equal(0.735);
     });
 
     it('returns an equal luminance for the same color in different formats', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #34438

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
