### PR TITLE
Reexport `createSvgIcon` from utils

### DIFF
--- a/packages/mui-joy/src/utils/index.ts
+++ b/packages/mui-joy/src/utils/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as createSvgIcon } from './createSvgIcon';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Preview**: https://codesandbox.io/s/joy-cra-typescript-forked-6fsov0?file=/src/App.tsx

This PR does the same as Material UI by exporting `createSvgIcon` from `utils`, so that the consumer can use yarn resolutions.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
