### PR TITLE
[Joy] Replace `row` prop with `orientation` prop in all Joy UI components

### DIFF
--- a/docs/data/joy/components/aspect-ratio/CarouselRatio.js
+++ b/docs/data/joy/components/aspect-ratio/CarouselRatio.js
@@ -40,7 +40,7 @@ export default function CarouselRatio() {
     >
       {data.map((item) => (
         <Card
-          row
+          orientation="horizontal"
           key={item.title}
           variant="outlined"
           sx={{

--- a/docs/data/joy/components/aspect-ratio/CarouselRatio.tsx
+++ b/docs/data/joy/components/aspect-ratio/CarouselRatio.tsx
@@ -40,7 +40,7 @@ export default function CarouselRatio() {
     >
       {data.map((item) => (
         <Card
-          row
+          orientation="horizontal"
           key={item.title}
           variant="outlined"
           sx={{

--- a/docs/data/joy/components/card/InteractiveCard.js
+++ b/docs/data/joy/components/card/InteractiveCard.js
@@ -9,7 +9,7 @@ export default function InteractiveCard() {
   return (
     <Card
       variant="outlined"
-      row
+      orientation="horizontal"
       sx={{
         width: 320,
         gap: 2,

--- a/docs/data/joy/components/card/InteractiveCard.tsx
+++ b/docs/data/joy/components/card/InteractiveCard.tsx
@@ -9,7 +9,7 @@ export default function InteractiveCard() {
   return (
     <Card
       variant="outlined"
-      row
+      orientation="horizontal"
       sx={{
         width: 320,
         gap: 2,

--- a/docs/data/joy/components/card/RowCard.js
+++ b/docs/data/joy/components/card/RowCard.js
@@ -8,7 +8,11 @@ import Typography from '@mui/joy/Typography';
 
 export default function RowCard() {
   return (
-    <Card row variant="outlined" sx={{ width: 260, bgcolor: 'background.body' }}>
+    <Card
+      orientation="horizontal"
+      variant="outlined"
+      sx={{ width: 260, bgcolor: 'background.body' }}
+    >
       <CardOverflow>
         <AspectRatio ratio="1" sx={{ width: 90 }}>
           <img

--- a/docs/data/joy/components/card/RowCard.tsx
+++ b/docs/data/joy/components/card/RowCard.tsx
@@ -8,7 +8,11 @@ import Typography from '@mui/joy/Typography';
 
 export default function RowCard() {
   return (
-    <Card row variant="outlined" sx={{ width: 260, bgcolor: 'background.body' }}>
+    <Card
+      orientation="horizontal"
+      variant="outlined"
+      sx={{ width: 260, bgcolor: 'background.body' }}
+    >
       <CardOverflow>
         <AspectRatio ratio="1" sx={{ width: 90 }}>
           <img

--- a/docs/data/joy/components/checkbox/ExampleButtonCheckbox.js
+++ b/docs/data/joy/components/checkbox/ExampleButtonCheckbox.js
@@ -14,7 +14,7 @@ export default function ExampleButtonCheckbox() {
       variant="outlined"
       aria-label="Screens"
       role="group"
-      row
+      orientation="horizontal"
       sx={{
         bgcolor: 'background.body',
         flexGrow: 0,

--- a/docs/data/joy/components/checkbox/ExampleChoiceChipCheckbox.js
+++ b/docs/data/joy/components/checkbox/ExampleChoiceChipCheckbox.js
@@ -19,7 +19,7 @@ export default function ExampleChoiceChipCheckbox() {
       </Typography>
       <Box role="group" aria-labelledby="rank">
         <List
-          row
+          orientation="horizontal"
           wrap
           sx={{
             '--List-gap': '8px',

--- a/docs/data/joy/components/checkbox/IconlessCheckbox.js
+++ b/docs/data/joy/components/checkbox/IconlessCheckbox.js
@@ -13,7 +13,7 @@ export default function IconlessCheckbox() {
       </Typography>
       <Box role="group" aria-labelledby="topping">
         <List
-          row
+          orientation="horizontal"
           wrap
           sx={{
             '--List-gap': '8px',

--- a/docs/data/joy/components/chip/RadioChip.js
+++ b/docs/data/joy/components/chip/RadioChip.js
@@ -18,7 +18,7 @@ export default function RadioChip() {
         <RadioGroup
           name="best-movie"
           aria-labelledby="best-movie"
-          row
+          orientation="horizontal"
           sx={{ flexWrap: 'wrap', gap: 1 }}
         >
           {[

--- a/docs/data/joy/components/chip/RadioChip.tsx
+++ b/docs/data/joy/components/chip/RadioChip.tsx
@@ -18,7 +18,7 @@ export default function RadioChip() {
         <RadioGroup
           name="best-movie"
           aria-labelledby="best-movie"
-          row
+          orientation="horizontal"
           sx={{ flexWrap: 'wrap', gap: 1 }}
         >
           {[

--- a/docs/data/joy/components/divider/DividerInCard.js
+++ b/docs/data/joy/components/divider/DividerInCard.js
@@ -8,17 +8,19 @@ import Typography from '@mui/joy/Typography';
 import ArrowForward from '@mui/icons-material/ArrowForward';
 
 export default function DividerInCard() {
-  const [row, setRow] = React.useState(false);
+  const [orientation, setOrientation] = React.useState('vertical');
   return (
     <Box>
       <Checkbox
         label="horizontal"
-        checked={row}
-        onChange={(event) => setRow(event.target.checked)}
+        checked={orientation === 'horizontal'}
+        onChange={(event) =>
+          setOrientation(event.target.checked ? 'horizontal' : 'vertical')
+        }
         sx={{ mb: 2 }}
       />
       <Card
-        row={row}
+        orientation={orientation}
         variant="outlined"
         sx={{ width: 400, maxWidth: '100%', gap: 1.5 }}
       >
@@ -26,7 +28,7 @@ export default function DividerInCard() {
           Headline
         </Typography>
         <Divider />
-        <Box sx={{ display: row ? 'block' : 'contents' }}>
+        <Box sx={{ display: orientation === 'horizontal' ? 'block' : 'contents' }}>
           <Typography level="body2">
             Lorem Ipsum is simply dummy text of the printing and typesetting
             industry. Lorem Ipsum has been the industry standard dummy text ever
@@ -37,7 +39,7 @@ export default function DividerInCard() {
             variant="soft"
             color="neutral"
             endDecorator={<ArrowForward />}
-            sx={{ width: '100%', mt: row ? 2 : 0 }}
+            sx={{ width: '100%', mt: orientation === 'horizontal' ? 2 : 0 }}
           >
             See more
           </Button>

--- a/docs/data/joy/components/grid/InteractiveGrid.js
+++ b/docs/data/joy/components/grid/InteractiveGrid.js
@@ -56,7 +56,7 @@ export default function InteractiveGrid() {
               <FormControl>
                 <FormLabel sx={{ mb: 1.5 }}>direction</FormLabel>
                 <RadioGroup
-                  row
+                  orientation="horizontal"
                   name="direction"
                   aria-label="direction"
                   value={direction}
@@ -76,7 +76,7 @@ export default function InteractiveGrid() {
               <FormControl>
                 <FormLabel sx={{ mb: 1.5 }}>justifyContent</FormLabel>
                 <RadioGroup
-                  row
+                  orientation="horizontal"
                   name="justifyContent"
                   aria-label="justifyContent"
                   value={justifyContent}
@@ -98,7 +98,7 @@ export default function InteractiveGrid() {
               <FormControl>
                 <FormLabel sx={{ mb: 1.5 }}>alignItems</FormLabel>
                 <RadioGroup
-                  row
+                  orientation="horizontal"
                   name="alignItems"
                   aria-label="align items"
                   value={alignItems}

--- a/docs/data/joy/components/grid/InteractiveGrid.tsx
+++ b/docs/data/joy/components/grid/InteractiveGrid.tsx
@@ -73,7 +73,7 @@ export default function InteractiveGrid() {
               <FormControl>
                 <FormLabel sx={{ mb: 1.5 }}>direction</FormLabel>
                 <RadioGroup
-                  row
+                  orientation="horizontal"
                   name="direction"
                   aria-label="direction"
                   value={direction}
@@ -95,7 +95,7 @@ export default function InteractiveGrid() {
               <FormControl>
                 <FormLabel sx={{ mb: 1.5 }}>justifyContent</FormLabel>
                 <RadioGroup
-                  row
+                  orientation="horizontal"
                   name="justifyContent"
                   aria-label="justifyContent"
                   value={justifyContent}
@@ -119,7 +119,7 @@ export default function InteractiveGrid() {
               <FormControl>
                 <FormLabel sx={{ mb: 1.5 }}>alignItems</FormLabel>
                 <RadioGroup
-                  row
+                  orientation="horizontal"
                   name="alignItems"
                   aria-label="align items"
                   value={alignItems}

--- a/docs/data/joy/components/grid/SpacingGrid.js
+++ b/docs/data/joy/components/grid/SpacingGrid.js
@@ -46,7 +46,7 @@ export default function SpacingGrid() {
                   aria-label="spacing"
                   value={spacing.toString()}
                   onChange={handleChange}
-                  row
+                  orientation="horizontal"
                   sx={{ flexWrap: 'wrap', gap: 2, '--RadioGroup-gap': '0px' }}
                 >
                   {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (

--- a/docs/data/joy/components/grid/SpacingGrid.tsx
+++ b/docs/data/joy/components/grid/SpacingGrid.tsx
@@ -46,7 +46,7 @@ export default function SpacingGrid() {
                   aria-label="spacing"
                   value={spacing.toString()}
                   onChange={handleChange}
-                  row
+                  orientation="horizontal"
                   sx={{ flexWrap: 'wrap', gap: 2, '--RadioGroup-gap': '0px' }}
                 >
                   {[0, 0.5, 1, 2, 3, 4, 8, 12].map((value) => (

--- a/docs/data/joy/components/list/ExampleNavigationMenu.js
+++ b/docs/data/joy/components/list/ExampleNavigationMenu.js
@@ -303,7 +303,7 @@ export default function ExampleNavigationMenu() {
     <Box sx={{ minHeight: 190 }}>
       <List
         role="menubar"
-        row
+        orientation="horizontal"
         sx={{
           '--List-radius': '8px',
           '--List-padding': '4px',

--- a/docs/data/joy/components/list/HorizontalDividedList.js
+++ b/docs/data/joy/components/list/HorizontalDividedList.js
@@ -8,7 +8,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 export default function HorizontalDividedList() {
   return (
     <List
-      row
+      orientation="horizontal"
       variant="outlined"
       sx={{
         bgcolor: 'background.body',

--- a/docs/data/joy/components/list/HorizontalList.js
+++ b/docs/data/joy/components/list/HorizontalList.js
@@ -10,7 +10,7 @@ import Person from '@mui/icons-material/Person';
 export default function HorizontalList() {
   return (
     <Box component="nav" aria-label="My site" sx={{ flexGrow: 1 }}>
-      <List role="menubar" row>
+      <List role="menubar" orientation="horizontal">
         <ListItem role="none">
           <ListItemButton
             role="menuitem"

--- a/docs/data/joy/components/list/list-pt.md
+++ b/docs/data/joy/components/list/list-pt.md
@@ -107,7 +107,7 @@ The nested list inherits the list `size` and a few other CSS variables, such as 
 
 ### Horizontal list
 
-To show a list in a horizontal direction, use the `row` prop on the `List` component.
+To show a list in a horizontal direction, use the `orientation="horizontal"` prop on the `List` component.
 
 :::warning
 **Note:** Nested lists don't work in the horizontal direction. To do that, create a custom pop-up component instead (see the [Navigation menu](#navigation-menu) example).

--- a/docs/data/joy/components/list/list-zh.md
+++ b/docs/data/joy/components/list/list-zh.md
@@ -107,7 +107,7 @@ The nested list inherits the list `size` and a few other CSS variables, such as 
 
 ### Horizontal list
 
-To show a list in a horizontal direction, use the `row` prop on the `List` component.
+To show a list in a horizontal direction, use the `orientation="horizontal"` prop on the `List` component.
 
 :::warning
 **Note:** Nested lists don't work in the horizontal direction. To do that, create a custom pop-up component instead (see the [Navigation menu](#navigation-menu) example).

--- a/docs/data/joy/components/list/list.md
+++ b/docs/data/joy/components/list/list.md
@@ -117,7 +117,7 @@ To add spacing to the start of the nested list, use `--List-nestedInsetStart: ${
 
 ### Horizontal list
 
-To show a list in a horizontal direction, use the `row` prop on the `List` component.
+To show a list in a horizontal direction, use the `orientation="horizontal"` prop on the `List` component.
 
 :::warning
 Nested lists don't work in the horizontal direction.

--- a/docs/data/joy/components/menu/MenuToolbarExample.js
+++ b/docs/data/joy/components/menu/MenuToolbarExample.js
@@ -144,7 +144,7 @@ export default function MenuToolbarExample() {
 
   return (
     <List
-      row
+      orientation="horizontal"
       aria-label="Example application menu bar"
       role="menubar"
       data-joy-color-scheme="dark"

--- a/docs/data/joy/components/radio/ExampleAlignmentButtons.js
+++ b/docs/data/joy/components/radio/ExampleAlignmentButtons.js
@@ -11,7 +11,7 @@ export default function ExampleAlignmentButtons() {
   const [alignment, setAlignment] = React.useState('left');
   return (
     <RadioGroup
-      row
+      orientation="horizontal"
       aria-label="Alignment"
       name="alignment"
       variant="outlined"

--- a/docs/data/joy/components/radio/ExamplePaymentChannels.js
+++ b/docs/data/joy/components/radio/ExamplePaymentChannels.js
@@ -9,7 +9,7 @@ import Typography from '@mui/joy/Typography';
 import Switch, { switchClasses } from '@mui/joy/Switch';
 
 export default function ExamplePaymentChannels() {
-  const [row, setRow] = React.useState(false);
+  const [orientation, setOrientation] = React.useState('vertical');
   return (
     <Box sx={{ minWidth: 240 }}>
       <Box
@@ -33,8 +33,10 @@ export default function ExamplePaymentChannels() {
           component="label"
           size="sm"
           endDecorator="Row view"
-          checked={row}
-          onChange={(event) => setRow(event.target.checked)}
+          checked={orientation === 'horizontal'}
+          onChange={(event) =>
+            setOrientation(event.target.checked ? 'horizontal' : 'vertical')
+          }
           sx={{
             [`&&:not(.${switchClasses.checked})`]: {
               '--Switch-track-background': (theme) =>
@@ -52,7 +54,7 @@ export default function ExamplePaymentChannels() {
         <List
           component="div"
           variant="outlined"
-          row={row}
+          orientation={orientation}
           sx={{
             borderRadius: 'sm',
             boxShadow: 'sm',

--- a/docs/data/joy/components/radio/ExampleSegmentedControls.js
+++ b/docs/data/joy/components/radio/ExampleSegmentedControls.js
@@ -12,7 +12,7 @@ export default function ExampleSegmentedControls() {
         Justify:
       </Typography>
       <RadioGroup
-        row
+        orientation="horizontal"
         aria-labelledby="segmented-controls-example"
         name="justify"
         value={justify}

--- a/docs/data/joy/components/radio/OverlayRadio.js
+++ b/docs/data/joy/components/radio/OverlayRadio.js
@@ -15,7 +15,7 @@ export default function OverlayRadio() {
         overlay
         name="member"
         defaultValue="person1"
-        row
+        orientation="horizontal"
         sx={{ gap: 2, mt: 1 }}
       >
         {[1, 2, 3].map((num) => (

--- a/docs/data/joy/components/radio/RadioUsage.js
+++ b/docs/data/joy/components/radio/RadioUsage.js
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import JoyUsageDemo, {
-  prependLinesSpace,
-} from 'docs/src/modules/components/JoyUsageDemo';
+import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
 import FormControl from '@mui/joy/FormControl';
 import FormLabel from '@mui/joy/FormLabel';
 import RadioGroup from '@mui/joy/RadioGroup';
@@ -36,14 +34,11 @@ export default function RadioUsage() {
           codeBlockDisplay: false,
         },
       ]}
-      getCodeBlock={(code, props) => `<RadioGroup${props.row ? ` row` : ''}>
-${prependLinesSpace(code, 2)}
-</RadioGroup>`}
-      renderDemo={({ row, ...props }) => (
+      renderDemo={({ orientation, ...props }) => (
         <FormControl>
           <FormLabel>Pizza crust</FormLabel>
           <RadioGroup
-            row={row}
+            orientation={orientation}
             defaultValue="1"
             name="radio-button-usage"
             sx={{ mt: 1 }}

--- a/docs/data/joy/components/stack/InteractiveStack.js
+++ b/docs/data/joy/components/stack/InteractiveStack.js
@@ -53,7 +53,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>direction</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="direction"
                 aria-label="direction"
                 value={direction}
@@ -73,7 +73,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>alignItems</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="alignItems"
                 aria-label="align items"
                 value={alignItems}
@@ -94,7 +94,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>justifyContent</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="justifyContent"
                 aria-label="justifyContent"
                 value={justifyContent}
@@ -116,7 +116,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>spacing</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="spacing"
                 aria-label="spacing"
                 value={spacing.toString()}

--- a/docs/data/joy/components/stack/InteractiveStack.tsx
+++ b/docs/data/joy/components/stack/InteractiveStack.tsx
@@ -53,7 +53,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>direction</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="direction"
                 aria-label="direction"
                 value={direction}
@@ -73,7 +73,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>alignItems</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="alignItems"
                 aria-label="align items"
                 value={alignItems}
@@ -94,7 +94,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>justifyContent</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="justifyContent"
                 aria-label="justifyContent"
                 value={justifyContent}
@@ -116,7 +116,7 @@ export default function InteractiveStack() {
             <FormControl>
               <FormLabel sx={{ mb: 1.5 }}>spacing</FormLabel>
               <RadioGroup
-                row
+                orientation="horizontal"
                 name="spacing"
                 aria-label="spacing"
                 value={spacing.toString()}

--- a/docs/data/joy/getting-started/templates/email/components/EmailContent.tsx
+++ b/docs/data/joy/getting-started/templates/email/components/EmailContent.tsx
@@ -166,7 +166,7 @@ export default function EmailContent() {
             />
           </AspectRatio>
         </Card>
-        <Card variant="outlined" row>
+        <Card variant="outlined" orientation="horizontal">
           <CardOverflow>
             <AspectRatio ratio="1" sx={{ minWidth: 80 }}>
               <Box>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionFooter.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionFooter.js
@@ -113,7 +113,12 @@ export default function ColorInversionFooter() {
             </Typography>
           </CardContent>
         </Card>
-        <List size="sm" row wrap sx={{ flexGrow: 0, '--List-item-radius': '8px' }}>
+        <List
+          size="sm"
+          orientation="horizontal"
+          wrap
+          sx={{ flexGrow: 0, '--List-item-radius': '8px' }}
+        >
           <ListItem nested sx={{ width: { xs: '50%', md: 140 } }}>
             <ListSubheader>Sitemap</ListSubheader>
             <List>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionFooter.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionFooter.tsx
@@ -112,7 +112,12 @@ export default function ColorInversionFooter() {
             </Typography>
           </CardContent>
         </Card>
-        <List size="sm" row wrap sx={{ flexGrow: 0, '--List-item-radius': '8px' }}>
+        <List
+          size="sm"
+          orientation="horizontal"
+          wrap
+          sx={{ flexGrow: 0, '--List-item-radius': '8px' }}
+        >
           <ListItem nested sx={{ width: { xs: '50%', md: 140 } }}>
             <ListSubheader>Sitemap</ListSubheader>
             <List>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -108,7 +108,7 @@ export default function ColorInversionNavigation() {
             </List>
           </ListItem>
         </List>
-        <Card variant="soft" row sx={{ mt: 1, mb: 2 }}>
+        <Card variant="soft" orientation="horizontal" sx={{ mt: 1, mb: 2 }}>
           <CircularProgress value={35} determinate thickness={2} size="lg">
             35%
           </CircularProgress>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -108,7 +108,7 @@ export default function ColorInversionNavigation() {
             </List>
           </ListItem>
         </List>
-        <Card variant="soft" row sx={{ mt: 1, mb: 2 }}>
+        <Card variant="soft" orientation="horizontal" sx={{ mt: 1, mb: 2 }}>
           <CircularProgress value={35} determinate thickness={2} size="lg">
             35%
           </CircularProgress>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionPopup.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionPopup.js
@@ -27,7 +27,7 @@ export default function ColorInversionPopup() {
   const [menuButton, setMenuButton] = React.useState(null);
   return (
     <Card
-      row
+      orientation="horizontal"
       variant="solid"
       color={color}
       invertedColors

--- a/docs/data/joy/main-features/color-inversion/ColorInversionPopup.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionPopup.tsx
@@ -27,7 +27,7 @@ export default function ColorInversionPopup() {
   const [menuButton, setMenuButton] = React.useState<HTMLElement | null>(null);
   return (
     <Card
-      row
+      orientation="horizontal"
       variant="solid"
       color={color}
       invertedColors

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -318,7 +318,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                 <FormControl key={propName} size="sm">
                   <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
                   <RadioGroup
-                    row
+                    orientation="horizontal"
                     name={labelId}
                     value={resolvedValue}
                     onChange={(event) => {
@@ -371,7 +371,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                 <FormControl key={propName} size="sm">
                   <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
                   <RadioGroup
-                    row
+                    orientation="horizontal"
                     name={labelId}
                     value={finalValue}
                     onChange={(event) => {
@@ -421,7 +421,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                 <FormControl key={propName} sx={{ mb: 1 }} size="sm">
                   <FormLabel>Color</FormLabel>
                   <RadioGroup
-                    row
+                    orientation="horizontal"
                     name={`${componentName}-color`}
                     value={resolvedValue || ''}
                     onChange={(event) =>

--- a/packages/mui-codemod/README.md
+++ b/packages/mui-codemod/README.md
@@ -62,6 +62,21 @@ npx @mui/codemod <transform> <path> --jscodeshift="--printOptions='{\"quote\":\"
 
 ### v5.0.0
 
+#### `joy-rename-row-prop`
+
+Transforms `row` prop to `orientation` prop across `Card`, `List` and `RadioGroup` components.
+
+```diff
+ <Card
+-  row
++  orientation={"horizontal"}
+ />;
+```
+
+```sh
+npx @mui/codemod v5.0.0/joy-rename-row-prop <path>
+```
+
 #### `joy-avatar-remove-imgProps`
 
 Remove `imgProps` prop by transferring its value into `slotProps.img`

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.js
@@ -1,0 +1,42 @@
+/**
+ * @param {import('jscodeshift').FileInfo} file
+ * @param {import('jscodeshift').API} api
+ */
+export default function transformer(file, api, options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const printOptions = options.printOptions;
+
+  root
+    .find(j.ImportDeclaration)
+    .filter(({ node }) => {
+      return node.source.value.startsWith('@mui/joy');
+    })
+    .forEach((path) => {
+      path.node.specifiers.forEach((node) => {
+        // Process only Joy UI components
+        root.findJSXElements(node.local.name).forEach((elementPath) => {
+          if (elementPath.node.type !== 'JSXElement') {
+            return;
+          }
+
+          elementPath.node.openingElement.attributes.forEach((attributeNode) => {
+            if (attributeNode.type !== 'JSXAttribute') {
+              return;
+            }
+            if (attributeNode.name.name === 'row') {
+              const val = attributeNode.value;
+              if (val === null || val?.expression?.value === true) {
+                attributeNode.name.name = 'orientation';
+                attributeNode.value = j.jsxExpressionContainer(j.literal('horizontal'));
+              }
+            }
+          });
+        });
+      });
+    });
+
+  const transformed = root.findJSXElements();
+
+  return transformed.toSource(printOptions);
+}

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test.js
@@ -1,0 +1,29 @@
+import path from 'path';
+import { expect } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from './joy-rename-row-prop';
+import readFile from '../util/readFile';
+
+function read(fileName) {
+  return readFile(path.join(__dirname, fileName));
+}
+
+describe('@mui/codemod', () => {
+  describe('v5.0.0', () => {
+    describe('joy-rename-row-prop', () => {
+      it('transforms `row` prop to `orientation="horizontal"`', () => {
+        const actual = transform(
+          {
+            source: read('./joy-rename-row-prop.test/actual.js'),
+            path: require.resolve('./joy-rename-components-to-slots.test/actual.js'),
+          },
+          { jscodeshift },
+          {},
+        );
+
+        const expected = read('./joy-rename-row-prop.test/expected.js');
+        expect(actual).to.equal(expected, 'The transformed version should be correct');
+      });
+    });
+  });
+});

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test/actual.js
@@ -1,0 +1,12 @@
+// the codemod should transform only Joy UI components;
+import { List as JoyList } from '@mui/joy';
+import JoyCard from '@mui/joy/Card';
+import RadioGroup from '@mui/joy/RadioGroup';
+import CustomComponent from 'components/Custom';
+
+<div>
+  <JoyCard row />
+  <JoyList row />
+  <RadioGroup row={true} />
+  <CustomComponent row />
+</div>;

--- a/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/joy-rename-row-prop.test/expected.js
@@ -1,0 +1,12 @@
+// the codemod should transform only Joy UI components;
+import { List as JoyList } from '@mui/joy';
+import JoyCard from '@mui/joy/Card';
+import RadioGroup from '@mui/joy/RadioGroup';
+import CustomComponent from 'components/Custom';
+
+<div>
+  <JoyCard orientation={"horizontal"} />
+  <JoyList orientation={"horizontal"} />
+  <RadioGroup orientation={"horizontal"} />
+  <CustomComponent row />
+</div>;

--- a/packages/mui-joy/src/Card/Card.tsx
+++ b/packages/mui-joy/src/Card/Card.tsx
@@ -16,15 +16,15 @@ import { resolveSxValue } from '../styles/styleUtils';
 import { CardRowContext } from './CardContext';
 
 const useUtilityClasses = (ownerState: CardOwnerState) => {
-  const { size, variant, color, row } = ownerState;
+  const { size, variant, color, orientation } = ownerState;
 
   const slots = {
     root: [
       'root',
+      orientation,
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
-      row && 'row',
     ],
   };
 
@@ -80,7 +80,7 @@ const CardRoot = styled('div', {
     transition: 'box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
     position: 'relative',
     display: 'flex',
-    flexDirection: ownerState.row ? 'row' : 'column',
+    flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
   },
   theme.variants[ownerState.variant!]?.[ownerState.color!],
   ownerState.color !== 'context' &&
@@ -102,7 +102,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
     size = 'md',
     variant = 'plain',
     children,
-    row = false,
+    orientation = 'vertical',
     ...other
   } = props;
   const { getColor } = useColorInversion(variant);
@@ -112,7 +112,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
     ...props,
     color,
     component,
-    row,
+    orientation,
     size,
     variant,
   };
@@ -120,7 +120,7 @@ const Card = React.forwardRef(function Card(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   const result = (
-    <CardRowContext.Provider value={row}>
+    <CardRowContext.Provider value={orientation === 'horizontal'}>
       <CardRoot
         as={component}
         ownerState={ownerState}
@@ -136,7 +136,6 @@ const Card = React.forwardRef(function Card(inProps, ref) {
           if (isMuiElement(child, ['Divider'])) {
             extraProps.inset = 'inset' in child.props ? child.props.inset : 'context';
 
-            const orientation = row ? 'vertical' : 'horizontal';
             extraProps.orientation =
               'orientation' in child.props ? child.props.orientation : orientation;
           }
@@ -191,10 +190,10 @@ Card.propTypes /* remove-proptypes */ = {
    */
   invertedColors: PropTypes.bool,
   /**
-   * If `true`, flex direction is set to 'row'.
-   * @default false
+   * The component orientation.
+   * @default 'vertical'
    */
-  row: PropTypes.bool,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   /**
    * The size of the component.
    * It accepts theme values between 'sm' and 'lg'.

--- a/packages/mui-joy/src/Card/Card.tsx
+++ b/packages/mui-joy/src/Card/Card.tsx
@@ -136,8 +136,9 @@ const Card = React.forwardRef(function Card(inProps, ref) {
           if (isMuiElement(child, ['Divider'])) {
             extraProps.inset = 'inset' in child.props ? child.props.inset : 'context';
 
+            const dividerOrientation = orientation === 'vertical' ? 'horizontal' : 'vertical';
             extraProps.orientation =
-              'orientation' in child.props ? child.props.orientation : orientation;
+              'orientation' in child.props ? child.props.orientation : dividerOrientation;
           }
           if (index === 0) {
             extraProps['data-first-child'] = '';

--- a/packages/mui-joy/src/Card/CardProps.ts
+++ b/packages/mui-joy/src/Card/CardProps.ts
@@ -26,10 +26,10 @@ export interface CardTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     invertedColors?: boolean;
     /**
-     * If `true`, flex direction is set to 'row'.
-     * @default false
+     * The component orientation.
+     * @default 'vertical'
      */
-    row?: boolean;
+    orientation?: 'horizontal' | 'vertical';
     /**
      * The size of the component.
      * It accepts theme values between 'sm' and 'lg'.

--- a/packages/mui-joy/src/Card/cardClasses.ts
+++ b/packages/mui-joy/src/Card/cardClasses.ts
@@ -31,8 +31,10 @@ export interface CardClasses {
   sizeMd: string;
   /** Styles applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Styles applied to the root element if `row={true}`. */
-  row: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
 }
 
 export type CardClassKey = keyof CardClasses;
@@ -57,7 +59,8 @@ const cardClasses: CardClasses = generateUtilityClasses('JoyCard', [
   'sizeSm',
   'sizeMd',
   'sizeLg',
-  'row',
+  'horizontal',
+  'vertical',
 ]);
 
 export default cardClasses;

--- a/packages/mui-joy/src/Divider/Divider.tsx
+++ b/packages/mui-joy/src/Divider/Divider.tsx
@@ -9,12 +9,9 @@ import { DividerOwnerState, DividerTypeMap } from './DividerProps';
 import { getDividerUtilityClass } from './dividerClasses';
 
 const useUtilityClasses = (ownerState: DividerOwnerState) => {
+  const { orientation, inset } = ownerState;
   const slots = {
-    root: [
-      'root',
-      ownerState.orientation === 'vertical' && 'vertical',
-      ownerState.inset && `inset${capitalize(ownerState.inset)}`,
-    ],
+    root: ['root', orientation, inset && `inset${capitalize(inset)}`],
   };
 
   return composeClasses(slots, getDividerUtilityClass, {});

--- a/packages/mui-joy/src/Divider/dividerClasses.ts
+++ b/packages/mui-joy/src/Divider/dividerClasses.ts
@@ -3,6 +3,8 @@ import { generateUtilityClass, generateUtilityClasses } from '../className';
 export interface DividerClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
   /** Styles applied to the root element if `orientation="vertical"`. */
   vertical: string;
   /** Styles applied to the root element if `inset="context"`. */
@@ -19,6 +21,7 @@ export function getDividerUtilityClass(slot: string): string {
 
 const dividerClasses: DividerClasses = generateUtilityClasses('JoyDivider', [
   'root',
+  'horizontal',
   'vertical',
   'insetContext',
   'insetNone',

--- a/packages/mui-joy/src/FormControl/FormControl.tsx
+++ b/packages/mui-joy/src/FormControl/FormControl.tsx
@@ -11,10 +11,11 @@ import formControlClasses, { getFormControlUtilityClass } from './formControlCla
 import { FormControlProps, FormControlOwnerState, FormControlTypeMap } from './FormControlProps';
 
 const useUtilityClasses = (ownerState: FormControlOwnerState) => {
-  const { disabled, error, size, color } = ownerState;
+  const { disabled, error, size, color, orientation } = ownerState;
   const slots = {
     root: [
       'root',
+      orientation,
       disabled && 'disabled',
       error && 'error',
       color && `color${capitalize(color)}`,
@@ -75,6 +76,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     error = false,
     color,
     size = 'md',
+    orientation = 'vertical',
     ...other
   } = props;
 
@@ -90,6 +92,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     error,
     required,
     size,
+    orientation,
   };
 
   let registerEffect: undefined | (() => () => void);

--- a/packages/mui-joy/src/FormControl/formControlClasses.ts
+++ b/packages/mui-joy/src/FormControl/formControlClasses.ts
@@ -25,6 +25,10 @@ export interface FormControlClasses {
   sizeMd: string;
   /** Styles applied to the root element if `size="lg"`. */
   sizeLg: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
 }
 
 export type FormControlClassKey = keyof FormControlClasses;
@@ -46,6 +50,8 @@ const formControlClasses: FormControlClasses = generateUtilityClasses('JoyFormCo
   'sizeSm',
   'sizeMd',
   'sizeLg',
+  'horizontal',
+  'vertical',
 ]);
 
 export default formControlClasses;

--- a/packages/mui-joy/src/List/List.test.js
+++ b/packages/mui-joy/src/List/List.test.js
@@ -52,7 +52,7 @@ describe('Joy <List />', () => {
     expect(container.firstChild).to.have.class(classes.sizeMd);
   });
 
-  it('should have nesting classes', () => {
+  it('should have `nesting` classes', () => {
     const { getByRole } = render(
       <ListItem nested>
         <List />
@@ -61,9 +61,9 @@ describe('Joy <List />', () => {
     expect(getByRole('list')).to.have.class(classes.nesting);
   });
 
-  it('should have row classes', () => {
-    const { getByRole } = render(<List row />);
-    expect(getByRole('list')).to.have.class(classes.row);
+  it('should have `orientation` classes', () => {
+    const { getByRole } = render(<List orientation="horizontal" />);
+    expect(getByRole('list')).to.have.class(classes.horizontal);
   });
 
   describe('MenuList - integration', () => {

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -16,16 +16,16 @@ import ListProvider from './ListProvider';
 import RadioGroupContext from '../RadioGroup/RadioGroupContext';
 
 const useUtilityClasses = (ownerState: ListOwnerState) => {
-  const { variant, color, size, nesting, row, instanceSize } = ownerState;
+  const { variant, color, size, nesting, orientation, instanceSize } = ownerState;
   const slots = {
     root: [
       'root',
+      orientation,
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       !instanceSize && !nesting && size && `size${capitalize(size)}`,
       instanceSize && `size${capitalize(instanceSize)}`,
       nesting && 'nesting',
-      row && 'row',
     ],
   };
 
@@ -41,7 +41,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
         '--List-item-paddingY': '0.25rem',
         '--List-item-paddingX': '0.5rem',
         '--List-item-fontSize': theme.vars.fontSize.sm,
-        '--List-decorator-size': ownerState.row ? '1.5rem' : '2rem',
+        '--List-decorator-size': ownerState.orientation === 'horizontal' ? '1.5rem' : '2rem',
         '--Icon-fontSize': '1.125rem',
       };
     }
@@ -52,7 +52,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
         '--List-item-paddingY': '0.375rem',
         '--List-item-paddingX': '0.75rem',
         '--List-item-fontSize': theme.vars.fontSize.md,
-        '--List-decorator-size': ownerState.row ? '1.75rem' : '2.5rem',
+        '--List-decorator-size': ownerState.orientation === 'horizontal' ? '1.75rem' : '2.5rem',
         '--Icon-fontSize': '1.25rem',
       };
     }
@@ -63,7 +63,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
         '--List-item-paddingY': '0.5rem',
         '--List-item-paddingX': '1rem',
         '--List-item-fontSize': theme.vars.fontSize.md,
-        '--List-decorator-size': ownerState.row ? '2.25rem' : '3rem',
+        '--List-decorator-size': ownerState.orientation === 'horizontal' ? '2.25rem' : '3rem',
         '--Icon-fontSize': '1.5rem',
       };
     }
@@ -103,7 +103,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
       '--List-item-endActionTranslateX': 'calc(-0.5 * var(--List-item-paddingRight))',
       margin: 'initial',
       // --List-padding is not declared to let list uses --List-divider-gap by default.
-      ...(ownerState.row
+      ...(ownerState.orientation === 'horizontal'
         ? {
             ...(ownerState.wrap
               ? {
@@ -126,7 +126,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
       borderRadius: 'var(--List-radius)',
       listStyle: 'none',
       display: 'flex',
-      flexDirection: ownerState.row ? 'row' : 'column',
+      flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
       ...(ownerState.wrap && {
         flexWrap: 'wrap',
       }),
@@ -158,7 +158,7 @@ const List = React.forwardRef(function List(inProps, ref) {
     className,
     children,
     size = inProps.size ?? 'md',
-    row = false,
+    orientation = 'vertical',
     wrap = false,
     variant = 'plain',
     color: colorProp = 'neutral',
@@ -184,7 +184,7 @@ const List = React.forwardRef(function List(inProps, ref) {
     instanceSize: inProps.size,
     size,
     nesting,
-    row,
+    orientation,
     wrap,
     variant,
     color,
@@ -206,7 +206,7 @@ const List = React.forwardRef(function List(inProps, ref) {
       <ComponentListContext.Provider
         value={`${typeof component === 'string' ? component : ''}:${role || ''}`}
       >
-        <ListProvider row={row} wrap={wrap}>
+        <ListProvider row={orientation === 'horizontal'} wrap={wrap}>
           {children}
         </ListProvider>
       </ComponentListContext.Provider>
@@ -241,14 +241,14 @@ List.propTypes /* remove-proptypes */ = {
    */
   component: PropTypes.elementType,
   /**
+   * The component orientation.
+   * @default 'vertical'
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
    * @ignore
    */
   role: PropTypes /* @typescript-to-proptypes-ignore */.string,
-  /**
-   * If `true`, display the list in horizontal direction.
-   * @default false
-   */
-  row: PropTypes.bool,
   /**
    * The size of the component (affect other nested list* components).
    * @default 'md'

--- a/packages/mui-joy/src/List/ListProps.ts
+++ b/packages/mui-joy/src/List/ListProps.ts
@@ -20,10 +20,10 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      */
     color?: OverridableStringUnion<ColorPaletteProp, ListPropsColorOverrides>;
     /**
-     * If `true`, display the list in horizontal direction.
-     * @default false
+     * The component orientation.
+     * @default 'vertical'
      */
-    row?: boolean;
+    orientation?: 'horizontal' | 'vertical';
     /**
      * The size of the component (affect other nested list* components).
      * @default 'md'

--- a/packages/mui-joy/src/List/listClasses.ts
+++ b/packages/mui-joy/src/List/listClasses.ts
@@ -5,8 +5,6 @@ export interface ListClasses {
   root: string;
   /** Classname applied to the root element if wrapped with nested context. */
   nesting: string;
-  /** Classname applied to the root element if `row` is true. */
-  row: string;
   /** Classname applied to the root element if `scoped` is true. */
   scoped: string;
   /** Classname applied to the root element if `size="sm"`. */
@@ -37,6 +35,10 @@ export interface ListClasses {
   variantSoft: string;
   /** Classname applied to the root element if `variant="solid"`. */
   variantSolid: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
 }
 
 export type ListClassKey = keyof ListClasses;
@@ -48,7 +50,6 @@ export function getListUtilityClass(slot: string): string {
 const listClasses: ListClasses = generateUtilityClasses('JoyList', [
   'root',
   'nesting',
-  'row',
   'scoped',
   'sizeSm',
   'sizeMd',
@@ -64,6 +65,8 @@ const listClasses: ListClasses = generateUtilityClasses('JoyList', [
   'variantOutlined',
   'variantSoft',
   'variantSolid',
+  'horizontal',
+  'vertical',
 ]);
 
 export default listClasses;

--- a/packages/mui-joy/src/ListDivider/ListDivider.test.js
+++ b/packages/mui-joy/src/ListDivider/ListDivider.test.js
@@ -38,7 +38,7 @@ describe('Joy <ListDivider />', () => {
 
     it('should have aria-orientation set to vertical', () => {
       render(
-        <List row>
+        <List orientation="horizontal">
           <ListDivider />
         </List>,
       );
@@ -47,7 +47,7 @@ describe('Joy <ListDivider />', () => {
 
     it('should not add aria-orientation if role is custom', () => {
       render(
-        <List row>
+        <List orientation="horizontal">
           <ListDivider role="presentation" />
         </List>,
       );

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -11,11 +11,13 @@ import { getListDividerUtilityClass } from './listDividerClasses';
 import RowListContext from '../List/RowListContext';
 
 const useUtilityClasses = (ownerState: ListDividerOwnerState) => {
+  const { orientation, inset } = ownerState;
   const slots = {
     root: [
       'root',
+      orientation,
       // `insetContext` class is already produced by Divider
-      ownerState.inset && ownerState.inset !== 'context' && `inset${capitalize(ownerState.inset)}`,
+      inset && inset !== 'context' && `inset${capitalize(inset)}`,
     ],
   };
 

--- a/packages/mui-joy/src/ListDivider/listDividerClasses.ts
+++ b/packages/mui-joy/src/ListDivider/listDividerClasses.ts
@@ -9,6 +9,10 @@ export interface ListDividerClasses {
   insetStartDecorator: string;
   /** Styles applied to the root element if `inset="startContent"`. */
   insetStartContent: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
 }
 
 export type ListDividerClassKey = keyof ListDividerClasses;
@@ -22,6 +26,8 @@ const listDividerClasses: ListDividerClasses = generateUtilityClasses('JoyListDi
   'insetGutter',
   'insetStartDecorator',
   'insetStartContent',
+  'horizontal',
+  'vertical',
 ]);
 
 export default listDividerClasses;

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -91,8 +91,10 @@ const RadioRoot = styled('span', {
       }),
       ...(ownerState['data-parent'] === 'RadioGroup' &&
         ownerState['data-first-child'] === undefined && {
-          marginInlineStart: ownerState.row ? 'var(--RadioGroup-gap)' : undefined,
-          marginBlockStart: ownerState.row ? undefined : 'var(--RadioGroup-gap)',
+          marginInlineStart:
+            ownerState.orientation === 'horizontal' ? 'var(--RadioGroup-gap)' : undefined,
+          marginBlockStart:
+            ownerState.orientation === 'horizontal' ? undefined : 'var(--RadioGroup-gap)',
         }),
     },
   ];
@@ -307,7 +309,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
     size,
     disableIcon,
     overlay,
-    row: radioGroup?.row,
+    orientation: radioGroup?.orientation,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/Radio/RadioProps.ts
+++ b/packages/mui-joy/src/Radio/RadioProps.ts
@@ -102,7 +102,7 @@ export interface RadioOwnerState extends ApplyColorInversion<RadioProps> {
    * @internal
    * The value from the RadioGroup component.
    */
-  row?: boolean;
+  orientation?: 'horizontal' | 'vertical';
   /**
    * @internal
    * The internal prop for controlling CSS margin of the element.

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.test.js
@@ -16,7 +16,7 @@ describe('<RadioGroup />', () => {
     ThemeProvider,
     muiName: 'JoyRadioGroup',
     refInstanceof: window.HTMLDivElement,
-    testVariantProps: { row: true },
+    testVariantProps: { orientation: 'horizontal' },
     testCustomVariant: true,
     skip: ['componentProp', 'componentsProp', 'classesRoot', 'propsSpread'],
   }));

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.test.js
@@ -21,10 +21,10 @@ describe('<RadioGroup />', () => {
     skip: ['componentProp', 'componentsProp', 'classesRoot', 'propsSpread'],
   }));
 
-  it('should have row class if `row` is true', () => {
-    const { getByRole } = render(<RadioGroup value="" row />);
+  it('should have `orientation` class', () => {
+    const { getByRole } = render(<RadioGroup value="" orientation="horizontal" />);
 
-    expect(getByRole('radiogroup')).to.have.class(classes.row);
+    expect(getByRole('radiogroup')).to.have.class(classes.horizontal);
   });
 
   it('the root component has the radiogroup role', () => {

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.tsx
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.tsx
@@ -15,11 +15,11 @@ import RadioGroupContext from './RadioGroupContext';
 import FormControlContext from '../FormControl/FormControlContext';
 
 const useUtilityClasses = (ownerState: RadioGroupOwnerState) => {
-  const { row, size, variant, color } = ownerState;
+  const { orientation, size, variant, color } = ownerState;
   const slots = {
     root: [
       'root',
-      row && 'row',
+      orientation,
       variant && `variant${capitalize(variant)}`,
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
@@ -44,7 +44,7 @@ const RadioGroupRoot = styled('div', {
     '--RadioGroup-gap': '1.25rem',
   }),
   display: 'flex',
-  flexDirection: ownerState.row ? 'row' : 'column',
+  flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
   borderRadius: theme.vars.radius.sm,
   ...theme.variants[ownerState.variant!]?.[ownerState.color!],
 }));
@@ -68,7 +68,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
     color = 'neutral',
     variant = 'plain',
     size = 'md',
-    row = false,
+    orientation = 'vertical',
     role = 'radiogroup',
     ...other
   } = props;
@@ -80,7 +80,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
   });
 
   const ownerState = {
-    row,
+    orientation,
     size,
     variant,
     color,
@@ -110,7 +110,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
     () => ({
       disableIcon,
       overlay,
-      row,
+      orientation,
       size,
       name,
       value,
@@ -122,7 +122,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(inProps, ref) {
         }
       },
     }),
-    [disableIcon, name, onChange, overlay, row, setValueState, size, value],
+    [disableIcon, name, onChange, overlay, orientation, setValueState, size, value],
   );
 
   return (
@@ -204,6 +204,11 @@ RadioGroup.propTypes /* remove-proptypes */ = {
    */
   onChange: PropTypes.func,
   /**
+   * The component orientation.
+   * @default 'vertical'
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
    * The radio's `overlay` prop. If specified, the value is passed down to every radios under this element.
    */
   overlay: PropTypes.bool,
@@ -211,11 +216,6 @@ RadioGroup.propTypes /* remove-proptypes */ = {
    * @ignore
    */
   role: PropTypes /* @typescript-to-proptypes-ignore */.string,
-  /**
-   * If `true`, flex direction is set to 'row'.
-   * @default false
-   */
-  row: PropTypes.bool,
   /**
    * The size of the component.
    * @default 'md'

--- a/packages/mui-joy/src/RadioGroup/RadioGroupContext.ts
+++ b/packages/mui-joy/src/RadioGroup/RadioGroupContext.ts
@@ -4,7 +4,7 @@ import { RadioProps } from '../Radio/RadioProps';
 const RadioGroupContext = React.createContext<
   | undefined
   | (Pick<RadioProps, 'size' | 'disableIcon' | 'overlay'> & {
-      row?: boolean;
+      orientation?: 'horizontal' | 'vertical';
       name?: string;
       value?: unknown;
       onChange?: React.ChangeEventHandler<HTMLInputElement>;

--- a/packages/mui-joy/src/RadioGroup/RadioGroupProps.ts
+++ b/packages/mui-joy/src/RadioGroup/RadioGroupProps.ts
@@ -45,10 +45,10 @@ export interface RadioGroupTypeMap<P = {}, D extends React.ElementType = 'div'> 
      */
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
     /**
-     * If `true`, flex direction is set to 'row'.
-     * @default false
+     * The component orientation.
+     * @default 'vertical'
      */
-    row?: boolean;
+    orientation?: 'horizontal' | 'vertical';
     /**
      * The size of the component.
      * @default 'md'

--- a/packages/mui-joy/src/RadioGroup/radioGroupClasses.ts
+++ b/packages/mui-joy/src/RadioGroup/radioGroupClasses.ts
@@ -3,8 +3,6 @@ import { generateUtilityClass, generateUtilityClasses } from '../className';
 export interface RadioGroupClasses {
   /** Styles applied to the root element. */
   root: string;
-  /** Styles applied to the root element, if `row` is true. */
-  row: string;
   /** Styles applied to the root element if `size="sm"`. */
   sizeSm: string;
   /** Styles applied to the root element if `size="md"`. */
@@ -31,6 +29,10 @@ export interface RadioGroupClasses {
   variantSoft: string;
   /** Styles applied to the root element if `variant="solid"`. */
   variantSolid: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
 }
 
 export type RadioGroupClassKey = keyof RadioGroupClasses;
@@ -41,7 +43,6 @@ export function getRadioGroupUtilityClass(slot: string): string {
 
 const radioGroupClasses: RadioGroupClasses = generateUtilityClasses('JoyRadioGroup', [
   'root',
-  'row',
   'colorPrimary',
   'colorNeutral',
   'colorDanger',
@@ -55,6 +56,8 @@ const radioGroupClasses: RadioGroupClasses = generateUtilityClasses('JoyRadioGro
   'sizeSm',
   'sizeMd',
   'sizeLg',
+  'horizontal',
+  'vertical',
 ]);
 
 export default radioGroupClasses;

--- a/packages/mui-joy/src/TabPanel/TabPanel.tsx
+++ b/packages/mui-joy/src/TabPanel/TabPanel.tsx
@@ -12,10 +12,10 @@ import { getTabPanelUtilityClass } from './tabPanelClasses';
 import { TabPanelOwnerState, TabPanelTypeMap } from './TabPanelProps';
 
 const useUtilityClasses = (ownerState: TabPanelOwnerState) => {
-  const { hidden, size } = ownerState;
+  const { hidden, size, orientation } = ownerState;
 
   const slots = {
-    root: ['root', hidden && 'hidden', size && `size${capitalize(size)}`],
+    root: ['root', hidden && 'hidden', size && `size${capitalize(size)}`, orientation],
   };
 
   return composeClasses(slots, getTabPanelUtilityClass, {});

--- a/packages/mui-joy/src/TabPanel/tabPanelClasses.ts
+++ b/packages/mui-joy/src/TabPanel/tabPanelClasses.ts
@@ -11,6 +11,10 @@ export interface TabPanelClasses {
   sizeMd: string;
   /** Classname applied to the root element if `size="lg"`. */
   sizeLg: string;
+  /** Styles applied to the root element if `orientation="horizontal"`. */
+  horizontal: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
 }
 
 export type TabPanelClassKey = keyof TabPanelClasses;
@@ -25,6 +29,8 @@ const tabListClasses: TabPanelClasses = generateUtilityClasses('JoyTabPanel', [
   'sizeSm',
   'sizeMd',
   'sizeLg',
+  'horizontal',
+  'vertical',
 ]);
 
 export default tabListClasses;

--- a/test/regressions/fixtures/JoyColorInversion/JoyColorInversionPortal.js
+++ b/test/regressions/fixtures/JoyColorInversion/JoyColorInversionPortal.js
@@ -30,7 +30,7 @@ export default function ColorInversionPopup() {
       <CssBaseline />
       <Stack spacing={2}>
         <Card
-          row
+          orientation="horizontal"
           variant="solid"
           color="primary"
           invertedColors

--- a/test/regressions/fixtures/JoyColorInversion/JoyColorInversionPortal.js
+++ b/test/regressions/fixtures/JoyColorInversion/JoyColorInversionPortal.js
@@ -75,7 +75,7 @@ export default function ColorInversionPopup() {
           </Tooltip>
         </Card>
         <Card
-          row
+          orientation="horizontal"
           variant="solid"
           color="primary"
           invertedColors

--- a/test/regressions/fixtures/ListJoy/Flexibility.js
+++ b/test/regressions/fixtures/ListJoy/Flexibility.js
@@ -36,7 +36,7 @@ export default function Flexibility() {
           <ListItemButton>Item 4</ListItemButton>
         </ListItem>
       </List>
-      <List role="menubar" row>
+      <List role="menubar" orientation="horizontal">
         <ListItem role="none">
           <ListItemButton
             variant="solid"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


**This PR includes**:
- replacing `row` prop (of boolean type)  with `orientation` prop (of type 'horizontal' or 'vertical') in `Card`, `List`, `RadioGroup` and some internal components relevant to `RadioGroup`
- replacing `row` prop with `orientation` prop in instances of components in Joy demos
- making sure that all Joy UI components that have `orientation` prop to have either `vertical` or `horizontal` classname
- Codemod script that transforms the prop only for Joy UI components