### PR TITLE
[test] Test all Base components with describeConformanceUnstyled

### DIFF
--- a/docs/pages/base/api/modal-unstyled.json
+++ b/docs/pages/base/api/modal-unstyled.json
@@ -38,7 +38,7 @@
     "globalClasses": { "root": "MuiModal-root", "hidden": "MuiModal-hidden" },
     "name": null
   },
-  "spread": false,
+  "spread": true,
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js",
   "inheritance": null,

--- a/docs/pages/base/api/popper-unstyled.json
+++ b/docs/pages/base/api/popper-unstyled.json
@@ -48,7 +48,7 @@
   },
   "name": "PopperUnstyled",
   "styles": { "classes": [], "globalClasses": {}, "name": null },
-  "spread": false,
+  "spread": true,
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js",
   "inheritance": null,

--- a/docs/pages/base/api/textarea-autosize.json
+++ b/docs/pages/base/api/textarea-autosize.json
@@ -8,7 +8,7 @@
   },
   "name": "TextareaAutosize",
   "styles": { "classes": [], "globalClasses": {}, "name": null },
-  "spread": true,
+  "spread": false,
   "forwardsRefTo": "HTMLTextAreaElement",
   "filename": "/packages/mui-base/src/TextareaAutosize/TextareaAutosize.js",
   "inheritance": null,

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.js
@@ -55,7 +55,7 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
     children,
     classes: classesProp,
     closeAfterTransition = false,
-    component = 'div',
+    component,
     container,
     disableAutoFocus = false,
     disableEnforceFocus = false,
@@ -235,7 +235,7 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled(props, ref) {
     childProps.onExited = createChainedFunction(handleExited, children.props.onExited);
   }
 
-  const Root = slots.root || component;
+  const Root = component ?? slots.root ?? 'div';
   const rootProps = useSlotProps({
     elementType: Root,
     externalSlotProps: slotProps.root,

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.test.js
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.test.js
@@ -21,7 +21,6 @@ describe('<ModalUnstyled />', () => {
       <div />
     </ModalUnstyled>,
     () => ({
-      classes,
       inheritComponent: 'div',
       render,
       mount,
@@ -29,12 +28,9 @@ describe('<ModalUnstyled />', () => {
       slots: {
         root: {
           expectedClassName: classes.root,
-          testWithElement: null,
         },
       },
       skip: [
-        'propsSpread',
-        'slotsProp',
         'reactTestRenderer', // portal https://github.com/facebook/react/issues/11565
       ],
     }),

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.test.js
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.test.js
@@ -19,10 +19,6 @@ describe('<PopperUnstyled />', () => {
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: [
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
-      'propsSpread',
       // https://github.com/facebook/react/issues/11565
       'reactTestRenderer',
     ],

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.test.tsx
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.test.tsx
@@ -34,7 +34,6 @@ describe('<TabPanelUnstyled />', () => {
         expectedClassName: tabPanelUnstyledClasses.root,
       },
     },
-
     skip: [
       'reactTestRenderer', // Need to be wrapped with TabsContext
     ],

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.test.tsx
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.test.tsx
@@ -34,7 +34,6 @@ describe('<TabUnstyled />', () => {
         expectedClassName: tabUnstyledClasses.root,
       },
     },
-
     skip: [
       'reactTestRenderer', // Need to be wrapped with TabsContext
     ],

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.test.tsx
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.test.tsx
@@ -34,7 +34,6 @@ describe('<TabsListUnstyled />', () => {
         expectedClassName: tabsListUnstyledClasses.root,
       },
     },
-
     skip: [
       'reactTestRenderer', // Need to be wrapped with TabsContext
     ],

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.js
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub } from 'sinon';
 import {
-  describeConformance,
+  describeConformanceUnstyled,
   act,
+  createMount,
   createRenderer,
   fireEvent,
   strictModeDoubleLoggingSupressed,
@@ -12,17 +13,23 @@ import TextareaAutosize from '@mui/base/TextareaAutosize';
 
 describe('<TextareaAutosize />', () => {
   const { clock, render } = createRenderer();
+  const mount = createMount;
 
-  describeConformance(<TextareaAutosize />, () => ({
+  describeConformanceUnstyled(<TextareaAutosize />, () => ({
+    render,
+    mount,
     inheritComponent: 'textarea',
     refInstanceof: window.HTMLTextAreaElement,
+    slots: {},
     skip: [
-      'rootClass',
+      // doesn't have slots, so these tests are irrelevant:
       'componentProp',
-      'componentsProp',
-      'themeDefaultProps',
-      'themeStyleOverrides',
-      'themeVariants',
+      'mergeClassName',
+      'ownerStatePropagation',
+      'propsSpread',
+      'refForwarding',
+      'rootClass',
+      'slotsProp',
     ],
   }));
 


### PR DESCRIPTION
Unstyled Modal and Popper weren't using all relevant `describeConformanceUnstyled`'s tests and TextareaAutosize was still using Material UI's `describeConformance` to test basic behavior. This PR fixes these issues.

An issue with the Unstyled Modal was found along the way. It incorrectly prioritized `slots.root` over `component`. Fixing this is a breaking change in Base, however, it should not affect most developers, as setting both `component` and `slots.root` makes no sense.
This change doesn't affect the Material UI's Modal as it has its own logic for choosing between `slots.root` and `component`.

This PR also improves how `describeConformanceUnstyled` works with portaled components and improves error display in the ownerStatePropagation test.

**Breaking change**
Prior to this change, if both `component` and `slots.root` were defined, `slots.root` would be used. After this PR, `component` will be chosen in this case.
There are no use cases for having both `component` and `slots.root` defined at the same time. Remove one of them to reduce confusion.