### PR TITLE
[test] Fix broken master branch

### DIFF
--- a/packages/mui-joy/src/Box/Box.test.js
+++ b/packages/mui-joy/src/Box/Box.test.js
@@ -23,13 +23,7 @@ describe('Joy <Box />', () => {
     refInstanceof: window.HTMLDivElement,
   }));
 
-  it('respects theme from context', function test() {
-    const isJSDOM = /jsdom/.test(window.navigator.userAgent);
-
-    if (isJSDOM) {
-      this.skip();
-    }
-
+  it('respects theme from context', () => {
     const { container } = render(
       <ThemeProvider
         theme={{
@@ -214,24 +208,6 @@ describe('Joy <Box />', () => {
       });
     });
 
-    it('letterSpacing', function test() {
-      const isJSDOM = /jsdom/.test(window.navigator.userAgent);
-
-      if (isJSDOM) {
-        this.skip();
-      }
-
-      const { container } = render(
-        <CssVarsProvider theme={theme}>
-          <Box sx={{ letterSpacing: 'md' }} />
-        </CssVarsProvider>,
-      );
-
-      expect(container.firstChild).toHaveComputedStyle({
-        letterSpacing: '1.328px',
-      });
-    });
-
     it('lineHeight', function test() {
       const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -248,6 +224,37 @@ describe('Joy <Box />', () => {
       expect(container.firstChild).toHaveComputedStyle({
         lineHeight: '24px',
       });
+    });
+  });
+});
+
+// eslint-disable-next-line mocha/max-top-level-suites
+describe('theme.unstable_sx', () => {
+  const theme = extendTheme({
+    colorSchemes: {
+      light: {
+        palette: {
+          primary: {
+            500: 'rgb(0, 0, 255)',
+          },
+        },
+      },
+    },
+  });
+
+  it('bgcolor', () => {
+    expect(theme.unstable_sx({ bgcolor: 'primary.500' })).to.deep.equal({
+      // TODO fixme
+      // backgroundColor: 'var(--joy-palette-primary-500)',
+      backgroundColor: 'primary.500',
+    });
+  });
+
+  it('borderRadius', () => {
+    expect(theme.unstable_sx({ borderRadius: 'md' })).to.deep.equal({
+      // TODO fixme
+      // borderRadius: 'var(--joy-radius-md)',
+      borderRadius: '12px',
     });
   });
 });

--- a/packages/mui-joy/src/Box/Box.test.js
+++ b/packages/mui-joy/src/Box/Box.test.js
@@ -227,34 +227,3 @@ describe('Joy <Box />', () => {
     });
   });
 });
-
-// eslint-disable-next-line mocha/max-top-level-suites
-describe('theme.unstable_sx', () => {
-  const theme = extendTheme({
-    colorSchemes: {
-      light: {
-        palette: {
-          primary: {
-            500: 'rgb(0, 0, 255)',
-          },
-        },
-      },
-    },
-  });
-
-  it('bgcolor', () => {
-    expect(theme.unstable_sx({ bgcolor: 'primary.500' })).to.deep.equal({
-      // TODO fixme
-      // backgroundColor: 'var(--joy-palette-primary-500)',
-      backgroundColor: 'primary.500',
-    });
-  });
-
-  it('borderRadius', () => {
-    expect(theme.unstable_sx({ borderRadius: 'md' })).to.deep.equal({
-      // TODO fixme
-      // borderRadius: 'var(--joy-radius-md)',
-      borderRadius: '12px',
-    });
-  });
-});

