### PR TITLE
[docs] Fix typo in `Back to top` section in AppBar docs

### DIFF
--- a/docs/data/material/components/app-bar/app-bar.md
+++ b/docs/data/material/components/app-bar/app-bar.md
@@ -113,7 +113,7 @@ The app bar elevates on scroll to communicate that the user is not at the top of
 
 ### Back to top
 
-A floating action buttons appears on scroll to make it easy to get back to the top of the page.
+A floating action button appears on scroll to make it easy to get back to the top of the page.
 
 {{"demo": "BackToTop.js", "iframe": true}}
 


### PR DESCRIPTION
Signed-off-by: Dustin-Digitar <113573618+Dustin-Digitar@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-34479--material-ui.netlify.app/material-ui/react-app-bar/#back-to-top