### PR TITLE
[icons] Replace @mui/material dependency with @mui/system

### DIFF
--- a/packages/mui-icons-material/lib/esm/utils/createSvgIcon.js
+++ b/packages/mui-icons-material/lib/esm/utils/createSvgIcon.js
@@ -1,1 +1,1 @@
-export { createSvgIcon as default } from '@mui/material/utils';
+export { createSvgIcon as default } from '@mui/system/utils';

--- a/packages/mui-icons-material/lib/utils/createSvgIcon.js
+++ b/packages/mui-icons-material/lib/utils/createSvgIcon.js
@@ -9,4 +9,4 @@ Object.defineProperty(exports, "default", {
     return _utils.createSvgIcon;
   }
 });
-var _utils = require("@mui/material/utils");
+var _utils = require("@mui/system/utils");

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -46,7 +46,7 @@
     "typescript": "tslint -p tsconfig.json \"src/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
-    "@mui/material": "^5.0.0",
+    "@mui/system": "^5.11.2",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0"
   },

--- a/packages/mui-icons-material/src/utils/createSvgIcon.js
+++ b/packages/mui-icons-material/src/utils/createSvgIcon.js
@@ -1,1 +1,1 @@
-export { createSvgIcon as default } from '@mui/material/utils';
+export { createSvgIcon as default } from '@mui/system/utils';

