### PR TITLE
[docs] Replace initial value with theme white

### DIFF
--- a/docs/src/BrandingCssVarsProvider.tsx
+++ b/docs/src/BrandingCssVarsProvider.tsx
@@ -32,7 +32,7 @@ const theme = extendTheme({
   typography: deepmerge(typography, {
     h1: {
       ':where([data-mui-color-scheme="dark"]) &': {
-        color: 'initial',
+        color: 'var(--muidocs-palette-common-white)',
       },
     },
     h2: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From https://github.com/mui/material-ui/pull/33545#issuecomment-1282948812.

## **Root cause**

I guess this is a bug on Safari and Firefox because the `color: initial` should use the system [`CanvasText` ](https://www.w3.org/TR/css-color-4/#valdef-system-color-canvastext) color but somehow it returns black (even though the `color-scheme: dark`).

Reference: https://www.w3.org/TR/css-color-4/#changes-from-20191105

## **Fix**

Force color to `theme.common.white` to make the color consistent across browsers.
  <img width="1245" alt="Screen Shot 2565-10-19 at 14 12 43" src="https://user-images.githubusercontent.com/18292247/196621765-9b760bbe-8c97-480b-a268-9d8932a99bb3.png">

---

I will merge the PR once the CIs are green and make a hotfix deployment.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
