### PR TITLE
[core] Fix markdown loader on Windows

### DIFF
--- a/docs/packages/markdown/loader.js
+++ b/docs/packages/markdown/loader.js
@@ -20,7 +20,7 @@ function upperCaseFirst(string) {
  * @example moduleIDToJSIdentifier('../Box-new.js') === '$$$BoxNewJs'
  */
 function moduleIDToJSIdentifier(moduleID) {
-  const delimiter = /(\.|-|\/)/;
+  const delimiter = /(\.|-|\/|:)/;
   return moduleID
     .split(delimiter)
     .filter((part) => !delimiter.test(part))
@@ -205,7 +205,7 @@ module.exports = async function demoLoader() {
   );
 
   componentNames.forEach((componentName) => {
-    const moduleID = path.join(this.rootContext, 'src', componentName);
+    const moduleID = path.join(this.rootContext, 'src', componentName).replace(/\\/g, '/');
 
     components[moduleID] = componentName;
     componentModuleIDs.add(moduleID);


### PR DESCRIPTION
Changes introduced in #34243 made it impossible to run components docs locally on Windows due to differences in path delimiters.
This PR fixes the problem by replacing backslashes with slashes and recognizing the `:` character after a drive letter.