### PR TITLE
[docs] Enforce correct git diff format

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,4 +1,5 @@
 const straightQuotes = require('./packages/markdownlint-rule-mui/straight-quotes');
+const gitDiff = require('./packages/markdownlint-rule-mui/git-diff');
 
 module.exports = {
   config: {
@@ -22,7 +23,14 @@ module.exports = {
     MD051: false, // MD051/link-fragments. Many false positives in the changelog.
     MD052: false, // MD052/reference-links-images. Many false positives in the changelog.
     straightQuotes: true,
+    gitDiff: true,
   },
-  customRules: [straightQuotes],
-  ignores: ['**/node_modules/**', '**/*-zh.md', '**/*-pt.md', '.github/PULL_REQUEST_TEMPLATE.md'],
+  customRules: [straightQuotes, gitDiff],
+  ignores: [
+    'CHANGELOG.old.md',
+    '**/node_modules/**',
+    '**/*-zh.md',
+    '**/*-pt.md',
+    '.github/PULL_REQUEST_TEMPLATE.md',
+  ],
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1851,7 +1851,7 @@ A big thanks to the 17 contributors who made this release possible. Here are som
   -import { Unstyled_TrapFocus } from '@mui/base';
   +import { TrapFocus } from '@mui/base';
 
-  // or
+   // or
 
   -import TrapFocus from '@mui/base/Unstyled_TrapFocus';
   +import TrapFocus from '@mui/base/TrapFocus';
@@ -4467,15 +4467,15 @@ A big thanks to the 13 contributors who made this release possible. Here are som
   Make the default rendered text field closer to the most common use cases (denser).
 
   ```diff
-  <DatePicker
-    label="Helper text example"
-    value={value}
-    onChange={onChange}
-    renderInput={(params) => (
+   <DatePicker
+     label="Helper text example"
+     value={value}
+     onChange={onChange}
+     renderInput={(params) => (
   -    <TextField {...params} />
   +    <TextField {...params} helperText={params?.inputProps?.placeholder} />
-    )}
-  >
+     )}
+   >
   ```
 
 #### Changes
@@ -4581,16 +4581,16 @@ A big thanks to the 18 contributors who made this release possible. Here are som
   The default breakpoints were changed to better match the common use cases. They also better match the Material Design guidelines. [Read more about the change](https://github.com/mui/material-ui/issues/21902).
 
   ```diff
-  {
-    xs: 0,
-    sm: 600,
-  - md: 960,
-  + md: 900,
-  - lg: 1280,
-  + lg: 1200,
-  - xl: 1920,
-  + xl: 1536,
-  }
+   {
+     xs: 0,
+     sm: 600,
+  -  md: 960,
+  +  md: 900,
+  -  lg: 1280,
+  +  lg: 1200,
+  -  xl: 1920,
+  +  xl: 1536,
+   }
   ```
 
   If you prefer the old breakpoint values, use the snippet below.
@@ -4635,11 +4635,11 @@ A big thanks to the 18 contributors who made this release possible. Here are som
   `span` element that wraps children has been removed. `label` classKey is also removed. More details about [this change](https://github.com/mui/material-ui/pull/26666).
 
   ```diff
-  <button class="MuiIconButton-root">
-  - <span class="MuiIconButton-label">
-      <svg />
-  - </span>
-  </button>
+   <button class="MuiIconButton-root">
+  -  <span class="MuiIconButton-label">
+       <svg />
+  -  </span>
+   </button>
   ```
 
 - &#8203;<!-- 19 -->[core] Remove `unstable_` prefix on the `useThemeProps` hook (#26777) @mnajdova
@@ -4765,11 +4765,11 @@ A big thanks to the 11 contributors who made this release possible. Here are som
   The `span` element that wraps children has been removed. `label` classKey is also removed. The nested span was required for fixing a flexbox issue with iOS < 11.0.
 
   ```diff
-  <button class="MuiButton-root">
-  - <span class="MuiButton-label">
-      children
-  - </span>
-  </button>
+   <button class="MuiButton-root">
+  -  <span class="MuiButton-label">
+       children
+  -  </span>
+   </button>
   ```
 
 #### Changes
@@ -4798,7 +4798,7 @@ A big thanks to the 11 contributors who made this release possible. Here are som
   +  const theme = useTheme();
   +  const isRtl = theme.direction === 'rtl';
      //.. rest of the code
-  }
+   }
   ```
 
 #### Changes
@@ -4921,13 +4921,14 @@ A big thanks to the 14 contributors who made this release possible. Here are som
 - &#8203;<!-- 29 -->[pickers] Remove `openPickerIcon` prop in favor of `components.OpenPickerIcon` (#26223) @vedadeepta
 
   ```diff
-  <DateTimePicker
-    components={{
-      LeftArrowIcon: AlarmIcon,
-      RightArrowIcon: SnoozeIcon,
-  +   OpenPickerIcon: ClockIcon,
-    }}
-  - openPickerIcon={<ClockIcon />}
+   <DateTimePicker
+     components={{
+       LeftArrowIcon: AlarmIcon,
+       RightArrowIcon: SnoozeIcon,
+  +    OpenPickerIcon: ClockIcon,
+     }}
+  -  openPickerIcon={<ClockIcon />}
+   >
   ```
 
 ### `@material-ui/system@5.0.0-alpha.36`
@@ -5150,10 +5151,10 @@ A big thanks to the 16 contributors who made this release possible. Here are som
   Move the custom class on `input` to `select`. The `input` key is being applied on another element.
 
   ```diff
-  <TablePagination
-  - classes={{ input: 'foo' }}
-  + classes={{ select: 'foo' }}
-  />
+   <TablePagination
+  -  classes={{ input: 'foo' }}
+  +  classes={{ select: 'foo' }}
+   />
   ```
 
 - &#8203;<!-- 45 -->[core] Move `StyledEngineProvider` to `@material-ui/core/styles` (#26265) @mnajdova
@@ -5198,10 +5199,10 @@ A big thanks to the 16 contributors who made this release possible. Here are som
 - &#8203;<!-- 63 -->[Autocomplete] Rename getOptionSelected to isOptionEqualToValue (#26173) @m4theushw
 
   ```diff
-  <Autocomplete
+   <Autocomplete
   -  getOptionSelected={(option, value) => option.title === value.title}
   +  isOptionEqualToValue={(option, value) => option.title === value.title}
-  />
+   />
   ```
 
 > Follow [this link](https://mui.com/material-ui/migration/migration-v4/) for full migration from v4 => v5
@@ -5304,18 +5305,20 @@ A big thanks to the 17 contributors who made this release possible. Here are som
   Replace the `innerRef` prop with the `ref` prop. Refs are now automatically forwarded to the inner component.
 
   ```diff
-  import * as React from 'react';
-  import { withStyles } from '@material-ui/core/styles';
-  const MyComponent = withStyles({
-    root: {
-      backgroundColor: 'red',
-    },
-  })(({ classes }) => <div className={classes.root} />);
-  function MyOtherComponent(props) {
-    const ref = React.useRef();
-  - return <MyComponent innerRef={ref} />;
-  + return <MyComponent ref={ref} />;
-  }
+   import * as React from 'react';
+   import { withStyles } from '@material-ui/core/styles';
+
+   const MyComponent = withStyles({
+     root: {
+       backgroundColor: 'red',
+     },
+   })(({ classes }) => <div className={classes.root} />);
+
+   function MyOtherComponent(props) {
+     const ref = React.useRef();
+  -  return <MyComponent innerRef={ref} />;
+  +  return <MyComponent ref={ref} />;
+   }
   ```
 
   **withTheme**
@@ -5323,14 +5326,16 @@ A big thanks to the 17 contributors who made this release possible. Here are som
   Replace the `innerRef` prop with the `ref` prop. Refs are now automatically forwarded to the inner component.
 
   ```diff
-  import * as React from 'react';
-  import { withTheme  } from '@material-ui/core/styles';
-  const MyComponent = withTheme(({ theme }) => <div>{props.theme.direction}</div>);
-  function MyOtherComponent(props) {
-    const ref = React.useRef();
-  - return <MyComponent innerRef={ref} />;
-  + return <MyComponent ref={ref} />;
-  }
+   import * as React from 'react';
+   import { withTheme } from '@material-ui/core/styles';
+
+   const MyComponent = withTheme(({ theme }) => <div>{props.theme.direction}</div>);
+
+   function MyOtherComponent(props) {
+     const ref = React.useRef();
+  -  return <MyComponent innerRef={ref} />;
+  +  return <MyComponent ref={ref} />;
+   }
   ```
 
 - &#8203;<!-- 10 -->[theme] Rename `createMuiTheme` to `createTheme` (#25992) @m4theushw
@@ -5672,23 +5677,23 @@ A big thanks to the 15 contributors who made this release possible. Here are som
 - &#8203;<!-- 41 -->[Checkbox][switch] Remove checked argument from onChange (#25871) @m4theushw
 
   ```diff
-  function MyCheckbox() {
-  - const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-  + const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-  +   const checked = event.target.checked;
-    };
-    return <Checkbox onChange={handleChange} />;
-  }
+   function MyCheckbox() {
+  -  const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
+  +  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  +    const checked = event.target.checked;
+     };
+     return <Checkbox onChange={handleChange} />;
+   }
   ```
 
   ```diff
