### PR TITLE
[website] Fix subscribe input with Safari

### DIFF
--- a/docs/src/components/footer/EmailSubscribe.tsx
+++ b/docs/src/components/footer/EmailSubscribe.tsx
@@ -121,17 +121,19 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
               bgcolor: '#fff',
               boxShadow: '0 1px 2px 0 rgba(0 0 0 / 0.1)',
               borderColor: 'grey.300',
-              px: 1,
-              py: 0.5,
               typography: 'body2',
               '&:hover': {
                 borderColor: 'grey.400',
                 boxShadow: '0 1px 2px 0 rgba(0 0 0 / 0.2)',
               },
               [`&.${inputBaseClasses.focused}`]: {
-                outline: '3px solid',
+                boxShadow: `0 0 0 3px ${(theme.vars || theme).palette.primary[200]}`,
                 borderColor: 'primary.500',
-                outlineColor: (theme.vars || theme).palette.primary[200],
+              },
+              [`& .${inputBaseClasses.input}`]: {
+                borderRadius: `calc(${theme.spacing(1)} - 1px)`,
+                py: '11px',
+                px: 1,
               },
             }),
             (theme) =>
@@ -144,8 +146,8 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
                   boxShadow: '0 1px 2px 0 rgba(0 0 0 / 1)',
                 },
                 [`&.${inputBaseClasses.focused}`]: {
+                  boxShadow: `0 0 0 3px ${(theme.vars || theme).palette.primaryDark[500]}`,
                   borderColor: 'primaryDark.300',
-                  outlineColor: (theme.vars || theme).palette.primaryDark[500],
                 },
               }),
           ]}


### PR DESCRIPTION
The issue can be seen at the bottom of any blog post, e.g. https://mui.com/blog/mui-x-v6-alpha-zero/

<img width="453" alt="Screenshot 2022-10-23 at 18 32 45" src="https://user-images.githubusercontent.com/3165635/197405023-b13141f2-ece4-48bf-ba1a-e21cf64ae285.png">

I have used the opportunity to fix the autofill style on Chrome:

<img width="361" alt="Screenshot 2022-10-23 at 18 55 04" src="https://user-images.githubusercontent.com/3165635/197405062-0c8961d0-fd65-4b04-9116-28d98cee391c.png">
