### PR TITLE
[docs] Enforce no trailing spaces

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,10 +1,17 @@
 const straightQuotes = require('./packages/markdownlint-rule-mui/straight-quotes');
 const gitDiff = require('./packages/markdownlint-rule-mui/git-diff');
 
+// https://github.com/DavidAnson/markdownlint#rules--aliases
 module.exports = {
   config: {
     default: true,
     MD004: false, // MD004/ul-style. Buggy
+    MD009: {
+      // MD009/no-trailing-spaces
+      br_spaces: 0,
+      strict: true,
+      list_item_empty_lines: false,
+    },
     MD013: false, // MD013/line-length. Already handled by Prettier.
     MD014: false, // MD014/commands-show-output. It's OK.
     MD024: { siblings_only: true }, // MD024/no-duplicate-heading/no-duplicate-header
@@ -31,6 +38,7 @@ module.exports = {
     '**/node_modules/**',
     '**/*-zh.md',
     '**/*-pt.md',
+    '**/build/**',
     '.github/PULL_REQUEST_TEMPLATE.md',
   ],
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1701,7 +1701,8 @@ All contributors of this release in alphabetical order: @abhinav-22-tech, @ainat
 
 _Apr 18, 2022_
 
-A big thanks to the 11 contributors who made this release possible. This release is mostly about 🐛 bug fixes and 📚 documentation improvements.
+A big thanks to the 11 contributors who made this release possible.
+This release is mostly about 🐛 bug fixes and 📚 documentation improvements.
 
 ### `@mui/material@5.6.2`
 
@@ -1760,7 +1761,7 @@ All contributors of this release in alphabetical order: @abaker93, @cherniavskii
 
 _Apr 11, 2022_
 
-A big thanks to the 8 contributors who made this release possible.  
+A big thanks to the 8 contributors who made this release possible.
 This release is mostly about 🐛 bug fixes and 📚 documentation improvements.
 
 ### `@mui/material@5.6.1`

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -16,8 +16,9 @@ includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?ico
 
 :::info
 The `@mui/icons-material` package depends on `@mui/material`, which requires Emotion packages.
+If you don't use Material UI in your project yet, install the icons package with:
+`npm install @mui/icons-material @mui/material @emotion/styled @emotion/react`.
 
-If you don't use Material UI in your project yet, install the icons package with `npm install @mui/icons-material @mui/material @emotion/styled @emotion/react`.  
 See the [Installation](/material-ui/getting-started/installation/) page for additional docs about how to make sure everything is set up correctly.
 :::
 

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -883,8 +883,3 @@ There is [an ESLint plugin](https://docs.tss-react.dev/detecting-unused-classes)
 ⚠️ **Keep `@emotion/styled` as a dependency of your project**. Even if you never use it explicitly,
 it's a peer dependency of `@mui/material`.
 :::
-
-:::warning
-For [Storybook](https://storybook.js.org): At the time of this writing, Storybook still uses Emotion 10 by default.  
-Material UI and TSS use Emotion 11, so you must make [some changes](https://github.com/InseeFrLab/onyxia-ui/blob/324de62248074582b227e584c53fb2e123f5325f/.storybook/main.js#L31-L32) to `.storybook/main.js` in order to use Storybook with Material UI.
-:::

--- a/docs/pages/blog/mui-x-v6-alpha-zero.md
+++ b/docs/pages/blog/mui-x-v6-alpha-zero.md
@@ -6,7 +6,9 @@ authors: ['josefreitas']
 tags: ['MUI X', 'News']
 ---
 
-We're kicking off the development of [MUI X v6](https://github.com/mui/mui-x/releases/tag/v6.0.0-alpha.0). Both the Data Grid and the Date and Time Pickers will get a new major version. We want to share our plans and invite you to join us on this next step.
+We're kicking off the development of [MUI X v6](https://github.com/mui/mui-x/releases/tag/v6.0.0-alpha.0).
+Both the Data Grid and the Date and Time Pickers will get a new major version.
+We want to share our plans and invite you to join us on this next step.
 
 :::warning
 It's important to note that only MUI X is getting a new version—MUI Core (including Material UI) will remain in v5 for now.
@@ -15,11 +17,15 @@ You can rest assured that all MUI X v6 components will be fully compatible with 
 
 ## What's the plan to get to a stable release?
 
-Before officially releasing v6, we'll go through a few months with pre-releases. We'll follow the current weekly release process and [semver versioning](https://semver.org/); the difference now is that instead of v5, we'll ship v6 pre-release packages.
+Before officially releasing v6, we'll go through a few months with pre-releases.
+We'll follow the current weekly release process and [semver versioning](https://semver.org/); the difference now is that instead of v5, we'll ship v6 pre-release packages.
 
-First, in the alpha phase, we'll introduce all the breaking changes planned for this major. We'll be exploring a bit, so it's expected that some APIs will be unstable—not in terms of functionality, but we may need to rename or adjust parameters. This phase is planned to take about two months.
+First, in the alpha phase, we'll introduce all the breaking changes planned for this major.
+We'll be exploring a bit, so it's expected that some APIs will be unstable—not in terms of functionality, but we may need to rename or adjust parameters.
+This phase is planned to take about two months.
 
-Next comes the beta phase, where the APIs will be more stable, and we'll focus on fixing bugs and polishing the hard edges. This phase is planned to take about one month.
+Next comes the beta phase, where the APIs will be more stable, and we'll focus on fixing bugs and polishing the hard edges.
+This phase is planned to take about one month.
 
 :::info
 Disclaimer: This timeline—2 months in alpha, 1 month in beta—is purely for reference.
@@ -49,19 +55,20 @@ The next version's documentation is in the `next` subdomain.
 
 ## What's coming next?
 
-The following is a list of enhancements in the pipeline for v6. It contains the highlights that will be included in the first versions.
+The following is a list of enhancements in the pipeline for v6.
+It contains the highlights that will be included in the first versions.
 
 ### Data Grid
 
-- **Extended customization abilities**.  
-   We want to empower more users to employ the Data Grid for complex use cases.
+- **Extended customization abilities**.\
+  We want to empower more users to employ the Data Grid for complex use cases.
 
   - [ApiRef in the community package](https://github.com/mui/mui-x/issues/6147).
   - [Filtering on header](https://github.com/mui/mui-x/issues/6247).
   - [Use the Data Grid internal components outside the grid](https://github.com/mui/mui-x/issues/2522).
 
-- **Improved look & feel**  
-   We're polishing edges in terms of design and usability.
+- **Improved look & feel**\
+  We're polishing edges in terms of design and usability.
 
   - [New column menu](https://github.com/mui/mui-x/issues/4929).
   - [New column visibility panel](https://github.com/mui/mui-x/issues/5700).
@@ -72,16 +79,17 @@ The following is a list of enhancements in the pipeline for v6. It contains the 
 
 ### Date and Time Pickers
 
-- **Improved UX**  
-   In the previous version we focused on developer experience and overall stability of the components. Now we're tackling ways to improve usability.
+- **Improved UX**\
+  In the previous version we focused on developer experience and overall stability of the components.
+  Now we're tackling ways to improve usability.
 
   - [Remove the clock view on time pickers (for desktop)](https://github.com/mui/mui-x/issues/4483).
   - [Visually edit a range by dragging date markers](https://github.com/mui/mui-x/issues/5311).
   - [Range shortcuts](https://github.com/mui/mui-x/issues/4563).
   - [A new text input for date and time values, retiring the mask solution (early preview)](https://next.mui.com/x/react-date-pickers/date-field/).
 
-- **Improved Customization**  
-   v6 will be packed with new customization abilities and support for new use cases.
+- **Improved Customization**\
+  v6 will be packed with new customization abilities and support for new use cases.
   - [The new fields are based on a headless approach with custom hooks. (Documentation is coming soon)](https://next.mui.com/x/react-date-pickers/date-field/#headless-usage).
   - [Single Input for Date Range](https://github.com/mui/mui-x/issues/5193).
   - [Enable customization through component slots on every component](https://github.com/mui/mui-x/issues/4466).
@@ -92,13 +100,17 @@ You can check our [roadmap](https://github.com/mui/mui-x/projects/1) for the ful
 
 ## How to migrate?
 
-We've prepared a [migration guide](https://deploy-preview-6235--material-ui-x.netlify.app/x/react-data-grid/migration-v5/), and we'll continuously update it as we make any breaking changes during the pre-releases. It lists every update you need to make to your code to use the most recent packages.
+We've prepared a [migration guide](https://deploy-preview-6235--material-ui-x.netlify.app/x/react-data-grid/migration-v5/), and we'll continuously update it as we make any breaking changes during the pre-releases.
+It lists every update you need to make to your code to use the most recent packages.
 
-We highly encourage you to try the new version. It is, after all, an improvement over the solid foundation we established with v5.
+We highly encourage you to try the new version.
+It is, after all, an improvement over the solid foundation we established with v5.
 
 ## How to get involved?
 
-Please consider joining our alpha testers group channel and [connecting with us](https://forms.gle/vsBv6CLPz9h57xg8A) for a user interview.  
+Please consider joining our alpha testers group channel and [connecting with us](https://forms.gle/vsBv6CLPz9h57xg8A) for a user interview.
 You'll get an insider's perspective on the development, and you'll be able to help us iterate early on the new features.
 
-As always, we're happy to get your feedback. You can participate in the discussion by commenting on new features or reporting bugs in our [GitHub repository](https://github.com/mui/mui-x/issues/new/choose). Finally, you can follow every step of the development through our [changelog](https://github.com/mui/mui-x/releases).
+As always, we're happy to get your feedback.
+You can participate in the discussion by commenting on new features or reporting bugs in our [GitHub repository](https://github.com/mui/mui-x/issues/new/choose).
+Finally, you can follow every step of the development through our [changelog](https://github.com/mui/mui-x/releases).

--- a/packages/markdownlint-rule-mui/straight-quotes.js
+++ b/packages/markdownlint-rule-mui/straight-quotes.js
@@ -11,7 +11,7 @@ module.exports = {
       // closing double quote: \xE2\x80\x9D
       if (line.match('[‘’“”]')) {
         onError({
-          lineNumber,
+          lineNumber: lineNumber + 1,
           details: `For line: ${line}`,
         });
       }


### PR DESCRIPTION
It's a continuation of this discussion https://github.com/mui/material-ui/pull/34686. The value is about being able to more accurately understand how the markdown will render. A double space for adding a line break is almost invisible during the PR reviews but `\` is visible.