### PR TITLE
[core] Fix the product license reference name

### DIFF
--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -123,9 +123,11 @@ async function prepend(file, string) {
 }
 
 async function addLicense(packageData) {
-  const license = `/** @license MUI Core v${packageData.version}
+  const license = `/**
+ * ${packageData.name} v${packageData.version}
  *
- * This source code is licensed under the MIT license found in the
+ * @license ${packageData.license}
+ * This source code is licensed under the ${packageData.license} license found in the
  * LICENSE file in the root directory of this source tree.
  */
 `;

--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -123,7 +123,7 @@ async function prepend(file, string) {
 }
 
 async function addLicense(packageData) {
-  const license = `/** @license MUI v${packageData.version}
+  const license = `/** @license MUI Core v${packageData.version}
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
To change https://unpkg.com/@mui/base@5.0.0-alpha.112/node/index.js. It matches with https://unpkg.com/browse/react-dom@18.2.0/cjs/react-dom-server.node.production.min.js.

Related to https://github.com/mui/mui-x/pull/7367