### PR TITLE
[core] Support `only` and `skip` on `describeConformance` (and other MUI describes)

### DIFF
--- a/test/utils/createDescribe.ts
+++ b/test/utils/createDescribe.ts
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+
+type MUIDescribe<P extends any[]> = {
+  (...args: P): void;
+
+  skip: (...args: P) => void;
+  only: (...args: P) => void;
+};
+export default <P extends any[]>(
+  message: string,
+  callback: (...args: P) => void,
+): MUIDescribe<P> => {
+  const muiDescribe = (...args: P) => {
+    describe(message, () => {
+      callback(...args);
+    });
+  };
+
+  muiDescribe.skip = (...args: P) => {
+    describe.skip(message, () => {
+      callback(...args);
+    });
+  };
+  muiDescribe.only = (...args: P) => {
+    describe.only(message, () => {
+      callback(...args);
+    });
+  };
+
+  return muiDescribe;
+};

--- a/test/utils/describeConformance.tsx
+++ b/test/utils/describeConformance.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider as MDThemeProvider, createTheme } from '@mui/material/sty
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import ReactTestRenderer from 'react-test-renderer';
 import createMount from './createMount';
+import createDescribe from './createDescribe';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 import { MuiRenderResult } from './createRenderer';
 
@@ -914,46 +915,46 @@ const fullSuite = {
  * Tests various aspects of a component that should be equal across MUI
  * components.
  */
-export default function describeConformance(
+function describeConformance(
   minimalElement: React.ReactElement,
   getOptions: () => InputConformanceOptions,
 ) {
-  describe('MUI component API', () => {
-    const {
-      after: runAfterHook = () => {},
-      only = Object.keys(fullSuite),
-      slots,
-      skip = [],
-      wrapMount,
-    } = getOptions();
+  const {
+    after: runAfterHook = () => {},
+    only = Object.keys(fullSuite),
+    slots,
+    skip = [],
+    wrapMount,
+  } = getOptions();
 
-    let filteredTests = Object.keys(fullSuite).filter(
-      (testKey) =>
-        only.indexOf(testKey) !== -1 && skip.indexOf(testKey as keyof typeof fullSuite) === -1,
-    ) as (keyof typeof fullSuite)[];
+  let filteredTests = Object.keys(fullSuite).filter(
+    (testKey) =>
+      only.indexOf(testKey) !== -1 && skip.indexOf(testKey as keyof typeof fullSuite) === -1,
+  ) as (keyof typeof fullSuite)[];
 
-    const slotBasedTests = ['slotsProp', 'slotPropsProp', 'slotPropsCallback'];
+  const slotBasedTests = ['slotsProp', 'slotPropsProp', 'slotPropsCallback'];
 
-    if (!slots) {
-      // if `slots` are not defined, do not run tests that depend on them
-      filteredTests = filteredTests.filter((testKey) => !slotBasedTests.includes(testKey));
-    }
+  if (!slots) {
+    // if `slots` are not defined, do not run tests that depend on them
+    filteredTests = filteredTests.filter((testKey) => !slotBasedTests.includes(testKey));
+  }
 
-    const baseMount = createMount();
-    const mount = wrapMount !== undefined ? wrapMount(baseMount) : baseMount;
+  const baseMount = createMount();
+  const mount = wrapMount !== undefined ? wrapMount(baseMount) : baseMount;
 
-    after(runAfterHook);
+  after(runAfterHook);
 
-    function getTestOptions(): ConformanceOptions {
-      return {
-        ...getOptions(),
-        mount,
-      };
-    }
+  function getTestOptions(): ConformanceOptions {
+    return {
+      ...getOptions(),
+      mount,
+    };
+  }
 
-    filteredTests.forEach((testKey) => {
-      const test = fullSuite[testKey];
-      test(minimalElement, getTestOptions);
-    });
+  filteredTests.forEach((testKey) => {
+    const test = fullSuite[testKey];
+    test(minimalElement, getTestOptions);
   });
 }
+
+export default createDescribe('MUI component API', describeConformance);

--- a/test/utils/describeConformanceUnstyled.tsx
+++ b/test/utils/describeConformanceUnstyled.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { MuiRenderResult, RenderOptions, screen } from './createRenderer';
+import createDescribe from './createDescribe';
 import {
   ConformanceOptions,
   SlotTestingOptions,
@@ -329,7 +330,7 @@ const fullSuite = {
   ownerStatePropagation: testOwnerStatePropagation,
 };
 
-export default function describeConformanceUnstyled(
+function describeConformanceUnstyled(
   minimalElement: React.ReactElement,
   getOptions: () => UnstyledConformanceOptions,
 ) {
@@ -340,12 +341,12 @@ export default function describeConformanceUnstyled(
       only.indexOf(testKey) !== -1 && skip.indexOf(testKey as keyof typeof fullSuite) === -1,
   ) as (keyof typeof fullSuite)[];
 
-  describe('MUI unstyled component API', () => {
-    after(runAfterHook);
+  after(runAfterHook);
 
-    filteredTests.forEach((testKey) => {
-      const test = fullSuite[testKey];
-      test(minimalElement, getOptions as any);
-    });
+  filteredTests.forEach((testKey) => {
+    const test = fullSuite[testKey];
+    test(minimalElement, getOptions as any);
   });
 }
+
+export default createDescribe('MUI unstyled component API', describeConformanceUnstyled);

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 export * from './components';
 export { default as describeConformance } from './describeConformance';
 export { default as describeConformanceUnstyled } from './describeConformanceUnstyled';
+export { default as createDescribe } from './createDescribe';
 export * from './createRenderer';
 export { default as createMount } from './createMount';
 export { default as findOutermostIntrinsic, wrapsIntrinsicElement } from './findOutermostIntrinsic';


### PR DESCRIPTION
The following now works

```tsx
  describeConformance.only(<Alert onClose={() => {}} />, () => ({ ... }));
```

I was missing it when developing the new pickers test suites.