### PR TITLE
[Tooltip][Joy] Fix arrow does not appear

### DIFF
--- a/docs/data/joy/components/tooltip/ArrowTooltips.js
+++ b/docs/data/joy/components/tooltip/ArrowTooltips.js
@@ -4,7 +4,7 @@ import Tooltip from '@mui/joy/Tooltip';
 
 export default function ArrowTooltips() {
   return (
-    <Tooltip title="Add" arrow>
+    <Tooltip title="Add" arrow open placement="right">
       <Button variant="plain">Arrow</Button>
     </Tooltip>
   );

--- a/docs/data/joy/components/tooltip/ArrowTooltips.tsx
+++ b/docs/data/joy/components/tooltip/ArrowTooltips.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@mui/joy/Tooltip';
 
 export default function ArrowTooltips() {
   return (
-    <Tooltip title="Add" arrow>
+    <Tooltip title="Add" arrow open placement="right">
       <Button variant="plain">Arrow</Button>
     </Tooltip>
   );

--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -588,9 +588,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   });
 
   const [SlotArrow, arrowProps] = useSlot('arrow', {
-    additionalProps: {
-      ref: setArrowRef,
-    },
+    ref: setArrowRef,
     className: classes.arrow,
     elementType: TooltipArrow,
     externalForwardedProps: other,

--- a/packages/mui-joy/src/utils/useSlot.ts
+++ b/packages/mui-joy/src/utils/useSlot.ts
@@ -52,7 +52,9 @@ export default function useSlot<
    * e.g. the `externalForwardedProps` are spread to `root` slot but not other slots.
    */
   name: T,
-  parameters: (T extends 'root' ? { ref: React.ForwardedRef<any> } : {}) & {
+  parameters: (T extends 'root' // root slot must pass a `ref` as a parameter
+    ? { ref: React.ForwardedRef<any> }
+    : { ref?: React.ForwardedRef<any> }) & {
     /**
      * The slot's className
      */
@@ -129,11 +131,7 @@ export default function useSlot<
     externalSlotProps: resolvedComponentsProps,
   });
 
-  const ref = useForkRef(
-    internalRef,
-    // @ts-ignore `ref` is required for the 'root' slot
-    useForkRef(resolvedComponentsProps?.ref, name === 'root' ? parameters.ref : undefined),
-  ) as ((instance: any | null) => void) | null;
+  const ref = useForkRef(internalRef, resolvedComponentsProps?.ref, parameters.ref);
 
   const finalOwnerState = getSlotOwnerState
     ? { ...ownerState, ...getSlotOwnerState(mergedProps as any) }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #35472 

## Root cause

The `ref` in `additionalProps` is not called by `useSlot` so `arrowRef` is always null.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
