### PR TITLE
[Joy] Improve `onKeyDown` event handler for demo

### DIFF
--- a/docs/src/modules/components/JoyVariablesDemo.tsx
+++ b/docs/src/modules/components/JoyVariablesDemo.tsx
@@ -181,7 +181,7 @@ export default function JoyVariablesDemo(props: {
                       slotProps={{
                         input: {
                           onKeyDown: (event) => {
-                            if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ') {
+                            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
                               setSx((prevSx) => {
                                 const newSx = { ...prevSx };
                                 delete newSx[item.var];

--- a/docs/src/modules/components/JoyVariablesDemo.tsx
+++ b/docs/src/modules/components/JoyVariablesDemo.tsx
@@ -181,7 +181,10 @@ export default function JoyVariablesDemo(props: {
                       slotProps={{
                         input: {
                           onKeyDown: (event) => {
-                            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+                            if (
+                              (event.ctrlKey || event.metaKey) &&
+                              event.key.toLowerCase() === 'z'
+                            ) {
                               setSx((prevSx) => {
                                 const newSx = { ...prevSx };
                                 delete newSx[item.var];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow-up on https://github.com/mui/mui-toolpad/pull/1274#discussion_r1017032943

- Using `event.code` works only for QWERTY keyboards