### PR TITLE
[Joy] Add button loading functionality

### DIFF
--- a/docs/data/joy/components/button/ButtonLoading.js
+++ b/docs/data/joy/components/button/ButtonLoading.js
@@ -1,95 +1,17 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
-import SaveIcon from '@mui/icons-material/Save';
+import Stack from '@mui/joy/Stack';
 import SendIcon from '@mui/icons-material/Send';
 import Button from '@mui/joy/Button';
-import Switch from '@mui/joy/Switch';
 
 export default function ButtonLoading() {
-  const [loading, setLoading] = React.useState(true);
-  function handleClick() {
-    setLoading(true);
-  }
-
   return (
-    <Box>
-      <Switch
-        checked={loading}
-        onChange={() => setLoading(!loading)}
-        endDecorator={loading ? 'On' : 'Off'}
-      />
-      <Box sx={{ '& > button': { m: 1 } }}>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          loading={loading}
-          variant="outlined"
-          disabled
-        >
-          disabled
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          loading={loading}
-          loadingIndicator="Loading…"
-          variant="outlined"
-        >
-          Fetch data
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          endDecorator={<SendIcon />}
-          loading={loading}
-          loadingPosition="end"
-          variant="solid"
-        >
-          Send
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          loading={loading}
-          loadingPosition="start"
-          startDecorator={<SaveIcon />}
-          variant="solid"
-        >
-          Save
-        </Button>
-      </Box>
-
-      <Box sx={{ '& > button': { m: 1 } }}>
-        <Button onClick={handleClick} loading={loading} variant="outlined" disabled>
-          disabled
-        </Button>
-        <Button
-          onClick={handleClick}
-          loading={loading}
-          loadingIndicator="Loading…"
-          variant="outlined"
-        >
-          Fetch data
-        </Button>
-        <Button
-          onClick={handleClick}
-          endDecorator={<SendIcon />}
-          loading={loading}
-          loadingPosition="end"
-          variant="solid"
-        >
-          Send
-        </Button>
-        <Button
-          onClick={handleClick}
-          loading={loading}
-          loadingPosition="start"
-          startDecorator={<SaveIcon />}
-          variant="solid"
-        >
-          Save
-        </Button>
-      </Box>
-    </Box>
+    <Stack spacing={2} direction="row">
+      <Button loading endDecorator={<SendIcon />} variant="solid">
+        Send
+      </Button>
+      <Button loading loadingIndicator="Loading…" variant="outlined">
+        Fetch data
+      </Button>
+    </Stack>
   );
 }

