### PR TITLE
[docs] Add `CardMedia` example without `component="img"` prop

### DIFF
--- a/docs/data/material/components/cards/MediaCard.js
+++ b/docs/data/material/components/cards/MediaCard.js
@@ -10,10 +10,9 @@ export default function MediaCard() {
   return (
     <Card sx={{ maxWidth: 345 }}>
       <CardMedia
-        component="img"
-        height="140"
+        sx={{ height: 140 }}
         image="/static/images/cards/contemplative-reptile.jpg"
-        alt="green iguana"
+        title="green iguana"
       />
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">

--- a/docs/data/material/components/cards/MediaCard.tsx
+++ b/docs/data/material/components/cards/MediaCard.tsx
@@ -10,10 +10,9 @@ export default function MediaCard() {
   return (
     <Card sx={{ maxWidth: 345 }}>
       <CardMedia
-        component="img"
-        height="140"
+        sx={{ height: 140 }}
         image="/static/images/cards/contemplative-reptile.jpg"
-        alt="green iguana"
+        title="green iguana"
       />
       <CardContent>
         <Typography gutterBottom variant="h5" component="div">


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/35468