### PR TITLE
[POC] slot overrides: interface per component

### DIFF
--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -1,8 +1,10 @@
+import * as React from 'react';
 import { OverrideProps, Simplify } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types';
 
-export interface SwitchUnstyledComponentsPropsOverrides {}
+export interface SwitchUnstyledSlotPropsOverrides
+  extends Partial<Record<'root' | 'thumb' | 'input' | 'track', undefined>> {}
 
 export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   /**
@@ -28,22 +30,22 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   slotProps?: {
     root?: SlotComponentProps<
       'span',
-      SwitchUnstyledComponentsPropsOverrides,
+      SwitchUnstyledSlotPropsOverrides['root'],
       SwitchUnstyledOwnerState
     >;
     thumb?: SlotComponentProps<
       'span',
-      SwitchUnstyledComponentsPropsOverrides,
+      SwitchUnstyledSlotPropsOverrides['thumb'],
       SwitchUnstyledOwnerState
     >;
     input?: SlotComponentProps<
       'input',
-      SwitchUnstyledComponentsPropsOverrides,
+      SwitchUnstyledSlotPropsOverrides['input'],
       SwitchUnstyledOwnerState
     >;
     track?: SlotComponentProps<
       'span',
-      SwitchUnstyledComponentsPropsOverrides,
+      SwitchUnstyledSlotPropsOverrides['track'],
       SwitchUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/utils/types.ts
+++ b/packages/mui-base/src/utils/types.ts
@@ -5,6 +5,5 @@ export type WithOptionalOwnerState<T extends { ownerState: unknown }> = Omit<T, 
 
 export type SlotComponentProps<TSlotComponent extends React.ElementType, TOverrides, TOwnerState> =
   | (Partial<React.ComponentPropsWithRef<TSlotComponent>> & TOverrides)
-  | ((
-      ownerState: TOwnerState,
-    ) => Partial<React.ComponentPropsWithRef<TSlotComponent>> & TOverrides);
+  | ((ownerState: TOwnerState) => Partial<React.ComponentPropsWithRef<TSlotComponent>> & TOverrides)
+  | {};


### PR DESCRIPTION
**DO NOT MERGE**

This is a playground to evaluate Option 2 from https://github.com/mui/material-ui/issues/34906 with a SwitchUnstyled.

The `SwitchUnstyledComponentsPropsOverrides` interface was renamed to `SwitchUnstyledSlotPropsOverrides` to match the `slotProps` prop.

I couldn't find a way to get Intellisense hints when augmenting the SwitchUnstyledSlotPropsOverrides interface members, unfortunately.

Playground: https://codesandbox.io/s/base-cra-typescript-forked-0injik?file=/src/App.tsx