### PR TITLE
[TextField] Fix error focus style

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -91,9 +91,13 @@ const FilledInputRoot = styled(InputBaseRoot, {
         // See https://github.com/mui/material-ui/issues/31766
         transform: 'scaleX(1) translateX(0)',
       },
-      [`&.${filledInputClasses.error}:after`]: {
-        borderBottomColor: (theme.vars || theme).palette.error.main,
-        transform: 'scaleX(1)', // error is always underlined in red
+      [`&.${filledInputClasses.error}`]: {
+        '&:before, &:after': {
+          borderBottomColor: (theme.vars || theme).palette.error.main,
+        },
+        '&:focus-within:after': {
+          transform: 'scaleX(1)', // error is always underlined in red
+        },
       },
       '&:before': {
         borderBottom: `1px solid ${
@@ -112,7 +116,7 @@ const FilledInputRoot = styled(InputBaseRoot, {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      [`&:hover:not(.${filledInputClasses.disabled}):before`]: {
+      [`&:hover:not(.${filledInputClasses.disabled}, .${filledInputClasses.error}):before`]: {
         borderBottom: `1px solid ${(theme.vars || theme).palette.text.primary}`,
       },
       [`&.${filledInputClasses.disabled}:before`]: {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -75,9 +75,13 @@ const InputRoot = styled(InputBaseRoot, {
         // See https://github.com/mui/material-ui/issues/31766
         transform: 'scaleX(1) translateX(0)',
       },
-      [`&.${inputClasses.error}:after`]: {
-        borderBottomColor: (theme.vars || theme).palette.error.main,
-        transform: 'scaleX(1)', // error is always underlined in red
+      [`&.${inputClasses.error}`]: {
+        '&:before, &:after': {
+          borderBottomColor: (theme.vars || theme).palette.error.main,
+        },
+        '&:focus-within:after': {
+          transform: 'scaleX(1)', // error is always underlined in red
+        },
       },
       '&:before': {
         borderBottom: `1px solid ${bottomLineColor}`,
@@ -92,8 +96,8 @@ const InputRoot = styled(InputBaseRoot, {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      [`&:hover:not(.${inputClasses.disabled}):before`]: {
-        borderBottom: `2px solid ${(theme.vars || theme).palette.text.primary}`,
+      [`&:hover:not(.${inputClasses.disabled}, .${inputClasses.error}):before`]: {
+        borderBottom: `1px solid ${(theme.vars || theme).palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
           borderBottom: `1px solid ${bottomLineColor}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes Input & FilledInput error focus state style. Fixes #35353 

According to [Material](https://m2.material.io/components/text-fields) these should be 1px default & 2px on focus. Thus having a visible focus state. 
In [MUI](https://mui.com/material-ui/react-text-field/#validation) these are currently 2px default & without any focus state.

Focus visible is an accessibility requirement by [WCAG 2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)