### PR TITLE
[docs] Fix code display in RTL

### DIFF
--- a/docs/src/components/markdown/MarkdownElement.tsx
+++ b/docs/src/components/markdown/MarkdownElement.tsx
@@ -12,7 +12,6 @@ const Root = styled('div')(({ theme }) => ({
   '& pre': {
     backgroundColor: theme.palette.primaryDark[800],
     color: '#f8f8f2', // fallback color until Prism's theme is loaded
-    direction: 'ltr',
     overflow: 'auto',
     margin: 0,
     WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -21,7 +21,7 @@ const Nav = styled('nav')(({ theme }) => ({
   overflowY: 'auto',
   paddingTop: 'calc(var(--MuiDocs-header-height) + 1rem)',
   paddingBottom: theme.spacing(2),
-  paddingRight: theme.spacing(4),
+  paddingRight: theme.spacing(4), // We can't use `padding` as stylis-plugin-rtl doesn't swap it
   display: 'none',
   [theme.breakpoints.up('sm')]: {
     display: 'block',

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -19,7 +19,9 @@ const Nav = styled('nav')(({ theme }) => ({
   position: 'sticky',
   height: '100vh',
   overflowY: 'auto',
-  padding: theme.spacing('calc(var(--MuiDocs-header-height) + 1rem)', 4, 2, 0),
+  paddingTop: 'calc(var(--MuiDocs-header-height) + 1rem)',
+  paddingBottom: theme.spacing(2),
+  paddingRight: theme.spacing(4),
   display: 'none',
   [theme.breakpoints.up('sm')]: {
     display: 'block',

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -47,6 +47,7 @@ const Root = styled('div')(({ theme }) => ({
     backgroundColor: alpha(theme.palette.primary.light, 0.15),
     borderRadius: 5,
     fontSize: theme.typography.pxToRem(13),
+    direction: 'ltr /*! @noflip */',
   },
   '& h1': {
     ...theme.typography.h3,

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -17,7 +17,6 @@ const Root = styled('div')(({ theme }) => ({
     backgroundColor: blueDark[800],
     color: '#f8f8f2', // fallback color until Prism's theme is loaded
     colorScheme: 'dark',
-    direction: 'ltr',
     borderRadius: theme.shape.borderRadius,
     border: '1px solid',
     borderColor: blueDark[700],
@@ -30,6 +29,7 @@ const Root = styled('div')(({ theme }) => ({
       maxWidth: 'calc(100vw - 32px - 16px)',
     },
   },
+  // Set the font for "inline" and "block" code elements
   '& code': {
     ...theme.typography.body2,
     fontFamily: brandingDarkTheme.typography.fontFamilyCode,
@@ -94,12 +94,7 @@ const Root = styled('div')(({ theme }) => ({
     color: theme.palette.mode === 'dark' ? theme.palette.grey[400] : theme.palette.grey[900],
   },
   '& ul': {
-    ...(theme.direction === 'rtl' && {
-      paddingRight: 30,
-    }),
-    ...(theme.direction !== 'rtl' && {
-      paddingLeft: 30,
-    }),
+    paddingLeft: 30,
   },
   '& h1, & h2, & h3, & h4': {
     '& code': {
@@ -408,6 +403,7 @@ const Root = styled('div')(({ theme }) => ({
     cursor: 'pointer',
   },
   '& .MuiCode-root': {
+    direction: 'ltr /*! @noflip */',
     position: 'relative',
     '&:hover': {
       '& .MuiCode-copy': {
@@ -422,7 +418,7 @@ const Root = styled('div')(({ theme }) => ({
     cursor: 'pointer',
     position: 'absolute',
     top: theme.spacing(1),
-    right: theme.spacing(1),
+    right: `${theme.spacing(1)} /*! @noflip */`,
     fontFamily: 'inherit',
     fontSize: theme.typography.pxToRem(13),
     fontWeight: 500,


### PR DESCRIPTION
We had a regression in the RTL handling of the code blocks from #15996 with the migration from JSS to emotion. 

Emotion swaps the direction in RTL, so we disable it to fix. The main value isn't to fix the RTL but to test that it can be fixed. I had to use https://github.com/styled-components/stylis-plugin-rtl/issues/24#issuecomment-1126894682 to make it work.

**Before**

<img width="1140" alt="Screenshot 2022-10-23 at 13 19 37" src="https://user-images.githubusercontent.com/3165635/197389130-0d3d7087-dcd6-4456-aeb4-e8e3696c6355.png">

https://6357aef90039260008eccf21--material-ui-docs.netlify.app/material-ui/react-avatar/#image-avatars

**After**

<img width="801" alt="Screenshot 2022-10-30 at 17 33 15" src="https://user-images.githubusercontent.com/3165635/198890132-8f67912e-bd0b-47e5-8a36-5f992903a068.png">

https://deploy-preview-34951--material-ui.netlify.app/material-ui/react-avatar/#image-avatars