### PR TITLE
[docs] Fix demo code selection through copy shortcut key on Firefox browser

### DIFF
--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -133,6 +133,23 @@ function InitCodeCopy() {
   return null;
 }
 
+function hasNativeSelection(element: HTMLTextAreaElement) {
+  if (window.getSelection()?.toString() !== '') {
+    return true;
+  }
+
+  if (!element) {
+    return false;
+  }
+
+  // window.getSelection() does not work for Firefox browser when user is highlighting a text. It always returns empty string. See: https://bugzilla.mozilla.org/show_bug.cgi?id=85686. So we need to use selectionStart and selectionEnd.
+  if ((element.selectionEnd || 0) - (element.selectionStart || 0) > 0) {
+    return true;
+  }
+
+  return false;
+}
+
 interface CodeCopyProviderProps {
   children: React.ReactNode;
 }
@@ -145,7 +162,7 @@ export function CodeCopyProvider({ children }: CodeCopyProviderProps) {
   const rootNode = React.useRef<HTMLDivElement | null>(null);
   React.useEffect(() => {
     document.addEventListener('keydown', (event) => {
-      if (document.getSelection()?.toString()) {
+      if (hasNativeSelection(event.target as HTMLTextAreaElement)) {
         // Skip if user is highlighting a text.
         return;
       }

--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -134,7 +134,7 @@ function InitCodeCopy() {
 }
 
 function hasNativeSelection(element: HTMLTextAreaElement) {
-  if (window.getSelection()?.toString() !== '') {
+  if (window.getSelection()?.toString()) {
     return true;
   }
 

--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -138,12 +138,10 @@ function hasNativeSelection(element: HTMLTextAreaElement) {
     return true;
   }
 
-  if (!element) {
-    return false;
-  }
-
-  // window.getSelection() does not work for Firefox browser when user is highlighting a text. It always returns empty string. See: https://bugzilla.mozilla.org/show_bug.cgi?id=85686. So we need to use selectionStart and selectionEnd.
-  if ((element.selectionEnd || 0) - (element.selectionStart || 0) > 0) {
+  // window.getSelection() returns an empty string in Firefox for selections inside a form element.
+  // See: https://bugzilla.mozilla.org/show_bug.cgi?id=85686.
+  // Instead, we can use element.selectionStart that is only defined on form elements.
+  if (element && (element.selectionEnd || 0) - (element.selectionStart || 0) > 0) {
     return true;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #35645 

The `window.getSelection()` returns an empty string on Firefox browser for a text inside a form field i.e textarea due to which the check fails and copies the whole code text. 
See bug opened 22 years ago which isn't yet fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=85686.

I copied the same logic as in https://github.com/mui/mui-x/pull/6593 which works well.

Link to test after fix: https://deploy-preview-35670--material-ui.netlify.app/material-ui/react-menu/#main-content