### PR TITLE
[docs] Fix ad margin on API pages

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -117,7 +117,7 @@ function Ad() {
   let children;
   let label;
   // Hide the content to google bot to avoid its indexation.
-  if (/Googlebot/.test(navigator.userAgent) || disableAd) {
+  if ((typeof window !== 'undefined' && /Googlebot/.test(navigator.userAgent)) || disableAd) {
     children = <span />;
   } else if (adblock) {
     if (randomAdblock < 0.2) {

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -10,6 +10,7 @@ import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
+import Ad from 'docs/src/modules/components/Ad';
 
 const Asterisk = styled('abbr')(({ theme }) => ({ color: theme.palette.error.main }));
 
@@ -207,8 +208,8 @@ Heading.propTypes = {
   level: PropTypes.string,
 };
 
-function ApiDocs(props) {
-  const { descriptions, pageContent } = props;
+export default function ApiPage(props) {
+  const { descriptions, disableAd = false, pageContent } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
 
@@ -287,7 +288,7 @@ function ApiDocs(props) {
   return (
     <AppLayoutDocs
       description={description}
-      disableAd={false}
+      disableAd={disableAd}
       disableToc={false}
       location={apiSourceLocation}
       title={`${componentName} API`}
@@ -295,8 +296,14 @@ function ApiDocs(props) {
     >
       <MarkdownElement>
         <h1>{componentName} API</h1>
-        <Typography variant="h5" component="p" className="description" gutterBottom>
+        <Typography
+          variant="h5"
+          component="p"
+          className={`description${disableAd ? '' : ' ad'}`}
+          gutterBottom
+        >
           {description}
+          {disableAd ? null : <Ad />}
         </Typography>
         <Heading hash="import" />
         <HighlightedCode
@@ -388,13 +395,12 @@ import { ${componentName} } from '${source}';`}
   );
 }
 
-ApiDocs.propTypes = {
+ApiPage.propTypes = {
   descriptions: PropTypes.object.isRequired,
+  disableAd: PropTypes.bool,
   pageContent: PropTypes.object.isRequired,
 };
 
 if (process.env.NODE_ENV !== 'production') {
-  ApiDocs.propTypes = exactProp(ApiDocs.propTypes);
+  ApiPage.propTypes = exactProp(ApiPage.propTypes);
 }
-
-export default ApiDocs;

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -11,9 +11,7 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import EditPage from 'docs/src/modules/components/EditPage';
 import AppContainer from 'docs/src/modules/components/AppContainer';
 import AppTableOfContents from 'docs/src/modules/components/AppTableOfContents';
-import Ad from 'docs/src/modules/components/Ad';
 import AdManager from 'docs/src/modules/components/AdManager';
-import AdGuest from 'docs/src/modules/components/AdGuest';
 import AppLayoutDocsFooter from 'docs/src/modules/components/AppLayoutDocsFooter';
 import BackToTop from 'docs/src/modules/components/BackToTop';
 
@@ -115,11 +113,6 @@ function AppLayoutDocs(props) {
           largeCard={false}
           card="https://mui.com/static/logo.png"
         />
-        {disableAd ? null : (
-          <AdGuest>
-            <Ad />
-          </AdGuest>
-        )}
         <Main disableToc={disableToc}>
           {/*
             Render the TOCs first to avoid layout shift when the HTML is streamed.

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -10,6 +10,8 @@ import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
 import BrandingProvider from 'docs/src/BrandingProvider';
+import Ad from 'docs/src/modules/components/Ad';
+import AdGuest from 'docs/src/modules/components/AdGuest';
 
 function noComponent(moduleID) {
   return function NoComponent() {
@@ -62,6 +64,11 @@ export default function MarkdownDocs(props) {
       toc={toc}
     >
       <Provider>
+        {disableAd ? null : (
+          <AdGuest>
+            <Ad />
+          </AdGuest>
+        )}
         {isJoy && <JoyModeObserver mode={theme.palette.mode} />}
         {rendered.map((renderedMarkdownOrDemo, index) => {
           if (typeof renderedMarkdownOrDemo === 'string') {


### PR DESCRIPTION
The bug: 
<img width="786" alt="Screenshot 2022-11-19 at 01 04 25" src="https://user-images.githubusercontent.com/3165635/202822683-6a1d4b4c-9860-4770-ab77-fc71c05d71d5.png">

https://mui.com/material-ui/api/dialog/

The root of the problem is that `AdGuest` use the DOM API to add the `ad` class name once the Ad component is portaled but on this page, we don't use `dangerouslySetInnerHTML` to render the markdown, we use the React API directly.

I could pinpoint the origin of the change of behavior to the v5.9.0 release. This release includes #33196, so very likely the origin.

https://github.com/mui/mui-x/blob/c8f112caed7bd50fb1ba723f7db47590d08d926b/docs/src/modules/components/ApiDocs.js duplicate this file, so I will need to apply the same fix there too, not ideal but no other choices.

Preview: https://deploy-preview-35201--material-ui.netlify.app/material-ui/api/dialog/