### PR TITLE
[core] Ensure that prettier CI step fails when code is badly formatted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
       - install_js
       - run:
           name: '`yarn prettier` changes committed?'
-          command: yarn prettier check-changed
+          command: yarn prettier --check
       - run:
           name: Generate PropTypes
           command: yarn proptypes


### PR DESCRIPTION
Due to the recent changes in how Prettier is executed (#34062), the CI step does not fail if badly formatted code is present. This PR restores the previous behavior.