### PR TITLE
[docs] Fix confusion in TOCs when reaching scroll bottom

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -20,7 +20,7 @@ const Nav = styled('nav')(({ theme }) => ({
   height: '100vh',
   overflowY: 'auto',
   paddingTop: 'calc(var(--MuiDocs-header-height) + 1rem)',
-  paddingBottom: theme.spacing(2),
+  paddingBottom: theme.spacing(4),
   paddingRight: theme.spacing(4), // We can't use `padding` as stylis-plugin-rtl doesn't swap it
   display: 'none',
   [theme.breakpoints.up('sm')]: {


### PR DESCRIPTION
In https://mui.com/x/introduction/licensing/#validation-failures, I'm always a bit confused about whether I'm at the bottom of the TOCs or not. I think that it's because I can't clearly see that there aren't any more items on the list.

**Before**
<img width="379" alt="Screenshot 2022-11-20 at 19 39 48" src="https://user-images.githubusercontent.com/3165635/202919885-2819fe86-1d08-4100-8eed-552ff4bb4f64.png">

**After**
<img width="373" alt="Screenshot 2022-11-20 at 19 39 29" src="https://user-images.githubusercontent.com/3165635/202919880-f9fc9b1a-273e-4d76-a288-83bcd096ab9f.png">
