### PR TITLE
[Utils] mergedeep deeply clones source key if it's an object

### DIFF
--- a/packages/mui-utils/src/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge.test.ts
@@ -45,4 +45,19 @@ describe('deepmerge', () => {
       bar: 'test',
     });
   });
+
+  it('should deep clone source key object if target key does not exist', () => {
+    const foo = { foo: { baz: 'test' } };
+    const bar = {};
+
+    const result = deepmerge(bar, foo);
+
+    expect(result).to.deep.equal({ foo: { baz: 'test' } });
+
+    // @ts-ignore
+    result.foo.baz = 'new test';
+
+    expect(result).to.deep.equal({ foo: { baz: 'new test' } });
+    expect(foo).to.deep.equal({ foo: { baz: 'test' } });
+  });
 });

--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -6,6 +6,20 @@ export interface DeepmergeOptions {
   clone?: boolean;
 }
 
+function deepClone<T>(source: T): T | Record<keyof any, unknown> {
+  if (!isPlainObject(source)) {
+    return source;
+  }
+
+  const output: Record<keyof any, unknown> = {};
+
+  Object.keys(source).forEach((key) => {
+    output[key] = deepClone(source[key]);
+  });
+
+  return output;
+}
+
 export default function deepmerge<T>(
   target: T,
   source: unknown,
@@ -23,6 +37,10 @@ export default function deepmerge<T>(
       if (isPlainObject(source[key]) && key in target && isPlainObject(target[key])) {
         // Since `output` is a clone of `target` and we have narrowed `target` in this block we can cast to the same type.
         (output as Record<keyof any, unknown>)[key] = deepmerge(target[key], source[key], options);
+      } else if (options.clone) {
+        (output as Record<keyof any, unknown>)[key] = isPlainObject(source[key])
+          ? deepClone(source[key])
+          : source[key];
       } else {
         (output as Record<keyof any, unknown>)[key] = source[key];
       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
I'm not sure about `lodash` but we definetly have to use deep copy for objects otherwise value assign by reference.
Test case has been added.

Fix #35363
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
