### PR TITLE
[docs] Move Joy UI templates to src component

### DIFF
--- a/docs/data/joy/getting-started/templates/index-pt.md
+++ b/docs/data/joy/getting-started/templates/index-pt.md
@@ -4,4 +4,4 @@
 
 If while using these examples you make changes or enhancements that could improve the developer experience, or you would like to contribute an additional example, please consider creating a [pull request on GitHub](https://github.com/mui/material-ui/pulls).
 
-{{"demo": "TemplateCollection.js", "hideToolbar": true, "bg": "inline"}}
+{{"component": "modules/components/TemplateCollection.js", "skipBrandingProvider": true}}

--- a/docs/data/joy/getting-started/templates/index-zh.md
+++ b/docs/data/joy/getting-started/templates/index-zh.md
@@ -4,4 +4,4 @@
 
 If while using these examples you make changes or enhancements that could improve the developer experience, or you would like to contribute an additional example, please consider creating a [pull request on GitHub](https://github.com/mui/material-ui/pulls).
 
-{{"demo": "TemplateCollection.js", "hideToolbar": true, "bg": "inline"}}
+{{"component": "modules/components/TemplateCollection.js", "skipBrandingProvider": true}}

--- a/docs/data/joy/getting-started/templates/index.md
+++ b/docs/data/joy/getting-started/templates/index.md
@@ -6,4 +6,4 @@ If while using these examples you make changes or enhancements that could improv
 developer experience, or you would like to contribute an additional example,
 please consider creating a [pull request on GitHub](https://github.com/mui/material-ui/pulls).
 
-{{"demo": "TemplateCollection.js", "hideToolbar": true, "bg": "inline"}}
+{{"component": "modules/components/TemplateCollection.js", "skipBrandingProvider": true}}

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -80,6 +80,9 @@ export default function MarkdownDocs(props) {
               throw new Error(`No component found at the path ${path.join('docs/src', name)}`);
             }
 
+            if (renderedMarkdownOrDemo.skipBrandingProvider) {
+              return <Component {...renderedMarkdownOrDemo} markdown={localizedDoc} />;
+            }
             return (
               <Wrapper key={index} {...(isJoy && { mode: theme.palette.mode })}>
                 <Component {...renderedMarkdownOrDemo} markdown={localizedDoc} />

--- a/docs/src/modules/components/TemplateCollection.js
+++ b/docs/src/modules/components/TemplateCollection.js
@@ -1,8 +1,8 @@
+/* eslint-disable material-ui/no-hardcoded-labels */
 import * as React from 'react';
 import LZString from 'lz-string';
 import startCase from 'lodash/startCase';
 import NextLink from 'next/link';
-import { useTheme } from '@mui/joy/styles';
 import AspectRatio from '@mui/joy/AspectRatio';
 import Box from '@mui/joy/Box';
 import Card from '@mui/joy/Card';
@@ -17,7 +17,11 @@ import codeSandbox from 'docs/src/modules/sandbox/CodeSandbox';
 import extractTemplates from 'docs/src/modules/utils/extractTemplates';
 
 const cache = {};
-const req = require.context('./?raw', true, /^\.\/[^/]+\/.*\.(js|tsx)$/);
+const req = require.context(
+  '../../../data/joy/getting-started/templates/?raw',
+  true,
+  /^\.\/[^/]+\/.*\.(js|tsx)$/,
+);
 req.keys().forEach((key) => {
   cache[key] = req(key);
 });
@@ -46,7 +50,6 @@ function addHiddenInput(form, name, value) {
 
 export default function TemplateCollection() {
   const templates = extractTemplates(cache);
-  const theme = useTheme();
   return (
     <List
       sx={{
@@ -85,10 +88,7 @@ export default function TemplateCollection() {
                 <Typography component="h3" fontSize="xl" fontWeight="xl">
                   {startCase(name)}
                 </Typography>
-                <NextLink
-                  href={`/joy-ui/getting-started/templates/${name}/`}
-                  passHref
-                >
+                <NextLink href={`/joy-ui/getting-started/templates/${name}/`} passHref>
                   <Button
                     component="a"
                     variant="outlined"
@@ -148,17 +148,15 @@ export default function TemplateCollection() {
               </Box>
               <AspectRatio ratio="2" variant="outlined">
                 <Box
-                  sx={{
-                    background: `center/cover no-repeat url(/static/screenshots/joy-ui/getting-started/templates/${name}${
-                      theme.palette.mode === 'dark' ? '-dark' : ''
-                    }.jpg)`,
+                  sx={(theme) => ({
+                    background: `center/cover no-repeat url(/static/screenshots/joy-ui/getting-started/templates/${name}.jpg)`,
                     transition: '0.3s',
-                  }}
+                    [theme.getColorSchemeSelector('dark')]: {
+                      background: `center/cover no-repeat url(/static/screenshots/joy-ui/getting-started/templates/${name}-dark.jpg)`,
+                    },
+                  })}
                 />
-                <NextLink
-                  href={`/joy-ui/getting-started/templates/${name}/`}
-                  passHref
-                >
+                <NextLink href={`/joy-ui/getting-started/templates/${name}/`} passHref>
                   {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                   <Link
                     tabIndex={-1}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Same issue as #34802. [Joy UI templates page](https://mui.com/joy-ui/getting-started/templates/) is clashing.

The fix is similar to #34802 by moving the `TemplateCollection.js` from demo to src component.

Will do a hotfix deployment after the CIs are green.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
