### PR TITLE
[core] Fix job name to match the CI

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -16,7 +16,7 @@ on:
 permissions: {}
 
 jobs:
-  build:
+  test-dev:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From the [docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks), "Make sure that the name key and required job name in both the workflow files are the same".

I hope I got it right this time to match the [main CI](https://github.com/siriwatknp/material-ui/blob/5ce57e9b874447f942a2ef48d1d557fab383f3f9/.github/workflows/ci.yml).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
