### PR TITLE
[typescript] Add null to return type of OverridableComponent

### DIFF
--- a/packages/mui-material/src/OverridableComponent.d.ts
+++ b/packages/mui-material/src/OverridableComponent.d.ts
@@ -21,7 +21,7 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
       component: C;
     } & OverrideProps<M, C>,
   ): JSX.Element | null;
-  (props: DefaultComponentProps<M>): JSX.Element;
+  (props: DefaultComponentProps<M>): JSX.Element | null;
 }
 
 /**

--- a/packages/mui-material/src/OverridableComponent.d.ts
+++ b/packages/mui-material/src/OverridableComponent.d.ts
@@ -20,7 +20,7 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
        */
       component: C;
     } & OverrideProps<M, C>,
-  ): JSX.Element;
+  ): JSX.Element | null;
   (props: DefaultComponentProps<M>): JSX.Element;
 }
 

--- a/packages/mui-types/index.d.ts
+++ b/packages/mui-types/index.d.ts
@@ -105,7 +105,7 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
       component: C;
     } & OverrideProps<M, C>,
   ): JSX.Element | null;
-  (props: DefaultComponentProps<M>): JSX.Element;
+  (props: DefaultComponentProps<M>): JSX.Element | null;
   propTypes?: any;
 }
 

--- a/packages/mui-types/index.d.ts
+++ b/packages/mui-types/index.d.ts
@@ -104,7 +104,7 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
        */
       component: C;
     } & OverrideProps<M, C>,
-  ): JSX.Element;
+  ): JSX.Element | null;
   (props: DefaultComponentProps<M>): JSX.Element;
   propTypes?: any;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

closes #32420