### PR TITLE
Add `string` as a possible value for `Dialog` `maxWidth` property

### DIFF
--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -46,7 +46,7 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
    * Set to `false` to disable `maxWidth`.
    * @default 'sm'
    */
-  maxWidth?: Breakpoint | false;
+  maxWidth?: Breakpoint | false | string;
   /**
    * Callback fired when the backdrop is clicked.
    * @deprecated Use the `onClose` prop with the `reason` argument to handle the `backdropClick` events.


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/35249

I didn't test this patch locally but it should be fine.