### PR TITLE
[docs] Fix missing emotion prefixes

### DIFF
--- a/docs/src/createEmotionCache.ts
+++ b/docs/src/createEmotionCache.ts
@@ -1,6 +1,6 @@
 /* eslint-disable default-case */
 import createCache from '@emotion/cache';
-import { Element, RULESET } from 'stylis';
+import { prefixer, Element, RULESET } from 'stylis';
 
 // A workaround to https://github.com/emotion-js/emotion/issues/2836
 // to be able to use `:where` selector for styling.
@@ -19,5 +19,5 @@ function globalSelector(element: Element) {
 
 export default function createEmotionCache() {
   // TODO remove prepend: true once JSS is out
-  return createCache({ key: 'css', prepend: true, stylisPlugins: [globalSelector] });
+  return createCache({ key: 'css', prepend: true, stylisPlugins: [prefixer, globalSelector] });
 }


### PR DESCRIPTION
This fixes a regression introduced in #33545. I have notice it when I was looking at the screenshot of #34859, it looked wrong, the header background is meant to be blurred:

<img width="481" alt="Screenshot 2022-10-30 at 21 37 38" src="https://user-images.githubusercontent.com/3165635/198900501-54f672b2-c6ae-4a52-a6bd-3de1e7c8a30f.png">

Why does this happen? Because of https://github.com/emotion-js/emotion/blob/d8a13bcae81812d3dff643bcf446709f965f0909/packages/cache/src/index.js#L84. My end goal is to get a nice reading experience for the blog on iOS.