### PR TITLE
[docs] Move the demo higher in the API TOC

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -256,9 +256,9 @@ function ApiDocs(props) {
     createTocEntry('import'),
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
+    createTocEntry('demos'),
     createTocEntry('props'),
     componentStyles.classes.length > 0 && createTocEntry('css'),
-    createTocEntry('demos'),
   ].filter(Boolean);
 
   // The `ref` is forwarded to the root element.
@@ -331,6 +331,14 @@ import { ${componentName} } from '${source}';`}
             />
           </React.Fragment>
         )}
+        <Heading hash="demos" />
+        <p
+          dangerouslySetInnerHTML={{
+            __html:
+              'The following component guides include examples on how to use this React component:',
+          }}
+        />
+        <span dangerouslySetInnerHTML={{ __html: demos }} />
         <Heading hash="props" />
         <p dangerouslySetInnerHTML={{ __html: spreadHint }} />
         <PropsTable componentProps={componentProps} propDescriptions={propDescriptions} />
@@ -376,8 +384,6 @@ import { ${componentName} } from '${source}';`}
             />
           </React.Fragment>
         ) : null}
-        <Heading hash="demos" />
-        <span dangerouslySetInnerHTML={{ __html: demos }} />
       </MarkdownElement>
       <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
         <symbol id="anchor-link-icon" viewBox="0 0 16 16">

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -299,13 +299,15 @@ function ApiDocs(props) {
           {description}
         </Typography>
         <Heading hash="demos" />
-        <p
-          dangerouslySetInnerHTML={{
-            __html:
-              'For examples and details on the usage of this React component, visit the component demo pages:',
-          }}
-        />
-        <span dangerouslySetInnerHTML={{ __html: demos }} />
+        <div className="MuiCallout-root MuiCallout-info">
+          <p
+            dangerouslySetInnerHTML={{
+              __html:
+                'For examples and details on the usage of this React component, visit the component demo pages:',
+            }}
+          />
+          <span dangerouslySetInnerHTML={{ __html: demos }} />
+        </div>
         <Heading hash="import" />
         <HighlightedCode
           code={`

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -302,7 +302,7 @@ function ApiDocs(props) {
         <p
           dangerouslySetInnerHTML={{
             __html:
-              'For examples and details on the usage of this React component, visit the component demo page:',
+              'For examples and details on the usage of this React component, visit the component demo pages:',
           }}
         />
         <span dangerouslySetInnerHTML={{ __html: demos }} />

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -166,11 +166,11 @@ ClassesTable.propTypes = {
 
 function getTranslatedHeader(t, header) {
   const translations = {
+    demos: t('api-docs.demos'),
     import: t('api-docs.import'),
     'component-name': t('api-docs.componentName'),
     props: t('api-docs.props'),
     inheritance: t('api-docs.inheritance'),
-    demos: t('api-docs.demos'),
     css: 'CSS',
   };
 
@@ -253,10 +253,10 @@ function ApiDocs(props) {
   }
 
   const toc = [
+    createTocEntry('demos'),
     createTocEntry('import'),
     ...componentDescriptionToc,
     componentStyles.name && createTocEntry('component-name'),
-    createTocEntry('demos'),
     createTocEntry('props'),
     componentStyles.classes.length > 0 && createTocEntry('css'),
   ].filter(Boolean);
@@ -298,6 +298,14 @@ function ApiDocs(props) {
         <Typography variant="h5" component="p" className="description" gutterBottom>
           {description}
         </Typography>
+        <Heading hash="demos" />
+        <p
+          dangerouslySetInnerHTML={{
+            __html:
+              'To see demos and examples on how to use this React component, visit the component guide section:',
+          }}
+        />
+        <span dangerouslySetInnerHTML={{ __html: demos }} />
         <Heading hash="import" />
         <HighlightedCode
           code={`
@@ -331,14 +339,6 @@ import { ${componentName} } from '${source}';`}
             />
           </React.Fragment>
         )}
-        <Heading hash="demos" />
-        <p
-          dangerouslySetInnerHTML={{
-            __html:
-              'The following component guides include examples on how to use this React component:',
-          }}
-        />
-        <span dangerouslySetInnerHTML={{ __html: demos }} />
         <Heading hash="props" />
         <p dangerouslySetInnerHTML={{ __html: spreadHint }} />
         <PropsTable componentProps={componentProps} propDescriptions={propDescriptions} />

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -302,7 +302,7 @@ function ApiDocs(props) {
         <p
           dangerouslySetInnerHTML={{
             __html:
-              'To see demos and examples on how to use this React component, visit the component guide section:',
+              'For examples and details on the usage of this React component, visit the component demo page:',
           }}
         />
         <span dangerouslySetInnerHTML={{ __html: demos }} />

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -17,7 +17,7 @@
     "nativeElement": "native",
     "overrideStyles": "You can override the style of the component using one of these customization options:\n",
     "overrideStylesStyledComponent": "<ul>\n<li>With a <a href=\"/material-ui/guides/interoperability/#global-css\">global class name</a>.</li>\n<li>With a rule name as part of the component's <a href=\"/material-ui/customization/theme-components/#global-style-overrides\"><code>styleOverrides</code> property</a> in a custom theme.</li>\n</ul>",
-    "pageDescription": "API documentation for the React {{name}} component. Learn about the available props and the CSS API.",
+    "pageDescription": "API reference docs for the React {{name}} component. Learn about the props, CSS, and other APIs of this exported module.",
     "props": "Props",
     "refNotHeld": "The component cannot hold a ref.",
     "refRootElement": "The <code>ref</code> is forwarded to the root element.",


### PR DESCRIPTION
It might solve these feedback:

<img width="336" alt="Screenshot 2022-11-19 at 01 35 45" src="https://user-images.githubusercontent.com/3165635/202824698-bc2dc92d-c10c-4269-9efc-9bbd7067f12f.png">

https://mui-org.slack.com/archives/C041SDSF32L/p1668804057511509

When I'm landing on the API page, I usually have to scroll to the bottom of the page to then go to the demo (it happens to me quite often). Maybe this is a better UX https://deploy-preview-35202--material-ui.netlify.app/material-ui/api/alert/. I have made sure that searching for "example" yield a result too on the page.

Close #35004