### PR TITLE
[typescript] changing borderRadius to accept string values in `Shape` interface

### DIFF
--- a/packages/mui-material/src/styles/createTheme.spec.ts
+++ b/packages/mui-material/src/styles/createTheme.spec.ts
@@ -186,7 +186,6 @@ const theme = createTheme();
 {
   createTheme({
     shape: {
-      // @ts-expect-error invalid borderRadius string value in theme
       borderRadius: '5px',
     },
   });

--- a/packages/mui-system/src/createTheme/shape.d.ts
+++ b/packages/mui-system/src/createTheme/shape.d.ts
@@ -1,5 +1,5 @@
 export interface Shape {
-  borderRadius: number;
+  borderRadius: number | string;
 }
 
 export type ShapeOptions = Partial<Shape>;


### PR DESCRIPTION
Fixes #35156

Changes `borderRadius` to the correct type.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
