### PR TITLE
[docs] Hotfix missing styles in dark mode

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -411,12 +411,16 @@ const Root = styled('div')(
   }),
   {
     ':where(.mode-dark) &': {
+      color: 'rgb(255, 255, 255)',
       '& :not(pre) > code': {
         // inline code block
-        color: '#fff',
+        color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
       },
       '& strong': {
         color: `var(--muidocs-palette-grey-200, ${darkTheme.palette.grey[200]})`,
+      },
+      '& hr': {
+        backgroundColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
       },
       '& h1': {
         color: `var(--muidocs-palette-grey-50, ${darkTheme.palette.grey[50]})`,
@@ -438,8 +442,12 @@ const Root = styled('div')(
       },
       '& h1, & h2, & h3, & h4': {
         '&:hover .anchor-link-style': {
+          color: `var(--muidocs-palette-text-secondary, ${darkTheme.palette.text.secondary})`,
           background: alpha(darkTheme.palette.primaryDark[800], 0.3),
           borderColor: `var(--muidocs-palette-primaryDark-500, ${darkTheme.palette.primaryDark[500]})`,
+          '&:hover': {
+            color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
+          },
         },
       },
       '& h1 code, & h2 code, & h3 code': {
@@ -455,6 +463,17 @@ const Root = styled('div')(
         '& .prop-type': {
           color: '#ffb6ec',
         },
+        '& .prop-default': {
+          borderColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
+        },
+      },
+      '& td': {
+        color: `var(--muidocs-palette-text-secondary, ${darkTheme.palette.text.secondary})`,
+        borderColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
+      },
+      '& th': {
+        color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
+        borderColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
       },
       '& blockquote': {
         borderColor: `var(--muidocs-palette-warning-500, ${darkTheme.palette.warning[500]})`,
@@ -512,7 +531,7 @@ const Root = styled('div')(
         color: `var(--muidocs-palette-primary-light, ${darkTheme.palette.primary.light})`,
       },
       '& kbd.key': {
-        color: '#fff',
+        color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
         backgroundColor: `var(--muidocs-palette-primaryDark-900, ${darkTheme.palette.primaryDark[900]})`,
         border: `1px solid var(--muidocs-palette-primaryDark-500, ${darkTheme.palette.primaryDark[500]})`,
         boxShadow: `inset 0 -1px 0 var(--muidocs-palette-primaryDark-700, ${darkTheme.palette.primaryDark[700]})`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Preview**: https://deploy-preview-35179--material-ui.netlify.app/material-ui/api/alert/

Reported in https://github.com/mui/material-ui/pull/34976#issuecomment-1317785335.

> @siriwatknp I have found a regression from this PR (looking a bit at https://mui-org.slack.com/archives/C042VP80PT5/p1667372692296329):
> 
> The commit on master just before this PR: https://636d3dbaea7a9900083c33e1--material-ui.netlify.app/material-ui/api/alert/
> 
> <img alt="Screenshot 2022-11-16 at 23 33 37" width="774" src="https://user-images.githubusercontent.com/3165635/202309100-224a5a3e-d967-436e-a9ba-2147b4554266.png">
> 
> This PR: https://deploy-preview-34976--material-ui.netlify.app/material-ui/api/alert/
> 
> <img alt="Screenshot 2022-11-16 at 23 33 43" width="771" src="https://user-images.githubusercontent.com/3165635/202309090-e3d0e50d-6caa-4224-adac-aeec358e89fa.png">

**After**: <img width="1440" alt="Screen Shot 2565-11-17 at 12 47 23" src="https://user-images.githubusercontent.com/18292247/202366600-23d8dde0-c104-4c22-84f7-a87b6ee923b1.png">

My mistake. Forgot the case where the tokens have different values between color modes.

will do a hotfix once the CIs are green.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
