### PR TITLE
[docs] Improve line-height readability

### DIFF
--- a/docs/public/static/styles/prism-okaidia.css
+++ b/docs/public/static/styles/prism-okaidia.css
@@ -16,7 +16,7 @@ pre[class*='language-'] {
   word-spacing: normal;
   word-break: normal;
   word-wrap: normal;
-  line-height: 1.5;
+  /* line-height: 1.5; */
 
   /* -moz-tab-size: 4; */
   /* -o-tab-size: 4; */

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -10,14 +10,14 @@ import {
 const Root = styled('div')(
   ({ theme }) => ({
     ...lightTheme.typography.body1,
-    lineHeight: 1.625,
+    lineHeight: 1.625, // Increased compared to the 1.5 default to make the docs easier to read.
     color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
     '& strong': {
       color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
     },
     wordBreak: 'break-word',
     '& pre': {
-      lineHeight: 1.5,
+      lineHeight: 1.5, // Developers likes when the code is dense.
       margin: theme.spacing(2, 'auto'),
       padding: theme.spacing(2),
       backgroundColor: `var(--muidocs-palette-primaryDark-800, ${lightTheme.palette.primaryDark[800]})`,

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -10,6 +10,7 @@ import {
 const Root = styled('div')(
   ({ theme }) => ({
     ...lightTheme.typography.body1,
+    lineHeight: 1.625,
     color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
     '& strong': {
       color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
@@ -422,7 +423,7 @@ const Root = styled('div')(
       },
     },
     '& li': {
-      marginBottom: 4,
+      marginBottom: 6,
       '& pre': {
         marginTop: theme.spacing(1),
       },

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -10,7 +10,7 @@ import {
 const Root = styled('div')(
   ({ theme }) => ({
     ...lightTheme.typography.body1,
-    lineHeight: 1.625, // Increased compared to the 1.5 default to make the docs easier to read.
+    lineHeight: 1.5625, // Increased compared to the 1.5 default to make the docs easier to read.
     color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
     '& strong': {
       color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -17,6 +17,7 @@ const Root = styled('div')(
     },
     wordBreak: 'break-word',
     '& pre': {
+      lineHeight: 1.5,
       margin: theme.spacing(2, 'auto'),
       padding: theme.spacing(2),
       backgroundColor: `var(--muidocs-palette-primaryDark-800, ${lightTheme.palette.primaryDark[800]})`,
@@ -423,7 +424,7 @@ const Root = styled('div')(
       },
     },
     '& li': {
-      marginBottom: 6,
+      marginBottom: 4,
       '& pre': {
         marginTop: theme.spacing(1),
       },

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -143,7 +143,6 @@ const Root = styled('div')(
         marginBottom: theme.spacing(3),
       },
       '& .markdown-body': {
-        fontSize: theme.typography.pxToRem(16),
         lineHeight: 1.7,
       },
       '& img, & video': {


### PR DESCRIPTION
A nitpick, a quick follow-up on https://groups.google.com/a/mui.com/g/design/c/S5t9m6klH7o.

The idea of this change is to bring a bit more space between each line of the docs. Right now, if you compare our line height of Tailwind CSS, https://mintlify.com/docs/quickstart or https://stripe.com/docs/billing/subscriptions/overview it seems that the new value match closer, and might be more enjoyable to read.

For the blog, maybe it makes sense to have a bit more line height?

