### PR TITLE
[Pagination] Fix table pagination label when direction is RTL

### DIFF
--- a/docs/pages/material-ui/api/table-pagination.json
+++ b/docs/pages/material-ui/api/table-pagination.json
@@ -14,7 +14,7 @@
     },
     "labelDisplayedRows": {
       "type": { "name": "func" },
-      "default": "function defaultLabelDisplayedRows({ from, to, count }) {\n  return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;\n}"
+      "default": "function defaultLabelDisplayedRows({ from, to, count, direction }) {\n  if (direction === 'rtl') {\n    return (\n      <React.Fragment>\n        {from}–{to} <span dir=\"rtl\">of </span>\n        {count !== -1 ? (\n          count\n        ) : (\n          <React.Fragment>\n            <span dir=\"rtl\">more </span>\n            <span dir=\"rtl\">than </span>\n            {to}\n          </React.Fragment>\n        )}\n      </React.Fragment>\n    );\n  }\n\n  return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;\n}"
     },
     "labelRowsPerPage": { "type": { "name": "node" }, "default": "'Rows per page:'" },
     "nextIconButtonProps": { "type": { "name": "object" } },

--- a/packages/mui-material/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material/src/TablePagination/TablePagination.d.ts
@@ -8,11 +8,13 @@ import { IconButtonProps } from '../IconButton';
 import { SelectProps } from '../Select';
 import { TablePaginationClasses } from './tablePaginationClasses';
 
+type Direction = 'rtl' | 'ltr';
 export interface LabelDisplayedRowsArgs {
   from: number;
   to: number;
   count: number;
   page: number;
+  direction: Direction;
 }
 
 export interface TablePaginationTypeMap<P, D extends React.ElementType> {

--- a/packages/mui-material/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material/src/TablePagination/TablePagination.d.ts
@@ -8,13 +8,11 @@ import { IconButtonProps } from '../IconButton';
 import { SelectProps } from '../Select';
 import { TablePaginationClasses } from './tablePaginationClasses';
 
-type Direction = 'rtl' | 'ltr';
 export interface LabelDisplayedRowsArgs {
   from: number;
   to: number;
   count: number;
   page: number;
-  direction: Direction;
 }
 
 export interface TablePaginationTypeMap<P, D extends React.ElementType> {
@@ -57,7 +55,24 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
        * object.
        *
        * For localization purposes, you can use the provided [translations](/material-ui/guides/localization/).
-       * @default function defaultLabelDisplayedRows({ from, to, count }) {
+       * @default function defaultLabelDisplayedRows({ from, to, count, direction }) {
+       *   if (direction === 'rtl') {
+       *     return (
+       *       <React.Fragment>
+       *         {from}–{to} <span dir="rtl">of </span>
+       *         {count !== -1 ? (
+       *           count
+       *         ) : (
+       *           <React.Fragment>
+       *             <span dir="rtl">more </span>
+       *             <span dir="rtl">than </span>
+       *             {to}
+       *           </React.Fragment>
+       *         )}
+       *       </React.Fragment>
+       *     );
+       *   }
+       *
        *   return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
        * }
        */

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { chainPropTypes, integerPropType } from '@mui/utils';
 import { unstable_composeClasses as composeClasses, isHostComponent } from '@mui/base';
 import styled from '../styles/styled';
+import useTheme from '../styles/useTheme';
 import useThemeProps from '../styles/useThemeProps';
 import InputBase from '../InputBase';
 import MenuItem from '../MenuItem';
@@ -106,7 +107,24 @@ const TablePaginationDisplayedRows = styled('p', {
   flexShrink: 0,
 }));
 
-function defaultLabelDisplayedRows({ from, to, count }) {
+function defaultLabelDisplayedRows({ from, to, count, direction }) {
+  if (direction === 'rtl') {
+    return (
+      <React.Fragment>
+        {from}–{to} <span dir="rtl">of </span>
+        {count !== -1 ? (
+          count
+        ) : (
+          <React.Fragment>
+            <span dir="rtl">more </span>
+            <span dir="rtl">than </span>
+            {to}
+          </React.Fragment>
+        )}
+      </React.Fragment>
+    );
+  }
+
   return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
 }
 
@@ -158,6 +176,8 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
     showLastButton = false,
     ...other
   } = props;
+
+  const theme = useTheme();
 
   const ownerState = props;
   const classes = useUtilityClasses(ownerState);
@@ -234,6 +254,7 @@ const TablePagination = React.forwardRef(function TablePagination(inProps, ref) 
             from: count === 0 ? 0 : page * rowsPerPage + 1,
             to: getLabelDisplayedRowsTo(),
             count: count === -1 ? -1 : count,
+            direction: theme.direction,
             page,
           })}
         </TablePaginationDisplayedRows>

