### PR TITLE
[POC] ownerState access: configure prop forwarding

### DIFF
--- a/docs/pages/experiments/base/ownerstate-forwarding.tsx
+++ b/docs/pages/experiments/base/ownerstate-forwarding.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { styled } from '@mui/system';
+import SwitchUnstyled, {
+  switchUnstyledClasses,
+  SwitchUnstyledThumbSlotProps,
+} from '@mui/base/SwitchUnstyled';
+
+const yellow = {
+  500: '#f9a825',
+};
+
+const grey = {
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+};
+
+const Root = styled('span')(
+  ({ theme }) => `
+  font-size: 0;
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 36px;
+  margin: 10px;
+  cursor: pointer;
+
+  &.${switchUnstyledClasses.disabled} {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  & .${switchUnstyledClasses.track} {
+    background: ${theme.palette.mode === 'dark' ? grey[600] : grey[400]};
+    border-radius: 18px;
+    display: block;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+
+  &.${switchUnstyledClasses.focusVisible} .${switchUnstyledClasses.thumb} {
+    background-color: ${grey[500]};
+    box-shadow: 0 0 1px 6px rgba(0, 0, 0, 0.25);
+  }
+
+  &.${switchUnstyledClasses.checked} .${switchUnstyledClasses.track} {
+    background: ${yellow[500]};
+  }
+
+  & .${switchUnstyledClasses.input} {
+    cursor: inherit;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: 1;
+    margin: 0;
+  }
+  `,
+);
+
+const Thumb = styled(
+  function Thumb({ ownerState, ...other }: SwitchUnstyledThumbSlotProps) {
+    // without the `provideOwnerStateToSlots` prop on the SwitchUnstyled, the `ownerState` prop will be undefined
+    // and the whole props object can be forwarded to the DOM element.
+    return <span {...other}>{ownerState.checked ? '🌞' : '🌜'}</span>;
+  },
+  {
+    // Must configure the `styled` utility to forward the `ownerState` prop.
+    // Potentially we can configure it in such way by default in the future.
+    shouldForwardProp: () => true,
+  },
+)(`font-size: 16px;
+    display: block;
+    width: 24px;
+    height: 24px;
+    top: 6px;
+    left: 6px;
+    border-radius: 12px;
+    background-color: #fff;
+    position: relative;
+    text-align: center;
+
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 120ms;
+    
+    .${switchUnstyledClasses.checked} & {
+      left: 30px;
+      top: 6px;
+      background-color: #fff;
+    }
+  `);
+
+export default function UnstyledSwitches() {
+  const label = { slotProps: { input: { 'aria-label': 'Demo switch' } } };
+  const slots = { root: Root, thumb: Thumb };
+
+  return (
+    <div>
+      <SwitchUnstyled slots={slots} provideOwnerStateToSlots {...label} defaultChecked />
+    </div>
+  );
+}

--- a/docs/pages/experiments/base/ownerstate-forwarding.tsx
+++ b/docs/pages/experiments/base/ownerstate-forwarding.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { styled } from '@mui/system';
 import SwitchUnstyled, {
   switchUnstyledClasses,
+  SwitchUnstyledProps,
   SwitchUnstyledThumbSlotProps,
 } from '@mui/base/SwitchUnstyled';
 
