### PR TITLE
[core] Fix API demos callout spacing

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -306,15 +306,13 @@ export default function ApiPage(props) {
           {disableAd ? null : <Ad />}
         </Typography>
         <Heading hash="demos" />
-        <div className="MuiCallout-root MuiCallout-info">
-          <p
-            dangerouslySetInnerHTML={{
-              __html:
-                'For examples and details on the usage of this React component, visit the component demo pages:',
-            }}
-          />
-          <span dangerouslySetInnerHTML={{ __html: demos }} />
-        </div>
+        <div
+          className="MuiCallout-root MuiCallout-info"
+          dangerouslySetInnerHTML={{
+            __html: `<p>For examples and details on the usage of this React component, visit the component demo pages:</p>
+              ${demos}`,
+          }}
+        />
         <Heading hash="import" />
         <HighlightedCode
           code={`


### PR DESCRIPTION
Before https://mui.com/material-ui/api/alert/#demos

<img width="782" alt="Screenshot 2022-12-22 at 19 24 17" src="https://user-images.githubusercontent.com/3165635/209211197-e62807f2-1b93-4618-85e8-68595b916c64.png">

After https://deploy-preview-35579--material-ui.netlify.app/material-ui/api/alert/#demos

<img width="787" alt="Screenshot 2022-12-22 at 19 32 34" src="https://user-images.githubusercontent.com/3165635/209212329-2470d737-aa90-41b2-8e5f-4de8368bc0ad.png">

It's about matching the same output of the markdown to HTML logic in this React component.