### PR TITLE
[docs] Improve the autogenerated "Unstyled" and "API" text

### DIFF
--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -284,9 +284,8 @@ function createRender(context) {
         return `<pre><code>${escaped ? code : escape(code, true)}</code></pre>\n`;
       }
 
-      return `<div class="MuiCode-root"><pre><code class="language-${escape(lang, true)}">${
-        escaped ? code : escape(code, true)
-      }</code></pre><button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">Copy <span class="MuiCode-copyKeypress"><span>(or</span> $keyC<span>)</span></span></button></div>\n`;
+      return `<div class="MuiCode-root"><pre><code class="language-${escape(lang, true)}">${escaped ? code : escape(code, true)
+        }</code></pre><button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">Copy <span class="MuiCode-copyKeypress"><span>(or</span> $keyC<span>)</span></span></button></div>\n`;
     };
 
     const markedOptions = {
@@ -414,7 +413,9 @@ function prepareMarkdown(config) {
         contents.push(`
 ## Unstyled
 
-The component also comes with an [unstyled version](${headers.unstyled}). It's ideal for doing heavy customizations and minimizing bundle size.
+:::success
+[MUI Base](/base/getting-started/overview/) provides a headless ("unstyled") version of this [${title}](${headers.unstyled}). Try it if you need more flexibility in customization and a smaller bundle size.
+:::
         `);
       }
 
@@ -422,17 +423,19 @@ The component also comes with an [unstyled version](${headers.unstyled}). It's i
         contents.push(`
 ## API
 
+See the document(s) below for a reference to all of the props and classes available to the components mentioned here.
+
 ${headers.components
-  .map((component) => {
-    const componentPkgMap = componentPackageMapping[headers.product];
-    const componentPkg = componentPkgMap ? componentPkgMap[component] : null;
-    return `- [\`<${component} />\`](${resolveComponentApiUrl(
-      headers.product,
-      componentPkg,
-      component,
-    )})`;
-  })
-  .join('\n')}
+            .map((component) => {
+              const componentPkgMap = componentPackageMapping[headers.product];
+              const componentPkg = componentPkgMap ? componentPkgMap[component] : null;
+              return `- [\`<${component} />\`](${resolveComponentApiUrl(
+                headers.product,
+                componentPkg,
+                component,
+              )})`;
+            })
+            .join('\n')}
   `);
       }
 

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -424,7 +424,7 @@ function prepareMarkdown(config) {
         contents.push(`
 ## API
 
-See the documentation below for a reference to all of the props and classes available to the components mentioned here.
+See the documentation below for a complete reference to all of the props and classes available to the components mentioned here.
 
 ${headers.components
   .map((component) => {

--- a/docs/packages/markdown/parseMarkdown.js
+++ b/docs/packages/markdown/parseMarkdown.js
@@ -284,8 +284,9 @@ function createRender(context) {
         return `<pre><code>${escaped ? code : escape(code, true)}</code></pre>\n`;
       }
 
-      return `<div class="MuiCode-root"><pre><code class="language-${escape(lang, true)}">${escaped ? code : escape(code, true)
-        }</code></pre><button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">Copy <span class="MuiCode-copyKeypress"><span>(or</span> $keyC<span>)</span></span></button></div>\n`;
+      return `<div class="MuiCode-root"><pre><code class="language-${escape(lang, true)}">${
+        escaped ? code : escape(code, true)
+      }</code></pre><button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">Copy <span class="MuiCode-copyKeypress"><span>(or</span> $keyC<span>)</span></span></button></div>\n`;
     };
 
     const markedOptions = {
@@ -423,19 +424,19 @@ function prepareMarkdown(config) {
         contents.push(`
 ## API
 
-See the document(s) below for a reference to all of the props and classes available to the components mentioned here.
+See the documentation below for a reference to all of the props and classes available to the components mentioned here.
 
 ${headers.components
-            .map((component) => {
-              const componentPkgMap = componentPackageMapping[headers.product];
-              const componentPkg = componentPkgMap ? componentPkgMap[component] : null;
-              return `- [\`<${component} />\`](${resolveComponentApiUrl(
-                headers.product,
-                componentPkg,
-                component,
-              )})`;
-            })
-            .join('\n')}
+  .map((component) => {
+    const componentPkgMap = componentPackageMapping[headers.product];
+    const componentPkg = componentPkgMap ? componentPkgMap[component] : null;
+    return `- [\`<${component} />\`](${resolveComponentApiUrl(
+      headers.product,
+      componentPkg,
+      component,
+    )})`;
+  })
+  .join('\n')}
   `);
       }
 


### PR DESCRIPTION
This PR updates the copy for the "Unstyled" and "API" sections of the docs pages. I always felt that the earlier version of the "Unstyled" text lacked clarity and context, and that the "API" section could use a description to explain what's on the other side of the links.

**Before:**

<img width="708" alt="Screen Shot 2022-11-17 at 6 00 44 PM" src="https://user-images.githubusercontent.com/71297412/202586023-4cfb87b7-8890-445f-9205-f3d16cb93495.png">

**After:**

<img width="708" alt="Screen Shot 2022-11-17 at 6 10 59 PM" src="https://user-images.githubusercontent.com/71297412/202586846-9dcb7e47-6e13-44ef-a0a1-88cb28e1482f.png">
