### PR TITLE
[docs] Gatsby Description in Joy dark-mode

### DIFF
--- a/docs/data/joy/guides/applying-dark-mode/applying-dark-mode.md
+++ b/docs/data/joy/guides/applying-dark-mode/applying-dark-mode.md
@@ -95,7 +95,7 @@ export default class MyDocument extends Document {
 
 ### Gatsby
 
-To use the Joy UI API with a Next.js project, add the following code to the custom [`gatsby-ssr.js`](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/) file:
+To use the Joy UI API with a Gatsby project, add the following code to the custom [`gatsby-ssr.js`](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-ssr/) file:
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
The description for Gatsby  mentions Next.js instead of Gatsby

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
