### PR TITLE
[docs] Fix layout jump on first mistake

### DIFF
--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -57,7 +57,7 @@ const StyledSimpleCodeEditor = styled(SimpleCodeEditor)(({ theme }) => ({
   },
 }));
 
-interface DemoEditorProps {
+interface DemoEditorProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   copyButtonProps: {};
   id: string;
@@ -67,7 +67,7 @@ interface DemoEditorProps {
 }
 
 export default function DemoEditor(props: DemoEditorProps) {
-  const { language, value, onChange, copyButtonProps, children, id } = props;
+  const { language, value, onChange, copyButtonProps, children, id, ...other } = props;
   const t = useTranslate();
   const contextTheme = useTheme();
   const wrapperRef = React.useRef<HTMLElement | null>(null);
@@ -100,6 +100,7 @@ export default function DemoEditor(props: DemoEditorProps) {
           }
         }
       }}
+      {...other}
     >
       <div className="MuiCode-root" {...handlers}>
         <div className="scrollContainer">


### PR DESCRIPTION
React runner has a cache to render an element in the case of an exception. However, if the very first update he's given to is broken, a layout shift breaks the DX:

**Before**

https://user-images.githubusercontent.com/3165635/202934449-37640d6e-5ac8-4295-90f1-124b9a033ceb.mov

https://mui.com/material-ui/react-alert/#basic-alerts

Instead, what we can do is render the correct version as soon as the develop start to interact with the demo:

**After**

https://user-images.githubusercontent.com/3165635/202934542-ef1def4a-df87-4685-9e59-5599a9801692.mov