### PR TITLE
[Stack] Fix spacing when there are <style> children

### DIFF
--- a/docs/data/material/components/dividers/DividerText.js
+++ b/docs/data/material/components/dividers/DividerText.js
@@ -6,7 +6,7 @@ import Chip from '@mui/material/Chip';
 const Root = styled('div')(({ theme }) => ({
   width: '100%',
   ...theme.typography.body2,
-  '& > :not(style) + :not(style)': {
+  '& > :not(style) ~ :not(style)': {
     marginTop: theme.spacing(2),
   },
 }));

--- a/docs/data/material/components/dividers/DividerText.tsx
+++ b/docs/data/material/components/dividers/DividerText.tsx
@@ -6,7 +6,7 @@ import Chip from '@mui/material/Chip';
 const Root = styled('div')(({ theme }) => ({
   width: '100%',
   ...theme.typography.body2,
-  '& > :not(style) + :not(style)': {
+  '& > :not(style) ~ :not(style)': {
     marginTop: theme.spacing(2),
   },
 }));

--- a/docs/data/material/components/links/Links.js
+++ b/docs/data/material/components/links/Links.js
@@ -10,7 +10,7 @@ export default function Links() {
     <Box
       sx={{
         typography: 'body1',
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           ml: 2,
         },
       }}

--- a/docs/data/material/components/links/Links.tsx
+++ b/docs/data/material/components/links/Links.tsx
@@ -10,7 +10,7 @@ export default function Links() {
     <Box
       sx={{
         typography: 'body1',
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           ml: 2,
         },
       }}

--- a/docs/data/material/components/links/UnderlineLink.js
+++ b/docs/data/material/components/links/UnderlineLink.js
@@ -13,7 +13,7 @@ export default function UnderlineLink() {
         flexWrap: 'wrap',
         justifyContent: 'center',
         typography: 'body1',
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           ml: 2,
         },
       }}

--- a/docs/data/material/components/links/UnderlineLink.tsx
+++ b/docs/data/material/components/links/UnderlineLink.tsx
@@ -13,7 +13,7 @@ export default function UnderlineLink() {
         flexWrap: 'wrap',
         justifyContent: 'center',
         typography: 'body1',
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           ml: 2,
         },
       }}

--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -29,21 +29,21 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       '@media (min-width:0px)': {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '8px',
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginLeft: '16px',
         },
         flexDirection: 'row',
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginLeft: '32px',
         },
@@ -64,14 +64,14 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '16px',
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginLeft: '16px',
         },
@@ -93,13 +93,13 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '16px',
         },
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '32px',
         },
@@ -120,19 +120,19 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '16px',
         },
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '0px',
         },
       },
       [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '32px',
         },
@@ -152,7 +152,7 @@ describe('<Stack />', () => {
         theme,
       }),
     ).to.deep.equal({
-      '& > :not(style) + :not(style)': {
+      '& > :not(style) ~ :not(style)': {
         margin: 0,
         marginLeft: '24px',
       },
@@ -172,14 +172,14 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       '@media (min-width:0px)': {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '8px',
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '16px',
         },
@@ -200,7 +200,7 @@ describe('<Stack />', () => {
           theme,
         }),
       ).to.deep.equal({
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginBottom: '8px',
         },
@@ -220,21 +220,21 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         '@media (min-width:0px)': {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '8px',
           },
           flexDirection: 'column',
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginLeft: '16px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginLeft: '24px',
           },
@@ -272,26 +272,26 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '0px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginLeft: '16px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginLeft: '32px',
           },
@@ -310,33 +310,33 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '0px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginLeft: '0px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginLeft: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '16px',
           },
           flexDirection: 'column',
         },
         [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '32px',
           },
@@ -359,19 +359,19 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         '@media (min-width:0px)': {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '8px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '24px',
           },
@@ -403,7 +403,7 @@ describe('<Stack />', () => {
           theme: customTheme,
         }),
       ).to.deep.equal({
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           marginTop: '32px',
         },
@@ -435,7 +435,7 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${customTheme.breakpoints.values.small}px)`]: {
-          '& > :not(style) + :not(style)': {
+          '& > :not(style) ~ :not(style)': {
             margin: 0,
             marginTop: '32px',
           },

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -135,7 +135,7 @@ export const style = ({ ownerState, theme }: StyleFunctionProps) => {
         return { gap: getValue(transformer, propValue) };
       }
       return {
-        '& > :not(style) + :not(style)': {
+        '& > :not(style) ~ :not(style)': {
           margin: 0,
           [`margin${getSideFromDirection(
             breakpoint ? directionValues[breakpoint] : ownerState.direction,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fix #34965.

And looking at the CSS used by the `<Stack>` component, it looks like the issue is the way the children that the margin is applied to are selected: `& > :not(style) + :not(style)`. This excludes any children that have a `<style>` element in front of them.

By swapping the `+`  (adjacent sibling) combinator for the `~` (general sibling) combinator, this issue should be fixed without affecting anything else.
