### PR TITLE
[docs] Force `light` theme mode when `activePage` is null

### DIFF
--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -13,6 +13,7 @@ import {
   getThemedComponents,
   getMetaThemeColor,
 } from 'docs/src/modules/brandingTheme';
+import PageContext from './PageContext';
 
 const languageMap = {
   en: enUS,
@@ -115,7 +116,10 @@ if (process.env.NODE_ENV !== 'production') {
 export function ThemeProvider(props) {
   const { children } = props;
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const preferredMode = prefersDarkMode ? 'dark' : 'light';
+  const pageContextValue = React.useContext(PageContext);
+  // `activePage` does not exist for playground pages
+  // forcing light mode in playground avoids the need for a wrapping theme in playground pages
+  const preferredMode = pageContextValue.activePage && prefersDarkMode ? 'dark' : 'light';
 
   const [themeOptions, dispatch] = React.useReducer(
     (state, action) => {


### PR DESCRIPTION
Fixes the need to use `light` computer mode or creating a wrapping theme in playground pages to avoid the following case:

**Before:**
![Screenshot 2022-12-22 at 15 48 03](https://user-images.githubusercontent.com/4941090/209149572-11251306-94aa-4352-9249-715b8ddb24d7.png)

**After:**
![Screenshot 2022-12-22 at 15 48 12](https://user-images.githubusercontent.com/4941090/209149663-c9144504-0de2-4a12-8bc2-517aa4ceda91.png)

 `activePage` does not exist for playground pages


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