--- a/packages/mui-system/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-system/src/SvgIcon/SvgIcon.test.js
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { describeConformance, createRenderer } from 'test/utils';
+import SvgIcon, { svgIconClasses as classes } from '@mui/system/SvgIcon';
+import { ThemeProvider, createTheme } from '@mui/system';
+
+describe('<SvgIcon />', () => {
+  const { render } = createRenderer();
+
+  let path;
+
+  before(() => {
+    path = <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" data-testid="test-path" />;
+  });
+
+  describeConformance(
+    <SvgIcon>
+      <path />
+    </SvgIcon>,
+    () => ({
+      classes,
+      inheritComponent: 'svg',
+      render,
+      muiName: 'MuiSvgIcon',
+      refInstanceof: window.SVGSVGElement,
+      testComponentPropWith: (props) => (
+        <svg {...props}>
+          <defs>
+            <linearGradient id="gradient1">
+              <stop offset="20%" stopColor="#39F" />
+              <stop offset="90%" stopColor="#F3F" />
+            </linearGradient>
+          </defs>
+          {props.children}
+        </svg>
+      ),
+      ThemeProvider,
+      createTheme,
+      skip: ['themeVariants', 'componentsProp'],
+    }),
+  );
+
+  it('renders children by default', () => {
+    const { container, queryByTestId } = render(<SvgIcon>{path}</SvgIcon>);
+
+    expect(queryByTestId('test-path')).not.to.equal(null);
+    expect(container.firstChild).to.have.attribute('aria-hidden', 'true');
+  });
+
+  describe('prop: titleAccess', () => {
+    it('should be able to make an icon accessible', () => {
+      const { container, queryByText } = render(
+        <SvgIcon title="Go to link" titleAccess="Network">
+          {path}
+        </SvgIcon>,
+      );
+
+      expect(queryByText('Network')).not.to.equal(null);
+      expect(container.firstChild).not.to.have.attribute('aria-hidden');
+    });
+  });
+
+  describe('prop: color', () => {
+    it('should render with the user and SvgIcon classes', () => {
+      const { container } = render(<SvgIcon className="meow">{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.class('meow');
+    });
+
+    it('should render with the secondary color', () => {
+      const { container } = render(<SvgIcon color="secondary">{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.class(classes.colorSecondary);
+    });
+
+    it('should render with the action color', () => {
+      const { container } = render(<SvgIcon color="action">{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.class(classes.colorAction);
+    });
+
+    it('should render with the error color', () => {
+      const { container } = render(<SvgIcon color="error">{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.class(classes.colorError);
+    });
+
+    it('should render with the primary class', () => {
+      const { container } = render(<SvgIcon color="primary">{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.class(classes.colorPrimary);
+    });
+  });
+
+  describe('prop: fontSize', () => {
+    it('should be able to change the fontSize', () => {
+      const { container } = render(<SvgIcon fontSize="inherit">{path}</SvgIcon>);
+
+      expect(container.firstChild).to.have.class(classes.fontSizeInherit);
+    });
+  });
+
+  describe('prop: inheritViewBox', () => {
+    function CustomSvg(props) {
+      return (
+        <svg viewBox="-4 -4 24 24" {...props}>
+          {path}
+        </svg>
+      );
+    }
+
+    it('should render with the default viewBox if neither inheritViewBox nor viewBox are provided', () => {
+      const { container } = render(<SvgIcon component={CustomSvg} />);
+      expect(container.firstChild).to.have.attribute('viewBox', '0 0 24 24');
+    });
+
+    it('should render with given viewBox if inheritViewBox is not provided', () => {
+      const { container } = render(<SvgIcon component={CustomSvg} viewBox="0 0 30 30" />);
+      expect(container.firstChild).to.have.attribute('viewBox', '0 0 30 30');
+    });
+
+    it("should use the custom component's viewBox if true", () => {
+      const { container } = render(<SvgIcon component={CustomSvg} inheritViewBox />);
+      expect(container.firstChild).to.have.attribute('viewBox', '-4 -4 24 24');
+    });
+  });
+
+  it('should not override internal ownerState with the ownerState passed to the icon', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const { container } = render(<SvgIcon ownerState={{ fontSize: 'large' }}>{path}</SvgIcon>);
+    expect(container.firstChild).toHaveComputedStyle({ fontSize: '24px' }); // fontSize: medium -> 1.5rem = 24px
+  });
+});

--- a/packages/mui-system/src/SvgIcon/SvgIcon.tsx
+++ b/packages/mui-system/src/SvgIcon/SvgIcon.tsx
@@ -1,0 +1,275 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { OverridableComponent } from '@mui/types';
+import {
+  unstable_capitalize as capitalize,
+  unstable_composeClasses as composeClasses,
+} from '@mui/utils';
+import styled from '../styled';
+import useThemeProps from '../useThemeProps';
+import { SvgIconTypeMap, SvgIconOwnerState, SvgIconProps } from './SvgIcon.types';
+import { getSvgIconUtilityClass } from './svgIconClasses';
+
+const useUtilityClasses = (ownerState: SvgIconOwnerState) => {
+  const { color, fontSize, classes } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      color !== 'inherit' && `color${capitalize(color)}`,
+      `fontSize${capitalize(fontSize)}`,
+    ],
+  };
+
+  return composeClasses(slots, getSvgIconUtilityClass, classes);
+};
+
+const defaultMaterialDesignColors: Record<SvgIconOwnerState['color'], string | undefined> = {
+  inherit: undefined,
+  action: 'rgba(0, 0, 0, 0.54)',
+  disabled: 'rgba(0, 0, 0, 0.26)',
+  primary: '#1976d2',
+  secondary: '#9c27b0',
+  error: '#d32f2f',
+  info: '#0288d1',
+  success: '#2e7d32',
+  warning: '#ed6c02',
+};
+
+interface Palette {
+  primary?: { main?: string };
+  secondary?: { main?: string };
+  error?: { main?: string };
+  info?: { main?: string };
+  success?: { main?: string };
+  warning?: { main?: string };
+  action?: {
+    active?: string;
+    disabled?: string;
+  };
+}
+
+interface Theme {
+  transitions?: {
+    create?: (cssProp: string, options: { duration: string | undefined }) => string;
+    duration?: {
+      shorter?: string;
+    };
+  };
+  typography?: {
+    pxToRem?: (arg: number) => string;
+  };
+  palette: Palette;
+  vars?: {
+    palette: Palette;
+  };
+}
+const SvgIconRoot = styled('svg', {
+  name: 'MuiSvgIcon',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      ownerState.color !== 'inherit' && styles[`color${capitalize(ownerState.color)}`],
+      styles[`fontSize${capitalize(ownerState.fontSize)}`],
+    ];
+  },
+})<{ ownerState: SvgIconOwnerState; theme: Theme }>(({ theme, ownerState }) => ({
+  userSelect: 'none',
+  width: '1em',
+  height: '1em',
+  display: 'inline-block',
+  fill: 'currentColor',
+  flexShrink: 0,
+  transition:
+    theme.transitions?.create?.('fill', {
+      duration: theme.transitions?.duration?.shorter,
+    }) ?? 'fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+  fontSize: {
+    inherit: 'inherit',
+    small: theme.typography?.pxToRem?.(20) || '1.25rem',
+    medium: theme.typography?.pxToRem?.(24) || '1.5rem',
+    large: theme.typography?.pxToRem?.(35) || '2.1875rem',
+  }[ownerState.fontSize],
+  // TODO v5 deprecate, v6 remove for sx
+  color:
+    // @ts-ignore some colors are not part of the theme
+    (theme.vars || theme).palette?.[ownerState.color]?.main ??
+    // @ts-ignore some colors are not part of the theme
+    {
+      action: (theme.vars || theme).palette?.action?.active,
+      disabled: (theme.vars || theme).palette?.action?.disabled,
+      inherit: undefined,
+    }[ownerState.color] ??
+    defaultMaterialDesignColors[ownerState.color],
+}));
+
+/**
+ *
+ * Demos:
+ *
+ * - [Icons](https://mui.com/material-ui/icons/)
+ * - [Material Icons](https://mui.com/material-ui/material-icons/)
+ *
+ * API:
+ *
+ * - [SvgIcon API](https://mui.com/material-ui/api/svg-icon/)
+ */
+const SvgIcon = React.forwardRef(function SvgIcon<
+  SvgIconComponentType extends React.ElementType = SvgIconTypeMap['defaultComponent'],
+>(inProps: SvgIconProps<SvgIconComponentType>, ref: React.ForwardedRef<any>) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSvgIcon' });
+  const {
+    children,
+    className,
+    color = 'inherit',
+    component = 'svg',
+    fontSize = 'medium',
+    htmlColor,
+    inheritViewBox = false,
+    titleAccess,
+    viewBox = '0 0 24 24',
+    classes: classesProp,
+    ...other
+  } = props;
+
+  const ownerState: SvgIconOwnerState = {
+    ...props,
+    classes: classesProp,
+    color,
+    component,
+    fontSize,
+    instanceFontSize: inProps.fontSize,
+    inheritViewBox,
+    viewBox,
+  };
+
+  const more = {};
+
+  if (!inheritViewBox) {
+    // @ts-ignore it's an html prop
+    more.viewBox = viewBox;
+  }
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <SvgIconRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      focusable="false"
+      color={htmlColor}
+      aria-hidden={titleAccess ? undefined : true}
+      role={titleAccess ? 'img' : undefined}
+      ref={ref}
+      {...more}
+      {...other}
+      // @ts-ignore all props with defaults are defined
+      ownerState={ownerState}
+    >
+      {children}
+      {titleAccess ? <title>{titleAccess}</title> : null}
+    </SvgIconRoot>
+  );
+}) as OverridableComponent<SvgIconTypeMap>;
+
+SvgIcon.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * Node passed into the SVG element.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   * You can use the `htmlColor` prop to apply a color attribute to the SVG element.
+   * @default 'inherit'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf([
+      'inherit',
+      'action',
+      'disabled',
+      'primary',
+      'secondary',
+      'error',
+      'info',
+      'success',
+      'warning',
+    ]),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
+   * @default 'medium'
+   */
+  fontSize: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['inherit', 'large', 'medium', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * Applies a color attribute to the SVG element.
+   */
+  htmlColor: PropTypes.string,
+  /**
+   * If `true`, the root node will inherit the custom `component`'s viewBox and the `viewBox`
+   * prop will be ignored.
+   * Useful when you want to reference a custom `component` and have `SvgIcon` pass that
+   * `component`'s viewBox to the root node.
+   * @default false
+   */
+  inheritViewBox: PropTypes.bool,
+  /**
+   * The shape-rendering attribute. The behavior of the different options is described on the
+   * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering).
+   * If you are having issues with blurry icons you should investigate this prop.
+   */
+  shapeRendering: PropTypes.string,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * Provides a human-readable title for the element that contains it.
+   * https://www.w3.org/TR/SVG-access/#Equivalent
+   */
+  titleAccess: PropTypes.string,
+  /**
+   * Allows you to redefine what the coordinates without units mean inside an SVG element.
+   * For example, if the SVG element is 500 (width) by 200 (height),
+   * and you pass viewBox="0 0 50 20",
+   * this means that the coordinates inside the SVG will go from the top left corner (0,0)
+   * to bottom right (50,20) and each unit will be worth 10px.
+   * @default '0 0 24 24'
+   */
+  viewBox: PropTypes.string,
+};
+
+// @ts-ignore custom MUI prop
+SvgIcon.muiName = 'SvgIcon';
+
+export default SvgIcon;

--- a/packages/mui-system/src/SvgIcon/SvgIcon.types.ts
+++ b/packages/mui-system/src/SvgIcon/SvgIcon.types.ts
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import { Theme } from '@mui/system';
+import { SvgIconClasses } from './svgIconClasses';
+
+export interface SvgIconPropsSizeOverrides {}
+
+export interface SvgIconPropsColorOverrides {}
+
+export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
+  props: P & {
+    /**
+     * Node passed into the SVG element.
+     */
+    children?: React.ReactNode;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<SvgIconClasses>;
+    /**
+     * The color of the component.
+     * It supports both default and custom theme colors, which can be added as shown in the
+     * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+     * You can use the `htmlColor` prop to apply a color attribute to the SVG element.
+     * @default 'inherit'
+     */
+    color?: OverridableStringUnion<
+      | 'inherit'
+      | 'action'
+      | 'disabled'
+      | 'primary'
+      | 'secondary'
+      | 'error'
+      | 'info'
+      | 'success'
+      | 'warning',
+      SvgIconPropsColorOverrides
+    >;
+    /**
+     * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
+     * @default 'medium'
+     */
+    fontSize?: OverridableStringUnion<
+      'inherit' | 'large' | 'medium' | 'small',
+      SvgIconPropsSizeOverrides
+    >;
+    /**
+     * Applies a color attribute to the SVG element.
+     */
+    htmlColor?: string;
+    /**
+     * If `true`, the root node will inherit the custom `component`'s viewBox and the `viewBox`
+     * prop will be ignored.
+     * Useful when you want to reference a custom `component` and have `SvgIcon` pass that
+     * `component`'s viewBox to the root node.
+     * @default false
+     */
+    inheritViewBox?: boolean;
+    /**
+     * The shape-rendering attribute. The behavior of the different options is described on the
+     * [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering).
+     * If you are having issues with blurry icons you should investigate this prop.
+     */
+    shapeRendering?: string;
+    /**
+     * The system prop that allows defining system overrides as well as additional CSS styles.
+     */
+    sx?: SxProps<Theme>;
+    /**
+     * Provides a human-readable title for the element that contains it.
+     * https://www.w3.org/TR/SVG-access/#Equivalent
+     */
+    titleAccess?: string;
+    /**
+     * Allows you to redefine what the coordinates without units mean inside an SVG element.
+     * For example, if the SVG element is 500 (width) by 200 (height),
+     * and you pass viewBox="0 0 50 20",
+     * this means that the coordinates inside the SVG will go from the top left corner (0,0)
+     * to bottom right (50,20) and each unit will be worth 10px.
+     * @default '0 0 24 24'
+     */
+    viewBox?: string;
+  };
+  defaultComponent: D;
+}
+
+export type SvgIconProps<
+  D extends React.ElementType = SvgIconTypeMap['defaultComponent'],
+  P = {},
+> = OverrideProps<SvgIconTypeMap<P, D>, D>;
+
+export type SvgIconOwnerState = Omit<SvgIconProps, 'color' | 'fontSize' | 'viewBox'> &
+  Required<Pick<SvgIconProps, 'color' | 'fontSize' | 'viewBox'>>;

--- a/packages/mui-system/src/SvgIcon/index.ts
+++ b/packages/mui-system/src/SvgIcon/index.ts
@@ -1,0 +1,4 @@
+export { default } from './SvgIcon';
+
+export { default as svgIconClasses } from './svgIconClasses';
+export * from './svgIconClasses';

--- a/packages/mui-system/src/SvgIcon/svgIconClasses.ts
+++ b/packages/mui-system/src/SvgIcon/svgIconClasses.ts
@@ -1,0 +1,48 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface SvgIconClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the root element if `color="action"`. */
+  colorAction: string;
+  /** Styles applied to the root element if `color="error"`. */
+  colorError: string;
+  /** Styles applied to the root element if `color="disabled"`. */
+  colorDisabled: string;
+  /** Styles applied to the root element if `fontSize="inherit"`. */
+  fontSizeInherit: string;
+  /** Styles applied to the root element if `fontSize="small"`. */
+  fontSizeSmall: string;
+  /** Styles applied to the root element if `fontSize="medium"`. */
+  fontSizeMedium: string;
+  /** Styles applied to the root element if `fontSize="large"`. */
+  fontSizeLarge: string;
+}
+
+export type SvgIconClassKey = keyof SvgIconClasses;
+
+export function getSvgIconUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiSvgIcon', slot);
+}
+
+const svgIconClasses: SvgIconClasses = generateUtilityClasses('MuiSvgIcon', [
+  'root',
+  'colorPrimary',
+  'colorSecondary',
+  'colorAction',
+  'colorError',
+  'colorDisabled',
+  'fontSizeInherit',
+  'fontSizeSmall',
+  'fontSizeMedium',
+  'fontSizeLarge',
+]);
+
+export default svgIconClasses;

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -181,3 +181,8 @@ export * from './Unstable_Grid';
 
 export { default as Stack } from './Stack';
 export * from './Stack';
