### PR TITLE
[core] Link Netlify in the danger comment

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,6 +1,6 @@
 // inspire by reacts dangerfile
 // danger has to be the first thing required!
-const { danger, markdown } = require('danger');
+const { danger, markdown, message } = require('danger');
 const { exec } = require('child_process');
 const { loadComparison } = require('./scripts/sizeSnapshot');
 
@@ -167,6 +167,9 @@ async function reportBundleSize() {
 }
 
 async function run() {
+  const netlifyPreview = `https://deploy-preview-${process.env.CIRCLE_PR_NUMBER}--material-ui.netlify.app/`;
+  message(`Netlify deploy preview: <a href="${netlifyPreview}">${netlifyPreview}</a>`);
+
   switch (dangerCommand) {
     case 'prepareBundleSizeReport':
       prepareBundleSizeReport();


### PR DESCRIPTION
It might be simpler than having to click on the Netlify status to find the preview URL. For the community, it might even make the difference between trying the preview out and not knowing it exists.

An alternative would be to enable this comment back (easy):

<img width="500" alt="Screenshot 2022-10-09 at 20 02 24" src="https://user-images.githubusercontent.com/3165635/194772356-0d304104-90f6-4a7a-811e-ecd626cfe47e.png">

https://github.com/netlify/open-api/pull/394#issuecomment-1233209606. However, for maintainers that aren't using emails to manage their GitHub notifications, this would create even more noise than `mui-bot` already creates (with the email you can create a filter to delete the mui-bot & Netlify comment notification). Netlify's native comment also uses more vertical space.