### PR TITLE
[docs] update grid2.md to match migration guide

### DIFF
--- a/docs/data/material/components/grid2/grid2.md
+++ b/docs/data/material/components/grid2/grid2.md
@@ -32,7 +32,7 @@ From now on, the `Grid` v1 and `Grid` v2 refer to the import as:
 
 ```js
 import Grid from '@mui/material/Grid'; // Grid version 1
-import Grid2 from '@mui/material/Unstable_Grid2'; // Grid version 2
+import Grid from '@mui/material/Unstable_Grid2'; // Grid version 2
 ```
 
 :::


### PR DESCRIPTION
* `import` statement doesn't match migration docs
* `import Grid2` doesn't build whereas `import Grid` does

Signed-off-by: Will Hedges <36576135+will-hedges@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
