### PR TITLE
[base] Avoid setting state during render

### DIFF
--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -95,9 +95,12 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
   const filled = hasValue(value);
 
   const [focused, setFocused] = React.useState(false);
-  if (disabled && focused) {
-    setFocused(false);
-  }
+
+  React.useEffect(() => {
+    if (disabled && focused) {
+      setFocused(false);
+    }
+  }, [disabled, focused]);
 
   const ownerState: FormControlUnstyledOwnerState = {
     ...props,

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -94,13 +94,10 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
 
   const filled = hasValue(value);
 
-  const [focused, setFocused] = React.useState(false);
+  const [focusedState, setFocused] = React.useState(false);
+  const focused = focusedState && !disabled;
 
-  React.useEffect(() => {
-    if (disabled && focused) {
-      setFocused(false);
-    }
-  }, [disabled, focused]);
+  React.useEffect(() => setFocused((isFocused) => (disabled ? false : isFocused)), [disabled]);
 
   const ownerState: FormControlUnstyledOwnerState = {
     ...props,


### PR DESCRIPTION
Separating from https://github.com/mui/material-ui/pull/34849#discussion_r1007890250 just in case. Slightly altered the suggestion to reset focus immediately when the component is disabled