-  function MySwitch() {
-  - const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-  + const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-  +   const checked = event.target.checked;
-    };
-    return <Switch onChange={handleChange} />;
-  }
+   function MySwitch() {
+  -  const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
+  +  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  +    const checked = event.target.checked;
+     };
+     return <Switch onChange={handleChange} />;
+   }
   ```
 
 - &#8203;<!-- 42 -->[theme] Remove theme.breakpoints.width helper (#25918) @m4theushw
@@ -5843,12 +5848,12 @@ A big thanks to the 19 contributors who made this release possible. Here are som
   -import DayPicker from '@material-ui/lab/DayPicker';
   +import CalendarPicker from '@material-ui/lab/CalendarPicker';
 
-  createMuiTheme({
-    components: {
-  -   MuiDayPicker: {},
-  +   MuiCalendarPicker: {},
-    }
-  })
+   createMuiTheme({
+     components: {
+  -    MuiDayPicker: {},
+  +    MuiCalendarPicker: {},
+     }
+   })
   ```
 
 - &#8203;<!-- 04 -->[Pickers] Rename PickersCalendarSkeleton to CalendarPickerSkeleton (#25679) @eps1lon
@@ -6375,7 +6380,7 @@ A big thanks to the 26 contributors who made this release possible. Here are som
   The icons were synchronized with https://material.io/resources/icons/. This change increases the number of supported icons from 1,349 to 1,781 per theme (we support 5 themes). The breaking changes:
 
   ```diff
-  // AmpStories -> Download
+   // AmpStories -> Download
   -AmpStories
   +Download
   -AmpStoriesOutlined
@@ -6386,7 +6391,7 @@ A big thanks to the 26 contributors who made this release possible. Here are som
   +DownloadSharp
   -AmpStoriesTwoTone
   +DownloadTwoTone
-  // Outbond -> Outbound
+   // Outbond -> Outbound
   -Outbond
   +Outbound
   -OutbondOutlined
@@ -6563,10 +6568,10 @@ A big thanks to the 30 contributors who made this release possible. Here are som
   If you were using a number previously, you need to provide the value in `px` to bypass the new transformation with `theme.spacing`. The change was done for consistency with the Grid spacing prop and the other system spacing properties, e.g. `<Box padding={2}>`.
 
   ```diff
-  <Box
-  - gap={2}
-  + gap="2px"
-  >
+   <Box
+  -  gap={2}
+  +  gap="2px"
+   >
   ```
 
 ### `@material-ui/styled-engine@5.0.0-alpha.25`
@@ -6807,14 +6812,14 @@ A big thanks to the 15 contributors who made this release possible. Here are som
   --- a/docs/src/pages/components/date-range-picker/BasicDateRangePicker.tsx
   +++ b/docs/src/pages/components/date-range-picker/BasicDateRangePicker.tsx
   @@ -3,7 +3,7 @@ import TextField from '@material-ui/core/TextField';
-  import DateRangePicker, { DateRange } from '@material-ui/lab/DateRangePicker';
-  import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
-  import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
+   import DateRangePicker, { DateRange } from '@material-ui/lab/DateRangePicker';
+   import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+   import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
   -import DateRangeDelimiter from '@material-ui/lab/DateRangeDelimiter';
   +import Box from '@material-ui/core/Box';
 
-  export default function BasicDateRangePicker() {
-    const [value, setValue] = React.useState<DateRange<Date>>([null, null]);
+   export default function BasicDateRangePicker() {
+     const [value, setValue] = React.useState<DateRange<Date>>([null, null]);
   @@ -20,7 +20,7 @@ export default function BasicDateRangePicker() {
           renderInput={(startProps, endProps) => (
             <React.Fragment>
@@ -7356,42 +7361,42 @@ A big thanks to the 18 contributors who made this release possible. Here are som
 - [Dialog] Remove the `disableBackdropClick` prop. It's redundant with the `reason` argument (#23607) @eps1lon.
 
   ```diff
