### PR TITLE
[test] Remove process/browser ponyfill

### DIFF
--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -23,10 +23,6 @@ module.exports = {
     }),
     // Avoid bundling the whole @mui/icons-material package. x2 the bundling speed.
     new webpack.IgnorePlugin({ resourceRegExp: /material-icons\/SearchIcons\.js/ }),
-    new webpack.ProvidePlugin({
-      // required by enzyme > cheerio > parse5 > util
-      process: 'process/browser',
-    }),
   ],
   module: {
     rules: [


### PR DESCRIPTION
The implicit dependency on process seems to be gone. webpack v5 do no longer add polyfills https://webpack.js.org/migrate/5/.