### PR TITLE
[TextField] Improve WCAG 2.4.7 with error={true}

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -91,9 +91,10 @@ const FilledInputRoot = styled(InputBaseRoot, {
         // See https://github.com/mui/material-ui/issues/31766
         transform: 'scaleX(1) translateX(0)',
       },
-      [`&.${filledInputClasses.error}:after`]: {
-        borderBottomColor: (theme.vars || theme).palette.error.main,
-        transform: 'scaleX(1)', // error is always underlined in red
+      [`&.${filledInputClasses.error}`]: {
+        '&:before, &:after': {
+          borderBottomColor: (theme.vars || theme).palette.error.main,
+        },
       },
       '&:before': {
         borderBottom: `1px solid ${
@@ -112,7 +113,7 @@ const FilledInputRoot = styled(InputBaseRoot, {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      [`&:hover:not(.${filledInputClasses.disabled}):before`]: {
+      [`&:hover:not(.${filledInputClasses.disabled}, .${filledInputClasses.error}):before`]: {
         borderBottom: `1px solid ${(theme.vars || theme).palette.text.primary}`,
       },
       [`&.${filledInputClasses.disabled}:before`]: {

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -91,13 +91,9 @@ const FilledInputRoot = styled(InputBaseRoot, {
         // See https://github.com/mui/material-ui/issues/31766
         transform: 'scaleX(1) translateX(0)',
       },
-      [`&.${filledInputClasses.error}`]: {
-        '&:before, &:after': {
-          borderBottomColor: (theme.vars || theme).palette.error.main,
-        },
-        '&:focus-within:after': {
-          transform: 'scaleX(1)', // error is always underlined in red
-        },
+      [`&.${filledInputClasses.error}:after`]: {
+        borderBottomColor: (theme.vars || theme).palette.error.main,
+        transform: 'scaleX(1)', // error is always underlined in red
       },
       '&:before': {
         borderBottom: `1px solid ${
@@ -116,7 +112,7 @@ const FilledInputRoot = styled(InputBaseRoot, {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      [`&:hover:not(.${filledInputClasses.disabled}, .${filledInputClasses.error}):before`]: {
+      [`&:hover:not(.${filledInputClasses.disabled}):before`]: {
         borderBottom: `1px solid ${(theme.vars || theme).palette.text.primary}`,
       },
       [`&.${filledInputClasses.disabled}:before`]: {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -75,9 +75,10 @@ const InputRoot = styled(InputBaseRoot, {
         // See https://github.com/mui/material-ui/issues/31766
         transform: 'scaleX(1) translateX(0)',
       },
-      [`&.${inputClasses.error}:after`]: {
-        borderBottomColor: (theme.vars || theme).palette.error.main,
-        transform: 'scaleX(1)', // error is always underlined in red
+      [`&.${inputClasses.error}`]: {
+        '&:before, &:after': {
+          borderBottomColor: (theme.vars || theme).palette.error.main,
+        },
       },
       '&:before': {
         borderBottom: `1px solid ${bottomLineColor}`,
@@ -92,7 +93,7 @@ const InputRoot = styled(InputBaseRoot, {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      [`&:hover:not(.${inputClasses.disabled}):before`]: {
+      [`&:hover:not(.${inputClasses.disabled}, .${inputClasses.error}):before`]: {
         borderBottom: `2px solid ${(theme.vars || theme).palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {

--- a/packages/mui-material/src/Input/Input.js
+++ b/packages/mui-material/src/Input/Input.js
@@ -75,13 +75,9 @@ const InputRoot = styled(InputBaseRoot, {
         // See https://github.com/mui/material-ui/issues/31766
         transform: 'scaleX(1) translateX(0)',
       },
-      [`&.${inputClasses.error}`]: {
-        '&:before, &:after': {
-          borderBottomColor: (theme.vars || theme).palette.error.main,
-        },
-        '&:focus-within:after': {
-          transform: 'scaleX(1)', // error is always underlined in red
-        },
+      [`&.${inputClasses.error}:after`]: {
+        borderBottomColor: (theme.vars || theme).palette.error.main,
+        transform: 'scaleX(1)', // error is always underlined in red
       },
       '&:before': {
         borderBottom: `1px solid ${bottomLineColor}`,
@@ -96,8 +92,8 @@ const InputRoot = styled(InputBaseRoot, {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      [`&:hover:not(.${inputClasses.disabled}, .${inputClasses.error}):before`]: {
-        borderBottom: `1px solid ${(theme.vars || theme).palette.text.primary}`,
+      [`&:hover:not(.${inputClasses.disabled}):before`]: {
+        borderBottom: `2px solid ${(theme.vars || theme).palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
           borderBottom: `1px solid ${bottomLineColor}`,


### PR DESCRIPTION
This fixes a regression at the same time, on hover:

**Expected**
<img width="246" alt="Screenshot 2022-12-31 at 21 04 19" src="https://user-images.githubusercontent.com/3165635/210154648-85a663f5-9a04-465e-a45e-b54f42fce452.png">

https://v1.mui.com/demos/text-fields/#textfield

**Actual**
<img width="252" alt="Screenshot 2022-12-31 at 21 03 57" src="https://user-images.githubusercontent.com/3165635/210154639-71ac4a99-71ca-4c18-aa59-7859ac7753d7.png">

https://mui.com/material-ui/react-text-field/#basic-textfield

It seems that we can simplify the logic in #35167. The first commit is a revert. The second is the fix. I got pulled into this by "Need final review from @oliviertassinari" and then when I had a quick look, the use of `:focus-within` which I couldn't wrap my head around: why it would be needed in the first place.