### PR TITLE
[system] Support CSS `grey` color in `sx`

### DIFF
--- a/packages/mui-system/src/palette.js
+++ b/packages/mui-system/src/palette.js
@@ -3,7 +3,7 @@ import compose from './compose';
 
 function transform(value, userValue) {
   if (process.env.NODE_ENV !== 'production') {
-    if (userValue === 'grey') {
+    if (value !== userValue && userValue === 'grey') {
       console.warn(
         [
           `MUI: Because "grey" is both a CSS color and part of the theme's color palette, the palette is being prioritized.`,

--- a/packages/mui-system/src/palette.js
+++ b/packages/mui-system/src/palette.js
@@ -9,8 +9,8 @@ function transform(value, userValue) {
           `MUI: Because "grey" is both a CSS color and part of the theme's` +
             'color palette, the palette is being prioritized.',
           '',
-          'To disambiguate, either specify a palette shade (e.g. "grey.500"), '
-            + 'use a different CSS color, or use the `style` prop.',
+          'To disambiguate, either specify a palette shade (e.g. "grey.500"), ' +
+            'use a different CSS color, or use the `style` prop.',
         ].join('\n'),
       );
     }

--- a/packages/mui-system/src/palette.js
+++ b/packages/mui-system/src/palette.js
@@ -1,20 +1,38 @@
 import style from './style';
 import compose from './compose';
 
+function transform(value, userValue) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (userValue === 'grey') {
+      console.warn(
+        [
+          `MUI: Because "grey" is both a CSS color and part of the theme's color palette, the palette is being prioritized.`,
+          '',
+          'Either specify a palette shade (e.g. "grey.500") or use a different CSS color to disambiguate.',
+        ].join('\n'),
+      );
+    }
+  }
+  return value;
+}
+
 export const color = style({
   prop: 'color',
   themeKey: 'palette',
+  transform,
 });
 
 export const bgcolor = style({
   prop: 'bgcolor',
   cssProperty: 'backgroundColor',
   themeKey: 'palette',
+  transform,
 });
 
 export const backgroundColor = style({
   prop: 'backgroundColor',
   themeKey: 'palette',
+  transform,
 });
 
 const palette = compose(color, bgcolor, backgroundColor);

--- a/packages/mui-system/src/palette.js
+++ b/packages/mui-system/src/palette.js
@@ -9,8 +9,8 @@ function transform(value, userValue) {
           `MUI: Because "grey" is both a CSS color and part of the theme's` +
             'color palette, the palette is being prioritized.',
           '',
-          'To disambiguate, either specify a palette shade (e.g. "grey.500"), ' +
-            'use a different CSS color, or use the `style` prop.',
+          'To disambiguate, either specify a palette shade (e.g. "grey.500") ' +
+            'or use a different CSS color (e.g. "gray").',
         ].join('\n'),
       );
     }

--- a/packages/mui-system/src/palette.js
+++ b/packages/mui-system/src/palette.js
@@ -6,9 +6,11 @@ function transform(value, userValue) {
     if (value !== userValue && userValue === 'grey') {
       console.warn(
         [
-          `MUI: Because "grey" is both a CSS color and part of the theme's color palette, the palette is being prioritized.`,
+          `MUI: Because "grey" is both a CSS color and part of the theme's` +
+            'color palette, the palette is being prioritized.',
           '',
-          'Either specify a palette shade (e.g. "grey.500") or use a different CSS color to disambiguate.',
+          'To disambiguate, either specify a palette shade (e.g. "grey.500"), '
+            + 'use a different CSS color, or use the `style` prop.',
         ].join('\n'),
       );
     }

--- a/packages/mui-system/src/palette.js
+++ b/packages/mui-system/src/palette.js
@@ -2,18 +2,8 @@ import style from './style';
 import compose from './compose';
 
 function transform(value, userValue) {
-  if (process.env.NODE_ENV !== 'production') {
-    if (value !== userValue && userValue === 'grey') {
-      console.warn(
-        [
-          `MUI: Because "grey" is both a CSS color and part of the theme's` +
-            'color palette, the palette is being prioritized.',
-          '',
-          'To disambiguate, either specify a palette shade (e.g. "grey.500") ' +
-            'or use a different CSS color (e.g. "gray").',
-        ].join('\n'),
-      );
-    }
+  if (userValue === 'grey') {
+    return userValue;
   }
   return value;
 }

--- a/packages/mui-system/src/palette.test.js
+++ b/packages/mui-system/src/palette.test.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import palette from './palette';
+
+const theme = {
+  palette: {
+    grey: { 100: '#f5f5f5' },
+  },
+};
+
+describe('palette', () => {
+  it('should treat grey as CSS color', () => {
+    const output = palette({
+      theme,
+      backgroundColor: 'grey',
+    });
+    expect(output).to.deep.equal({
+      backgroundColor: 'grey',
+    });
+  });
+
+  it('should treat grey.100 as theme color', () => {
+    const output = palette({
+      theme,
+      backgroundColor: 'grey.100',
+    });
+    expect(output).to.deep.equal({
+      backgroundColor: '#f5f5f5',
+    });
+  });
+});

--- a/packages/mui-system/src/style.d.ts
+++ b/packages/mui-system/src/style.d.ts
@@ -8,7 +8,10 @@ export interface StyleOptions<PropKey> {
    * dot access in `Theme`
    */
   themeKey?: string;
-  transform?: (cssValue: unknown) => number | string | React.CSSProperties | CSSObject;
+  transform?: (
+    cssValue: unknown,
+    userValue: unknown,
+  ) => number | string | React.CSSProperties | CSSObject;
 }
 export function style<PropKey extends string, Theme extends object>(
   options: StyleOptions<PropKey>,

--- a/packages/mui-system/src/style.js
+++ b/packages/mui-system/src/style.js
@@ -36,7 +36,7 @@ function getValue(themeMapping, transform, propValueFinal, userValue = propValue
   }
 
   if (transform) {
-    value = transform(value);
+    value = transform(value, userValue);
   }
 
   return value;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Issues
- #31203

## Changes
When `"grey"` is used as the value for a color prop in `sx`, a warning will now be printed to the console explaining the issue and a number of potential remedies.

Resolves #31203