### PR TITLE
[docs] Document the workaround for crashing a translated page

### DIFF
--- a/docs/data/material/components/buttons/LoadingButtonsTransition.js
+++ b/docs/data/material/components/buttons/LoadingButtonsTransition.js
@@ -36,7 +36,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          disabled
+          <span>disabled</span>
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -45,7 +45,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          Fetch data
+          <span>Fetch data</span>
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -55,7 +55,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          Send
+          <span>Send</span>
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -66,7 +66,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          Save
+          <span>Save</span>
         </LoadingButton>
       </Box>
 
@@ -77,7 +77,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          disabled
+          <span>disabled</span>
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -85,7 +85,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          Fetch data
+          <span>Fetch data</span>
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -94,7 +94,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          Send
+          <span>Send</span>
         </LoadingButton>
         <LoadingButton
           color="secondary"
@@ -104,7 +104,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          Save
+          <span>Save</span>
         </LoadingButton>
       </Box>
     </Box>

--- a/docs/data/material/components/buttons/LoadingButtonsTransition.tsx
+++ b/docs/data/material/components/buttons/LoadingButtonsTransition.tsx
@@ -36,7 +36,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          disabled
+          <span>disabled</span>
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -45,7 +45,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          Fetch data
+          <span>Fetch data</span>
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -55,7 +55,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          Send
+          <span>Send</span>
         </LoadingButton>
         <LoadingButton
           size="small"
@@ -66,7 +66,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          Save
+          <span>Save</span>
         </LoadingButton>
       </Box>
 
@@ -77,7 +77,7 @@ export default function LoadingButtonsTransition() {
           variant="outlined"
           disabled
         >
-          disabled
+          <span>disabled</span>
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -85,7 +85,7 @@ export default function LoadingButtonsTransition() {
           loadingIndicator="Loading…"
           variant="outlined"
         >
-          Fetch data
+          <span>Fetch data</span>
         </LoadingButton>
         <LoadingButton
           onClick={handleClick}
@@ -94,7 +94,7 @@ export default function LoadingButtonsTransition() {
           loadingPosition="end"
           variant="contained"
         >
-          Send
+          <span>Send</span>
         </LoadingButton>
         <LoadingButton
           color="secondary"
@@ -104,7 +104,7 @@ export default function LoadingButtonsTransition() {
           startIcon={<SaveIcon />}
           variant="contained"
         >
-          Save
+          <span>Save</span>
         </LoadingButton>
       </Box>
     </Box>

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -194,6 +194,7 @@ To prevent it, ensure that the contents of the Loading Button is inside any HTML
   <span>Submit</span>
 </LoadingButton>
 ```
+
 :::
 
 ### Material You version

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -184,6 +184,18 @@ Toggle the loading switch to see the transition between the different states.
 
 {{"demo": "LoadingButtonsTransition.js"}}
 
+:::warning
+There is a [known issue](https://github.com/mui/material-ui/issues/27853) with translating the page with Chrome tools when Loading Buttons are present.
+After the page is translated, the application crashes when the loading state of a Button changes.
+To prevent it, ensure that the contents of the Loading Button is inside any HTML element (a `span` will suffice):
+
+```jsx
+<LoadingButton loading variant="outlined">
+  <span>Submit</span>
+</LoadingButton>
+```
+:::
+
 ### Material You version
 
 The default Button component follows the Material Design 2 specs.

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -185,9 +185,9 @@ Toggle the loading switch to see the transition between the different states.
 {{"demo": "LoadingButtonsTransition.js"}}
 
 :::warning
-There is a [known issue](https://github.com/mui/material-ui/issues/27853) with translating the page with Chrome tools when Loading Buttons are present.
+There is a [known issue](https://github.com/mui/material-ui/issues/27853) with translating a page using Chrome tools when a Loading Button is present.
 After the page is translated, the application crashes when the loading state of a Button changes.
-To prevent it, ensure that the contents of the Loading Button is inside any HTML element (a `span` will suffice):
+To prevent this, ensure that the contents of the Loading Button are nested inside any HTML element, such as a `<span>`:
 
 ```jsx
 <LoadingButton loading variant="outlined">


### PR DESCRIPTION
This explains the workaround for #27853, as discussed in the issue.
