### PR TITLE
[Popover] Fix paper position flash on open

### DIFF
--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -382,7 +382,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
           {...PaperProps}
           ref={handlePaperRef}
           className={clsx(classes.paper, PaperProps.className)}
-          {...(isPositioned ? undefined : { style: { ...PaperProps.style, visibility: 'hidden' } })}
+          {...(isPositioned ? undefined : { style: { ...PaperProps.style, opacity: 0 } })}
           ownerState={ownerState}
         >
           {children}

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -304,6 +304,13 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     setPositioningStyles();
   };
 
+  // Ensure that the menu doesn't appear until the positioning styles have been set.
+  // Related to the effect that calls `setPositioningStyles` directly below this one.
+  const [isPositioned, setIsPositioned] = React.useState(open);
+  React.useEffect(() => {
+    setIsPositioned(open);
+  }, [open]);
+
   React.useEffect(() => {
     if (open) {
       setPositioningStyles();
@@ -364,7 +371,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     >
       <TransitionComponent
         appear
-        in={open}
+        in={open && isPositioned}
         onEntering={handleEntering}
         timeout={transitionDuration}
         {...TransitionProps}

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -278,6 +278,8 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     [anchorEl, anchorReference, getAnchorOffset, getTransformOrigin, marginThreshold],
   );
 
+  const [isPositioned, setIsPositioned] = React.useState(open);
+
   const setPositioningStyles = React.useCallback(() => {
     const element = paperRef.current;
 
@@ -294,6 +296,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       element.style.left = positioning.left;
     }
     element.style.transformOrigin = positioning.transformOrigin;
+    setIsPositioned(true);
   }, [getPositioningStyle]);
 
   const handleEntering = (element, isAppearing) => {
@@ -304,12 +307,9 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     setPositioningStyles();
   };
 
-  // Ensure that the menu doesn't appear until the positioning styles have been set.
-  // Related to the effect that calls `setPositioningStyles` directly below this one.
-  const [isPositioned, setIsPositioned] = React.useState(open);
-  React.useEffect(() => {
-    setIsPositioned(open);
-  }, [open]);
+  const handleExited = () => {
+    setIsPositioned(false);
+  };
 
   React.useEffect(() => {
     if (open) {
@@ -371,8 +371,9 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     >
       <TransitionComponent
         appear
-        in={open && isPositioned}
+        in={open}
         onEntering={handleEntering}
+        onExited={handleExited}
         timeout={transitionDuration}
         {...TransitionProps}
       >
@@ -381,6 +382,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
           {...PaperProps}
           ref={handlePaperRef}
           className={clsx(classes.paper, PaperProps.className)}
+          style={isPositioned ? undefined : { visibility: 'hidden' }}
           ownerState={ownerState}
         >
           {children}

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -382,7 +382,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
           {...PaperProps}
           ref={handlePaperRef}
           className={clsx(classes.paper, PaperProps.className)}
-          {...isPositioned ? undefined : { style: { ...PaperProps.style, visibility: 'hidden' } }}
+          {...(isPositioned ? undefined : { style: { ...PaperProps.style, visibility: 'hidden' } })}
           ownerState={ownerState}
         >
           {children}

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -382,7 +382,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
           {...PaperProps}
           ref={handlePaperRef}
           className={clsx(classes.paper, PaperProps.className)}
-          style={isPositioned ? undefined : { visibility: 'hidden' }}
+          {...isPositioned ? undefined : { style: { ...PaperProps.style, visibility: 'hidden' } }}
           ownerState={ownerState}
         >
           {children}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Issues
* #33308
* #33743 (probably)

## Changes
Previously popovers could have been rendered before they were positioned, resulting in them briefly appearing in the top-left corner particularly on slower devices and with low `transitionDuration`. This PR hides the popover paper until positioning is complete.

## Drawbacks
On slower devices, the opening animation may be completely skipped since the animation would complete before positioning would finish. This can be demonstrated with the Chrome dev tools' CPU throttling feature. Due to the current way that popover is designed, there is a sort of catch-22 in which the the paper only mounts once the transition begins, but positioning can only occur after the paper mounts. Changing other parts of the code to get around that issue is certainly possible, but I have not attempted to do that in this PR.

Resolves #33308