### PR TITLE
[core] Make the reproduction more important in the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -26,14 +26,12 @@ body:
     attributes:
       label: Steps to reproduce 🕹
       description: |
-        Please provide a link to a live example and an unambiguous set of steps to reproduce this bug.
-             
-        As a starting point, we recommend you browse our [documentation](https://mui.com/material-ui/getting-started/installation/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case.
+        **⚠️ Issues that we can't reproduce will be closed.**
 
-        Or you can use the [official template](https://mui.com/r/issue-template) to build a reproduction case.
-
-        Issues that we can't reproduce will be closed.
+        Please provide a link to a live example and an unambiguous set of steps to reproduce this bug. As a starting point, we recommend you browse our [documentation](https://mui.com/material-ui/getting-started/installation/), and [select](https://mui.com/static/docs/forking-an-example.png) the closest example to your use case. Or you can use the [official template](https://mui.com/r/issue-template) to build a reproduction case.
       value: |
+        Link to live example:
+
         Steps:
 
         1.


### PR DESCRIPTION
An attempt at https://www.notion.so/mui-org/Weekly-meeting-2022-10-18-0566064ded784ef786b163b1c8dff280#3ff2cf52fdbf4bdf86c00e287e74b122.

**Before**

<img width="869" alt="Screenshot 2022-10-24 at 17 36 10" src="https://user-images.githubusercontent.com/3165635/197566663-7b7d1e8f-5eef-49f6-9943-908f557809db.png">

**After**

<img width="862" alt="Screenshot 2022-10-24 at 17 37 05" src="https://user-images.githubusercontent.com/3165635/197566904-60fe2c09-a1e0-4ec0-bcbf-be1cf3fb8c05.png">
