### PR TITLE
[core] Save a few bytes

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -496,7 +496,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   const handleRef = useForkRef(children.ref, focusVisibleRef, setChildNode, ref);
 
   // There is no point in displaying an empty tooltip.
-  if (typeof title !== 'number' && !title) {
+  if (!title && title !== 0) {
     open = false;
   }
 

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -44,82 +44,91 @@ describe('<Tooltip />', () => {
   );
 
   it('should render a popper', () => {
-    const { getByRole } = render(
+    render(
       <Tooltip title="Hello World" open>
         <button type="submit">Hello World</button>
       </Tooltip>,
     );
 
-    expect(getByRole('tooltip')).to.have.class(classes.popper);
+    expect(screen.getByRole('tooltip')).to.have.class(classes.popper);
   });
 
   describe('prop: disableHoverListener', () => {
     it('should hide the native title', () => {
-      const { getByRole } = render(
+      render(
         <Tooltip title="Hello World" disableHoverListener>
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-
-      expect(getByRole('button')).not.to.have.attribute('title', 'Hello World');
+      expect(screen.getByRole('button')).not.to.have.attribute('title', 'Hello World');
     });
   });
 
   describe('prop: title', () => {
     it('should display if the title is present', () => {
-      const { getByRole } = render(
+      render(
         <Tooltip title="Hello World" open>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
+      expect(screen.getByRole('tooltip')).toBeVisible();
+    });
 
-      expect(getByRole('tooltip')).toBeVisible();
+    it('should display if the title is 0', () => {
+      render(
+        <Tooltip title={0} open>
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
     it('should not display if the title is an empty string', () => {
-      const { queryByRole } = render(
+      render(
         <Tooltip title="" open>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
     it('should not display if the title is a false', () => {
-      const { queryByRole } = render(
+      render(
         <Tooltip title={false} open>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
     it('should not display if the title is a null', () => {
-      const { queryByRole } = render(
+      render(
         <Tooltip title={null} open>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
     it('should not display if the title is an undefined', () => {
-      const { queryByRole } = render(
+      render(
         <Tooltip title={undefined} open>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
     it('should label the child when closed', () => {
@@ -253,7 +262,7 @@ describe('<Tooltip />', () => {
   it('should respond to external events', () => {
     const transitionTimeout = 10;
     const enterDelay = 100;
-    const { queryByRole, getByRole } = render(
+    render(
       <Tooltip
         enterDelay={enterDelay}
         title="Hello World"
@@ -264,25 +273,25 @@ describe('<Tooltip />', () => {
         </button>
       </Tooltip>,
     );
-    expect(queryByRole('tooltip')).to.equal(null);
+    expect(screen.queryByRole('tooltip')).to.equal(null);
 
-    fireEvent.mouseOver(getByRole('button'));
+    fireEvent.mouseOver(screen.getByRole('button'));
     clock.tick(enterDelay);
 
-    expect(getByRole('tooltip')).toBeVisible();
+    expect(screen.getByRole('tooltip')).toBeVisible();
 
-    fireEvent.mouseLeave(getByRole('button'));
+    fireEvent.mouseLeave(screen.getByRole('button'));
     // Tooltip schedules timeout even with no delay
     clock.tick(0);
     clock.tick(transitionTimeout);
 
-    expect(queryByRole('tooltip')).to.equal(null);
+    expect(screen.queryByRole('tooltip')).to.equal(null);
   });
 
   it('should be controllable', () => {
     const eventLog = [];
 
-    const { getByRole, setProps } = render(
+    const { setProps } = render(
       <Tooltip
         enterDelay={100}
         title="Hello World"
@@ -303,13 +312,13 @@ describe('<Tooltip />', () => {
 
     expect(eventLog).to.deep.equal([]);
 
-    fireEvent.mouseOver(getByRole('button'));
+    fireEvent.mouseOver(screen.getByRole('button'));
     clock.tick(100);
 
     expect(eventLog).to.deep.equal(['mouseover', 'open']);
     setProps({ open: true });
 
-    fireEvent.mouseLeave(getByRole('button'));
+    fireEvent.mouseLeave(screen.getByRole('button'));
     clock.tick(0);
 
     expect(eventLog).to.deep.equal(['mouseover', 'open', 'mouseleave', 'close']);
@@ -317,7 +326,7 @@ describe('<Tooltip />', () => {
 
   it('should not call onOpen again if already open', () => {
     const eventLog = [];
-    const { getByTestId } = render(
+    render(
       <Tooltip enterDelay={100} title="Hello World" onOpen={() => eventLog.push('open')} open>
         <button data-testid="trigger" onMouseOver={() => eventLog.push('mouseover')} />
       </Tooltip>,
@@ -325,7 +334,7 @@ describe('<Tooltip />', () => {
 
     expect(eventLog).to.deep.equal([]);
 
-    fireEvent.mouseOver(getByTestId('trigger'));
+    fireEvent.mouseOver(screen.getByTestId('trigger'));
     clock.tick(100);
 
     expect(eventLog).to.deep.equal(['mouseover']);
@@ -333,13 +342,13 @@ describe('<Tooltip />', () => {
 
   it('should not call onClose if already closed', () => {
     const eventLog = [];
-    const { getByTestId } = render(
+    render(
       <Tooltip title="Hello World" onClose={() => eventLog.push('close')} open={false}>
         <button data-testid="trigger" onMouseLeave={() => eventLog.push('mouseleave')} />
       </Tooltip>,
     );
 
-    fireEvent.mouseLeave(getByTestId('trigger'));
+    fireEvent.mouseLeave(screen.getByTestId('trigger'));
     clock.tick(0);
 
     expect(eventLog).to.deep.equal(['mouseleave']);
@@ -373,16 +382,16 @@ describe('<Tooltip />', () => {
 
   describe('touch screen', () => {
     it('should not respond to quick events', () => {
-      const { getByRole, queryByRole } = render(
+      render(
         <Tooltip title="Hello World">
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      fireEvent.touchStart(getByRole('button'));
-      fireEvent.touchEnd(getByRole('button'));
-      expect(queryByRole('tooltip')).to.equal(null);
+      fireEvent.touchStart(screen.getByRole('button'));
+      fireEvent.touchEnd(screen.getByRole('button'));
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
     it('should open on long press', () => {
@@ -390,7 +399,7 @@ describe('<Tooltip />', () => {
       const enterDelay = 100;
       const leaveTouchDelay = 1500;
       const transitionTimeout = 10;
-      const { getByRole, queryByRole } = render(
+      render(
         <Tooltip
           enterTouchDelay={enterTouchDelay}
           enterDelay={enterDelay}
@@ -401,23 +410,23 @@ describe('<Tooltip />', () => {
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-      fireEvent.touchStart(getByRole('button'));
+      fireEvent.touchStart(screen.getByRole('button'));
       clock.tick(enterTouchDelay + enterDelay);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
-      fireEvent.touchEnd(getByRole('button'));
+      fireEvent.touchEnd(screen.getByRole('button'));
       act(() => {
-        getByRole('button').blur();
+        screen.getByRole('button').blur();
       });
       clock.tick(leaveTouchDelay);
       clock.tick(transitionTimeout);
 
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
 
     it('should not open if disableTouchListener', () => {
-      const { getByRole, queryByRole } = render(
+      render(
         <Tooltip title="Hello World" disableTouchListener>
           <button id="testChild" type="submit">
             Hello World
@@ -425,9 +434,9 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      fireEvent.touchStart(getByRole('button'));
-      fireEvent.mouseOver(getByRole('button'));
-      expect(queryByRole('tooltip')).to.equal(null);
+      fireEvent.touchStart(screen.getByRole('button'));
+      fireEvent.mouseOver(screen.getByRole('button'));
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
   });
 
@@ -454,7 +463,7 @@ describe('<Tooltip />', () => {
         </div>
       );
 
-      const { setProps, getByRole } = render(
+      const { setProps } = render(
         <AutoFocus />,
         // TODO: https://github.com/reactwg/react-18/discussions/18#discussioncomment-893076
         { strictEffects: false },
@@ -463,14 +472,14 @@ describe('<Tooltip />', () => {
       setProps({ open: true });
       clock.tick(100);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
       expect(handleFocus.callCount).to.equal(1);
     });
   });
 
   describe('prop: delay', () => {
     it('should take the enterDelay into account', async () => {
-      const { queryByRole, getByRole } = render(
+      const { queryByRole } = render(
         <Tooltip title="Hello World" enterDelay={111}>
           <button id="testChild" type="submit">
             Hello World
@@ -479,16 +488,16 @@ describe('<Tooltip />', () => {
       );
       simulatePointerDevice();
 
-      focusVisible(getByRole('button'));
+      focusVisible(screen.getByRole('button'));
       expect(queryByRole('tooltip')).to.equal(null);
 
       clock.tick(111);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
     it('should use hysteresis with the enterDelay', () => {
-      const { queryByRole, getByRole } = render(
+      render(
         <Tooltip
           title="Hello World"
           enterDelay={111}
@@ -501,14 +510,14 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      const children = getByRole('button');
+      const children = screen.getByRole('button');
       focusVisible(children);
 
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
 
       clock.tick(111);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
       act(() => {
         document.activeElement.blur();
@@ -516,24 +525,24 @@ describe('<Tooltip />', () => {
       clock.tick(5);
       clock.tick(6);
 
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
 
       focusVisible(children);
       // Bypass `enterDelay` wait, use `enterNextDelay`.
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
 
       act(() => {
         clock.tick(30);
       });
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
     it('should take the leaveDelay into account', () => {
       const leaveDelay = 111;
       const enterDelay = 0;
       const transitionTimeout = 10;
-      const { getByRole, queryByRole } = render(
+      render(
         <Tooltip
           leaveDelay={leaveDelay}
           enterDelay={enterDelay}
@@ -547,21 +556,21 @@ describe('<Tooltip />', () => {
       );
       simulatePointerDevice();
 
-      focusVisible(getByRole('button'));
+      focusVisible(screen.getByRole('button'));
       clock.tick(enterDelay);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
       act(() => {
-        getByRole('button').blur();
+        screen.getByRole('button').blur();
       });
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
       clock.tick(leaveDelay);
       clock.tick(transitionTimeout);
 
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
     });
   });
 
@@ -576,7 +585,7 @@ describe('<Tooltip />', () => {
     ].forEach((name) => {
       it(`should be transparent for the ${name} event`, () => {
         const handler = spy();
-        const { getByRole } = render(
+        render(
           <Tooltip followCursor title="Hello World">
             <button id="testChild" type="submit" {...{ [name]: handler }}>
               Hello World
@@ -584,7 +593,7 @@ describe('<Tooltip />', () => {
           </Tooltip>,
         );
         const type = camelCase(name.slice(2));
-        fireEvent[type](getByRole('button'));
+        fireEvent[type](screen.getByRole('button'));
         expect(handler.callCount).to.equal(1, `${name} should've been called`);
       });
     });
@@ -592,14 +601,14 @@ describe('<Tooltip />', () => {
     it(`should be transparent for the focus and blur event`, () => {
       const handleBlur = spy();
       const handleFocus = spy();
-      const { getByRole } = render(
+      render(
         <Tooltip title="Hello World">
           <button id="testChild" type="submit" onFocus={handleFocus} onBlur={handleBlur}>
             Hello World
           </button>
         </Tooltip>,
       );
-      const button = getByRole('button');
+      const button = screen.getByRole('button');
 
       act(() => {
         button.focus();
@@ -618,7 +627,7 @@ describe('<Tooltip />', () => {
 
     it('should ignore event from the tooltip', () => {
       const handleMouseOver = spy();
-      const { getByRole } = render(
+      render(
         <Tooltip title="Hello World" open>
           <button type="submit" onMouseOver={handleMouseOver}>
             Hello World
@@ -626,7 +635,7 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      fireEvent.mouseOver(getByRole('tooltip'));
+      fireEvent.mouseOver(screen.getByRole('tooltip'));
 
       expect(handleMouseOver.callCount).to.equal(0);
     });
@@ -672,7 +681,7 @@ describe('<Tooltip />', () => {
 
   describe('prop: disableInteractive', () => {
     it('when false should keep the overlay open if the popper element is hovered', () => {
-      const { getByRole } = render(
+      render(
         <Tooltip
           title="Hello World"
           enterDelay={100}
@@ -685,23 +694,23 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      fireEvent.mouseOver(getByRole('button'));
+      fireEvent.mouseOver(screen.getByRole('button'));
       clock.tick(100);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
-      fireEvent.mouseLeave(getByRole('button'));
+      fireEvent.mouseLeave(screen.getByRole('button'));
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
-      fireEvent.mouseOver(getByRole('tooltip'));
+      fireEvent.mouseOver(screen.getByRole('tooltip'));
       clock.tick(111 + 10);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
     });
 
     it('when `true` should not keep the overlay open if the popper element is hovered', () => {
-      const { getByRole } = render(
+      render(
         <Tooltip
           title="Hello World"
           enterDelay={100}
@@ -714,33 +723,32 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      fireEvent.mouseOver(getByRole('button'));
+      fireEvent.mouseOver(screen.getByRole('button'));
       clock.tick(100);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
-      fireEvent.mouseLeave(getByRole('button'));
+      fireEvent.mouseLeave(screen.getByRole('button'));
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
 
-      fireEvent.mouseOver(getByRole('tooltip'));
+      fireEvent.mouseOver(screen.getByRole('tooltip'));
       clock.tick(111 + 10);
 
-      expect(getByRole('tooltip')).not.toBeVisible();
+      expect(screen.getByRole('tooltip')).not.toBeVisible();
     });
   });
 
   describe('prop: PopperProps', () => {
     it('should pass PopperProps to Popper Component', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip title="Hello World" open PopperProps={{ 'data-testid': 'popper' }}>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-
-      expect(getByTestId('popper')).not.to.equal(null);
+      expect(screen.getByTestId('popper')).not.to.equal(null);
     });
 
     it('should merge popperOptions with arrow modifier', () => {
@@ -837,47 +845,47 @@ describe('<Tooltip />', () => {
 
   describe('focus', () => {
     it('ignores base focus', () => {
-      const { getByRole, queryByRole } = render(
+      render(
         <Tooltip enterDelay={0} title="Some information">
           <button />
         </Tooltip>,
       );
       simulatePointerDevice();
 
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
 
       act(() => {
-        getByRole('button').focus();
+        screen.getByRole('button').focus();
       });
 
       if (programmaticFocusTriggersFocusVisible()) {
-        expect(queryByRole('tooltip')).not.to.equal(null);
+        expect(screen.queryByRole('tooltip')).not.to.equal(null);
       } else {
-        expect(queryByRole('tooltip')).to.equal(null);
+        expect(screen.queryByRole('tooltip')).to.equal(null);
       }
     });
 
     it('opens on focus-visible', () => {
       const eventLog = [];
-      const { queryByRole, getByRole } = render(
+      render(
         <Tooltip enterDelay={0} onOpen={() => eventLog.push('open')} title="Some information">
           <button onFocus={() => eventLog.push('focus')} />
         </Tooltip>,
       );
       simulatePointerDevice();
 
-      expect(queryByRole('tooltip')).to.equal(null);
+      expect(screen.queryByRole('tooltip')).to.equal(null);
 
-      focusVisible(getByRole('button'));
+      focusVisible(screen.getByRole('button'));
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
       expect(eventLog).to.deep.equal(['focus', 'open']);
     });
 
     it('closes on blur', () => {
       const eventLog = [];
       const transitionTimeout = 0;
-      const { getByRole } = render(
+      render(
         <Tooltip
           enterDelay={0}
           leaveDelay={0}
@@ -889,7 +897,7 @@ describe('<Tooltip />', () => {
           <button onBlur={() => eventLog.push('blur')} />
         </Tooltip>,
       );
-      const button = getByRole('button');
+      const button = screen.getByRole('button');
 
       act(() => {
         button.focus();
@@ -899,7 +907,7 @@ describe('<Tooltip />', () => {
       });
       clock.tick(transitionTimeout);
 
-      expect(getByRole('tooltip')).toBeVisible();
+      expect(screen.getByRole('tooltip')).toBeVisible();
       expect(eventLog).to.deep.equal(['blur', 'close']);
     });
 
@@ -916,12 +924,12 @@ describe('<Tooltip />', () => {
           </div>
         );
       });
-      const { getByRole } = render(
+      render(
         <Tooltip open title="test">
           <TextField onFocus={handleFocus} variant="standard" />
         </Tooltip>,
       );
-      const input = getByRole('textbox');
+      const input = screen.getByRole('textbox');
 
       act(() => {
         input.focus();
@@ -988,14 +996,14 @@ describe('<Tooltip />', () => {
   describe('prop: PopperComponent', () => {
     it('can render a different component', () => {
       const CustomPopper = () => <div data-testid="CustomPopper" />;
-      const { getByTestId } = render(
+      render(
         <Tooltip title="Hello World" open PopperComponent={CustomPopper}>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomPopper')).toBeVisible();
+      expect(screen.getByTestId('CustomPopper')).toBeVisible();
     });
   });
 
@@ -1051,48 +1059,48 @@ describe('<Tooltip />', () => {
   describe('prop: components', () => {
     it('can render a different Popper component', () => {
       const CustomPopper = () => <div data-testid="CustomPopper" />;
-      const { getByTestId } = render(
+      render(
         <Tooltip title="Hello World" open components={{ Popper: CustomPopper }}>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomPopper')).toBeVisible();
+      expect(screen.getByTestId('CustomPopper')).toBeVisible();
     });
 
     it('can render a different Tooltip component', () => {
       const CustomTooltip = React.forwardRef((props, ref) => (
         <div data-testid="CustomTooltip" ref={ref} />
       ));
-      const { getByTestId } = render(
+      render(
         <Tooltip title="Hello World" open components={{ Tooltip: CustomTooltip }}>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomTooltip')).toBeVisible();
+      expect(screen.getByTestId('CustomTooltip')).toBeVisible();
     });
 
     it('can render a different Arrow component', () => {
       const CustomArrow = React.forwardRef((props, ref) => (
         <div data-testid="CustomArrow" ref={ref} />
       ));
-      const { getByTestId } = render(
+      render(
         <Tooltip title="Hello World" open arrow components={{ Arrow: CustomArrow }}>
           <button id="testChild" type="submit">
             Hello World
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomArrow')).toBeVisible();
+      expect(screen.getByTestId('CustomArrow')).toBeVisible();
     });
   });
 
   describe('prop: componentsProps', () => {
     it('can provide custom props for the inner Popper component', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip
           title="Hello World"
           open
@@ -1103,11 +1111,11 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomPopper')).toBeVisible();
+      expect(screen.getByTestId('CustomPopper')).toBeVisible();
     });
 
     it('can provide custom props for the inner Tooltip component', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip
           title="Hello World"
           open
@@ -1118,11 +1126,11 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomTooltip')).toBeVisible();
+      expect(screen.getByTestId('CustomTooltip')).toBeVisible();
     });
 
     it('can provide custom props for the inner Arrow component', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip
           title="Hello World"
           open
@@ -1134,7 +1142,7 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      expect(getByTestId('CustomArrow')).toBeVisible();
+      expect(screen.getByTestId('CustomArrow')).toBeVisible();
     });
   });
 
@@ -1153,7 +1161,7 @@ describe('<Tooltip />', () => {
       const enterDelay = 100;
       const leaveTouchDelay = 1500;
       const transitionTimeout = 10;
-      const { getByRole } = render(
+      render(
         <Tooltip
           enterTouchDelay={enterTouchDelay}
           enterDelay={enterDelay}
@@ -1166,7 +1174,7 @@ describe('<Tooltip />', () => {
       );
       document.body.style.WebkitUserSelect = 'text';
 
-      fireEvent.touchStart(getByRole('button'));
+      fireEvent.touchStart(screen.getByRole('button'));
 
       expect(document.body.style.WebkitUserSelect).to.equal('none');
 
@@ -1175,19 +1183,17 @@ describe('<Tooltip />', () => {
     });
 
     it('ensures text-selection is reset after single press', () => {
-      const { getByRole } = render(
+      render(
         <Tooltip title="Hello World">
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
       document.body.style.WebkitUserSelect = 'text';
 
-      fireEvent.touchStart(getByRole('button'));
-
+      fireEvent.touchStart(screen.getByRole('button'));
       expect(document.body.style.WebkitUserSelect).to.equal('none');
 
-      fireEvent.touchEnd(getByRole('button'));
-
+      fireEvent.touchEnd(screen.getByRole('button'));
       expect(document.body.style.WebkitUserSelect).to.equal('text');
     });
 
@@ -1196,7 +1202,7 @@ describe('<Tooltip />', () => {
       const enterDelay = 100;
       const leaveTouchDelay = 1500;
       const transitionTimeout = 10;
-      const { unmount, getByRole } = render(
+      const { unmount } = render(
         <Tooltip
           enterTouchDelay={enterTouchDelay}
           enterDelay={enterDelay}
@@ -1210,7 +1216,7 @@ describe('<Tooltip />', () => {
 
       document.body.style.WebkitUserSelect = 'text';
       // Let updates flush before unmounting
-      fireEvent.touchStart(getByRole('button'));
+      fireEvent.touchStart(screen.getByRole('button'));
       unmount();
 
       expect(document.body.style.WebkitUserSelect).to.equal('text');
@@ -1219,7 +1225,7 @@ describe('<Tooltip />', () => {
 
   describe('className', () => {
     it('should allow className from PopperProps', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip
           title="Hello World"
           open
@@ -1229,11 +1235,11 @@ describe('<Tooltip />', () => {
         </Tooltip>,
       );
 
-      expect(getByTestId('popper')).to.have.class('my-class');
+      expect(screen.getByTestId('popper')).to.have.class('my-class');
     });
 
     it('should allow className from componentsProps.popper', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip
           title="Hello World"
           open
@@ -1242,12 +1248,11 @@ describe('<Tooltip />', () => {
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-
-      expect(getByTestId('popper')).to.have.class('my-class');
+      expect(screen.getByTestId('popper')).to.have.class('my-class');
     });
 
     it('should apply both the className from PopperProps and componentsProps.popper if both are passed', () => {
-      const { getByTestId } = render(
+      render(
         <Tooltip
           title="Hello World"
           open
@@ -1257,9 +1262,8 @@ describe('<Tooltip />', () => {
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-
-      expect(getByTestId('popper')).to.have.class('my-class-2');
-      expect(getByTestId('popper')).to.have.class('my-class');
+      expect(screen.getByTestId('popper')).to.have.class('my-class-2');
+      expect(screen.getByTestId('popper')).to.have.class('my-class');
     });
   });
 });


### PR DESCRIPTION
This is a follow-up on #34289, I'm giving up on the idea of having title !== '' && title !== node an invalid value. We can be less opinionated about the best practice. Instead:

1. I believe we can shorten the logic
2. While I am at it, I'm continuing the migration to use `screen` as much as possible that Sebastian started.