### PR TITLE
Emotion fix select

### DIFF
--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -115,7 +115,7 @@ const Select = React.forwardRef(function Select(inProps, ref) {
         },
         ...(multiple && native && variant === 'outlined' ? { notched: true } : {}),
         ref: inputComponentRef,
-        className: clsx(InputComponent.props.className, className),
+        className: clsx(classes.select, InputComponent.props.className, className),
         // If a custom input is provided via 'input' prop, do not allow 'variant' to be propagated to it's root element. See https://github.com/mui/material-ui/issues/33894.
         ...(!input && { variant }),
         ...other,

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
+import { ClassNames } from '@emotion/react';
 import {
   describeConformance,
   ErrorBoundary,
   act,
   createRenderer,
   fireEvent,
-  screen,
+  screen
 } from 'test/utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import MenuItem from '@mui/material/MenuItem';
@@ -375,7 +376,7 @@ describe('<Select />', () => {
           'MUI: You have provided an out-of-range value `20` for the select component.',
           // React 18 Strict Effects run mount effects twice
           React.version.startsWith('18') &&
-            'MUI: You have provided an out-of-range value `20` for the select component.',
+          'MUI: You have provided an out-of-range value `20` for the select component.',
           'MUI: You have provided an out-of-range value `20` for the select component.',
         ]);
       });
@@ -1440,4 +1441,31 @@ describe('<Select />', () => {
 
     expect(getByRole('button')).not.toHaveFocus();
   });
+
+  describe('Emotion compatibility', () => {
+    it('classes.select should overwrite built-in styles.', () => {
+      // This is pink
+      const color = 'rgb(255, 192, 204)';
+
+      const { getByTestId } = render(
+        <ClassNames>
+          {({ css }) => (
+            <Select
+              data-testid="root"
+              value={"0"}
+              classes={{ select: css({ backgroundColor: color }) }}
+            >
+              <MenuItem  value={"0"}>
+                This is the text of the menu item
+              </MenuItem>
+            </Select>
+          )}
+        </ClassNames>
+      );
+      const root = getByTestId("root");
+
+      expect(getComputedStyle(root).backgroundColor).to.equal(color);
+    });
+  });
+
 });

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -8,7 +8,7 @@ import {
   act,
   createRenderer,
   fireEvent,
-  screen
+  screen,
 } from 'test/utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import MenuItem from '@mui/material/MenuItem';
@@ -376,7 +376,7 @@ describe('<Select />', () => {
           'MUI: You have provided an out-of-range value `20` for the select component.',
           // React 18 Strict Effects run mount effects twice
           React.version.startsWith('18') &&
-          'MUI: You have provided an out-of-range value `20` for the select component.',
+            'MUI: You have provided an out-of-range value `20` for the select component.',
           'MUI: You have provided an out-of-range value `20` for the select component.',
         ]);
       });
@@ -1452,20 +1452,17 @@ describe('<Select />', () => {
           {({ css }) => (
             <Select
               data-testid="root"
-              value={"0"}
+              value={'0'}
               classes={{ select: css({ backgroundColor: color }) }}
             >
-              <MenuItem  value={"0"}>
-                This is the text of the menu item
-              </MenuItem>
+              <MenuItem value={'0'}>This is the text of the menu item</MenuItem>
             </Select>
           )}
-        </ClassNames>
+        </ClassNames>,
       );
-      const root = getByTestId("root");
+      const root = getByTestId('root');
 
       expect(getComputedStyle(root).backgroundColor).to.equal(color);
     });
   });
-
 });


### PR DESCRIPTION
Hello @mnajdova,  

Sorry to bother you again, this is yet another following up to [33205](https://github.com/mui/material-ui/pull/33205).  
It [was reported to me](https://github.com/garronej/tss-react/issues/103#issuecomment-1266999107) that the `<Select />` component hadn't been fixed by [my previous PR](https://github.com/mui/material-ui/pull/34451).   

Best regards,  