### PR TITLE
[docs] Improve code font family v2

### DIFF
--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -224,9 +224,13 @@ export const getDesignTokens = (mode: 'light' | 'dark') =>
     spacing: 10,
     typography: {
       fontFamily: ['"IBM Plex Sans"', ...systemFont].join(','),
+      // Match VS Code
+      // https://github.com/microsoft/vscode/blob/b38691f611d1ce3ef437c67a1b047c757b7b4e53/src/vs/editor/common/config/editorOptions.ts#L4578-L4580
+      // https://github.com/microsoft/vscode/blob/d950552131d7350a45dac8b59bf179469c36c2ac/src/vs/editor/standalone/browser/standalone-tokens.css#L10
       fontFamilyCode: [
         'Menlo', // macOS
-        'Lucida Console', // Windows
+        'Consolas', // Windows
+        '"Droid Sans Mono"', // Linux
         'monospace', // fallback
       ].join(','),
       fontFamilyTagline: ['"PlusJakartaSans-ExtraBold"', ...systemFont].join(','),


### PR DESCRIPTION
Act on https://github.com/mui/material-ui/pull/35027#issuecomment-1307291985. I think that we have it right this time on macOS and Windows. We match the default font on VS Code.

Regarding Linux, I'm not sure. @flaviendelangle As you are on Linux, do you see changes between 

Before: https://631f4503cb19a90009794dfc--material-ui-docs.netlify.app/material-ui/react-alert/#basic-alerts
After: https://deploy-preview-35053--material-ui.netlify.app/material-ui/react-alert/#basic-alerts?

I'm adding 3 reviewers, each on a different platform.

---

Off-topic, I saw a few interesting custom fonts used during my benchmark:

- Replit: `ReplitHack`
- Codesandbox: https://www.monolisa.dev/
- Tailwind CSS: https://github.com/tonsky/FiraCode