### PR TITLE
[docs] Fix scroll issue on expanded live demos

### DIFF
--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -42,8 +42,10 @@ const StyledSimpleCodeEditor = styled(SimpleCodeEditor)(({ theme }) => ({
   minWidth: '100%',
   '& pre': {
     // The scroll container needs to be the parent of the editor
-    maxHeight: 'initial',
     maxWidth: 'initial',
+    // Avoid this https://github.com/mui/material-ui/blob/master/docs/src/modules/components/MarkdownElement.js#L27
+    // from taking precedence for the max-height
+    maxHeight: 'initial!important',
   },
   '& textarea': {
     outline: 'none',

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -28,6 +28,12 @@ const StyledMarkdownElement = styled(MarkdownElement)(({ theme }) => ({
       }`,
     },
   },
+  '& pre': {
+    // The scroll container needs to be the parent of the editor, overriding:
+    // https://github.com/mui/material-ui/blob/269c1d0c7572fcb6ae3b270a2622d16c7e40c848/docs/src/modules/components/MarkdownElement.js#L27-L26
+    maxWidth: 'initial',
+    maxHeight: 'initial',
+  },
 })) as any;
 
 const StyledSimpleCodeEditor = styled(SimpleCodeEditor)(({ theme }) => ({
@@ -40,13 +46,6 @@ const StyledSimpleCodeEditor = styled(SimpleCodeEditor)(({ theme }) => ({
   direction: 'ltr /*! @noflip */' as any,
   float: 'left',
   minWidth: '100%',
-  '& pre': {
-    // The scroll container needs to be the parent of the editor
-    maxWidth: 'initial',
-    // Avoid this https://github.com/mui/material-ui/blob/master/docs/src/modules/components/MarkdownElement.js#L27
-    // from taking precedence for the max-height
-    maxHeight: 'initial!important',
-  },
   '& textarea': {
     outline: 'none',
   },


### PR DESCRIPTION
close #35095

This is a follow-up on #34870, fixing this bug:

1. Open https://mui.com/material-ui/react-tabs/#basic-tabs, e.g. Chrome (I'm using Brave)
2. Turn the dark mode on
3.

https://user-images.githubusercontent.com/19550456/200823731-69ffddf1-6054-4c9c-82c1-2c015590c448.mov

The solution is to move the style override to the same `styled()` element so that emotion can inject the styles in the right order in the DOM.

https://deploy-preview-35064--material-ui.netlify.app/material-ui/react-tabs/#basic-tabs