### PR TITLE
[System] Calls unstable_createStyleFunctionSx with passed in arg

### DIFF
--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.js
@@ -95,7 +95,7 @@ export function unstable_createStyleFunctionSx(styleFunctionMapping = defaultSty
   return styleFunctionSx;
 }
 
-const styleFunctionSx = unstable_createStyleFunctionSx();
+const styleFunctionSx = unstable_createStyleFunctionSx(defaultStyleFunctionMapping);
 
 styleFunctionSx.filterProps = ['sx'];
 


### PR DESCRIPTION
- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

# What does this fix
The purpose of this PR is to fix compatibility issues with [turbopack](https://turbo.build/repo) for next.js 13. The issue can be found in [this open issue](https://github.com/mui/material-ui/issues/34910)

Fixes #34910 


## What changes were made to fix this
For uknown reasons `unstable_createStyleFunctionSx` on line 98 was not able to grab the import to use as a default on its own when ran with [turbopack](https://turbo.build/repo) bundler causing a reference error shown in git issue link above

