### PR TITLE
[examples][vitejs] Load Roboto font

### DIFF
--- a/examples/vitejs/index.html
+++ b/examples/vitejs/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <title>Vite App with Material UI</title>
   </head>
   <body>


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The [documentation](https://mui.com/material-ui/react-typography/#general) says Roboto font is not automatically loaded by MUI. The user should explicitly load this font in the vitejs example project.


