### PR TITLE
fix: wrong element type for emotionRoot

### DIFF
--- a/docs/data/material/guides/shadow-dom/shadow-dom.md
+++ b/docs/data/material/guides/shadow-dom/shadow-dom.md
@@ -14,7 +14,7 @@ The following code snippet shows how to apply styles inside of the shadow DOM:
 ```tsx
 const container = document.querySelector('#root');
 const shadowContainer = container.attachShadow({ mode: 'open' });
-const emotionRoot = document.createElement('style');
+const emotionRoot = document.createElement('div');
 const shadowRootElement = document.createElement('div');
 shadowContainer.appendChild(emotionRoot);
 shadowContainer.appendChild(shadowRootElement);


### PR DESCRIPTION
The current documentation will produce style elements within style elements which is not valid in HTML5.

![image](https://user-images.githubusercontent.com/476567/205306921-bf2d6314-bd1f-47ea-9b4d-1a740ece9def.png)

Made the PR with the edit button in Github because is so small and docs only.