### PR TITLE
[Autocomplete] Fix keyboard navigation when using custom popover

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -280,6 +280,7 @@ const AutocompleteListbox = styled('div', {
   padding: '8px 0',
   maxHeight: '40vh',
   overflow: 'auto',
+  position: 'relative',
   [`& .${autocompleteClasses.option}`]: {
     minHeight: 48,
     display: 'flex',

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -214,6 +214,7 @@ describe('<Autocomplete />', () => {
           open
           options={['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']}
           renderInput={(params) => <TextField {...params} />}
+          ListboxProps={{ style: { padding: 0 } }}
           PopperComponent={(props) => {
             const { disablePortal, anchorEl, open, ...other } = props;
             return <Box {...other} />;

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -19,7 +19,7 @@ import Autocomplete, {
 } from '@mui/material/Autocomplete';
 import { paperClasses } from '@mui/material/Paper';
 import { iconButtonClasses } from '@mui/material/IconButton';
-import { Box } from '@mui/system';
+import Box from '@mui/system/Box';
 
 function checkHighlightIs(listbox, expected) {
   const focused = listbox.querySelector(`.${classes.focused}`);
@@ -208,13 +208,18 @@ describe('<Autocomplete />', () => {
       checkHighlightIs(getByRole('listbox'), 'two');
     });
 
-    it('should have focused on first element after navigating all elements once by keyboard', () => {
+    // https://github.com/mui/material-ui/issues/34998
+    it('should scroll the listbox to the top when keyboard highlight wraps around after the last item is highlighted', () => {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
       const { getByRole } = render(
         <Autocomplete
           open
-          options={['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']}
+          options={['one', 'two', 'three', 'four', 'five']}
           renderInput={(params) => <TextField {...params} />}
-          ListboxProps={{ style: { padding: 0 } }}
+          ListboxProps={{ style: { padding: 0, maxHeight: '100px' } }}
           PopperComponent={(props) => {
             const { disablePortal, anchorEl, open, ...other } = props;
             return <Box {...other} />;
@@ -232,11 +237,7 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+
       checkHighlightIs(getByRole('listbox'), 'one');
       expect(getByRole('listbox')).to.have.property('scrollTop', 0);
     });

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -203,7 +203,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-      
+
       checkHighlightIs(getByRole('listbox'), 'one');
       setProps({ value: 'two' });
       checkHighlightIs(getByRole('listbox'), 'two');

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -209,7 +209,7 @@ describe('<Autocomplete />', () => {
     });
 
     // https://github.com/mui/material-ui/issues/34998
-    it('should scroll the listbox to the top when keyboard highlight wraps around after the last item is highlighted', () => {
+    it('should scroll the listbox to the top when keyboard highlight wraps around after the last item is highlighted', function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -203,6 +203,7 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
+      
       checkHighlightIs(getByRole('listbox'), 'one');
       setProps({ value: 'two' });
       checkHighlightIs(getByRole('listbox'), 'two');

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -19,6 +19,7 @@ import Autocomplete, {
 } from '@mui/material/Autocomplete';
 import { paperClasses } from '@mui/material/Paper';
 import { iconButtonClasses } from '@mui/material/IconButton';
+import { Box } from '@mui/system';
 
 function checkHighlightIs(listbox, expected) {
   const focused = listbox.querySelector(`.${classes.focused}`);
@@ -202,25 +203,41 @@ describe('<Autocomplete />', () => {
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );
-
       checkHighlightIs(getByRole('listbox'), 'one');
       setProps({ value: 'two' });
       checkHighlightIs(getByRole('listbox'), 'two');
     });
 
-    it('AutocompleteListbox should have position relative', () => {
+    it('should have focused on first element after navigating all elements once by keyboard', () => {
       const { getByRole } = render(
         <Autocomplete
-          value="one"
           open
-          options={['one', 'two', 'three']}
+          options={['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']}
           renderInput={(params) => <TextField {...params} />}
+          PopperComponent={(props) => {
+            const { disablePortal, anchorEl, open, ...other } = props;
+            return <Box {...other} />;
+          }}
         />,
       );
-
-      expect(
-        window.getComputedStyle(getByRole('listbox')).getPropertyValue('position'),
-      ).to.have.equal('relative');
+      const textbox = getByRole('combobox');
+      act(() => {
+        textbox.focus();
+      });
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      checkHighlightIs(getByRole('listbox'), 'one');
+      expect(getByRole('listbox')).to.have.property('scrollTop', 0);
     });
 
     it('should keep the current highlight if possible', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -230,7 +230,6 @@ describe('<Autocomplete />', () => {
       act(() => {
         textbox.focus();
       });
-      fireEvent.keyDown(textbox, { key: 'Enter' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });
       fireEvent.keyDown(textbox, { key: 'ArrowDown' });

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -208,6 +208,21 @@ describe('<Autocomplete />', () => {
       checkHighlightIs(getByRole('listbox'), 'two');
     });
 
+    it('AutocompleteListbox should have position relative', () => {
+      const { getByRole } = render(
+        <Autocomplete
+          value="one"
+          open
+          options={['one', 'two', 'three']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+
+      expect(
+        window.getComputedStyle(getByRole('listbox')).getPropertyValue('position'),
+      ).to.have.equal('relative');
+    });
+
     it('should keep the current highlight if possible', () => {
       const { getByRole } = render(
         <Autocomplete


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes: https://github.com/mui/material-ui/issues/34998

working proof: https://www.loom.com/share/8641a1e8a33844b0a48bff6e0d392289

Issue: element.offsetTop from below code returns incorrect value if parent element doesn't have relative position . attached some references below on this

https://github.com/mui/material-ui/blob/c789ca6d448f6032086c2268140c1d6c32bd1f0d/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js#L376-L389

https://stackoverflow.com/questions/29277608/jquery-offset-top-returns-wrong-value-error-with-margin#:~:text=if%20you%20try%20to%20get,will%20get%20a%20wrong%20value.&text=Try%20removing%20the%20margin%2Dtop,will%20see%20it%20will%20work.

https://medium.com/@alexcambose/js-offsettop-property-is-not-great-and-here-is-why-b79842ef7582.

So i've added position relative to parent element and added test.



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
