### PR TITLE
[docs] updated Grid2 import statement

### DIFF
--- a/docs/data/material/components/grid2/grid2.md
+++ b/docs/data/material/components/grid2/grid2.md
@@ -32,7 +32,7 @@ From now on, the `Grid` v1 and `Grid` v2 refer to the import as:
 
 ```js
 import Grid from '@mui/material/Grid'; // Grid version 1
-import Grid2 from '@mui/material/Unstable_Grid2'; // Grid version 2
+import Grid from '@mui/material/Unstable_Grid2'; // Grid version 2
 ```
 
 :::


### PR DESCRIPTION
- `Grid2` docs currently show `import Grid2 from "@mui/material/Unstable_Grid2";`
- updated `grid2.md` to import statement example in the migration guide 
  - `import Grid from "@mui/material/Unstable_Grid2";`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
