### PR TITLE
[docs] Make navbar backdrop filter consistent with website

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -108,7 +108,7 @@ const StyledAppBar = styled(AppBar, {
       },
     }),
     boxShadow: 'none',
-    backdropFilter: 'blur(20px)',
+    backdropFilter: 'blur(8px)',
     borderStyle: 'solid',
     borderColor:
       theme.palette.mode === 'dark'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR is just a follow-up to [this one](https://github.com/mui/material-ui/pull/35111#issuecomment-1315251821) where we adjust the website _and_ documentation backdrop filter to alleviate contrast a bit.
