### PR TITLE
[TableCell]  Fix `scope` prop to be not set when a data cell is rendered within a table head

### DIFF
--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -140,7 +140,6 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
   }
 
   let scope = scopeProp;
-  // https://github.com/mui/material-ui/issues/35031#issuecomment-1359346668
   // scope is not a valid attribute for <td/> elements.
   // source: https://html.spec.whatwg.org/multipage/tables.html#the-td-element
   if (component === 'td') {

--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -139,10 +139,7 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
     component = isHeadCell ? 'th' : 'td';
   }
 
-  let scope = scopeProp;
-  if (!scope && isHeadCell) {
-    scope = 'col';
-  }
+  const scope = scopeProp;
 
   const variant = variantProp || (tablelvl2 && tablelvl2.variant);
 

--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -139,7 +139,13 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
     component = isHeadCell ? 'th' : 'td';
   }
 
-  const scope = scopeProp;
+  let scope = scopeProp;
+  // https://github.com/mui/material-ui/issues/35031#issuecomment-1359346668
+  if (component === 'td') {
+    scope = undefined;
+  } else if (!scope && isHeadCell) {
+    scope = 'col';
+  }
 
   const variant = variantProp || (tablelvl2 && tablelvl2.variant);
 

--- a/packages/mui-material/src/TableCell/TableCell.js
+++ b/packages/mui-material/src/TableCell/TableCell.js
@@ -141,6 +141,8 @@ const TableCell = React.forwardRef(function TableCell(inProps, ref) {
 
   let scope = scopeProp;
   // https://github.com/mui/material-ui/issues/35031#issuecomment-1359346668
+  // scope is not a valid attribute for <td/> elements.
+  // source: https://html.spec.whatwg.org/multipage/tables.html#the-td-element
   if (component === 'td') {
     scope = undefined;
   } else if (!scope && isHeadCell) {

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -93,8 +93,16 @@ describe('<TableCell />', () => {
     const { container } = renderInTable(<TableCell component="th" scope="row" />);
     expect(container.querySelector('th')).not.to.have.attribute('role');
   });
-  it('scope should be undefined in table cell when component is td', () => {
-    const { container } = renderInTable(<TableCell component="td" />);
+  it('scope should be undefined in table cell when component is td even when table cell is rendered with in table head', () => {
+    const { container } = render(
+      <table>
+        <thead>
+          <tr>
+            <TableCell component="td" />
+          </tr>
+        </thead>
+      </table>,
+    );
     expect(container.querySelector('td')).not.to.have.attribute('scope');
   });
 });

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -96,7 +96,7 @@ describe('<TableCell />', () => {
     const { container } = renderInTable(<TableCell component="th" scope="row" />);
     expect(container.querySelector('th')).not.to.have.attribute('role');
   });
-  it('scope should be undefined in table cell when component is td even when table cell is rendered with in table head', () => {
+  it('should not set scope attribute when TableCell is rendered as <td> within table head', () => {
     const { container } = render(
       <Table>
         <TableHead>

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, describeConformance } from 'test/utils';
 import TableCell, { tableCellClasses as classes } from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Table from '@mui/material/Table';
 
 describe('<TableCell />', () => {
   const { render } = createRenderer();
@@ -95,13 +98,13 @@ describe('<TableCell />', () => {
   });
   it('scope should be undefined in table cell when component is td even when table cell is rendered with in table head', () => {
     const { container } = render(
-      <table>
-        <thead>
-          <tr>
+      <Table>
+        <TableHead>
+          <TableRow>
             <TableCell component="td" />
-          </tr>
-        </thead>
-      </table>,
+          </TableRow>
+        </TableHead>
+      </Table>,
     );
     expect(container.querySelector('td')).not.to.have.attribute('scope');
   });

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -93,4 +93,16 @@ describe('<TableCell />', () => {
     const { container } = renderInTable(<TableCell component="th" scope="row" />);
     expect(container.querySelector('th')).not.to.have.attribute('role');
   });
+  it('should allow scope to be undefined value even when table cell is within table head', () => {
+    const { container } = render(
+      <table>
+        <thead>
+          <tr>
+            <TableCell />
+          </tr>
+        </thead>
+      </table>,
+    );
+    expect(container.querySelector('td')).not.to.have.attribute('scope');
+  });
 });

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -93,16 +93,8 @@ describe('<TableCell />', () => {
     const { container } = renderInTable(<TableCell component="th" scope="row" />);
     expect(container.querySelector('th')).not.to.have.attribute('role');
   });
-  it('should allow scope to be undefined value even when table cell is within table head', () => {
-    const { container } = render(
-      <table>
-        <thead>
-          <tr>
-            <TableCell />
-          </tr>
-        </thead>
-      </table>,
-    );
+  it('scope should be undefined in table cell when component is td', () => {
+    const { container } = renderInTable(<TableCell component="td" />);
     expect(container.querySelector('td')).not.to.have.attribute('scope');
   });
 });

--- a/packages/mui-material/test/integration/TableCell.test.js
+++ b/packages/mui-material/test/integration/TableCell.test.js
@@ -21,7 +21,7 @@ describe('<TableRow> integration', () => {
   }
 
   it('should render a th with the head class when in the context of a table head', () => {
-    const { getByTestId } = renderInTable(<TableCell data-testid="cell" scope="col" />, TableHead);
+    const { getByTestId } = renderInTable(<TableCell data-testid="cell" />, TableHead);
     expect(getByTestId('cell')).to.have.tagName('th');
     expect(getByTestId('cell')).to.have.class(classes.root);
     expect(getByTestId('cell')).to.have.class(classes.head);

--- a/packages/mui-material/test/integration/TableCell.test.js
+++ b/packages/mui-material/test/integration/TableCell.test.js
@@ -21,7 +21,7 @@ describe('<TableRow> integration', () => {
   }
 
   it('should render a th with the head class when in the context of a table head', () => {
-    const { getByTestId } = renderInTable(<TableCell data-testid="cell" />, TableHead);
+    const { getByTestId } = renderInTable(<TableCell data-testid="cell" scope="col" />, TableHead);
     expect(getByTestId('cell')).to.have.tagName('th');
     expect(getByTestId('cell')).to.have.class(classes.root);
     expect(getByTestId('cell')).to.have.class(classes.head);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes: https://github.com/mui/material-ui/issues/35031

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
