### PR TITLE
[examples] Updated Remix examples with the lates changes using React 18

### DIFF
--- a/examples/remix-with-typescript/app/entry.client.tsx
+++ b/examples/remix-with-typescript/app/entry.client.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { startTransition } from "react";
-import { hydrateRoot } from "react-dom/client";
+import { startTransition } from 'react';
+import { hydrateRoot } from 'react-dom/client';
 import { RemixBrowser } from 'remix';
 import { CacheProvider } from '@emotion/react';
 import { ThemeProvider } from '@mui/material/styles';

--- a/examples/remix-with-typescript/app/entry.client.tsx
+++ b/examples/remix-with-typescript/app/entry.client.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { hydrate } from 'react-dom';
+import { startTransition, StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
 import { RemixBrowser } from 'remix';
 import { CacheProvider } from '@emotion/react';
 import { ThemeProvider } from '@mui/material/styles';
@@ -31,13 +32,25 @@ function ClientCacheProvider({ children }: ClientCacheProviderProps) {
   );
 }
 
-hydrate(
-  <ClientCacheProvider>
-    <ThemeProvider theme={theme}>
-      {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-      <CssBaseline />
-      <RemixBrowser />
-    </ThemeProvider>
-  </ClientCacheProvider>,
-  document,
-);
+const hydrate = () => {
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <ClientCacheProvider>
+        <ThemeProvider theme={theme}>
+          {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
+          <CssBaseline />
+          <RemixBrowser />
+        </ThemeProvider>
+      </ClientCacheProvider>,
+    );
+  });
+};
+
+if (window.requestIdleCallback) {
+  window.requestIdleCallback(hydrate);
+} else {
+  // Safari doesn't support requestIdleCallback
+  // https://caniuse.com/requestidlecallback
+  window.setTimeout(hydrate, 1);
+}

--- a/examples/remix-with-typescript/app/entry.client.tsx
+++ b/examples/remix-with-typescript/app/entry.client.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { startTransition, StrictMode } from "react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { RemixBrowser } from 'remix';
 import { CacheProvider } from '@emotion/react';

--- a/examples/remix-with-typescript/package.json
+++ b/examples/remix-with-typescript/package.json
@@ -14,8 +14,10 @@
     "@emotion/server": "latest",
     "@emotion/styled": "latest",
     "@mui/material": "latest",
+    "@remix-run/node": "latest",
     "@remix-run/react": "latest",
     "@remix-run/serve": "latest",
+    "@remix-run/server-runtime": "latest",
     "react": "latest",
     "react-dom": "latest",
     "remix": "latest"


### PR DESCRIPTION
From https://github.com/mui/material-ui/issues/34991 

This should 'just work' with the updated `entry.client.tsx` for Remix latest and React 18

Note that the latest `entry.server.tsx` in the Remix blog tutorial uses `renderToPipeableStream`, although based on https://github.com/emotion-js/emotion/issues/2800 - I'm not sure this is possible yet.

For interest only, below is what the `renderToPipeableStream` would look like in `entry.server.tsx` if it were supported.

Hope this helps.

```js
import { PassThrough } from "stream";
import type { EntryContext } from "@remix-run/node";
import { Response } from "@remix-run/node";
import { RemixServer } from "@remix-run/react";
import isbot from "isbot";
import { renderToPipeableStream } from "react-dom/server";

const ABORT_DELAY = 5000;

export default function handleRequest(
  request: Request,
  responseStatusCode: number,
  responseHeaders: Headers,
  remixContext: EntryContext
) {
  const callbackName = isbot(request.headers.get("user-agent"))
    ? "onAllReady"
    : "onShellReady";

  return new Promise((resolve, reject) => {
    let didError = false;

    const { pipe, abort } = renderToPipeableStream(
      <RemixServer context={remixContext} url={request.url} />,
      {
        [callbackName]: () => {
          const body = new PassThrough();

          responseHeaders.set("Content-Type", "text/html");

          resolve(
            new Response(body, {
              headers: responseHeaders,
              status: didError ? 500 : responseStatusCode,
            })
          );

          pipe(body);
        },
        onShellError: (err: unknown) => {
          reject(err);
        },
        onError: (error: unknown) => {
          didError = true;

          console.error(error);
        },
      }
    );

    setTimeout(abort, ABORT_DELAY);
  });
}
```
