### PR TITLE
[docs][draft] Allows to duplicate markdown

### DIFF
--- a/docs/data/base/common/Test.js
+++ b/docs/data/base/common/Test.js
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import Button from '@mui/base/ButtonUnstyled';
+
+function Test() {
+  return <Button>Test me</Button>;
+}
+
+export default Test;

--- a/docs/data/base/common/test.md
+++ b/docs/data/base/common/test.md
@@ -1,0 +1,11 @@
+This is en experimentation
+
+
+On multi line
+
+
+:::info
+Testing Markdown parsing
+:::
+
+{{"demo": "data/base/common/Test.js"}}

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -8,6 +8,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 
 # Unstyled Button
 
+{{"insert": "../../common/test.md"}}
+
 <p class="description">Buttons let users take actions and make choices with a single tap.</p>
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}


### PR DESCRIPTION
## Context

In the package, `@mui/x-date-pickers` components are not fully independent. Props are shared between multiple components, but not all of them, which makes it difficult to build the documentation. For example, the `DatePicker` shares a lot of logic with `DateTimePickers` and with their subcomponent the `DayCalendar`.

To avoid having to read the entire docs to customize components, we thought about the following strategy:
- Shared properties are deeply discussed in the smallest component using them. For example calendar customization are discussed in a page about `DayCalendar`
- A brief introduction is added to each page using them.

## Problem

Such an approach has a major drawback: creating duplicate content. Which can lead to outdated content.

## Solution 

The proposed solution is to keep one source of truth for the content we want to repeat.

For example we could add the following in different doc pages

```md
{{"insert": "../../common/pickers/DayCalendar"}}
```

And define the introduction with 

```md
## Calendar customization

The Calendar can be deeply customized by ...

Here is an example of how to ...

{{"demo": ....}}

For more information, have a look at ... page
```