### PR TITLE
[test] Set the URL to better match real environments

### DIFF
--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -23,6 +23,7 @@ const blacklist = ['sessionStorage', 'localStorage'];
 function createDOM() {
   const dom = new JSDOM('', {
     pretendToBeVisual: true,
+    url: 'http://localhost',
   });
   global.window = dom.window;
   // Not yet supported: https://github.com/jsdom/jsdom/issues/2152

--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -23,7 +23,6 @@ const blacklist = ['sessionStorage', 'localStorage'];
 function createDOM() {
   const dom = new JSDOM('', {
     pretendToBeVisual: true,
-    url: 'http://localhost', // https://github.com/jsdom/jsdom/issues/2383
   });
   global.window = dom.window;
   // Not yet supported: https://github.com/jsdom/jsdom/issues/2152


### PR DESCRIPTION
This logic was added in #31273. I'm testing that we no longer need it. I suspect that it was added to solve #33853. Removing it makes the test environment better capture the complexity of the production environments, it can also be seen as a test for #34027.