### PR TITLE
[core] Temporary remove the authorization

### DIFF
--- a/docs/pages/versions.js
+++ b/docs/pages/versions.js
@@ -22,12 +22,13 @@ function formatVersion(version) {
 }
 
 async function getBranches() {
-  const githubAuthorizationToken = process.env.GITHUB_AUTH || '';
+  // TODO: find an appropriate way to prevent "API rate limit exceeded"
+  // const githubAuthorizationToken = process.env.GITHUB_AUTH || '';
 
   const result = await fetch('https://api.github.com/repos/mui/material-ui-docs/branches', {
-    headers: {
-      Authorization: `Basic ${Buffer.from(githubAuthorizationToken).toString('base64')}`,
-    },
+    // headers: {
+    //   Authorization: `Basic ${Buffer.from(githubAuthorizationToken).toString('base64')}`,
+    // },
   });
   const text = await result.text();
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The `/versions` error "API exceeds limit" is blocking a lot of PRs recently. I think we can remove the authorization for now and I will open another PR to have an appropriate solution.

<img width="1197" alt="Screen Shot 2565-10-17 at 10 10 51" src="https://user-images.githubusercontent.com/18292247/196081214-2a3e3538-c458-4717-96b1-6e4c07dc78b5.png">

The interesting part is that even though the authorization is removed, the API call still works 🤷

---


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
