### PR TITLE
[docs] Revise and expand Joy UI "Tutorial" doc

### DIFF
--- a/docs/data/joy/getting-started/tutorial/LoginFinal.js
+++ b/docs/data/joy/getting-started/tutorial/LoginFinal.js
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import Sheet from '@mui/joy/Sheet';
+import Typography from '@mui/joy/Typography';
+import TextField from '@mui/joy/TextField';
+import Button from '@mui/joy/Button';
+import Link from '@mui/joy/Link';
+
+const ModeToggle = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  // necessary for server-side rendering
+  // because mode is undefined on the server
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? 'Turn dark' : 'Turn light'}
+    </Button>
+  );
+};
+
+export default function App() {
+  return (
+    <CssVarsProvider>
+      <main>
+        <ModeToggle />
+        <Sheet
+          sx={{
+            maxWidth: 400,
+            mx: 'auto', // margin left & right
+            my: 4, // margin top & botom
+            py: 3, // padding top & bottom
+            px: 2, // padding left & right
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            borderRadius: 'sm',
+            boxShadow: 'md',
+          }}
+          variant="outlined"
+        >
+          <div>
+            <Typography level="h4" component="h1">
+              <b>Welcome!</b>
+            </Typography>
+            <Typography level="body2">Sign in to continue.</Typography>
+          </div>
+          <TextField
+            // html input attribute
+            name="email"
+            type="email"
+            placeholder="johndoe@email.com"
+            // pass down to FormLabel as children
+            label="Email"
+          />
+          <TextField
+            name="password"
+            type="password"
+            placeholder="password"
+            label="Password"
+          />
+          <Button
+            sx={{
+              mt: 1, // margin top
+            }}
+          >
+            Log in
+          </Button>
+          <Typography
+            endDecorator={<Link href="/sign-up">Sign up</Link>}
+            fontSize="sm"
+            sx={{ alignSelf: 'center' }}
+          >
+            Don&apos;t have an account?
+          </Typography>
+        </Sheet>
+      </main>
+    </CssVarsProvider>
+  );
+}

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -10,21 +10,14 @@ By the end, you should understand how to:
 2. add styles to Joy UI components
 3. create a button to toggle light and dark modes
 
-:::info
-This tutorial does _not_ cover theming and general component customization.
-Learn more about [different customization approaches](/joy-ui/customization/approaches/) after you're done on this page.
-:::
-
 ## Prerequisites
 
-This tutorial assumes:
+This tutorial assumes that you've already:
 
