### PR TITLE
[test] Move Firefox tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,6 +346,7 @@ jobs:
             exit 0
   test_browser:
     <<: *defaults
+    resource_class: 'medium+'
     docker:
       - image: mcr.microsoft.com/playwright:v1.26.1-focal
         environment:

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "~1.6.0",
     "karma-chrome-launcher": "^3.1.1",
+    "karma-firefox-launcher": "^2.1.2",
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-mocha": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -34,18 +34,13 @@ describe('<IconButton />', () => {
     expect(container.querySelector('.touch-ripple')).not.to.equal(null);
   });
 
-  ['default', 'primary'].forEach((color) => {
-    it(`can disable the ripple and hover effect for color ${color}`, () => {
-      const { container, getByRole } = render(
-        <IconButton disableRipple color={color} TouchRippleProps={{ className: 'touch-ripple' }}>
-          book
-        </IconButton>,
-      );
-      expect(container.querySelector('.touch-ripple')).to.equal(null);
-      expect(getComputedStyle(getByRole('button'), ':hover').backgroundColor).to.equal(
-        getComputedStyle(getByRole('button')).backgroundColor,
-      );
-    });
+  it('can disable the ripple and hover effect', () => {
+    const { container } = render(
+      <IconButton disableRipple TouchRippleProps={{ className: 'touch-ripple' }}>
+        book
+      </IconButton>,
+    );
+    expect(container.querySelector('.touch-ripple')).to.equal(null);
   });
 
   describe('prop: size', () => {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -31,6 +31,7 @@ const browserStack = {
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();
+process.env.FIREFOX_BIN = playwright.firefox.executablePath();
 
 // BrowserStack rate limit after 1600 calls every 5 minutes.
 // Per second, https://www.browserstack.com/docs/automate/api-reference/selenium/introduction#rest-api-projects
@@ -45,7 +46,7 @@ const MAX_CIRCLE_CI_CONCURRENCY = 83;
 module.exports = function setKarmaConfig(config) {
   const baseConfig = {
     basePath: '../',
-    browsers: ['chromeHeadless'],
+    browsers: ['chromeHeadless', 'FirefoxHeadless'],
     browserDisconnectTimeout: 3 * 60 * 1000, // default 2000
     browserDisconnectTolerance: 1, // default 0
     browserNoActivityTimeout: 3 * 60 * 1000, // default 30000
@@ -83,6 +84,7 @@ module.exports = function setKarmaConfig(config) {
       'karma-coverage-istanbul-reporter',
       'karma-sourcemap-loader',
       'karma-webpack',
+      'karma-firefox-launcher',
     ],
     /**
      * possible values:
@@ -212,7 +214,7 @@ module.exports = function setKarmaConfig(config) {
     newConfig = {
       ...baseConfig,
       browserStack,
-      browsers: baseConfig.browsers.concat(['chrome', 'firefox', 'safari', 'edge']),
+      browsers: baseConfig.browsers.concat(['chrome', 'safari', 'edge']),
       plugins: baseConfig.plugins.concat(['karma-browserstack-launcher']),
       customLaunchers: {
         ...baseConfig.customLaunchers,
@@ -225,13 +227,6 @@ module.exports = function setKarmaConfig(config) {
           // However, >=88 fails on seemingly all focus-related tests.
           // TODO: Investigate why.
           browser_version: '87.0',
-        },
-        firefox: {
-          base: 'BrowserStack',
-          os: 'Windows',
-          os_version: '10',
-          browser: 'firefox',
-          browser_version: '78.0',
         },
         safari: {
           base: 'BrowserStack',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10310,6 +10310,14 @@ karma-coverage-istanbul-reporter@^3.0.3:
     istanbul-reports "^3.0.2"
     minimatch "^3.0.4"
 
+karma-firefox-launcher@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-2.1.2.tgz#9a38cc783c579a50f3ed2a82b7386186385cfc2d"
+  integrity sha512-VV9xDQU1QIboTrjtGVD4NCfzIH7n01ZXqy/qpBhnOeGVOkG5JYPEm8kuSd7psHE6WouZaQ9Ool92g8LFweSNMA==
+  dependencies:
+    is-wsl "^2.2.0"
+    which "^2.0.1"
+
 karma-mocha@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/karma-mocha/-/karma-mocha-2.0.1.tgz#4b0254a18dfee71bdbe6188d9a6861bf86b0cd7d"


### PR DESCRIPTION
Firefox seems to disconnect quite often looking at the CI runs in https://github.com/mui/material-ui/commits/master, e.g. https://app.circleci.com/pipelines/github/mui/material-ui/82679/workflows/2da72430-6074-47cb-8bbe-e959f815d794/jobs/437658 so why not run Firefox in CircleCI. The one limitation is that we run the latest version but 🤷‍♂️

Firefox is also slow on BrowserStack relative to the others, maybe why it's unstable:

<img width="985" alt="Screenshot 2022-10-15 at 00 49 49" src="https://user-images.githubusercontent.com/3165635/195954707-d1858c1a-4f36-4fbe-bc7d-cde6e507347f.png">

https://automate.browserstack.com/dashboard/v2/builds/db108dc8dfacc0894749d3eac1271e4d8da8ac4c