### PR TITLE
[docs] Fix layout shift when streaming the page

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -18,24 +18,27 @@ import BackToTop from 'docs/src/modules/components/BackToTop';
 const Main = styled('main', {
   shouldForwardProp: (prop) => prop !== 'disableToc',
 })(({ disableToc, theme }) => ({
-  display: 'flex',
+  display: 'grid',
   width: '100%',
-  ...(disableToc && {
-    [theme.breakpoints.up('lg')]: {
-      marginRight: '5%',
-    },
-  }),
-  [theme.breakpoints.up('lg')]: {
-    width: 'calc(100% - var(--MuiDocs-navDrawer-width))',
-  },
+  ...(disableToc
+    ? {
+        [theme.breakpoints.up('lg')]: {
+          marginRight: '5%',
+        },
+      }
+    : {
+        [theme.breakpoints.up('md')]: {
+          gridTemplateColumns: '1fr 242px',
+        },
+      }),
   '& .markdown-body .comment-link': {
     display: 'inline-block',
   },
 }));
 
 const StyledAppContainer = styled(AppContainer, {
-  shouldForwardProp: (prop) => prop !== 'disableAd' && prop !== 'disableToc',
-})(({ disableAd, disableToc, theme }) => {
+  shouldForwardProp: (prop) => prop !== 'disableAd',
+})(({ disableAd, theme }) => {
   return {
     position: 'relative',
     ...(!disableAd && {
@@ -46,15 +49,10 @@ const StyledAppContainer = styled(AppContainer, {
         marginBottom: 40,
       },
     }),
-    ...(!disableToc && {
-      [theme.breakpoints.up('sm')]: {
-        width: 'calc(100% - var(--MuiDocs-toc-width))',
-      },
-      [theme.breakpoints.up('lg')]: {
-        paddingLeft: '60px',
-        paddingRight: '60px',
-      },
-    }),
+    [theme.breakpoints.up('lg')]: {
+      paddingLeft: '60px',
+      paddingRight: '60px',
+    },
   };
 });
 
@@ -105,7 +103,6 @@ function AppLayoutDocs(props) {
         styles={{
           ':root': {
             '--MuiDocs-navDrawer-width': '300px',
-            '--MuiDocs-toc-width': '242px',
           },
         }}
       />
@@ -121,14 +118,14 @@ function AppLayoutDocs(props) {
             Render the TOCs first to avoid layout shift when the HTML is streamed.
             See https://jakearchibald.com/2014/dont-use-flexbox-for-page-layout/ for more details.
           */}
-          {disableToc ? null : <AppTableOfContents toc={toc} />}
-          <StyledAppContainer disableAd={disableAd} disableToc={disableToc}>
+          <StyledAppContainer disableAd={disableAd}>
             <ActionsDiv>{location && <EditPage markdownLocation={location} />}</ActionsDiv>
             {children}
             <NoSsr>
               <AppLayoutDocsFooter tableOfContents={toc} />
             </NoSsr>
           </StyledAppContainer>
+          {disableToc ? null : <AppTableOfContents toc={toc} />}
         </Main>
       </AdManager>
       <BackToTop />

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -12,10 +12,7 @@ import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBan
 
 const Nav = styled('nav')(({ theme }) => ({
   top: 0,
-  order: 1,
-  width: 'var(--MuiDocs-toc-width)',
   paddingLeft: 2, // Fix truncated focus outline style
-  flexShrink: 0,
   position: 'sticky',
   height: '100vh',
   overflowY: 'auto',
@@ -23,7 +20,7 @@ const Nav = styled('nav')(({ theme }) => ({
   paddingBottom: theme.spacing(4),
   paddingRight: theme.spacing(4), // We can't use `padding` as stylis-plugin-rtl doesn't swap it
   display: 'none',
-  [theme.breakpoints.up('sm')]: {
+  [theme.breakpoints.up('md')]: {
     display: 'block',
   },
 }));


### PR DESCRIPTION
The problem can be seen in:

https://user-images.githubusercontent.com/3165635/209475086-f0f183a0-1214-481d-b4bf-35a2033ad21d.mov

There is this intermediary layout shift:

<img width="410" alt="Screenshot 2022-12-25 at 17 19 50" src="https://user-images.githubusercontent.com/3165635/209475259-f135bf67-e341-4d65-a00b-f40b978618ef.png">

It's detailed in depth in this blog post: https://twitter.com/jaffathecake/status/1149637428388360197 (from 8 years ago, but still true, and might be true forever).

> Browsers can progressively render content as it's streamed from the server, this is great because it means users can start consuming content before it's all arrived. However, when combined with flexbox it causes misalignment and horizontal shifting.

I believe we are allowed to use CSS Grid https://caniuse.com/css-grid as it's compatible with our browser support.

Preview: https://deploy-preview-35627--material-ui.netlify.app/material-ui/react-autocomplete/