### PR TITLE
[TextField] Apply spellCheck for type password

### DIFF
--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.test.tsx
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.test.tsx
@@ -31,6 +31,11 @@ describe('<InputUnstyled />', () => {
     expect(screen.getByRole('textbox')).to.have.tagName('textarea');
   });
 
+  it('should set spellCheck if type is password', () => {
+    render(<InputUnstyled type="password" />);
+    expect(document.querySelector('input')).to.have.attribute('spellcheck', 'false');
+  });
+
   describe('prop: multiline', () => {
     it('should pass the rows prop to the underlying textarea when multiline=true', () => {
       const { getByRole } = render(<InputUnstyled multiline rows={5} />);

--- a/packages/mui-base/src/InputUnstyled/useInput.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.ts
@@ -186,6 +186,7 @@ export default function useInput(parameters: UseInputParameters) {
     };
 
     return {
+      ...(mergedEventHandlers.type === 'password' ? { spellCheck: false } : {}),
       ...mergedEventHandlers,
       'aria-invalid': error || undefined,
       defaultValue: defaultValue as string | number | readonly string[] | undefined,

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -505,7 +505,11 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
   const rootProps = componentsProps.root || {};
 
   const Input = components.Input || InputBaseComponent;
-  inputProps = { ...inputProps, ...componentsProps.input };
+  inputProps = {
+    ...(type === 'password' ? { spellCheck: false } : {}),
+    ...inputProps,
+    ...componentsProps.input,
+  };
 
   return (
     <React.Fragment>

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -37,6 +37,11 @@ describe('<InputBase />', () => {
     expect(container.firstChild).to.have.class(classes.sizeSmall);
   });
 
+  it('should set spellCheck if type is password', () => {
+    render(<InputBase type="password" />);
+    expect(document.querySelector('input')).to.have.attribute('spellcheck', 'false');
+  });
+
   describe('multiline', () => {
     it('should render a `textbox` with `aria-multiline`', () => {
       render(<InputBase multiline />);


### PR DESCRIPTION
The problem: https://www.bleepingcomputer.com/news/security/google-microsoft-can-get-your-passwords-via-web-browsers-spellcheck/.

> But, features like Chrome's Enhanced Spellcheck or Microsoft Editor when manually enabled by the user, exhibit this potential privacy risk.

For example, Google has a couple of attributes on the password fiels

<img width="388" alt="Screenshot 2022-10-12 at 15 53 17" src="https://user-images.githubusercontent.com/3165635/195364069-52838797-51bc-4546-93f5-d2a6d86582d1.png">
<img width="399" alt="Screenshot 2022-10-12 at 15 52 56" src="https://user-images.githubusercontent.com/3165635/195364063-6aed144c-cfce-4cce-86b6-408dc17f8aeb.png">

~The solution, it's not clear to me if this is the right solution, feel free to close if you feel it's not, maybe it should be done userland, or maybe it's simply browsers that should fix this. At least, I don't see why browsers should try to spell-check password fields. If we reject this approach~

I think that we can update the password demos at https://mui.com/material-ui/react-text-field/#form-props. It might actually be better.