@@ -98,10 +99,13 @@ const Thumb = styled(
 export default function UnstyledSwitches() {
   const label = { slotProps: { input: { 'aria-label': 'Demo switch' } } };
   const slots = { root: Root, thumb: Thumb };
+  const slotConfig: SwitchUnstyledProps['slotConfig'] = {
+    thumb: { provideOwnerState: true },
+  };
 
   return (
     <div>
-      <SwitchUnstyled slots={slots} provideOwnerStateToSlots {...label} defaultChecked />
+      <SwitchUnstyled slots={slots} slotConfig={slotConfig} {...label} defaultChecked />
     </div>
   );
 }

--- a/docs/pages/experiments/base/ownerstate-forwarding.tsx
+++ b/docs/pages/experiments/base/ownerstate-forwarding.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { styled } from '@mui/system';
 import SwitchUnstyled, {
   switchUnstyledClasses,
-  SwitchUnstyledProps,
   SwitchUnstyledThumbSlotProps,
 } from '@mui/base/SwitchUnstyled';
 
@@ -99,13 +98,10 @@ const Thumb = styled(
 export default function UnstyledSwitches() {
   const label = { slotProps: { input: { 'aria-label': 'Demo switch' } } };
   const slots = { root: Root, thumb: Thumb };
-  const slotConfig: SwitchUnstyledProps['slotConfig'] = {
-    thumb: { provideOwnerState: true },
-  };
 
   return (
     <div>
-      <SwitchUnstyled slots={slots} slotConfig={slotConfig} {...label} defaultChecked />
+      <SwitchUnstyled slots={slots} provideOwnerState={['thumb']} {...label} defaultChecked />
     </div>
   );
 }

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -57,6 +57,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     onChange,
     onFocus,
     onFocusVisible,
+    provideOwnerStateToSlots = false,
     readOnly: readOnlyProp,
     required,
     slotProps = {},
@@ -123,6 +124,13 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     ownerState,
     className: classes.track,
   });
+
+  if (!provideOwnerStateToSlots) {
+    delete rootProps.ownerState;
+    delete thumbProps.ownerState;
+    delete inputProps.ownerState;
+    delete trackProps.ownerState;
+  }
 
   return (
     <Root {...rootProps}>

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -57,9 +57,9 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     onChange,
     onFocus,
     onFocusVisible,
+    provideOwnerState = [],
     readOnly: readOnlyProp,
     required,
-    slotConfig = {},
     slotProps = {},
     slots = {},
     ...other
@@ -100,7 +100,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.root,
   });
 
-  if (!slotConfig.root?.provideOwnerState) {
+  if (!provideOwnerState.includes('root')) {
     delete rootProps.ownerState;
   }
 
@@ -112,7 +112,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.thumb,
   });
 
-  if (!slotConfig.thumb?.provideOwnerState) {
+  if (!provideOwnerState.includes('thumb')) {
     delete thumbProps.ownerState;
   }
 
@@ -125,7 +125,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.input,
   });
 
-  if (!slotConfig.input?.provideOwnerState) {
+  if (!provideOwnerState.includes('input')) {
     delete inputProps.ownerState;
   }
 
@@ -137,7 +137,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.track,
   });
 
-  if (!slotConfig.track?.provideOwnerState) {
+  if (!provideOwnerState.includes('track')) {
     delete trackProps.ownerState;
   }
 

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -57,9 +57,9 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     onChange,
     onFocus,
     onFocusVisible,
-    provideOwnerStateToSlots = false,
     readOnly: readOnlyProp,
     required,
+    slotConfig = {},
     slotProps = {},
     slots = {},
     ...other
@@ -100,6 +100,10 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.root,
   });
 
+  if (!slotConfig.root?.provideOwnerState) {
+    delete rootProps.ownerState;
+  }
+
   const Thumb: React.ElementType = slots.thumb ?? 'span';
   const thumbProps: WithOptionalOwnerState<SwitchUnstyledThumbSlotProps> = useSlotProps({
     elementType: Thumb,
@@ -107,6 +111,10 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     ownerState,
     className: classes.thumb,
   });
+
+  if (!slotConfig.thumb?.provideOwnerState) {
+    delete thumbProps.ownerState;
+  }
 
   const Input: React.ElementType = slots.input ?? 'input';
   const inputProps: WithOptionalOwnerState<SwitchUnstyledInputSlotProps> = useSlotProps({
@@ -117,6 +125,10 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.input,
   });
 
