### PR TITLE
[POC] ownerState access: use context

### DIFF
--- a/docs/pages/experiments/base/ownerstate-context.tsx
+++ b/docs/pages/experiments/base/ownerstate-context.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { styled } from '@mui/system';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+  SwitchUnstyledThumbSlotProps,
+  useSwitchUnstyledOwnerState,
+} from '@mui/base/SwitchUnstyled';
+
+const yellow = {
+  500: '#f9a825',
+};
+
+const grey = {
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+};
+
+const Root = styled('span')(
+  ({ theme }) => `
+  font-size: 0;
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 36px;
+  margin: 10px;
+  cursor: pointer;
+
+  &.${switchUnstyledClasses.disabled} {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  & .${switchUnstyledClasses.track} {
+    background: ${theme.palette.mode === 'dark' ? grey[600] : grey[400]};
+    border-radius: 18px;
+    display: block;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+
+  &.${switchUnstyledClasses.focusVisible} .${switchUnstyledClasses.thumb} {
+    background-color: ${grey[500]};
+    box-shadow: 0 0 1px 6px rgba(0, 0, 0, 0.25);
+  }
+
+  &.${switchUnstyledClasses.checked} .${switchUnstyledClasses.track} {
+    background: ${yellow[500]};
+  }
+
+  & .${switchUnstyledClasses.input} {
+    cursor: inherit;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: 1;
+    margin: 0;
+  }
+  `,
+);
+
+const Thumb = styled(function Thumb(props: SwitchUnstyledThumbSlotProps) {
+  const { checked } = useSwitchUnstyledOwnerState();
+  return <span {...props}>{checked ? '🌞' : '🌜'}</span>;
+})(`font-size: 16px;
+    display: block;
+    width: 24px;
+    height: 24px;
+    top: 6px;
+    left: 6px;
+    border-radius: 12px;
+    background-color: #fff;
+    position: relative;
+    text-align: center;
+
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 120ms;
+    
+    .${switchUnstyledClasses.checked} & {
+      left: 30px;
+      top: 6px;
+      background-color: #fff;
+    }
+  `);
+
+export default function UnstyledSwitches() {
+  const label = { slotProps: { input: { 'aria-label': 'Demo switch' } } };
+  const slots = { root: Root, thumb: Thumb };
+
+  return (
+    <div>
+      <SwitchUnstyled slots={slots} {...label} defaultChecked />
+      <SwitchUnstyled slots={slots} {...label} />
+    </div>
+  );
+}

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -15,6 +15,19 @@ import {
 } from './SwitchUnstyled.types';
 import { useSlotProps, WithOptionalOwnerState } from '../utils';
 
+const SwitchUnstyledOwnerStateContext = React.createContext<SwitchUnstyledOwnerState | null>(null);
+
+export function useSwitchUnstyledOwnerState(): SwitchUnstyledOwnerState {
+  const context = React.useContext(SwitchUnstyledOwnerStateContext);
+  if (context === null) {
+    throw new Error(
+      'useSwitchUnstyledOwnerState() can only be called in a slot component of SwitchUnstyled',
+    );
+  }
+
+  return context;
+}
+
 const useUtilityClasses = (ownerState: SwitchUnstyledOwnerState) => {
   const { checked, disabled, focusVisible, readOnly } = ownerState;
 
@@ -77,13 +90,15 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
 
   const { getInputProps, checked, disabled, focusVisible, readOnly } = useSwitch(useSwitchProps);
 
-  const ownerState: SwitchUnstyledOwnerState = {
-    ...props,
-    checked,
-    disabled,
-    focusVisible,
-    readOnly,
-  };
+  const ownerState: SwitchUnstyledOwnerState = React.useMemo(
+    () => ({
+      checked,
+      disabled,
+      focusVisible,
+      readOnly,
+    }),
+    [checked, disabled, focusVisible, readOnly],
+  );
 
   const classes = useUtilityClasses(ownerState);
 
@@ -95,41 +110,53 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     additionalProps: {
       ref,
     },
-    ownerState,
+    // @ts-ignore
+    ownerState: undefined,
     className: classes.root,
   });
