### PR TITLE
[base-ui][Autocomplete] Implement undo / redo

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -5,6 +5,7 @@ import {
   unstable_useEventCallback as useEventCallback,
   unstable_useControlled as useControlled,
   unstable_useId as useId,
+  unstable_useUndoAndRedo as useUndoAndRedo,
 } from '@mui/utils';
 
 // https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript
@@ -118,6 +119,7 @@ export default function useAutocomplete(props) {
   } = props;
 
   const id = useId(idProp);
+  const { storeValue, undo, redo } = useUndoAndRedo(defaultValue);
 
   let getOptionLabel = getOptionLabelProp;
 
@@ -608,6 +610,7 @@ export default function useAutocomplete(props) {
     }
 
     setValueState(newValue);
+    storeValue(newValue);
   };
 
   const isTouch = React.useRef(false);
@@ -925,6 +928,15 @@ export default function useAutocomplete(props) {
     }
   };
 
+  const handleInputKeyDown = (event) => {
+    if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ') {
+      const newValue = event.shiftKey ? redo() : undo();
+      if (newValue !== undefined) {
+        setValueState(newValue);
+      }
+    }
+  };
+
   const handleOptionMouseOver = (event) => {
     setHighlightedIndex({
       event,
@@ -1049,6 +1061,7 @@ export default function useAutocomplete(props) {
       onFocus: handleFocus,
       onChange: handleInputChange,
       onMouseDown: handleInputMouseDown,
+      onKeyDown: handleInputKeyDown,
       // if open then this is handled imperativeley so don't let react override
       // only have an opinion about this when closed
       'aria-activedescendant': popupOpen ? '' : null,

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -929,7 +929,7 @@ export default function useAutocomplete(props) {
   };
 
   const handleInputKeyDown = (event) => {
-    if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ') {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
       const newValue = event.shiftKey ? redo() : undo();
       if (newValue !== undefined) {
         setValueState(newValue);

--- a/packages/mui-utils/src/index.ts
+++ b/packages/mui-utils/src/index.ts
@@ -24,6 +24,7 @@ export { default as unstable_unsupportedProp } from './unsupportedProp';
 export { default as unstable_useControlled } from './useControlled';
 export { default as unstable_useEventCallback } from './useEventCallback';
 export { default as unstable_useForkRef } from './useForkRef';
+export { default as unstable_useUndoAndRedo } from './useUndoAndRedo';
 export { default as unstable_useIsFocusVisible } from './useIsFocusVisible';
 export { default as unstable_getScrollbarSize } from './getScrollbarSize';
 export {

--- a/packages/mui-utils/src/useUndoAndRedo.ts
+++ b/packages/mui-utils/src/useUndoAndRedo.ts
@@ -12,7 +12,7 @@ const useUndoAndRedo = <T>(initialValue?: T) => {
       return;
     }
 
-    setValues((prev) => [...prev, value]);
+    setValues((prev) => [...prev.slice(0, index + 1), value]);
     setIndex((prev) => prev + 1);
   };
 

--- a/packages/mui-utils/src/useUndoAndRedo.ts
+++ b/packages/mui-utils/src/useUndoAndRedo.ts
@@ -1,0 +1,55 @@
+import isEqual from 'lodash/isEqual';
+import { useState } from 'react';
+
+const useUndoAndRedo = <T>(initialValue?: T) => {
+  const [values, setValues] = useState<T[]>(initialValue !== undefined ? [initialValue] : []);
+  const [index, setIndex] = useState(initialValue !== undefined ? 0 : -1);
+
+  const currentValue = values[index];
+
+  const setValue = (value: T) => {
+    if (isEqual(currentValue, value)) {
+      return;
+    }
+
+    setValues((prev) => [...prev, value]);
+    setIndex((prev) => prev + 1);
+  };
+
+  const clearHistory = () => {
+    setIndex(0);
+    setValues(initialValue !== undefined ? [initialValue] : []);
+  };
+
+  const undo = (jumps: number = 1): T | undefined => {
+    if (values.length > 0 && index > 0) {
+      const destination = index - jumps;
+      const newIndex = Math.max(destination, 0);
+      setIndex(newIndex);
+      return values[newIndex];
+    }
+    return undefined;
+  };
+
+  const redo = (jumps: number = 1): T | undefined => {
+    if (values.length > 0 && index < values.length - 1) {
+      const destination = index + jumps;
+      const newIndex = Math.min(destination, values.length - 1);
+      setIndex(newIndex);
+      return values[newIndex];
+    }
+    return undefined;
+  };
+
+  return {
+    value: currentValue,
+    storeValue: setValue,
+    clearHistory,
+    currIndex: index,
+    lastIndex: values.length - 1,
+    undo,
+    redo,
+  };
+};
+
+export default useUndoAndRedo;

--- a/packages/mui-utils/src/useUndoAndRedo.ts
+++ b/packages/mui-utils/src/useUndoAndRedo.ts
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual';
 import { useState } from 'react';
 
 const useUndoAndRedo = <T>(initialValue?: T) => {
@@ -8,7 +7,7 @@ const useUndoAndRedo = <T>(initialValue?: T) => {
   const currentValue = values[index];
 
   const setValue = (value: T) => {
-    if (isEqual(currentValue, value)) {
+    if (currentValue === value) {
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow-up on https://github.com/mui/material-ui/pull/35545#issuecomment-1362105900

**This PR contains:**
- a new hook: `useUndoAndRedo`
- using `useUndoAndRedo` in `useAutocomplete`

**Before:**
- Try undo (Ctrl + z) and redo ( Ctrl + Shift + z) in https://mui.com/material-ui/react-autocomplete/#combo-box and https://mui.com/material-ui/react-autocomplete/#multiple-values

**After:**
- Try undo (Ctrl + z) and redo ( Ctrl + Shift + z) in https://deploy-preview-35636--material-ui.netlify.app/material-ui/react-autocomplete/#combo-box and https://deploy-preview-35636--material-ui.netlify.app/material-ui/react-autocomplete/#multiple-values