### PR TITLE
[icons] replace ViewCompact and ViewComfy

### DIFF
--- a/packages/mui-icons-material/lib/ViewComfy.js
+++ b/packages/mui-icons-material/lib/ViewComfy.js
@@ -12,7 +12,7 @@ var _createSvgIcon = _interopRequireDefault(require("./utils/createSvgIcon"));
 var _jsxRuntime = require("react/jsx-runtime");
 
 var _default = (0, _createSvgIcon.default)( /*#__PURE__*/(0, _jsxRuntime.jsx)("path", {
-  d: "M2 4v7h20V4H2zm8 16h12v-7H10v7zm-8 0h6v-7H2v7z"
+  d: "M4 18h2.5v-2.5H4V18zm0-4.75h2.5v-2.5H4v2.5zM4 8.5h2.5V6H4v2.5zM17.5 6v2.5H20V6h-2.5zM13 8.5h2.5V6H13v2.5zm4.5 9.5H20v-2.5h-2.5V18zm0-4.75H20v-2.5h-2.5v2.5zM8.5 18H11v-2.5H8.5V18zm4.5 0h2.5v-2.5H13V18zM8.5 8.5H11V6H8.5v2.5zm4.5 4.75h2.5v-2.5H13v2.5zm-4.5 0H11v-2.5H8.5v2.5z"
 }), 'ViewComfy');
 
 exports.default = _default;

--- a/packages/mui-icons-material/lib/ViewCompact.js
+++ b/packages/mui-icons-material/lib/ViewCompact.js
@@ -12,7 +12,7 @@ var _createSvgIcon = _interopRequireDefault(require("./utils/createSvgIcon"));
 var _jsxRuntime = require("react/jsx-runtime");
 
 var _default = (0, _createSvgIcon.default)( /*#__PURE__*/(0, _jsxRuntime.jsx)("path", {
-  d: "M4 18h2.5v-2.5H4V18zm0-4.75h2.5v-2.5H4v2.5zM4 8.5h2.5V6H4v2.5zM17.5 6v2.5H20V6h-2.5zM13 8.5h2.5V6H13v2.5zm4.5 9.5H20v-2.5h-2.5V18zm0-4.75H20v-2.5h-2.5v2.5zM8.5 18H11v-2.5H8.5V18zm4.5 0h2.5v-2.5H13V18zM8.5 8.5H11V6H8.5v2.5zm4.5 4.75h2.5v-2.5H13v2.5zm-4.5 0H11v-2.5H8.5v2.5z"
+  d: "M2 4v7h20V4H2zm8 16h12v-7H10v7zm-8 0h6v-7H2v7z"
 }), 'ViewCompact');
 
 exports.default = _default;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Changing ViewCompact and ViewComfy according to the material ui.

Based on this: https://github.com/mui/material-ui/issues/34818
