### PR TITLE
[SwipeableDrawer] Fix React 18 issues

### DIFF
--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -563,7 +563,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
           // Ensures that paperRef.current will be defined inside the touch start event handler
           // See https://github.com/mui/material-ui/issues/30414 for more information
           ...(variant === 'temporary' && {
-            keepMounted: true
+            keepMounted: true,
           }),
           ...ModalPropsProp,
         }}

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { flushSync } from "react-dom";
+import { flushSync } from 'react-dom';
 import PropTypes from 'prop-types';
 import { elementTypeAcceptingRef } from '@mui/utils';
 import { useThemeProps } from '@mui/system';

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -560,7 +560,11 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
             ...BackdropProps,
             ref: backdropRef,
           },
-          keepMounted: true,
+          // Ensures that paperRef.current will be defined inside the touch start event handler
+          // See https://github.com/mui/material-ui/issues/30414 for more information
+          ...(variant === 'temporary' && {
+            keepMounted: true
+          }),
           ...ModalPropsProp,
         }}
         hideBackdrop={hideBackdrop}

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { flushSync } from "react-dom";
 import PropTypes from 'prop-types';
 import { elementTypeAcceptingRef } from '@mui/utils';
 import { useThemeProps } from '@mui/system';
@@ -234,7 +235,9 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
     }
     claimedSwipeInstance = null;
     touchDetected.current = false;
-    setMaybeSwiping(false);
+    flushSync(() => {
+      setMaybeSwiping(false);
+    });
 
     // The swipe wasn't started.
     if (!swipeInstance.current.isSwiping) {
@@ -488,7 +491,10 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
     swipeInstance.current.startX = currentX;
     swipeInstance.current.startY = currentY;
 
-    setMaybeSwiping(true);
+    flushSync(() => {
+      setMaybeSwiping(true);
+    });
+
     if (!open && paperRef.current) {
       // The ref may be null when a parent component updates while swiping.
       setPosition(
@@ -554,6 +560,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
             ...BackdropProps,
             ref: backdropRef,
           },
+          keepMounted: true,
           ...ModalPropsProp,
         }}
         hideBackdrop={hideBackdrop}

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -59,7 +59,7 @@ const NullPaper = React.forwardRef(function NullPaper(props, ref) {
 });
 
 describe('<SwipeableDrawer />', () => {
-  const { render, clock } = createRenderer({ clock: 'fake' });
+  const { render } = createRenderer({ clock: 'fake' });
 
   describeConformance(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />, () => ({
     classes: {},

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -268,7 +268,6 @@ describe('<SwipeableDrawer />', () => {
           if (params.anchor === 'bottom') {
             startPosition = windowHeight - DRAG_STARTED_SIGNAL;
           }
-          // The 20 comes from the DRAG_STARTED_SIGNAL, defined in the SwipeableDrawer
           expect(getByTestId('drawer').getBoundingClientRect()[testParam]).to.equal(startPosition);
 
           fireEvent.touchMove(swipeArea, {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/30414

Steps to reproduce:
1. Open the sandbox
2. Open the rendered demo in new tab, inspect element and change the device to mobile
3. Try swapping the drawer and you will notice the two problems mentioned in the issue:
    - Discovery opens drawer completely
    - Partially opened drawer (> hysteresis) is not opened completely (it gets stuck at the position it was when the touch move ended)
  
❌ Current master [Sandbox](https://codesandbox.io/s/kd0jb8?file=/demo.tsx)  

<img src="https://user-images.githubusercontent.com/4512430/192794982-8de71369-40d8-44c4-adb2-c4e773040597.gif" height="400px" />

✅ This PR [Sandbox](https://codesandbox.io/s/7qkr9k?file=/demo.tsx)

<img src="https://user-images.githubusercontent.com/4512430/192795038-8f8a0aa6-37d8-49a3-a6b8-4bdaf3fb9dcb.gif" height="400px" />

## Remarks

Not happy about the `keepMounted`, but if that is not set, the `paperRef.current` is `undefined` when the touch start event on the body is invoked. At first I thought using `flushAsync` on the set state before the check would be sufficient, as the DOM should be updated after the callback is being invoked, at least that is how I understand based on the description https://reactjs.org/docs/react-dom.html#flushsync, but that's not the case. Interestingly, using only `keepMounted` without the `flushSync` doesn't work too.
