### PR TITLE
[lab][LoadingButton] Apply wrapping element to prevent React crash on Google page translation

### DIFF
--- a/docs/data/material/components/buttons/LoadingButtonsTransition.js
+++ b/docs/data/material/components/buttons/LoadingButtonsTransition.js
@@ -34,7 +34,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -43,7 +43,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -53,7 +53,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -64,7 +64,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
       <Box sx={{ '& > button': { m: 1 } }}>
@@ -74,7 +74,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -82,7 +82,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -91,7 +91,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           color="secondary"
@@ -101,7 +101,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
     </div>

--- a/docs/data/material/components/buttons/LoadingButtonsTransition.tsx
+++ b/docs/data/material/components/buttons/LoadingButtonsTransition.tsx
@@ -34,7 +34,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -43,7 +43,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -53,7 +53,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -64,7 +64,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
       <Box sx={{ '& > button': { m: 1 } }}>
@@ -74,7 +74,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          <span>disabled</span>
+          Disabled
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -82,7 +82,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          <span>Fetch data</span>
+          Fetch data
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -91,7 +91,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          <span>Send</span>
+          Send
         </LoadingButton>
         <LoadingButton
           color="secondary"
@@ -101,7 +101,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          <span>Save</span>
+          Save
         </LoadingButton>
       </Box>
     </div>

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -185,14 +185,3 @@ This has the advantage of supporting any element, for instance, a link `<a>` ele
 Toggle the loading switch to see the transition between the different states.
 
 {{"demo": "LoadingButtonsTransition.js"}}
-
-:::warning
-There is a [known issue](https://github.com/mui/material-ui/issues/27853) with translating a page using Chrome tools when a Loading Button is present.
-After the page is translated, the application crashes when the loading state of a Button changes.
-To prevent this, ensure that the contents of the Loading Button are nested inside any HTML element, such as a `<span>`:
-
-```jsx
-<LoadingButton loading variant="outlined">
-  <span>Submit</span>
-</LoadingButton>
-```

--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1242,6 +1242,12 @@ The Grid's `wrap` prop was deprecated in favor of `flexWrap` MUI System prop:
  />;
 ```
 
+## LoadingButton
+
+### Contents wrapped in a <span>
+
+The `children` passed to the LoadingButton component is now wrapped in a `<span>` tag to avoid [issues](https://github.com/mui/material-ui/issues/27853) when using tools to translate websites.
+
 ## Modal
 
 Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#modal-props) below to migrate the code as described in the following sections:

--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1242,12 +1242,6 @@ The Grid's `wrap` prop was deprecated in favor of `flexWrap` MUI System prop:
  />;
 ```
 
-## LoadingButton
-
-### Contents wrapped in a <span>
-
-The `children` passed to the LoadingButton component is now wrapped in a `<span>` tag to avoid [issues](https://github.com/mui/material-ui/issues/27853) when using tools to translate websites.
-
 ## Modal
 
 Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#modal-props) below to migrate the code as described in the following sections:

--- a/docs/data/material/migration/migration-v5/migration-v5.md
+++ b/docs/data/material/migration/migration-v5/migration-v5.md
@@ -117,3 +117,9 @@ Both of these changes might slightly affect your layout.
 Note that the items' position doesn't change.
 We recommend adopting this new behavior and **not trying to replicate the old one**, as this is a more predictable and modern approach.
 :::
+
+### LoadingButton
+
+#### Contents wrapped in a <span>
+
+The `children` passed to the LoadingButton component is now wrapped in a `<span>` tag to avoid [issues](https://github.com/mui/material-ui/issues/27853) when using tools to translate websites.

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -34,10 +34,6 @@ const useUtilityClasses = (ownerState) => {
   };
 };
 
-const contentDivStyles = {
-  display: 'contents',
-};
-
 // TODO use `import rootShouldForwardProp from '../styles/rootShouldForwardProp';` once move to core
 const rootShouldForwardProp = (prop) =>
   prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as' && prop !== 'classes';
@@ -247,14 +243,15 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       ownerState={ownerState}
     >
       {ownerState.loadingPosition === 'end' ? (
-        <div style={contentDivStyles}>{children}</div>
+        <span>{children}</span>
       ) : (
         loadingButtonLoadingIndicator
       )}
+
       {ownerState.loadingPosition === 'end' ? (
         loadingButtonLoadingIndicator
       ) : (
-        <div style={contentDivStyles}>{children}</div>
+        <span>{children}</span>
       )}
     </LoadingButtonRoot>
   );

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -242,8 +242,8 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       classes={classes}
       ownerState={ownerState}
     >
-      {ownerState.loadingPosition === 'end' ? children : loadingButtonLoadingIndicator}
-      {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : children}
+      {ownerState.loadingPosition === 'end' ? <div>{children}</div> : loadingButtonLoadingIndicator}
+      {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : <div>{children}</div>}
     </LoadingButtonRoot>
   );
 });

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -34,6 +34,10 @@ const useUtilityClasses = (ownerState) => {
   };
 };
 
+const contentDivStyles = {
+  display: 'contents',
+};
+
 // TODO use `import rootShouldForwardProp from '../styles/rootShouldForwardProp';` once move to core
 const rootShouldForwardProp = (prop) =>
   prop !== 'ownerState' && prop !== 'theme' && prop !== 'sx' && prop !== 'as' && prop !== 'classes';
@@ -242,8 +246,16 @@ const LoadingButton = React.forwardRef(function LoadingButton(inProps, ref) {
       classes={classes}
       ownerState={ownerState}
     >
-      {ownerState.loadingPosition === 'end' ? <div>{children}</div> : loadingButtonLoadingIndicator}
-      {ownerState.loadingPosition === 'end' ? loadingButtonLoadingIndicator : <div>{children}</div>}
+      {ownerState.loadingPosition === 'end' ? (
+        <div style={contentDivStyles}>{children}</div>
+      ) : (
+        loadingButtonLoadingIndicator
+      )}
+      {ownerState.loadingPosition === 'end' ? (
+        loadingButtonLoadingIndicator
+      ) : (
+        <div style={contentDivStyles}>{children}</div>
+      )}
     </LoadingButtonRoot>
   );
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Hey folks 👋 
I ran into this issue where some of our customers on our site were trapped by this react crashing loading button. I wanted to to invest some time to get it out of the package.

### Use case summary:
Using the LoadingButton while have Google translation (chrome feature) active on your site. 
Problem: Google modifies the button contents and React can't figure out its bindings anymore. Causes crash 💥

### How to reproduce: 
https://codesandbox.io/s/dry-water-eig2e7?file=/demo.tsx

**Steps:**
- Open sandbox in external browser
- Use google chrome's translate feature (see screenshot)
- Click the loading button 
- Notice crash 💥
![image](https://user-images.githubusercontent.com/4742816/202733890-b27c584a-861e-4433-a23f-2446c4a60db9.png)


### Why this solution?
I've implemented one of the suggestion in the issue, tested it locally and it seemed to work out perfectly.

😃 This is my first contribution to MUI, so if I need to change something, let me know.

Closes #27853 

