### PR TITLE
[website] Disable SEO for performance pages

### DIFF
--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Head from 'docs/src/modules/components/Head';
 import { capitalize } from '@mui/material/utils';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -32,6 +33,9 @@ export default function Experiments({ experiments }) {
 
   return (
     <React.Fragment>
+      <Head>
+        <meta name="robots" content="noindex,nofollow" />
+      </Head>
       <CssBaseline />
       <Container>
         <Box

--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -66,7 +66,7 @@ export default function Experiments({ experiments }) {
                 URLs start with <code>/experiments/*</code> are deployed only on the pull request.
               </Typography>
               <Typography component="li">
-                <code>/experiments/*</code> are not included in docsearch indexing.
+                <code>/experiments/*</code> are not included in the index of Algolia nor Google.
               </Typography>
             </ul>
           </Box>

--- a/docs/pages/experiments/index.js
+++ b/docs/pages/experiments/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Head from 'docs/src/modules/components/Head';
 import { capitalize } from '@mui/material/utils';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -33,9 +32,6 @@ export default function Experiments({ experiments }) {
 
   return (
     <React.Fragment>
-      <Head>
-        <meta name="robots" content="noindex,nofollow" />
-      </Head>
       <CssBaseline />
       <Container>
         <Box
@@ -66,7 +62,7 @@ export default function Experiments({ experiments }) {
                 URLs start with <code>/experiments/*</code> are deployed only on the pull request.
               </Typography>
               <Typography component="li">
-                <code>/experiments/*</code> are not included in the index of Algolia nor Google.
+                <code>/experiments/*</code> are not included in docsearch indexing.
               </Typography>
             </ul>
           </Box>

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -7,9 +7,6 @@
 /favicon.ico
   Content-Type: image/x-icon
 
-/experiments/*
-  X-Robots-Tag: noindex
-
 /performance/*
   X-Robots-Tag: noindex
 

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -10,6 +10,9 @@
 /experiments/*
   X-Robots-Tag: noindex
 
+/performance/*
+  X-Robots-Tag: noindex
+
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   # Block usage in iframes.

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -7,6 +7,9 @@
 /favicon.ico
   Content-Type: image/x-icon
 
+/experiments/*
+  X-Robots-Tag: noindex
+
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   # Block usage in iframes.


### PR DESCRIPTION
We don't need these pages, e.g. https://deploy-preview-35173--material-ui.netlify.app/performance/table-raw/ in the index or Google to spend our crawling budget on them. The goal is to be able to add them and not have to care in any way that these pages exist.

Why work on this? I saw https://search.google.com/search-console/index/drilldown?resource_id=sc-domain:mui.com&item_key=CAMYEyAC, it seems to be something that can be a quick win.

<img width="1015" alt="Screenshot 2022-11-17 at 12 19 46" src="https://user-images.githubusercontent.com/3165635/202432987-b68bcdf8-5774-45a7-b057-d57812705d50.png">
