### PR TITLE
[Autocomplete] Add index to renderOption's AutocompleteRenderOptionState

### DIFF
--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -29,7 +29,7 @@ function renderRow(props) {
 
   return (
     <Typography component="li" {...dataSet[0]} noWrap style={inlineStyle}>
-      {dataSet[1]}
+      {`#${dataSet[2] + 1} - ${dataSet[1]}`}
     </Typography>
   );
 }
@@ -146,7 +146,7 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
-      renderOption={(props, option) => [props, option]}
+      renderOption={(props, option, state) => [props, option, state.index]}
       // TODO: Post React 18 update - validate this conversion, look like a hidden bug
       renderGroup={(params) => params}
     />

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -146,7 +146,9 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
-      renderOption={(props, option, state) => [props, option, state.index] as React.ReactNode}
+      renderOption={(props, option, state) =>
+        [props, option, state.index] as React.ReactNode
+      }
       // TODO: Post React 18 update - validate this conversion, look like a hidden bug
       renderGroup={(params) => params as unknown as React.ReactNode}
     />

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -28,7 +28,7 @@ function renderRow(props: ListChildComponentProps) {
 
   return (
     <Typography component="li" {...dataSet[0]} noWrap style={inlineStyle}>
-      {dataSet[1]}
+      {`#${dataSet[2] + 1} - ${dataSet[1]}`}
     </Typography>
   );
 }
@@ -146,7 +146,7 @@ export default function Virtualize() {
       options={OPTIONS}
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
-      renderOption={(props, option) => [props, option] as React.ReactNode}
+      renderOption={(props, option, state) => [props, option, state.index] as React.ReactNode}
       // TODO: Post React 18 update - validate this conversion, look like a hidden bug
       renderGroup={(params) => params as unknown as React.ReactNode}
     />

--- a/docs/data/material/components/autocomplete/Virtualize.tsx.preview
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx.preview
@@ -7,7 +7,7 @@
   options={OPTIONS}
   groupBy={(option) => option[0].toUpperCase()}
   renderInput={(params) => <TextField {...params} label="10,000 options" />}
-  renderOption={(props, option) => [props, option] as React.ReactNode}
+  renderOption={(props, option, state) => [props, option, state.index] as React.ReactNode}
   // TODO: Post React 18 update - validate this conversion, look like a hidden bug
   renderGroup={(params) => params as unknown as React.ReactNode}
 />

--- a/docs/data/material/components/autocomplete/Virtualize.tsx.preview
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx.preview
@@ -7,7 +7,9 @@
   options={OPTIONS}
   groupBy={(option) => option[0].toUpperCase()}
   renderInput={(params) => <TextField {...params} label="10,000 options" />}
-  renderOption={(props, option, state) => [props, option, state.index] as React.ReactNode}
+  renderOption={(props, option, state) =>
+    [props, option, state.index] as React.ReactNode
+  }
   // TODO: Post React 18 update - validate this conversion, look like a hidden bug
   renderGroup={(params) => params as unknown as React.ReactNode}
 />

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -52,6 +52,7 @@ export type AutocompleteRenderGetTagProps = ({ index }: { index: number }) => {
 
 export interface AutocompleteRenderOptionState {
   inputValue: string;
+  index: number;
   selected: boolean;
 }
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -529,6 +529,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
 
     return renderOption({ ...optionProps, className: classes.option }, option, {
       selected: optionProps['aria-selected'],
+      index,
       inputValue,
     });
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The purpose of this PR is to simply expose the index that `renderListOption` intakes, coming from the `AutcompleteListbox` `groupedOptions.map` rendering. This allows a developer to have an easy, and more performant, way to reference the current option's index inside the `renderOption` callback method.

The use-case that brought up this issue was during my attempts at adding virtualization to our Autocomplete components. Our autocompletes that need virtualization may already be using `renderOptions`, or they may simply be using `getOptionLabel`. Either way, in order to create a single "VirtualizedAutocomplete" wrapper that can accept varying render sources as well as support lists where the rendered options have varying heights we need to be able to reference the index of the option being rendered.

## Example Without this PR's Change - Inline Comments Denoting What Would Change
> I am omitting the code that defines `GetVirtualListbox` that handles the dynamic listHeight/itemSize as it does not change with this PR.

```tsx
function VirtualAutocomplete<
  T,
  Multiple extends boolean = undefined,
  DisableClearable extends boolean = undefined,
  FreeSolo extends boolean = undefined,
>(autocompleteProps: AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>): JSX.Element {
  const virtualListboxRef = useRef<VariableSizeList>(null);
  const itemSizes = useRef<Record<string, number>>({});
  const stringifiedOptions = autocompleteProps.options.map((o) => JSON.stringify(o));

  const getItemSize = (index) => {
    return itemSizes.current[index] || 48;
  };

  const setItemSize = (index, size) => {
    itemSizes.current = { ...itemSizes.current, [index]: size };
    virtualListboxRef.current.resetAfterIndex(0, true);
  };

  const getOptionIndex = (option) => {
    const flatOption = JSON.stringify(option);
    return stringifiedOptions.findIndex((o) => o === flatOption);
  };

  return (
    <VirtualListboxContext.Provider value={{ getItemSize, setItemSize, virtualListboxRef }}>
      <Autocomplete
        {...autocompleteProps}
        renderOption={(props, option, state) => {
          // Everything surrounding this getOptionIndex will be removed and replaced with state.index.
          const index = getOptionIndex(option);
          return typeof autocompleteProps.renderOption === 'function' ? (
            <TrackedOption
              key={`trackedOption-${index}`}
              optionIndex={index}
              renderType="renderOption"
            >
              {autocompleteProps.renderOption(props, option, state)}
            </TrackedOption>
          ) : (
            <TrackedOption
              key={`trackedOption-${index}`}
              optionIndex={index}
              renderType="getOptionLabel"
              renderProps={props}
            >
              {autocompleteProps.getOptionLabel(option)}
            </TrackedOption>
          );
        }}
        ListboxComponent={GetVirtualListbox()}
      />
    </VirtualListboxContext.Provider>
  );
}
```

While my use-case is specific to Virtualization, and there are other ways to may be more performant to index all the options, I believe this addition is generic enough that other developers will find it useful and comes at no cost as the index was already being supplied to the method that calls `renderOption`.
