### PR TITLE
[MultiSelect][base] Prevent the renderValue prop from being propagated to the DOM

### DIFF
--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -258,33 +258,60 @@ describe('MultiSelectUnstyled', () => {
       expect(handleChange.args[0][0]).to.haveOwnProperty('target', optionTwo);
       expect(handleChange.args[0][1]).to.deep.equal([1, 2]);
     });
+
+    it('does not call onChange if `value` is modified externally', () => {
+      function TestComponent({ onChange }: { onChange: (value: number[]) => void }) {
+        const [value, setValue] = React.useState([1]);
+        const handleChange = (ev: React.SyntheticEvent | null, newValue: number[]) => {
+          setValue(newValue);
+          onChange(newValue);
+        };
+
+        return (
+          <div>
+            <button onClick={() => setValue([1, 2])}>Update value</button>
+            <MultiSelectUnstyled value={value} onChange={handleChange}>
+              <OptionUnstyled value={1}>1</OptionUnstyled>
+              <OptionUnstyled value={2}>2</OptionUnstyled>
+            </MultiSelectUnstyled>
+          </div>
+        );
+      }
+
+      const onChange = spy();
+      const { getByText } = render(<TestComponent onChange={onChange} />);
+
+      const button = getByText('Update value');
+      act(() => button.click());
+      expect(onChange.notCalled).to.equal(true);
+    });
   });
 
-  it('does not call onChange if `value` is modified externally', () => {
-    function TestComponent({ onChange }: { onChange: (value: number[]) => void }) {
-      const [value, setValue] = React.useState([1]);
-      const handleChange = (ev: React.SyntheticEvent | null, newValue: number[]) => {
-        setValue(newValue);
-        onChange(newValue);
-      };
-
-      return (
-        <div>
-          <button onClick={() => setValue([1, 2])}>Update value</button>
-          <MultiSelectUnstyled value={value} onChange={handleChange}>
-            <OptionUnstyled value={1}>1</OptionUnstyled>
-            <OptionUnstyled value={2}>2</OptionUnstyled>
-          </MultiSelectUnstyled>
-        </div>
+  describe('prop: renderValue', () => {
+    it('renders the selected values using the renderValue prop', () => {
+      const { getByRole } = render(
+        <MultiSelectUnstyled
+          defaultValue={[1, 2]}
+          renderValue={(values) => values.map((v) => `${v.label} (${v.value})`).join(', ')}
+        >
+          <OptionUnstyled value={1}>One</OptionUnstyled>
+          <OptionUnstyled value={2}>Two</OptionUnstyled>
+        </MultiSelectUnstyled>,
       );
-    }
 
-    const onChange = spy();
-    const { getByText } = render(<TestComponent onChange={onChange} />);
+      expect(getByRole('button')).to.have.text('One (1), Two (2)');
+    });
 
-    const button = getByText('Update value');
-    act(() => button.click());
-    expect(onChange.notCalled).to.equal(true);
+    it('renders the selected values as comma-separated list of labels if renderValue is not provided', () => {
+      const { getByRole } = render(
+        <MultiSelectUnstyled defaultValue={[1, 2]}>
+          <OptionUnstyled value={1}>One</OptionUnstyled>
+          <OptionUnstyled value={2}>Two</OptionUnstyled>
+        </MultiSelectUnstyled>,
+      );
+
+      expect(getByRole('button')).to.have.text('One, Two');
+    });
   });
 
   it('sets a value correctly when interacted by a user and external code', () => {

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -95,11 +95,12 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
     onChange,
     onListboxOpenChange,
     optionStringifier = defaultOptionStringifier,
+    renderValue: renderValueProp,
     value: valueProp,
     ...other
   } = props;
 
-  const renderValue = props.renderValue ?? defaultRenderMultipleValues;
+  const renderValue = renderValueProp ?? defaultRenderMultipleValues;
 
   const [groupedOptions, setGroupedOptions] = React.useState<SelectChild<TValue>[]>([]);
   const options = React.useMemo(() => flattenOptionGroups(groupedOptions), [groupedOptions]);

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.test.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.test.tsx
@@ -476,6 +476,33 @@ describe('SelectUnstyled', () => {
     });
   });
 
+  describe('prop: renderValue', () => {
+    it('renders the selected values using the renderValue prop', () => {
+      const { getByRole } = render(
+        <SelectUnstyled
+          defaultValue={1}
+          renderValue={(value) => `${value?.label} (${value?.value})`}
+        >
+          <OptionUnstyled value={1}>One</OptionUnstyled>
+          <OptionUnstyled value={2}>Two</OptionUnstyled>
+        </SelectUnstyled>,
+      );
+
+      expect(getByRole('button')).to.have.text('One (1)');
+    });
+
+    it('renders the selected values as a label if renderValue is not provided', () => {
+      const { getByRole } = render(
+        <SelectUnstyled defaultValue={1}>
+          <OptionUnstyled value={1}>One</OptionUnstyled>
+          <OptionUnstyled value={2}>Two</OptionUnstyled>
+        </SelectUnstyled>,
+      );
+
+      expect(getByRole('button')).to.have.text('One');
+    });
+  });
+
   it('closes the listbox without selecting an option when focus is lost', () => {
     const { getByRole, getByTestId } = render(
       <div>


### PR DESCRIPTION
When a `renderValue` prop is used on a MultiSelectUnstyled, it gets propagated to the DOM causing console warnings. This PR fixes this problem.