### PR TITLE
[docs] Fix typo in `Progress` docs

### DIFF
--- a/docs/data/material/components/progress/progress.md
+++ b/docs/data/material/components/progress/progress.md
@@ -69,7 +69,7 @@ The progress components accept a value in the range 0 - 100. This simplifies thi
 
 ```jsx
 // MIN = Minimum expected value
-// MAX = Maximium expected value
+// MAX = Maximum expected value
 // Function to normalise the values (MIN / MAX could be integrated)
 const normalise = (value) => ((value - MIN) * 100) / (MAX - MIN);
 


### PR DESCRIPTION
Errata: `Maximium` => `Maximum`

Signed-off-by: Jason Sturges <jason@jasonsturges.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
