### PR TITLE
[POC] Add `button` prop to the Menu

### DIFF
--- a/docs/data/joy/components/menu/BasicMenu.js
+++ b/docs/data/joy/components/menu/BasicMenu.js
@@ -4,38 +4,18 @@ import Menu from '@mui/joy/Menu';
 import MenuItem from '@mui/joy/MenuItem';
 
 export default function BasicMenu() {
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
   return (
     <div>
-      <Button
-        id="basic-demo-button"
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        variant="outlined"
-        color="neutral"
-        onClick={handleClick}
-      >
-        Dashboard
-      </Button>
       <Menu
-        id="basic-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="basic-demo-button"
+        button={
+          <Button variant="outlined" color="neutral">
+            Dashboard
+          </Button>
+        }
       >
-        <MenuItem onClick={handleClose}>Profile</MenuItem>
-        <MenuItem onClick={handleClose}>My account</MenuItem>
-        <MenuItem onClick={handleClose}>Logout</MenuItem>
+        <MenuItem>Profile</MenuItem>
+        <MenuItem>My account</MenuItem>
+        <MenuItem>Logout</MenuItem>
       </Menu>
     </div>
   );

--- a/packages/mui-joy/src/Menu/MenuProps.ts
+++ b/packages/mui-joy/src/Menu/MenuProps.ts
@@ -21,6 +21,10 @@ export interface MenuTypeMap<P = {}, D extends React.ElementType = 'ul'> {
        */
       actions?: React.Ref<MenuUnstyledActions>;
       /**
+       * A menu button that will open the menu when users interact on it.
+       */
+      button?: React.ReactElement;
+      /**
        * The color of the component. It supports those theme colors that make sense for this component.
        * @default 'neutral'
        */

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -7,6 +7,7 @@ import { useMenuItem } from '@mui/base/MenuItemUnstyled';
 import { ListItemButtonRoot } from '../ListItemButton/ListItemButton';
 import { styled, useThemeProps } from '../styles';
 import { getMenuItemUtilityClass } from './menuItemClasses';
+import { MenuCloseContext } from '../Menu/Menu';
 import {
   MenuItemProps,
   MenuItemOwnerState,
@@ -46,6 +47,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
   });
 
   const row = React.useContext(RowListContext);
+  const handleClose = React.useContext(MenuCloseContext);
 
   const {
     children,
@@ -77,7 +79,13 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
 
   const rootProps = useSlotProps({
     elementType: MenuItemRoot,
-    getSlotProps: getRootProps,
+    getSlotProps: (handlers) =>
+      getRootProps({
+        onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+          handlers.onClick?.(event);
+          handleClose?.();
+        },
+      }),
     externalSlotProps: {},
     additionalProps: {
       as: component,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Preview**: https://deploy-preview-34730--material-ui.netlify.app/joy-ui/react-menu/#basic-usage
**Diff**: https://github.com/mui/material-ui/pull/34730/files#r993106236

---

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
