### PR TITLE
[docs] Fix spelling mistake

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -94,7 +94,7 @@ const pages: MuiPage[] = [
         pathname: '/material-ui/components/navigation',
         subheader: 'navigation',
         children: [
-          { pathname: '/material-ui/react-bottom-navigation', title: 'Button Navigation' },
+          { pathname: '/material-ui/react-bottom-navigation', title: 'Bottom Navigation' },
           { pathname: '/material-ui/react-breadcrumbs' },
           { pathname: '/material-ui/react-drawer' },
           { pathname: '/material-ui/react-link' },

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -266,7 +266,7 @@
     "/material-ui/react-app-bar": "App Bar",
     "/material-ui/react-card": "Card",
     "/material-ui/react-paper": "Paper",
-    "/material-ui/react-bottom-navigation": "Button Navigation",
+    "/material-ui/react-bottom-navigation": "Bottom Navigation",
     "/material-ui/react-breadcrumbs": "Breadcrumbs",
     "/material-ui/react-drawer": "Drawer",
     "/material-ui/react-link": "Link",


### PR DESCRIPTION
Changed the spelling on the documentation site. The URL with [https://mui.com/material-ui/react-bottom-navigation/](https://mui.com/material-ui/react-bottom-navigation/)
had button navigation as a sub-heading.

originally it should be the bottom navigation subheading..


![Screenshot_20221030_112354](https://user-images.githubusercontent.com/110713318/198894278-315710e7-8d9d-4053-af42-9bafabbe2ec9.png)
