### PR TITLE
[docs] Remove flow, its legacy

### DIFF
--- a/docs/data/material/guides/flow/flow-pt.md
+++ b/docs/data/material/guides/flow/flow-pt.md
@@ -1,7 +1,0 @@
-# Flow
-
-<p class="description">Você pode adicionar tipagem estática para o JavaScript para melhorar a produtividade do desenvolvedor e a qualidade do código graças ao Flow.</p>
-
-## flow-typed
-
-[flow-typed](https://github.com/flow-typed/flow-typed) is a repository of third-party library interface definitions for use with Flow. A comunidade está mantendo [ as definições deste projeto ](https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/%40material-ui).

--- a/docs/data/material/guides/flow/flow-zh.md
+++ b/docs/data/material/guides/flow/flow-zh.md
@@ -1,7 +1,0 @@
-# Flow
-
-<p class="description">借助 Flow，你可以为 JavaScript 添加静态类型，从而提高代码质量及开发者的工作效率。</p>
-
-## flow-typed
-
-[flow-typed](https://github.com/flow-typed/flow-typed) is a repository of third-party library interface definitions for use with Flow. [flow-typed](https://github.com/flow-typed/flow-typed) is a repository of third-party library interface definitions for use with Flow. 社区正在维护[此项目的定义](https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/%40material-ui)。

--- a/docs/data/material/guides/flow/flow.md
+++ b/docs/data/material/guides/flow/flow.md
@@ -1,8 +1,0 @@
-# Flow
-
-<p class="description">You can add static typing to JavaScript to improve developer productivity and code quality thanks to Flow.</p>
-
-## flow-typed
-
-[flow-typed](https://github.com/flow-typed/flow-typed) is a repository of third-party library interface definitions for use with Flow.
-The community is maintaining [the definitions under this project](https://github.com/flow-typed/flow-typed/tree/master/definitions/npm/%40material-ui).

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -208,7 +208,6 @@ const pages: MuiPage[] = [
       { pathname: '/material-ui/guides/localization' },
       { pathname: '/material-ui/guides/content-security-policy', title: 'Content Security Policy' },
       { pathname: '/material-ui/guides/right-to-left', title: 'Right-to-left' },
-      { pathname: '/material-ui/guides/flow' },
       { pathname: '/material-ui/guides/shadow-dom', title: 'Shadow DOM' },
     ],
   },

--- a/docs/pages/material-ui/guides/flow.js
+++ b/docs/pages/material-ui/guides/flow.js
@@ -1,7 +1,0 @@
-import * as React from 'react';
-import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
-import * as pageProps from 'docs/data/material/guides/flow/flow.md?@mui/markdown';
-
-export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
-}

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -408,7 +408,8 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /zh/base/* /base/:splat 301
 /pt/system/* /system/:splat 301
 /zh/system/* /system/:splat 301
-
+/material-ui/guides/flow/ https://v4.mui.com/guides/flow/ 301
+/:lang/material-ui/guides/flow/ https://v4.mui.com/:lang/guides/flow/ 301
 # 2023
 
 # Proxies

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -277,7 +277,6 @@ const pages: readonly MuiPage[] = [
       { pathname: '/guides/localization' },
       { pathname: '/guides/content-security-policy', title: 'Content Security Policy' },
       { pathname: '/guides/right-to-left', title: 'Right-to-left' },
-      { pathname: '/guides/flow' },
     ],
   },
   {

--- a/docs/translations/translations-pt.json
+++ b/docs/translations/translations-pt.json
@@ -327,7 +327,6 @@
     "/material-ui/guides/localization": "Localization",
     "/material-ui/guides/content-security-policy": "Content Security Policy",
     "/material-ui/guides/right-to-left": "Right-to-left",
-    "/material-ui/guides/flow": "Flow",
     "/material-ui/guides/shadow-dom": "Shadow DOM",
     "/material-ui/experimental-api": "Experimental APIs",
     "/material-ui/experimental-api/classname-generator": "ClassName generator",

--- a/docs/translations/translations-zh.json
+++ b/docs/translations/translations-zh.json
@@ -327,7 +327,6 @@
     "/material-ui/guides/localization": "Localization",
     "/material-ui/guides/content-security-policy": "内容安全策略（CSP）",
     "/material-ui/guides/right-to-left": "Right-to-left",
-    "/material-ui/guides/flow": "Flow",
     "/material-ui/guides/shadow-dom": "Shadow DOM",
     "/material-ui/experimental-api": "Experimental APIs",
     "/material-ui/experimental-api/classname-generator": "ClassName generator",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -339,7 +339,6 @@
     "/material-ui/guides/localization": "Localization",
     "/material-ui/guides/content-security-policy": "Content Security Policy",
     "/material-ui/guides/right-to-left": "Right-to-left",
-    "/material-ui/guides/flow": "Flow",
     "/material-ui/guides/shadow-dom": "Shadow DOM",
     "/material-ui/experimental-api": "Experimental APIs",
     "/material-ui/experimental-api/classname-generator": "ClassName generator",


### PR DESCRIPTION
At this point, few outsides of Meta care about flow. I think that it's better to push people to use TypeScript. We can remove https://mui.com/material-ui/guides/flow/. Related to https://github.com/flow-typed/flow-typed/issues/4051.