### PR TITLE
[docs] Temporary remove date picker from home page

### DIFF
--- a/docs/src/components/home/Hero.tsx
+++ b/docs/src/components/home/Hero.tsx
@@ -50,6 +50,7 @@ const FolderTable = dynamic(() => import('../showcase/FolderTable'), {
   loading: createLoading({ width: 360, height: 212 }),
 });
 
+// TODO Revert #34541 when https://github.com/mui/mui-x/pull/6362 is released
 // const ThemeDatePicker = dynamic(() => import('../showcase/ThemeDatePicker'), {
 //   ssr: false,
 //   loading: createLoading({ width: { md: 360, xl: 400 }, height: 260 }),

--- a/docs/src/components/home/Hero.tsx
+++ b/docs/src/components/home/Hero.tsx
@@ -50,10 +50,10 @@ const FolderTable = dynamic(() => import('../showcase/FolderTable'), {
   loading: createLoading({ width: 360, height: 212 }),
 });
 
-const ThemeDatePicker = dynamic(() => import('../showcase/ThemeDatePicker'), {
-  ssr: false,
-  loading: createLoading({ width: { md: 360, xl: 400 }, height: 260 }),
-});
+// const ThemeDatePicker = dynamic(() => import('../showcase/ThemeDatePicker'), {
+//   ssr: false,
+//   loading: createLoading({ width: { md: 360, xl: 400 }, height: 260 }),
+// });
 const ThemeTabs = dynamic(() => import('../showcase/ThemeTabs'), {
   ssr: false,
   loading: createLoading({ width: { md: 360, xl: 400 }, height: 48 }),
@@ -153,12 +153,15 @@ export default function Hero() {
                 <ThemeChip />
               </Box>
               <ThemeTimeline />
-              <FolderTable />
+              {/* Temporary moved FolderTable to the next column due to ThemeDatePicker automatic focus */}
+              {/* <FolderTable /> */}
             </Stack>
           )}
           {isMdUp && (
             <Stack spacing={4} sx={{ ml: 4, '& > .MuiPaper-root': { maxWidth: 'none' } }}>
-              <ThemeDatePicker />
+              {/* Temporary removed ThemeDatePicker due to layout crash from auto focus */}
+              {/* <ThemeDatePicker /> */}
+              <FolderTable />
               <ThemeTabs />
               <Box sx={{ display: 'flex' }}>
                 <Box sx={{ flexGrow: 1 }}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The date picker auto-focus causes the home page layout to shift.

https://user-images.githubusercontent.com/18292247/193400051-22fb3c26-a007-4853-9783-c1544350e0e8.mov

This is a temporary fix until we have a proper solution. We need to investigate further with the X team.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
