### PR TITLE
[blog] Fix handling of markdown links

### DIFF
--- a/docs/src/BrandingCssVarsProvider.tsx
+++ b/docs/src/BrandingCssVarsProvider.tsx
@@ -8,6 +8,8 @@ import {
 import CssBaseline from '@mui/material/CssBaseline';
 import { NextNProgressBar } from 'docs/src/modules/components/AppFrame';
 import { getDesignTokens, getThemedComponents } from 'docs/src/modules/brandingTheme';
+import SkipLink from 'docs/src/modules/components/SkipLink';
+import MarkdownLinks from 'docs/src/modules/components/MarkdownLinks';
 
 declare module '@mui/material/styles' {
   interface PaletteOptions {
@@ -54,6 +56,8 @@ export default function BrandingCssVarsProvider({ children }: { children: React.
     <CssVarsProvider theme={theme} defaultMode="system" disableTransitionOnChange>
       <NextNProgressBar />
       <CssBaseline />
+      <SkipLink />
+      <MarkdownLinks />
       {children}
     </CssVarsProvider>
   );

--- a/docs/src/BrandingProvider.tsx
+++ b/docs/src/BrandingProvider.tsx
@@ -4,6 +4,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { brandingDarkTheme, brandingLightTheme } from 'docs/src/modules/brandingTheme';
 import { NextNProgressBar } from 'docs/src/modules/components/AppFrame';
 import SkipLink from 'docs/src/modules/components/SkipLink';
+import MarkdownLinks from 'docs/src/modules/components/MarkdownLinks';
 
 interface BrandingProviderProps {
   children: React.ReactNode;
@@ -23,6 +24,7 @@ export default function BrandingProvider(props: BrandingProviderProps) {
       {modeProp ? null : <NextNProgressBar />}
       {modeProp ? null : <CssBaseline />}
       {modeProp ? null : <SkipLink />}
+      {modeProp ? null : <MarkdownLinks />}
       {children}
     </ThemeProvider>
   );

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -199,7 +199,7 @@ export default function AppFrame(props) {
             </Box>
           </NextLink>
           <GrowingDiv />
-          <Stack direction="row" spacing={1.3}>
+          <Stack direction="row" spacing="10px">
             <AppFrameBanner />
             <DeferredAppSearch />
             <Tooltip title={t('appFrame.github')} enterDelay={300}>

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -5,7 +5,7 @@ import KeyboardArrowRightRoundedIcon from '@mui/icons-material/KeyboardArrowRigh
 import { alpha, styled } from '@mui/material/styles';
 import Collapse from '@mui/material/Collapse';
 import Chip from '@mui/material/Chip';
-import { openLinkInNewTab } from 'docs/src/modules/components/MarkdownLinks';
+import { shoudHandleLinkClick } from 'docs/src/modules/components/MarkdownLinks';
 import Link from 'docs/src/modules/components/Link';
 import ArticleRoundedIcon from '@mui/icons-material/ArticleRounded';
 import ToggleOffRoundedIcon from '@mui/icons-material/ToggleOffRounded';
@@ -217,7 +217,7 @@ export default function AppNavDrawerItem(props) {
   const [open, setOpen] = React.useState(openImmediately);
   const handleClick = (event) => {
     // Ignore the action if opening the link in a new tab
-    if (openLinkInNewTab(event)) {
+    if (shoudHandleLinkClick(event)) {
       return;
     }
 

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography';
 import NoSsr from '@mui/material/NoSsr';
 import Link from 'docs/src/modules/components/Link';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
-import { openLinkInNewTab } from 'docs/src/modules/components/MarkdownLinks';
+import { shoudHandleLinkClick } from 'docs/src/modules/components/MarkdownLinks';
 import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBanner';
 
 const Nav = styled('nav')(({ theme }) => ({
@@ -180,7 +180,7 @@ export default function AppTableOfContents(props) {
 
   const handleClick = (hash) => (event) => {
     // Ignore click for new tab/new window behavior
-    if (openLinkInNewTab(event)) {
+    if (shoudHandleLinkClick(event)) {
       return;
     }
 

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -16,13 +16,6 @@ export function shoudHandleLinkClick(event) {
   return false;
 }
 
-export function handleEvent(event, as) {
-  event.preventDefault();
-
-  const canonicalPathname = pathnameToLanguage(as).canonicalPathname;
-  Router.push(canonicalPathname, as);
-}
-
 /**
  * @param {MouseEvent} event
  */
@@ -48,7 +41,10 @@ function handleClick(event) {
     return;
   }
 
-  handleEvent(event, activeElement.getAttribute('href'));
+  event.preventDefault();
+  const as = activeElement.getAttribute('href');
+  const canonicalPathname = pathnameToLanguage(as).canonicalPathname;
+  Router.push(canonicalPathname, as);
 }
 
 export default function MarkdownLinks() {

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Router from 'next/router';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 
-export function openLinkInNewTab(event) {
+export function shoudHandleLinkClick(event) {
   if (
     event.defaultPrevented ||
     event.button !== 0 || // ignore everything but left-click
@@ -17,11 +17,6 @@ export function openLinkInNewTab(event) {
 }
 
 export function handleEvent(event, as) {
-  // Ignore click for new tab/new window behavior
-  if (openLinkInNewTab(event)) {
-    return;
-  }
-
   event.preventDefault();
 
   const canonicalPathname = pathnameToLanguage(as).canonicalPathname;
@@ -37,7 +32,7 @@ function handleClick(event) {
     activeElement = activeElement.parentElement;
   }
 
-  // Ignore non link clicks
+  // Ignore non internal link clicks
   if (
     activeElement === null ||
     activeElement.nodeName !== 'A' ||
@@ -45,6 +40,11 @@ function handleClick(event) {
     activeElement.getAttribute('data-no-markdown-link') === 'true' ||
     activeElement.getAttribute('href').indexOf('/') !== 0
   ) {
+    return;
+  }
+
+  // Ignore click meant for native link handling, e.g. open in new tab
+  if (shoudHandleLinkClick(event)) {
     return;
   }
 


### PR DESCRIPTION
To reproduce the issue: 

1. Open https://mui.com/blog/first-look-at-joy/#global-variants
2. Have the dark mode in
3. Click on the "Global variants" link. 
4. See the flash, it's a server-side page reload, not a client side one.

https://deploy-preview-35628--material-ui.netlify.app/blog/first-look-at-joy/#global-variants