### PR TITLE
[docs] Improve UI display for copy code

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -286,7 +286,7 @@ function createRender(context) {
 
       return `<div class="MuiCode-root"><pre><code class="language-${escape(lang, true)}">${
         escaped ? code : escape(code, true)
-      }</code></pre><button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">Copy <span class="MuiCode-copyKeypress"><span>(Or</span> $keyC<span>)</span></span></button></div>\n`;
+      }</code></pre><button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">Copy <span class="MuiCode-copyKeypress"><span>(or</span> $keyC<span>)</span></span></button></div>\n`;
     };
 
     const markedOptions = {

--- a/docs/src/modules/components/HighlightedCode.js
+++ b/docs/src/modules/components/HighlightedCode.js
@@ -64,7 +64,7 @@ const HighlightedCode = React.forwardRef(function HighlightedCode(props, ref) {
           >
             {copied ? 'Copied' : 'Copy'}&nbsp;
             <span className="MuiCode-copyKeypress">
-              <span>(Or</span> {key}C<span>)</span>
+              <span>(or</span> {key}C<span>)</span>
             </span>
           </button>
         )}


### PR DESCRIPTION
I suspect that it yields a better experience in lowercase:

**Before**
<img width="165" alt="Screenshot 2022-10-23 at 01 44 06" src="https://user-images.githubusercontent.com/3165635/197366376-428dcd61-39b9-438b-807b-dd59a5aad127.png">

https://6357aef90039260008eccf21--material-ui-docs.netlify.app/material-ui/react-avatar/#image-avatars

**After**
<img width="153" alt="Screenshot 2022-10-23 at 13 46 06" src="https://user-images.githubusercontent.com/3165635/197390240-e63c73e7-4b4e-4e57-9c69-8165da3aabf0.png">

https://deploy-preview-34950--material-ui.netlify.app/material-ui/react-avatar/#image-avatars