### PR TITLE
[docs] Fix navigation layout shift

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -159,6 +159,7 @@ const ToolbarDiv = styled('div')(({ theme }) => ({
   padding: theme.spacing(1.45, 2),
   paddingRight: 0,
   height: 'var(--MuiDocs-header-height)',
+  boxSizing: 'border-box', // TODO have CssBaseline in the Next.js layout
   display: 'flex',
   flexGrow: 1,
   flexDirection: 'row',
@@ -179,6 +180,7 @@ const AppNavPaperComponent = styled('div')(({ theme }) => {
   return {
     width: 'var(--MuiDocs-navDrawer-width)',
     boxShadow: 'none',
+    boxSizing: 'border-box', // TODO have CssBaseline in the Next.js layout
     paddingBottom: theme.spacing(5),
     [theme.breakpoints.up('xs')]: {
       borderRadius: '0px 10px 10px 0px',

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -49,6 +49,7 @@ export default function DiamondSponsors() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            boxSizing: 'border-box',
             border: `1px solid ${
               theme.palette.mode === 'dark'
                 ? theme.palette.primaryDark[700]

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -49,7 +49,7 @@ export default function DiamondSponsors() {
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            boxSizing: 'border-box',
+            boxSizing: 'border-box', // TODO have CssBaseline in the Next.js layout
             border: `1px solid ${
               theme.palette.mode === 'dark'
                 ? theme.palette.primaryDark[700]


### PR DESCRIPTION
The scroll position moves by 6 pixels each time you change page:

https://user-images.githubusercontent.com/3165635/210135763-d099ae62-d191-4229-880c-abed56052d94.mov

This regression was introduced between v4.12.4 and v5.0.0, e.g. https://v5-0-6.mui.com/components/typography/ KO, v4.12.4: OK https://v4.mui.com/components/radio-buttons/. It has been driving me crazy for over a year, it won't make it to 2023 (end of 2021: https://github.com/mui/material-ui/pull/29994#issuecomment-983816368).

Why does this happen? Because Next.js REMOUNTs each page. This means that the CssBaseline that is inside the page gets unmounted, removes the `boxSizing: 'border-box',` style, which then means that the 3 diamond sponsors' 1px border is no longer taken into account in the height set, which means +6 pixels when this logic runs:

https://github.com/mui/material-ui/blob/6205492d7e1649f4e7a11faf910a5dbc2d6fd344/docs/src/modules/components/AppNavDrawer.js#L145

---

On a related note, in my video, it's fireworks when changing pages 🎆, the search bar blinks, the notification badge blinks, the sponsors blink. It also feels laggy. We could solve this by moving the main layout to _app.js so it rerenders, not remounts. However, this might lead to bundle size bloat to be able to support many different layouts (marketing, docs, template, blog, etc.). Maybe it's better to wait for: https://beta.nextjs.org/docs/routing/pages-and-layouts#layouts "A layout is UI that is shared between multiple pages".