### PR TITLE
[test] Terminate BrowserStack after 5 minutes

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -27,7 +27,7 @@ const browserStack = {
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 10 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 5 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();


### PR DESCRIPTION
Since #34764, the tests in BrowserStack are faster (Firefox could be quite slow).

<img width="743" alt="Screenshot 2022-12-12 at 15 48 24" src="https://user-images.githubusercontent.com/3165635/207075510-a1eea57f-6448-4958-8ce3-9171ab49e4d4.png">

https://automate.browserstack.com/dashboard/v2/builds/a388cf32b522d21452ff09cc50ef498ef4c20d33

So when something is going wrong:

<img width="903" alt="Screenshot 2022-12-12 at 15 50 39" src="https://user-images.githubusercontent.com/3165635/207076120-b62dcf4c-ad45-485e-8079-551d86452fdf.png">

https://automate.browserstack.com/dashboard/v2/builds/444a887beff83e259a560b75df57988643f4eb0b

I think that we could reduce how much it starves the CI.