+
+export { default as SvgIcon } from './SvgIcon';
+export * from './SvgIcon';
+
+export * from './utils';

--- a/packages/mui-system/src/index.js
+++ b/packages/mui-system/src/index.js
@@ -71,3 +71,8 @@ export * from './Unstable_Grid';
 
 export { default as Stack } from './Stack/Stack';
 export * from './Stack';
+
+export { default as SvgIcon } from './SvgIcon';
+export * from './SvgIcon';
+
+export * from './utils';

--- a/packages/mui-system/src/utils/createSvgIcon.d.ts
+++ b/packages/mui-system/src/utils/createSvgIcon.d.ts
@@ -1,0 +1,3 @@
+import SvgIcon from '@mui/material/SvgIcon';
+
+export default function createSvgIcon(path: React.ReactNode, displayName: string): typeof SvgIcon;

--- a/packages/mui-system/src/utils/createSvgIcon.js
+++ b/packages/mui-system/src/utils/createSvgIcon.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import SvgIcon from '../SvgIcon';
+
+/**
+ * Private module reserved for @mui packages.
+ */
+export default function createSvgIcon(path, displayName) {
+  function Component(props, ref) {
+    return (
+      <SvgIcon data-testid={`${displayName}Icon`} ref={ref} {...props}>
+        {path}
+      </SvgIcon>
+    );
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // Need to set `displayName` on the inner component for React.memo.
+    // React prior to 16.14 ignores `displayName` on the wrapper.
+    Component.displayName = `${displayName}Icon`;
+  }
+
+  Component.muiName = SvgIcon.muiName;
+
+  return React.memo(React.forwardRef(Component));
+}

--- a/packages/mui-system/src/utils/index.ts
+++ b/packages/mui-system/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as createSvgIcon } from './createSvgIcon';


### PR DESCRIPTION
This PR aims to remove the `@mui/material` dependency from `@mui/icons-material`, by making the package depend on the @mui/system. This is done by moving the `SvgIcon` and `createSvgIcon` util to the @mui/system and using hardcoded Material Design values if no theme is provided. This will allow us to use the package with @mui/joy much more easily, by just providing a style override for the `SvgIcon` without the [need for yarn resolution](https://mui.com/joy-ui/guides/using-icon-libraries/).

TODOs:

- [ ] Update joy's default theme to add overrides for the `SvgIcon`
- [ ] Update joy's Using icon libraries guide