### PR TITLE
[Popper][Base] Fix Tooltip Anchor Element Setter

### DIFF
--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
@@ -84,7 +84,9 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
    * modifiers.flip is essentially a flip for controlled/uncontrolled behavior
    */
   const [placement, setPlacement] = React.useState(rtlPlacement);
-  const [tooltipAnchorEl, setTooltipAnchorEl] = React.useState(resolveAnchorEl(anchorEl));
+  const [resolvedAnchorElement, setResolvedAnchorElement] = React.useState(
+    resolveAnchorEl(anchorEl),
+  );
 
   React.useEffect(() => {
     if (popperRef.current) {
@@ -94,12 +96,12 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
 
   React.useEffect(() => {
     if (anchorEl) {
-      setTooltipAnchorEl(resolveAnchorEl(anchorEl));
+      setResolvedAnchorElement(resolveAnchorEl(anchorEl));
     }
   }, [anchorEl]);
 
   useEnhancedEffect(() => {
-    if (!tooltipAnchorEl || !open) {
+    if (!resolvedAnchorElement || !open) {
       return undefined;
     }
 
@@ -108,8 +110,8 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
     };
 
     if (process.env.NODE_ENV !== 'production') {
-      if (tooltipAnchorEl && tooltipAnchorEl.nodeType === 1) {
-        const box = tooltipAnchorEl.getBoundingClientRect();
+      if (resolvedAnchorElement && resolvedAnchorElement.nodeType === 1) {
+        const box = resolvedAnchorElement.getBoundingClientRect();
 
         if (
           process.env.NODE_ENV !== 'test' &&
@@ -159,7 +161,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       popperModifiers = popperModifiers.concat(popperOptions.modifiers);
     }
 
-    const popper = createPopper(tooltipAnchorEl, tooltipRef.current, {
+    const popper = createPopper(resolvedAnchorElement, tooltipRef.current, {
       placement: rtlPlacement,
       ...popperOptions,
       modifiers: popperModifiers,
@@ -171,7 +173,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       popper.destroy();
       handlePopperRefRef.current(null);
     };
-  }, [tooltipAnchorEl, disablePortal, modifiers, open, popperOptions, rtlPlacement]);
+  }, [resolvedAnchorElement, disablePortal, modifiers, open, popperOptions, rtlPlacement]);
 
   const childProps = { placement };
 

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.js
@@ -84,7 +84,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
    * modifiers.flip is essentially a flip for controlled/uncontrolled behavior
    */
   const [placement, setPlacement] = React.useState(rtlPlacement);
-  const [tooltipAnchorEl, setTooltipAnchorEl] = React.useState(anchorEl);
+  const [tooltipAnchorEl, setTooltipAnchorEl] = React.useState(resolveAnchorEl(anchorEl));
 
   React.useEffect(() => {
     if (popperRef.current) {
@@ -94,7 +94,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
 
   React.useEffect(() => {
     if (anchorEl) {
-      setTooltipAnchorEl(anchorEl);
+      setTooltipAnchorEl(resolveAnchorEl(anchorEl));
     }
   }, [anchorEl]);
 
@@ -107,11 +107,9 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       setPlacement(data.placement);
     };
 
-    const resolvedAnchorEl = resolveAnchorEl(tooltipAnchorEl);
-
     if (process.env.NODE_ENV !== 'production') {
-      if (resolvedAnchorEl && resolvedAnchorEl.nodeType === 1) {
-        const box = resolvedAnchorEl.getBoundingClientRect();
+      if (tooltipAnchorEl && tooltipAnchorEl.nodeType === 1) {
+        const box = tooltipAnchorEl.getBoundingClientRect();
 
         if (
           process.env.NODE_ENV !== 'test' &&
@@ -161,7 +159,7 @@ const PopperTooltip = React.forwardRef(function PopperTooltip(props, ref) {
       popperModifiers = popperModifiers.concat(popperOptions.modifiers);
     }
 
-    const popper = createPopper(resolveAnchorEl(tooltipAnchorEl), tooltipRef.current, {
+    const popper = createPopper(tooltipAnchorEl, tooltipRef.current, {
       placement: rtlPlacement,
       ...popperOptions,
       modifiers: popperModifiers,


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


#### Problem

When `props.anchorEl` is a function, it sometimes gets called with one argument when it expects no arguments (see [codesandbox example](https://codesandbox.io/s/anchorel-called-with-arg-r5qbgm?file=/demo.tsx)).

#### Cause

This is happening because the state setter `setTooltipAnchorEl(anchorEl)` (recently added in #34714) calls a function `anchorEl` as if it were in the form of `setTooltipAnchorEl((prev) => next)`.

#### Solution

We should call `resolveAnchorEl` on `anchorEl` before setting `tooltipAnchorEl`.