### PR TITLE
[docs] Improve code font family

### DIFF
--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -224,7 +224,11 @@ export const getDesignTokens = (mode: 'light' | 'dark') =>
     spacing: 10,
     typography: {
       fontFamily: ['"IBM Plex Sans"', ...systemFont].join(','),
-      fontFamilyCode: ['Menlo', 'Monaco', 'Consolas', 'monospace'].join(','),
+      fontFamilyCode: [
+        'Menlo', // macOS
+        'Lucida Console', // Windows
+        'monospace', // fallback
+      ].join(','),
       fontFamilyTagline: ['"PlusJakartaSans-ExtraBold"', ...systemFont].join(','),
       fontFamilySystem: systemFont.join(','),
       fontWeightSemiBold: 600,

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -224,7 +224,7 @@ export const getDesignTokens = (mode: 'light' | 'dark') =>
     spacing: 10,
     typography: {
       fontFamily: ['"IBM Plex Sans"', ...systemFont].join(','),
-      fontFamilyCode: ['Consolas', 'Monaco', 'Andale Mono', 'Ubuntu Mono', 'monospace'].join(','),
+      fontFamilyCode: ['Menlo', 'Monaco', 'Consolas', 'monospace'].join(','),
       fontFamilyTagline: ['"PlusJakartaSans-ExtraBold"', ...systemFont].join(','),
       fontFamilySystem: systemFont.join(','),
       fontWeightSemiBold: 600,


### PR DESCRIPTION
The regression was introduced in https://github.com/mui/material-ui/pull/34954/files#r1008895718. It wasn't such a good idea.

Instead, we can use https://reactjs.org/docs/higher-order-components.html, https://beta.nextjs.org/docs/optimizing/images, https://beta.reactjs.org/learn/state-as-a-snapshot, https://tailwindcss.com/docs/installation, VS Code font families as benchmarks for what might look best

Before: https://master--material-ui.netlify.app/material-ui/react-button/#basic-button
After: https://deploy-preview-35027--material-ui.netlify.app/material-ui/react-button/#basic-button 