+  if (!slotConfig.input?.provideOwnerState) {
+    delete inputProps.ownerState;
+  }
+
   const Track: React.ElementType = slots.track === null ? () => null : slots.track ?? 'span';
   const trackProps: WithOptionalOwnerState<SwitchUnstyledTrackSlotProps> = useSlotProps({
     elementType: Track,
@@ -125,10 +137,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     className: classes.track,
   });
 
-  if (!provideOwnerStateToSlots) {
-    delete rootProps.ownerState;
-    delete thumbProps.ownerState;
-    delete inputProps.ownerState;
+  if (!slotConfig.track?.provideOwnerState) {
     delete trackProps.ownerState;
   }
 

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -4,21 +4,12 @@ import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types'
 
 export interface SwitchUnstyledComponentsPropsOverrides {}
 
-export interface SlotConfig {
-  provideOwnerState?: boolean;
-}
-
 export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   /**
    * Class name applied to the root element.
    */
   className?: string;
-  slotConfig?: {
-    root?: SlotConfig;
-    thumb?: SlotConfig;
-    input?: SlotConfig;
-    track?: SlotConfig;
-  };
+  provideOwnerState?: (keyof Required<SwitchUnstyledOwnProps>['slots'])[];
   /**
    * The components used for each slot inside the Switch.
    * Either a string to use a HTML element or a component.

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -4,12 +4,21 @@ import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types'
 
 export interface SwitchUnstyledComponentsPropsOverrides {}
 
+export interface SlotConfig {
+  provideOwnerState?: boolean;
+}
+
 export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   /**
    * Class name applied to the root element.
    */
   className?: string;
-  provideOwnerStateToSlots?: boolean;
+  slotConfig?: {
+    root?: SlotConfig;
+    thumb?: SlotConfig;
+    input?: SlotConfig;
+    track?: SlotConfig;
+  };
   /**
    * The components used for each slot inside the Switch.
    * Either a string to use a HTML element or a component.

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -9,6 +9,7 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
    * Class name applied to the root element.
    */
   className?: string;
+  provideOwnerStateToSlots?: boolean;
   /**
    * The components used for each slot inside the Switch.
    * Either a string to use a HTML element or a component.
@@ -20,7 +21,6 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
     input?: React.ElementType;
     track?: React.ElementType | null;
   };
-
   /**
    * The props used for each slot inside the Switch.
    * @default {}


### PR DESCRIPTION
**DO NOT MERGE**

This is a playground that illustrates an alternative way of accessing ownerState in slot components.
A SwitchUnstyled is used for this example.

Related issue: https://github.com/mui/material-ui/issues/32882

This is a solution similar to #35655, but with the ability to configure individual slots.

A new prop was added to SwitchUnstyled - `slotConfig`. Its keys match available slots, while values are objects with a single key: `provideOwnerState`. It controls whether ownerState is passed as a prop to the slot component. Developers can set this prop when they intend to make rendering of a slot dependent on the state of the owner component (as shown in this PR and on the linked codesandbox). The prop would be set to false (or not set) when slot components don't expect ownerState in props. This will be especially useful when using 3rd party components as slots (for example React Router's Link as a root slot of a Button).

Advantages over the existing API:

1. 3rd party components can be used in slots without wrapping them in custom code that strips out the `ownerState` from props.
2. Potentially better performance than #35654

Disadvantages:

1. Low discoverability - it is not immediately obvious why slot components don't work with ownerState out of the box
2. Another prop to support in all components
3. High verbosity. Developers who want to override slots must provide two props that are objects.
4. Worse locality of the configuration in comparison to #35654 - developers must configure this option on a component level when they want to use the `ownerState` in a slot (the hook proposed in #35654 is used exactly in the same place the ownerState is required)

## Playgrounds

New API: https://codesandbox.io/s/base-cra-typescript-forked-1mvxfe?file=/src/App.tsx

Existing API: https://codesandbox.io/s/confident-hermann-q1kiwf?file=/src/App.tsx