### PR TITLE
[docs] Fix bugs with live edit demos

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -94,13 +94,7 @@ function useDemoData(codeVariant, demo, githubLocation) {
   }, [canonicalAs, codeVariant, demo, githubLocation, userLanguage]);
 }
 
-function useDemoElement({
-  demoOptions,
-  demoData,
-  editorCode,
-  initialEditorCode,
-  setDebouncedError,
-}) {
+function useDemoElement({ demoOptions, demoData, editorCode, setDebouncedError }) {
   const debouncedSetError = React.useMemo(
     () => debounce(setDebouncedError, 300),
     [setDebouncedError],
@@ -114,17 +108,9 @@ function useDemoElement({
 
   // Memoize to avoid rendering the demo more than it needs to be.
   // For example, avoid a render when the demo is hovered.
-  return React.useMemo(() => {
-    if (
-      // No need for a live environment if the code matches with the component rendered server-side.
-      editorCode.value === initialEditorCode ||
-      // A limitation from https://github.com/nihgwu/react-runner, we can inject the `window` of the iframe
-      demoOptions.disableLiveEdit
-    ) {
-      return <demoData.Component />;
-    }
-
-    return (
+  const BundledComponent = React.useMemo(() => <demoData.Component />, [demoData]);
+  const LiveComponent = React.useMemo(
+    () => (
       <ReactRunner
         scope={demoData.scope}
         onError={debouncedSetError}
@@ -137,8 +123,17 @@ function useDemoElement({
             : editorCode.value
         }
       />
-    );
-  }, [demoData, demoOptions.disableLiveEdit, editorCode, initialEditorCode, debouncedSetError]);
+    ),
+    [demoData, debouncedSetError, editorCode.isPreview, editorCode.value],
+  );
+
+  const renderBundledComponent =
+    // No need for a live environment if the code matches with the component rendered server-side.
+    editorCode.value === editorCode.initialEditorCode ||
+    // A limitation from https://github.com/nihgwu/react-runner, we can inject the `window` of the iframe
+    demoOptions.disableLiveEdit;
+
+  return renderBundledComponent ? BundledComponent : LiveComponent;
 }
 
 const Root = styled('div')(({ theme }) => ({
@@ -374,12 +369,14 @@ export default function Demo(props) {
   const [editorCode, setEditorCode] = React.useState({
     value: initialEditorCode,
     isPreview,
+    initialEditorCode,
   });
 
   const resetDemo = () => {
     setEditorCode({
       value: initialEditorCode,
       isPreview,
+      initialEditorCode,
     });
     setDemoKey();
   };
@@ -388,6 +385,7 @@ export default function Demo(props) {
     setEditorCode({
       value: initialEditorCode,
       isPreview,
+      initialEditorCode,
     });
   }, [initialEditorCode, isPreview]);
 
@@ -397,7 +395,6 @@ export default function Demo(props) {
     demoOptions,
     demoData,
     editorCode,
-    initialEditorCode,
     setDebouncedError,
   });
 


### PR DESCRIPTION
Fix issue 2 reported in https://github.com/mui/material-ui/pull/34870#issuecomment-1307966805. To reproduce:

1. Open https://mui.com/material-ui/react-switch/#basic-switches
2. Enjoy, the switch shouldn't change its state

![bad](https://user-images.githubusercontent.com/3165635/201476487-276ed755-6222-49c8-a3d5-1a2659333345.gif)

This is particularly a bad UX on the data grid demos, where you most often need to open the demos, and where you lose the state of what you were looking at on the grid. 

https://deploy-preview-35106--material-ui.netlify.app/material-ui/react-switch/#basic-switches