### PR TITLE
[Radio] Skip default hover style when disableRipple is set

### DIFF
--- a/docs/data/material/components/radio-buttons/CustomizedRadios.js
+++ b/docs/data/material/components/radio-buttons/CustomizedRadios.js
@@ -52,11 +52,6 @@ const BpCheckedIcon = styled(BpIcon)({
 function BpRadio(props) {
   return (
     <Radio
-      sx={{
-        '&:hover': {
-          bgcolor: 'transparent',
-        },
-      }}
       disableRipple
       color="default"
       checkedIcon={<BpCheckedIcon />}

--- a/docs/data/material/components/radio-buttons/CustomizedRadios.tsx
+++ b/docs/data/material/components/radio-buttons/CustomizedRadios.tsx
@@ -52,11 +52,6 @@ const BpCheckedIcon = styled(BpIcon)({
 function BpRadio(props: RadioProps) {
   return (
     <Radio
-      sx={{
-        '&:hover': {
-          bgcolor: 'transparent',
-        },
-      }}
       disableRipple
       color="default"
       checkedIcon={<BpCheckedIcon />}

--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -37,24 +37,26 @@ const RadioRoot = styled(SwitchBase, {
   },
 })(({ theme, ownerState }) => ({
   color: (theme.vars || theme).palette.text.secondary,
-  '&:hover': {
-    backgroundColor: theme.vars
-      ? `rgba(${
-          ownerState.color === 'default'
-            ? theme.vars.palette.action.activeChannel
-            : theme.vars.palette[ownerState.color].mainChannel
-        } / ${theme.vars.palette.action.hoverOpacity})`
-      : alpha(
-          ownerState.color === 'default'
-            ? theme.palette.action.active
-            : theme.palette[ownerState.color].main,
-          theme.palette.action.hoverOpacity,
-        ),
-    // Reset on touch devices, it doesn't add specificity
-    '@media (hover: none)': {
-      backgroundColor: 'transparent',
+  ...(!ownerState.disableRipple && {
+    '&:hover': {
+      backgroundColor: theme.vars
+        ? `rgba(${
+            ownerState.color === 'default'
+              ? theme.vars.palette.action.activeChannel
+              : theme.vars.palette[ownerState.color].mainChannel
+          } / ${theme.vars.palette.action.hoverOpacity})`
+        : alpha(
+            ownerState.color === 'default'
+              ? theme.palette.action.active
+              : theme.palette[ownerState.color].main,
+            theme.palette.action.hoverOpacity,
+          ),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
     },
-  },
+  }),
   ...(ownerState.color !== 'default' && {
     [`&.${radioClasses.checked}`]: {
       color: (theme.vars || theme).palette[ownerState.color].main,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This is follow-up of #16866. As per this [comment](https://github.com/mui/material-ui/issues/16866#issuecomment-888439054), checkbox has been done, and I have checked that IconButton is also done [here](https://github.com/mui/material-ui/pull/29298). Only the Radio component left to be handled.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
