### PR TITLE
[core] Exclude documentation of Base props not used in styled libraries

### DIFF
--- a/docs/pages/material-ui/api/popper.json
+++ b/docs/pages/material-ui/api/popper.json
@@ -8,9 +8,13 @@
       }
     },
     "children": { "type": { "name": "union", "description": "node<br>&#124;&nbsp;func" } },
-    "components": { "type": { "name": "shape", "description": "{ Root?: elementType }" } },
+    "components": {
+      "type": { "name": "shape", "description": "{ Root?: elementType }" },
+      "default": "{}"
+    },
     "componentsProps": {
-      "type": { "name": "shape", "description": "{ root?: func<br>&#124;&nbsp;object }" }
+      "type": { "name": "shape", "description": "{ root?: func<br>&#124;&nbsp;object }" },
+      "default": "{}"
     },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
     "disablePortal": { "type": { "name": "bool" } },
@@ -25,19 +29,25 @@
       "type": {
         "name": "enum",
         "description": "'auto-end'<br>&#124;&nbsp;'auto-start'<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;'bottom-end'<br>&#124;&nbsp;'bottom-start'<br>&#124;&nbsp;'bottom'<br>&#124;&nbsp;'left-end'<br>&#124;&nbsp;'left-start'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right-end'<br>&#124;&nbsp;'right-start'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top-end'<br>&#124;&nbsp;'top-start'<br>&#124;&nbsp;'top'"
-      }
+      },
+      "default": "'bottom'"
     },
     "popperOptions": {
       "type": {
         "name": "shape",
         "description": "{ modifiers?: array, onFirstUpdate?: func, placement?: 'auto-end'<br>&#124;&nbsp;'auto-start'<br>&#124;&nbsp;'auto'<br>&#124;&nbsp;'bottom-end'<br>&#124;&nbsp;'bottom-start'<br>&#124;&nbsp;'bottom'<br>&#124;&nbsp;'left-end'<br>&#124;&nbsp;'left-start'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right-end'<br>&#124;&nbsp;'right-start'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top-end'<br>&#124;&nbsp;'top-start'<br>&#124;&nbsp;'top', strategy?: 'absolute'<br>&#124;&nbsp;'fixed' }"
-      }
+      },
+      "default": "{}"
     },
     "popperRef": { "type": { "name": "custom", "description": "ref" } },
     "slotProps": {
-      "type": { "name": "shape", "description": "{ root?: func<br>&#124;&nbsp;object }" }
+      "type": { "name": "shape", "description": "{ root?: func<br>&#124;&nbsp;object }" },
+      "default": "{}"
     },
-    "slots": { "type": { "name": "shape", "description": "{ root?: elementType }" } },
+    "slots": {
+      "type": { "name": "shape", "description": "{ root?: elementType }" },
+      "default": "{}"
+    },
     "sx": {
       "type": {
         "name": "union",

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -12,7 +12,6 @@ import { Link } from 'mdast';
 import { defaultHandlers, parse as docgenParse, ReactDocgenApi } from 'react-docgen';
 import { unstable_generateUtilityClass as generateUtilityClass } from '@mui/utils';
 import { renderInline as renderMarkdownInline } from '@mui/markdown';
-import { getUnstyledFilename } from '@mui-internal/docs-utilities';
 import * as ttp from 'typescript-to-proptypes';
 import { LANGUAGES } from 'docs/config';
 
@@ -574,43 +573,6 @@ const generateComponentApi = async (componentInfo: ComponentInfo, program: ttp.t
   } else {
     reactApi = docgenParse(src, null, defaultHandlers.concat(muiDefaultPropsHandler), { filename });
   }
-
-  // === Handle unstyled component ===
-  const unstyledFileName = getUnstyledFilename(filename);
-  let unstyledSrc;
-
-  // Try to get data for the unstyled component
-  try {
-    unstyledSrc = readFileSync(unstyledFileName, 'utf8');
-  } catch (err) {
-    // Unstyled component does not exist
-  }
-
-  if (unstyledSrc) {
-    const unstyledReactAPI = docgenParse(
-      unstyledSrc,
-      null,
-      defaultHandlers.concat(muiDefaultPropsHandler),
-      {
-        filename: unstyledFileName,
-      },
-    );
-
-    Object.keys(unstyledReactAPI.props).forEach((prop) => {
-      if (
-        unstyledReactAPI.props[prop].defaultValue &&
-        reactApi.props &&
-        (!reactApi.props[prop] || !reactApi.props[prop].defaultValue)
-      ) {
-        if (reactApi.props[prop]) {
-          reactApi.props[prop].defaultValue = unstyledReactAPI.props[prop].defaultValue;
-          reactApi.props[prop].jsdocDefaultValue = unstyledReactAPI.props[prop].jsdocDefaultValue;
-        } else {
-          reactApi.props[prop] = unstyledReactAPI.props[prop];
-        }
-      }
-    });
-  } // ================================
 
   // Ignore what we might have generated in `annotateComponentDefinition`
   const annotatedDescriptionMatch = reactApi.description.match(/(Demos|API):\r?\n\r?\n/);

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -49,10 +49,12 @@ const Popper = React.forwardRef(function Popper(
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const theme = useTheme<{ direction?: Direction }>();
-  const { components, componentsProps, slots, slotProps, ...other } = useThemeProps({
+  const props = useThemeProps({
     props: inProps,
     name: 'MuiPopper',
   });
+
+  const { components, componentsProps, slots, slotProps, ...other } = props;
 
   const RootComponent = slots?.root ?? components?.Root;
 


### PR DESCRIPTION
The Popper component has a `direction` prop documented, even though this prop exists only in the PopperUnstyled props. This PR makes sure that omitted props are not taken into consideration when building the API docs.