### PR TITLE
[Joy] Fix `variantPlain` classname missing in few components

### DIFF
--- a/packages/mui-joy/src/Alert/alertClasses.ts
+++ b/packages/mui-joy/src/Alert/alertClasses.ts
@@ -27,6 +27,8 @@ export interface AlertClasses {
   sizeMd: string;
   /** Styles applied to the root element if `size="lg"`. */
   sizeLg: string;
+  /** Styles applied to the root element if `variant="plain"`. */
+  variantPlain: string;
   /** Styles applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
   /** Styles applied to the root element if `variant="soft"`. */
@@ -55,6 +57,7 @@ const alertClasses: AlertClasses = generateUtilityClasses('JoyAlert', [
   'sizeSm',
   'sizeMd',
   'sizeLg',
+  'variantPlain',
   'variantOutlined',
   'variantSoft',
   'variantSolid',

--- a/packages/mui-joy/src/Badge/badgeClasses.ts
+++ b/packages/mui-joy/src/Badge/badgeClasses.ts
@@ -37,6 +37,8 @@ export interface BadgeClasses {
   sizeMd: string;
   /** Styles applied to the badge `span` element if `size="lg"`. */
   sizeLg: string;
+  /** Styles applied to the root element if `variant="plain"`. */
+  variantPlain: string;
   /** Styles applied to the badge `span` element if `variant="outlined"`. */
   variantOutlined: string;
   /** Styles applied to the badge `span` element if `variant="soft"`. */
@@ -70,6 +72,7 @@ const badgeClasses: BadgeClasses = generateUtilityClasses('JoyBadge', [
   'sizeSm',
   'sizeMd',
   'sizeLg',
+  'variantPlain',
   'variantOutlined',
   'variantSoft',
   'variantSolid',

--- a/packages/mui-joy/src/Chip/chipClasses.ts
+++ b/packages/mui-joy/src/Chip/chipClasses.ts
@@ -37,6 +37,8 @@ export interface ChipClasses {
   sizeLg: string;
   /** Styles applied to the startDecorator element if supplied. */
   startDecorator: string;
+  /** Styles applied to the root element if `variant="plain"`. */
+  variantPlain: string;
   /** Styles applied to the root element if `variant="solid"`. */
   variantSolid: string;
   /** Styles applied to the root element if `variant="soft"`. */
@@ -71,6 +73,7 @@ const chipClasses: ChipClasses = generateUtilityClasses('JoyChip', [
   'sizeMd',
   'sizeLg',
   'startDecorator',
+  'variantPlain',
   'variantSolid',
   'variantSoft',
   'variantOutlined',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Problem**:
-> For Alert, Badge and Chip components, `variantPlain` classname is missing.