### PR TITLE
fix(material): add support for exactOptionalPropertyTypes typescript …

### DIFF
--- a/packages/mui-material/src/OverridableComponent.d.ts
+++ b/packages/mui-material/src/OverridableComponent.d.ts
@@ -57,7 +57,7 @@ export type BaseProps<M extends OverridableTypeMap> =
  */
 // each component declares it's classes in a separate interface for proper JSDoc.
 export interface CommonProps extends StyledComponentProps<never> {
-  className?: string;
+  className?: string | undefined;
   style?: React.CSSProperties;
 }
 


### PR DESCRIPTION
…option in CommonProps (#28745)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This fixes #28745
PR title and commit message are probably wrong

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
