### PR TITLE
[Typography] Fix `styleOverrides`, `variants`, and remaining colors

### DIFF
--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -43,7 +43,10 @@ export const TypographyRoot = styled('span', {
   },
 })(({ theme, ownerState }) => ({
   margin: 0,
-  color: getPath(theme, `palette.${ownerState.color}`, false) || ownerState.color,
+  color:
+    getPath(theme, `palette.${ownerState.color}.main`, false) ||
+    getPath(theme, `palette.${ownerState.color}`, false) ||
+    ownerState.color,
   ...(ownerState.variant && theme.typography[ownerState.variant]),
   ...(ownerState.align !== 'inherit' && {
     textAlign: ownerState.align,

--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { getPath } from '@mui/system';
+import { unstable_extendSxProp as extendSxProp, getPath } from '@mui/system';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
@@ -92,7 +92,8 @@ const transformDeprecatedColors = (color) => {
 };
 
 const Typography = React.forwardRef(function Typography(inProps, ref) {
-  const props = useThemeProps({ props: inProps, name: 'MuiTypography' });
+  const themeProps = useThemeProps({ props: inProps, name: 'MuiTypography' });
+  const props = { ...extendSxProp(themeProps), color: themeProps.color };
 
   const {
     align = 'inherit',

--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { unstable_extendSxProp as extendSxProp } from '@mui/system';
+import { getPath } from '@mui/system';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import styled from '../styles/styled';
+import styled, { rootShouldForwardProp } from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import { getTypographyUtilityClass } from './typographyClasses';
@@ -28,6 +28,7 @@ const useUtilityClasses = (ownerState) => {
 export const TypographyRoot = styled('span', {
   name: 'MuiTypography',
   slot: 'Root',
+  shouldForwardProp: (prop) => rootShouldForwardProp(prop) && prop !== 'color',
   overridesResolver: (props, styles) => {
     const { ownerState } = props;
 
@@ -42,6 +43,7 @@ export const TypographyRoot = styled('span', {
   },
 })(({ theme, ownerState }) => ({
   margin: 0,
+  color: getPath(theme, `palette.${ownerState.color}`, false) || ownerState.color,
   ...(ownerState.variant && theme.typography[ownerState.variant]),
   ...(ownerState.align !== 'inherit' && {
     textAlign: ownerState.align,
@@ -87,26 +89,27 @@ const transformDeprecatedColors = (color) => {
 };
 
 const Typography = React.forwardRef(function Typography(inProps, ref) {
-  const themeProps = useThemeProps({ props: inProps, name: 'MuiTypography' });
-  const color = transformDeprecatedColors(themeProps.color);
-  const props = extendSxProp({ ...themeProps, color });
+  const props = useThemeProps({ props: inProps, name: 'MuiTypography' });
 
   const {
     align = 'inherit',
     className,
+    // eslint-disable-next-line react/prop-types
+    color,
     component,
     gutterBottom = false,
     noWrap = false,
     paragraph = false,
     variant = 'body1',
     variantMapping = defaultVariantMapping,
+    sx,
     ...other
   } = props;
 
   const ownerState = {
     ...props,
     align,
-    color,
+    color: transformDeprecatedColors(color),
     className,
     component,
     gutterBottom,
@@ -129,6 +132,11 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
       ref={ref}
       ownerState={ownerState}
       className={clsx(classes.root, className)}
+      color={color}
+      sx={[
+        ...(!Object.keys(colorTransformations).includes(color) ? [{ color }] : []),
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       {...other}
     />
   );

--- a/test/regressions/fixtures/TypographyColor/TypographyColor.js
+++ b/test/regressions/fixtures/TypographyColor/TypographyColor.js
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+
+export default function TypographyColor() {
+  return (
+    <div>
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiTypography: {
+              styleOverrides: {
+                root: ({ ownerState, theme }) => ({
+                  ...(ownerState.color === 'secondary.main' && {
+                    color: theme.palette.error.main,
+                  }),
+                }),
+              },
+              variants: [
+                {
+                  props: { color: 'textPrimary' },
+                  style: ({ theme }) => ({
+                    color: theme.palette.warning.main,
+                  }),
+                },
+              ],
+            },
+          },
+        })}
+      >
+        <Typography>default</Typography>
+        <Typography color="primary">primary</Typography>
+        <Typography color="secondary">error (styleOverride)</Typography>
+        <Typography color="textPrimary">warning (variant)</Typography>
+      </ThemeProvider>
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiTypography: {
+              styleOverrides: {
+                root: {
+                  color: '#fbca04',
+                },
+              },
+            },
+          },
+        })}
+      >
+        <Typography>#fbca04</Typography>
+        <Typography color="#ff5252">#ff5252</Typography>
+        <Typography sx={{ color: '#ff5252' }}>#ff5252</Typography>
+        <Typography sx={(theme) => ({ color: theme.palette.secondary.main })}>secondary</Typography>
+        <Typography sx={{ color: (theme) => theme.palette.error.main }}>error</Typography>
+      </ThemeProvider>
+    </div>
+  );
+}

--- a/test/regressions/fixtures/TypographyColor/TypographyColor.js
+++ b/test/regressions/fixtures/TypographyColor/TypographyColor.js
@@ -32,6 +32,8 @@ export default function TypographyColor() {
         <Typography color="primary">primary</Typography>
         <Typography color="secondary">error (styleOverride)</Typography>
         <Typography color="textPrimary">warning (variant)</Typography>
+        <Typography color="success">success</Typography>
+        <Typography color="success.light">success.light</Typography>
       </ThemeProvider>
       <ThemeProvider
         theme={createTheme({


### PR DESCRIPTION
Fixes #34290.
Fixes #29564.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

TODO:
- Fix extra generated CSS rule `color: textPrimary`.