### PR TITLE
[POC] Configure setting ownerState on slots

### DIFF
--- a/docs/pages/experiments/base/ownerstate-forwarding.tsx
+++ b/docs/pages/experiments/base/ownerstate-forwarding.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { styled } from '@mui/system';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+  SwitchUnstyledThumbSlotProps,
+} from '@mui/base/SwitchUnstyled';
+
+const yellow = {
+  500: '#f9a825',
+};
+
+const grey = {
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+};
+
+const Root = styled('span')(
+  ({ theme }) => `
+  font-size: 0;
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 36px;
+  margin: 10px;
+  cursor: pointer;
+
+  &.${switchUnstyledClasses.disabled} {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  & .${switchUnstyledClasses.track} {
+    background: ${theme.palette.mode === 'dark' ? grey[600] : grey[400]};
+    border-radius: 18px;
+    display: block;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+
+  &.${switchUnstyledClasses.focusVisible} .${switchUnstyledClasses.thumb} {
+    background-color: ${grey[500]};
+    box-shadow: 0 0 1px 6px rgba(0, 0, 0, 0.25);
+  }
+
+  &.${switchUnstyledClasses.checked} .${switchUnstyledClasses.track} {
+    background: ${yellow[500]};
+  }
+
+  & .${switchUnstyledClasses.input} {
+    cursor: inherit;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: 1;
+    margin: 0;
+  }
+  `,
+);
+
+const Thumb = styled(
+  function Thumb({ ownerState, ...other }: SwitchUnstyledThumbSlotProps) {
+    // without the `provideOwnerStateToSlots` prop on the SwitchUnstyled, the `ownerState` prop will be undefined
+    // and the whole props object can be forwarded to the DOM element.
+    return <span {...other}>{ownerState.checked ? '🌞' : '🌜'}</span>;
+  },
+  {
+    // Must configure the `styled` utility to forward the `ownerState` prop.
+    // Potentially we can configure it in such way by default in the future.
+    shouldForwardProp: () => true,
+  },
+)(`font-size: 16px;
+    display: block;
+    width: 24px;
+    height: 24px;
+    top: 6px;
+    left: 6px;
+    border-radius: 12px;
+    background-color: #fff;
+    position: relative;
+    text-align: center;
+
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 120ms;
+    
+    .${switchUnstyledClasses.checked} & {
+      left: 30px;
+      top: 6px;
+      background-color: #fff;
+    }
+  `);
+
+export default function UnstyledSwitches() {
+  const label = { slotProps: { input: { 'aria-label': 'Demo switch' } } };
+  const slots = { root: Root, thumb: Thumb };
+
+  return (
+    <div>
+      <SwitchUnstyled slots={slots} provideOwnerStateToSlots {...label} defaultChecked />
+    </div>
+  );
+}

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -57,6 +57,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     onChange,
     onFocus,
     onFocusVisible,
+    provideOwnerStateToSlots = false,
     readOnly: readOnlyProp,
     required,
     slotProps = {},
@@ -123,6 +124,13 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     ownerState,
     className: classes.track,
   });
+
+  if (!provideOwnerStateToSlots) {
+    delete rootProps.ownerState;
+    delete thumbProps.ownerState;
+    delete inputProps.ownerState;
+    delete trackProps.ownerState;
+  }
 
   return (
     <Root {...rootProps}>

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -9,6 +9,7 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
    * Class name applied to the root element.
    */
   className?: string;
+  provideOwnerStateToSlots?: boolean;
   /**
    * The components used for each slot inside the Switch.
    * Either a string to use a HTML element or a component.
@@ -20,7 +21,6 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
     input?: React.ElementType;
     track?: React.ElementType | null;
   };
-
   /**
    * The props used for each slot inside the Switch.
    * @default {}


### PR DESCRIPTION
**DO NOT MERGE**

This is a playground that illustrates an alternative way of accessing `ownerState` in slot components.
A SwitchUnstyled is used for this example.

Related issue: #32882

This is one of the possible solutions. The other one is described in #35654.

A new prop was added to SwitchUnstyled - `provideOwnerStateToSlots`. It controls whether `ownerState` is passed as a prop to slot components. Developers can set this prop when they intend to make rendering of a slot dependent on the state of the owner component (as shown in this PR and on the linked codesandbox). The prop would be set to `false` (or not set) when slot components don't expect `ownerState` in props. This will be especially useful when using 3rd party components as slots (for example React Router's Link as a root slot of a Button).

**Advantages over the existing API:**
1. 3rd party components can be used in slots without wrapping them in custom code that strips out the `ownerState` from props.
2. Potentially better performance than #35654

**Disadvantages:**
1. Low granularity - the prop doesn't work per slot, but on the whole component. If one slot require customisation using ownerState and the other is a 3rd party component, they will require additional code to work together.
3. Low discoverability - it is not immediately obvious why slot components don't work with ownerState out of the box
4. Another prop to support on all components

## Playgrounds

New API: https://codesandbox.io/s/recursing-turing-8m5yvj?file=/src/App.tsx

Existing API: https://codesandbox.io/s/confident-hermann-q1kiwf?file=/src/App.tsx