### PR TITLE
[website] Fix call-to-action buttons layout for some smaller screens

### DIFF
--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -26,6 +26,7 @@ export default function GetStartedButtons({
       sx={{
         display: 'flex',
         flexWrap: 'wrap',
+        gap: '20px',
         '&& > *': { minWidth: 'clamp(0px, (492px - 100%) * 999 ,100%)' },
         ...props.sx,
       }}
@@ -37,10 +38,6 @@ export default function GetStartedButtons({
         size="large"
         variant="contained"
         endIcon={<KeyboardArrowRightRounded />}
-        sx={{
-          mr: { xs: 0, sm: 2 },
-          mb: { xs: 2, sm: 0 },
-        }}
       >
         Get started
       </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
As you can see in the attached video (refresh the page if you see just an image), the call-to-action buttons get glued for some smaller screens. This PR fixes this issue (demo also in the attached video).
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://user-images.githubusercontent.com/63708012/200124486-17ae1147-9903-48f3-a23e-45e10b63a881.mp4

