### PR TITLE
[docs] Improve `Responsive App bar with Drawer` demo

### DIFF
--- a/docs/data/material/components/app-bar/DrawerAppBar.js
+++ b/docs/data/material/components/app-bar/DrawerAppBar.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
@@ -22,7 +23,7 @@ function DrawerAppBar(props) {
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
   const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
+    setMobileOpen((prevState) => !prevState);
   };
 
   const drawer = (
@@ -47,6 +48,7 @@ function DrawerAppBar(props) {
 
   return (
     <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
       <AppBar component="nav">
         <Toolbar>
           <IconButton

--- a/docs/data/material/components/app-bar/DrawerAppBar.tsx
+++ b/docs/data/material/components/app-bar/DrawerAppBar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
@@ -29,7 +30,7 @@ export default function DrawerAppBar(props: Props) {
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
   const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
+    setMobileOpen((prevState) => !prevState);
   };
 
   const drawer = (
@@ -54,6 +55,7 @@ export default function DrawerAppBar(props: Props) {
 
   return (
     <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
       <AppBar component="nav">
         <Toolbar>
           <IconButton


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #35351 

Also updated the text color in dark mode in [Responsive App bar with Drawer demo](https://mui.com/material-ui/react-app-bar/#responsive-app-bar-with-drawer) demo. It was not visible.

Check the demo in dark mode - 
Before: https://mui.com/material-ui/react-app-bar/#responsive-app-bar-with-drawer
After: https://deploy-preview-35418--material-ui.netlify.app/material-ui/react-app-bar/#responsive-app-bar-with-drawer

I also approved the Argos build: https://app.argos-ci.com/mui/material-ui/builds/8116/31127253 (I think the font changed which is fine).