### PR TITLE
[base] Avoid calling setstate during renders

### DIFF
--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.tsx
@@ -94,10 +94,10 @@ const FormControlUnstyled = React.forwardRef(function FormControlUnstyled<
 
   const filled = hasValue(value);
 
-  const [focused, setFocused] = React.useState(false);
-  if (disabled && focused) {
-    setFocused(false);
-  }
+  const [focusedState, setFocused] = React.useState(false);
+  const focused = focusedState && !disabled;
+
+  React.useEffect(() => setFocused((isFocused) => (disabled ? false : isFocused)), [disabled]);
 
   const ownerState: FormControlUnstyledOwnerState = {
     ...props,


### PR DESCRIPTION
Extracting from https://github.com/mui/material-ui/pull/34849#discussion_r1007890250 just in case. I altered the suggestion to have the effect run less frequently, and to have the focus state update in the same render as the disabled state