### PR TITLE
[SwipeableDrawer] Make component `defaultProps` overridable

### DIFF
--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.spec.ts
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.spec.ts
@@ -1,4 +1,4 @@
-import createTheme from '../styles/createTheme';
+import { createTheme } from '@mui/material';
 
 createTheme({
   components: {

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.spec.ts
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.spec.ts
@@ -1,0 +1,11 @@
+import createTheme from '../styles/createTheme';
+
+createTheme({
+  components: {
+    MuiSwipeableDrawer: {
+      defaultProps: {
+        disableSwipeToOpen: true,
+      },
+    },
+  },
+});

--- a/packages/mui-material/src/styles/components.d.ts
+++ b/packages/mui-material/src/styles/components.d.ts
@@ -480,6 +480,9 @@ export interface Components<Theme = unknown> {
     styleOverrides?: ComponentsOverrides<Theme>['MuiSvgIcon'];
     variants?: ComponentsVariants['MuiSvgIcon'];
   };
+  MuiSwipeableDrawer?: {
+    defaultProps?: ComponentsProps['MuiSwipeableDrawer'];
+  };
   MuiSwitch?: {
     defaultProps?: ComponentsProps['MuiSwitch'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiSwitch'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/34500

**This PR includes:**
- Make the component defaultProps overridable

**Codesandbox Before**:
- https://codesandbox.io/s/silent-flower-ysdx81

**Codesandbox After**:
- https://codesandbox.io/s/quizzical-lamarr-me5rcf