### PR TITLE
fix: wrong element type for emotionRoot

### DIFF
--- a/docs/data/material/guides/shadow-dom/shadow-dom.md
+++ b/docs/data/material/guides/shadow-dom/shadow-dom.md
@@ -14,7 +14,7 @@ The following code snippet shows how to apply styles inside of the shadow DOM:
 ```tsx
 const container = document.querySelector('#root');
 const shadowContainer = container.attachShadow({ mode: 'open' });
-const emotionRoot = document.createElement('style');
+const emotionRoot = document.createElement('div');
 const shadowRootElement = document.createElement('div');
 shadowContainer.appendChild(emotionRoot);
 shadowContainer.appendChild(shadowRootElement);


### PR DESCRIPTION
The current documentation will produce style elements within style elements which is not valid in HTML5.

![image](https://user-images.githubusercontent.com/476567/205305716-3f371bb8-9c12-4d7a-95d9-a020e45fbeff.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Made the PR with the edit button in Github because is so small.