### PR TITLE
Fix font size of ImageIcon

### DIFF
--- a/docs/data/joy/components/aspect-ratio/PlaceholderAspectRatio.js
+++ b/docs/data/joy/components/aspect-ratio/PlaceholderAspectRatio.js
@@ -9,7 +9,7 @@ export default function BasicRatio() {
     <Card variant="outlined" sx={{ width: 300 }}>
       <AspectRatio>
         <div>
-          <ImageIcon fontSize="xl5" sx={{ color: 'text.tertiary' }} />
+          <ImageIcon fontSize="medium" sx={{ color: 'text.tertiary' }} />
         </div>
       </AspectRatio>
       <Typography mt={2}>Title</Typography>


### PR DESCRIPTION
The value of fontSize should be one of the following:  "small" , "large" ,"medium" 

Signed-off-by: Dani Matuko <57415306+danimatuko@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
