### PR TITLE
[docs] Fix webpack file name to the standard: `webpack.config.js`

### DIFF
--- a/docs/data/material/guides/styled-engine/styled-engine.md
+++ b/docs/data/material/guides/styled-engine/styled-engine.md
@@ -45,7 +45,7 @@ If you are using yarn, you can configure it using a package resolution:
 
 As package resolutions are not available in npm at this moment, you need to update you bundler's config to add this alias. Here is an example of how you can do it, if you use `webpack`:
 
-**webpack.alias.js**
+**webpack.config.js**
 
 ```diff
  module.exports = {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In the Styled Engine Guide, there is an example of configuring an alias in webpack. The file shown is labeled `webpack.alias.js`; this PR updates it to `webpack.config.js`. [Preview link](https://deploy-preview-34446--material-ui.netlify.app/material-ui/guides/styled-engine/#npm)

I think the intent here is just to indicate "put this in your webpack config," and [`webpack.config.js` is the default webpack config file name](https://webpack.js.org/configuration). Additionally, the [webpack docs for resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) show the configuration in `webpack.config.js`. Also, in trying out this config option I added it to my `webpack.config.js` and it succeeded.

There are a few references around the web to `webpack.alias.js`, but none in the webpack docs. I believe what happened here is that was the author was thinking about the `alias` configuration, and accidentally put that into the file name.