--- a/packages/mui-joy/src/styles/extendTheme.test.js
+++ b/packages/mui-joy/src/styles/extendTheme.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import extendTheme from './extendTheme';
+import { createRenderer } from 'test/utils';
+import { extendTheme, useTheme, CssVarsProvider } from '@mui/joy/styles';
 
 describe('extendTheme', () => {
   it('the output contains required fields', () => {
@@ -45,5 +46,83 @@ describe('extendTheme', () => {
     const theme = extendTheme({ cssVarPrefix: '' });
     expect(theme.cssVarPrefix).to.equal('');
     expect(theme.typography.body1.fontSize).to.equal('var(--fontSize-md)');
+  });
+
+  describe('theme.unstable_sx', () => {
+    let originalMatchmedia;
+    const { render } = createRenderer();
+    const storage = {};
+    beforeEach(() => {
+      originalMatchmedia = window.matchMedia;
+      // Create mocks of localStorage getItem and setItem functions
+      Object.defineProperty(global, 'localStorage', {
+        value: {
+          getItem: (key) => storage[key],
+          setItem: (key, value) => {
+            storage[key] = value;
+          },
+        },
+        configurable: true,
+      });
+      window.matchMedia = () => ({
+        addListener: () => {},
+        removeListener: () => {},
+      });
+    });
+    afterEach(() => {
+      window.matchMedia = originalMatchmedia;
+    });
+    
+    const theme = extendTheme({
+      colorSchemes: {
+        light: {
+          palette: {
+            primary: {
+              500: 'rgb(0, 0, 255)',
+            },
+          },
+        },
+      },
+    });
+
+    it('bgcolor', () => {
+      let styles = {};
+
+      const Test = () => {
+        const theme = useTheme();
+        styles = theme.unstable_sx({ bgcolor: 'primary.500' });
+        return null;
+      };
+
+      const { container } = render(
+        <CssVarsProvider theme={theme}>
+          <Test />
+        </CssVarsProvider>,
+      );
+
+      expect(styles).to.deep.equal({
+        backgroundColor: 'var(--joy-palette-primary-500)',
+      });
+    });
+
+    it('borderRadius', () => {
+      let styles = {};
+
+      const Test = () => {
+        const theme = useTheme();
+        styles = theme.unstable_sx({ borderRadius: 'md' });
+        return null;
+      };
+
+      const { container } = render(
+        <CssVarsProvider theme={theme}>
+          <Test />
+        </CssVarsProvider>,
+      );
+
+      expect(styles).to.deep.equal({
+        borderRadius: 'var(--joy-radius-md)',
+      });
+    });
   });
 });

--- a/packages/mui-joy/src/styles/extendTheme.test.js
+++ b/packages/mui-joy/src/styles/extendTheme.test.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer } from 'test/utils';
 import { extendTheme, useTheme, CssVarsProvider } from '@mui/joy/styles';
@@ -49,8 +50,9 @@ describe('extendTheme', () => {
   });
 
   describe('theme.unstable_sx', () => {
-    let originalMatchmedia;
     const { render } = createRenderer();
+
+    let originalMatchmedia;
     const storage = {};
     beforeEach(() => {
       originalMatchmedia = window.matchMedia;
@@ -72,8 +74,8 @@ describe('extendTheme', () => {
     afterEach(() => {
       window.matchMedia = originalMatchmedia;
     });
-    
-    const theme = extendTheme({
+
+    const customTheme = extendTheme({
       colorSchemes: {
         light: {
           palette: {
@@ -88,14 +90,14 @@ describe('extendTheme', () => {
     it('bgcolor', () => {
       let styles = {};
 
-      const Test = () => {
+      function Test() {
         const theme = useTheme();
         styles = theme.unstable_sx({ bgcolor: 'primary.500' });
         return null;
-      };
+      }
 
-      const { container } = render(
-        <CssVarsProvider theme={theme}>
+      render(
+        <CssVarsProvider theme={customTheme}>
           <Test />
         </CssVarsProvider>,
       );
@@ -108,14 +110,14 @@ describe('extendTheme', () => {
     it('borderRadius', () => {
       let styles = {};
 
-      const Test = () => {
+      function Test() {
         const theme = useTheme();
         styles = theme.unstable_sx({ borderRadius: 'md' });
         return null;
-      };
+      }
 
-      const { container } = render(
-        <CssVarsProvider theme={theme}>
+      render(
+        <CssVarsProvider theme={customTheme}>
           <Test />
         </CssVarsProvider>,
       );


### PR DESCRIPTION
Something I noticed while I was working on the KPI page. master is broken:

<img width="531" alt="Screenshot 2022-12-11 at 13 58 42" src="https://user-images.githubusercontent.com/3165635/206904957-49dd2215-6917-4c98-9df8-5bfa633afd66.png">

https://www.notion.so/mui-org/KPIs-1ce9658b85ce4628a2a2ed2ae74ff69c#59bb101e5eab4375a6018d6694d036a7

The issue is that since #35150, this test never pass:

<img width="651" alt="Screenshot 2022-12-11 at 13 59 16" src="https://user-images.githubusercontent.com/3165635/206904978-ebfdf8e9-b3ab-414f-83b5-bdc33a0ec1b5.png">

https://app.circleci.com/pipelines/github/mui/material-ui/87228/workflows/4504c13e-6d89-49fe-9589-60586b34e23a/jobs/461431

My proposed solution is to remove it.

---

I was also curious, I saw we had no tests for `theme.unstable_sx` so I added one. On my end, it doesn't behave exactly like I was exepecting:

1. Colors aren't supported.
1. When using `createTheme()` I would expect it returns the raw value.
1. When using `extendTheme()` I would expect it returns the CSS variable.

I even wonder if we shouldn't rename these helpers for clarity:

- `createTheme` -> `createRawTheme`. It's the plain values
- `extendTheme` -> `createTheme`. It's the new one

Live demo https://codesandbox.io/s/red-meadow-eejvie?file=/demo.tsx.