### PR TITLE
[core] Fix deduplicate script for dependant repos

### DIFF
--- a/scripts/deduplicate.mjs
+++ b/scripts/deduplicate.mjs
@@ -3,9 +3,9 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import deduplicate from 'yarn-deduplicate';
-import { getWorkspaceRoot } from './utils.mjs';
+import { findUp } from './utils.mjs';
 
-const lockFile = path.resolve(getWorkspaceRoot(), 'yarn.lock');
+const lockFile = await findUp('yarn.lock');
 const yarnlock = fs.readFileSync(lockFile, 'utf8');
 
 const duplicates = deduplicate.listDuplicates(yarnlock);
@@ -34,7 +34,7 @@ fs.writeFileSync(lockFile, deduplicate.fixDuplicates(yarnlock));
 const yarn = spawn('yarn', {
   shell: true,
   stdio: 'inherit',
-  cwd: getWorkspaceRoot(),
+  cwd: path.dirname(lockFile),
 });
 
 yarn.on('close', (code) => {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -22,18 +22,20 @@ export async function findUp(file, dir = process.cwd()) {
   if (!path.isAbsolute(dir)) {
     throw new Error(`Path "${dir}" must be absolute`);
   }
-  while (path.relative(dir, '/') !== '') {
-    const filepath = path.resolve(dir, file);
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      await fs.stat(filepath);
-      return filepath;
-    } catch (err) {
-      if (err.code !== 'ENOENT') {
-        throw err;
-      }
+
+  const filepath = path.resolve(dir, file);
+  try {
+    await fs.stat(filepath);
+    return filepath;
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
     }
-    dir = path.dirname(dir);
   }
-  return null;
+
+  if (path.relative(dir, '/') === '') {
+    return null;
+  }
+
+  return findUp(file, path.dirname(dir));
 }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -14,7 +14,7 @@ export function getWorkspaceRoot() {
 }
 
 /**
- * Find a file or directory by walking up parent directories
+ * Find a file or directory by walking up parent directories.
  * @param {string} file
  * @param {string} dir
  * @returns {Promise<string | null>}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -14,6 +14,7 @@ export function getWorkspaceRoot() {
 }
 
 /**
+ * Find a file or directory by walking up parent directories
  * @param {string} file
  * @param {string} dir
  * @returns {Promise<string | null>}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,12 +1,39 @@
 import path from 'path';
 import url from 'url';
+import fs from 'fs/promises';
 
 /**
  * Returns the full path of the root directory of this repository.
+ * @returns {string}
  */
 // eslint-disable-next-line import/prefer-default-export
 export function getWorkspaceRoot() {
   const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
   const workspaceRoot = path.resolve(currentDirectory, '..');
   return workspaceRoot;
+}
+
+/**
+ * @param {string} file
+ * @param {string} dir
+ * @returns {Promise<string | null>}
+ */
+export async function findUp(file, dir = process.cwd()) {
+  if (!path.isAbsolute(dir)) {
+    throw new Error(`Path "${dir}" must be absolute`);
+  }
+  while (path.relative(dir, '/') !== '') {
+    const filepath = path.resolve(dir, file);
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.stat(filepath);
+      return filepath;
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
 }


### PR DESCRIPTION
When used in MUI X or Toolpad, this will resolve to folder of the monorepo dependency, not to the MUIX or Toolpad workspace root. This PR bases the search of lockfile on cwd.

See https://github.com/mui/material-ui/pull/35036#discussion_r1017765723 and #35070