### PR TITLE
[Joy] Replace `Joy[Component]` classname with `Mui[Component]` classname for all slots of components

### DIFF
--- a/docs/data/joy/components/avatar/BadgeAvatars.js
+++ b/docs/data/joy/components/avatar/BadgeAvatars.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/joy/Box';
-import Badge from '@mui/joy/Badge';
+import Badge, { badgeClasses } from '@mui/joy/Badge';
 import Avatar from '@mui/joy/Avatar';
 
 export default function BadgeAvatars() {
@@ -11,7 +11,7 @@ export default function BadgeAvatars() {
         badgeInset="14%"
         color="success"
         sx={{
-          '& .JoyBadge-badge': {
+          [`& .${badgeClasses.badge}`]: {
             '&::after': {
               position: 'absolute',
               top: 0,

--- a/docs/data/joy/components/avatar/BadgeAvatars.tsx
+++ b/docs/data/joy/components/avatar/BadgeAvatars.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/joy/Box';
-import Badge from '@mui/joy/Badge';
+import Badge, { badgeClasses } from '@mui/joy/Badge';
 import Avatar from '@mui/joy/Avatar';
 
 export default function BadgeAvatars() {
@@ -11,7 +11,7 @@ export default function BadgeAvatars() {
         badgeInset="14%"
         color="success"
         sx={{
-          '& .JoyBadge-badge': {
+          [`& .${badgeClasses.badge}`]: {
             '&::after': {
               position: 'absolute',
               top: 0,

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -25,7 +25,6 @@ For this case, the Material UI theme should override the Joy UI's.
 ```js
 import { deepmerge } from '@mui/utils';
 import {
-  useColorScheme,
   Experimental_CssVarsProvider as CssVarsProvider,
   experimental_extendTheme as extendMuiTheme,
 } from '@mui/material/styles';
@@ -115,7 +114,6 @@ import colors from '@mui/joy/colors';
 import {
   extendTheme as extendJoyTheme,
   CssVarsProvider,
-  useColorScheme,
 } from '@mui/joy/styles';
 
 const muiTheme = extendMuiTheme({

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -203,6 +203,61 @@ Visit the following CodeSandbox to preview this use case setup.
 
 [![Edit Material UI in a Joy UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/joy-ui-feat-material-ui-k86j2j?file=/demo.tsx)
 
+## Case C: Using the custom themes of Joy UI and Material UI together
+
+```js
+import { deepmerge } from '@mui/utils';
+import { createTheme as createMuiTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/joy/styles';
+import MaterialTypography from '@mui/material/Typography';
+import JoyTypography from '@mui/joy/Typography';
+import Stack from '@mui/material/Stack';
+
+const muiTheme = createMuiTheme({
+  components: {
+    MuiTypography: {
+      styleOverrides: {
+        root: { color: 'blue', textAlign: 'center' },
+      },
+    },
+  },
+});
+
+const joyTheme = {
+  components: {
+    JoyTypography: {
+      defaultProps: {
+        variant: 'outlined',
+      },
+      styleOverrides: {
+        root: { color: 'red', marginTop: 10, textAlign: 'center' },
+      },
+    },
+  }
+};
+
+// You can use your own `deepmerge` function.
+// joyTheme will deeply merge to muiTheme.
+const theme = deepmerge(muiTheme, joyTheme);
+
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack>
+        <MaterialTypography>Material Typography</MaterialTypography>
+        <JoyTypography>Joy Typography</JoyTypography>
+      </Stack>
+    </ThemeProvider>
+  );
+}
+```
+
+### CodeSandbox
+
+Visit the following CodeSandbox to preview this use case setup.
+
+[![Edit Using the custom themes of Joy UI and Material UI together](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-custom-themes-of-joy-ui-and-material-ui-txbdb4?file=/demo.tsx)
+
 ## TypeScript setup
 
 The snippet can be used with both of the above use cases. Here, we augment the Material UI and Joy UI theme to have the same tokens so that you have the same experience when customizing components via APIs like `styled` or `sx`.

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -27,10 +27,14 @@ import { deepmerge } from '@mui/utils';
 import {
   Experimental_CssVarsProvider as CssVarsProvider,
   experimental_extendTheme as extendMuiTheme,
+  shouldSkipGeneratingVar as muiShouldSkipGeneratingVar,
 } from '@mui/material/styles';
-import { extendTheme as extendJoyTheme } from '@mui/joy/styles';
+import {
+  extendTheme as extendJoyTheme,
+  shouldSkipGeneratingVar as joyShouldSkipGeneratingVar,
+} from '@mui/joy/styles';
 
-const joyTheme = extendJoyTheme({
+const { unstable_sxConfig: joySxConfig, ...joyTheme } = extendTheme({
   // This is required to point to `var(--mui-*)` because we are using
   // `CssVarsProvider` from Material UI.
   cssVarPrefix: 'mui',
@@ -82,15 +86,27 @@ const joyTheme = extendJoyTheme({
 // Note: you can't put `joyTheme` inside Material UI's `extendMuiTheme(joyTheme)`
 // because some of the values in the Joy UI theme refers to CSS variables and
 // not raw colors.
-const muiTheme = extendMuiTheme();
+const { unstable_sxConfig: muiSxConfig, ...muiTheme } = extendMuiTheme();
 
 // You can use your own `deepmerge` function.
 // muiTheme will deeply merge to joyTheme.
-const theme = deepmerge(joyTheme, muiTheme);
+const mergedTheme = (deepmerge(joyTheme, muiTheme) as unknown) as ReturnType<
+  typeof extendMuiTheme
+>;
+
+mergedTheme.unstable_sxConfig = {
+  ...joySxConfig,
+  ...muiSxConfig
+};
 
 export default function App() {
   return (
-    <CssVarsProvider theme={theme}>
+    <CssVarsProvider
+      theme={mergedTheme}
+      shouldSkipGeneratingVar={(keys) =>
+        muiShouldSkipGeneratingVar(keys) || joyShouldSkipGeneratingVar(keys)
+      }
+    >
       ...Material UI and Joy UI components
     </CssVarsProvider>
   );
@@ -109,11 +125,18 @@ This setup uses the `CssVarsProvider` component from Joy UI and configures the M
 
 ```js
 import { deepmerge } from '@mui/utils';
-import { experimental_extendTheme as extendMuiTheme } from '@mui/material/styles';
+import {
+  experimental_extendTheme as extendMuiTheme,
+  shouldSkipGeneratingVar as muiShouldSkipGeneratingVar,
+} from '@mui/material/styles';
 import colors from '@mui/joy/colors';
-import { extendTheme as extendJoyTheme, CssVarsProvider } from '@mui/joy/styles';
+import {
+  extendTheme as extendJoyTheme,
+  CssVarsProvider,
+  shouldSkipGeneratingVar as joyShouldSkipGeneratingVar,
+} from '@mui/joy/styles';
 
-const muiTheme = extendMuiTheme({
+const { unstable_sxConfig: muiSxConfig, ...muiTheme } = extendMuiTheme({
   // This is required to point to `var(--joy-*)` because we are using
   // `CssVarsProvider` from Joy UI.
   cssVarPrefix: 'joy',
@@ -179,15 +202,27 @@ const muiTheme = extendMuiTheme({
   },
 });
 
-const joyTheme = extendJoyTheme();
+const { unstable_sxConfig: joySxConfig, ...joyTheme} = extendJoyTheme();
 
 // You can use your own `deepmerge` function.
 // joyTheme will deeply merge to muiTheme.
-const theme = deepmerge(muiTheme, joyTheme);
+const mergedTheme = (deepmerge(muiTheme, joyTheme) as unknown) as ReturnType<
+  typeof extendJoyTheme
+>;
+
+mergedTheme.unstable_sxConfig = {
+  ...muiSxConfig,
+  ...joySxConfig
+};
 
 export default function App() {
   return (
-    <CssVarsProvider theme={theme}>
+    <CssVarsProvider
+      theme={mergedTheme}
+      shouldSkipGeneratingVar={(keys) =>
+        muiShouldSkipGeneratingVar(keys) || joyShouldSkipGeneratingVar(keys)
+      }
+    >
       ...Material UI and Joy UI components
     </CssVarsProvider>
   );
@@ -199,55 +234,6 @@ export default function App() {
 Visit the following CodeSandbox to preview this use case setup.
 
 [![Edit Material UI in a Joy UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/joy-ui-feat-material-ui-k86j2j?file=/demo.tsx)
-
-## Case C: Using the custom themes of Joy UI and Material UI together
-
-```js
-import { deepmerge } from '@mui/utils';
-import { createTheme as createMuiTheme } from '@mui/material/styles';
-import { ThemeProvider } from '@mui/joy/styles';
-import MaterialTypography from '@mui/material/Typography';
-import JoyTypography from '@mui/joy/Typography';
-import Stack from '@mui/material/Stack';
-
-const muiTheme = createMuiTheme({
-  components: {
-    MuiTypography: {
-      styleOverrides: {
-        root: { color: 'blue', textAlign: 'center' },
-      },
-    },
-  },
-});
-
-const joyTheme = {
-  components: {
-    JoyTypography: {
-      defaultProps: {
-        variant: 'outlined',
-      },
-      styleOverrides: {
-        root: { color: 'red', marginTop: 10, textAlign: 'center' },
-      },
-    },
-  },
-};
-
-// You can use your own `deepmerge` function.
-// joyTheme will deeply merge to muiTheme.
-const theme = deepmerge(muiTheme, joyTheme);
-
-export default function App() {
-  return (
-    <ThemeProvider theme={theme}>
-      <Stack>
-        <MaterialTypography>Material Typography</MaterialTypography>
-        <JoyTypography>Joy Typography</JoyTypography>
-      </Stack>
-    </ThemeProvider>
-  );
-}
-```
 
 ### CodeSandbox
 
@@ -337,3 +323,32 @@ declare module '@mui/material/styles' {
   }
 }
 ```
+
+## Caveat
+
+Both libraries have the same class name prefix:
+
+```js
+import MaterialTypography, {
+  typographyClasses as muiTypographyClasses,
+} from '@mui/material/Typography';
+import JoyTypography, {
+  typographyClasses as joyTyographyClasses,
+} from '@mui/joy/Typography';
+import Stack from '@mui/material/Stack';
+
+<Stack
+  sx={{
+    // similar to `& .${joyTyographyClasses.root}`
+    [`& .${muiTypographyClasses.root}`]: {
+      color: 'red',
+    },
+  }}
+>
+  {/* Both components are red. */}
+  <MaterialTypography>Red</MaterialTypography>
+  <JoyTypography>Red</JoyTypography>
+</Stack>;
+```
+
+However, the class name prefix are the same

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -111,10 +111,7 @@ This setup uses the `CssVarsProvider` component from Joy UI and configures the M
 import { deepmerge } from '@mui/utils';
 import { experimental_extendTheme as extendMuiTheme } from '@mui/material/styles';
 import colors from '@mui/joy/colors';
-import {
-  extendTheme as extendJoyTheme,
-  CssVarsProvider,
-} from '@mui/joy/styles';
+import { extendTheme as extendJoyTheme, CssVarsProvider } from '@mui/joy/styles';
 
 const muiTheme = extendMuiTheme({
   // This is required to point to `var(--joy-*)` because we are using
@@ -233,7 +230,7 @@ const joyTheme = {
         root: { color: 'red', marginTop: 10, textAlign: 'center' },
       },
     },
-  }
+  },
 };
 
 // You can use your own `deepmerge` function.

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -235,12 +235,6 @@ Visit the following CodeSandbox to preview this use case setup.
 
 [![Edit Material UI in a Joy UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/joy-ui-feat-material-ui-k86j2j?file=/demo.tsx)
 
-### CodeSandbox
-
-Visit the following CodeSandbox to preview this use case setup.
-
-[![Edit Using the custom themes of Joy UI and Material UI together](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/using-the-custom-themes-of-joy-ui-and-material-ui-txbdb4?file=/demo.tsx)
-
 ## TypeScript setup
 
 The snippet can be used with both of the above use cases. Here, we augment the Material UI and Joy UI theme to have the same tokens so that you have the same experience when customizing components via APIs like `styled` or `sx`.

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.js
@@ -1,0 +1,6 @@
+/**
+ * @param {import('jscodeshift').FileInfo} file
+ */
+export default function transformer(file) {
+  return file.source.replace(/Joy([A-Z]+)/gm, 'Mui$1');
+}

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test.js
@@ -1,0 +1,29 @@
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from './joy-rename-classname-prefix';
+import readFile from '../util/readFile';
+
+function read(fileName) {
+  return readFile(path.join(__dirname, fileName));
+}
+
+describe('@mui/codemod', () => {
+  describe('v5.0.0', () => {
+    describe('joy-rename-classname-prefix', () => {
+      it('transforms classname prefix from Joy to Mui', () => {
+        const actual = transform(
+          {
+            source: read('./joy-rename-classname-prefix.test/actual.js'),
+            path: require.resolve('./joy-rename-classname-prefix.test/actual.js'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./joy-rename-classname-prefix.test/expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
+  });
+});

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test/actual.js
@@ -1,0 +1,2 @@
+<button className="JoyButton-button" />;
+<Button sx={{ '& .JoyButton-root': { '& .JoyButton-button': {} } }} />;

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-classname-prefix.test/expected.js
@@ -1,0 +1,2 @@
+<button className="MuiButton-button" />;
+<Button sx={{ '& .MuiButton-root': { '& .MuiButton-button': {} } }} />;

--- a/packages/mui-joy/src/Alert/alertClasses.ts
+++ b/packages/mui-joy/src/Alert/alertClasses.ts
@@ -40,10 +40,10 @@ export interface AlertClasses {
 export type AlertClassKey = keyof AlertClasses;
 
 export function getAlertUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAlert', slot);
+  return generateUtilityClass('MuiAlert', slot);
 }
 
-const alertClasses: AlertClasses = generateUtilityClasses('JoyAlert', [
+const alertClasses: AlertClasses = generateUtilityClasses('MuiAlert', [
   'root',
   'startDecorator',
   'endDecorator',

--- a/packages/mui-joy/src/AspectRatio/aspectRatioClasses.ts
+++ b/packages/mui-joy/src/AspectRatio/aspectRatioClasses.ts
@@ -32,10 +32,10 @@ export interface AspectRatioClasses {
 export type AspectRatioClassKey = keyof AspectRatioClasses;
 
 export function getAspectRatioUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAspectRatio', slot);
+  return generateUtilityClass('MuiAspectRatio', slot);
 }
 
-const aspectRatioClasses: AspectRatioClasses = generateUtilityClasses('JoyAspectRatio', [
+const aspectRatioClasses: AspectRatioClasses = generateUtilityClasses('MuiAspectRatio', [
   'root',
   'content',
   'colorPrimary',

--- a/packages/mui-joy/src/Autocomplete/autocompleteClasses.ts
+++ b/packages/mui-joy/src/Autocomplete/autocompleteClasses.ts
@@ -74,10 +74,10 @@ export interface AutocompleteClasses {
 export type AutocompleteClassKey = keyof AutocompleteClasses;
 
 export function getAutocompleteUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAutocomplete', slot);
+  return generateUtilityClass('MuiAutocomplete', slot);
 }
 
-const autocompleteClasses: AutocompleteClasses = generateUtilityClasses('JoyAutocomplete', [
+const autocompleteClasses: AutocompleteClasses = generateUtilityClasses('MuiAutocomplete', [
   'root',
   'wrapper',
   'input',

--- a/packages/mui-joy/src/AutocompleteListbox/autocompleteListboxClasses.ts
+++ b/packages/mui-joy/src/AutocompleteListbox/autocompleteListboxClasses.ts
@@ -40,7 +40,7 @@ export function getAutocompleteListboxUtilityClass(slot: string): string {
 }
 
 const autocompleteListboxClasses: AutocompleteListboxClasses = generateUtilityClasses(
-  'JoyAutocompleteListbox',
+  'MuiAutocompleteListbox',
   [
     'root',
     'sizeSm',

--- a/packages/mui-joy/src/AutocompleteListbox/autocompleteListboxClasses.ts
+++ b/packages/mui-joy/src/AutocompleteListbox/autocompleteListboxClasses.ts
@@ -36,7 +36,7 @@ export interface AutocompleteListboxClasses {
 export type AutocompleteListboxClassKey = keyof AutocompleteListboxClasses;
 
 export function getAutocompleteListboxUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAutocompleteListbox', slot);
+  return generateUtilityClass('MuiAutocompleteListbox', slot);
 }
 
 const autocompleteListboxClasses: AutocompleteListboxClasses = generateUtilityClasses(

--- a/packages/mui-joy/src/AutocompleteOption/autocompleteOptionClasses.ts
+++ b/packages/mui-joy/src/AutocompleteOption/autocompleteOptionClasses.ts
@@ -38,7 +38,7 @@ export function getAutocompleteOptionUtilityClass(slot: string): string {
 }
 
 const autocompleteOptionClasses: AutocompleteOptionClasses = generateUtilityClasses(
-  'JoyAutocompleteOption',
+  'MuiAutocompleteOption',
   [
     'root',
     'focused',

--- a/packages/mui-joy/src/AutocompleteOption/autocompleteOptionClasses.ts
+++ b/packages/mui-joy/src/AutocompleteOption/autocompleteOptionClasses.ts
@@ -34,7 +34,7 @@ export interface AutocompleteOptionClasses {
 export type AutocompleteOptionClassKey = keyof AutocompleteOptionClasses;
 
 export function getAutocompleteOptionUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAutocompleteOption', slot);
+  return generateUtilityClass('MuiAutocompleteOption', slot);
 }
 
 const autocompleteOptionClasses: AutocompleteOptionClasses = generateUtilityClasses(

--- a/packages/mui-joy/src/Avatar/avatarClasses.ts
+++ b/packages/mui-joy/src/Avatar/avatarClasses.ts
@@ -38,10 +38,10 @@ export interface AvatarClasses {
 export type AvatarClassKey = keyof AvatarClasses;
 
 export function getAvatarUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAvatar', slot);
+  return generateUtilityClass('MuiAvatar', slot);
 }
 
-const avatarClasses: AvatarClasses = generateUtilityClasses('JoyAvatar', [
+const avatarClasses: AvatarClasses = generateUtilityClasses('MuiAvatar', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/AvatarGroup/avatarGroupClasses.ts
+++ b/packages/mui-joy/src/AvatarGroup/avatarGroupClasses.ts
@@ -8,9 +8,9 @@ export interface AvatarGroupClasses {
 export type AvatarGroupClassKey = keyof AvatarGroupClasses;
 
 export function getAvatarGroupUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyAvatarGroup', slot);
+  return generateUtilityClass('MuiAvatarGroup', slot);
 }
 
-const avatarGroupClasses: AvatarGroupClasses = generateUtilityClasses('JoyAvatarGroup', ['root']);
+const avatarGroupClasses: AvatarGroupClasses = generateUtilityClasses('MuiAvatarGroup', ['root']);
 
 export default avatarGroupClasses;

--- a/packages/mui-joy/src/Badge/badgeClasses.ts
+++ b/packages/mui-joy/src/Badge/badgeClasses.ts
@@ -52,10 +52,10 @@ export interface BadgeClasses {
 export type BadgeClassKey = keyof BadgeClasses;
 
 export function getBadgeUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyBadge', slot);
+  return generateUtilityClass('MuiBadge', slot);
 }
 
-const badgeClasses: BadgeClasses = generateUtilityClasses('JoyBadge', [
+const badgeClasses: BadgeClasses = generateUtilityClasses('MuiBadge', [
   'root',
   'badge',
   'anchorOriginTopRight',

--- a/packages/mui-joy/src/Button/buttonClasses.ts
+++ b/packages/mui-joy/src/Button/buttonClasses.ts
@@ -50,10 +50,10 @@ export interface ButtonClasses {
 export type ButtonClassKey = keyof ButtonClasses;
 
 export function getButtonUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyButton', slot);
+  return generateUtilityClass('MuiButton', slot);
 }
 
-const buttonClasses: ButtonClasses = generateUtilityClasses('JoyButton', [
+const buttonClasses: ButtonClasses = generateUtilityClasses('MuiButton', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Card/cardClasses.ts
+++ b/packages/mui-joy/src/Card/cardClasses.ts
@@ -40,10 +40,10 @@ export interface CardClasses {
 export type CardClassKey = keyof CardClasses;
 
 export function getCardUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyCard', slot);
+  return generateUtilityClass('MuiCard', slot);
 }
 
-const cardClasses: CardClasses = generateUtilityClasses('JoyCard', [
+const cardClasses: CardClasses = generateUtilityClasses('MuiCard', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/CardContent/cardContentClasses.ts
+++ b/packages/mui-joy/src/CardContent/cardContentClasses.ts
@@ -8,9 +8,9 @@ export interface CardContentClasses {
 export type CardContentClassKey = keyof CardContentClasses;
 
 export function getCardContentUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyCardContent', slot);
+  return generateUtilityClass('MuiCardContent', slot);
 }
 
-const cardClasses: CardContentClasses = generateUtilityClasses('JoyCardContent', ['root']);
+const cardClasses: CardContentClasses = generateUtilityClasses('MuiCardContent', ['root']);
 
 export default cardClasses;

--- a/packages/mui-joy/src/CardCover/cardCoverClasses.ts
+++ b/packages/mui-joy/src/CardCover/cardCoverClasses.ts
@@ -8,9 +8,9 @@ export interface CardCoverClasses {
 export type CardCoverClassKey = keyof CardCoverClasses;
 
 export function getCardCoverUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyCardCover', slot);
+  return generateUtilityClass('MuiCardCover', slot);
 }
 
-const cardCoverClasses: CardCoverClasses = generateUtilityClasses('JoyCardCover', ['root']);
+const cardCoverClasses: CardCoverClasses = generateUtilityClasses('MuiCardCover', ['root']);
 
 export default cardCoverClasses;

--- a/packages/mui-joy/src/CardOverflow/cardOverflowClasses.ts
+++ b/packages/mui-joy/src/CardOverflow/cardOverflowClasses.ts
@@ -30,10 +30,10 @@ export interface CardOverflowClasses {
 export type CardOverflowClassKey = keyof CardOverflowClasses;
 
 export function getCardOverflowUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyCardOverflow', slot);
+  return generateUtilityClass('MuiCardOverflow', slot);
 }
 
-const aspectRatioClasses: CardOverflowClasses = generateUtilityClasses('JoyCardOverflow', [
+const aspectRatioClasses: CardOverflowClasses = generateUtilityClasses('MuiCardOverflow', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Checkbox/checkboxClasses.ts
+++ b/packages/mui-joy/src/Checkbox/checkboxClasses.ts
@@ -50,10 +50,10 @@ export interface CheckboxClasses {
 export type CheckboxClassKey = keyof CheckboxClasses;
 
 export function getCheckboxUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyCheckbox', slot);
+  return generateUtilityClass('MuiCheckbox', slot);
 }
 
-const checkboxClasses: CheckboxClasses = generateUtilityClasses('JoyCheckbox', [
+const checkboxClasses: CheckboxClasses = generateUtilityClasses('MuiCheckbox', [
   'root',
   'checkbox',
   'action',

--- a/packages/mui-joy/src/Chip/chipClasses.ts
+++ b/packages/mui-joy/src/Chip/chipClasses.ts
@@ -52,10 +52,10 @@ export interface ChipClasses {
 export type ChipClassKey = keyof ChipClasses;
 
 export function getChipUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyChip', slot);
+  return generateUtilityClass('MuiChip', slot);
 }
 
-const chipClasses: ChipClasses = generateUtilityClasses('JoyChip', [
+const chipClasses: ChipClasses = generateUtilityClasses('MuiChip', [
   'root',
   'clickable',
   'colorPrimary',

--- a/packages/mui-joy/src/ChipDelete/chipDeleteClasses.ts
+++ b/packages/mui-joy/src/ChipDelete/chipDeleteClasses.ts
@@ -32,10 +32,10 @@ export interface ChipDeleteClasses {
 }
 
 export function getChipDeleteUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyChipDelete', slot);
+  return generateUtilityClass('MuiChipDelete', slot);
 }
 
-const chipDeleteClasses: ChipDeleteClasses = generateUtilityClasses('JoyChipDelete', [
+const chipDeleteClasses: ChipDeleteClasses = generateUtilityClasses('MuiChipDelete', [
   'root',
   'disabled',
   'focusVisible',

--- a/packages/mui-joy/src/CircularProgress/circularProgressClasses.ts
+++ b/packages/mui-joy/src/CircularProgress/circularProgressClasses.ts
@@ -48,7 +48,7 @@ export function getCircularProgressUtilityClass(slot: string): string {
 }
 
 const circularProgressClasses: CircularProgressClasses = generateUtilityClasses(
-  'JoyCircularProgress',
+  'MuiCircularProgress',
   [
     'root',
     'determinate',

--- a/packages/mui-joy/src/CircularProgress/circularProgressClasses.ts
+++ b/packages/mui-joy/src/CircularProgress/circularProgressClasses.ts
@@ -44,7 +44,7 @@ export interface CircularProgressClasses {
 export type CircularProgressClassKey = keyof CircularProgressClasses;
 
 export function getCircularProgressUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyCircularProgress', slot);
+  return generateUtilityClass('MuiCircularProgress', slot);
 }
 
 const circularProgressClasses: CircularProgressClasses = generateUtilityClasses(

--- a/packages/mui-joy/src/Container/containerClasses.ts
+++ b/packages/mui-joy/src/Container/containerClasses.ts
@@ -5,10 +5,10 @@ export type { ContainerClassKey } from '@mui/system';
 export type { ContainerClasses };
 
 export function getContainerUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyContainer', slot);
+  return generateUtilityClass('MuiContainer', slot);
 }
 
-const containerClasses: ContainerClasses = generateUtilityClasses('JoyContainer', [
+const containerClasses: ContainerClasses = generateUtilityClasses('MuiContainer', [
   'root',
   'disableGutters',
   'fixed',

--- a/packages/mui-joy/src/Divider/dividerClasses.ts
+++ b/packages/mui-joy/src/Divider/dividerClasses.ts
@@ -16,10 +16,10 @@ export interface DividerClasses {
 export type DividerClassKey = keyof DividerClasses;
 
 export function getDividerUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyDivider', slot);
+  return generateUtilityClass('MuiDivider', slot);
 }
 
-const dividerClasses: DividerClasses = generateUtilityClasses('JoyDivider', [
+const dividerClasses: DividerClasses = generateUtilityClasses('MuiDivider', [
   'root',
   'horizontal',
   'vertical',

--- a/packages/mui-joy/src/FormControl/formControlClasses.ts
+++ b/packages/mui-joy/src/FormControl/formControlClasses.ts
@@ -34,10 +34,10 @@ export interface FormControlClasses {
 export type FormControlClassKey = keyof FormControlClasses;
 
 export function getFormControlUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyFormControl', slot);
+  return generateUtilityClass('MuiFormControl', slot);
 }
 
-const formControlClasses: FormControlClasses = generateUtilityClasses('JoyFormControl', [
+const formControlClasses: FormControlClasses = generateUtilityClasses('MuiFormControl', [
   'root',
   'error',
   'disabled',

--- a/packages/mui-joy/src/FormHelperText/formHelperTextClasses.ts
+++ b/packages/mui-joy/src/FormHelperText/formHelperTextClasses.ts
@@ -8,10 +8,10 @@ export interface FormHelperTextClasses {
 export type FormHelperTextClassKey = keyof FormHelperTextClasses;
 
 export function getFormHelperTextUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyFormHelperText', slot);
+  return generateUtilityClass('MuiFormHelperText', slot);
 }
 
-const formHelperTextClasses: FormHelperTextClasses = generateUtilityClasses('JoyFormHelperText', [
+const formHelperTextClasses: FormHelperTextClasses = generateUtilityClasses('MuiFormHelperText', [
   'root',
 ]);
 

--- a/packages/mui-joy/src/FormLabel/formLabelClasses.ts
+++ b/packages/mui-joy/src/FormLabel/formLabelClasses.ts
@@ -10,10 +10,10 @@ export interface FormLabelClasses {
 export type FormLabelClassKey = keyof FormLabelClasses;
 
 export function getFormLabelUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyFormLabel', slot);
+  return generateUtilityClass('MuiFormLabel', slot);
 }
 
-const formLabelClasses: FormLabelClasses = generateUtilityClasses('JoyFormLabel', [
+const formLabelClasses: FormLabelClasses = generateUtilityClasses('MuiFormLabel', [
   'root',
   'asterisk',
 ]);

--- a/packages/mui-joy/src/Grid/Grid.test.js
+++ b/packages/mui-joy/src/Grid/Grid.test.js
@@ -18,6 +18,6 @@ describe('Joy UI <Grid />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'JoyGrid',
     testVariantProps: { container: true, spacing: 5 },
-    skip: ['componentsProp', 'classesRoot'],
+    skip: ['componentsProp', 'classesRoot', 'rootClass'],
   }));
 });

--- a/packages/mui-joy/src/Grid/gridClasses.ts
+++ b/packages/mui-joy/src/Grid/gridClasses.ts
@@ -7,7 +7,7 @@ import { GridClasses } from '@mui/system/Unstable_Grid';
 export type GridClassKey = keyof GridClasses;
 
 export function getGridUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyGrid', slot);
+  return generateUtilityClass('MuiGrid', slot);
 }
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
@@ -15,7 +15,7 @@ const DIRECTIONS = ['column-reverse', 'column', 'row-reverse', 'row'] as const;
 const WRAPS = ['nowrap', 'wrap-reverse', 'wrap'] as const;
 const GRID_SIZES = ['auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 
-const gridClasses: GridClasses = generateUtilityClasses('JoyGrid', [
+const gridClasses: GridClasses = generateUtilityClasses('MuiGrid', [
   'root',
   'container',
   'item',

--- a/packages/mui-joy/src/IconButton/iconButtonClasses.ts
+++ b/packages/mui-joy/src/IconButton/iconButtonClasses.ts
@@ -40,10 +40,10 @@ export interface IconButtonClasses {
 export type IconButtonClassKey = keyof IconButtonClasses;
 
 export function getIconButtonUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyIconButton', slot);
+  return generateUtilityClass('MuiIconButton', slot);
 }
 
-const iconButtonClasses: IconButtonClasses = generateUtilityClasses('JoyIconButton', [
+const iconButtonClasses: IconButtonClasses = generateUtilityClasses('MuiIconButton', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Input/inputClasses.ts
+++ b/packages/mui-joy/src/Input/inputClasses.ts
@@ -52,10 +52,10 @@ export interface InputClasses {
 export type InputClassKey = keyof InputClasses;
 
 export function getInputUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyInput', slot);
+  return generateUtilityClass('MuiInput', slot);
 }
 
-const inputClasses: InputClasses = generateUtilityClasses('JoyInput', [
+const inputClasses: InputClasses = generateUtilityClasses('MuiInput', [
   'root',
   'input',
   'formControl',

--- a/packages/mui-joy/src/LinearProgress/linearProgressClasses.ts
+++ b/packages/mui-joy/src/LinearProgress/linearProgressClasses.ts
@@ -38,10 +38,10 @@ export interface LinearProgressClasses {
 export type LinearProgressClassKey = keyof LinearProgressClasses;
 
 export function getLinearProgressUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyLinearProgress', slot);
+  return generateUtilityClass('MuiLinearProgress', slot);
 }
 
-const linearProgressClasses: LinearProgressClasses = generateUtilityClasses('JoyLinearProgress', [
+const linearProgressClasses: LinearProgressClasses = generateUtilityClasses('MuiLinearProgress', [
   'root',
   'determinate',
   'colorPrimary',

--- a/packages/mui-joy/src/Link/linkClasses.ts
+++ b/packages/mui-joy/src/Link/linkClasses.ts
@@ -62,10 +62,10 @@ export interface LinkClasses {
 export type LinkClassKey = keyof LinkClasses;
 
 export function getLinkUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyLink', slot);
+  return generateUtilityClass('MuiLink', slot);
 }
 
-const linkClasses: LinkClasses = generateUtilityClasses('JoyLink', [
+const linkClasses: LinkClasses = generateUtilityClasses('MuiLink', [
   'root',
   'disabled',
   'focusVisible',

--- a/packages/mui-joy/src/List/listClasses.ts
+++ b/packages/mui-joy/src/List/listClasses.ts
@@ -44,10 +44,10 @@ export interface ListClasses {
 export type ListClassKey = keyof ListClasses;
 
 export function getListUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyList', slot);
+  return generateUtilityClass('MuiList', slot);
 }
 
-const listClasses: ListClasses = generateUtilityClasses('JoyList', [
+const listClasses: ListClasses = generateUtilityClasses('MuiList', [
   'root',
   'nesting',
   'scoped',

--- a/packages/mui-joy/src/ListDivider/listDividerClasses.ts
+++ b/packages/mui-joy/src/ListDivider/listDividerClasses.ts
@@ -18,10 +18,10 @@ export interface ListDividerClasses {
 export type ListDividerClassKey = keyof ListDividerClasses;
 
 export function getListDividerUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyListDivider', slot);
+  return generateUtilityClass('MuiListDivider', slot);
 }
 
-const listDividerClasses: ListDividerClasses = generateUtilityClasses('JoyListDivider', [
+const listDividerClasses: ListDividerClasses = generateUtilityClasses('MuiListDivider', [
   'root',
   'insetGutter',
   'insetStartDecorator',

--- a/packages/mui-joy/src/ListItem/listItemClasses.ts
+++ b/packages/mui-joy/src/ListItem/listItemClasses.ts
@@ -40,10 +40,10 @@ export interface ListItemClasses {
 export type ListItemClassKey = keyof ListItemClasses;
 
 export function getListItemUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyListItem', slot);
+  return generateUtilityClass('MuiListItem', slot);
 }
 
-const listItemClasses: ListItemClasses = generateUtilityClasses('JoyListItem', [
+const listItemClasses: ListItemClasses = generateUtilityClasses('MuiListItem', [
   'root',
   'startAction',
   'endAction',

--- a/packages/mui-joy/src/ListItemButton/listItemButtonClasses.ts
+++ b/packages/mui-joy/src/ListItemButton/listItemButtonClasses.ts
@@ -40,10 +40,10 @@ export interface ListItemButtonClasses {
 export type ListItemButtonClassKey = keyof ListItemButtonClasses;
 
 export function getListItemButtonUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyListItemButton', slot);
+  return generateUtilityClass('MuiListItemButton', slot);
 }
 
-const listItemButtonClasses: ListItemButtonClasses = generateUtilityClasses('JoyListItemButton', [
+const listItemButtonClasses: ListItemButtonClasses = generateUtilityClasses('MuiListItemButton', [
   'root',
   'horizontal',
   'vertical',

--- a/packages/mui-joy/src/ListItemContent/listItemContentClasses.ts
+++ b/packages/mui-joy/src/ListItemContent/listItemContentClasses.ts
@@ -8,7 +8,7 @@ export interface ListItemContentClasses {
 export type ListItemContentClassKey = keyof ListItemContentClasses;
 
 export function getListItemContentUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyListItemContent', slot);
+  return generateUtilityClass('MuiListItemContent', slot);
 }
 
 const listItemContentClasses: ListItemContentClasses = generateUtilityClasses(

--- a/packages/mui-joy/src/ListItemContent/listItemContentClasses.ts
+++ b/packages/mui-joy/src/ListItemContent/listItemContentClasses.ts
@@ -12,7 +12,7 @@ export function getListItemContentUtilityClass(slot: string): string {
 }
 
 const listItemContentClasses: ListItemContentClasses = generateUtilityClasses(
-  'JoyListItemContent',
+  'MuiListItemContent',
   ['root'],
 );
 

--- a/packages/mui-joy/src/ListItemDecorator/listItemDecoratorClasses.ts
+++ b/packages/mui-joy/src/ListItemDecorator/listItemDecoratorClasses.ts
@@ -8,7 +8,7 @@ export interface ListItemDecoratorClasses {
 export type ListItemDecoratorClassKey = keyof ListItemDecoratorClasses;
 
 export function getListItemDecoratorUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyListItemDecorator', slot);
+  return generateUtilityClass('MuiListItemDecorator', slot);
 }
 
 const listItemDecoratorClasses: ListItemDecoratorClasses = generateUtilityClasses(

--- a/packages/mui-joy/src/ListItemDecorator/listItemDecoratorClasses.ts
+++ b/packages/mui-joy/src/ListItemDecorator/listItemDecoratorClasses.ts
@@ -12,7 +12,7 @@ export function getListItemDecoratorUtilityClass(slot: string): string {
 }
 
 const listItemDecoratorClasses: ListItemDecoratorClasses = generateUtilityClasses(
-  'JoyListItemDecorator',
+  'MuiListItemDecorator',
   ['root'],
 );
 

--- a/packages/mui-joy/src/ListSubheader/listSubheaderClasses.ts
+++ b/packages/mui-joy/src/ListSubheader/listSubheaderClasses.ts
@@ -32,10 +32,10 @@ export interface ListSubheaderClasses {
 export type ListSubheaderClassKey = keyof ListSubheaderClasses;
 
 export function getListSubheaderUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyListSubheader', slot);
+  return generateUtilityClass('MuiListSubheader', slot);
 }
 
-const listSubheaderClasses: ListSubheaderClasses = generateUtilityClasses('JoyListSubheader', [
+const listSubheaderClasses: ListSubheaderClasses = generateUtilityClasses('MuiListSubheader', [
   'root',
   'sticky',
   'colorPrimary',

--- a/packages/mui-joy/src/Menu/menuClasses.ts
+++ b/packages/mui-joy/src/Menu/menuClasses.ts
@@ -38,10 +38,10 @@ export interface MenuClasses {
 export type MenuClassKey = keyof MenuClasses;
 
 export function getMenuUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyMenu', slot);
+  return generateUtilityClass('MuiMenu', slot);
 }
 
-const menuClasses: MenuClasses = generateUtilityClasses('JoyMenu', [
+const menuClasses: MenuClasses = generateUtilityClasses('MuiMenu', [
   'root',
   'expanded',
   'colorPrimary',

--- a/packages/mui-joy/src/MenuItem/menuItemClasses.ts
+++ b/packages/mui-joy/src/MenuItem/menuItemClasses.ts
@@ -36,10 +36,10 @@ export interface MenuItemClasses {
 export type MenuItemClassKey = keyof MenuItemClasses;
 
 export function getMenuItemUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyMenuItem', slot);
+  return generateUtilityClass('MuiMenuItem', slot);
 }
 
-const menuItemClasses: MenuItemClasses = generateUtilityClasses('JoyMenuItem', [
+const menuItemClasses: MenuItemClasses = generateUtilityClasses('MuiMenuItem', [
   'root',
   'focusVisible',
   'disabled',

--- a/packages/mui-joy/src/MenuList/menuListClasses.ts
+++ b/packages/mui-joy/src/MenuList/menuListClasses.ts
@@ -36,10 +36,10 @@ export interface MenuListClasses {
 export type MenuListClassKey = keyof MenuListClasses;
 
 export function getMenuListUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyMenuList', slot);
+  return generateUtilityClass('MuiMenuList', slot);
 }
 
-const menuClasses: MenuListClasses = generateUtilityClasses('JoyMenuList', [
+const menuClasses: MenuListClasses = generateUtilityClasses('MuiMenuList', [
   'root',
   'nested',
   'sizeSm',

--- a/packages/mui-joy/src/Modal/modalClasses.ts
+++ b/packages/mui-joy/src/Modal/modalClasses.ts
@@ -10,9 +10,9 @@ export interface ModalClasses {
 export type ModalClassKey = keyof ModalClasses;
 
 export function getModalUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyModal', slot);
+  return generateUtilityClass('MuiModal', slot);
 }
 
-const modalClasses: ModalClasses = generateUtilityClasses('JoyModal', ['root', 'backdrop']);
+const modalClasses: ModalClasses = generateUtilityClasses('MuiModal', ['root', 'backdrop']);
 
 export default modalClasses;

--- a/packages/mui-joy/src/ModalClose/modalCloseClasses.ts
+++ b/packages/mui-joy/src/ModalClose/modalCloseClasses.ts
@@ -36,10 +36,10 @@ export interface ModalCloseClasses {
 export type ModalCloseClassKey = keyof ModalCloseClasses;
 
 export function getModalCloseUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyModalClose', slot);
+  return generateUtilityClass('MuiModalClose', slot);
 }
 
-const modalCloseClasses: ModalCloseClasses = generateUtilityClasses('JoyModalClose', [
+const modalCloseClasses: ModalCloseClasses = generateUtilityClasses('MuiModalClose', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/ModalDialog/modalDialogClasses.ts
+++ b/packages/mui-joy/src/ModalDialog/modalDialogClasses.ts
@@ -40,10 +40,10 @@ export interface ModalDialogClasses {
 export type ModalDialogClassKey = keyof ModalDialogClasses;
 
 export function getModalDialogUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyModalDialog', slot);
+  return generateUtilityClass('MuiModalDialog', slot);
 }
 
-const modalDialogClasses: ModalDialogClasses = generateUtilityClasses('JoyModalDialog', [
+const modalDialogClasses: ModalDialogClasses = generateUtilityClasses('MuiModalDialog', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Option/optionClasses.ts
+++ b/packages/mui-joy/src/Option/optionClasses.ts
@@ -36,10 +36,10 @@ export interface OptionClasses {
 export type OptionClassKey = keyof OptionClasses;
 
 export function getOptionUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyOption', slot);
+  return generateUtilityClass('MuiOption', slot);
 }
 
-const optionClasses: OptionClasses = generateUtilityClasses('JoyOption', [
+const optionClasses: OptionClasses = generateUtilityClasses('MuiOption', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Radio/radioClasses.ts
+++ b/packages/mui-joy/src/Radio/radioClasses.ts
@@ -50,10 +50,10 @@ export interface RadioClasses {
 export type RadioClassKey = keyof RadioClasses;
 
 export function getRadioUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyRadio', slot);
+  return generateUtilityClass('MuiRadio', slot);
 }
 
-const radioClasses: RadioClasses = generateUtilityClasses('JoyRadio', [
+const radioClasses: RadioClasses = generateUtilityClasses('MuiRadio', [
   'root',
   'radio',
   'icon',

--- a/packages/mui-joy/src/RadioGroup/radioGroupClasses.ts
+++ b/packages/mui-joy/src/RadioGroup/radioGroupClasses.ts
@@ -38,10 +38,10 @@ export interface RadioGroupClasses {
 export type RadioGroupClassKey = keyof RadioGroupClasses;
 
 export function getRadioGroupUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyRadioGroup', slot);
+  return generateUtilityClass('MuiRadioGroup', slot);
 }
 
-const radioGroupClasses: RadioGroupClasses = generateUtilityClasses('JoyRadioGroup', [
+const radioGroupClasses: RadioGroupClasses = generateUtilityClasses('MuiRadioGroup', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/ScopedCssBaseline/scopedCssBaselineClasses.ts
+++ b/packages/mui-joy/src/ScopedCssBaseline/scopedCssBaselineClasses.ts
@@ -8,9 +8,9 @@ export interface ScopedCssBaselineClasses {
 export type ScopedCssBaselineClassKey = keyof ScopedCssBaselineClasses;
 
 export function getScopedCssBaselineUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyScopedCssBaseline', slot);
+  return generateUtilityClass('MuiScopedCssBaseline', slot);
 }
 
-const scopedCssBaselineClasses = generateUtilityClasses('JoyScopedCssBaseline', ['root']);
+const scopedCssBaselineClasses = generateUtilityClasses('MuiScopedCssBaseline', ['root']);
 
 export default scopedCssBaselineClasses;

--- a/packages/mui-joy/src/Select/selectClasses.ts
+++ b/packages/mui-joy/src/Select/selectClasses.ts
@@ -54,10 +54,10 @@ export interface SelectClasses {
 export type SelectClassKey = keyof SelectClasses;
 
 export function getSelectUtilityClass(slot: string): string {
-  return generateUtilityClass('JoySelect', slot);
+  return generateUtilityClass('MuiSelect', slot);
 }
 
-const selectClasses: SelectClasses = generateUtilityClasses('JoySelect', [
+const selectClasses: SelectClasses = generateUtilityClasses('MuiSelect', [
   'root',
   'button',
   'indicator',

--- a/packages/mui-joy/src/Sheet/sheetClasses.ts
+++ b/packages/mui-joy/src/Sheet/sheetClasses.ts
@@ -30,10 +30,10 @@ export interface SheetClasses {
 export type SheetClassKey = keyof SheetClasses;
 
 export function getSheetUtilityClass(slot: string): string {
-  return generateUtilityClass('JoySheet', slot);
+  return generateUtilityClass('MuiSheet', slot);
 }
 
-const sheetClasses: SheetClasses = generateUtilityClasses('JoySheet', [
+const sheetClasses: SheetClasses = generateUtilityClasses('MuiSheet', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Slider/sliderClasses.ts
+++ b/packages/mui-joy/src/Slider/sliderClasses.ts
@@ -66,10 +66,10 @@ export interface SliderClasses {
 export type SliderClassKey = keyof SliderClasses;
 
 export function getSliderUtilityClass(slot: string): string {
-  return generateUtilityClass('JoySlider', slot);
+  return generateUtilityClass('MuiSlider', slot);
 }
 
-const sliderClasses: SliderClasses = generateUtilityClasses('JoySlider', [
+const sliderClasses: SliderClasses = generateUtilityClasses('MuiSlider', [
   'root',
   'disabled',
   'dragging',

--- a/packages/mui-joy/src/Stack/stackClasses.ts
+++ b/packages/mui-joy/src/Stack/stackClasses.ts
@@ -5,9 +5,9 @@ export type { StackClassKey } from '@mui/system';
 export type { StackClasses };
 
 export function getStackUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyStack', slot);
+  return generateUtilityClass('MuiStack', slot);
 }
 
-const stackClasses: StackClasses = generateUtilityClasses('JoyStack', ['root']);
+const stackClasses: StackClasses = generateUtilityClasses('MuiStack', ['root']);
 
 export default stackClasses;

--- a/packages/mui-joy/src/SvgIcon/svgIconClasses.ts
+++ b/packages/mui-joy/src/SvgIcon/svgIconClasses.ts
@@ -44,10 +44,10 @@ export interface SvgIconClasses {
 export type SvgIconClassKey = keyof SvgIconClasses;
 
 export function getSvgIconUtilityClass(slot: string): string {
-  return generateUtilityClass('JoySvgIcon', slot);
+  return generateUtilityClass('MuiSvgIcon', slot);
 }
 
-const svgIconClasses: SvgIconClasses = generateUtilityClasses('JoySvgIcon', [
+const svgIconClasses: SvgIconClasses = generateUtilityClasses('MuiSvgIcon', [
   'root',
   'colorInherit',
   'colorPrimary',

--- a/packages/mui-joy/src/Switch/switchClasses.ts
+++ b/packages/mui-joy/src/Switch/switchClasses.ts
@@ -52,10 +52,10 @@ export interface SwitchClasses {
 export type SwitchClassKey = keyof SwitchClasses;
 
 export function getSwitchUtilityClass(slot: string): string {
-  return generateUtilityClass('JoySwitch', slot);
+  return generateUtilityClass('MuiSwitch', slot);
 }
 
-const switchClasses: SwitchClasses = generateUtilityClasses('JoySwitch', [
+const switchClasses: SwitchClasses = generateUtilityClasses('MuiSwitch', [
   'root',
   'checked',
   'disabled',

--- a/packages/mui-joy/src/Tab/tabClasses.ts
+++ b/packages/mui-joy/src/Tab/tabClasses.ts
@@ -40,10 +40,10 @@ export interface TabClasses {
 export type TabClassKey = keyof TabClasses;
 
 export function getTabUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTab', slot);
+  return generateUtilityClass('MuiTab', slot);
 }
 
-const tabListClasses: TabClasses = generateUtilityClasses('JoyTab', [
+const tabListClasses: TabClasses = generateUtilityClasses('MuiTab', [
   'root',
   'disabled',
   'focusVisible',

--- a/packages/mui-joy/src/TabList/tabListClasses.ts
+++ b/packages/mui-joy/src/TabList/tabListClasses.ts
@@ -36,10 +36,10 @@ export interface TabListClasses {
 export type TabListClassKey = keyof TabListClasses;
 
 export function getTabListUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTabList', slot);
+  return generateUtilityClass('MuiTabList', slot);
 }
 
-const tabListClasses: TabListClasses = generateUtilityClasses('JoyTabList', [
+const tabListClasses: TabListClasses = generateUtilityClasses('MuiTabList', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/TabPanel/tabPanelClasses.ts
+++ b/packages/mui-joy/src/TabPanel/tabPanelClasses.ts
@@ -20,10 +20,10 @@ export interface TabPanelClasses {
 export type TabPanelClassKey = keyof TabPanelClasses;
 
 export function getTabPanelUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTabPanel', slot);
+  return generateUtilityClass('MuiTabPanel', slot);
 }
 
-const tabListClasses: TabPanelClasses = generateUtilityClasses('JoyTabPanel', [
+const tabListClasses: TabPanelClasses = generateUtilityClasses('MuiTabPanel', [
   'root',
   'hidden',
   'sizeSm',

--- a/packages/mui-joy/src/Tabs/tabsClasses.ts
+++ b/packages/mui-joy/src/Tabs/tabsClasses.ts
@@ -40,10 +40,10 @@ export interface TabsClasses {
 export type TabsClassKey = keyof TabsClasses;
 
 export function getTabsUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTabs', slot);
+  return generateUtilityClass('MuiTabs', slot);
 }
 
-const tabListClasses: TabsClasses = generateUtilityClasses('JoyTabs', [
+const tabListClasses: TabsClasses = generateUtilityClasses('MuiTabs', [
   'root',
   'horizontal',
   'vertical',

--- a/packages/mui-joy/src/Textarea/textareaClasses.ts
+++ b/packages/mui-joy/src/Textarea/textareaClasses.ts
@@ -48,10 +48,10 @@ export interface TextareaClasses {
 export type TextareaClassKey = keyof TextareaClasses;
 
 export function getTextareaUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTextarea', slot);
+  return generateUtilityClass('MuiTextarea', slot);
 }
 
-const textareaClasses: TextareaClasses = generateUtilityClasses('JoyTextarea', [
+const textareaClasses: TextareaClasses = generateUtilityClasses('MuiTextarea', [
   'root',
   'textarea',
   'startDecorator',

--- a/packages/mui-joy/src/Tooltip/tooltipClasses.ts
+++ b/packages/mui-joy/src/Tooltip/tooltipClasses.ts
@@ -50,10 +50,10 @@ export interface TooltipClasses {
 export type TooltipClassKey = keyof TooltipClasses;
 
 export function getTooltipUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTooltip', slot);
+  return generateUtilityClass('MuiTooltip', slot);
 }
 
-const tooltipClasses: TooltipClasses = generateUtilityClasses('JoyTooltip', [
+const tooltipClasses: TooltipClasses = generateUtilityClasses('MuiTooltip', [
   'root',
   'tooltipArrow',
   'arrow',

--- a/packages/mui-joy/src/Typography/typographyClasses.ts
+++ b/packages/mui-joy/src/Typography/typographyClasses.ts
@@ -56,10 +56,10 @@ export interface TypographyClasses {
 export type TypographyClassKey = keyof TypographyClasses;
 
 export function getTypographyUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTypography', slot);
+  return generateUtilityClass('MuiTypography', slot);
 }
 
-const typographyClasses: TypographyClasses = generateUtilityClasses('JoyTypography', [
+const typographyClasses: TypographyClasses = generateUtilityClasses('MuiTypography', [
   'root',
   'h1',
   'h2',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Follow-up** on https://github.com/mui/material-ui/issues/33260#issuecomment-1243841054

**This PR includes**:
- renaming the classname prefix of all Joy UI components from `Joy` to `Mui`
- Codemod script that renames classname prefix of Joy components. It uses this regex: `(/Joy([A-Z]+)/gm, 'Mui$1')` 

**P.S.** This PR does not rename `Joy*` for `theme.components`