### PR TITLE
[docs] Use proper state handling in basic Menu example

### DIFF
--- a/docs/data/material/components/menus/BasicMenu.js
+++ b/docs/data/material/components/menus/BasicMenu.js
@@ -4,18 +4,19 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 
 export default function BasicMenu() {
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+  const anchorEl = React.useRef(null);
+  const [open, setOpen] = React.useState(false);
+  const handleClick = React.useCallback(() => {
+    setOpen(true);
+  }, []);
+  const handleClose = React.useCallback(() => {
+    setOpen(false);
+  }, []);
 
   return (
     <div>
       <Button
+        ref={anchorEl}
         id="basic-button"
         aria-controls={open ? 'basic-menu' : undefined}
         aria-haspopup="true"
@@ -26,7 +27,7 @@ export default function BasicMenu() {
       </Button>
       <Menu
         id="basic-menu"
-        anchorEl={anchorEl}
+        anchorEl={anchorEl.current}
         open={open}
         onClose={handleClose}
         MenuListProps={{

--- a/docs/data/material/components/menus/BasicMenu.tsx
+++ b/docs/data/material/components/menus/BasicMenu.tsx
@@ -4,18 +4,19 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 
 export default function BasicMenu() {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+  const anchorEl = React.useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = React.useState(false);
+  const handleClick = React.useCallback(() => {
+    setOpen(true);
+  }, []);
+  const handleClose = React.useCallback(() => {
+    setOpen(false);
+  }, []);
 
   return (
     <div>
       <Button
+        ref={anchorEl}
         id="basic-button"
         aria-controls={open ? 'basic-menu' : undefined}
         aria-haspopup="true"
@@ -26,7 +27,7 @@ export default function BasicMenu() {
       </Button>
       <Menu
         id="basic-menu"
-        anchorEl={anchorEl}
+        anchorEl={anchorEl.current}
         open={open}
         onClose={handleClose}
         MenuListProps={{


### PR DESCRIPTION
Using an element as state is bad practice since drawn elements should be based on the state and not the other way around. It's also not intuitive to have the element be kept as state and the `open` prop as derived state.

Changed the basic example to use a simple `boolean` state for the open and closed state and use the `ref` prop on the `Button` element to pass the element to the `Menu` component. Also wrapped the callbacks with `useCallback` to avoid creating new callback references on subsequent renders.