### PR TITLE
[Tooltip] Remove `data-foo` attribute

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -703,7 +703,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
             timeout={theme.transitions.duration.shorter}
             {...TransitionPropsInner}
             {...transitionProps}
-            data-foo="bar"
           >
             <TooltipComponent {...tooltipProps}>
               {title}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

`data-foo="bar"` was unnecessarily added to the `TransitionComponent` in [#34873](https://github.com/mui/material-ui/pull/34873/files#diff-9e609b09872335393b32162304d39d96eb2cfda2822cc913a1af9ce17942ff12R706)