### PR TITLE
[docs] Fix codesandbox export with dayjs

### DIFF
--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -26,7 +26,7 @@ export default function SandboxDependencies(
    * @param deps - list of dependency as `name => version`
    */
   function addTypeDeps(deps: Record<string, string>): void {
-    const packagesWithBundledTypes = ['date-fns', '@emotion/react', '@emotion/styled'];
+    const packagesWithBundledTypes = ['date-fns', '@emotion/react', '@emotion/styled', 'dayjs'];
     const packagesWithDTPackage = Object.keys(deps)
       .filter((name) => packagesWithBundledTypes.indexOf(name) === -1)
       // All the MUI packages come with bundled types


### PR DESCRIPTION
Since https://github.com/mui/mui-x/pull/5481 the bug is a lot more visible. When you export a codesandbox from https://mui.com/x/react-date-pickers/date-picker/#basic-usage

<img width="366" alt="Screenshot 2022-10-05 at 11 19 14" src="https://user-images.githubusercontent.com/3165635/194026365-afac7584-2464-4064-9516-258bde0efe51.png">

you will get https://codesandbox.io/s/3sem4m?file=/package.json:161-172

<img width="291" alt="Screenshot 2022-10-05 at 11 19 44" src="https://user-images.githubusercontent.com/3165635/194026440-51a127bc-aca5-4df1-9c74-a23e01b87105.png">

but this package doesn't exist. Dayjs already includes the types, proof: https://unpkg.com/browse/dayjs@1.11.5/index.d.ts.

--- 

I found this while I was doing a bit of support in https://groups.google.com/a/mui.com/g/x/c/xHe-_HUVhjc.