### PR TITLE
[core] Fix header link layout shift and clash

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -194,7 +194,7 @@ function Heading(props) {
   return (
     <Level id={hash}>
       {getTranslatedHeader(t, hash)}
-      <a aria-labelledby={hash} className="anchor-link-style" href={`#${hash}`} tabIndex={-1}>
+      <a aria-labelledby={hash} className="anchor-link" href={`#${hash}`} tabIndex={-1}>
         <svg>
           <use xlinkHref="#anchor-link-icon" />
         </svg>

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -28,7 +28,7 @@ const Main = styled('main', {
   [theme.breakpoints.up('lg')]: {
     width: 'calc(100% - var(--MuiDocs-navDrawer-width))',
   },
-  '& .markdown-body .comment-link-style': {
+  '& .markdown-body .comment-link': {
     display: 'inline-block',
   },
 }));

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -108,25 +108,28 @@ const Root = styled('div')(
     },
     '& h1, & h2, & h3, & h4': {
       position: 'relative',
+      paddingRight: 26 * 2 + 10,
       '& code': {
         fontSize: 'inherit',
         lineHeight: 'inherit',
         // Remove scroll on small screens.
         wordBreak: 'break-all',
       },
-      '& .anchor-link-style': {
+      '& .anchor-link': {
         // To prevent the link to get the focus.
         display: 'none',
       },
-      '& a:not(.anchor-link-style):hover': {
+      '& a:not(.anchor-link):hover': {
         color: 'currentColor',
         borderBottom: '1px solid currentColor',
         textDecoration: 'none',
       },
-      '&:hover .anchor-link-style, & .comment-link-style': {
+      '&:hover .anchor-link, & .comment-link': {
         lineHeight: '21.5px',
+        position: 'absolute',
         textAlign: 'center',
         marginLeft: 10,
+        marginTop: 5,
         height: 26,
         width: 26,
         backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
@@ -146,10 +149,9 @@ const Root = styled('div')(
           pointerEvents: 'none',
         },
       },
-      '& .comment-link-style': {
-        display: 'none',
-        position: 'absolute',
-        top: `calc(50% - ${26 / 2}px)`,
+      '& .comment-link': {
+        display: 'none', // So we can have the comment button opt-in.
+        top: 0,
         right: 0,
         opacity: 0.5,
         transition: theme.transitions.create('opacity', {
@@ -462,7 +464,7 @@ const Root = styled('div')(
         color: `var(--muidocs-palette-grey-400, ${darkTheme.palette.grey[400]})`,
       },
       '& h1, & h2, & h3, & h4': {
-        '&:hover .anchor-link-style, & .comment-link-style': {
+        '&:hover .anchor-link, & .comment-link': {
           color: `var(--muidocs-palette-text-secondary, ${darkTheme.palette.text.secondary})`,
           backgroundColor: alpha(darkTheme.palette.primaryDark[800], 0.3),
           borderColor: `var(--muidocs-palette-primaryDark-500, ${darkTheme.palette.primaryDark[500]})`,

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -246,10 +246,10 @@ function createRender(context) {
       return [
         `<h${level} id="${hash}">`,
         headingHtml,
-        `<a aria-labelledby="${hash}" class="anchor-link-style" href="#${hash}" tabindex="-1">`,
+        `<a aria-labelledby="${hash}" class="anchor-link" href="#${hash}" tabindex="-1">`,
         '<svg><use xlink:href="#anchor-link-icon" /></svg>',
         '</a>',
-        `<button title="Post a comment" class="comment-link-style" data-feedback-hash="${hash}">`,
+        `<button title="Post a comment" class="comment-link" data-feedback-hash="${hash}">`,
         '<svg><use xlink:href="#comment-link-icon" /></svg>',
         `</button>`,
         `</h${level}>`,


### PR DESCRIPTION
The bugs can be seen here: https://mui.com/material-ui/getting-started/faq/#why-are-the-colors-i-am-seeing-different-from-what-i-see-here

1. Wrong vertical alignment between the two links
2. Overlap possible between the two links

<img width="156" alt="Screenshot 2022-12-25 at 16 50 16" src="https://user-images.githubusercontent.com/3165635/209474434-4e267123-a0d1-42dc-9aa0-83b1659f6687.png">

3. No reserved space for the links

<img width="219" alt="Screenshot 2022-12-25 at 16 50 09" src="https://user-images.githubusercontent.com/3165635/209474433-45a96624-3498-4b83-86e4-115e2321029e.png">

4. Layout shift on hover

https://user-images.githubusercontent.com/3165635/209474478-2b38492f-4525-4c51-b76a-8c36789cee76.mov

It's all solved: https://deploy-preview-35626--material-ui.netlify.app/material-ui/getting-started/faq/#why-does-component-x-require-a-dom-node-in-a-prop-instead-of-a-ref-object.