-  <Dialog
-  - disableBackdropClick
-  - onClose={handleClose}
-  + onClose={(event, reason) => {
-  +   if (reason !== 'backdropClick') {
-  +     onClose(event, reason);
-  +   }
-  + }}
-  />
+   <Dialog
+  -  disableBackdropClick
+  -  onClose={handleClose}
+  +  onClose={(event, reason) => {
+  +    if (reason !== 'backdropClick') {
+  +      onClose(event, reason);
+  +    }
+  +  }}
+   />
   ```
 
 - [Modal] Remove the `disableBackdropClick` prop. It's redundant with the `reason` argument (#23607) @eps1lon.
 
   ```diff
-  <Modal
-  - disableBackdropClick
-  - onClose={handleClose}
-  + onClose={(event, reason) => {
-  +   if (reason !== 'backdropClick') {
-  +     onClose(event, reason);
-  +   }
-  + }}
-  />
+   <Modal
+  -  disableBackdropClick
+  -  onClose={handleClose}
+  +  onClose={(event, reason) => {
+  +    if (reason !== 'backdropClick') {
+  +      onClose(event, reason);
+  +    }
+  +  }}
+   />
   ```
 
 - [Modal] Remove the `onEscapeKeyDown` prop. It's redundant with the `reason` argument. (#23571) @eps1lon
 
   ```diff
-  <Modal
+   <Modal
   -  onEscapeKeyDown={handleEscapeKeyDown}
   +  onClose={(event, reason) => {
   +    if (reason === "escapeKeyDown") {
   +      handleEscapeKeyDown(event);
   +    }
   +  }}
-  />;
+   />;
   ```
 
 #### Changes
@@ -7744,10 +7749,10 @@ Here are some highlights ✨:
   - The CSS prefixes have changed:
 
     ```diff