--- a/packages/mui-material/src/TablePagination/TablePagination.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.js
@@ -330,7 +330,24 @@ TablePagination.propTypes /* remove-proptypes */ = {
    * object.
    *
    * For localization purposes, you can use the provided [translations](/material-ui/guides/localization/).
-   * @default function defaultLabelDisplayedRows({ from, to, count }) {
+   * @default function defaultLabelDisplayedRows({ from, to, count, direction }) {
+   *   if (direction === 'rtl') {
+   *     return (
+   *       <React.Fragment>
+   *         {from}–{to} <span dir="rtl">of </span>
+   *         {count !== -1 ? (
+   *           count
+   *         ) : (
+   *           <React.Fragment>
+   *             <span dir="rtl">more </span>
+   *             <span dir="rtl">than </span>
+   *             {to}
+   *           </React.Fragment>
+   *         )}
+   *       </React.Fragment>
+   *     );
+   *   }
+   *
    *   return `${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`;
    * }
    */

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -10,6 +10,7 @@ import TablePagination, { tablePaginationClasses as classes } from '@mui/materia
 import { inputClasses } from '@mui/material/Input';
 import { outlinedInputClasses } from '@mui/material/OutlinedInput';
 import { filledInputClasses } from '@mui/material/FilledInput';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 describe('<TablePagination />', () => {
   const noop = () => {};
@@ -273,6 +274,36 @@ describe('<TablePagination />', () => {
       expect(container).not.to.include.text('Rows per page');
       expect(queryByRole('listbox')).to.equal(null);
     });
+
+    it('renders the RTL tags', () => {
+      const { container } = render(
+        <div dir="rtl">
+          <table>
+            <TableFooter>
+              <TableRow>
+                <TablePagination
+                  count={0}
+                  page={0}
+                  rowsPerPage={10}
+                  onPageChange={noop}
+                  onRowsPerPageChange={noop}
+                />
+              </TableRow>
+            </TableFooter>
+          </table>
+        </div>,
+        {
+          wrapper: ({ children }) => (
+            <ThemeProvider theme={createTheme({ direction: 'rtl' })}>{children}</ThemeProvider>
+          ),
+        },
+      );
+
+      const directionNode = container.querySelector('p > span');
+
+      expect(directionNode).to.have.text('of ');
+      expect(directionNode).to.have.attribute('dir', 'rtl');
+    });
   });
 
   describe('prop: count=-1', () => {
@@ -302,6 +333,41 @@ describe('<TablePagination />', () => {
       expect(container).to.have.text('Rows per page:101–10 of more than 10');
       fireEvent.click(getByRole('button', { name: 'Go to next page' }));
       expect(container).to.have.text('Rows per page:1011–20 of more than 20');
+    });
+
+    it('renders the "of more than" RTL tags', () => {
+      const { container } = render(
+        <div dir="rtl">
+          <table>
+            <TableFooter>
+              <TableRow>
+                <TablePagination
+                  page={0}
+                  count={-1}
+                  rowsPerPage={10}
+                  onPageChange={noop}
+                  onRowsPerPageChange={noop}
+                />
+              </TableRow>
+            </TableFooter>
+          </table>
+        </div>,
+        {
+          wrapper: ({ children }) => (
+            <ThemeProvider theme={createTheme({ direction: 'rtl' })}>{children}</ThemeProvider>
+          ),
+        },
+      );
+
+      const rtlElements = container.querySelectorAll('p > span');
+
+      expect(rtlElements[0]).to.have.text('of ');
+      expect(rtlElements[1]).to.have.text('more ');
+      expect(rtlElements[2]).to.have.text('than ');
+
+      expect(rtlElements[0]).to.have.attribute('dir', 'rtl');
+      expect(rtlElements[1]).to.have.attribute('dir', 'rtl');
+      expect(rtlElements[2]).to.have.attribute('dir', 'rtl');
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR addresses Issue #35169

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### What does this PR do?
- It fixes the table pagination labels when the direction is RTL by tightly wrapping the English text and setting its direction. 
I needed to do that because, even though the direction is RTL, the English words are LTR and since there's no RTL text in the sentence, the text displays incorrectly. 
Another possible way to fix that is by using an invisible Unicode right-to-left mark character. I can change to this solution if you think it's a better solution.

#### References 
- https://www.w3.org/TR/WCAG20-TECHS/H34.html
- https://www.w3.org/International/articles/inline-bidi-markup/

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/46506018/208936407-22256b75-3c6f-4de5-b3b0-31c0db59349d.png)

![image](https://user-images.githubusercontent.com/46506018/208936684-ff78ce82-9df9-4cce-b0a5-1590e5fb7f01.png)

After:
![image](https://user-images.githubusercontent.com/46506018/208936913-846787e0-1818-48a5-8b49-9c60ed9c0711.png)

![image](https://user-images.githubusercontent.com/46506018/208937189-d7b5b43c-d7ff-4176-9be6-99417a57c9bd.png)

- I change the "of more than" text to display as `30 than more of  30-21`, but if you guys prefer I can display it as `30 of more than 30-21`.
- If you guys found something wrong or bad, please tell me and I will try my best to fix it.

Thank you for your time!



