### PR TITLE
[docs] Fix layout shift with modal

### DIFF
--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -126,15 +126,19 @@ In order to display an Unstyled Modal rendered on the server, you need to disabl
 
 {{"demo": "ServerModal.js", "defaultCodeOpen": false}}
 
-## Position fixed elements
-
-The modal disables the page scrolling while open by setting the `overflow: hidden` CSS property on the relevant scroll container.
-This hides the scrollbar and hence impacts the page layout.
-To compensate for this offset (~15px under normal conditions) and avoid a layout shift, the modal also set a padding property on the scroll container.
-
-However, `position: fixed` elements are also impacted, the modal doesn't handle them automatically, you need to add the `.mui-fixed` class name on these elements to get the padding added when necessary to avoid layout shift.
-
 ## Limitations
+
+### Overflow layout shift
+
+The modal disables the page scrolling while open by setting `overflow: hidden` as inline-style on the relevant scroll container, this hides the scrollbar and hence impacts the page layout.
+To compensate for this offset and avoid a layout shift, the modal also set a padding property on the scroll container (~15px under normal conditions).
+
+This can create a layout shift with `position: fixed` and `position: sticky` elements.
+You need to add the `.mui-fixed` class name on these elements so the modal can add a CSS padding property when the scroll is disabled.
+
+```jsx
+<Box sx={{ position: 'sticky', right: 0, top: 0, left: 0 }} className="mui-fixed">
+```
 
 ### Focus trap
 

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -15,7 +15,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 Unstyled Modal is a utility component that renders its children in front of a backdrop.
 This lets you create an element that your users must interact with before continuing in the parent application.
 
-### Features
+**Features**:
 
 - 🥞 Manages modal stacking when more than one is needed
 - 🪟 Creates a backdrop to disable interaction with the rest of the app
@@ -125,6 +125,14 @@ React [doesn't support](https://github.com/facebook/react/issues/13097) the [`cr
 In order to display an Unstyled Modal rendered on the server, you need to disable the portal feature with the `disablePortal` prop, as shown in the following demo:
 
 {{"demo": "ServerModal.js", "defaultCodeOpen": false}}
+
+## Position fixed elements
+
+The modal disables the page scrolling while open by setting the `overflow: hidden` CSS property on the relevant scroll container.
+This hides the scrollbar and hence impacts the page layout.
+To compensate for this offset (~15px under normal conditions) and avoid a layout shift, the modal also set a padding property on the scroll container.
+
+However, `position: fixed` elements are also impacted, the modal doesn't handle them automatically, you need to add the `.mui-fixed` class name on these elements to get the padding added when necessary to avoid layout shift.
 
 ## Limitations
 

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -15,7 +15,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 Unstyled Modal is a utility component that renders its children in front of a backdrop.
 This lets you create an element that your users must interact with before continuing in the parent application.
 
-**Features**:
+### Features
 
 - 🥞 Manages modal stacking when more than one is needed
 - 🪟 Creates a backdrop to disable interaction with the rest of the app

--- a/docs/src/modules/components/BackToTop.tsx
+++ b/docs/src/modules/components/BackToTop.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
 import Fab from '@mui/material/Fab';
+import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
 import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
 import Fade from '@mui/material/Fade';
@@ -32,46 +33,52 @@ export default function BackToTop() {
   return (
     <Fade in={trigger}>
       <Tooltip title="Scroll to top" open={open} onClose={handleClose} onOpen={handleOpen}>
-        <Fab
-          sx={(theme) => ({
+        <Box
+          className="mui-fixed"
+          sx={{
             position: 'fixed',
             bottom: 24,
             right: 24,
             zIndex: 10,
-            backgroundColor:
-              theme.palette.mode === 'dark'
-                ? theme.palette.primaryDark[400]
-                : theme.palette.primary[100],
-            boxShadow: `0px 4px 20px ${
-              theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(170, 180, 190, 0.3)'
-            }`,
-            '&:hover': {
+          }}
+        >
+          <Fab
+            sx={(theme) => ({
               backgroundColor:
                 theme.palette.mode === 'dark'
-                  ? theme.palette.primaryDark[500]
-                  : theme.palette.primary[200],
-            },
-            '&:active': {
+                  ? theme.palette.primaryDark[400]
+                  : theme.palette.primary[100],
               boxShadow: `0px 4px 20px ${
-                theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.7)' : 'rgba(170, 180, 190, 0.6)'
+                theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(170, 180, 190, 0.3)'
               }`,
-            },
-          })}
-          size="small"
-          aria-label={t('backToTop')}
-          onClick={handleClick}
-          data-ga-event-category="docs"
-          data-ga-event-action="click-back-to-top"
-        >
-          <KeyboardArrowUpRoundedIcon
-            sx={{
-              color: (theme: Theme) =>
-                theme.palette.mode === 'dark'
-                  ? theme.palette.primary[200]
-                  : theme.palette.primary[800],
-            }}
-          />
-        </Fab>
+              '&:hover': {
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? theme.palette.primaryDark[500]
+                    : theme.palette.primary[200],
+              },
+              '&:active': {
+                boxShadow: `0px 4px 20px ${
+                  theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.7)' : 'rgba(170, 180, 190, 0.6)'
+                }`,
+              },
+            })}
+            size="small"
+            aria-label={t('backToTop')}
+            onClick={handleClick}
+            data-ga-event-category="docs"
+            data-ga-event-action="click-back-to-top"
+          >
+            <KeyboardArrowUpRoundedIcon
+              sx={{
+                color: (theme: Theme) =>
+                  theme.palette.mode === 'dark'
+                    ? theme.palette.primary[200]
+                    : theme.palette.primary[800],
+              }}
+            />
+          </Fab>
+        </Box>
       </Tooltip>
     </Fade>
   );


### PR DESCRIPTION
Fix https://mui-org.slack.com/archives/C041SDSF32L/p1671799892568439.

> When you click on the menu, you'll notice the FAB at your right hand side of the right drawer shifts position. And the scroll bar on the right hand side appears and disappears. I'm also having this same issue in an app I'm building for a client, and the client is not happy about it. Menus and right hand drawers do not like each other

It's simpler to review the change without whitespace: https://github.com/mui/material-ui/pull/35591/files?diff=unified&w=1.

Before: https://mui.com/material-ui/react-select/#basic-select

https://user-images.githubusercontent.com/3165635/209343563-c43bacaa-33db-4fe2-865c-415b893234cd.mov

After: https://deploy-preview-35591--material-ui.netlify.app/material-ui/react-select/#basic-select

The new docs: https://deploy-preview-35591--material-ui.netlify.app/base/react-modal/#position-fixed-elements. I wanted to document this since forever.