### PR TITLE
[docs] Fix inconsistent theme colors when applying custom colors in playground

### DIFF
--- a/docs/data/material/customization/color/ColorTool.js
+++ b/docs/data/material/customization/color/ColorTool.js
@@ -155,8 +155,8 @@ function ColorTool() {
 
   const handleChangeDocsColors = () => {
     const paletteColors = {
-      primary: { main: state.primary },
-      secondary: { main: state.secondary },
+      primary: { ...colors[state.primaryHue], main: state.primary },
+      secondary: { ...colors[state.secondaryHue], main: state.secondary },
     };
 
     dispatch({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/34865

Preview: https://deploy-preview-34866--material-ui.netlify.app/material-ui/customization/color/#playground

Before:
<img width="1370" alt="Screenshot 2022-10-23 at 15 07 27" src="https://user-images.githubusercontent.com/13808724/197394756-67e3c66c-b3eb-47e7-95cb-6300e4a749c6.png">

After:
<img width="1368" alt="Screenshot 2022-10-23 at 15 55 15" src="https://user-images.githubusercontent.com/13808724/197396252-db737d8f-ee98-4e7a-ba78-256c3ca144ab.png">

