### PR TITLE
[test] Update JSDOM env to include `HTMLTextAreaElement`

### DIFF
--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -13,6 +13,7 @@ const whitelist = [
   'Image',
   'HTMLElement',
   'HTMLInputElement',
+  'HTMLTextAreaElement',
   'Node',
   'Performance',
   'document',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I need this for https://github.com/mui/mui-x/pull/6593 to fix [unit tests that fail](https://app.circleci.com/pipelines/github/mui/mui-x/29722/workflows/e20d1b36-d161-47c1-9b82-2e33fced1926/jobs/170375) with the following error message:
```
console.error message #1:
  Error: Uncaught [ReferenceError: HTMLTextAreaElement is not defined]
```