--- a/docs/data/joy/components/button/ButtonLoading.js
+++ b/docs/data/joy/components/button/ButtonLoading.js
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import SaveIcon from '@mui/icons-material/Save';
+import SendIcon from '@mui/icons-material/Send';
+import Button from '@mui/joy/Button';
+import Switch from '@mui/joy/Switch';
+
+export default function ButtonLoading() {
+  const [loading, setLoading] = React.useState(true);
+  function handleClick() {
+    setLoading(true);
+  }
+
+  return (
+    <Box>
+      <Switch
+        checked={loading}
+        onChange={() => setLoading(!loading)}
+        endDecorator={loading ? 'On' : 'Off'}
+      />
+      <Box sx={{ '& > button': { m: 1 } }}>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          loading={loading}
+          variant="outlined"
+          disabled
+        >
+          disabled
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          loading={loading}
+          loadingIndicator="Loading…"
+          variant="outlined"
+        >
+          Fetch data
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          endDecorator={<SendIcon />}
+          loading={loading}
+          loadingPosition="end"
+          variant="solid"
+        >
+          Send
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          loading={loading}
+          loadingPosition="start"
+          startDecorator={<SaveIcon />}
+          variant="solid"
+        >
+          Save
+        </Button>
+      </Box>
+
+      <Box sx={{ '& > button': { m: 1 } }}>
+        <Button onClick={handleClick} loading={loading} variant="outlined" disabled>
+          disabled
+        </Button>
+        <Button
+          onClick={handleClick}
+          loading={loading}
+          loadingIndicator="Loading…"
+          variant="outlined"
+        >
+          Fetch data
+        </Button>
+        <Button
+          onClick={handleClick}
+          endDecorator={<SendIcon />}
+          loading={loading}
+          loadingPosition="end"
+          variant="solid"
+        >
+          Send
+        </Button>
+        <Button
+          onClick={handleClick}
+          loading={loading}
+          loadingPosition="start"
+          startDecorator={<SaveIcon />}
+          variant="solid"
+        >
+          Save
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/button/ButtonLoading.tsx
+++ b/docs/data/joy/components/button/ButtonLoading.tsx
@@ -1,95 +1,17 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
-import SaveIcon from '@mui/icons-material/Save';
+import Stack from '@mui/joy/Stack';
 import SendIcon from '@mui/icons-material/Send';
 import Button from '@mui/joy/Button';
-import Switch from '@mui/joy/Switch';
 
 export default function ButtonLoading() {
-  const [loading, setLoading] = React.useState<boolean>(true);
-  function handleClick() {
-    setLoading(true);
-  }
-
   return (
-    <Box>
-      <Switch
-        checked={loading}
-        onChange={() => setLoading(!loading)}
-        endDecorator={loading ? 'On' : 'Off'}
-      />
-      <Box sx={{ '& > button': { m: 1 } }}>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          loading={loading}
-          variant="outlined"
-          disabled
-        >
-          disabled
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          loading={loading}
-          loadingIndicator="Loading…"
-          variant="outlined"
-        >
-          Fetch data
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          endDecorator={<SendIcon />}
-          loading={loading}
-          loadingPosition="end"
-          variant="solid"
-        >
-          Send
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleClick}
-          loading={loading}
-          loadingPosition="start"
-          startDecorator={<SaveIcon />}
-          variant="solid"
-        >
-          Save
-        </Button>
-      </Box>
-
-      <Box sx={{ '& > button': { m: 1 } }}>
-        <Button onClick={handleClick} loading={loading} variant="outlined" disabled>
-          disabled
-        </Button>
-        <Button
-          onClick={handleClick}
-          loading={loading}
-          loadingIndicator="Loading…"
-          variant="outlined"
-        >
-          Fetch data
-        </Button>
-        <Button
-          onClick={handleClick}
-          endDecorator={<SendIcon />}
-          loading={loading}
-          loadingPosition="end"
-          variant="solid"
-        >
-          Send
-        </Button>
-        <Button
-          onClick={handleClick}
-          loading={loading}
-          loadingPosition="start"
-          startDecorator={<SaveIcon />}
-          variant="solid"
-        >
-          Save
-        </Button>
-      </Box>
-    </Box>
+    <Stack spacing={2} direction="row">
+      <Button loading endDecorator={<SendIcon />} variant="solid">
+        Send
+      </Button>
+      <Button loading loadingIndicator="Loading…" variant="outlined">
+        Fetch data
+      </Button>
+    </Stack>
   );
 }

--- a/docs/data/joy/components/button/ButtonLoading.tsx
+++ b/docs/data/joy/components/button/ButtonLoading.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import SaveIcon from '@mui/icons-material/Save';
+import SendIcon from '@mui/icons-material/Send';
+import Button from '@mui/joy/Button';
+import Switch from '@mui/joy/Switch';
+
+export default function ButtonLoading() {
+  const [loading, setLoading] = React.useState<boolean>(true);
+  function handleClick() {
+    setLoading(true);
+  }
+
+  return (
+    <Box>
+      <Switch
+        checked={loading}
+        onChange={() => setLoading(!loading)}
+        endDecorator={loading ? 'On' : 'Off'}
+      />
+      <Box sx={{ '& > button': { m: 1 } }}>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          loading={loading}
+          variant="outlined"
+          disabled
+        >
+          disabled
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          loading={loading}
+          loadingIndicator="Loading…"
+          variant="outlined"
+        >
+          Fetch data
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          endDecorator={<SendIcon />}
+          loading={loading}
+          loadingPosition="end"
+          variant="solid"
+        >
+          Send
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleClick}
+          loading={loading}
+          loadingPosition="start"
+          startDecorator={<SaveIcon />}
+          variant="solid"
+        >
+          Save
+        </Button>
+      </Box>
+
+      <Box sx={{ '& > button': { m: 1 } }}>
+        <Button onClick={handleClick} loading={loading} variant="outlined" disabled>
+          disabled
+        </Button>
+        <Button
+          onClick={handleClick}
+          loading={loading}
+          loadingIndicator="Loading…"
+          variant="outlined"
+        >
+          Fetch data
+        </Button>
+        <Button
+          onClick={handleClick}
+          endDecorator={<SendIcon />}
+          loading={loading}
+          loadingPosition="end"
+          variant="solid"
+        >
+          Send
+        </Button>
+        <Button
+          onClick={handleClick}
+          loading={loading}
+          loadingPosition="start"
+          startDecorator={<SaveIcon />}
+          variant="solid"
+        >
+          Save
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/button/ButtonLoading.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoading.tsx.preview
@@ -1,0 +1,6 @@
+<Button loading endDecorator={<SendIcon />} variant="solid">
+  Send
+</Button>
+<Button loading loadingIndicator="Loading…" variant="outlined">
+  Fetch data
+</Button>

--- a/docs/data/joy/components/button/ButtonLoadingPosition.js
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Stack from '@mui/joy/Stack';
+import SendIcon from '@mui/icons-material/Send';
+import Button from '@mui/joy/Button';
+
+export default function ButtonLoadingPosition() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button loading loadingPosition="start" variant="outlined">
+        Fetch data
+      </Button>
+      <Button
+        loading
+        loadingPosition="end"
+        endDecorator={<SendIcon />}
+        variant="solid"
+      >
+        Send
+      </Button>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/button/ButtonLoadingPosition.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Stack from '@mui/joy/Stack';
+import SendIcon from '@mui/icons-material/Send';
+import Button from '@mui/joy/Button';
+
+export default function ButtonLoadingPosition() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button loading loadingPosition="start" variant="outlined">
+        Fetch data
+      </Button>
+      <Button
+        loading
+        loadingPosition="end"
+        endDecorator={<SendIcon />}
+        variant="solid"
+      >
+        Send
+      </Button>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/button/ButtonLoadingPosition.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.tsx.preview
@@ -1,0 +1,11 @@
+<Button loading loadingPosition="start" variant="outlined">
+  Fetch data
+</Button>
+<Button
+  loading
+  loadingPosition="end"
+  endDecorator={<SendIcon />}
+  variant="solid"
+>
+  Send
+</Button>

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -70,6 +70,13 @@ Use the `startDecorator` and/or `endDecorator` props to add supporting decorator
 
 {{"demo": "ButtonIcons.js"}}
 
+### Loading
+
+The loading buttons can show loading state and disable interactions.
+Toggle the loading switch to see the transition between the different states.
+
+{{"demo": "ButtonLoading.js"}}
+
 ### Icon button
 
 Use the `IconButton` component if you want width and height to be the same while not having a label.

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -72,10 +72,21 @@ Use the `startDecorator` and/or `endDecorator` props to add supporting decorator
 
 ### Loading
 
-The loading buttons can show loading state and disable interactions.
-Toggle the loading switch to see the transition between the different states.
+Enable `loading` prop to show button's loading state. The button will be `disabled` when it is in the loading state.
+
+The default loading indicator uses the [`CircularProgress`](/joy-ui/react-circular-progress/) component which can be customized using the `loadingIndicator` prop.
 
 {{"demo": "ButtonLoading.js"}}
+
+### Loading position
+
+The `loadingPosition` prop supports 3 values:
+
+- `center` (default): The loading indicator element is wrapped inside the button's `loadingIndicatorCenter` slot to create a proper style.
+- `start`: The loading indicator replaces the **start** decorator's content when the button is in loading state.
+- `end`: The loading indicator replaces the **end** decorator's content when the button is in loading state.
+
+{{"demo": "ButtonLoadingPosition.js"}}
 
 ### Icon button
 

--- a/packages/mui-joy/src/Button/Button.spec.tsx
+++ b/packages/mui-joy/src/Button/Button.spec.tsx
@@ -84,3 +84,16 @@ function Icon() {
 <Button variant="outlined" endDecorator={<Icon />} color="success">
   Checkout
 </Button>;
+
+<Button loading variant="outlined" disabled>
+  disabled
+</Button>;
+<Button loading loadingIndicator="Loading…" variant="outlined">
+  Fetch data
+</Button>;
+<Button endDecorator={<Icon />} loading loadingPosition="end">
+  Send
+</Button>;
+<Button loading loadingPosition="start" startDecorator={<Icon />}>
+  Save
+</Button>;

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -124,7 +124,9 @@ describe('Joy <Button />', () => {
         </Button>,
       );
 
-      expect(container.querySelector(`.${classes.loadingIndicator}`)).to.have.text('loading..');
+      expect(container.querySelector(`.${classes.loadingIndicatorCenter}`)).to.have.text(
+        'loading..',
+      );
       expect(getByRole('button')).to.have.style('color', 'transparent');
     });
   });