-    popper: {
-      zIndex: 1,
-    - '&[x-placement*="bottom"] $arrow': {
-    + '&[data-popper-placement*="bottom"] $arrow': {
+     popper: {
+       zIndex: 1,
+    -  '&[x-placement*="bottom"] $arrow': {
+    +  '&[data-popper-placement*="bottom"] $arrow': {
     ```
 
   - Method names have changed.
@@ -7771,13 +7776,13 @@ Here are some highlights ✨:
   -import withMobileDialog from '@material-ui/core/withMobileDialog';
   +import { useTheme, useMediaQuery } from '@material-ui/core';
 
-  function ResponsiveDialog(props) {
-  - const { fullScreen } = props;
-  + const theme = useTheme();
-  + const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
-    const [open, setOpen] = React.useState(false);
+   function ResponsiveDialog(props) {
+  -  const { fullScreen } = props;
+  +  const theme = useTheme();
+  +  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+     const [open, setOpen] = React.useState(false);
 
-  // ...
+   // ...
 
   -export default withMobileDialog()(ResponsiveDialog);
   +export default ResponsiveDialog;
@@ -8023,24 +8028,24 @@ Here are some highlights ✨:
   The change was done to match the API convention.
 
   ```diff
-  <TablePagination
-  - onChangeRowsPerPage={()=>{}}
-  - onChangePage={()=>{}}
-  + onRowsPerPageChange={()=>{}}
-  + onPageChange={()=>{}}
+   <TablePagination
+  -  onChangeRowsPerPage={()=>{}}
+  -  onChangePage={()=>{}}
+  +  onRowsPerPageChange={()=>{}}
+  +  onPageChange={()=>{}}
   ```
 
 - [theme] Rename fade to alpha (#22834) @mnajdova
   Better describe its functionality. The previous name was leading to confusion when the input color already had an alpha value. The helper **overrides** the alpha value of the color.
 
   ```diff
-  - import { fade } from '@material-ui/core/styles';
-  + import { alpha } from '@material-ui/core/styles';
+  -import { fade } from '@material-ui/core/styles';
+  +import { alpha } from '@material-ui/core/styles';
 
-  const classes = makeStyles(theme => ({
+   const classes = makeStyles(theme => ({
   -  backgroundColor: fade(theme.palette.primary.main, theme.palette.action.selectedOpacity),
   +  backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
-  }));
+   }));
   ```
 
 - [Tooltip] Make `interactive` default (#22382) @eps1lon
@@ -8051,7 +8056,7 @@ Here are some highlights ✨:
   ```diff
   -<Tooltip>
   +<Tooltip disableInteractive>
-  # Interactive tooltips no longer need the `interactive` prop.
+   # Interactive tooltips no longer need the `interactive` prop.
   -<Tooltip interactive>
   +<Tooltip>
   ```
@@ -8299,7 +8304,7 @@ Here are some highlights ✨:
   Renames `theme.palette.type` to `theme.palette.mode`, to better follow the "dark mode" term that is usually used for describing this feature.
 
   ```diff
-  import { createMuiTheme } from '@material-ui/core/styles';
+   import { createMuiTheme } from '@material-ui/core/styles';
 
   -const theme = createMuiTheme({palette: { type: 'dark' }}),
   +const theme = createMuiTheme({palette: { mode: 'dark' }}),
@@ -8364,22 +8369,22 @@ Here are some highlights ✨:
   You can recover from the change with:
 
   ```diff
-  <Autocomplete
-  - renderOption={(option, { selected }) => (
-  -   <React.Fragment>
-  + renderOption={(props, option, { selected }) => (
-  +   <li {...props}>
-        <Checkbox
-          icon={icon}
-          checkedIcon={checkedIcon}
-          style={{ marginRight: 8 }}
-          checked={selected}
-        />
-        {option.title}
-  -   </React.Fragment>
-  +   </li>
-    )}
-  />
+   <Autocomplete
+  -  renderOption={(option, { selected }) => (
+  -    <React.Fragment>
+  +  renderOption={(props, option, { selected }) => (
+  +    <li {...props}>
+         <Checkbox
+           icon={icon}
+           checkedIcon={checkedIcon}
+           style={{ marginRight: 8 }}
+           checked={selected}
+         />
+         {option.title}
+  -    </React.Fragment>
+  +    </li>
+     )}
+   />
   ```
 
 #### Changes
@@ -8465,12 +8470,12 @@ Here are some highlights ✨:
   Rename `focused` to `focusVisible` for consistency with the other components:
 
   ```diff
-  <Accordion
-    classes={{
-  -   focused: 'custom-focus-visible-classname',
-  +   focusVisible: 'custom-focus-visible-classname',
-    }}
-  />
+   <Accordion
+     classes={{
+  -    focused: 'custom-focus-visible-classname',
+  +    focusVisible: 'custom-focus-visible-classname',
+     }}
+   />
   ```
 
 - [Stepper] Remove Paper and built-in padding (#22564) @mbrookes
@@ -8550,10 +8555,10 @@ Here are some highlights ✨:
   If you have a custom `icon` prop but no `emptyIcon` prop, you can restore the previous behavior with:
 
   ```diff
-  <Rating
-    icon={customIcon}
-  + emptyIcon={null}
-  />
+   <Rating
+     icon={customIcon}
+  +  emptyIcon={null}
+   />
   ```
 
 #### Changes
@@ -8679,9 +8684,9 @@ const theme = createMuiTheme({
   1. `props`
 
   ```diff
-  import { createMuiTheme } from '@material-ui/core/styles';
+   import { createMuiTheme } from '@material-ui/core/styles';
 
-  const theme = createMuiTheme({
+   const theme = createMuiTheme({
   -  props: {
   -    MuiButton: {
   -      disableRipple: true,
@@ -8694,15 +8699,15 @@ const theme = createMuiTheme({
   +      },
   +    },
   +  },
-  });
+   });
   ```
 
   2. `overrides`
 
   ```diff
-  import { createMuiTheme } from '@material-ui/core/styles';
+   import { createMuiTheme } from '@material-ui/core/styles';
 
-  const theme = createMuiTheme({
+   const theme = createMuiTheme({
   -  overrides: {
   -    MuiButton: {
   -      root: { padding: 0 },
@@ -8715,7 +8720,7 @@ const theme = createMuiTheme({
   +      },
   +    },
   +  },
-  });
+   });
   ```
 
   Note that if you don't have the time to upgrade the structure of the theme, you
@@ -8826,7 +8831,7 @@ Here are some highlights ✨:
   The onE\* transition props were removed. Use TransitionProps instead.
 
   ```diff
-  <Menu
+   <Menu
   -  onEnter={onEnter}
   -  onEntered={onEntered},
   -  onEntering={onEntered},
@@ -8841,14 +8846,14 @@ Here are some highlights ✨:
   +    onExited,
   +    onExiting,
   +  }}
-  >
+   >
   ```
 
 - [Popover] Remove transition onX props (#22184) @mbrookes
   The onE\* transition props were removed. Use TransitionProps instead.
 
   ```diff
-  <Popover
+   <Popover
   -  onEnter={onEnter}
   -  onEntered={onEntered},
   -  onEntering={onEntered},
@@ -8863,7 +8868,7 @@ Here are some highlights ✨:
   +    onExited,
   +    onExiting,
   +  }}
-  />
+   />
   ```
 
 - [TextField] Improve line-height reset (#22149) @imnasnainaec
@@ -9017,7 +9022,7 @@ Here are some highlights ✨:
   The onE\* transition props were removed. Use TransitionProps instead.
 
   ```diff
-  <Dialog
+   <Dialog
   -  onEnter={onEnter}
   -  onEntered={onEntered},
   -  onEntering={onEntered},
@@ -9032,7 +9037,7 @@ Here are some highlights ✨:
   +    onExited,
   +    onExiting,
   +  }}
-  />
+   />
   ```
 
 - [Fab] Rename round -> circular for consistency (#21903) @kodai3
@@ -9079,7 +9084,7 @@ Here are some highlights ✨:
   The onE\* transition props were removed. Use TransitionProps instead.
 
   ```diff
-  <Snackbar
+   <Snackbar
   -  onEnter={onEnter}
   -  onEntered={onEntered},
   -  onEntering={onEntered},
@@ -9094,7 +9099,7 @@ Here are some highlights ✨:
   +    onExited,
   +    onExiting,
   +  }}
-  />
+   />
   ```
 
 - [TextareaAutosize] Rename rowsMax->maxRows & rowsMin->minRows (#21873) @mhayk
@@ -9463,21 +9468,21 @@ A big thanks to the 33 contributors who made this release possible. Here are som
   It prevents inconsistent height on scaled screens. For people customizing the color of the border, the change requires changing the override CSS property:
 
   ```diff
-  .MuiDivider-root {
-  - background-color: #f00;
-  + border-color: #f00;
-  }
+   .MuiDivider-root {
+  -  background-color: #f00;
+  +  border-color: #f00;
+   }
   ```
 
 - [Rating] Rename `visuallyhidden` to `visuallyHidden` for consistency (#21413) @mnajdova.
 
   ```diff
-  <Rating
-    classes={{
+   <Rating
+     classes={{
   -    visuallyhidden: 'custom-visually-hidden-classname',
   +    visuallyHidden: 'custom-visually-hidden-classname',
-    }}
-  />
+     }}
+   />
   ```
 
 - [Typography] Replace the `srOnly` prop so as to not duplicate the capabilities of [System](https://mui.com/system/getting-started/overview/) (#21413) @mnajdova.
@@ -9497,10 +9502,10 @@ A big thanks to the 33 contributors who made this release possible. Here are som
   The customization of the table pagination's actions labels must be done with the `getItemAriaLabel` prop. This increases consistency with the `Pagination` component.
 
   ```diff
-  <TablePagination
-  - backIconButtonText="Avant"
-  - nextIconButtonText="Après
-  + getItemAriaLabel={…}
+   <TablePagination
+  -  backIconButtonText="Avant"
+  -  nextIconButtonText="Après
+  +  getItemAriaLabel={…}
   ```
 
 - [ExpansionPanel] Rename to Accordion (#21494) @mnajdova.

--- a/docs/data/joy/getting-started/usage/usage.md
+++ b/docs/data/joy/getting-started/usage/usage.md
@@ -25,18 +25,18 @@ export default App;
 To render any Joy UI component, make sure you place them inside the `CssVarProvider` element.
 
 ```diff
-import { CssVarsProvider } from '@mui/joy/styles';
-+ import Button from '@mui/joy/Button';
+ import { CssVarsProvider } from '@mui/joy/styles';
++import Button from '@mui/joy/Button';
 
-function App() {
-  return (
-    <CssVarsProvider>
-+     <Button>Joy UI</Button>
-    </CssVarsProvider>
-  );
-}
+ function App() {
+   return (
+     <CssVarsProvider>
++      <Button>Joy UI</Button>
+     </CssVarsProvider>
+   );
+ }
 
-export default App;
+ export default App;
 ```
 
 It's that fast to have your first app with Joy UI going!

--- a/docs/data/material/experimental-api/css-variables/css-variables.md
+++ b/docs/data/material/experimental-api/css-variables/css-variables.md
@@ -91,19 +91,19 @@ const theme = experimental_extendTheme({
 If you are using [`ThemeProvider`](/material-ui/customization/theming/#theme-provider), you can replace it with the new experimental provider.
 
 ```diff
-- import { ThemeProvider, createTheme } from '@mui/material/styles';
-+ import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
+-import { ThemeProvider, createTheme } from '@mui/material/styles';
++import { Experimental_CssVarsProvider as CssVarsProvider } from '@mui/material/styles';
 
-function App() {
-  return (
+ function App() {
+   return (
 -    <ThemeProvider theme={createTheme()}>
 -      ...
 -    </ThemeProvider>
 +    <CssVarsProvider>
 +      ...
 +    </CssVarsProvider>
-  )
-}
+   )
+ }
 ```
 
 ### Toggle between light and dark mode

--- a/docs/data/material/getting-started/faq/faq.md
+++ b/docs/data/material/getting-started/faq/faq.md
@@ -392,14 +392,14 @@ Example of fix:
 -// Create a sheets instance.
 -const sheets = new ServerStyleSheets();
 
-function handleRender(req, res) {
-+ // Create a sheets instance.
-+ const sheets = new ServerStyleSheets();
+ function handleRender(req, res) {
++  // Create a sheets instance.
++  const sheets = new ServerStyleSheets();
 
-  //…
+   //…
 
-  // Render the component to a string.
-  const html = ReactDOMServer.renderToString(
+   // Render the component to a string.
+   const html = ReactDOMServer.renderToString(
 ```
 
 ### [v4] React class name hydration mismatch
@@ -428,14 +428,14 @@ This generator needs to behave identically on the server and on the client. For 
   -// Create a new class name generator.
   -const generateClassName = createGenerateClassName();
 
-  function handleRender(req, res) {
-  + // Create a new class name generator.
-  + const generateClassName = createGenerateClassName();
+   function handleRender(req, res) {
+  +  // Create a new class name generator.
+  +  const generateClassName = createGenerateClassName();
 
-    //…
+     //…
 
-    // Render the component to a string.
-    const html = ReactDOMServer.renderToString(
+     // Render the component to a string.
+     const html = ReactDOMServer.renderToString(
   ```
 
 - You need to verify that your client and server are running the **exactly the same version** of MUI.

--- a/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -183,15 +183,15 @@ If you wish, `babel-plugin-import` can be configured through `config-overrides.j
 Modify your `package.json` commands:
 
 ```diff
-  "scripts": {
--   "start": "react-scripts start",
-+   "start": "react-app-rewired start",
--   "build": "react-scripts build",
-+   "build": "react-app-rewired build",
--   "test": "react-scripts test",
-+   "test": "react-app-rewired test",
-    "eject": "react-scripts eject"
-}
+   "scripts": {
+-    "start": "react-scripts start",
++    "start": "react-app-rewired start",
+-    "build": "react-scripts build",
++    "build": "react-app-rewired build",
+-    "test": "react-scripts test",
++    "test": "react-app-rewired test",
+     "eject": "react-scripts eject"
+  }
 ```
 
 Enjoy significantly faster start times.

--- a/docs/data/material/migration/migration-v0x/migration-v0x.md
+++ b/docs/data/material/migration/migration-v0x/migration-v0x.md
@@ -97,7 +97,7 @@ This will apply a change such as the following:
 -import AddIcon from 'material-ui/svg-icons/Add';
 +import AddIcon from '@mui/icons-material/Add';
 
-<AddIcon />
+ <AddIcon />
 ```
 
 ### Flat Button

--- a/docs/data/material/migration/migration-v3/migration-v3.md
+++ b/docs/data/material/migration/migration-v3/migration-v3.md
@@ -132,26 +132,26 @@ yarn add @material-ui/styles
   -theme.palette.augmentColor(background);
   +const background = theme.palette.augmentColor({ main: color });
 
-  console.log({ background });
+   console.log({ background });
   ```
 
 - You can safely remove the next variant from the theme creation:
 
   ```diff
-  typography: {
-  - useNextVariants: true,
-  },
+   typography: {
+  -  useNextVariants: true,
+   },
   ```
 
 - `theme.spacing.unit` usage is deprecated, you can use the new API:
 
   ```diff
-  label: {
-    [theme.breakpoints.up('sm')]: {
-  -   paddingTop: theme.spacing.unit * 12,
-  +   paddingTop: theme.spacing(12),
-    },
-  }
+   label: {
+     [theme.breakpoints.up('sm')]: {
+  -    paddingTop: theme.spacing.unit * 12,
+  +    paddingTop: theme.spacing(12),
+     },
+   }
   ```
 
   _Tip: you can provide more than 1 argument: `theme.spacing(1, 2) // = '8px 16px'`_.
@@ -188,14 +188,14 @@ Normalized `value` prop type for input components to use `unknown`. This affects
 `InputBase`, `NativeSelect`, `OutlinedInput`, `Radio`, `RadioGroup`, `Select`, `SelectInput`, `Switch`, `TextArea`, and `TextField`.
 
 ```diff
-function MySelect({ children }) {
-- const handleChange = (event: any, value: string) => {
-+ const handleChange = (event: any, value: unknown) => {
-    // handle value
-  };
+ function MySelect({ children }) {
+-  const handleChange = (event: any, value: string) => {
++  const handleChange = (event: any, value: unknown) => {
+     // handle value
+   };
 
-  return <Select onChange={handleChange}>{children}</Select>
-}
+   return <Select onChange={handleChange}>{children}</Select>
+ }
 ```
 
 This change is explained in more detail in the [TypeScript guide](/material-ui/guides/typescript/#handling-value-and-event-handlers)
@@ -397,12 +397,12 @@ This change is explained in more detail in the [TypeScript guide](/material-ui/g
   The `FormLabelClasses` property has been removed.
 
   ```diff
-  <InputLabel
-  - FormLabelClasses={{ asterisk: 'bar' }}
-  + classes={{ asterisk: 'bar' }}
-  >
-    Foo
-  </InputLabel>
+   <InputLabel
+  -  FormLabelClasses={{ asterisk: 'bar' }}
+  +  classes={{ asterisk: 'bar' }}
+   >
+     Foo
+   </InputLabel>
   ```
 
 - [InputBase] Change the default box sizing model.
@@ -462,9 +462,9 @@ This change is explained in more detail in the [TypeScript guide](/material-ui/g
 - This change eases the use of Material UI with a CDN:
 
   ```diff
-  const {
-    Button,
-    TextField,
+   const {
+     Button,
+     TextField,
   -} = window['material-ui'];
   +} = MaterialUI;
   ```

--- a/docs/data/material/migration/migration-v4/migrating-from-jss.md
+++ b/docs/data/material/migration/migration-v4/migrating-from-jss.md
@@ -365,11 +365,11 @@ The following is a comprehensive example using the `$` syntax, `useStyles()` par
          The Background take the primary theme color when the mouse hovers the parent.
          I am smaller than the other child.
        </div>
-    </div>
-  );
-}
+     </div>
+   );
+ }
 
-export default App;
+ export default App;
 ```
 
 After running the codemod, search your code for "TODO jss-to-tss-react codemod" to find cases that the codemod could not handle reliably.

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -427,24 +427,24 @@ You should remove the `@global` key when defining the style overrides for it.
 You could also start using the CSS template syntax over the JavaScript object syntax.
 
 ```diff
-const theme = createTheme({
-  components: {
-    MuiCssBaseline: {
--     styleOverrides: {
--       '@global': {
--         html: {
--           WebkitFontSmoothing: 'auto',
--         },
--       },
--     },
-+     styleOverrides: `
-+       html {
-+         -webkit-font-smoothing: auto;
-+       }
-+     `
-    },
-  },
-});
+ const theme = createTheme({
+   components: {
+     MuiCssBaseline: {
+-      styleOverrides: {
+-        '@global': {
+-          html: {
+-            WebkitFontSmoothing: 'auto',
+-          },
+-        },
+-      },
++      styleOverrides: `
++        html {
++          -webkit-font-smoothing: auto;
++        }
++      `
+     },
+   },
+ });
 ```
 
 ### Update body font size
@@ -526,13 +526,13 @@ The hook API allows a simpler and more flexible solution:
 -import withMobileDialog from '@mui/material/withMobileDialog';
 +import { useTheme, useMediaQuery } from '@mui/material';
 
-function ResponsiveDialog(props) {
-- const { fullScreen } = props;
-+ const theme = useTheme();
-+ const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
-  const [open, setOpen] = React.useState(false);
+ function ResponsiveDialog(props) {
+-  const { fullScreen } = props;
++  const theme = useTheme();
++  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+   const [open, setOpen] = React.useState(false);
 
-// ...
+ // ...
 
 -export default withMobileDialog()(ResponsiveDialog);
 +export default ResponsiveDialog;
@@ -561,10 +561,10 @@ This prevents inconsistent height on scaled screens.
 If you have customized the color of the border, you will need to update the CSS property override:
 
 ```diff
-.MuiDivider-root {
-- background-color: #f00;
-+ border-color: #f00;
-}
+ .MuiDivider-root {
+-  background-color: #f00;
++  border-color: #f00;
+ }
 ```
 
 ## ExpansionPanel
@@ -721,22 +721,22 @@ These props are now considered part of the System, not the `Grid` component itse
 If you still wish to add overrides for them, you can use the [callback as a value in `styleOverrides`](/material-ui/customization/theme-components/#overrides-based-on-props).
 
 ```diff
-const theme = createTheme({
-  components: {
-    MuiGrid: {
--     styleOverrides: {
--       "align-items-xs-flex-end": {
--         marginTop: '20px',
--       },
--     },
-+     styleOverrides: ({ ownerState }) => ({
-+       ...ownerState.alignItems === 'flex-end' && {
-+         marginTop: '20px',
-+       },
-+     }),
-    },
-  },
-});
+ const theme = createTheme({
+   components: {
+     MuiGrid: {
+-      styleOverrides: {
+-        'align-items-xs-flex-end': {
+-          marginTop: 20,
+-        },
+-      },
++      styleOverrides: ({ ownerState }) => ({
++        ...ownerState.alignItems === 'flex-end' && {
++          marginTop: 20,
++        },
++      }),
+     },
+   },
+ });
 ```
 
 ### Change negative margins
@@ -1048,13 +1048,13 @@ This change was made to better conform to the Material Design guidelines.
 You can revert it in the theme:
 
 ```diff
-const theme = createTheme({
-  components: {
-    MuiPaper: {
-+     styleOverrides: { root: { backgroundImage: 'unset' } },
-    },
-  },
-});
+ const theme = createTheme({
+   components: {
+     MuiPaper: {
++      styleOverrides: { root: { backgroundImage: 'unset' } },
+     },
+   },
+ });
 ```
 
 ## Pagination
@@ -1465,8 +1465,8 @@ In the unlikely event that you were using the value `default`, the prop can be r
 ```diff
 -<SvgIcon fontSize="default">
 +<SvgIcon>
-    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
-  </SvgIcon>
+   <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+ </SvgIcon>
 ```
 
 ## Switch
@@ -1478,14 +1478,14 @@ The second argument from `onChange` has been deprecated.
 You can pull out the checked state by accessing `event.target.checked`.
 
 ```diff
-function MySwitch() {
-- const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-+ const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-+   const checked = event.target.checked;
-  };
+ function MySwitch() {
+-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
++  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
++    const checked = event.target.checked;
+   };
 
-  return <Switch onChange={handleChange} />;
-}
+   return <Switch onChange={handleChange} />;
+ }
 ```
 
 ### Update default color prop
@@ -1804,7 +1804,7 @@ If you want to restore the v4 behavior, you can apply the following diff:
 -<Tooltip>
 +<Tooltip disableInteractive>
 
-# Interactive tooltips no longer need the `interactive` prop.
+ # Interactive tooltips no longer need the `interactive` prop.
 -<Tooltip interactive>
 +<Tooltip>
 ```
@@ -1837,22 +1837,22 @@ If you still wish to add overrides for them, you can use the [callback as a valu
 For example:
 
 ```diff
-const theme = createTheme({
-  components: {
-    MuiTypography: {
--     styleOverrides: {
--       colorSecondary: {
--         marginTop: '20px',
--       },
--     },
-+     styleOverrides: ({ ownerState }) => ({
-+       ...ownerState.color === 'secondary' && {
-+         marginTop: '20px',
-+       },
-+     }),
-    },
-  },
-});
+ const theme = createTheme({
+   components: {
+     MuiTypography: {
+-      styleOverrides: {
+-        colorSecondary: {
+-          marginTop: '20px',
+-        },
+-      },
++      styleOverrides: ({ ownerState }) => ({
++        ...ownerState.color === 'secondary' && {
++          marginTop: '20px',
++        },
++      }),
+     },
+   },
+ });
 ```
 
 ## Theme
@@ -1906,16 +1906,16 @@ The default breakpoints were changed to better match common use cases as well as
 You can find out more details about this change in [this GitHub issue](https://github.com/mui/material-ui/issues/21902)
 
 ```diff
-{
-  xs: 0,
-  sm: 600,
-- md: 960,
-+ md: 900,
-- lg: 1280,
-+ lg: 1200,
-- xl: 1920,
-+ xl: 1536,
-}
+ {
+   xs: 0,
+   sm: 600,
+-  md: 960,
++  md: 900,
+-  lg: 1280,
++  lg: 1200,
+-  xl: 1920,
++  xl: 1536,
+ }
 ```
 
 If you prefer the old breakpoint values, use the snippet below:

--- a/docs/data/material/migration/migration-v4/v5-style-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-style-changes.md
@@ -56,20 +56,20 @@ You need to replace those selectors with a valid class selector.
 ### Replace nested classes selectors with global class names
 
 ```diff
-const theme = createTheme({
-  components: {
-    MuiOutlinedInput: {
-      styleOverrides: {
-        root: {
--         '& $notchedOutline': {
-+         '& .MuiOutlinedInput-notchedOutline': {
-            borderWidth: 1,
-          }
-        }
-      }
-    }
-  }
-});
+ const theme = createTheme({
+   components: {
+     MuiOutlinedInput: {
+       styleOverrides: {
+         root: {
+-          '& $notchedOutline': {
++          '& .MuiOutlinedInput-notchedOutline': {
+             borderWidth: 1,
+           }
+         }
+       }
+     }
+   }
+ });
 ```
 
 :::info

--- a/packages/markdownlint-rule-mui/git-diff.js
+++ b/packages/markdownlint-rule-mui/git-diff.js
@@ -1,0 +1,27 @@
+module.exports = {
+  names: ['gitDiff'],
+  description: 'Respect the format ouput of git diff.',
+  tags: ['spaces'],
+  function: (params, onError) => {
+    params.tokens.forEach((token) => {
+      if (token.type === 'fence' && token.info === 'diff') {
+        token.content.split('\n').forEach((line, index) => {
+          if (
+            line[0] !== ' ' &&
+            line[0] !== '-' &&
+            line[0] !== '+' &&
+            line !== '' &&
+            line.indexOf('@@ ') !== 0 &&
+            line.indexOf('diff --git ') !== 0 &&
+            line.indexOf('index ') !== 0
+          ) {
+            onError({
+              lineNumber: token.lineNumber + index + 1,
+              detail: `The line start with "+" or "-" or " ": ${line}`,
+            });
+          }
+        });
+      }
+    });
+  },
+};

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -169,10 +169,10 @@ You can find more details about this breaking change in [the migration guide](ht
 Renames `Autocomplete`'s `getOptionSelected` to `isOptionEqualToValue`.
 
 ```diff
-<Autocomplete
-- getOptionSelected={(option, value) => option.title === value.title}
-+ isOptionEqualToValue={(option, value) => option.title === value.title}
-/>
+ <Autocomplete
+-  getOptionSelected={(option, value) => option.title === value.title}
++  isOptionEqualToValue={(option, value) => option.title === value.title}
+ />
 ```
 
 <!-- #default-branch-switch -->
@@ -211,22 +211,22 @@ Renames the badge's props.
 -<Badge overlap="rectangle">
 +<Badge overlap="circular">
 +<Badge overlap="rectangular">
-<Badge classes={{
-- anchorOriginTopRightRectangle: 'className',
-- anchorOriginBottomRightRectangle: 'className',
-- anchorOriginTopLeftRectangle: 'className',
-- anchorOriginBottomLeftRectangle: 'className',
-- anchorOriginTopRightCircle: 'className',
-- anchorOriginBottomRightCircle: 'className',
-- anchorOriginTopLeftCircle: 'className',
-+ anchorOriginTopRightRectangular: 'className',
-+ anchorOriginBottomRightRectangular: 'className',
-+ anchorOriginTopLeftRectangular: 'className',
-+ anchorOriginBottomLeftRectangular: 'className',
-+ anchorOriginTopRightCircular: 'className',
-+ anchorOriginBottomRightCircular: 'className',
-+ anchorOriginTopLeftCircular: 'className',
-}}>
+ <Badge classes={{
+-  anchorOriginTopRightRectangle: 'className',
+-  anchorOriginBottomRightRectangle: 'className',
+-  anchorOriginTopLeftRectangle: 'className',
+-  anchorOriginBottomLeftRectangle: 'className',
+-  anchorOriginTopRightCircle: 'className',
+-  anchorOriginBottomRightCircle: 'className',
+-  anchorOriginTopLeftCircle: 'className',
++  anchorOriginTopRightRectangular: 'className',
++  anchorOriginBottomRightRectangular: 'className',
++  anchorOriginTopLeftRectangular: 'className',
++  anchorOriginBottomLeftRectangular: 'className',
++  anchorOriginTopRightCircular: 'className',
++  anchorOriginBottomRightCircular: 'className',
++  anchorOriginTopLeftCircular: 'className',
+ }}>
 ```
 
 <!-- #default-branch-switch -->
@@ -440,10 +440,10 @@ You can find more details about this breaking change in [the migration guide](ht
 Adds `prepend: true` to Emotion `createCache`
 
 ```diff
-const cache = emotionCreateCache({
-  key: 'css',
-+ prepend: true,
-});
+ const cache = emotionCreateCache({
+   key: 'css',
++  prepend: true,
+ });
 ```
 
 ```sh
@@ -542,7 +542,7 @@ You can find more details about this breaking change in [the migration guide](ht
 Replace JSS styling with `makeStyles` or `withStyles` to `styled` API.
 
 ```diff
-import Typography from '@material-ui/core/Typography';
+ import Typography from '@material-ui/core/Typography';
 -import makeStyles from '@material-ui/styles/makeStyles';
 +import { styled } from '@material-ui/core/styles';
 
@@ -583,17 +583,17 @@ import Typography from '@material-ui/core/Typography';
 +  },
 +}))
 
-export const MyCard = () => {
-  const classes = useStyles();
-  return (
--   <div className={classes.root}>
-+   <Root className={classes.root}>
-      <Typography className={classes.content}>...</Typography>
-      <Button className={classes.cta}>Go</Button>
-+   </Root>
--   </div>
-  )
-}
+ export const MyCard = () => {
+   const classes = useStyles();
+   return (
+-    <div className={classes.root}>
++    <Root className={classes.root}>
+       <Typography className={classes.content}>...</Typography>
+       <Button className={classes.cta}>Go</Button>
+-    </div>
++    </Root>
+   )
+ }
 ```
 
 ```sh
@@ -661,11 +661,11 @@ Migrate JSS styling with `makeStyles` or `withStyles` to the corresponding `tss-
          The Background take the primary theme color when the mouse hovers the parent.
          I am smaller than the other child.
        </div>
-    </div>
-  );
-}
+     </div>
+   );
+ }
 
-export default App;
+ export default App;
 ```
 
 ```sh
@@ -731,7 +731,7 @@ Moves JSS imports to `@material-ui/styles`
 +import withStyles from '@material-ui/styles/withStyles';
 +import withTheme from '@material-ui/styles/withTheme';
 +import getStylesCreator from '@material-ui/styles/getStylesCreator';
-import mergeClasses from '@material-ui/styles/mergeClasses';
+ import mergeClasses from '@material-ui/styles/mergeClasses';
 ```
 
 ```sh
@@ -758,10 +758,10 @@ You can find more details about this breaking change in [the migration guide](ht
 Removes `disableBackdropClick` and `onEscapeKeyDown` from `<Modal>`
 
 ```diff
-<Modal
-- disableBackdropClick
-- onEscapeKeyDown={handleEscapeKeyDown}
-/>
+ <Modal
+-  disableBackdropClick
+-  onEscapeKeyDown={handleEscapeKeyDown}
+ />
 ```
 
 ```sh
@@ -1100,7 +1100,7 @@ npx @mui/codemod v5.0.0/use-autocomplete <path>
 Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to replace the `onEnter*` and `onExit*` props.
 
 ```diff
-<Dialog
+ <Dialog
 -  onEnter={onEnter}
 -  onEntered={onEntered}
 -  onEntering={onEntering}
@@ -1115,7 +1115,7 @@ Updates Dialog, Menu, Popover, and Snackbar to use the `TransitionProps` prop to
 +    onExited,
 +    onExiting,
 +  }}
-/>
+ />
 ```
 
 <!-- #default-branch-switch -->
@@ -1159,9 +1159,9 @@ npx @mui/codemod v5.0.0/variant-prop <path>
 Removes imported `withMobileDialog`, and inserts hardcoded version to prevent application crash.
 
 ```diff
-- import withMobileDialog from '@material-ui/core/withMobileDialog';
-+ // FIXME checkout https://mui.com/material-ui/migration/v5-component-changes/#dialog
-+ const withMobileDialog = () => (WrappedComponent) => (props) => <WrappedComponent {...props} width="lg" fullScreen={false} />;
+-import withMobileDialog from '@material-ui/core/withMobileDialog';
++// FIXME checkout https://mui.com/material-ui/migration/v5-component-changes/#dialog
++const withMobileDialog = () => (WrappedComponent) => (props) => <WrappedComponent {...props} width="lg" fullScreen={false} />;
 ```
 
 ```sh
@@ -1175,9 +1175,9 @@ You can find more details about this breaking change in [the migration guide](ht
 Removes `withWidth` import, and inserts hardcoded version to prevent application crash.
 
 ```diff
-- import withWidth from '@material-ui/core/withWidth';
-+ // FIXME checkout https://mui.com/components/use-media-query/#migrating-from-withwidth
-+ const withWidth = () => (WrappedComponent) => (props) => <WrappedComponent {...props} width="xs" />;
+-import withWidth from '@material-ui/core/withWidth';
++// FIXME checkout https://mui.com/components/use-media-query/#migrating-from-withwidth
++const withWidth = () => (WrappedComponent) => (props) => <WrappedComponent {...props} width="xs" />;
 ```
 
 ```sh
@@ -1228,7 +1228,7 @@ Replace every occurrence of `material-ui` related package with the new package n
 **Dependencies**
 
 ```diff
-// package.json
+  // package.json
 -"@material-ui/core": "next",
 -"@material-ui/icons": "next",
 -"@material-ui/lab": "next",
@@ -1271,7 +1271,7 @@ This codemod tries to perform a basic expression simplification which can be imp
 -const spacing = theme.spacing.unit / 5;
 +const spacing = theme.spacing(0.2);
 
-// Limitation
+ // Limitation
 -const spacing = theme.spacing.unit * 5 * 5;
 +const spacing = theme.spacing(5) * 5;
 ```
@@ -1411,11 +1411,11 @@ MUI v0.15.0 is reorganizing the folder distribution of the project.
 The diff should look like this:
 
 ```diff
-// From the source
+ // From the source
 -import FlatButton from 'material-ui/src/flat-button';
 +import FlatButton from 'material-ui/src/FlatButton';
 
-// From npm
+ // From npm
 -import RaisedButton from 'material-ui/lib/raised-button';
 +import RaisedButton from 'material-ui/RaisedButton';
 ```


### PR DESCRIPTION
Enforce the git diff format with a custom rule for https://github.com/DavidAnson/markdownlint. It's simply about respecting `git show` output. The new rule is in `packages/markdownlint-rule-mui/git-diff.js`. I felt that I was frequently leaving comments about this aspect, this will save me time 😁.

The discussion in https://github.com/mui/mui-x/pull/6523#discussion_r996671316 covers a bit more the value of it.