### PR TITLE
[core] Hide keyboard shortcut if no hover feature

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -393,8 +393,16 @@ const Root = styled('div')(
         backgroundColor: alpha(lightTheme.palette.primaryDark[600], 0.7),
         borderColor: lightTheme.palette.primaryDark[500],
         '& .MuiCode-copyKeypress': {
-          opacity: 1,
+          display: 'block',
+          // Approximate no hover capabilities with no keyboard
+          // https://github.com/w3c/csswg-drafts/issues/3871
+          '@media (any-hover: none)': {
+            display: 'none',
+          },
         },
+      },
+      '& .MuiCode-copyKeypress': {
+        display: 'none',
       },
       '&[data-copied]': {
         // style of the button when it is in copied state.
@@ -411,7 +419,6 @@ const Root = styled('div')(
     '& .MuiCode-copyKeypress': {
       pointerEvents: 'none',
       userSelect: 'none',
-      opacity: 0,
       position: 'absolute',
       left: '50%',
       top: '100%',


### PR DESCRIPTION
Something that annoyed me while I used the demo "Copy" button on my phone. I have no keyboard so I can't use the shortcut.

<img width="371" alt="Screenshot 2022-12-25 at 16 23 58" src="https://user-images.githubusercontent.com/3165635/209473698-1deb5f26-e068-403f-90af-f3f5f3bf069b.png">

The solution relies on https://developer.mozilla.org/en-US/docs/Web/CSS/@media/any-hover. in the future, we might be able to use: https://github.com/w3c/csswg-drafts/issues/3871.