### PR TITLE
[TrapFocus] Restore the previously exported type from @mui/material

### DIFF
--- a/packages/mui-material/src/Unstable_TrapFocus/index.d.ts
+++ b/packages/mui-material/src/Unstable_TrapFocus/index.d.ts
@@ -1,2 +1,2 @@
 export { default } from '@mui/base/FocusTrap';
-export * from '@mui/base/FocusTrap';
+export { FocusTrapProps as TrapFocusProps } from '@mui/base/FocusTrap';


### PR DESCRIPTION
#34216 inadvertently introduced a breaking change by renaming a type re-exported from @mui/material.
This caused an issue in MUI X (https://github.com/mui/mui-x/issues/6308), as reported in https://github.com/mui/material-ui/issues/33966#issuecomment-1263210842.

This PR restores the previously exported `TrapFocusProps` type in @mui/material. @mui/base continues to export the renamed `FocusTrapProps`, as intended.

Technically, this is a breaking change in relation to @mui/material 5.10.7 and 5.10.8, but not a breaking change in relation to earlier versions.

cc @flaviendelangle 