### PR TITLE
[docs] Fix undo/redo in live editor

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -472,6 +472,8 @@ export default function Demo(props) {
             />
           ) : (
             <DemoEditor
+              // Mount a new text editor when the preview mode change to reset the undo/redo history.
+              key={editorCode.isPreview}
               value={editorCode.value}
               onChange={(value) => {
                 setEditorCode({


### PR DESCRIPTION
A continuation on #34870.

While I using the live environment (for a real use case), I realize that the UX wasn't great. See this reproduction:

1. Open https://mui.com/material-ui/react-avatar/#letter-avatars
2. Click on "Show the full source" button
3. Make a change
4. Press <kbd>Cmd</kbd>+<kbd>Z</kbd> (undo)
5. 💥

I went with the YOLO solution. The clean solution would have been to store the [`session`](https://github.com/react-simple-code-editor/react-simple-code-editor/blob/4065fa6da6b7ca5eefc660b151fe5ab8b1a740cf/src/index.tsx#L497) between each mode and to restore it, but this feels overkill.

**Before**

https://user-images.githubusercontent.com/3165635/202039207-8a2ccbb1-deb0-40c8-9db2-9f98a5e337c5.mov

**After**

https://user-images.githubusercontent.com/3165635/202039306-d7c67fb2-4dcc-4bd4-b972-6fd30283fe19.mov

