### PR TITLE
[typescript] Use type union instead of type intersection for SelectChangeEvent

### DIFF
--- a/packages/mui-material/src/Select/SelectInput.d.ts
+++ b/packages/mui-material/src/Select/SelectInput.d.ts
@@ -9,8 +9,8 @@ import { MenuProps } from '../Menu';
  * For example, when the browser auto-fills the `Select` you'll receive a `React.ChangeEvent`.
  */
 export type SelectChangeEvent<T = string> =
-  | (Event & { target: { value: T; name: string } })
-  | React.ChangeEvent<HTMLInputElement>;
+  & (Event & { target: { value: T; name: string } })
+  & React.ChangeEvent<HTMLInputElement>;
 
 export interface SelectInputProps<T = unknown> {
   autoFocus?: boolean;


### PR DESCRIPTION
This fixes what seems to be a typo in type definition for SelectChangeEvent, so that event.target.value is of the same type as the SelectInput value prop, in the onChange event handler.
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
