### PR TITLE
[docs] Fix typos in Base (Menu, Tabs) and Joy UI (Chip)

### DIFF
--- a/docs/data/base/components/menu/menu-pt.md
+++ b/docs/data/base/components/menu/menu-pt.md
@@ -99,7 +99,7 @@ Note that `componentsProps` slot names are written in lowercase (`root`) while `
 `MenuItemUnstyled` can set the following classes:
 
 - `Mui-disabled` - set when the MenuItem has the `disabled` prop
-- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation. This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
+- `Mui-focusVisible` - set when the MenuItem is highlighted via keyboard navigation. This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
 
 ## Hooks
 

--- a/docs/data/base/components/menu/menu-zh.md
+++ b/docs/data/base/components/menu/menu-zh.md
@@ -99,7 +99,7 @@ Note that `componentsProps` slot names are written in lowercase (`root`) while `
 `MenuItemUnstyled` can set the following classes:
 
 - `Mui-disabled` - set when the MenuItem has the `disabled` prop
-- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation. This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
+- `Mui-focusVisible` - set when the MenuItem is highlighted via keyboard navigation. This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
 
 ## Hooks
 

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -108,7 +108,7 @@ Note that `componentsProps` slot names are written in lowercase (`root`) while `
 `MenuItemUnstyled` can set the following classes:
 
 - `Mui-disabled` - set when the MenuItem has the `disabled` prop
-- `Mui-focusVisible` - set when the MenuItem is highligthed via keyboard navigation.
+- `Mui-focusVisible` - set when the MenuItem is highlighted via keyboard navigation.
   This is a polyfill for the native `:focus-visible` pseudoclass as it's not available in Safari.
 
 ## Hooks

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -139,7 +139,7 @@ The demos below illustrate the proper use of ARIA labels.
 
 By default, when using keyboard navigation, the tab components open via **manual activation**—that is, the next panel is displayed only after the user activates the tab with either <kbd class="key">Space</kbd>, <kbd class="key">Enter</kbd>, or a mouse click.
 
-This is the preferable behavior for tabs in most cases, acccording to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
+This is the preferable behavior for tabs in most cases, according to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 Alternatively, you can set the panels to be displayed automatically when their corresponding tabs are in focus—this behavior of the selection following the focus is known as **automatic activation**.
 

--- a/docs/data/joy/components/chip/chip-zh.md
+++ b/docs/data/joy/components/chip/chip-zh.md
@@ -62,7 +62,7 @@ Doing so will automatically change the rendered HTML tag from `<div>` to `<a>`.
 
 ### Clickable
 
-To make chips clikcable, pass a function to the `onClick` prop.
+To make chips clickable, pass a function to the `onClick` prop.
 
 {{"demo": "ClickableChip.js"}}
 

--- a/docs/data/joy/components/chip/chip.md
+++ b/docs/data/joy/components/chip/chip.md
@@ -68,7 +68,7 @@ Doing so will automatically change the rendered HTML tag from `<div>` to `<a>`.
 
 ### Clickable
 
-To make chips clikcable, pass a function to the `onClick` prop.
+To make chips clickable, pass a function to the `onClick` prop.
 
 {{"demo": "ClickableChip.js"}}
 


### PR DESCRIPTION
This PR fixes a handful of typos in the following docs:
- Base
  - Menu (95e97e2b49b3ed5177c54a647689d3b0e4ebf113)
  - Tabs (c63624439032502308dbde16756ef97dd1563cbc)
- Joy UI
  -  Chip (02759de9bfec5cde842a86b7da3e9642684986cc)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
