### PR TITLE
fix(popover): use different transition event for style calculation

### DIFF
--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -280,11 +280,9 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
 
   const setPositioningStyles = React.useCallback(() => {
     const element = paperRef.current;
-
     if (!element) {
       return;
     }
-
     const positioning = getPositioningStyle(element);
 
     if (positioning.top !== null) {
@@ -300,24 +298,14 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
     if (onEntering) {
       onEntering(element, isAppearing);
     }
-
-    setPositioningStyles();
   };
-
-  React.useEffect(() => {
-    if (open) {
-      setPositioningStyles();
-    }
-  });
 
   React.useImperativeHandle(
     action,
     () =>
       open
         ? {
-            updatePosition: () => {
-              setPositioningStyles();
-            },
+            updatePosition: setPositioningStyles,
           }
         : null,
     [open, setPositioningStyles],
@@ -365,6 +353,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
       <TransitionComponent
         appear
         in={open}
+        onEnter={setPositioningStyles}
         onEntering={handleEntering}
         timeout={transitionDuration}
         {...TransitionProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/34236 by changing event for style calculation, also removed an effect to avoid unnecessary reflows, as the transition event callback handles it well enough
