### PR TITLE
[website] Use `span` for icon image

### DIFF
--- a/docs/src/components/icon/IconImage.tsx
+++ b/docs/src/components/icon/IconImage.tsx
@@ -96,7 +96,7 @@ export default function IconImage(props: IconImageProps) {
   }
   if (!mounted && !!theme.vars) {
     // Prevent hydration mismatch between the light and dark mode image source.
-    return <Box sx={{ width, height, display: 'inline-block' }} />;
+    return <Box component="span" sx={{ width, height, display: 'inline-block' }} />;
   }
   const element = (
     <Img


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Found this issue while [migrating pages to CSS theme variables](https://github.com/mui/material-ui/issues/34880). The `Box` defaults to div which can not be used inside a Typography.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
