### PR TITLE
[docs][Autocomplete] Fix GoogleMaps demo

### DIFF
--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -103,6 +103,7 @@ export default function GoogleMaps() {
       includeInputInList
       filterSelectedOptions
       value={value}
+      noOptionsText="No locations"
       onChange={(event, newValue) => {
         setOptions(newValue ? [newValue, ...options] : options);
         setValue(newValue);
@@ -142,6 +143,7 @@ export default function GoogleMaps() {
                     key={index}
                     style={{
                       fontWeight: part.highlight ? 700 : 400,
+                      wordWrap: 'break-word',
                     }}
                   >
                     {part.text}

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -133,9 +133,7 @@ export default function GoogleMaps() {
                   <Box
                     key={index}
                     component="span"
-                    sx={{
-                      fontWeight: part.highlight ? 700 : 400,
-                    }}
+                    sx={{ fontWeight: part.highlight ? 700 : 400 }}
                   >
                     {part.text}
                   </Box>

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -114,7 +114,8 @@ export default function GoogleMaps() {
         <TextField {...params} label="Add a location" fullWidth />
       )}
       renderOption={(props, option) => {
-        const matches = option.structured_formatting.main_text_matched_substrings;
+        const matches =
+          option.structured_formatting.main_text_matched_substrings || [];
 
         const parts = parse(
           option.structured_formatting.main_text,

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -7,7 +7,6 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
 import throttle from 'lodash/throttle';
-import { ListItem } from '@mui/material';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -116,13 +115,7 @@ export default function GoogleMaps() {
       )}
       renderOption={(props, option) => {
         const matches = option.structured_formatting.main_text_matched_substrings;
-        if (!matches) {
-          return (
-            <ListItem sx={{ color: 'text.secondary', pt: '6px', pb: '6px' }}>
-              No options
-            </ListItem>
-          );
-        }
+
         const parts = parse(
           option.structured_formatting.main_text,
           matches.map((match) => [match.offset, match.offset + match.length]),
@@ -131,13 +124,13 @@ export default function GoogleMaps() {
         return (
           <li {...props}>
             <Grid container alignItems="center">
-              <Grid item>
+              <Grid item xs={2}>
                 <Box
                   component={LocationOnIcon}
                   sx={{ color: 'text.secondary', mr: 2 }}
                 />
               </Grid>
-              <Grid item xs>
+              <Grid item xs={10}>
                 {parts.map((part, index) => (
                   <span
                     key={index}
@@ -150,7 +143,11 @@ export default function GoogleMaps() {
                   </span>
                 ))}
 
-                <Typography variant="body2" color="text.secondary">
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ wordWrap: 'break-word' }}
+                >
                   {option.structured_formatting.secondary_text}
                 </Typography>
               </Grid>

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -116,7 +116,11 @@ export default function GoogleMaps() {
       renderOption={(props, option) => {
         const matches = option.structured_formatting.main_text_matched_substrings;
         if (!matches) {
-          return <ListItem sx={{ color: 'text.secondary' }}>No options</ListItem>;
+          return (
+            <ListItem sx={{ color: 'text.secondary', padding: '14px 16px' }}>
+              No options
+            </ListItem>
+          );
         }
         const parts = parse(
           option.structured_formatting.main_text,

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -125,27 +125,23 @@ export default function GoogleMaps() {
         return (
           <li {...props}>
             <Grid container alignItems="center">
-              <Grid item xs={2}>
-                <LocationOnIcon sx={{ color: 'text.secondary', mr: 2 }} />
+              <Grid item sx={{ display: 'flex', width: 44 }}>
+                <LocationOnIcon sx={{ color: 'text.secondary' }} />
               </Grid>
-              <Grid item xs={10}>
+              <Grid item sx={{ width: 'calc(100% - 44px)', wordWrap: 'break-word' }}>
                 {parts.map((part, index) => (
                   <Box
                     key={index}
+                    component="span"
                     sx={{
                       fontWeight: part.highlight ? 700 : 400,
-                      wordWrap: 'break-word',
                     }}
                   >
                     {part.text}
                   </Box>
                 ))}
 
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ wordWrap: 'break-word' }}
-                >
+                <Typography variant="body2" color="text.secondary">
                   {option.structured_formatting.secondary_text}
                 </Typography>
               </Grid>

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -126,22 +126,19 @@ export default function GoogleMaps() {
           <li {...props}>
             <Grid container alignItems="center">
               <Grid item xs={2}>
-                <Box
-                  component={LocationOnIcon}
-                  sx={{ color: 'text.secondary', mr: 2 }}
-                />
+                <LocationOnIcon sx={{ color: 'text.secondary', mr: 2 }} />
               </Grid>
               <Grid item xs={10}>
                 {parts.map((part, index) => (
-                  <span
+                  <Box
                     key={index}
-                    style={{
+                    sx={{
                       fontWeight: part.highlight ? 700 : 400,
                       wordWrap: 'break-word',
                     }}
                   >
                     {part.text}
-                  </span>
+                  </Box>
                 ))}
 
                 <Typography

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -117,7 +117,7 @@ export default function GoogleMaps() {
         const matches = option.structured_formatting.main_text_matched_substrings;
         if (!matches) {
           return (
-            <ListItem sx={{ color: 'text.secondary', padding: '14px 16px' }}>
+            <ListItem sx={{ color: 'text.secondary', pt: '6px', pb: '6px' }}>
               No options
             </ListItem>
           );

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -7,6 +7,7 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
 import throttle from 'lodash/throttle';
+import { ListItem } from '@mui/material';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -114,6 +115,9 @@ export default function GoogleMaps() {
       )}
       renderOption={(props, option) => {
         const matches = option.structured_formatting.main_text_matched_substrings;
+        if (!matches) {
+          return <ListItem sx={{ color: 'text.secondary' }}>No options</ListItem>;
+        }
         const parts = parse(
           option.structured_formatting.main_text,
           matches.map((match) => [match.offset, match.offset + match.length]),

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -6,7 +6,7 @@ import LocationOnIcon from '@mui/icons-material/LocationOn';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
-import throttle from 'lodash/throttle';
+import { debounce } from '@mui/material/utils';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -46,9 +46,9 @@ export default function GoogleMaps() {
 
   const fetch = React.useMemo(
     () =>
-      throttle((request, callback) => {
+      debounce((request, callback) => {
         autocompleteService.current.getPlacePredictions(request, callback);
-      }, 200),
+      }, 400),
     [],
   );
 

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -133,7 +133,7 @@ export default function GoogleMaps() {
                   <Box
                     key={index}
                     component="span"
-                    sx={{ fontWeight: part.highlight ? 700 : 400 }}
+                    sx={{ fontWeight: part.highlight ? 'bold' : 'regular' }}
                   >
                     {part.text}
                   </Box>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -157,7 +157,7 @@ export default function GoogleMaps() {
                   <Box
                     key={index}
                     component="span"
-                    sx={{ fontWeight: part.highlight ? 700 : 400 }}
+                    sx={{ fontWeight: part.highlight ? 'bold' : 'regular' }}
                   >
                     {part.text}
                   </Box>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -127,6 +127,7 @@ export default function GoogleMaps() {
       includeInputInList
       filterSelectedOptions
       value={value}
+      noOptionsText="No locations"
       onChange={(event: any, newValue: PlaceType | null) => {
         setOptions(newValue ? [newValue, ...options] : options);
         setValue(newValue);
@@ -166,6 +167,7 @@ export default function GoogleMaps() {
                     key={index}
                     style={{
                       fontWeight: part.highlight ? 700 : 400,
+                      wordWrap:'break-word'
                     }}
                   >
                     {part.text}

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -7,6 +7,7 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
 import throttle from 'lodash/throttle';
+import { ListItem } from '@mui/material';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -138,6 +139,9 @@ export default function GoogleMaps() {
       )}
       renderOption={(props, option) => {
         const matches = option.structured_formatting.main_text_matched_substrings;
+        if (!matches) {
+          return <ListItem sx={{ color: 'text.secondary' }}>No options</ListItem>;
+        }
         const parts = parse(
           option.structured_formatting.main_text,
           matches.map((match: any) => [match.offset, match.offset + match.length]),

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -33,7 +33,7 @@ interface MainTextMatchedSubstrings {
 interface StructuredFormatting {
   main_text: string;
   secondary_text: string;
-  main_text_matched_substrings: readonly MainTextMatchedSubstrings[];
+  main_text_matched_substrings?: readonly MainTextMatchedSubstrings[];
 }
 interface PlaceType {
   description: string;
@@ -138,7 +138,8 @@ export default function GoogleMaps() {
         <TextField {...params} label="Add a location" fullWidth />
       )}
       renderOption={(props, option) => {
-        const matches = option.structured_formatting.main_text_matched_substrings;
+        const matches =
+          option.structured_formatting.main_text_matched_substrings || [];
 
         const parts = parse(
           option.structured_formatting.main_text,

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -6,7 +6,7 @@ import LocationOnIcon from '@mui/icons-material/LocationOn';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
-import throttle from 'lodash/throttle';
+import { debounce } from '@mui/material/utils';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -60,7 +60,7 @@ export default function GoogleMaps() {
 
   const fetch = React.useMemo(
     () =>
-      throttle(
+      debounce(
         (
           request: { input: string },
           callback: (results?: readonly PlaceType[]) => void,
@@ -70,7 +70,7 @@ export default function GoogleMaps() {
             callback,
           );
         },
-        200,
+        400,
       ),
     [],
   );

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -150,22 +150,19 @@ export default function GoogleMaps() {
           <li {...props}>
             <Grid container alignItems="center">
               <Grid item xs={2}>
-                <Box
-                  component={LocationOnIcon}
-                  sx={{ color: 'text.secondary', mr: 2 }}
-                />
+                <LocationOnIcon sx={{ color: 'text.secondary', mr: 2 }} />
               </Grid>
               <Grid item xs={10}>
                 {parts.map((part, index) => (
-                  <span
+                  <Box
                     key={index}
-                    style={{
+                    sx={{
                       fontWeight: part.highlight ? 700 : 400,
                       wordWrap: 'break-word',
                     }}
                   >
                     {part.text}
-                  </span>
+                  </Box>
                 ))}
                 <Typography
                   variant="body2"

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -7,7 +7,6 @@ import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import parse from 'autosuggest-highlight/parse';
 import throttle from 'lodash/throttle';
-import { ListItem } from '@mui/material';
 
 // This key was created specifically for the demo in mui.com.
 // You need to create a new one for your application.
@@ -140,13 +139,7 @@ export default function GoogleMaps() {
       )}
       renderOption={(props, option) => {
         const matches = option.structured_formatting.main_text_matched_substrings;
-        if (!matches) {
-          return (
-            <ListItem sx={{ color: 'text.secondary', pt: '6px', pb: '6px' }}>
-              No options
-            </ListItem>
-          );
-        }
+
         const parts = parse(
           option.structured_formatting.main_text,
           matches.map((match: any) => [match.offset, match.offset + match.length]),
@@ -155,25 +148,29 @@ export default function GoogleMaps() {
         return (
           <li {...props}>
             <Grid container alignItems="center">
-              <Grid item>
+              <Grid item xs={2}>
                 <Box
                   component={LocationOnIcon}
                   sx={{ color: 'text.secondary', mr: 2 }}
                 />
               </Grid>
-              <Grid item xs>
+              <Grid item xs={10}>
                 {parts.map((part, index) => (
                   <span
                     key={index}
                     style={{
                       fontWeight: part.highlight ? 700 : 400,
-                      wordWrap:'break-word'
+                      wordWrap: 'break-word',
                     }}
                   >
                     {part.text}
                   </span>
                 ))}
-                <Typography variant="body2" color="text.secondary">
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ wordWrap: 'break-word' }}
+                >
                   {option.structured_formatting.secondary_text}
                 </Typography>
               </Grid>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -149,26 +149,22 @@ export default function GoogleMaps() {
         return (
           <li {...props}>
             <Grid container alignItems="center">
-              <Grid item xs={2}>
-                <LocationOnIcon sx={{ color: 'text.secondary', mr: 2 }} />
+              <Grid item sx={{ display: 'flex', width: 44 }}>
+                <LocationOnIcon sx={{ color: 'text.secondary' }} />
               </Grid>
-              <Grid item xs={10}>
+              <Grid item sx={{ width: 'calc(100% - 44px)', wordWrap: 'break-word' }}>
                 {parts.map((part, index) => (
                   <Box
                     key={index}
+                    component="span"
                     sx={{
                       fontWeight: part.highlight ? 700 : 400,
-                      wordWrap: 'break-word',
                     }}
                   >
                     {part.text}
                   </Box>
                 ))}
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ wordWrap: 'break-word' }}
-                >
+                <Typography variant="body2" color="text.secondary">
                   {option.structured_formatting.secondary_text}
                 </Typography>
               </Grid>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -141,7 +141,7 @@ export default function GoogleMaps() {
         const matches = option.structured_formatting.main_text_matched_substrings;
         if (!matches) {
           return (
-            <ListItem sx={{ color: 'text.secondary', padding: '14px 16px' }}>
+            <ListItem sx={{ color: 'text.secondary', pt: '6px', pb: '6px' }}>
               No options
             </ListItem>
           );

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -157,9 +157,7 @@ export default function GoogleMaps() {
                   <Box
                     key={index}
                     component="span"
-                    sx={{
-                      fontWeight: part.highlight ? 700 : 400,
-                    }}
+                    sx={{ fontWeight: part.highlight ? 700 : 400 }}
                   >
                     {part.text}
                   </Box>

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -140,7 +140,11 @@ export default function GoogleMaps() {
       renderOption={(props, option) => {
         const matches = option.structured_formatting.main_text_matched_substrings;
         if (!matches) {
-          return <ListItem sx={{ color: 'text.secondary' }}>No options</ListItem>;
+          return (
+            <ListItem sx={{ color: 'text.secondary', padding: '14px 16px' }}>
+              No options
+            </ListItem>
+          );
         }
         const parts = parse(
           option.structured_formatting.main_text,

--- a/docs/data/material/components/autocomplete/autocomplete-pt.md
+++ b/docs/data/material/components/autocomplete/autocomplete-pt.md
@@ -170,7 +170,7 @@ A customized UI for Google Maps Places Autocomplete. For this demo, we need to l
 {{"demo": "GoogleMaps.js"}}
 
 :::warning
-⚠️ Before you can start using the Google Maps JavaScript API and Places API, you must sign up and create a billing account.
+⚠️ Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 :::
 
 ## Múltiplos valores

--- a/docs/data/material/components/autocomplete/autocomplete-zh.md
+++ b/docs/data/material/components/autocomplete/autocomplete-zh.md
@@ -170,7 +170,7 @@ A customized UI for Google Maps Places Autocomplete. For this demo, we need to l
 {{"demo": "GoogleMaps.js"}}
 
 :::warning
-⚠️ Before you can start using the Google Maps JavaScript API and Places API, you must sign up and create a billing account.
+⚠️ Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 :::
 
 ## 多个输入值

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -188,7 +188,7 @@ For this demo, we need to load the [Google Maps JavaScript](https://developers.g
 {{"demo": "GoogleMaps.js"}}
 
 :::error
-Before you can start using the Google Maps JavaScript API and Places API, you must sign up and create a billing account.
+Before you can start using the Google Maps JavaScript API and Places API, you need to get your own [API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 :::
 
 ## Multiple values


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/35391

**Problem**:
- For some queries, the [Google Maps Autocomplete demo](https://mui.com/material-ui/react-autocomplete/#GoogleMaps.js) crashes

**Before**:
(1) Go to https://mui.com/material-ui/react-autocomplete/#google-maps-place
(2) Enter "Darse de Baudour"
(3) Demo crashes

**After**: 
(1) Go to https://deploy-preview-35545--material-ui.netlify.app/material-ui/react-autocomplete/#google-maps-place
(2) Enter "Darse de Baudour"
(3) Demo doesn't crash