### PR TITLE
[system] Fix color-scheme implementation

### DIFF
--- a/docs/data/joy/components/css-baseline/css-baseline.md
+++ b/docs/data/joy/components/css-baseline/css-baseline.md
@@ -1,0 +1,168 @@
+---
+product: joy-ui
+githubLabel: 'component: CssBaseline'
+---
+
+# CSS Baseline
+
+<p class="description">Joy UI provides a CssBaseline component to kickstart an elegant, consistent, and simple baseline to build upon.</p>
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
+## Global reset
+
+You might be familiar with [normalize.css](https://github.com/necolas/normalize.css), a collection of HTML element and attribute style-normalizations.
+
+```jsx
+import * as React from 'react';
+import { CssVarsProvider } from '@mui/joy/styles';
+import CssBaseline from '@mui/joy/CssBaseline';
+
+export default function MyApp() {
+  return (
+    <CssVarsProvider>
+      {/* must be used under CssVarsProvider */}
+      <CssBaseline />
+
+      {/* The rest of your application */}
+    </CssVarsProvider>
+  );
+}
+```
+
+## Scoping on children
+
+However, you might be progressively migrating a website to MUI, using a global reset might not be an option.
+It's possible to apply the baseline only to the children by using the `ScopedCssBaseline` component.
+
+```jsx
+import * as React from 'react';
+import { CssVarsProvider } from '@mui/joy/styles';
+import ScopedCssBaseline from '@mui/joy/ScopedCssBaseline';
+import MyApp from './MyApp';
+
+export default function MyApp() {
+  const [root, setRoot] = React.useState(null);
+  return (
+    {/* target the node to ScopedCssBaseline's div */}
+    <CssVarsProvider colorSchemeNode={root}>
+      {/* must be used under CssVarsProvider */}
+      <ScopedCssBaseline ref={(element) => setRoot(element)}>
+        {/* The rest of your application */}
+        <MyApp />
+      </ScopedCssBaseline>
+    </CssVarsProvider>
+  );
+}
+```
+
+⚠️ Make sure you import `ScopedCssBaseline` first to avoid box-sizing conflicts as in the above example.
+
+## Approach
+
+### Page
+
+The `<html>` and `<body>` elements are updated to provide better page-wide defaults. More specifically:
+
+- The margin in all browsers is removed.
+- The default Material Design background color is applied.
+  It's using `theme.palette.background.body` for standard devices and a white background for print devices.
+- The CSS [`color-scheme`](https://web.dev/color-scheme/) is applied by default. You can disable it by setting `disableColorScheme` to true on the `CssBaseline` or `ScopedCssBaseline`.
+
+### Layout
+
+- `box-sizing` is set globally on the `<html>` element to `border-box`.
+  Every element—including `*::before` and `*::after` are declared to inherit this property,
+  which ensures that the declared width of the element is never exceeded due to padding or border.
+
+### Color scheme
+
+The CSS [`color-scheme`](https://web.dev/color-scheme/) is applied by default to render proper built-in components on the web. You can disable it by setting `disableColorScheme` to true on the `CssBaseline` or `ScopedCssBaseline`.
+
+```jsx
+<CssVarsProvider>
+  <CssBaseline disableColorScheme />
+</CssVarsProvider>
+
+// or
+<CssVarsProvider>
+  <ScopedCssBaseline disableColorScheme >
+    {/* The rest of your application */}
+  </ScopedCssBaseline>
+</CssVarsProvider>
+```
+
+### Typography
+
+- No base font-size is declared on the `<html>`, but 16px is assumed (the browser default).
+  You can learn more about the implications of changing the `<html>` default font size in [the theme documentation](/material-ui/customization/typography/#html-font-size) page.
+- Set the `theme.typography.body1` style on the `<body>` element.
+- Set the font-weight to `bold` for the `<b>` and `<strong>` elements.
+- Custom font-smoothing is enabled for better display of the default font.
+
+## Customization
+
+### CssBaseline
+
+To custom the styles produced by the `CssBaseline` component, append the `GlobalStyles` next to it:
+
+```js
+import { CssVarsProvider } from '@mui/joy/styles';
+import CssBaseline from '@mui/joy/CssBaseline';
+import GlobalStyles from '@mui/joy/GlobalStyles';
+
+function App() {
+  return (
+    <CssVarsProvider>
+      <CssBaseline /> {/* CssBaseline must come first */}
+      <GlobalStyles
+        styles={{
+          // CSS object styles
+          html: {
+            // ...
+          },
+          body: {
+            // ...
+          },
+        }}
+      />
+    </CssVarsProvider>
+  );
+}
+```
+
+### ScopedCssBaseline
+
+You can customize it using the [themed components](https://mui.com/joy-ui/customization/themed-components/) approach. The component identifier is `JoyScopedCssBaseline` which contains only the `root` slot.
+
+```js
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import ScopedCssBaseline from '@mui/joy/ScopedCssBaseline';
+import MyApp from './MyApp';
+
+const theme = extendTheme({
+  components: {
+    JoyScopedCssBaseline: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          // ...CSS object styles
+        })
+      }
+    }
+  }
+})
+
+export default function MyApp() {
+  const [root, setRoot] = React.useState(null);
+  return (
+    {/* target the node to ScopedCssBaseline's div */}
+    <CssVarsProvider colorSchemeNode={root}>
+      {/* must be used under CssVarsProvider */}
+      <ScopedCssBaseline ref={(element) => setRoot(element)}>
+        {/* The rest of your application */}
+        <MyApp />
+      </ScopedCssBaseline>
+    </CssVarsProvider>
+  );
+}
+```

--- a/docs/data/joy/components/css-baseline/css-baseline.md
+++ b/docs/data/joy/components/css-baseline/css-baseline.md
@@ -72,8 +72,7 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 ### Layout
 
 - `box-sizing` is set globally on the `<html>` element to `border-box`.
-  Every element—including `*::before` and `*::after` are declared to inherit this property,
-  which ensures that the declared width of the element is never exceeded due to padding or border.
+  Every element—including `*::before` and `*::after` are declared to inherit this property, which ensures that the declared width of the element is never exceeded due to padding or border.
 
 ### Color scheme
 

--- a/docs/data/joy/pages.ts
+++ b/docs/data/joy/pages.ts
@@ -76,6 +76,11 @@ const pages = [
           { pathname: '/joy-ui/react-tabs' },
         ],
       },
+      {
+        pathname: '/joy-ui/components/utils',
+        subheader: 'utils',
+        children: [{ pathname: '/joy-ui/react-css-baseline' }],
+      },
     ],
   },
   {

--- a/docs/pages/joy-ui/react-css-baseline.js
+++ b/docs/pages/joy-ui/react-css-baseline.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/joy/components/css-baseline/css-baseline.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -7,13 +7,13 @@ import { CssBaselineProps } from './CssBaselineProps';
 /**
  * Kickstart an elegant, consistent, and simple baseline to build upon.
  */
-function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) {
+function CssBaseline({ children, disableColorScheme = false }: CssBaselineProps) {
   return (
     <React.Fragment>
       <GlobalStyles
         styles={(theme: Theme) => {
           const colorSchemeStyles: Record<string, any> = {};
-          if (enableColorScheme) {
+          if (!disableColorScheme) {
             // The CssBaseline is wrapped inside a CssVarsProvider
             (
               Object.entries(theme.colorSchemes) as Array<[DefaultColorScheme, ColorSystem]>
@@ -37,7 +37,7 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
               boxSizing: 'inherit',
             },
             'strong, b': {
-              fontWeight: theme.vars.fontWeight.lg,
+              fontWeight: 'bold',
             },
             body: {
               margin: 0, // Remove the margin in all browsers.
@@ -73,12 +73,13 @@ CssBaseline.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Enable `color-scheme` CSS property to use `theme.palette.mode`.
+   * Disable `color-scheme` CSS property.
+   *
    * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
    * For browser support, check out https://caniuse.com/?search=color-scheme
    * @default false
    */
-  enableColorScheme: PropTypes.bool,
+  disableColorScheme: PropTypes.bool,
 } as any;
 
 export default CssBaseline;

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { GlobalStyles } from '@mui/system';
+import { Theme, DefaultColorScheme, ColorSystem } from '../styles/types';
+import { CssBaselineProps } from './CssBaselineProps';
+
+/**
+ * Kickstart an elegant, consistent, and simple baseline to build upon.
+ */
+function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) {
+  return (
+    <React.Fragment>
+      <GlobalStyles
+        styles={(theme: Theme) => {
+          const styleSheets: Record<string, any> = {};
+          if (enableColorScheme) {
+            if (theme.vars) {
+              // The CssBaseline is wrapped inside a CssVarsProvider
+              (
+                Object.entries(theme.colorSchemes) as Array<[DefaultColorScheme, ColorSystem]>
+              ).forEach(([key, scheme]) => {
+                styleSheets[theme.getColorSchemeSelector(key)] = {
+                  colorScheme: scheme.palette?.mode,
+                };
+              });
+            } else {
+              styleSheets.colorScheme = theme.palette.mode;
+            }
+          }
+          return {
+            html: {
+              WebkitFontSmoothing: 'antialiased',
+              MozOsxFontSmoothing: 'grayscale',
+              // Change from `box-sizing: content-box` so that `width`
+              // is not affected by `padding` or `border`.
+              boxSizing: 'border-box',
+              // Fix font resize problem in iOS
+              WebkitTextSizeAdjust: '100%',
+              ...styleSheets,
+            },
+            '*, *::before, *::after': {
+              boxSizing: 'inherit',
+            },
+            'strong, b': {
+              fontWeight: theme.vars.fontWeight.lg,
+            },
+            body: {
+              margin: 0, // Remove the margin in all browsers.
+              color: theme.vars.palette.text.primary,
+              ...(theme.typography.body1 as any),
+              backgroundColor: theme.vars.palette.background.body,
+              '@media print': {
+                // Save printer ink.
+                backgroundColor: theme.vars.palette.common.white,
+              },
+              // Add support for document.body.requestFullScreen().
+              // Other elements, if background transparent, are not supported.
+              '&::backdrop': {
+                backgroundColor: theme.vars.palette.background.tooltip,
+              },
+            },
+          };
+        }}
+      />
+      {children}
+    </React.Fragment>
+  );
+}
+
+CssBaseline.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * You can wrap a node.
+   */
+  children: PropTypes.node,
+  /**
+   * Enable `color-scheme` CSS property to use `theme.palette.mode`.
+   * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
+   * For browser support, check out https://caniuse.com/?search=color-scheme
+   * @default false
+   */
+  enableColorScheme: PropTypes.bool,
+};
+
+export default CssBaseline;

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -12,20 +12,16 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
     <React.Fragment>
       <GlobalStyles
         styles={(theme: Theme) => {
-          const styleSheets: Record<string, any> = {};
+          const colorSchemeStyles: Record<string, any> = {};
           if (enableColorScheme) {
-            if (theme.vars) {
-              // The CssBaseline is wrapped inside a CssVarsProvider
-              (
-                Object.entries(theme.colorSchemes) as Array<[DefaultColorScheme, ColorSystem]>
-              ).forEach(([key, scheme]) => {
-                styleSheets[theme.getColorSchemeSelector(key)] = {
-                  colorScheme: scheme.palette?.mode,
-                };
-              });
-            } else {
-              styleSheets.colorScheme = theme.palette.mode;
-            }
+            // The CssBaseline is wrapped inside a CssVarsProvider
+            (
+              Object.entries(theme.colorSchemes) as Array<[DefaultColorScheme, ColorSystem]>
+            ).forEach(([key, scheme]) => {
+              colorSchemeStyles[theme.getColorSchemeSelector(key)] = {
+                colorScheme: scheme.palette?.mode,
+              };
+            });
           }
           return {
             html: {
@@ -36,7 +32,6 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
               boxSizing: 'border-box',
               // Fix font resize problem in iOS
               WebkitTextSizeAdjust: '100%',
-              ...styleSheets,
             },
             '*, *::before, *::after': {
               boxSizing: 'inherit',
@@ -59,6 +54,7 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
                 backgroundColor: theme.vars.palette.background.backdrop,
               },
             },
+            ...colorSchemeStyles,
           };
         }}
       />

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -18,7 +18,7 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
             (
               Object.entries(theme.colorSchemes) as Array<[DefaultColorScheme, ColorSystem]>
             ).forEach(([key, scheme]) => {
-              colorSchemeStyles[theme.getColorSchemeSelector(key)] = {
+              colorSchemeStyles[theme.getColorSchemeSelector(key).replace(/\s*&/, '')] = {
                 colorScheme: scheme.palette?.mode,
               };
             });

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -70,7 +70,7 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
 CssBaseline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
   // | These PropTypes are generated from the TypeScript type definitions |
-  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
   // ----------------------------------------------------------------------
   /**
    * You can wrap a node.
@@ -83,6 +83,6 @@ CssBaseline.propTypes /* remove-proptypes */ = {
    * @default false
    */
   enableColorScheme: PropTypes.bool,
-};
+} as any;
 
 export default CssBaseline;

--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -56,7 +56,7 @@ function CssBaseline({ children, enableColorScheme = false }: CssBaselineProps) 
               // Add support for document.body.requestFullScreen().
               // Other elements, if background transparent, are not supported.
               '&::backdrop': {
-                backgroundColor: theme.vars.palette.background.tooltip,
+                backgroundColor: theme.vars.palette.background.backdrop,
               },
             },
           };

--- a/packages/mui-joy/src/CssBaseline/CssBaselineProps.ts
+++ b/packages/mui-joy/src/CssBaseline/CssBaselineProps.ts
@@ -4,10 +4,11 @@ export interface CssBaselineProps {
    */
   children?: React.ReactNode;
   /**
-   * Enable `color-scheme` CSS property to use `theme.palette.mode`.
+   * Disable `color-scheme` CSS property.
+   *
    * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
    * For browser support, check out https://caniuse.com/?search=color-scheme
    * @default false
    */
-  enableColorScheme?: boolean;
+  disableColorScheme?: boolean;
 }

--- a/packages/mui-joy/src/CssBaseline/CssBaselineProps.ts
+++ b/packages/mui-joy/src/CssBaseline/CssBaselineProps.ts
@@ -1,0 +1,13 @@
+export interface CssBaselineProps {
+  /**
+   * You can wrap a node.
+   */
+  children?: React.ReactNode;
+  /**
+   * Enable `color-scheme` CSS property to use `theme.palette.mode`.
+   * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
+   * For browser support, check out https://caniuse.com/?search=color-scheme
+   * @default false
+   */
+  enableColorScheme?: boolean;
+}

--- a/packages/mui-joy/src/CssBaseline/index.ts
+++ b/packages/mui-joy/src/CssBaseline/index.ts
@@ -1,0 +1,2 @@
+export { default } from './CssBaseline';
+export * from './CssBaselineProps';

--- a/packages/mui-joy/src/GlobalStyles/index.ts
+++ b/packages/mui-joy/src/GlobalStyles/index.ts
@@ -1,0 +1,1 @@
+export { GlobalStyles as default } from '@mui/system';

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.test.tsx
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { createRenderer, describeConformance } from 'test/utils';
+import { ThemeProvider } from '@mui/joy/styles';
+import ScopedCssBaseline, { scopedCssBaselineClasses as classes } from '@mui/joy/ScopedCssBaseline';
+
+describe('<ScopedCssBaseline />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<ScopedCssBaseline />, () => ({
+    classes,
+    inheritComponent: 'div',
+    render,
+    ThemeProvider,
+    muiName: 'JoyScopedCssBaseline',
+    refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: 'span',
+    skip: ['classesRoot', 'componentsProp'],
+  }));
+});

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.test.tsx
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.test.tsx
@@ -14,6 +14,7 @@ describe('<ScopedCssBaseline />', () => {
     muiName: 'JoyScopedCssBaseline',
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
+    testVariantProps: { disableColorScheme: true },
     skip: ['classesRoot', 'componentsProp'],
   }));
 });

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.tsx
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { OverridableComponent } from '@mui/types';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import useThemeProps from '../styles/useThemeProps';
+import styled from '../styles/styled';
+import { DefaultColorScheme, ColorSystem } from '../styles/types';
+import {
+  ScopedCssBaselineTypeMap,
+  ScopedCssBaselineOwnerState,
+  ScopedCssBaselineProps,
+} from './ScopedCssBaselineProps';
+import { getScopedCssBaselineUtilityClass } from './scopedCssBaselineClasses';
+
+const useUtilityClasses = () => {
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getScopedCssBaselineUtilityClass, {});
+};
+
+const ScopedCssBaselineRoot = styled('div', {
+  name: 'JoyScopedCssBaseline',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})<{ ownerState: ScopedCssBaselineOwnerState }>(({ theme, ownerState }) => {
+  const colorSchemeStyles: Record<string, any> = {};
+  if (!ownerState.disableColorScheme && theme.colorSchemes) {
+    (Object.entries(theme.colorSchemes) as Array<[DefaultColorScheme, ColorSystem]>).forEach(
+      ([key, scheme]) => {
+        colorSchemeStyles[`&${theme.getColorSchemeSelector(key).replace(/\s*&/, '')}`] = {
+          colorScheme: scheme.palette?.mode,
+        };
+      },
+    );
+  }
+  return {
+    WebkitFontSmoothing: 'antialiased',
+    MozOsxFontSmoothing: 'grayscale',
+    // Change from `box-sizing: content-box` so that `width`
+    // is not affected by `padding` or `border`.
+    boxSizing: 'border-box',
+    // Fix font resize problem in iOS
+    WebkitTextSizeAdjust: '100%',
+    color: theme.vars.palette.text.primary,
+    ...(theme.typography.body1 as any),
+    backgroundColor: theme.vars.palette.background.body,
+    '@media print': {
+      // Save printer ink.
+      backgroundColor: theme.vars.palette.common.white,
+    },
+    '& *, & *::before, & *::after': {
+      boxSizing: 'inherit',
+    },
+    '& strong, & b': {
+      fontWeight: 'bold',
+    },
+    ...colorSchemeStyles,
+  };
+});
+
+const ScopedCssBaseline = React.forwardRef(function ScopedCssBaseline(inProps, ref) {
+  const props = useThemeProps<typeof inProps & ScopedCssBaselineProps>({
+    props: inProps,
+    name: 'MuiScopedCssBaseline',
+  });
+
+  const { className, component = 'div', disableColorScheme = false, ...other } = props;
+
+  const ownerState = {
+    ...props,
+    component,
+    disableColorScheme,
+  };
+
+  const classes = useUtilityClasses();
+
+  return (
+    <ScopedCssBaselineRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      ref={ref}
+      ownerState={ownerState}
+      {...other}
+    />
+  );
+}) as OverridableComponent<ScopedCssBaselineTypeMap>;
+
+ScopedCssBaseline.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit TypeScript types and run "yarn proptypes"  |
+  // ----------------------------------------------------------------------
+  /**
+   * You can wrap a node.
+   */
+  children: PropTypes.node,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * Disable `color-scheme` CSS property.
+   *
+   * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
+   * For browser support, check out https://caniuse.com/?search=color-scheme
+   * @default false
+   */
+  disableColorScheme: PropTypes.bool,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+} as any;
+
+export default ScopedCssBaseline;

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.tsx
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.tsx
@@ -64,7 +64,7 @@ const ScopedCssBaselineRoot = styled('div', {
 const ScopedCssBaseline = React.forwardRef(function ScopedCssBaseline(inProps, ref) {
   const props = useThemeProps<typeof inProps & ScopedCssBaselineProps>({
     props: inProps,
-    name: 'MuiScopedCssBaseline',
+    name: 'JoyScopedCssBaseline',
   });
 
   const { className, component = 'div', disableColorScheme = false, ...other } = props;

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaselineProps.ts
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaselineProps.ts
@@ -1,0 +1,33 @@
+import { OverrideProps } from '@mui/types';
+import { SxProps } from '../styles/types';
+
+export type ScopedCssBaselineSlot = 'root';
+
+export interface ScopedCssBaselineTypeMap<P = {}, D extends React.ElementType = 'div'> {
+  props: P & {
+    /**
+     * You can wrap a node.
+     */
+    children?: React.ReactNode;
+    /**
+     * Disable `color-scheme` CSS property.
+     *
+     * For more details, check out https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
+     * For browser support, check out https://caniuse.com/?search=color-scheme
+     * @default false
+     */
+    disableColorScheme?: boolean;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps;
+  };
+  defaultComponent: D;
+}
+
+export type ScopedCssBaselineProps<
+  D extends React.ElementType = ScopedCssBaselineTypeMap['defaultComponent'],
+  P = { component?: React.ElementType },
+> = OverrideProps<ScopedCssBaselineTypeMap<P, D>, D>;
+
+export interface ScopedCssBaselineOwnerState extends ScopedCssBaselineProps {}

--- a/packages/mui-joy/src/ScopedCssBaseline/index.ts
+++ b/packages/mui-joy/src/ScopedCssBaseline/index.ts
@@ -1,0 +1,3 @@
+export { default } from './ScopedCssBaseline';
+export * from './ScopedCssBaselineProps';
+export { default as scopedCssBaselineClasses } from './scopedCssBaselineClasses';

--- a/packages/mui-joy/src/ScopedCssBaseline/scopedCssBaselineClasses.ts
+++ b/packages/mui-joy/src/ScopedCssBaseline/scopedCssBaselineClasses.ts
@@ -1,0 +1,16 @@
+import { generateUtilityClass, generateUtilityClasses } from '../className';
+
+export interface ScopedCssBaselineClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type ScopedCssBaselineClassKey = keyof ScopedCssBaselineClasses;
+
+export function getScopedCssBaselineUtilityClass(slot: string): string {
+  return generateUtilityClass('JoyScopedCssBaseline', slot);
+}
+
+const scopedCssBaselineClasses = generateUtilityClasses('JoyScopedCssBaseline', ['root']);
+
+export default scopedCssBaselineClasses;

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -55,6 +55,9 @@ export * from './Container';
 export { default as CssBaseline } from './CssBaseline';
 export * from './CssBaseline';
 
+export { default as ScopedCssBaseline } from './ScopedCssBaseline';
+export * from './ScopedCssBaseline';
+
 export { default as Divider } from './Divider';
 export * from './Divider';
 

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -52,6 +52,10 @@ export * from './ChipDelete';
 export { default as Container } from './Container';
 export * from './Container';
 
+export { default as CssBaseline } from './CssBaseline';
+// eslint-disable-next-line import/export
+export * from './CssBaseline';
+
 export { default as Divider } from './Divider';
 export * from './Divider';
 

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -53,7 +53,6 @@ export { default as Container } from './Container';
 export * from './Container';
 
 export { default as CssBaseline } from './CssBaseline';
-// eslint-disable-next-line import/export
 export * from './CssBaseline';
 
 export { default as Divider } from './Divider';

--- a/packages/mui-joy/src/index.ts
+++ b/packages/mui-joy/src/index.ts
@@ -1,6 +1,8 @@
 export { default as colors } from './colors';
 export * from './styles';
 
+export { default as GlobalStyles } from './GlobalStyles';
+
 export { default as AspectRatio } from './AspectRatio';
 export * from './AspectRatio';
 

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -4,6 +4,7 @@ import type { DefaultColorScheme, ExtendedColorScheme } from './types';
 
 const shouldSkipGeneratingVar = (keys: string[]) =>
   !!keys[0].match(/(typography|variants|breakpoints)/) ||
+  (keys[0] === 'palette' && !!keys[1]?.match(/(mode)/)) ||
   (keys[0] === 'focus' && keys[1] !== 'thickness');
 
 const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<

--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -4,7 +4,7 @@ import type { DefaultColorScheme, ExtendedColorScheme } from './types';
 
 const shouldSkipGeneratingVar = (keys: string[]) =>
   !!keys[0].match(/(typography|variants|breakpoints)/) ||
-  (keys[0] === 'palette' && !!keys[1]?.match(/(mode)/)) ||
+  (keys[0] === 'palette' && !!keys[1]?.match(/^(mode)$/)) ||
   (keys[0] === 'focus' && keys[1] !== 'thickness');
 
 const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -45,6 +45,11 @@ import {
   CircularProgressSlot,
 } from '../CircularProgress/CircularProgressProps';
 import { ContainerProps, ContainerSlot } from '../Container/ContainerProps';
+import {
+  ScopedCssBaselineProps,
+  ScopedCssBaselineOwnerState,
+  ScopedCssBaselineSlot,
+} from '../ScopedCssBaseline/ScopedCssBaselineProps';
 import { DividerProps, DividerOwnerState, DividerSlot } from '../Divider/DividerProps';
 import {
   FormControlProps,
@@ -218,6 +223,10 @@ export interface Components<Theme = unknown> {
   JoyContainer?: {
     defaultProps?: Partial<ContainerProps>;
     styleOverrides?: OverridesStyleRules<ContainerSlot, ContainerProps, Theme>;
+  };
+  JoyScopedCssBaseline?: {
+    defaultProps?: Partial<ScopedCssBaselineProps>;
+    styleOverrides?: OverridesStyleRules<ScopedCssBaselineSlot, ScopedCssBaselineOwnerState, Theme>;
   };
   JoyDivider?: {
     defaultProps?: Partial<DividerProps>;

--- a/packages/mui-joy/src/styles/defaultTheme.test.js
+++ b/packages/mui-joy/src/styles/defaultTheme.test.js
@@ -26,6 +26,7 @@ describe('extendTheme', () => {
         'variants',
         'vars',
         'cssVarPrefix',
+        'getColorSchemeSelector',
       ]).to.includes(field);
     });
   });

--- a/packages/mui-joy/src/styles/defaultTheme.ts
+++ b/packages/mui-joy/src/styles/defaultTheme.ts
@@ -7,6 +7,7 @@ export const getThemeWithVars = (
   themeInput?: Omit<CssVarsThemeOptions, 'colorSchemes'> & ColorSystemOptions,
 ) => {
   const {
+    cssVarPrefix,
     colorSchemes,
     focus,
     fontFamily,
@@ -59,6 +60,7 @@ export const getThemeWithVars = (
       shadow,
       palette,
     },
+    getColorSchemeSelector: () => '&',
   } as unknown as Theme;
 };
 

--- a/packages/mui-joy/src/styles/extendTheme.spec.ts
+++ b/packages/mui-joy/src/styles/extendTheme.spec.ts
@@ -14,6 +14,7 @@ import { ChipOwnerState } from '@mui/joy/Chip';
 import { ChipDeleteOwnerState } from '@mui/joy/ChipDelete';
 import { CircularProgressOwnerState } from '@mui/joy/CircularProgress';
 import { ContainerProps } from '@mui/joy/Container';
+import { ScopedCssBaselineOwnerState } from '@mui/joy/ScopedCssBaseline';
 import { DividerOwnerState } from '@mui/joy/Divider';
 import { FormControlOwnerState } from '@mui/joy/FormControl';
 import { FormHelperTextOwnerState } from '@mui/joy/FormHelperText';
@@ -349,6 +350,19 @@ extendTheme({
       styleOverrides: {
         root: ({ ownerState }) => {
           expectType<ContainerProps & Record<string, unknown>, typeof ownerState>(ownerState);
+          return {};
+        },
+      },
+    },
+    JoyScopedCssBaseline: {
+      defaultProps: {
+        disableColorScheme: true,
+      },
+      styleOverrides: {
+        root: ({ ownerState }) => {
+          expectType<ScopedCssBaselineOwnerState & Record<string, unknown>, typeof ownerState>(
+            ownerState,
+          );
           return {};
         },
       },

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -142,6 +142,7 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
 
   const lightColorSystem = {
     palette: {
+      mode: 'light',
       primary: {
         ...colors.blue,
         ...createLightModeVariantVariables('primary'),
@@ -242,6 +243,7 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
     shadowChannel: '187 187 187',
   };
   const darkColorSystem = {
+    mode: 'dark',
     palette: {
       primary: {
         ...colors.blue,

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -243,8 +243,8 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
     shadowChannel: '187 187 187',
   };
   const darkColorSystem = {
-    mode: 'dark',
     palette: {
+      mode: 'dark',
       primary: {
         ...colors.blue,
         ...createDarkModeVariantVariables('primary'),

--- a/packages/mui-joy/src/styles/types/colorSystem.ts
+++ b/packages/mui-joy/src/styles/types/colorSystem.ts
@@ -135,6 +135,7 @@ export interface PaletteSuccess extends PaletteRange {}
 export interface PaletteWarning extends PaletteRange {}
 
 export interface Palette {
+  mode: 'light' | 'dark';
   primary: PalettePrimary;
   neutral: PaletteNeutral;
   danger: PaletteDanger;

--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -43,7 +43,6 @@ type NormalizeVars<T> = ConcatDeep<Split<T>>;
 
 export interface RuntimeColorSystem extends Omit<ColorSystem, 'palette'> {
   palette: ColorSystem['palette'] & {
-    mode: 'light' | 'dark';
     colorScheme: DefaultColorScheme | ExtendedColorScheme;
   };
 }
@@ -59,7 +58,10 @@ export interface ThemeScales {
   letterSpacing: LetterSpacing;
 }
 
-export interface ThemeVars extends ThemeScales, ColorSystem {}
+interface ColorSystemVars extends Omit<ColorSystem, 'palette'> {
+  palette: Omit<ColorSystem['palette'], 'mode'>;
+}
+export interface ThemeVars extends ThemeScales, ColorSystemVars {}
 
 export interface ThemeCssVarOverrides {}
 

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -3,45 +3,17 @@ import PropTypes from 'prop-types';
 import useThemeProps from '../styles/useThemeProps';
 import GlobalStyles from '../GlobalStyles';
 
-export const html = (theme, enableColorScheme) => {
-  const styleSheets = {};
-  if (enableColorScheme) {
-    if (theme.vars) {
-      // The CssBaseline is wrapped inside a CssVarsProvider
-      Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
-        styleSheets[theme.getColorSchemeSelector(key)] = {
-          colorScheme: scheme.palette?.mode,
-        };
-      });
-    } else {
-      styleSheets.colorScheme = theme.palette.mode;
-    }
-  }
-  return {
-    WebkitFontSmoothing: 'antialiased',
-    MozOsxFontSmoothing: 'grayscale',
-    // Change from `box-sizing: content-box` so that `width`
-    // is not affected by `padding` or `border`.
-    boxSizing: 'border-box',
-    // Fix font resize problem in iOS
-    WebkitTextSizeAdjust: '100%',
-    ...styleSheets,
-  };
-};
-
-export const body = (theme) => ({
-  color: (theme.vars || theme).palette.text.primary,
-  ...theme.typography.body1,
-  backgroundColor: (theme.vars || theme).palette.background.default,
-  '@media print': {
-    // Save printer ink.
-    backgroundColor: (theme.vars || theme).palette.common.white,
-  },
-});
-
 export const styles = (theme, enableColorScheme = false) => {
-  let defaultStyles = {
-    html: html(theme, enableColorScheme),
+  const defaultStyles = {
+    html: {
+      WebkitFontSmoothing: 'antialiased',
+      MozOsxFontSmoothing: 'grayscale',
+      // Change from `box-sizing: content-box` so that `width`
+      // is not affected by `padding` or `border`.
+      boxSizing: 'border-box',
+      // Fix font resize problem in iOS
+      WebkitTextSizeAdjust: '100%',
+    },
     '*, *::before, *::after': {
       boxSizing: 'inherit',
     },
@@ -50,7 +22,13 @@ export const styles = (theme, enableColorScheme = false) => {
     },
     body: {
       margin: 0, // Remove the margin in all browsers.
-      ...body(theme),
+      color: (theme.vars || theme).palette.text.primary,
+      ...theme.typography.body1,
+      backgroundColor: (theme.vars || theme).palette.background.default,
+      '@media print': {
+        // Save printer ink.
+        backgroundColor: (theme.vars || theme).palette.common.white,
+      },
       // Add support for document.body.requestFullScreen().
       // Other elements, if background transparent, are not supported.
       '&::backdrop': {
@@ -59,12 +37,28 @@ export const styles = (theme, enableColorScheme = false) => {
     },
   };
 
-  const themeOverrides = theme.components?.MuiCssBaseline?.styleOverrides;
-  if (themeOverrides) {
-    defaultStyles = [defaultStyles, themeOverrides];
+  const colorSchemeStyles = {};
+  if (enableColorScheme) {
+    if (theme.vars) {
+      // The CssBaseline is wrapped inside a CssVarsProvider
+      Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
+        colorSchemeStyles[theme.getColorSchemeSelector(key).replace(' &', '')] = {
+          colorScheme: scheme.palette?.mode,
+        };
+      });
+    } else {
+      colorSchemeStyles.html = {
+        colorScheme: theme.palette.mode,
+      };
+    }
   }
 
-  return defaultStyles;
+  const themeOverrides = theme.components?.MuiCssBaseline?.styleOverrides;
+  if (themeOverrides) {
+    return [defaultStyles, colorSchemeStyles, themeOverrides];
+  }
+
+  return [defaultStyles, colorSchemeStyles];
 };
 
 /**

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -4,7 +4,7 @@ import useThemeProps from '../styles/useThemeProps';
 import GlobalStyles from '../GlobalStyles';
 
 export const styles = (theme, enableColorScheme = false) => {
-  const defaultStyles = {
+  let defaultStyles = {
     html: {
       WebkitFontSmoothing: 'antialiased',
       MozOsxFontSmoothing: 'grayscale',
@@ -47,18 +47,18 @@ export const styles = (theme, enableColorScheme = false) => {
         };
       });
     } else {
-      colorSchemeStyles.html = {
-        colorScheme: theme.palette.mode,
-      };
+      defaultStyles.html.colorScheme = theme.palette.mode;
     }
   }
 
+  defaultStyles = { ...defaultStyles, ...colorSchemeStyles };
+
   const themeOverrides = theme.components?.MuiCssBaseline?.styleOverrides;
   if (themeOverrides) {
-    return [defaultStyles, colorSchemeStyles, themeOverrides];
+    defaultStyles = [defaultStyles, themeOverrides];
   }
 
-  return [defaultStyles, colorSchemeStyles];
+  return defaultStyles;
 };
 
 /**

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -4,7 +4,7 @@ import useThemeProps from '../styles/useThemeProps';
 import GlobalStyles from '../GlobalStyles';
 
 export const colorScheme = (theme, enableColorScheme) => {
-  if (!enableColorScheme) {
+  if (!enableColorScheme || !theme.colorSchemes) {
     return {};
   }
   const colorSchemeStyles = {};

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -3,19 +3,6 @@ import PropTypes from 'prop-types';
 import useThemeProps from '../styles/useThemeProps';
 import GlobalStyles from '../GlobalStyles';
 
-export const colorScheme = (theme, enableColorScheme) => {
-  if (!enableColorScheme || !theme.colorSchemes) {
-    return {};
-  }
-  const colorSchemeStyles = {};
-  Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
-    colorSchemeStyles[theme.getColorSchemeSelector(key).replace(/\s*&/, '')] = {
-      colorScheme: scheme.palette?.mode,
-    };
-  });
-  return colorSchemeStyles;
-};
-
 export const html = (theme, enableColorScheme) => ({
   WebkitFontSmoothing: 'antialiased', // Antialiasing.
   MozOsxFontSmoothing: 'grayscale', // Antialiasing.
@@ -39,6 +26,14 @@ export const body = (theme) => ({
 });
 
 export const styles = (theme, enableColorScheme = false) => {
+  const colorSchemeStyles = {};
+  if (enableColorScheme && theme.colorSchemes) {
+    Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
+      colorSchemeStyles[theme.getColorSchemeSelector(key).replace(/\s*&/, '')] = {
+        colorScheme: scheme.palette?.mode,
+      };
+    });
+  }
   let defaultStyles = {
     html: html(theme, enableColorScheme),
     '*, *::before, *::after': {
@@ -56,7 +51,7 @@ export const styles = (theme, enableColorScheme = false) => {
         backgroundColor: (theme.vars || theme).palette.background.default,
       },
     },
-    ...colorScheme(theme, enableColorScheme),
+    ...colorSchemeStyles,
   };
 
   const themeOverrides = theme.components?.MuiCssBaseline?.styleOverrides;

--- a/packages/mui-material/src/CssBaseline/CssBaseline.js
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.js
@@ -3,16 +3,31 @@ import PropTypes from 'prop-types';
 import useThemeProps from '../styles/useThemeProps';
 import GlobalStyles from '../GlobalStyles';
 
-export const html = (theme, enableColorScheme) => ({
-  WebkitFontSmoothing: 'antialiased', // Antialiasing.
-  MozOsxFontSmoothing: 'grayscale', // Antialiasing.
-  // Change from `box-sizing: content-box` so that `width`
-  // is not affected by `padding` or `border`.
-  boxSizing: 'border-box',
-  // Fix font resize problem in iOS
-  WebkitTextSizeAdjust: '100%',
-  ...(enableColorScheme && { colorScheme: theme.palette.mode }),
-});
+export const html = (theme, enableColorScheme) => {
+  const styleSheets = {};
+  if (enableColorScheme) {
+    if (theme.vars) {
+      // The CssBaseline is wrapped inside a CssVarsProvider
+      Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
+        styleSheets[theme.getColorSchemeSelector(key)] = {
+          colorScheme: scheme.palette?.mode,
+        };
+      });
+    } else {
+      styleSheets.colorScheme = theme.palette.mode;
+    }
+  }
+  return {
+    WebkitFontSmoothing: 'antialiased',
+    MozOsxFontSmoothing: 'grayscale',
+    // Change from `box-sizing: content-box` so that `width`
+    // is not affected by `padding` or `border`.
+    boxSizing: 'border-box',
+    // Fix font resize problem in iOS
+    WebkitTextSizeAdjust: '100%',
+    ...styleSheets,
+  };
+};
 
 export const body = (theme) => ({
   color: (theme.vars || theme).palette.text.primary,

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
-import { html, body, colorScheme } from '../CssBaseline/CssBaseline';
+import { html, body } from '../CssBaseline/CssBaseline';
 import { getScopedCssBaselineUtilityClass } from './scopedCssBaselineClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -22,6 +22,14 @@ const ScopedCssBaselineRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })(({ theme, ownerState }) => {
+  const colorSchemeStyles = {};
+  if (ownerState.enableColorScheme && theme.colorSchemes) {
+    Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
+      colorSchemeStyles[`&${theme.getColorSchemeSelector(key).replace(/\s*&/, '')}`] = {
+        colorScheme: scheme.palette?.mode,
+      };
+    });
+  }
   return {
     ...html(theme, ownerState.enableColorScheme),
     ...body(theme),
@@ -31,7 +39,7 @@ const ScopedCssBaselineRoot = styled('div', {
     '& strong, & b': {
       fontWeight: theme.typography.fontWeightBold,
     },
-    ...colorScheme(theme, ownerState.enableColorScheme),
+    ...colorSchemeStyles,
   };
 });
 

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
-import { html, body } from '../CssBaseline/CssBaseline';
+import { html, body, colorScheme } from '../CssBaseline/CssBaseline';
 import { getScopedCssBaselineUtilityClass } from './scopedCssBaselineClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -31,6 +31,7 @@ const ScopedCssBaselineRoot = styled('div', {
     '& strong, & b': {
       fontWeight: theme.typography.fontWeightBold,
     },
+    ...colorScheme(theme, ownerState.enableColorScheme),
   };
 });
 

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -193,7 +193,7 @@ export interface PaletteTooltip {
 
 // The Palette should be sync with `../themeCssVarsAugmentation/index.d.ts`
 export interface ColorSystemOptions {
-  palette?: Omit<PaletteOptions, 'mode'> & {
+  palette?: PaletteOptions & {
     common?: Partial<PaletteCommonChannel>;
     primary?: Partial<PaletteColorChannel>;
     secondary?: Partial<PaletteColorChannel>;

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -40,11 +40,6 @@ export interface CssVarsProviderConfig<ColorScheme extends string> {
    */
   disableTransitionOnChange?: boolean;
   /**
-   * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
-   * @default true
-   */
-  enableColorScheme?: boolean;
-  /**
    * A function to determine if the key, value should be attached as CSS Variable
    * `keys` is an array that represents the object path keys.
    *  Ex, if the theme is { foo: { bar: 'var(--test)' } }

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -307,12 +307,23 @@ export default function createCssVarsProvider(options) {
     theme: PropTypes.object,
   };
 
+  const defaultLightColorScheme =
+    typeof designSystemColorScheme === 'string'
+      ? designSystemColorScheme
+      : designSystemColorScheme.light;
+  const defaultDarkColorScheme =
+    typeof designSystemColorScheme === 'string'
+      ? designSystemColorScheme
+      : designSystemColorScheme.dark;
+
   const getInitColorSchemeScript = (params) =>
     systemGetInitColorSchemeScript({
       attribute: defaultAttribute,
       colorSchemeStorageKey: defaultColorSchemeStorageKey,
+      defaultMode: designSystemMode,
+      defaultLightColorScheme,
+      defaultDarkColorScheme,
       modeStorageKey: defaultModeStorageKey,
-      enableColorScheme: designSystemEnableColorScheme,
       ...params,
     });
 

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -24,7 +24,6 @@ export default function createCssVarsProvider(options) {
     defaultMode: designSystemMode = 'light',
     defaultColorScheme: designSystemColorScheme,
     disableTransitionOnChange: designSystemTransitionOnChange = false,
-    enableColorScheme: designSystemEnableColorScheme = true,
     shouldSkipGeneratingVar: designSystemShouldSkipGeneratingVar,
     resolveTheme,
     excludeVariablesFromRoot,
@@ -60,7 +59,6 @@ export default function createCssVarsProvider(options) {
     defaultMode = designSystemMode,
     defaultColorScheme = designSystemColorScheme,
     disableTransitionOnChange = designSystemTransitionOnChange,
-    enableColorScheme = designSystemEnableColorScheme,
     storageWindow = typeof window === 'undefined' ? undefined : window,
     documentNode = typeof document === 'undefined' ? undefined : document,
     colorSchemeNode = typeof document === 'undefined' ? undefined : document.documentElement,
@@ -174,19 +172,11 @@ export default function createCssVarsProvider(options) {
           });
           defaultColorSchemeStyleSheet[`[${attribute}="${key}"]`] = excludedVariables;
         }
-        defaultColorSchemeStyleSheet[`${colorSchemeSelector}, [${attribute}="${key}"]`] = {
-          // 4.2 the CSS color-scheme is attached using the `mode` defined in the palette, if enabled.
-          ...(enableColorScheme && { colorScheme: scheme.palette?.mode }),
-          ...css,
-        };
+        defaultColorSchemeStyleSheet[`${colorSchemeSelector}, [${attribute}="${key}"]`] = css;
       } else {
         otherColorSchemesStyleSheet[
           `${colorSchemeSelector === ':root' ? '' : colorSchemeSelector}[${attribute}="${key}"]`
-        ] = {
-          // 4.2 same as other color schemes.
-          ...(enableColorScheme && { colorScheme: scheme.palette?.mode }),
-          ...css,
-        };
+        ] = css;
       }
     });
 
@@ -284,10 +274,6 @@ export default function createCssVarsProvider(options) {
      * The document to attach the attribute to
      */
     documentNode: PropTypes.any,
-    /**
-     * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
-     */
-    enableColorScheme: PropTypes.bool,
     /**
      * The key in the local storage used to store current color scheme.
      */

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -161,7 +161,9 @@ export default function createCssVarsProvider(options) {
       if (key === calculatedColorScheme) {
         // 4.1 Merge the selected color scheme to the theme
         theme = { ...theme, ...parsedScheme };
-        theme.palette.colorScheme = key;
+        if (theme.palette) {
+          theme.palette.colorScheme = key;
+        }
       }
       if (key === resolvedDefaultColorScheme) {
         if (excludeVariablesFromRoot) {
@@ -174,7 +176,7 @@ export default function createCssVarsProvider(options) {
         }
         defaultColorSchemeStyleSheet[`${colorSchemeSelector}, [${attribute}="${key}"]`] = {
           // 4.2 the CSS color-scheme is attached using the `mode` defined in the palette, if enabled.
-          ...(enableColorScheme && { colorScheme: scheme.palette.mode }),
+          ...(enableColorScheme && { colorScheme: scheme.palette?.mode }),
           ...css,
         };
       } else {
@@ -182,7 +184,7 @@ export default function createCssVarsProvider(options) {
           `${colorSchemeSelector === ':root' ? '' : colorSchemeSelector}[${attribute}="${key}"]`
         ] = {
           // 4.2 same as other color schemes.
-          ...(enableColorScheme && { colorScheme: scheme.palette.mode }),
+          ...(enableColorScheme && { colorScheme: scheme.palette?.mode }),
           ...css,
         };
       }

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -75,15 +75,6 @@ export default function createCssVarsProvider(options) {
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.light;
     const defaultDarkColorScheme =
       typeof defaultColorScheme === 'string' ? defaultColorScheme : defaultColorScheme.dark;
-    const resolvedDefaultColorScheme = (() => {
-      if (typeof defaultColorScheme === 'string') {
-        return defaultColorScheme;
-      }
-      if (defaultMode === 'dark') {
-        return defaultColorScheme.dark;
-      }
-      return defaultColorScheme.light;
-    })();
 
     // 1. Get the data about the `mode`, `colorScheme`, and setter functions.
     const {
@@ -165,6 +156,15 @@ export default function createCssVarsProvider(options) {
           theme.palette.colorScheme = key;
         }
       }
+      const resolvedDefaultColorScheme = (() => {
+        if (typeof defaultColorScheme === 'string') {
+          return defaultColorScheme;
+        }
+        if (defaultMode === 'dark') {
+          return defaultColorScheme.dark;
+        }
+        return defaultColorScheme.light;
+      })();
       if (key === resolvedDefaultColorScheme) {
         if (excludeVariablesFromRoot) {
           const excludedVariables = {};

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.test.js
@@ -15,7 +15,6 @@ describe('createCssVarsProvider', () => {
     addListener: () => {},
     removeListener: () => {},
   });
-  let shouldSupportColorScheme;
 
   beforeEach(() => {
     originalMatchmedia = window.matchMedia;
@@ -34,11 +33,6 @@ describe('createCssVarsProvider', () => {
     // clear the localstorage
     storage = {};
     window.matchMedia = createMatchMedia(false);
-
-    // Currently supported Firefox does not support `color-scheme`.
-    // Instead of skipping relevant tests entirely we assert that they work differently in Firefox.
-    // This ensures that we're automatically notified once we remove older Firefox versions from the support matrix.
-    shouldSupportColorScheme = !/Firefox/.test(navigator.userAgent);
   });
   afterEach(() => {
     window.matchMedia = originalMatchmedia;
@@ -247,109 +241,6 @@ describe('createCssVarsProvider', () => {
       );
       expect(screen.getByText('var(--palette-primary)')).not.to.equal(null);
       expect(screen.getByText('var(--palette-grey)')).not.to.equal(null);
-    });
-
-    describe('[option]: `enableColorScheme`', () => {
-      it('set `color-scheme` property on <html> with correct mode, given `enableColorScheme` is true and `mode` is `light` or `dark`', () => {
-        const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
-          theme: {
-            colorSchemes: { light: {}, dark: {} },
-          },
-          defaultColorScheme: 'light',
-          enableColorScheme: true,
-        });
-        const Consumer = () => {
-          const { setMode } = useColorScheme();
-          return <button onClick={() => setMode('dark')}>change to dark</button>;
-        };
-        render(
-          <CssVarsProvider>
-            <Consumer />
-          </CssVarsProvider>,
-        );
-        expect(document.documentElement).toHaveComputedStyle({
-          colorScheme: shouldSupportColorScheme ? 'light' : '',
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: 'change to dark' }));
-
-        expect(document.documentElement).toHaveComputedStyle({
-          colorScheme: shouldSupportColorScheme ? 'dark' : '',
-        });
-      });
-
-      it('set `color-scheme` property on <html> with correct mode, given `enableColorScheme` is true and mode is `system`', () => {
-        window.matchMedia = createMatchMedia(true); // system matches 'prefers-color-scheme: dark'
-
-        const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
-          theme: {
-            colorSchemes: { light: {}, dark: {} },
-          },
-          defaultColorScheme: 'light',
-          enableColorScheme: true,
-        });
-        const Consumer = () => {
-          const { setMode } = useColorScheme();
-          return <button onClick={() => setMode('system')}>change to system</button>;
-        };
-        render(
-          <CssVarsProvider>
-            <Consumer />
-          </CssVarsProvider>,
-        );
-        expect(document.documentElement).toHaveComputedStyle({
-          colorScheme: shouldSupportColorScheme ? 'light' : '',
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: 'change to system' }));
-
-        expect(document.documentElement).toHaveComputedStyle({
-          colorScheme: shouldSupportColorScheme ? 'dark' : '',
-        });
-      });
-
-      it('does not set `color-scheme` property on <html> with correct mode, given`enableColorScheme` is false', () => {
-        const currentColorScheme = window
-          .getComputedStyle(document.documentElement)
-          .getPropertyValue('color-scheme');
-        const { CssVarsProvider } = createCssVarsProvider({
-          theme: {
-            colorSchemes: { light: {}, dark: {} },
-          },
-          defaultColorScheme: 'light',
-          enableColorScheme: false,
-        });
-        const Consumer = () => <div />;
-
-        render(
-          <CssVarsProvider>
-            <Consumer />
-          </CssVarsProvider>,
-        );
-        expect(document.documentElement).toHaveComputedStyle({
-          colorScheme: shouldSupportColorScheme ? currentColorScheme : '',
-        });
-      });
-
-      it('cleans up `color-scheme` property on <html>, given`enableColorScheme` is true', () => {
-        const previousColorScheme = window
-          .getComputedStyle(document.documentElement)
-          .getPropertyValue('color-scheme');
-        const { CssVarsProvider } = createCssVarsProvider({
-          theme: {
-            colorSchemes: { light: {}, dark: {} },
-          },
-          defaultColorScheme: 'light',
-          enableColorScheme: true,
-        });
-        const { unmount } = render(<CssVarsProvider />);
-
-        unmount();
-
-        expect(document.documentElement).toHaveComputedStyle({
-          colorScheme: previousColorScheme,
-        });
-      });
     });
 
     describe('[option]: `disableTransitionOnChange`', () => {

--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -6,11 +6,6 @@ export const DEFAULT_ATTRIBUTE = 'data-color-scheme';
 
 export interface GetInitColorSchemeScriptOptions {
   /**
-   * Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
-   * @default true
-   */
-  enableColorScheme?: boolean;
-  /**
    * The mode to be used for the first visit
    * @default 'light'
    */
@@ -49,7 +44,6 @@ export interface GetInitColorSchemeScriptOptions {
 
 export default function getInitColorSchemeScript(options?: GetInitColorSchemeScriptOptions) {
   const {
-    enableColorScheme = true,
     defaultMode = 'light',
     defaultLightColorScheme = 'light',
     defaultDarkColorScheme = 'dark',
@@ -85,9 +79,6 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
         }
         if (colorScheme) {
           ${colorSchemeNode}.setAttribute('${attribute}', colorScheme);
-        }
-        if (${enableColorScheme} && !!cssColorScheme) {
-          ${colorSchemeNode}.style.setProperty('color-scheme', cssColorScheme);
         }
       } catch (e) {} })();`,
       }}

--- a/test/regressions/fixtures/CssBaseline/JoyCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/JoyCssBaseline.js
@@ -9,14 +9,14 @@ export default function JoyCssBaseline() {
       <CssBaseline enableColorScheme />
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
         <Box sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.level1' }}>
-          {/* The the color-scheme of the scrollbar */}
+          {/* The scrollbar should be light */}
           <Box sx={{ height: 1000 }} />
         </Box>
         <Box
           data-joy-color-scheme="dark"
           sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.level1' }}
         >
-          {/* The the color-scheme of the scrollbar */}
+          {/* The scrollbar should be dark */}
           <Box sx={{ height: 1000 }} />
         </Box>
       </Box>

--- a/test/regressions/fixtures/CssBaseline/JoyCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/JoyCssBaseline.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { CssVarsProvider } from '@mui/joy/styles';
+import Box from '@mui/joy/Box';
+import CssBaseline from '@mui/joy/CssBaseline';
+
+export default function JoyCssBaseline() {
+  return (
+    <CssVarsProvider>
+      <CssBaseline enableColorScheme />
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.level1' }}>
+          {/* The the color-scheme of the scrollbar */}
+          <Box sx={{ height: 1000 }} />
+        </Box>
+        <Box
+          data-joy-color-scheme="dark"
+          sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.level1' }}
+        >
+          {/* The the color-scheme of the scrollbar */}
+          <Box sx={{ height: 1000 }} />
+        </Box>
+      </Box>
+    </CssVarsProvider>
+  );
+}

--- a/test/regressions/fixtures/CssBaseline/JoyCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/JoyCssBaseline.js
@@ -6,7 +6,7 @@ import CssBaseline from '@mui/joy/CssBaseline';
 export default function JoyCssBaseline() {
   return (
     <CssVarsProvider>
-      <CssBaseline enableColorScheme />
+      <CssBaseline />
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
         <Box sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.level1' }}>
           {/* The scrollbar should be light */}

--- a/test/regressions/fixtures/CssBaseline/JoyScopedCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/JoyScopedCssBaseline.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { CssVarsProvider, extendTheme } from '@mui/joy/styles';
+import colors from '@mui/joy/colors';
+import Box from '@mui/joy/Box';
+import ScopedCssBaseline from '@mui/joy/ScopedCssBaseline';
+
+const theme = extendTheme({
+  colorSchemes: {
+    forest: {
+      palette: {
+        mode: 'dark',
+        background: {
+          body: colors.green[200],
+        },
+      },
+    },
+  },
+});
+
+export default function JoyScopedCssBaseline() {
+  return (
+    <CssVarsProvider theme={theme}>
+      <ScopedCssBaseline
+        data-joy-color-scheme="forest"
+        sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.body' }}
+      >
+        {/* The scrollbar should be dark */}
+        <Box sx={{ height: 1000 }} />
+      </ScopedCssBaseline>
+    </CssVarsProvider>
+  );
+}

--- a/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
-import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 
 export default function JoyCssBaseline() {
   return (
@@ -20,14 +19,6 @@ export default function JoyCssBaseline() {
           {/* The scrollbar should be dark */}
           <Box sx={{ height: 1000 }} />
         </Box>
-        <ScopedCssBaseline
-          enableColorScheme
-          data-mui-color-scheme="dark"
-          sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}
-        >
-          {/* The scrollbar should be dark */}
-          <Box sx={{ height: 1000 }} />
-        </ScopedCssBaseline>
       </Box>
     </CssVarsProvider>
   );

--- a/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
@@ -3,7 +3,7 @@ import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/s
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
 
-export default function JoyCssBaseline() {
+export default function MaterialCssBaseline() {
   return (
     <CssVarsProvider>
       <CssBaseline enableColorScheme />

--- a/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
+import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 
 export default function JoyCssBaseline() {
   return (
@@ -9,16 +10,24 @@ export default function JoyCssBaseline() {
       <CssBaseline enableColorScheme />
       <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
         <Box sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}>
-          {/* The the color-scheme of the scrollbar */}
+          {/* The scrollbar should be light */}
           <Box sx={{ height: 1000 }} />
         </Box>
         <Box
-          data-joy-color-scheme="dark"
+          data-mui-color-scheme="dark"
           sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}
         >
-          {/* The the color-scheme of the scrollbar */}
+          {/* The scrollbar should be dark */}
           <Box sx={{ height: 1000 }} />
         </Box>
+        <ScopedCssBaseline
+          enableColorScheme
+          data-mui-color-scheme="dark"
+          sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}
+        >
+          {/* The scrollbar should be dark */}
+          <Box sx={{ height: 1000 }} />
+        </ScopedCssBaseline>
       </Box>
     </CssVarsProvider>
   );

--- a/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/MaterialCssBaseline.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+
+export default function JoyCssBaseline() {
+  return (
+    <CssVarsProvider>
+      <CssBaseline enableColorScheme />
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}>
+          {/* The the color-scheme of the scrollbar */}
+          <Box sx={{ height: 1000 }} />
+        </Box>
+        <Box
+          data-joy-color-scheme="dark"
+          sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}
+        >
+          {/* The the color-scheme of the scrollbar */}
+          <Box sx={{ height: 1000 }} />
+        </Box>
+      </Box>
+    </CssVarsProvider>
+  );
+}

--- a/test/regressions/fixtures/CssBaseline/MaterialScopedCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/MaterialScopedCssBaseline.js
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import {
+  Experimental_CssVarsProvider as CssVarsProvider,
+  experimental_extendTheme as extendTheme,
+  createTheme,
+} from '@mui/material/styles';
+import { cyan } from '@mui/material/colors';
+import Box from '@mui/material/Box';
+import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
+
+const ocean = createTheme({
+  palette: {
+    mode: 'dark',
+    background: {
+      paper: cyan[200],
+    },
+  },
+});
+
+const theme = extendTheme({
+  colorSchemes: {
+    ocean: {
+      palette: ocean.palette,
+    },
+  },
+});
+
+export default function JoyCssBaseline() {
+  return (
+    <CssVarsProvider theme={theme}>
+      <ScopedCssBaseline
+        enableColorScheme
+        data-mui-color-scheme="ocean"
+        sx={{ width: 300, height: 100, overflow: 'scroll', bgcolor: 'background.paper' }}
+      >
+        {/* The scrollbar should be dark */}
+        <Box sx={{ height: 1000 }} />
+      </ScopedCssBaseline>
+    </CssVarsProvider>
+  );
+}

--- a/test/regressions/fixtures/CssBaseline/MaterialScopedCssBaseline.js
+++ b/test/regressions/fixtures/CssBaseline/MaterialScopedCssBaseline.js
@@ -25,7 +25,7 @@ const theme = extendTheme({
   },
 });
 
-export default function JoyCssBaseline() {
+export default function MaterialScopedCssBaseline() {
   return (
     <CssVarsProvider theme={theme}>
       <ScopedCssBaseline


### PR DESCRIPTION
https://deploy-preview-34639--material-ui.netlify.app/

**BREAKING CHANGE**

The `enableColorScheme` prop has been removed from `CssVarsProvider` and `getInitColorScheme` (both Material UI and Joy UI).

Migration:
- **Material UI**: you can enable the CSS color scheme via `<CssBaseline enableColorScheme />`.
- **Joy UI**: it is enabled automatically if you use `<CssBaseline />`, [see the docs](https://mui.com/joy-ui/react-css-baseline/).

---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Preview**:
- Joy: https://codesandbox.io/s/joy-cra-typescript-forked-vhukxn?file=/src/App.tsx
- Material: https://codesandbox.io/s/create-react-app-with-typescript-forked-9wcemh?file=/src/App.tsx
- Material Scoped: https://codesandbox.io/s/create-react-app-with-typescript-forked-0m6fgn?file=/src/App.tsx

**Docs**:
- https://deploy-preview-34639--material-ui.netlify.app/joy-ui/react-css-baseline/

## Motivation

From @oliviertassinari's [comment](https://github.com/mui/material-ui/pull/33261#issuecomment-1267690625), applying inline `color-scheme: light | dark` to the html tag creates a global effect for complex application (our website is one of the examples where some pages use `CssVarsProvider` but some are not).

With the current implementation (inline style), the [homepage improvement](https://github.com/mui/material-ui/pull/33545) requires several workarounds to override the inline color-scheme.

To fix this, the `color-scheme` should be moved to `CssBaseline` so that

## Changes

- Delegate the `enableColorScheme` flag to `CssBaseline`.
- Add `CssBaseline` and `ScopedCssBaseline` to Joy UI because the `enableColorScheme` is removed from the `CssVarsProvider`.

**⚠️ Note**: This is considered a **BREAKING CHANGE** for the experimental CssVarsProvider

## How it works

The logic lives in `CssBaseline` which generates style sheets for each color scheme (to prevent flashing) when enabled:

```js
// CssBaseline.tsx
  const colorSchemeStyles = {};
  if (enableColorScheme && theme.colorSchemes) {
    Object.entries(theme.colorSchemes).forEach(([key, scheme]) => {
      colorSchemeStyles[theme.getColorSchemeSelector(key).replace(/\s*&/, '')] = {
        colorScheme: scheme.palette?.mode, // each palette must contain the `mode`
      };
    });
  }
```

For example, if the theme has three color schemes: `light, dark, and orange(custom)`. Each color scheme must contain the mode to be used (either `light` or `dark`). Material UI already contains the mode in the default light and dark palette, so this PR does the same for Joy UI.

Developers can configure the mode like this:

```js
extendTheme({
  colorSchemes: {
    light: {
      palette: {
        mode: 'light', // this is `light` by default
      }
    },
    dark: {
      palette: {
        mode: 'dark', // this is `dark` by default
      }
    },
    orange: {
      palette: {
        mode: 'dark', // it could be `light` if the palette has high contrast.
      }
    },
  }
})
```

## Benefits

- Works perfectly with the current Material UI CssBaseline. The existing projects will automatically get the benefits of this.
- Also works with Material UI `ScopedCssBaseline`.
- More dynamic because the `color-scheme` is not attached as an inline style anymore, it is in the stylesheet. This work with any element that `data-color-scheme="..."`
   ```js
   <div data-joy-color-scheme="dark"> /* the scrollbar color-scheme is dark */
   ```
- Reduce the complexity of `CssVarsProvider` and `getInitColorSchemeScript`.

Tested that it works well in https://github.com/mui/material-ui/pull/33545

## Test

Added visual regression to make sure that CssBaseline works for both Material UI and Joy UI. https://app.argos-ci.com/mui/material-ui/builds/5852

<img width="1017" alt="Screen Shot 2565-10-07 at 13 20 57" src="https://user-images.githubusercontent.com/18292247/194481032-67257321-5323-4620-8bc3-5a3a1f871564.png">

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