@@ -137,7 +139,18 @@ describe('Joy <Button />', () => {
       expect(loader.parentElement).to.have.class(classes.loadingIndicatorCenter);
     });
 
-    it('is rendered before the children when `loadingPosition=start` and startDecorator is not visible', () => {
+    it('there should be only one loading indicator', () => {
+      const { getAllByRole } = render(
+        <Button loading startDecorator="🚀" endDecorator="👍">
+          Test
+        </Button>,
+      );
+      const loaders = getAllByRole('progressbar');
+
+      expect(loaders).to.have.length(1);
+    });
+
+    it('loading indicator with `position="start"` replaces the `startDecorator` content', () => {
       const { getByRole } = render(
         <Button
           loading
@@ -151,12 +164,11 @@ describe('Joy <Button />', () => {
       const loader = getByRole('progressbar');
       const button = getByRole('button');
 
-      expect(loader.parentElement).to.have.class(classes.loadingIndicatorStart);
-      expect(button.querySelector(`.${classes.startDecorator}`)).to.have.style('opacity', '0');
-      expect(button).to.have.text('iconloading..Test');
+      expect(loader).toBeVisible();
+      expect(button).to.have.text('loading..Test');
     });
 
-    it('is rendered after the children when `loadingPosition=end` and endDecorator is not visible', () => {
+    it('loading indicator with `position="end"` replaces the `startDecorator` content', () => {
       const { getByRole } = render(
         <Button
           loading
@@ -170,9 +182,8 @@ describe('Joy <Button />', () => {
       const loader = getByRole('progressbar');
       const button = getByRole('button');
 
-      expect(loader.parentElement).to.have.class(classes.loadingIndicatorEnd);
-      expect(button.querySelector(`.${classes.endDecorator}`)).to.have.style('opacity', '0');
-      expect(button).to.have.text('Testloading..icon');
+      expect(loader).toBeVisible();
+      expect(button).to.have.text('Testloading..');
     });
   });
 });

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -117,7 +117,10 @@ describe('Joy <Button />', () => {
       expect(getByRole('button')).to.have.text('Test');
     });
 
-    it('is rendered properly when `loading` and children should not be visible', () => {
+    it('is rendered properly when `loading` and children should not be visible', function test() {
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
       const { container, getByRole } = render(
         <Button loadingIndicator="loading.." loading>
           Test
@@ -127,7 +130,7 @@ describe('Joy <Button />', () => {
       expect(container.querySelector(`.${classes.loadingIndicatorCenter}`)).to.have.text(
         'loading..',
       );
-      expect(getByRole('button')).to.have.style('color', 'transparent');
+      expect(getByRole('button')).toHaveComputedStyle({ color: 'transparent' });
     });
   });
 

--- a/packages/mui-joy/src/Button/Button.test.js
+++ b/packages/mui-joy/src/Button/Button.test.js
@@ -93,4 +93,86 @@ describe('Joy <Button />', () => {
     expect(button).to.have.class(classes.root);
     expect(endDecorator).not.to.have.class(classes.startDecorator);
   });
+
+  describe('prop: loading', () => {
+    it('disables the button', () => {
+      const { getByRole } = render(<Button loading />);
+
+      const button = getByRole('button');
+      expect(button).to.have.property('disabled', true);
+    });
+
+    it('renders a progressbar', () => {
+      const { getByRole } = render(<Button loading>Submit</Button>);
+
+      const progressbar = getByRole('progressbar');
+      expect(progressbar).toBeVisible();
+    });
+  });
+
+  describe('prop: loadingIndicator', () => {
+    it('is not rendered by default', () => {
+      const { getByRole } = render(<Button loadingIndicator="loading">Test</Button>);
+
+      expect(getByRole('button')).to.have.text('Test');
+    });
+
+    it('is rendered properly when `loading` and children should not be visible', () => {
+      const { container, getByRole } = render(
+        <Button loadingIndicator="loading.." loading>
+          Test
+        </Button>,
+      );
+
+      expect(container.querySelector(`.${classes.loadingIndicator}`)).to.have.text('loading..');
+      expect(getByRole('button')).to.have.style('color', 'transparent');
+    });
+  });
+
+  describe('prop: loadingPosition', () => {
+    it('center is rendered by default', () => {
+      const { getByRole } = render(<Button loading>Test</Button>);
+      const loader = getByRole('progressbar');
+
+      expect(loader.parentElement).to.have.class(classes.loadingIndicatorCenter);
+    });
+
+    it('is rendered before the children when `loadingPosition=start` and startDecorator is not visible', () => {
+      const { getByRole } = render(
+        <Button
+          loading
+          startDecorator={<span>icon</span>}
+          loadingPosition="start"
+          loadingIndicator={<span role="progressbar">loading..</span>}
+        >
+          Test
+        </Button>,
+      );
+      const loader = getByRole('progressbar');
+      const button = getByRole('button');
+
+      expect(loader.parentElement).to.have.class(classes.loadingIndicatorStart);
+      expect(button.querySelector(`.${classes.startDecorator}`)).to.have.style('opacity', '0');
+      expect(button).to.have.text('iconloading..Test');
+    });
+
+    it('is rendered after the children when `loadingPosition=end` and endDecorator is not visible', () => {
+      const { getByRole } = render(
+        <Button
+          loading
+          endDecorator={<span>icon</span>}
+          loadingPosition="end"
+          loadingIndicator={<span role="progressbar">loading..</span>}
+        >
+          Test
+        </Button>,
+      );
+      const loader = getByRole('progressbar');
+      const button = getByRole('button');
+
+      expect(loader.parentElement).to.have.class(classes.loadingIndicatorEnd);
+      expect(button.querySelector(`.${classes.endDecorator}`)).to.have.style('opacity', '0');
+      expect(button).to.have.text('Testloading..icon');
+    });
+  });
 });

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useButton } from '@mui/base/ButtonUnstyled';
@@ -20,7 +19,6 @@ const useUtilityClasses = (ownerState: ButtonOwnerState) => {
     size,
     variant,
     loading,
-    loadingPosition,
   } = ownerState;
 
   const slots = {
@@ -34,18 +32,9 @@ const useUtilityClasses = (ownerState: ButtonOwnerState) => {
       size && `size${capitalize(size)}`,
       loading && 'loading',
     ],
-    startDecorator: [
-      'startDecorator',
-      loading && loadingPosition && `startDecoratorLoading${capitalize(loadingPosition)}`,
-    ],
-    endDecorator: [
-      'endDecorator',
-      loading && loadingPosition && `endDecoratorLoading${capitalize(loadingPosition)}`,
-    ],
-    loadingIndicator: [
-      'loadingIndicator',
-      loading && loadingPosition && `loadingIndicator${capitalize(loadingPosition)}`,
-    ],
+    startDecorator: ['startDecorator'],
+    endDecorator: ['endDecorator'],
+    loadingIndicatorCenter: ['loadingIndicatorCenter'],
   };
 
   const composedClasses = composeClasses(slots, getButtonUtilityClass, {});
@@ -63,6 +52,7 @@ const ButtonStartDecorator = styled('span', {
   overridesResolver: (props, styles) => styles.startDecorator,
 })<{ ownerState: ButtonOwnerState }>({
   '--Icon-margin': '0 0 0 calc(var(--Button-gap) / -2)',
+  '--CircularProgress-margin': '0 0 0 calc(var(--Button-gap) / -2)',
   display: 'inherit',
   marginRight: 'var(--Button-gap)',
 });
@@ -73,9 +63,25 @@ const ButtonEndDecorator = styled('span', {
   overridesResolver: (props, styles) => styles.endDecorator,
 })<{ ownerState: ButtonOwnerState }>({
   '--Icon-margin': '0 calc(var(--Button-gap) / -2) 0 0',
+  '--CircularProgress-margin': '0 calc(var(--Button-gap) / -2) 0 0',
   display: 'inherit',
   marginLeft: 'var(--Button-gap)',
 });
+
+const ButtonLoadingCenter = styled('span', {
+  name: 'JoyButton',
+  slot: 'LoadingCenter',
+  overridesResolver: (props, styles) => styles.loadingIndicatorCenter,
+})<{ ownerState: ButtonOwnerState }>(({ theme, ownerState }) => ({
+  display: 'inherit',
+  position: 'absolute',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  color: theme.variants[ownerState.variant!]?.[ownerState.color!]?.color,
+  ...(ownerState.disabled && {
+    color: theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!]?.color,
+  }),
+}));
 
 export const ButtonRoot = styled('button', {
   name: 'JoyButton',
@@ -138,80 +144,16 @@ export const ButtonRoot = styled('button', {
     {
       [`&.${buttonClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-    },
-    {
-      [`& .${buttonClasses.startDecoratorLoadingStart}, & .${buttonClasses.endDecoratorLoadingEnd}`]:
-        {
-          transition: 'opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-          opacity: 0,
-        },
       ...(ownerState.loadingPosition === 'center' && {
-        transition:
-          'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
         [`&.${buttonClasses.loading}`]: {
+          transition:
+            'background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
           color: 'transparent',
         },
       }),
-      ...(ownerState.loadingPosition === 'start' &&
-        ownerState.fullWidth && {
-          [`& .${buttonClasses.startDecoratorLoadingStart}, & .${buttonClasses.endDecoratorLoadingEnd}`]:
-            {
-              transition: 'opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-              opacity: 0,
-              marginRight: ownerState.size === 'sm' ? -11 : ownerState.size === 'md' ? -12 : -10,
-            },
-        }),
-      ...(ownerState.loadingPosition === 'end' &&
-        ownerState.fullWidth && {
-          [`& .${buttonClasses.startDecoratorLoadingStart}, & .${buttonClasses.endDecoratorLoadingEnd}`]:
-            {
-              transition: 'opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-              opacity: 0,
-              marginLeft: ownerState.size === 'sm' ? -11 : ownerState.size === 'md' ? -12 : -10,
-            },
-        }),
     },
   ];
 });
-
-const ButtonLoadingIndicator = styled('div', {
-  name: 'JoyButton',
-  slot: 'LoadingIndicator',
-  overridesResolver: (props, styles) => {
-    const { ownerState } = props;
-    return [
-      styles.loadingIndicator,
-      styles[`loadingIndicator${capitalize(ownerState.loadingPosition)}`],
-    ];
-  },
-})<{ ownerState: ButtonOwnerState }>(({ theme, ownerState }) => ({
-  position: 'absolute',
-  visibility: 'visible',
-  display: 'flex',
-  ...(ownerState.loadingPosition === 'start' && {
-    left: ownerState.size === 'sm' ? '0.75rem' : ownerState.size === 'md' ? '1rem' : '1.5rem',
-    '--CircularProgress-margin': '0 0 0 calc(var(--Button-gap) / -2)',
-  }),
-  ...(ownerState.loadingPosition === 'center' && {
-    left: '50%',
-    transform: 'translate(-50%)',
-    color: theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!].color,
-  }),
-  ...(ownerState.loadingPosition === 'end' && {
-    right: ownerState.size === 'sm' ? '0.75rem' : ownerState.size === 'md' ? '1rem' : '1.5rem',
-    '--CircularProgress-margin': '0 calc(var(--Button-gap) / -2) 0 0',
-  }),
-  ...(ownerState.loadingPosition === 'start' &&
-    ownerState.fullWidth && {
-      position: 'relative',
-      left: ownerState.size === 'sm' ? -6 : ownerState.size === 'md' ? -8 : -12,
-    }),
-  ...(ownerState.loadingPosition === 'end' &&
-    ownerState.fullWidth && {
-      position: 'relative',
-      right: ownerState.size === 'sm' ? -6 : ownerState.size === 'md' ? -8 : -12,
-    }),
-}));
 
 const Button = React.forwardRef(function Button(inProps, ref) {
   const props = useThemeProps<typeof inProps & { component?: React.ElementType }>({
@@ -247,7 +189,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   });
 
   const loadingIndicator = loadingIndicatorProp ?? (
-    <CircularProgress color="primary" thickness={2} />
+    <CircularProgress color={color} thickness={{ sm: 2, md: 3, lg: 4 }[size] || 3} />
   );
 
   React.useImperativeHandle(
@@ -302,30 +244,32 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     className: classes.endDecorator,
   });
 
-  const buttonLoadingIndicatorProps = useSlotProps({
-    elementType: ButtonLoadingIndicator,
-    externalSlotProps: componentsProps.loadingIndicator,
+  const loadingIndicatorCenterProps = useSlotProps({
+    elementType: ButtonLoadingCenter,
+    externalSlotProps: componentsProps.loadingIndicatorCenter,
     ownerState,
-    className: classes.loadingIndicator,
+    className: classes.loadingIndicatorCenter,
   });
-
-  const buttonLoadingIndicator = loading ? (
-    <ButtonLoadingIndicator {...buttonLoadingIndicatorProps}>
-      {loadingIndicator}
-    </ButtonLoadingIndicator>
-  ) : null;
 
   return (
     <ButtonRoot {...rootProps}>
-      {startDecorator && (
-        <ButtonStartDecorator {...startDecoratorProps}>{startDecorator}</ButtonStartDecorator>
+      {(startDecorator || (loading && loadingPosition === 'start')) && (
+        <ButtonStartDecorator {...startDecoratorProps}>
+          {loading && loadingPosition === 'start' ? loadingIndicator : startDecorator}
+        </ButtonStartDecorator>
       )}
 
-      {loadingPosition === 'end' ? children : buttonLoadingIndicator}
-      {loadingPosition === 'end' ? buttonLoadingIndicator : children}
+      {children}
+      {loading && loadingPosition === 'center' && (
+        <ButtonLoadingCenter {...loadingIndicatorCenterProps}>
+          {loadingIndicator}
+        </ButtonLoadingCenter>
+      )}
 
-      {endDecorator && (
-        <ButtonEndDecorator {...endDecoratorProps}>{endDecorator}</ButtonEndDecorator>
+      {(endDecorator || (loading && loadingPosition === 'end')) && (
+        <ButtonEndDecorator {...endDecoratorProps}>
+          {loading && loadingPosition === 'end' ? loadingIndicator : endDecorator}
+        </ButtonEndDecorator>
       )}
     </ButtonRoot>
   );

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -314,7 +314,7 @@ Button.propTypes /* remove-proptypes */ = {
    */
   componentsProps: PropTypes.shape({
     endDecorator: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    loadingIndicator: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    loadingIndicatorCenter: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     startDecorator: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   }),
@@ -344,7 +344,7 @@ Button.propTypes /* remove-proptypes */ = {
   /**
    * The node should contain an element with `role="progressbar"` with an accessible name.
    * By default we render a `CircularProgress` that is labelled by the button itself.
-   * @default <CircularProgress color="primary" thickness={2} />
+   * @default <CircularProgress />
    */
   loadingIndicator: PropTypes.node,
   /**

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -20,6 +20,7 @@ interface ComponentsProps {
   root?: SlotComponentProps<'button', { sx?: SxProps }, ButtonOwnerState>;
   startDecorator?: SlotComponentProps<'span', { sx?: SxProps }, ButtonOwnerState>;
   endDecorator?: SlotComponentProps<'span', { sx?: SxProps }, ButtonOwnerState>;
+  loadingIndicator?: SlotComponentProps<'div', { sx?: SxProps }, ButtonOwnerState>;
 }
 
 export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
@@ -84,6 +85,22 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
      * @default 'solid'
      */
     variant?: OverridableStringUnion<VariantProp, ButtonPropsVariantOverrides>;
+    /**
+     * If `true`, the loading indicator is shown.
+     * @default false
+     */
+    loading?: boolean;
+    /**
+     * The node should contain an element with `role="progressbar"` with an accessible name.
+     * By default we render a `CircularProgress` that is labelled by the button itself.
+     * @default <CircularProgress color="primary" thickness={2} />
+     */
+    loadingIndicator?: React.ReactNode;
+    /**
+     * The loading indicator can be positioned on the start, end, or the center of the button.
+     * @default 'center'
+     */
+    loadingPosition?: 'start' | 'end' | 'center';
   };
   defaultComponent: D;
 }

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -20,7 +20,7 @@ interface ComponentsProps {
   root?: SlotComponentProps<'button', { sx?: SxProps }, ButtonOwnerState>;
   startDecorator?: SlotComponentProps<'span', { sx?: SxProps }, ButtonOwnerState>;
   endDecorator?: SlotComponentProps<'span', { sx?: SxProps }, ButtonOwnerState>;
-  loadingIndicator?: SlotComponentProps<'div', { sx?: SxProps }, ButtonOwnerState>;
+  loadingIndicatorCenter?: SlotComponentProps<'span', { sx?: SxProps }, ButtonOwnerState>;
 }
 
 export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
@@ -93,7 +93,7 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
     /**
      * The node should contain an element with `role="progressbar"` with an accessible name.
      * By default we render a `CircularProgress` that is labelled by the button itself.
-     * @default <CircularProgress color="primary" thickness={2} />
+     * @default <CircularProgress />
      */
     loadingIndicator?: React.ReactNode;
     /**

--- a/packages/mui-joy/src/Button/buttonClasses.ts
+++ b/packages/mui-joy/src/Button/buttonClasses.ts
@@ -39,6 +39,20 @@ export interface ButtonClasses {
   startDecorator: string;
   /** Styles applied to the endDecorator element if supplied. */
   endDecorator: string;
+  /** Styles applied to the root element if `loading={true}`. */
+  loading: string;
+  /** Styles applied to the loadingIndicator element. */
+  loadingIndicator: string;
+  /** Styles applied to the loadingIndicator element if `loadingPosition="center"`. */
+  loadingIndicatorCenter: string;
+  /** Styles applied to the loadingIndicator element if `loadingPosition="start"`. */
+  loadingIndicatorStart: string;
+  /** Styles applied to the loadingIndicator element if `loadingPosition="end"`. */
+  loadingIndicatorEnd: string;
+  /** Styles applied to the endDecorator element if `loading={true}` and `loadingPosition="end"`. */
+  endDecoratorLoadingEnd: string;
+  /** Styles applied to the startDecorator element if `loading={true}` and `loadingPosition="start"`. */
+  startDecoratorLoadingStart: string;
 }
 
 export type ButtonClassKey = keyof ButtonClasses;
@@ -67,6 +81,13 @@ const buttonClasses: ButtonClasses = generateUtilityClasses('JoyButton', [
   'fullWidth',
   'startDecorator',
   'endDecorator',
+  'loading',
+  'loadingIndicator',
+  'loadingIndicatorCenter',
+  'loadingIndicatorStart',
+  'loadingIndicatorEnd',
+  'endDecoratorLoadingEnd',
+  'startDecoratorLoadingStart',
 ]);
 
 export default buttonClasses;

--- a/packages/mui-joy/src/Button/buttonClasses.ts
+++ b/packages/mui-joy/src/Button/buttonClasses.ts
@@ -41,18 +41,8 @@ export interface ButtonClasses {
   endDecorator: string;
   /** Styles applied to the root element if `loading={true}`. */
   loading: string;
-  /** Styles applied to the loadingIndicator element. */
-  loadingIndicator: string;
-  /** Styles applied to the loadingIndicator element if `loadingPosition="center"`. */
+  /** Styles applied to the loadingIndicatorCenter element. */
   loadingIndicatorCenter: string;
-  /** Styles applied to the loadingIndicator element if `loadingPosition="start"`. */
-  loadingIndicatorStart: string;
-  /** Styles applied to the loadingIndicator element if `loadingPosition="end"`. */
-  loadingIndicatorEnd: string;
-  /** Styles applied to the endDecorator element if `loading={true}` and `loadingPosition="end"`. */
-  endDecoratorLoadingEnd: string;
-  /** Styles applied to the startDecorator element if `loading={true}` and `loadingPosition="start"`. */
-  startDecoratorLoadingStart: string;
 }
 
 export type ButtonClassKey = keyof ButtonClasses;
@@ -82,12 +72,7 @@ const buttonClasses: ButtonClasses = generateUtilityClasses('JoyButton', [
   'startDecorator',
   'endDecorator',
   'loading',
-  'loadingIndicator',
   'loadingIndicatorCenter',
-  'loadingIndicatorStart',
-  'loadingIndicatorEnd',
-  'endDecoratorLoadingEnd',
-  'startDecoratorLoadingStart',
 ]);
 
 export default buttonClasses;


### PR DESCRIPTION
Fixes: https://github.com/mui/material-ui/issues/33999

**Preview**: https://deploy-preview-34658--material-ui.netlify.app/joy-ui/react-button/#loading

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
