### PR TITLE
[website] Remove one DOM node

### DIFF
--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -37,11 +37,13 @@ export default function GetStartedButtons({
         size="large"
         variant="contained"
         endIcon={<KeyboardArrowRightRounded />}
-        sx={{ mr: { xs: 0, sm: 2 } }}
+        sx={{
+          mr: { xs: 0, sm: 2 },
+          mb: { xs: 2, sm: 0 },
+        }}
       >
         Get started
       </Button>
-      <Box sx={{ py: 1, display: { xs: 'block', sm: 'hidden' } }} />
       <Button
         size="large"
         // @ts-expect-error


### PR DESCRIPTION
To reproduce the issue: https://validator.w3.org/nu/?doc=https%3A%2F%2Fmui.com%2F

<img width="507" alt="Screenshot 2022-10-30 at 23 38 47" src="https://user-images.githubusercontent.com/3165635/198905087-920662c6-7e23-4d8d-aecf-cc0ad9c71417.png">

We mixed `display: none` with `visibility: hidden`, the CSS is wrong. As it turns out, we don't need to create a Box, the performance should be better without it.