### PR TITLE
[docs] Add missing comma to `Providing the colors directly` section

### DIFF
--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -87,10 +87,10 @@ const theme = createTheme({
       // dark: will be calculated from palette.secondary.main,
       contrastText: '#ffcc00',
     },
-     // Provide every color token (light, main, dark, and contrastText) when using
-     // custom colors for props in Material UI's components.
-     // Then you will be able to use it like this: `<Button color="custom">`
-     // (For TypeScript, you need to add module augmentation for the `custom` value)
+    // Provide every color token (light, main, dark, and contrastText) when using
+    // custom colors for props in Material UI's components.
+    // Then you will be able to use it like this: `<Button color="custom">`
+    // (For TypeScript, you need to add module augmentation for the `custom` value)
     custom: {
       light: '#ffa726',
       main: '#f57c00',
@@ -192,7 +192,7 @@ declare module '@mui/material/styles' {
   interface Palette {
     neutral: Palette['primary'];
   }
-  
+
   interface PaletteOptions {
     neutral: PaletteOptions['primary'];
   }
@@ -200,11 +200,11 @@ declare module '@mui/material/styles' {
   interface PaletteColor {
     darker?: string;
   }
-  
+
   interface SimplePaletteColorOptions {
     darker?: string;
   }
-  
+
   interface ThemeOptions {
     status: {
       danger: React.CSSProperties['color'];

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -96,7 +96,7 @@ const theme = createTheme({
       main: '#f57c00',
       dark: '#ef6c00',
       contrastText: 'rgba(0, 0, 0, 0.87)',
-    }
+    },
     // Used by `getContrastText()` to maximize the contrast between
     // the background and the text.
     contrastThreshold: 3,
@@ -192,6 +192,7 @@ declare module '@mui/material/styles' {
   interface Palette {
     neutral: Palette['primary'];
   }
+  
   interface PaletteOptions {
     neutral: PaletteOptions['primary'];
   }
@@ -199,9 +200,11 @@ declare module '@mui/material/styles' {
   interface PaletteColor {
     darker?: string;
   }
+  
   interface SimplePaletteColorOptions {
     darker?: string;
   }
+  
   interface ThemeOptions {
     status: {
       danger: React.CSSProperties['color'];


### PR DESCRIPTION
This is very minor, but I was pasting this section into an example and noticed the missing comma!

Signed-off-by: Cassidy Williams <1454517+cassidoo@users.noreply.github.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
