### PR TITLE
[blog] Fix hydration mistmatch

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -36,7 +36,7 @@ const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
 
 export default class MyDocument extends Document {
   render() {
-    const { canonicalAs, userLanguage } = this.props;
+    const { canonicalAsServer, userLanguage } = this.props;
 
     return (
       <Html lang={userLanguage}>
@@ -63,9 +63,11 @@ export default class MyDocument extends Document {
           {/* SEO */}
           <link
             rel="canonical"
-            href={`https://mui.com${userLanguage === 'en' ? '' : `/${userLanguage}`}${canonicalAs}`}
+            href={`https://mui.com${
+              userLanguage === 'en' ? '' : `/${userLanguage}`
+            }${canonicalAsServer}`}
           />
-          <link rel="alternate" href={`https://mui.com${canonicalAs}`} hrefLang="x-default" />
+          <link rel="alternate" href={`https://mui.com${canonicalAsServer}`} hrefLang="x-default" />
           {/*
             Preconnect allows the browser to setup early connections before an HTTP request
             is actually sent to the server.
@@ -233,7 +235,7 @@ MyDocument.getInitialProps = async (ctx) => {
 
     return {
       ...initialProps,
-      canonicalAs: pathnameToLanguage(url).canonicalAs,
+      canonicalAsServer: pathnameToLanguage(url).canonicalAsServer,
       userLanguage: ctx.query.userLanguage || 'en',
       // Styles fragment is rendered after the app and page rendering finish.
       styles: [

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -64,8 +64,8 @@ function GoogleAnalytics() {
   React.useEffect(() => {
     // Wait for the title to be updated.
     setTimeout(() => {
-      const { canonicalAs } = pathnameToLanguage(window.location.pathname);
-      window.ga('set', { page: canonicalAs });
+      const { canonicalAsServer } = pathnameToLanguage(window.location.pathname);
+      window.ga('set', { page: canonicalAsServer });
       window.ga('send', { hitType: 'pageview' });
     });
   }, [router.route]);

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -215,7 +215,7 @@ function TopLayoutBlog(props) {
   const finalTitle = title || headers.title;
   const router = useRouter();
   const slug = router.pathname.replace(/\/blog\//, '');
-  const { canonicalAs } = pathnameToLanguage(router.asPath);
+  const { canonicalAsServer } = pathnameToLanguage(router.asPath);
   const card =
     headers.card === 'true'
       ? `https://mui.com/static/blog/${slug}/card.png`
@@ -328,7 +328,7 @@ function TopLayoutBlog(props) {
     ]
   },
   "headline": "${finalTitle}",
-  "url": "https://mui.com${canonicalAs}",
+  "url": "https://mui.com${canonicalAsServer}",
   "datePublished": "${headers.date}",
   "dateModified": "${headers.date}",
   "image": {

--- a/docs/src/modules/utils/helpers.ts
+++ b/docs/src/modules/utils/helpers.ts
@@ -78,6 +78,7 @@ export function getCookie(name: string): string | undefined {
 export function pathnameToLanguage(pathname: string): {
   userLanguage: string;
   canonicalAs: string;
+  canonicalAsServer: string;
   canonicalPathname: string;
 } {
   let userLanguage;
@@ -93,14 +94,15 @@ export function pathnameToLanguage(pathname: string): {
   }
 
   const canonicalAs = userLanguage === 'en' ? pathname : pathname.substring(3);
-  const canonicalPathname = canonicalAs
-    .replace(/^\/api/, '/api-docs')
-    .replace(/#(.*)$/, '')
-    .replace(/\/$/, '');
+  // Remove hash as it's never sent to the server
+  // https://github.com/vercel/next.js/issues/25202
+  const canonicalAsServer = canonicalAs.replace(/#(.*)$/, '');
+  const canonicalPathname = canonicalAsServer.replace(/^\/api/, '/api-docs').replace(/\/$/, '');
 
   return {
     userLanguage,
     canonicalAs,
+    canonicalAsServer,
     canonicalPathname,
   };
 }


### PR DESCRIPTION
I saw this during the review of #34325. Open http://0.0.0.0:3000/blog/mui-x-v6-alpha-zero/#whats-the-plan-to-get-to-a-stable-release and you will get and hydration mismatch error:

<img width="476" alt="Screenshot 2022-10-22 at 21 06 34" src="https://user-images.githubusercontent.com/3165635/197358259-74438cd9-5a52-4c40-b53e-3ce7422f46c3.png">

A git diff of the server output with the client output returns:

<img width="1088" alt="Screenshot 2022-10-22 at 21 08 47" src="https://user-images.githubusercontent.com/3165635/197358367-cebfd46f-4dbe-4f46-be10-410f3d790059.png">


https://github.com/vercel/next.js/issues/25202 explains what's going on.