### PR TITLE
[docs] Avoid scrollbar in the code demos

### DIFF
--- a/docs/data/material/customization/how-to-customize/how-to-customize.md
+++ b/docs/data/material/customization/how-to-customize/how-to-customize.md
@@ -204,7 +204,7 @@ The `styleOverrides` key in the `MuiCssBaseline` component slot also supports ca
 
 +const inputGlobalStyles = <GlobalStyles styles={...} />;
 
- const Input = (props) => {
+ function Input(props) {
    return (
      <React.Fragment>
 -      <GlobalStyles styles={...} />

--- a/docs/data/material/experimental-api/css-theme-variables/migration.md
+++ b/docs/data/material/experimental-api/css-theme-variables/migration.md
@@ -29,64 +29,64 @@ This moves palette customization to within the `colorSchemes` node.
 Other properties can be copied and pasted.
 
 ```diff
-- import { createTheme } from '@mui/material/styles';
-+ import { experimental_extendTheme as extendTheme} from '@mui/material/styles';
+-import { createTheme } from '@mui/material/styles';
++import { experimental_extendTheme as extendTheme} from '@mui/material/styles';
 
-- const lightTheme = createTheme({
--   palette: {
--    primary: {
--      main: '#ff5252',
--    },
--    ...
--  },
--  // ...other properties, e.g. breakpoints, spacing, shape, typography, components
-- });
+-const lightTheme = createTheme({
+-  palette: {
+-   primary: {
+-     main: '#ff5252',
+-   },
+-   ...
+- },
+- // ...other properties, e.g. breakpoints, spacing, shape, typography, components
+-});
 
-- const darkTheme = createTheme({
--   palette: {
--    mode: 'dark',
--    primary: {
--      main: '#000',
--    },
--    ...
--  },
-- });
+-const darkTheme = createTheme({
+-  palette: {
+-   mode: 'dark',
+-   primary: {
+-     main: '#000',
+-   },
+-   ...
+- },
+-});
 
-+ const theme = extendTheme({
-+   colorSchemes: {
-+     light: {
-+       palette: {
-+         primary: {
-+           main: '#ff5252',
-+         },
-+         ...
-+       },
-+     },
-+     dark: {
-+       palette: {
-+         primary: {
-+           main: '#000',
-+         },
-+         ...
-+       },
-+     },
-+   },
-+   // ...other properties
-+ });
++const theme = extendTheme({
++  colorSchemes: {
++    light: {
++      palette: {
++        primary: {
++          main: '#ff5252',
++        },
++        ...
++      },
++    },
++    dark: {
++      palette: {
++        primary: {
++          main: '#000',
++        },
++        ...
++      },
++    },
++  },
++  // ...other properties
++});
 ```
 
 Then, replace the `ThemeProvider` with the `CssVarsProvider`:
 
 ```diff
-- import { ThemeProvider } from '@mui/material/styles';
-+ import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
+-import { ThemeProvider } from '@mui/material/styles';
++import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
 
-const theme = extendTheme(...)
+ const theme = extendTheme(...);
 
-function App() {
-- return <ThemeProvider theme={theme}>...</ThemeProvider>
-+ return <CssVarsProvider theme={theme}>...</CssVarsProvider>
-}
+ function App() {
+-  return <ThemeProvider theme={theme}>...</ThemeProvider>
++  return <CssVarsProvider theme={theme}>...</CssVarsProvider>
+ }
 ```
 
 Save the file and start the development server.
@@ -104,8 +104,8 @@ You can remove your existing logic that handles the user-selected mode and repla
 
 **Before**:
 
-```js
-// This is just a minimal example to demonstrate the migration.
+```jsx
+// This is only a minimal example to demonstrate the migration.
 function App() {
   const [mode, setMode] = React.useState(() => {
     if (typeof window !== 'undefined') {
@@ -125,13 +125,9 @@ function App() {
     <ThemeProvider theme={theme}>
       <Button
         onClick={() => {
-          if (mode === 'light') {
-            setMode('dark');
-            localStorage.setItem('dark');
-          } else {
-            setMode('light');
-            localStorage.setItem('light');
-          }
+          const newMode = mode === 'light' ? 'dark' : 'light';
+          setMode(newMode);
+          localStorage.setItem('mode', newMode);
         }}
       >
         {mode === 'light' ? 'Turn dark' : 'Turn light'}
@@ -156,11 +152,7 @@ function ModeToggle() {
   return (
     <Button
       onClick={() => {
-        if (mode === 'light') {
-          setMode('dark');
-        } else {
-          setMode('light');
-        }
+        setMode(mode === 'light' ? 'dark' : 'light');
       }}
     >
       {mode === 'light' ? 'Turn dark' : 'Turn light'}

--- a/docs/data/material/experimental-api/css-theme-variables/overview.md
+++ b/docs/data/material/experimental-api/css-theme-variables/overview.md
@@ -98,7 +98,8 @@ extendTheme({
       styleOverrides: {
         root: ({ theme }) => ({
           color: theme.vars.palette.primary.main,
-          // When the mode switches to dark, the attribute selector is attached to the <html> tag by default.
+          // When the mode switches to dark, the attribute selector is attached to
+          // the <html> tag by default.
           '[data-mui-color-scheme="dark"] &': {
             color: '#fff',
           },

--- a/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
@@ -267,10 +267,11 @@ const style = {
 export default function App() {
   return <Button sx={style}>Example</Button>;
 }
-//    Type '{ flexDirection: string; }' is not assignable to type 'SxProps<Theme> | undefined'.
-//    Type '{ flexDirection: string; }' is not assignable to type 'CSSSelectorObject<Theme>'.
-//      Property 'flexDirection' is incompatible with index signature.
-//        Type 'string' is not assignable to type 'SystemStyleObject<Theme>'.
+
+// Type '{ flexDirection: string; }' is not assignable to type 'SxProps<Theme> | undefined'
+// Type '{ flexDirection: string; }' is not assignable to type 'CSSSelectorObject<Theme>'
+//   Property 'flexDirection' is incompatible with index signature
+//     Type 'string' is not assignable to type 'SystemStyleObject<Theme>'
 ```
 
 The problem is that the type of the `flexDirection` prop is inferred as `string`, which is too wide.

--- a/docs/data/system/spacing/spacing.md
+++ b/docs/data/system/spacing/spacing.md
@@ -64,8 +64,8 @@ const theme = {
 - input: `string`: the prop value is passed as raw CSS value.
 
 ```jsx
-<Box sx={{ m: "2rem" }} /> // margin: 2rem;
-<Box sx={{ mx: "auto" }} /> // margin-left: auto; margin-right: auto;
+<Box sx={{ m: '2rem' }} /> // margin: 2rem;
+<Box sx={{ mx: 'auto' }} /> // margin-left: auto; margin-right: auto;
 ```
 
 ## Example
@@ -86,7 +86,7 @@ However, you can also use `margin-left: auto;`, `margin-right: auto;`, and a wid
 {{"demo": "HorizontalCentering.js", "defaultCodeOpen": false, "bg": true}}
 
 ```jsx
-<Box sx={{ mx: "auto", width: 200 }}>…
+<Box sx={{ mx: 'auto', width: 200 }}>…
 ```
 
 ## API


### PR DESCRIPTION
A small detail I saw while reading https://twitter.com/siriwatknp/status/1579729991642009600. This scrollbar is now gone. I have fixed a few out of sync with the standard syntax that I could notice along the way, quick wins.

<img width="791" alt="Screenshot 2022-10-12 at 23 25 23" src="https://user-images.githubusercontent.com/3165635/195450890-2e0abb2e-273c-4b56-a000-597a400459cd.png">