-- you've already set up a React app—try [Create React App](https://create-react-app.dev/) if you need a boilerplate
-- you've installed Joy UI in your app—see [Installation](/joy-ui/getting-started/installation/) for instructions
+- set up a React app—try [Create React App](https://create-react-app.dev/) if you need a boilerplate
+- installed Joy UI in your app—see [Installation](/joy-ui/getting-started/installation/) for instructions
 
-## Building the login page
-
-### 1. Creating the basic layout
+## Import the Sheet component for structure
 
 To create the structure for the login page, we'll use the `Sheet` component, which is simply an HTML div that supports the global variant feature.
 
@@ -50,7 +43,7 @@ export default App;
 **Don't forget:** always render Joy UI components inside the `<CssVarsProvider/>` component.
 :::
 
-### 2. Using the `sx` prop for quick styling
+### Add styles with the sx prop
 
 Every Joy UI component accepts the `sx` prop, which allows a shorthand syntax for writing CSS.
 It's great for creating one-off customizations or rapidly experimenting with different styles.
@@ -78,7 +71,7 @@ Don't worry if you're confused about the `sx` prop's syntax at this moment.
 You'll get the hang of it as you use it more.
 Check the [MUI System's documentation](/system/getting-started/the-sx-prop/) to learn more about its foundation.
 
-### 3. Using `Typography` to create a welcome text
+## Add text with the Typography component
 
 The `Typography` component supports the `level` prop, allowing you to choose between a pre-defined scale of typography values.
 Joy UI provides 13 typography levels out of the box: `display 1 | display 2 | h1 | h2 | h3 | h4 | h5 | h6 | body1 | body2 | body3 | body4 | body5`.
@@ -101,7 +94,7 @@ import Typography from '@mui/joy/Typography';
 </Sheet>;
 ```
 
-### 4. Using `TextField` to create user name and password inputs
+## Add TextField for user inputs
 
 The `TextField` component is made of the `FormLabel`, `Input` and `FormHelperText` components.
 
@@ -134,7 +127,7 @@ import TextField from '@mui/joy/TextField';
 </Sheet>;
 ```
 
-### 5. Using `Button` and `Link` for actions
+## Import Button and Link for user actions
 
 The `Button` component has `solid` and `primary` as its default variant and color, respectively.
 Play around with changing their values to see how each variant differs from one another.
@@ -174,7 +167,7 @@ import Link from '@mui/joy/Link';
 
 <!-- TODO: Add the result image -->
 
-## 🎁 Bonus: Setting up dark mode
+## 🎁 Bonus: Build a toggle for light and dark mode
 
 Joy UI provides an effortless way to toggle between modes by using the React hook `useColorScheme`.
 All you need to do is create a component that uses the hook and then render it under the `CssVarsProvider` component.
@@ -228,3 +221,8 @@ export default function App() {
 :::
 
 Congratulations 🎉! You've built your first good looking UI with Joy UI!
+
+:::info
+This tutorial does _not_ cover theming and general component customization.
+Learn more about [different customization approaches](/joy-ui/customization/approaches/) when you're ready to go deeper on this topic.
+:::

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -101,7 +101,7 @@ Replace `Welcome!` inside your Sheet component with this `<div>`:
   <Typography level="h4" component="h1">
     Welcome!
   </Typography>
-  <Typography level="body2">Sign in to continue</Typography>
+  <Typography level="body2">Sign in to continue.</Typography>
 </div>
 ```
 
@@ -141,40 +141,33 @@ Insert these two Text Fields below the `<div>` from the previous step, inside th
 
 ## Import Button and Link for user actions
 
-The `Button` component has `solid` and `primary` as its default variant and color, respectively.
-Play around with changing their values to see how each variant differs from one another.
-Try `plain`, `outlined`, or `soft`.
+The Button and Link components replace the HTML `<button>` and `<a>` tags, respectively, giving you access to global variants, the `sx` and `component` props, and more.
 
-We'll also use a `Link` component inside the `endDecorator` prop of the `Typography` component to pull off the sign up anchor link.
+Add the following imports with the rest in your app:
 
 ```jsx
-// ...other imports
 import Button from '@mui/joy/Button';
 import Link from '@mui/joy/Link';
+```
 
-<Sheet
-  sx={
-    {
-      // ...
-    }
-  }
+Add the following Button, Typography, and Link components after the Text Fields from the previous step, still nested inside the Sheet.
+Notice that the Link is appended to the Typography inside of [the `endDecorator` prop](/joy-ui/react-typography/#decorators):
+
+```jsx
+<Button
+  sx={{
+    mt: 1, // margin top
+  }}
 >
-  ...typography and text-fields
-  <Button
-    sx={{
-      mt: 1, // margin top
-    }}
-  >
-    Log in
-  </Button>
-  <Typography
-    endDecorator={<Link href="/sign-up">Sign up</Link>}
-    fontSize="sm"
-    sx={{ alignSelf: 'center' }}
-  >
-    Don't have an account?
-  </Typography>
-</Sheet>;
+  Log in
+</Button>
+<Typography
+  endDecorator={<Link href="/sign-up">Sign up</Link>}
+  fontSize="sm"
+  sx={{ alignSelf: 'center' }}
+>
+  Don't have an account?
+</Typography>
 ```
 
 <!-- TODO: Add the result image -->
@@ -297,7 +290,7 @@ export default function App() {
           <Typography level="h4" component="h1">
             <b>Welcome!</b>
           </Typography>
-          <Typography level="body2">Sign in to continue</Typography>
+          <Typography level="body2">Sign in to continue.</Typography>
         </div>
         <TextField
           // html input attribute

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -8,9 +8,16 @@ You'll also encounter key features of Joy UI such as global variants, the `sx` p
 
 By the end, you should understand how to:
 
-1. import Joy UI components into your React app
-2. add styles to Joy UI components
-3. toggle light and dark mode with `useColorScheme`
+1. import and customize Joy UI components
+2. add styles to Joy UI components with `sx`
+3. override default HTML elements with `component`
+4. toggle light and dark mode with `useColorScheme`
+
+## Interactive demo
+
+Here's what the final product looks like—click on the **< >** icon underneath to see the full source code:
+
+{{"demo": "LoginFinal.js", "hideToolbar": false, "bg": true}}
 
 ## Prerequisites
 

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -1,6 +1,6 @@
 # Introductory tutorial
 
-<p class="description">Learn how to import and style Joy UI components to build a simple login page.</p>
+<p class="description">Learn how to import and style Joy UI components to build a simple login page with light and dark modes.</p>
 
 This tutorial will walk you through how to assemble the UI for a basic login page using Joy UI.
 You'll be introduced to several common components as well as some of the props you can use to control their styles.
@@ -120,7 +120,7 @@ Try changing the values for the `level` and `component` props to see how they af
 
 ## Add Text Field for user inputs
 
-The Text Field component bundles together the Form Control, Form Label, Input, and Form Helper Text components to provide you with a sophisticated field for user input.
+The [Text Field](/joy-ui/react-text-field/) component bundles together the Form Control, Form Label, Input, and Form Helper Text components to provide you with a sophisticated field for user input.
 
 Add an import for Text Field with the rest of your imports:
 
@@ -149,7 +149,7 @@ Insert these two Text Fields below the `<div>` from the previous step, inside th
 
 ## Import Button and Link for user actions
 
-The Button and Link components replace the HTML `<button>` and `<a>` tags, respectively, giving you access to global variants, the `sx` and `component` props, and more.
+The [Button](/joy-ui/react-button/) and [Link](/joy-ui/react-link/) components replace the HTML `<button>` and `<a>` tags, respectively, giving you access to global variants, the `sx` and `component` props, and more.
 
 Add the following imports with the rest in your app:
 
@@ -180,7 +180,7 @@ Notice that the Link is appended to the Typography inside of [the `endDecorator`
 
 ## 🎁 Bonus: Build a toggle for light and dark mode
 
-The `useColorScheme` hook greatly simplifies the implementation of a toggle button for switching between light and dark mode in an app.
+The `useColorScheme` hook aids in the implementation of a toggle button for switching between light and dark mode in an app.
 It also enables Joy UI to ensure that the user-selected mode (which is stored in `localStorage` by default) stays in sync across browser tabs.
 
 Add `useColorScheme` to your import from `@mui/joy/styles`:
@@ -238,7 +238,28 @@ Finally, add your newly built `<ModeToggle />` button above `<Sheet />`:
 Your app should now look like the [interactive demo](#interactive-demo) at the top of the page.
 Great job making it all the way to the end!
 
-:::info
-This tutorial does _not_ cover theming and general component customization.
-Learn more about [different customization approaches](/joy-ui/customization/approaches/) when you're ready to go deeper on this topic.
-:::
+## Summary
+
+Here's a recap of the components used:
+
+- [Sheet](/joy-ui/react-sheet/)
+- [Typography](/joy-ui/react-typography/)
+- [Button](/joy-ui/react-button/)
+- [Link](/joy-ui/react-link/)
+- [Text Field](/joy-ui/react-text-field/)
+
+Here are some of the major features introduced:
+
+- [global variants](/joy-ui/main-features/global-variants/)
+- [the `sx` prop](/system/getting-started/the-sx-prop/)
+- [dark mode](/joy-ui/guides/applying-dark-mode/)
+
+## Next steps
+
+This tutorial does not cover theming or general component customization.
+Learn more about [different customization approaches](/joy-ui/customization/approaches/) and when to apply them.
+
+To see some more sophisticated examples of Joy UI in action, check out our [collection of templates](/joy-ui/getting-started/templates/).
+
+Are you migrating from Material UI?
+Learn how to work with [Joy UI and Material UI together in one app](/joy-ui/guides/using-joy-ui-and-material-ui-together/).

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -15,7 +15,7 @@ By the end, you should understand how to:
 
 ## Interactive demo
 
-Here's what the final product looks like—click on the **< >** icon underneath to see the full source code:
+Here's what the final product looks like—click on the **< >** icon underneath the demo to see the full source code:
 
 {{"demo": "LoginFinal.js", "hideToolbar": false, "bg": true}}
 
@@ -31,6 +31,7 @@ This tutorial assumes that you've already:
 The [Sheet](/joy-ui/react-sheet/) component is a `<div>` container that supports Joy UI's [global variants feature](/joy-ui/main-features/global-variants/), helping to ensure consistency across your app.
 
 Import Sheet and add it to your app as shown below.
+(If you're using Create React App, for example, all of this code should go in `App.js`.)
 Notice that Joy UI components must be nested within `<CssVarsProvider />`:
 
 ```jsx
@@ -177,18 +178,20 @@ Notice that the Link is appended to the Typography inside of [the `endDecorator`
 </Typography>
 ```
 
-<!-- TODO: Add the result image -->
-
 ## 🎁 Bonus: Build a toggle for light and dark mode
 
-Joy UI provides an effortless way to toggle between modes by using the React hook `useColorScheme`.
-All you need to do is create a component that uses the hook and then render it under the `CssVarsProvider` component.
+The `useColorScheme` hook greatly simplifies the implementation of a toggle button for switching between light and dark mode in an app.
+It also enables Joy UI to ensure that the user-selected mode (which is stored in `localStorage` by default) stays in sync across browser tabs.
+
+Add `useColorScheme` to your import from `@mui/joy/styles`:
 
 ```jsx
-import React from 'react';
 import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
-// ...other imports
+```
 
+Next, create a light/dark mode toggle button by adding the following code snippet in between your imports and your `App()`:
+
+```jsx
 const ModeToggle = () => {
   const { mode, setMode } = useColorScheme();
   const [mounted, setMounted] = React.useState(false);
@@ -217,123 +220,23 @@ const ModeToggle = () => {
     </Button>
   );
 };
+```
 
-export default function App() {
+Finally, add your newly built `<ModeToggle />` button above `<Sheet />`:
+
+```diff
+ export default function App() {
   return (
     <CssVarsProvider>
-      <ModeToggle />
++      <ModeToggle />
       <Sheet>...</Sheet>
     </CssVarsProvider>
   );
 }
 ```
 
-:::info
-💡 **Note:** With the `useColorScheme` hook, Joy UI ensures that the user selected mode (stored in localStorage by default) is in-sync across browser tabs.
-:::
-
-## Putting it all together
-
-Your completed app should look like this:
-
-```jsx
-import * as React from 'react';
-import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
-import Sheet from '@mui/joy/Sheet';
-import Typography from '@mui/joy/Typography';
-import TextField from '@mui/joy/TextField';
-import Button from '@mui/joy/Button';
-import Link from '@mui/joy/Link';
-
-const ModeToggle = () => {
-  const { mode, setMode } = useColorScheme();
-  const [mounted, setMounted] = React.useState(false);
-
-  // necessary for server-side rendering
-  // because mode is undefined on the server
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-  if (!mounted) {
-    return null;
-  }
-
-  return (
-    <Button
-      variant="outlined"
-      onClick={() => {
-        if (mode === 'light') {
-          setMode('dark');
-        } else {
-          setMode('light');
-        }
-      }}
-    >
-      {mode === 'light' ? 'Turn dark' : 'Turn light'}
-    </Button>
-  );
-};
-
-export default function App() {
-  return (
-    <CssVarsProvider>
-      <ModeToggle />
-      <Sheet
-        sx={{
-          maxWidth: 400,
-          mx: 'auto', // margin left & right
-          my: 4, // margin top & botom
-          py: 3, // padding top & bottom
-          px: 2, // padding left & right
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 2,
-          borderRadius: 'sm',
-          boxShadow: 'md',
-        }}
-        variant="outlined"
-      >
-        <div>
-          <Typography level="h4" component="h1">
-            <b>Welcome!</b>
-          </Typography>
-          <Typography level="body2">Sign in to continue.</Typography>
-        </div>
-        <TextField
-          // html input attribute
-          name="email"
-          type="email"
-          placeholder="johndoe@email.com"
-          // pass down to FormLabel as children
-          label="Email"
-        />
-        <TextField
-          name="password"
-          type="password"
-          placeholder="password"
-          label="Password"
-        />
-        <Button
-          sx={{
-            mt: 1, // margin top
-          }}
-        >
-          Log in
-        </Button>
-        <Typography
-          endDecorator={<Link href="/sign-up">Sign up</Link>}
-          fontSize="sm"
-          sx={{ alignSelf: 'center' }}
-        >
-          Don't have an account?
-        </Typography>
-      </Sheet>
-    </CssVarsProvider>
-  );
-}
-```
-
-Congratulations 🎉! You've built your first good looking UI with Joy UI!
+Your app should now look like the [interactive demo](#interactive-demo) at the top of the page.
+Great job making it all the way to the end!
 
 :::info
 This tutorial does _not_ cover theming and general component customization.

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -2,7 +2,7 @@
 
 <p class="description">Learn how to import and style Joy UI components to build a simple login page.</p>
 
-This tutorial will walk you through how to set up the user interface for a basic login page using Joy UI.
+This tutorial will walk you through how to set up a user interface for a basic login page using Joy UI.
 
 By the end, you should understand how to:
 
@@ -19,34 +19,35 @@ This tutorial assumes that you've already:
 
 ## Import the Sheet component for structure
 
-To create the structure for the login page, we'll use the `Sheet` component, which is simply an HTML div that supports the global variant feature.
+The [Sheet](/joy-ui/react-sheet/) component is a `<div>` container that supports Joy UI's [global variants feature](/joy-ui/main-features/global-variants/), helping to ensure consistency across your app.
 
-Try playing around with different variant values to see how they look like.
-You can use `solid`, `soft`, `outlined`, or `plain`.
+Import Sheet and add it to your app as shown below.
+Notice that Joy UI components must be nested within `<CssVarsProvider />`:
 
 ```jsx
 import { CssVarsProvider } from '@mui/joy/styles';
 import Sheet from '@mui/joy/Sheet';
 
-function App() {
+export default function App() {
   return (
     <CssVarsProvider>
       <Sheet variant="outlined">Welcome!</Sheet>
     </CssVarsProvider>
   );
 }
-
-export default App;
 ```
 
-:::info
-**Don't forget:** always render Joy UI components inside the `<CssVarsProvider/>` component.
+:::success
+Try playing around with different `variant` values to see the available styles.
+In addition to `outlined`, you can also use `solid`, `soft`, or `plain`—these are Joy UI's [global variants](/joy-ui/main-features/global-variants/), and they're available on all components.
 :::
 
 ### Add styles with the sx prop
 
-Every Joy UI component accepts the `sx` prop, which allows a shorthand syntax for writing CSS.
+All Joy UI components accept [the `sx` prop](/system/getting-started/the-sx-prop/), which gives you access to a shorthand syntax for writing CSS.
 It's great for creating one-off customizations or rapidly experimenting with different styles.
+
+Replace your basic Sheet from the previous step with the following `sx`-styled Sheet:
 
 ```jsx
 <Sheet
@@ -67,64 +68,72 @@ It's great for creating one-off customizations or rapidly experimenting with dif
 </Sheet>
 ```
 
-Don't worry if you're confused about the `sx` prop's syntax at this moment.
-You'll get the hang of it as you use it more.
-Check the [MUI System's documentation](/system/getting-started/the-sx-prop/) to learn more about its foundation.
+:::success
+Try changing some of the values for the CSS properties above based on the patterns you observe to see how `sx` works.
+To go deeper, read about the `sx` prop in the [MUI System documentation](/system/getting-started/the-sx-prop/).
+:::
 
 ## Add text with the Typography component
 
-The `Typography` component supports the `level` prop, allowing you to choose between a pre-defined scale of typography values.
-Joy UI provides 13 typography levels out of the box: `display 1 | display 2 | h1 | h2 | h3 | h4 | h5 | h6 | body1 | body2 | body3 | body4 | body5`.
+The [Typography](/joy-ui/react-typography/) component replaces HTML header, paragraph, and span tags to help maintain a consistent hierarchy of text on the page.
 
-You can also change which HTML tag gets rendered in each `Typography` component using the `component` prop.
+:::info
+The `level` prop gives you access to a pre-defined scale of typographic values.
+Joy UI provides 13 typography levels out of the box:
+
+`display1 | display2 | h1 | h2 | h3 | h4 | h5 | h6 | body1 | body2 | body3 | body4 | body5`
+
+:::
+
+Add an import for Typography with the rest of your imports:
 
 ```jsx
-// ...other imports
 import Typography from '@mui/joy/Typography';
-
-<Sheet
-  sx={...}
->
-  <div>
-    <Typography level="h4" component="h1">
-      <b>Welcome!</b>
-    </Typography>
-    <Typography level="body2">Sign in to continue</Typography>
-  </div>
-</Sheet>;
 ```
 
-## Add TextField for user inputs
-
-The `TextField` component is made of the `FormLabel`, `Input` and `FormHelperText` components.
+Replace `Welcome!` inside your Sheet component with this `<div>`:
 
 ```jsx
-// ...other imports
-import TextField from '@mui/joy/TextField';
+<div>
+  <Typography level="h4" component="h1">
+    Welcome!
+  </Typography>
+  <Typography level="body2">Sign in to continue</Typography>
+</div>
+```
 
-<Sheet
-  sx={
-    {
-      // ...
-    }
-  }
->
-  ...typography
-  <TextField
-    // html input attribute
-    name="email"
-    type="email"
-    placeholder="johndoe@email.com"
-    // pass down to FormLabel as children
-    label="Email"
-  />
-  <TextField
-    name="password"
-    type="password"
-    placeholder="password"
-    label="Password"
-  />
-</Sheet>;
+:::success
+Try changing the values for the `level` and `component` props to see how they affect the typographic values and the elements rendered.
+(In the example above, the first Typography component renders an `<h1>` with the typographic values of an `<h4>`.)
+:::
+
+## Add Text Field for user inputs
+
+The Text Field component bundles together the Form Control, Form Label, Input, and Form Helper Text components to provide you with a sophisticated field for user input.
+
+Add an import for Text Field with the rest of your imports:
+
+```jsx
+import TextField from '@mui/joy/TextField';
+```
+
+Insert these two Text Fields below the `<div>` from the previous step, inside the Sheet:
+
+```jsx
+<TextField
+  // html input attribute
+  name="email"
+  type="email"
+  placeholder="johndoe@email.com"
+  // pass down to FormLabel as children
+  label="Email"
+/>
+<TextField
+  name="password"
+  type="password"
+  placeholder="password"
+  label="Password"
+/>
 ```
 
 ## Import Button and Link for user actions

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -2,13 +2,15 @@
 
 <p class="description">Learn how to import and style Joy UI components to build a simple login page.</p>
 
-This tutorial will walk you through how to set up a user interface for a basic login page using Joy UI.
+This tutorial will walk you through how to assemble the UI for a basic login page using Joy UI.
+You'll be introduced to several common components as well as some of the props you can use to control their styles.
+You'll also encounter key features of Joy UI such as global variants, the `sx` prop, and the `useColorScheme` hook.
 
 By the end, you should understand how to:
 
 1. import Joy UI components into your React app
 2. add styles to Joy UI components
-3. create a button to toggle light and dark modes
+3. toggle light and dark mode with `useColorScheme`
 
 ## Prerequisites
 
@@ -25,6 +27,7 @@ Import Sheet and add it to your app as shown below.
 Notice that Joy UI components must be nested within `<CssVarsProvider />`:
 
 ```jsx
+import * as React from 'react';
 import { CssVarsProvider } from '@mui/joy/styles';
 import Sheet from '@mui/joy/Sheet';
 
@@ -69,7 +72,7 @@ Replace your basic Sheet from the previous step with the following `sx`-styled S
 ```
 
 :::success
-Try changing some of the values for the CSS properties above based on the patterns you observe to see how `sx` works.
+Try changing some of the values for the CSS properties above based on the patterns you observe.
 To go deeper, read about the `sx` prop in the [MUI System documentation](/system/getting-started/the-sx-prop/).
 :::
 
@@ -79,7 +82,7 @@ The [Typography](/joy-ui/react-typography/) component replaces HTML header, para
 
 :::info
 The `level` prop gives you access to a pre-defined scale of typographic values.
-Joy UI provides 13 typography levels out of the box:
+Joy UI provides 13 typographic levels out of the box:
 
 `display1 | display2 | h1 | h2 | h3 | h4 | h5 | h6 | body1 | body2 | body3 | body4 | body5`
 
@@ -104,7 +107,7 @@ Replace `Welcome!` inside your Sheet component with this `<div>`:
 
 :::success
 Try changing the values for the `level` and `component` props to see how they affect the typographic values and the elements rendered.
-(In the example above, the first Typography component renders an `<h1>` with the typographic values of an `<h4>`.)
+(Note that while `level` only accepts the 13 values listed above, you can pass any HTML tag to `component`, as well as custom React components.)
 :::
 
 ## Add Text Field for user inputs
@@ -228,6 +231,107 @@ export default function App() {
 :::info
 💡 **Note:** With the `useColorScheme` hook, Joy UI ensures that the user selected mode (stored in localStorage by default) is in-sync across browser tabs.
 :::
+
+## Putting it all together
+
+Your completed app should look like this:
+
+```jsx
+import * as React from 'react';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import Sheet from '@mui/joy/Sheet';
+import Typography from '@mui/joy/Typography';
+import TextField from '@mui/joy/TextField';
+import Button from '@mui/joy/Button';
+import Link from '@mui/joy/Link';
+
+const ModeToggle = () => {
+  const { mode, setMode } = useColorScheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  // necessary for server-side rendering
+  // because mode is undefined on the server
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => {
+        if (mode === 'light') {
+          setMode('dark');
+        } else {
+          setMode('light');
+        }
+      }}
+    >
+      {mode === 'light' ? 'Turn dark' : 'Turn light'}
+    </Button>
+  );
+};
+
+export default function App() {
+  return (
+    <CssVarsProvider>
+      <ModeToggle />
+      <Sheet
+        sx={{
+          maxWidth: 400,
+          mx: 'auto', // margin left & right
+          my: 4, // margin top & botom
+          py: 3, // padding top & bottom
+          px: 2, // padding left & right
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          borderRadius: 'sm',
+          boxShadow: 'md',
+        }}
+        variant="outlined"
+      >
+        <div>
+          <Typography level="h4" component="h1">
+            <b>Welcome!</b>
+          </Typography>
+          <Typography level="body2">Sign in to continue</Typography>
+        </div>
+        <TextField
+          // html input attribute
+          name="email"
+          type="email"
+          placeholder="johndoe@email.com"
+          // pass down to FormLabel as children
+          label="Email"
+        />
+        <TextField
+          name="password"
+          type="password"
+          placeholder="password"
+          label="Password"
+        />
+        <Button
+          sx={{
+            mt: 1, // margin top
+          }}
+        >
+          Log in
+        </Button>
+        <Typography
+          endDecorator={<Link href="/sign-up">Sign up</Link>}
+          fontSize="sm"
+          sx={{ alignSelf: 'center' }}
+        >
+          Don't have an account?
+        </Typography>
+      </Sheet>
+    </CssVarsProvider>
+  );
+}
+```
 
 Congratulations 🎉! You've built your first good looking UI with Joy UI!
 

--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -1,19 +1,26 @@
-# Tutorial
+# Introductory tutorial
 
-<p class="description">Quickly learn how to create a login page using Joy UI components.</p>
+<p class="description">Learn how to import and style Joy UI components to build a simple login page.</p>
 
-In this small tutorial, you'll learn how to:
+This tutorial will walk you through how to set up the user interface for a basic login page using Joy UI.
 
-1. Import Joy UI components.
-2. Build a basic login page with them.
-3. Toggle light and dark mode.
+By the end, you should understand how to:
 
-The only **prerequesite** is [having Joy UI installed](/joy-ui/getting-started/installation/).
+1. import Joy UI components into your React app
+2. add styles to Joy UI components
+3. create a button to toggle light and dark modes
 
-:::warning
-⚠️ **Note:** We won't cover theming and general component customization at this moment.
-Learn more about [the different customization approaches](/joy-ui/customization/approaches/) later.
+:::info
+This tutorial does _not_ cover theming and general component customization.
+Learn more about [different customization approaches](/joy-ui/customization/approaches/) after you're done on this page.
 :::
+
+## Prerequisites
+
+This tutorial assumes:
+
+- you've already set up a React app—try [Create React App](https://create-react-app.dev/) if you need a boilerplate
+- you've installed Joy UI in your app—see [Installation](/joy-ui/getting-started/installation/) for instructions
 
 ## Building the login page
 


### PR DESCRIPTION
Part of #33998 

This PR revises and expands the Joy UI "Tutorial" page. The biggest changes include:

- expanded introduction
- embedded demo of the final product
- revised headers
- "Summary" and "Next steps" sections
- overhauled code snippets
  - the way they were originally written, you couldn't use the **Copy** button efficiently. I edited them to optimize for this.

https://deploy-preview-34569--material-ui.netlify.app/joy-ui/getting-started/tutorial/