### PR TITLE
[examples] Fix Next.js errors

### DIFF
--- a/examples/nextjs-with-typescript-v4-migration/package.json
+++ b/examples/nextjs-with-typescript-v4-migration/package.json
@@ -10,10 +10,10 @@
     "post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest"
   },
   "dependencies": {
-    "@emotion/cache": "^11.0.0",
-    "@emotion/react": "^11.0.0",
-    "@emotion/server": "^11.0.0",
-    "@emotion/styled": "^11.0.0",
+    "@emotion/cache": "latest",
+    "@emotion/react": "latest",
+    "@emotion/server": "latest",
+    "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/styles": "latest",

--- a/examples/nextjs-with-typescript-v4-migration/package.json
+++ b/examples/nextjs-with-typescript-v4-migration/package.json
@@ -10,23 +10,23 @@
     "post-update": "echo \"codesandbox preview only, need an update\" && yarn upgrade --latest"
   },
   "dependencies": {
-    "@emotion/cache": "^11.7.1",
-    "@emotion/react": "^11.9.0",
-    "@emotion/server": "^11.4.0",
-    "@emotion/styled": "^11.8.1",
+    "@emotion/cache": "^11.0.0",
+    "@emotion/react": "^11.0.0",
+    "@emotion/server": "^11.0.0",
+    "@emotion/styled": "^11.0.0",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
     "@mui/styles": "latest",
     "autoprefixer": "latest",
     "clean-css": "latest",
-    "next": "latest",
+    "next": "^12.0.0",
     "postcss": "latest",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   },
   "devDependencies": {
     "@types/node": "latest",
-    "@types/react": "17.0.2",
+    "@types/react": "^17.0.0",
     "eslint": "latest",
     "eslint-config-next": "latest",
     "typescript": "latest"

--- a/examples/nextjs-with-typescript-v4-migration/src/Link.tsx
+++ b/examples/nextjs-with-typescript-v4-migration/src/Link.tsx
@@ -10,7 +10,7 @@ const Anchor = styled('a')({});
 
 interface NextLinkComposedProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
-    Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter'> {
+    Omit<NextLinkProps, 'href' | 'as' | 'passHref' | 'onMouseEnter' | 'onClick' | 'onTouchStart'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];
 }

--- a/examples/nextjs-with-typescript/src/Link.tsx
+++ b/examples/nextjs-with-typescript/src/Link.tsx
@@ -10,7 +10,7 @@ const Anchor = styled('a')({});
 
 interface NextLinkComposedProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
-    Omit<NextLinkProps, 'href' | 'as' | 'onClick' | 'onMouseEnter' | 'onTouchStart'> {
+    Omit<NextLinkProps, 'href' | 'as' | 'passHref' | 'onMouseEnter' | 'onClick' | 'onTouchStart'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];
 }


### PR DESCRIPTION
1. `examples/nextjs-with-typescript-v4-migration` is meant to show how to use @mui/styles, so React 17 only, which doesn't work with Next 13 (React 18). It currently crashes when you follow https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration.
2. I forgot to remove `passHref` in #28178
3. We did a fix in #33842 but forgot about the other examples