### PR TITLE
[core] Pin GitHub Action to digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,10 @@
     {
       "groupName": "Playwright",
       "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"]
+    },
+    {
+      "matchDepTypes": ["action"],
+      "pinDigests": true
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"],


### PR DESCRIPTION
The idea is to follow https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

> You can help mitigate this risk by following these good practices: **Pin actions to a full length commit SHA**

It uses: https://docs.renovatebot.com/modules/manager/github-actions/. If it works well, we need to apply it to all the other repositories.