### PR TITLE
[docs] New API design rule disabled > disable

### DIFF
--- a/docs/data/material/guides/api/api.md
+++ b/docs/data/material/guides/api/api.md
@@ -91,16 +91,23 @@ Nested components inside a component have:
 
 ### Prop naming
 
-The name of a boolean prop should be chosen based on the **default value**. This choice allows:
+- **Boolean**
 
-- the shorthand notation. For example, the `disabled` attribute on an input element, if supplied, defaults to `true`:
+  - The default value of a boolean prop should be `false`. This choice allows the shorthand notation For example an input is by default enabled: How to name the prop that controls this state? It should be called `disabled` because:
 
-  ```jsx
-  <Input enabled={false} /> ❌
-  <Input disabled /> ✅
-  ```
+    ```jsx
+    ❌ <Input enabled={false} />
+    ✅ <Input disabled />
+    ```
 
-- developers to know what the default value is from the name of the boolean prop. It's always the opposite.
+  - The name of the boolean, if composed of a single word, should be an adjective or a noun and not a verb. This is because the prop describes a state. For example an input prop can be controlled by a state, which wouldn't be called with a verb:
+
+    ```jsx
+    const [disabled, setDisabled] = React.useState(false);
+
+    ❌ <Input disable={disabled} />
+    ✅ <Input disabled={disabled} />
+    ```
 
 ### Controlled components
 

--- a/docs/data/material/guides/api/api.md
+++ b/docs/data/material/guides/api/api.md
@@ -93,14 +93,14 @@ Nested components inside a component have:
 
 - **Boolean**
 
-  - The default value of a boolean prop should be `false`. This choice allows the shorthand notation For example an input is by default enabled: How to name the prop that controls this state? It should be called `disabled` because:
+  - The default value of a boolean prop should be `false`. This allows for better shorthand notation. Consider an example of an input that is enabled by default. How should you name the prop that controls this state? It should be called `disabled`:
 
     ```jsx
     ❌ <Input enabled={false} />
     ✅ <Input disabled />
     ```
 
-  - The name of the boolean, if composed of a single word, should be an adjective or a noun and not a verb. This is because the prop describes a state. For example an input prop can be controlled by a state, which wouldn't be called with a verb:
+  - If the name of the boolean is a single word, it should be an adjective or a noun rather than a verb. This is because props describe _states_ and not _actions_. For example an input prop can be controlled by a state, which wouldn't be described with a verb:
 
     ```jsx
     const [disabled, setDisabled] = React.useState(false);


### PR DESCRIPTION
Close #34895. It's a quick iteration. From the outcome of the meeting, it seemed that the conclusion was: pick what's most consistent with the rest of the codebase. This definitely feels like what the rest of the codebase is doing.

Preview: https://deploy-preview-34972--material-ui.netlify.app/material-ui/guides/api/#prop-naming

---

Regarding https://github.com/mui/material-ui/issues/34895#issuecomment-1295913044, I increasingly feel that A > B.