### PR TITLE
[Select] Add aria-label and aria-labelledby to hidden select input

### DIFF
--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -535,6 +535,8 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         name={name}
         ref={inputRef}
         aria-hidden
+        aria-label={ariaLabel}
+        aria-labelledby={[labelId, buttonId].filter(Boolean).join(' ') || undefined}
         onChange={handleChange}
         tabIndex={-1}
         disabled={disabled}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR resolves #30085

Before:
![before](https://user-images.githubusercontent.com/30778707/193647846-34c25a13-e2b7-413c-a6bf-6e3d25646ff7.png)

After:
![after](https://user-images.githubusercontent.com/30778707/193647901-f5d9ad66-6546-4165-8d41-5e8c0ee6db76.png)

