### PR TITLE
[docs] Fix Safari button misalignment

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -26,6 +26,7 @@ const SearchButton = styled('button')(({ theme }) => {
     minHeight: 34,
     display: 'flex',
     alignItems: 'center',
+    margin: 0, // Reset for Safari
     paddingLeft: theme.spacing(1),
     [theme.breakpoints.only('xs')]: {
       backgroundColor: 'transparent',


### PR DESCRIPTION
Safari adds 2px of margin on the `<button>` by default, which leads to the following:

<img width="431" alt="Screenshot 2022-10-23 at 02 24 30" src="https://user-images.githubusercontent.com/3165635/197367337-14ab7701-be94-47aa-879b-b83aa2e5e8cd.png">

Eww, it feels off, it also leads to a layout shift when loading.

We need to reset the margin. We might want to revamp how we handle the CssBaseline to take care of this. I shouldn't have to do this change. For example, normalize.css takes care of it: https://github.com/necolas/normalize.css/blob/fc091cce1534909334c1911709a39c22d406977b/normalize.css#L157. I have added the idea to #30660 for v6.