### PR TITLE
[SpeedDialAction] apply tooltip class if tooltipOpen is true

### DIFF
--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
@@ -117,7 +117,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
     icon,
     id,
     open,
-    TooltipClasses = { tooltip: '' },
+    TooltipClasses,
     tooltipOpen: tooltipOpenProp = false,
     tooltipPlacement = 'left',
     tooltipTitle,
@@ -168,7 +168,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
         <SpeedDialActionStaticTooltipLabel
           style={transitionStyle}
           id={`${id}-label`}
-          className={clsx(classes.staticTooltipLabel, TooltipClasses.tooltip)}
+          className={clsx(classes.staticTooltipLabel, TooltipClasses?.tooltip)}
           ownerState={ownerState}
         >
           {tooltipTitle}

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.js
@@ -117,7 +117,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
     icon,
     id,
     open,
-    TooltipClasses,
+    TooltipClasses = { tooltip: '' },
     tooltipOpen: tooltipOpenProp = false,
     tooltipPlacement = 'left',
     tooltipTitle,
@@ -168,7 +168,7 @@ const SpeedDialAction = React.forwardRef(function SpeedDialAction(inProps, ref) 
         <SpeedDialActionStaticTooltipLabel
           style={transitionStyle}
           id={`${id}-label`}
-          className={classes.staticTooltipLabel}
+          className={clsx(classes.staticTooltipLabel, TooltipClasses.tooltip)}
           ownerState={ownerState}
         >
           {tooltipTitle}

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -39,6 +39,23 @@ describe('<SpeedDialAction />', () => {
     expect(getByText('placeholder')).to.have.class('bar');
   });
 
+  it('should be able to change the Tooltip classes when tooltipOpen is true', () => {
+    const { getByText, container } = render(
+      <SpeedDialAction
+        icon={<Icon>add</Icon>}
+        open
+        tooltipOpen
+        tooltipTitle="placeholder"
+        TooltipClasses={{ tooltip: 'bar' }}
+      />,
+    );
+
+    fireEvent.mouseOver(container.querySelector('button'));
+    clock.tick(100);
+
+    expect(getByText('placeholder')).to.have.class('bar');
+  });
+
   it('should render a Fab', () => {
     const { container } = render(
       <SpeedDialAction icon={<Icon>add</Icon>} tooltipTitle="placeholder" />,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes: https://github.com/mui/material-ui/issues/35230

TooltipClasses wasn't applied to tooltip when `tooltipOpen` is true, this PR solves that.

`Just Fyi: below test was failing before this change if tooltipOpen={true} is added to props.`

https://github.com/mui/material-ui/blob/bf8b63249595b2557fb551fa8e1b29489a2e3f9b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js#L26-L40

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
