### PR TITLE
[PopperUnstyled] Update PopperTooltip to have correct width when closing with transition

### DIFF
--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
@@ -84,6 +84,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
    * modifiers.flip is essentially a flip for controlled/uncontrolled behavior
    */
   const [placement, setPlacement] = React.useState(rtlPlacement);
+  const [tooltipAnchorEl, setTooltipAnchorEl] = React.useState(anchorEl);
 
   React.useEffect(() => {
     if (popperRef.current) {
@@ -91,8 +92,14 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
     }
   });
 
+  React.useEffect(() => {
+    if (anchorEl) {
+      setTooltipAnchorEl(anchorEl);
+    }
+  }, [anchorEl]);
+
   useEnhancedEffect(() => {
-    if (!anchorEl || !open) {
+    if (!tooltipAnchorEl || !open) {
       return undefined;
     }
 
@@ -100,7 +107,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       setPlacement(data.placement);
     };
 
-    const resolvedAnchorEl = resolveAnchorEl(anchorEl);
+    const resolvedAnchorEl = resolveAnchorEl(tooltipAnchorEl);
 
     if (process.env.NODE_ENV !== 'production') {
       if (resolvedAnchorEl && resolvedAnchorEl.nodeType === 1) {
@@ -154,7 +161,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       popperModifiers = popperModifiers.concat(popperOptions.modifiers);
     }
 
-    const popper = createPopper(resolveAnchorEl(anchorEl), tooltipRef.current, {
+    const popper = createPopper(resolveAnchorEl(tooltipAnchorEl), tooltipRef.current, {
       placement: rtlPlacement,
       ...popperOptions,
       modifiers: popperModifiers,
@@ -166,7 +173,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       popper.destroy();
       handlePopperRefRef.current(null);
     };
-  }, [anchorEl, disablePortal, modifiers, open, popperOptions, rtlPlacement]);
+  }, [tooltipAnchorEl, disablePortal, modifiers, open, popperOptions, rtlPlacement]);
 
   const childProps = { placement };
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes #31112

### Before:
![wrong](https://user-images.githubusercontent.com/30778707/195137054-20f51304-9c61-4a76-93a3-ce909a6fd23e.gif)

### After:
![correct](https://user-images.githubusercontent.com/30778707/195137083-e81db83b-4646-48ef-bea1-a023b86e3f10.gif)
