### PR TITLE
[Autocomplete] use Autocomplete size prop in renderInput directly

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -550,7 +550,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
           id,
           disabled,
           fullWidth: true,
-          size: size === 'small' ? 'small' : undefined,
+          size,
           InputLabelProps: getInputLabelProps(),
           InputProps: {
             ref: setAnchorEl,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes https://github.com/mui/material-ui/issues/35343

When we defined `size: 'small'` as default on `TextField` in a custom theme, passing `size: medium` on  `Autocomplete` does not work.

I'm not sure if this was on purpose but this seems like it's assuming default size prop to be `medium`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Before: https://codesandbox.io/s/mui-autocomplete-size-issue-forked-hpv53z?file=/demo.tsx

After: 