### PR TITLE
[core] Use componentStyles.name over componentName

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -119,7 +119,7 @@ PropsTable.propTypes = {
 };
 
 function ClassesTable(props) {
-  const { componentName, componentStyles, classDescriptions } = props;
+  const { componentStyles, classDescriptions } = props;
   const t = useTranslate();
 
   return (
@@ -139,7 +139,8 @@ function ClassesTable(props) {
             </td>
             <td align="left">
               <span className="prop-name">
-                .{componentStyles.globalClasses[className] || `Mui${componentName}-${className}`}
+                .
+                {componentStyles.globalClasses[className] || `${componentStyles.name}-${className}`}
               </span>
             </td>
             <td
@@ -161,7 +162,6 @@ function ClassesTable(props) {
 
 ClassesTable.propTypes = {
   classDescriptions: PropTypes.object.isRequired,
-  componentName: PropTypes.string.isRequired,
   componentStyles: PropTypes.object.isRequired,
 };
 
@@ -371,11 +371,7 @@ import { ${componentName} } from '${source}';`}
         {Object.keys(componentStyles.classes).length ? (
           <React.Fragment>
             <Heading hash="css" />
-            <ClassesTable
-              componentName={componentName}
-              componentStyles={componentStyles}
-              classDescriptions={classDescriptions}
-            />
+            <ClassesTable componentStyles={componentStyles} classDescriptions={classDescriptions} />
             <br />
             <span dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />
             <span


### PR DESCRIPTION
A continuation of https://github.com/mui/mui-x/pull/7051, one step closer to sharing the same `ApiPage` component with MUI X. The difference is that in MUI X, there are components that have different names than there style sheet. This happens because of the Pro and Premium components. It's stays the same:

Before: https://mui.com/material-ui/api/alert/
After: https://deploy-preview-35303--material-ui.netlify.app/material-ui/api/alert/