### PR TITLE
[website] Fix theme mode toggle state

### DIFF
--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -145,7 +145,7 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
-          {getMuiInitColorSchemeScript()}
+          {getMuiInitColorSchemeScript({ defaultMode: 'system' })}
           <Main />
           <script
             // eslint-disable-next-line react/no-danger

--- a/docs/src/BrandingCssVarsProvider.tsx
+++ b/docs/src/BrandingCssVarsProvider.tsx
@@ -51,7 +51,7 @@ const theme = extendTheme({
 
 export default function BrandingCssVarsProvider({ children }: { children: React.ReactNode }) {
   return (
-    <CssVarsProvider theme={theme} disableTransitionOnChange>
+    <CssVarsProvider theme={theme} defaultMode="system" disableTransitionOnChange>
       <NextNProgressBar />
       <CssBaseline />
       {children}

--- a/docs/src/components/header/ThemeModeToggle.tsx
+++ b/docs/src/components/header/ThemeModeToggle.tsx
@@ -11,24 +11,24 @@ function CssVarsModeToggle(props: { onChange: (checked: boolean) => void }) {
   React.useEffect(() => {
     setMounted(true);
   }, []);
+  const calculatedMode = mode === 'system' ? systemMode : mode;
   return (
-    <Tooltip title={mode === 'dark' ? 'Turn on the light' : 'Turn off the light'}>
+    <Tooltip title={calculatedMode === 'dark' ? 'Turn on the light' : 'Turn off the light'}>
       <IconButton
         color="primary"
         disableTouchRipple
-        disabled={!mode}
+        disabled={!calculatedMode}
         onClick={() => {
-          props.onChange(mode === 'light' || systemMode === 'light');
-          setMode(mode === 'dark' ? 'light' : 'dark');
+          props.onChange(calculatedMode === 'light');
+          setMode(calculatedMode === 'dark' ? 'light' : 'dark');
         }}
       >
-        {!mode || !mounted
+        {!calculatedMode || !mounted
           ? null
           : {
               light: <DarkModeOutlined fontSize="small" />,
-              system: <DarkModeOutlined fontSize="small" />,
               dark: <LightModeOutlined fontSize="small" />,
-            }[mode]}
+            }[calculatedMode]}
       </IconButton>
     </Tooltip>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

On https://mui.com/material-ui/getting-started/overview/, when setting mode as `system` (user's preference is "dark") and goto the homepage the mode toggle appearance is incorrect.

https://user-images.githubusercontent.com/18292247/202992090-5a58e859-afb2-4939-b56b-54ebd3e531c3.mov

## Fix

Use the `systemMode` to determine if the actual mode is `light` or `dark`.


https://user-images.githubusercontent.com/18292247/202995814-df6937e0-a535-4990-bc27-4ce41ab5afcc.mov



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