+
+  delete rootProps.ownerState;
 
   const Thumb: React.ElementType = slots.thumb ?? 'span';
   const thumbProps: WithOptionalOwnerState<SwitchUnstyledThumbSlotProps> = useSlotProps({
     elementType: Thumb,
     externalSlotProps: slotProps.thumb,
-    ownerState,
+    // @ts-ignore
+    ownerState: undefined,
     className: classes.thumb,
   });
+
+  delete thumbProps.ownerState;
 
   const Input: React.ElementType = slots.input ?? 'input';
   const inputProps: WithOptionalOwnerState<SwitchUnstyledInputSlotProps> = useSlotProps({
     elementType: Input,
     getSlotProps: getInputProps,
     externalSlotProps: slotProps.input,
-    ownerState,
+    // @ts-ignore
+    ownerState: undefined,
     className: classes.input,
   });
+
+  delete rootProps.ownerState;
 
   const Track: React.ElementType = slots.track === null ? () => null : slots.track ?? 'span';
   const trackProps: WithOptionalOwnerState<SwitchUnstyledTrackSlotProps> = useSlotProps({
     elementType: Track,
     externalSlotProps: slotProps.track,
-    ownerState,
+    // @ts-ignore
+    ownerState: undefined,
     className: classes.track,
   });
 
   return (
-    <Root {...rootProps}>
-      <Track {...trackProps} />
-      <Thumb {...thumbProps} />
-      <Input {...inputProps} />
-    </Root>
+    <SwitchUnstyledOwnerStateContext.Provider value={ownerState}>
+      <Root {...rootProps}>
+        <Track {...trackProps} />
+        <Thumb {...thumbProps} />
+        <Input {...inputProps} />
+      </Root>
+    </SwitchUnstyledOwnerStateContext.Provider>
   );
 }) as OverridableComponent<SwitchUnstyledTypeMap>;
 

--- a/packages/mui-base/src/SwitchUnstyled/index.ts
+++ b/packages/mui-base/src/SwitchUnstyled/index.ts
@@ -1,4 +1,4 @@
-export { default } from './SwitchUnstyled';
+export { default, useSwitchUnstyledOwnerState } from './SwitchUnstyled';
 export * from './SwitchUnstyled.types';
 
 export { default as useSwitch } from './useSwitch';


### PR DESCRIPTION
**DO NOT MERGE**

This is a playground that illustrates an alternative way of accessing `ownerState` in slot components.
A SwitchUnstyled is used for this example.

Related issue: #32882

This is one of the possible solutions. The other one is described in #35668.

A new hook, `useSwitchUnstyledOwnerState` is introduced. It can be used within slot components to get the state of the owner component and affect what's being rendered.
In this example, a different emoji is displayed depending on the state of the Switch.

**Advantages over the existing API:**
1. All props passed to the slot component can be forwarded to its DOM element. This is especially important when using 3rd party components as slots, as they don't know anything about our `ownerState` prop and may forward everything they receive. `ownerState` should not be placed on a DOM element as it's not a valid attribute (and React rightfully complains about this).
2. When using MUI System to style components, developers won't need to configure it to forward `ownerState`.
3. Merging `ownerState`s from different "layers" (i.e., Base and Joy components) won't be an issue anymore. Each ownerState will be in a different context and will be able to be accessed independently. Also this will eliminate the problems with `ownerState` types we currently have when using Base components as slots in other Base components.

**Disadvantages:**
1. The new API is more verbose and harder to find. It may be simpler to type `const { ownerState } = props;` than `const ownerState = useSwitchUnstyledOwnerState();`. It won't be possible to use a shorthand notation to define a simple component:
   ```jsx
   // existing:
   const MyButton = ({ ownerState, ...other }) => <button {...other} className={ownerState.active ? 'active' : ''} />;

   // new:
   const MyButton = (props) => {
     const { active } = useButtonUnstyledOwnerState();
     return <button {...props} className={active ? 'active' : ''} />;
   };
   ```
2. Extensive use of contexts may negatively affect performance (I haven't done any measurements yet, though)

## Playgrounds

New API: https://codesandbox.io/s/sharp-booth-hx3xtn?file=/src/App.tsx

Existing API: https://codesandbox.io/s/confident-hermann-q1kiwf?file=/src/App.tsx