### PR TITLE
[examples] Next.js examples v13 - fonts

### DIFF
--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
+    "@next/font": "^13.0.0",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
-    "@next/font": "^13.0.0",
+    "@next/font": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
 import theme, { roboto } from '../src/theme';

--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -1,21 +1,16 @@
-import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
-import theme from '../src/theme';
+import theme, { roboto } from '../src/theme';
 import createEmotionCache from '../src/createEmotionCache';
 
 export default class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className={roboto.className}>
         <Head>
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link rel="shortcut icon" href="/favicon.ico" />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-          />
           <meta name="emotion-insertion-point" content="" />
           {(this.props as any).emotionStyleTags}
         </Head>

--- a/examples/nextjs-with-typescript/src/theme.ts
+++ b/examples/nextjs-with-typescript/src/theme.ts
@@ -1,5 +1,8 @@
+import { Roboto } from '@next/font/google';
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
+
+export const roboto = Roboto({ weight: '400', subsets: ['latin'], fallback: [ 'Helvetica', 'Arial', 'sans-serif'] });
 
 // Create a theme instance.
 const theme = createTheme({
@@ -14,6 +17,9 @@ const theme = createTheme({
       main: red.A400,
     },
   },
+  typography: {
+    fontFamily: roboto.style.fontFamily,
+  }
 });
 
 export default theme;

--- a/examples/nextjs-with-typescript/src/theme.ts
+++ b/examples/nextjs-with-typescript/src/theme.ts
@@ -3,10 +3,10 @@ import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
 export const roboto = Roboto({
-  weight: ['300','400','500','700'],
+  weight: ['300', '400', '500', '700'],
   subsets: ['latin'],
   display: 'swap',
-  fallback: [ 'Helvetica', 'Arial', 'sans-serif']
+  fallback: ['Helvetica', 'Arial', 'sans-serif'],
 });
 
 // Create a theme instance.
@@ -24,7 +24,7 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: roboto.style.fontFamily,
-  }
+  },
 });
 
 export default theme;

--- a/examples/nextjs-with-typescript/src/theme.ts
+++ b/examples/nextjs-with-typescript/src/theme.ts
@@ -2,7 +2,12 @@ import { Roboto } from '@next/font/google';
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
-export const roboto = Roboto({ weight: '400', subsets: ['latin'], fallback: [ 'Helvetica', 'Arial', 'sans-serif'] });
+export const roboto = Roboto({
+  weight: '400',
+  subsets: ['latin'],
+  display: 'swap',
+  fallback: [ 'Helvetica', 'Arial', 'sans-serif']
+});
 
 // Create a theme instance.
 const theme = createTheme({

--- a/examples/nextjs-with-typescript/src/theme.ts
+++ b/examples/nextjs-with-typescript/src/theme.ts
@@ -3,7 +3,7 @@ import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
 export const roboto = Roboto({
-  weight: '400',
+  weight: ['300','400','500','700'],
   subsets: ['latin'],
   display: 'swap',
   fallback: [ 'Helvetica', 'Arial', 'sans-serif']

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
-    "@next/font": "^13.0.0",
+    "@next/font": "latest",
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
+    "@next/font": "^13.0.0",
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,21 +1,16 @@
-import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
-import theme from '../src/theme';
+import theme, { roboto } from '../src/theme';
 import createEmotionCache from '../src/createEmotionCache';
 
 export default class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className={roboto.className}>
         <Head>
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link rel="shortcut icon" href="/favicon.ico" />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-          />
           <meta name="emotion-insertion-point" content="" />
           {this.props.emotionStyleTags}
         </Head>

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
 import theme, { roboto } from '../src/theme';

--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -1,5 +1,8 @@
+import { Roboto } from '@next/font/google';
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
+
+export const roboto = Roboto({ weight: '400', subsets: ['latin'], fallback: [ 'Helvetica', 'Arial', 'sans-serif'] });
 
 // Create a theme instance.
 const theme = createTheme({
@@ -14,6 +17,9 @@ const theme = createTheme({
       main: red.A400,
     },
   },
+  typography: {
+    fontFamily: roboto.style.fontFamily,
+  }
 });
 
 export default theme;

--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -3,10 +3,10 @@ import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
 export const roboto = Roboto({
-  weight: ['300','400','500','700'],
+  weight: ['300', '400', '500', '700'],
   subsets: ['latin'],
   display: 'swap',
-  fallback: [ 'Helvetica', 'Arial', 'sans-serif']
+  fallback: ['Helvetica', 'Arial', 'sans-serif'],
 });
 
 // Create a theme instance.
@@ -24,7 +24,7 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: roboto.style.fontFamily,
-  }
+  },
 });
 
 export default theme;

--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -2,7 +2,12 @@ import { Roboto } from '@next/font/google';
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
-export const roboto = Roboto({ weight: '400', subsets: ['latin'], fallback: [ 'Helvetica', 'Arial', 'sans-serif'] });
+export const roboto = Roboto({
+  weight: '400',
+  subsets: ['latin'],
+  display: 'swap',
+  fallback: [ 'Helvetica', 'Arial', 'sans-serif']
+});
 
 // Create a theme instance.
 const theme = createTheme({

--- a/examples/nextjs/src/theme.js
+++ b/examples/nextjs/src/theme.js
@@ -3,7 +3,7 @@ import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 
 export const roboto = Roboto({
-  weight: '400',
+  weight: ['300','400','500','700'],
   subsets: ['latin'],
   display: 'swap',
   fallback: [ 'Helvetica', 'Arial', 'sans-serif']


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Background 📚
Relates to #34898

Next.js v13 introduces a brand new font system which automatically optimizes your fonts and makes using Google fonts super convinient. This feature is currently in beta

[Next.js v13 release blog post](https://nextjs.org/blog/next-13#breaking-changes)
[Next.js font optimization docs](https://beta.nextjs.org/docs/optimizing/fonts)
[@next/font API reference](https://beta.nextjs.org/docs/api-reference/components/font)

This feature is currently in beta but could improve the font loading experience already today. Multiple fontWeigths aren't yet supported without multiple individual font variables, https://github.com/vercel/next.js/issues/41969

If we feel like the pull request is too early and should wait for a stable `@next/font` release then this could be turned into a draft and brought back later

## Changes 🕹

- Install `@next/font` package
- Use `@next/font` for loading fonts instead of a link stylesheet

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
