### PR TITLE
[Radio][Joy] Use precise dimensions for radio icon

### DIFF
--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -204,8 +204,8 @@ const RadioIcon = styled('span', {
   slot: 'Icon',
   overridesResolver: (props, styles) => styles.icon,
 })<{ ownerState: RadioOwnerState }>(({ ownerState }) => ({
-  width: 'calc((var(--Radio-size) - var(--variant-borderWidth, 0px)) / 2)',
-  height: 'calc((var(--Radio-size) - var(--variant-borderWidth, 0px)) / 2)',
+  width: 'calc(var(--Radio-size) / 2)',
+  height: 'calc(var(--Radio-size) / 2)',
   borderRadius: 'inherit',
   color: 'inherit',
   backgroundColor: 'currentColor',

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -204,8 +204,8 @@ const RadioIcon = styled('span', {
   slot: 'Icon',
   overridesResolver: (props, styles) => styles.icon,
 })<{ ownerState: RadioOwnerState }>(({ ownerState }) => ({
-  width: '50%',
-  height: '50%',
+  width: 'calc((var(--Radio-size) - var(--variant-borderWidth)) / 2)',
+  height: 'calc((var(--Radio-size) - var(--variant-borderWidth)) / 2)',
   borderRadius: 'inherit',
   color: 'inherit',
   backgroundColor: 'currentColor',

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -204,8 +204,8 @@ const RadioIcon = styled('span', {
   slot: 'Icon',
   overridesResolver: (props, styles) => styles.icon,
 })<{ ownerState: RadioOwnerState }>(({ ownerState }) => ({
-  width: 'calc((var(--Radio-size) - var(--variant-borderWidth)) / 2)',
-  height: 'calc((var(--Radio-size) - var(--variant-borderWidth)) / 2)',
+  width: 'calc((var(--Radio-size) - var(--variant-borderWidth, 0px)) / 2)',
+  height: 'calc((var(--Radio-size) - var(--variant-borderWidth, 0px)) / 2)',
   borderRadius: 'inherit',
   color: 'inherit',
   backgroundColor: 'currentColor',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/35531
Closes https://github.com/mui/material-ui/issues/34167

**Problem**:
- For `variant="outlined"`, radio icon isn't precisely centered due to the border of radio element.

**Solution**:
```diff --git a/packages/mui-joy/src/Radio/Radio.tsx b/packages/mui-joy/src/Radio/Radio.tsx
--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -204,8 +204,8 @@ const RadioIcon = styled('span', {
   slot: 'Icon',
   overridesResolver: (props, styles) => styles.icon,
 })<{ ownerState: RadioOwnerState }>(({ ownerState }) => ({
-  width: '50%',
-  height: '50%',
+  width: 'calc((var(--Radio-size) - var(--variant-borderWidth)) / 2)',
+  height: 'calc((var(--Radio-size) - var(--variant-borderWidth)) / 2)',
```

**Preview**: https://deploy-preview-35548--material-ui.netlify.app/joy-ui/react-radio-button/

P.S. Argos changes are expected.