### PR TITLE
[docs] Improve spacing with ul

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -99,7 +99,6 @@ const Root = styled('div')(
     '& p, & ul, & ol': {
       marginTop: 0,
       marginBottom: 16,
-      color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
     },
     '& ul': {
       paddingLeft: 30,
@@ -246,14 +245,10 @@ const Root = styled('div')(
       borderRadius: `var(--muidocs-shape-borderRadius, ${
         theme.shape?.borderRadius ?? lightTheme.shape.borderRadius
       }px)`,
-      '& > p': {
-        color: 'inherit',
+      '& > p, & > ul': {
         '&:last-child': {
           margin: 0,
         },
-      },
-      '& ul, li': {
-        color: 'inherit',
       },
       '&.MuiCallout-error': {
         color: `var(--muidocs-palette-error-900, ${lightTheme.palette.error[900]})`,
@@ -423,6 +418,7 @@ const Root = styled('div')(
       },
     },
     '& li': {
+      marginBottom: 2,
       '& pre': {
         marginTop: theme.spacing(1),
       },
@@ -455,9 +451,6 @@ const Root = styled('div')(
       },
       '& h5': {
         color: `var(--muidocs-palette-grey-300, ${darkTheme.palette.grey[300]})`,
-      },
-      '& p, & ul, & ol': {
-        color: `var(--muidocs-palette-grey-400, ${darkTheme.palette.grey[400]})`,
       },
       '& h1, & h2, & h3, & h4': {
         '&:hover .anchor-link-style, & .comment-link-style': {

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -99,6 +99,7 @@ const Root = styled('div')(
     '& p, & ul, & ol': {
       marginTop: 0,
       marginBottom: 16,
+      color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
     },
     '& ul': {
       paddingLeft: 30,
@@ -245,10 +246,13 @@ const Root = styled('div')(
       borderRadius: `var(--muidocs-shape-borderRadius, ${
         theme.shape?.borderRadius ?? lightTheme.shape.borderRadius
       }px)`,
-      '& > p, & > ul': {
+      '& > ul, & > p': {
         '&:last-child': {
           margin: 0,
         },
+      },
+      '& > p, & ul, li': {
+        color: 'inherit',
       },
       '&.MuiCallout-error': {
         color: `var(--muidocs-palette-error-900, ${lightTheme.palette.error[900]})`,
@@ -418,7 +422,7 @@ const Root = styled('div')(
       },
     },
     '& li': {
-      marginBottom: 2,
+      marginBottom: 4,
       '& pre': {
         marginTop: theme.spacing(1),
       },
@@ -451,6 +455,9 @@ const Root = styled('div')(
       },
       '& h5': {
         color: `var(--muidocs-palette-grey-300, ${darkTheme.palette.grey[300]})`,
+      },
+      '& p, & ul, & ol': {
+        color: `var(--muidocs-palette-grey-400, ${darkTheme.palette.grey[400]})`,
       },
       '& h1, & h2, & h3, & h4': {
         '&:hover .anchor-link-style, & .comment-link-style': {


### PR DESCRIPTION
1. Add a bit more spacing between list items, [Bootstrap uses 4px](https://getbootstrap.com/docs/5.2/getting-started/javascript/#usage-with-javascript-frameworks), [Tailwind CSS uses 8px](https://tailwindcss.com/docs/reusing-styles#avoiding-premature-abstraction). I saw the problem in https://github.com/mui/mui-x/pull/6567#discussion_r1018500264.

  Before: https://mui.com/material-ui/getting-started/overview/#advantages-of-material-ui
  After: https://deploy-preview-35302--material-ui.netlify.app/material-ui/getting-started/overview/#advantages-of-material-ui

2. Remove the leading margin for the list item. I saw the problem in https://github.com/mui/material-ui/pull/35202.

  Before: https://mui.com/joy-ui/customization/using-css-variables/#raw-value
  After https://deploy-preview-35302--material-ui.netlify.app/joy-ui/customization/using-css-variables/#raw-value

3. ~Remove useless color override, use CSS inheritance by default~