### PR TITLE
[website] Update the state of the date pickers on the landing page

### DIFF
--- a/docs/src/components/productX/XComponents.tsx
+++ b/docs/src/components/productX/XComponents.tsx
@@ -27,7 +27,7 @@ import IconImage from 'docs/src/components/icon/IconImage';
 import { brandingDarkTheme } from 'docs/src/modules/brandingTheme';
 
 const DEMOS = ['Data Grid', 'Date Range Picker', 'Tree View', 'Sparkline', 'Charts'];
-const WIP = DEMOS.slice(1);
+const WIP = DEMOS.slice(2);
 
 const AspectRatioImage = styled('div', {
   shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'src' && prop !== 'ratio',

--- a/docs/src/components/productX/XDateRangeDemo.tsx
+++ b/docs/src/components/productX/XDateRangeDemo.tsx
@@ -1,17 +1,16 @@
-import * as React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
+import { ThemeProvider } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import { DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import Frame from 'docs/src/components/action/Frame';
 import { brandingDarkTheme } from 'docs/src/modules/brandingTheme';
-import EmailSubscribe from 'docs/src/components/footer/EmailSubscribe';
+import * as React from 'react';
 
 const startDate = new Date();
 startDate.setDate(10);

--- a/docs/src/components/productX/XDateRangeDemo.tsx
+++ b/docs/src/components/productX/XDateRangeDemo.tsx
@@ -88,7 +88,7 @@ export default function XDateRangeDemo() {
             }}
           >
             <Typography variant="body2" fontWeight="bold" sx={{ mr: 1 }}>
-              v5 stable release available!
+              Available now for your project.
             </Typography>
             <Chip
               label="See docs"

--- a/docs/src/components/productX/XDateRangeDemo.tsx
+++ b/docs/src/components/productX/XDateRangeDemo.tsx
@@ -1,16 +1,16 @@
+import * as React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Paper from '@mui/material/Paper';
-import { ThemeProvider } from '@mui/material/styles';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
 import { DateRange } from '@mui/x-date-pickers-pro/DateRangePicker';
 import { StaticDateRangePicker } from '@mui/x-date-pickers-pro/StaticDateRangePicker';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import Frame from 'docs/src/components/action/Frame';
 import { brandingDarkTheme } from 'docs/src/modules/brandingTheme';
-import * as React from 'react';
 
 const startDate = new Date();
 startDate.setDate(10);

--- a/docs/src/components/productX/XDateRangeDemo.tsx
+++ b/docs/src/components/productX/XDateRangeDemo.tsx
@@ -88,7 +88,7 @@ export default function XDateRangeDemo() {
             }}
           >
             <Typography variant="body2" fontWeight="bold" sx={{ mr: 1 }}>
-              Available in alpha!
+              v5 stable release available!
             </Typography>
             <Chip
               label="See docs"
@@ -98,11 +98,6 @@ export default function XDateRangeDemo() {
               sx={{ fontWeight: 500, cursor: 'pointer' }}
             />
           </Box>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Subscribe to our newsletter to get first-hand info about the development and release of
-            new components.
-          </Typography>
-          <EmailSubscribe />
         </Frame.Info>
       </ThemeProvider>
     </Frame>


### PR DESCRIPTION
## Summary

Update landing page to display with date pickers availability.

### Preview link:
https://deploy-preview-34750--material-ui.netlify.app/x/

### After:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/550141/195647924-c8220c4c-53d2-4cd7-a8bd-17d7079c66ed.png">


### Before:
![image](https://user-images.githubusercontent.com/550141/195647989-ec2242f2-467b-44a0-af53-eb83d3f1c73b.png)

## Note

There's a planned initiative this quarter to fully refactor the landing page. This is just a small update to clear any potential confusion about the availability of the date pickers.