### PR TITLE
[website] Improve visual design app bar

### DIFF
--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -26,11 +26,11 @@ const Header = styled('header')(({ theme }) => [
     zIndex: theme.zIndex.appBar,
     backdropFilter: 'blur(20px)',
     boxShadow: `inset 0px -1px 1px ${(theme.vars || theme).palette.grey[100]}`,
-    backgroundColor: 'rgba(255,255,255,0.72)',
+    backgroundColor: 'rgba(255,255,255,0.8)',
   },
   theme.applyDarkStyles({
     boxShadow: `inset 0px -1px 1px ${(theme.vars || theme).palette.primaryDark[700]}`,
-    backgroundColor: alpha(theme.palette.primaryDark[900], 0.72),
+    backgroundColor: alpha(theme.palette.primaryDark[900], 0.7),
   }),
 ]);
 

--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -24,7 +24,7 @@ const Header = styled('header')(({ theme }) => [
     top: 0,
     transition: theme.transitions.create('top'),
     zIndex: theme.zIndex.appBar,
-    backdropFilter: 'blur(20px)',
+    backdropFilter: 'blur(8px)',
     boxShadow: `inset 0px -1px 1px ${(theme.vars || theme).palette.grey[100]}`,
     backgroundColor: 'rgba(255,255,255,0.8)',
   },

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -116,10 +116,10 @@ const StyledAppBar = styled(AppBar, {
         : theme.palette.grey[100],
     borderWidth: 0,
     borderBottomWidth: 'thin',
-    background:
+    backgroundColor:
       theme.palette.mode === 'dark'
         ? alpha(theme.palette.primaryDark[900], 0.7)
-        : 'rgba(255,255,255,0.7)',
+        : 'rgba(255,255,255,0.8)',
     color: theme.palette.mode === 'dark' ? theme.palette.grey[500] : theme.palette.grey[800],
   };
 });


### PR DESCRIPTION
A visual bug that I saw on https://mui.com/blog/date-pickers-stable-v5/

**Before**

<img width="459" alt="Screenshot 2022-11-12 at 18 49 24" src="https://user-images.githubusercontent.com/3165635/201487713-bd812b80-0ee9-4142-b33f-e8fe3b464406.png">

**After**

<img width="461" alt="Screenshot 2022-11-12 at 18 49 12" src="https://user-images.githubusercontent.com/3165635/201487715-6fbed489-1d39-41e4-b981-01e2aaee5e4f.png">

The dark background color leaks too much into the app bar, reducing the opacity helps, I'm not sure that I went far enough, but at least, this feels already a step forward.