### PR TITLE
[Select] Fix `MenuProps.PopoverClasses` being overriden

### DIFF
--- a/packages/mui-material/src/Menu/Menu.js
+++ b/packages/mui-material/src/Menu/Menu.js
@@ -158,7 +158,6 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
 
   return (
     <MenuRoot
-      classes={PopoverClasses}
       onClose={onClose}
       anchorOrigin={{
         vertical: 'bottom',
@@ -180,6 +179,7 @@ const Menu = React.forwardRef(function Menu(inProps, ref) {
       TransitionProps={{ onEntering: handleEntering, ...TransitionProps }}
       ownerState={ownerState}
       {...other}
+      classes={PopoverClasses}
     >
       <MenuMenuList
         onKeyDown={handleListKeyDown}

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -112,17 +112,17 @@ describe('<Menu />', () => {
       expect(screen.getByTestId('paper')).to.have.class('bar');
     });
 
-    it('should be able to change the root element style', () => {
+    it('should be able to change the Popover root element style when Menu classes prop is also provided', () => {
       render(
         <Menu
           anchorEl={document.createElement('div')}
           open
-          PaperProps={{ 'data-testid': 'paper' }}
+          data-testid="popover"
+          classes={{ paper: 'bar' }}
           PopoverClasses={{ root: 'foo' }}
         />,
       );
-
-      expect(screen.getByTestId('paper').parentElement).to.have.class('foo');
+      expect(screen.getByTestId('popover')).to.have.class('foo');
     });
   });
 

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -111,6 +111,19 @@ describe('<Menu />', () => {
 
       expect(screen.getByTestId('paper')).to.have.class('bar');
     });
+
+    it('should be able to change the root element style', () => {
+      render(
+        <Menu
+          anchorEl={document.createElement('div')}
+          open
+          PaperProps={{ 'data-testid': 'paper' }}
+          PopoverClasses={{ root: 'foo' }}
+        />,
+      );
+
+      expect(screen.getByTestId('paper').parentElement).to.have.class('foo');
+    });
   });
 
   it('should pass onClose prop to Popover', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
----
Fixes [#35376](https://github.com/mui/material-ui/issues/35376)