### PR TITLE
[docs] Fix incorrect link in minimizing-bundle-size

### DIFF
--- a/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -59,7 +59,7 @@ import { Button, TextField } from '@mui/material';
 
 This is the option we document in all the demos since it requires no configuration.
 It is encouraged for library authors that are extending the components.
-Head to [Option 2](#option-2) for the approach that yields the best DX and UX.
+Head to [Option 2](#option-two-use-a-babel-plugin) for the approach that yields the best DX and UX.
 
 While importing directly in this manner doesn't use the exports in [the main file of `@mui/material`](https://unpkg.com/@mui/material), this file can serve as a handy reference as to which modules are public.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Currently the "Head to **Option 2**" is pointing to the wrong ID
![image](https://user-images.githubusercontent.com/20135478/204738936-87baf8bd-51fe-4d3c-9278-8526dfd9f58d.png)


The correct ID should be `option-two-use-a-babel-plugin`
![image](https://user-images.githubusercontent.com/20135478/204738707-af124677-3bc6-4bb6-a862-f21bce5f5f21.png)
