### PR TITLE
[docs] Revise and expand Joy UI Button doc

### DIFF
--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -10,13 +10,13 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 
 <p class="description">Buttons let users take actions and make choices with a single tap.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
-
 ## Introduction
 
 The Unstyled Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
 
 {{"demo": "UnstyledButtonIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/button/BasicButtons.js
+++ b/docs/data/joy/components/button/BasicButtons.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Button from '@mui/joy/Button';
+import Box from '@mui/joy/Box';
+
+export default function BasicButtons() {
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Button>Button</Button>
+      <Button disabled>Disabled</Button>
+      <Button loading>Loading</Button>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/button/BasicButtons.tsx
+++ b/docs/data/joy/components/button/BasicButtons.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Button from '@mui/joy/Button';
+import Box from '@mui/joy/Box';
+
+export default function BasicButtons() {
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Button>Button</Button>
+      <Button disabled>Disabled</Button>
+      <Button loading>Loading</Button>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/button/BasicButtons.tsx.preview
+++ b/docs/data/joy/components/button/BasicButtons.tsx.preview
@@ -1,0 +1,3 @@
+<Button>Button</Button>
+<Button disabled>Disabled</Button>
+<Button loading>Loading</Button>

--- a/docs/data/joy/components/button/ButtonDisabled.js
+++ b/docs/data/joy/components/button/ButtonDisabled.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 
-export default function ButtonVariants() {
+export default function DisabledButtons() {
   return (
     <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
       <Button disabled variant="solid">

--- a/docs/data/joy/components/button/ButtonDisabled.tsx
+++ b/docs/data/joy/components/button/ButtonDisabled.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 
-export default function ButtonVariants() {
+export default function DisabledButtons() {
   return (
     <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
       <Button disabled variant="solid">

--- a/docs/data/joy/components/button/ButtonLoading.js
+++ b/docs/data/joy/components/button/ButtonLoading.js
@@ -1,17 +1,22 @@
 import * as React from 'react';
-import Stack from '@mui/joy/Stack';
-import SendIcon from '@mui/icons-material/Send';
+import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 
-export default function ButtonLoading() {
+export default function LoadingButtons() {
   return (
-    <Stack spacing={2} direction="row">
-      <Button loading endDecorator={<SendIcon />} variant="solid">
-        Send
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Button loading variant="solid">
+        Solid
       </Button>
-      <Button loading loadingIndicator="Loading…" variant="outlined">
-        Fetch data
+      <Button loading variant="soft">
+        Soft
       </Button>
-    </Stack>
+      <Button loading variant="outlined">
+        Outlined
+      </Button>
+      <Button loading variant="plain">
+        Plain
+      </Button>
+    </Box>
   );
 }

--- a/docs/data/joy/components/button/ButtonLoading.tsx
+++ b/docs/data/joy/components/button/ButtonLoading.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
-import Stack from '@mui/joy/Stack';
-import SendIcon from '@mui/icons-material/Send';
+import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 
-export default function ButtonLoading() {
+export default function LoadingButtons() {
   return (
-    <Stack spacing={2} direction="row">
-      <Button loading endDecorator={<SendIcon />} variant="solid">
-        Send
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      <Button loading variant="solid">
+        Solid
       </Button>
-      <Button loading loadingIndicator="Loading…" variant="outlined">
-        Fetch data
+      <Button loading variant="soft">
+        Soft
       </Button>
-    </Stack>
+      <Button loading variant="outlined">
+        Outlined
+      </Button>
+      <Button loading variant="plain">
+        Plain
+      </Button>
+    </Box>
   );
 }

--- a/docs/data/joy/components/button/ButtonLoading.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoading.tsx.preview
@@ -1,6 +1,12 @@
-<Button loading endDecorator={<SendIcon />} variant="solid">
-  Send
+<Button loading variant="solid">
+  Solid
 </Button>
-<Button loading loadingIndicator="Loading…" variant="outlined">
-  Fetch data
+<Button loading variant="soft">
+  Soft
+</Button>
+<Button loading variant="outlined">
+  Outlined
+</Button>
+<Button loading variant="plain">
+  Plain
 </Button>

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.js
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import Stack from '@mui/joy/Stack';
+import SendIcon from '@mui/icons-material/Send';
+import Button from '@mui/joy/Button';
+
+export default function ButtonLoading() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button loading endDecorator={<SendIcon />} variant="solid">
+        Send
+      </Button>
+      <Button loading loadingIndicator="Loading…" variant="outlined">
+        Fetch data
+      </Button>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import Stack from '@mui/joy/Stack';
+import SendIcon from '@mui/icons-material/Send';
+import Button from '@mui/joy/Button';
+
+export default function ButtonLoading() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button loading endDecorator={<SendIcon />} variant="solid">
+        Send
+      </Button>
+      <Button loading loadingIndicator="Loading…" variant="outlined">
+        Fetch data
+      </Button>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
@@ -1,0 +1,6 @@
+<Button loading endDecorator={<SendIcon />} variant="solid">
+  Send
+</Button>
+<Button loading loadingIndicator="Loading…" variant="outlined">
+  Fetch data
+</Button>

--- a/docs/data/joy/components/button/ButtonsSimple.js
+++ b/docs/data/joy/components/button/ButtonsSimple.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Button from '@mui/joy/Button';
+import Box from '@mui/joy/Box';
+
+export default function UnstyledButtonsSimple() {
+  return (
+    <Box>
+      <Button>Button</Button>
+      <Button disabled>Disabled</Button>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/button/ButtonsSimple.tsx.preview
+++ b/docs/data/joy/components/button/ButtonsSimple.tsx.preview
@@ -1,0 +1,2 @@
+<Button>Button</Button>
+<Button disabled>Disabled</Button>

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -8,37 +8,44 @@ unstyled: /base/react-button/
 
 # Button
 
-<p class="description">Buttons allow users to take actions, and make choices, with a single tap.</p>
+<p class="description">Buttons let users take actions and make choices with a single tap.</p>
 
 ## Introduction
 
 Buttons communicate actions that users can take.
+The Jopy UI Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
 
 {{"demo": "ButtonUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
-## Component
-
-After [installation](/joy-ui/getting-started/installation/), you can start building with this component using the following basic elements:
+## Basics
 
 ```jsx
 import Button from '@mui/joy/Button';
-
-export default function MyApp() {
-  return <Button>My button</Button>;
-}
 ```
+
+## Customization
 
 ### Variants
 
-The button component supports the four global variants: `solid` (default), `soft`, `outlined`, and `plain`.
-Which variant you should choose depends on the relative importance of the button's action—see [Global variants—Hierarchy of importance](/joy-ui/main-features/global-variants/#hierarchy-of-importance) for details.
+The Alert component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid` (default), `soft`, `outlined`, and `plain`.
 
 {{"demo": "ButtonVariants.js"}}
 
 :::info
-To learn how to add more variants to the component, check out [Themed components—Extend variants](/joy-ui/customization/themed-components/#extend-variants).
+To learn how to add your own variants, check out [Themed components—Extend variants](/joy-ui/customization/themed-components/#extend-variants).
+Note that you lose the global variants when you add custom variants.
+:::
+
+### Sizes
+
+The button components comes with three sizes out of the box: `sm`, `md` (the default), and `lg`.
+
+{{"demo": "ButtonSizes.js"}}
+
+:::info
+To learn how to add custom sizes to the component, check out [Themed components—Extend sizes](/joy-ui/customization/themed-components/#extend-sizes).
 :::
 
 ### Colors
@@ -48,70 +55,70 @@ Play around combining different colors with different variants.
 
 {{"demo": "ButtonColors.js"}}
 
-### Sizes
+### Decorators
 
-The button components comes with three sizes out of the box: `sm`, `md` (the default), and `lg`.
-
-{{"demo": "ButtonSizes.js"}}
-
-:::info
-To learn how to add more sizes to the component, check out [Themed components—Extend sizes](/joy-ui/customization/themed-components/#extend-sizes).
-:::
-
-### Disabled
-
-Use the `disabled` prop to disable interaction and focus.
-
-{{"demo": "ButtonDisabled.js"}}
-
-### With decorators
-
-Use the `startDecorator` and/or `endDecorator` props to add supporting decorators to the button.
+Use the `startDecorator` and `endDecorator` props to append actions and icons to either side of the Button:
 
 {{"demo": "ButtonIcons.js"}}
 
+### Disabled
+
+Use the `disabled` prop to disable interaction and focus:
+
+{{"demo": "ButtonDisabled.js"}}
+
 ### Loading
 
-Enable `loading` prop to show button's loading state. The button will be `disabled` when it is in the loading state.
+Add the `loading` prop to show the Button's loading state.
+The Button is [disabled]](#disabled) as long as it's loading.
 
-The default loading indicator uses the [`CircularProgress`](/joy-ui/react-circular-progress/) component which can be customized using the `loadingIndicator` prop.
+#### Loading indicator
+
+The default loading indicator uses the [Circular Progress](/joy-ui/react-circular-progress/) component.
+Use the `loadingIndicator` prop to replace it with a custom indicator, as shown below:
 
 {{"demo": "ButtonLoading.js"}}
 
-### Loading position
+#### Loading position
 
-The `loadingPosition` prop supports 3 values:
+The `loadingPosition` prop sets the position of the Button's loading indicator.
+It supports three values:
 
-- `center` (default): The loading indicator element is wrapped inside the button's `loadingIndicatorCenter` slot to create a proper style.
-- `start`: The loading indicator replaces the **start** decorator's content when the button is in loading state.
-- `end`: The loading indicator replaces the **end** decorator's content when the button is in loading state.
+- `center` (default): The loading indicator is nested inside the `loadingIndicatorCenter` slot and replaces the Button's contents when in the loading state.
+- `start`: The loading indicator replaces the [starting decorator](#decorators) when the Button is in the loading state.
+- `end`: The loading indicator replaces the [ending decorator](#decorators) when the Button is in the loading state.
 
 {{"demo": "ButtonLoadingPosition.js"}}
 
-### Icon button
-
-Use the `IconButton` component if you want width and height to be the same while not having a label.
-Every prop previously covered are available for this component as well.
+## Icon Button
 
 ```jsx
 import IconButton from '@mui/joy/IconButton';
 ```
 
+Use the Icon Button component for a square button to house an icon with no text contents.
+
 {{"demo": "IconButtons.js"}}
 
 :::warning
-Make sure to provide a meaningful [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) to the icon button.
-It helps screen readers to properly identify the component.
+Icon Buttons must have a meaningful [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) so their purpose can be understood by users who require assistive technology.
+They've been omitted from the demo above for the sake of brevity, but an appropriate label would look like this:
 
 ```js
-<IconButton aria-label="Add to favorite">
+<IconButton aria-label="Add to favorites">
   <FavoriteBorder />
 </IconButton>
 ```
 
 :::
 
-### As a link
+## CSS Variables
+
+{{"demo": "ButtonVariables.js", "hideToolbar": true}}
+
+{{"demo": "IconButtonVariables.js", "hideToolbar": true}}
+
+## Anatomy
 
 You can also use the button component as a link by assigning a value of `a` to the `component` prop.
 Since links are the most appropriate component for navigating through pages, that's useful when you want the same button design for a link.
@@ -119,9 +126,3 @@ Since links are the most appropriate component for navigating through pages, tha
 Doing so will automatically change the rendered HTML tag from `<button>` to `<a>`.
 
 {{"demo": "ButtonLink.js"}}
-
-## CSS Variables
-
-{{"demo": "ButtonVariables.js", "hideToolbar": true}}
-
-{{"demo": "IconButtonVariables.js", "hideToolbar": true}}

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -13,7 +13,7 @@ unstyled: /base/react-button/
 ## Introduction
 
 Buttons communicate actions that users can take.
-The Jopy UI Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
+The Joy UI Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
 
 {{"demo": "ButtonUsage.js", "hideToolbar": true, "bg": "gradient"}}
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -112,7 +112,15 @@ They've been omitted from the demo above for the sake of brevity, but an appropr
 
 :::
 
-## CSS Variables
+## Link Button
+
+Buttons let users take actions, but if that action is to navigate to a new page, then an anchor tag may be preferable over a button.
+
+If you need the style of a button with the functionality of a link, you can use the `component` prop to replace the default `<button>` with an `<a>` tag, as shown below:
+
+{{"demo": "ButtonLink.js"}}
+
+## CSS variables
 
 {{"demo": "ButtonVariables.js", "hideToolbar": true}}
 
@@ -120,9 +128,10 @@ They've been omitted from the demo above for the sake of brevity, but an appropr
 
 ## Anatomy
 
-You can also use the button component as a link by assigning a value of `a` to the `component` prop.
-Since links are the most appropriate component for navigating through pages, that's useful when you want the same button design for a link.
+The Button component is composed of a single root `<button>` element:
 
-Doing so will automatically change the rendered HTML tag from `<button>` to `<a>`.
-
-{{"demo": "ButtonLink.js"}}
+```html
+<button>
+  <!-- Button contents -->
+</button>
+```

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -25,6 +25,26 @@ The Jopy UI Button component replaces the native HTML `<button>` element, and of
 import Button from '@mui/joy/Button';
 ```
 
+The Joy UI Button behaves similar to the native HTML `<button>`, so it wraps around the text that will be displayed on its surface.
+
+The demo below shows the three basic states available to the Button: default, disabled, and loading.
+
+{{"demo": "BasicButtons.js"}}
+
+### Disabled
+
+Use the `disabled` prop to disable interaction and focus:
+
+{{"demo": "ButtonDisabled.js"}}
+
+### Loading
+
+Add the `loading` prop to show the Button's loading state.
+The Button is [disabled](#disabled) as long as it's loading.
+See [Loading indicator](#loading-indicator) and [Loading position](#loading-position) for customization options.
+
+{{"demo": "ButtonLoading.js"}}
+
 ## Customization
 
 ### Variants
@@ -40,7 +60,7 @@ Note that you lose the global variants when you add custom variants.
 
 ### Sizes
 
-The button components comes with three sizes out of the box: `sm`, `md` (the default), and `lg`.
+The Button component comes in three sizes: `sm`, `md` (default), and `lg`.
 
 {{"demo": "ButtonSizes.js"}}
 
@@ -61,25 +81,14 @@ Use the `startDecorator` and `endDecorator` props to append actions and icons to
 
 {{"demo": "ButtonIcons.js"}}
 
-### Disabled
-
-Use the `disabled` prop to disable interaction and focus:
-
-{{"demo": "ButtonDisabled.js"}}
-
-### Loading
-
-Add the `loading` prop to show the Button's loading state.
-The Button is [disabled]](#disabled) as long as it's loading.
-
-#### Loading indicator
+### Loading indicator
 
 The default loading indicator uses the [Circular Progress](/joy-ui/react-circular-progress/) component.
 Use the `loadingIndicator` prop to replace it with a custom indicator, as shown below:
 
-{{"demo": "ButtonLoading.js"}}
+{{"demo": "ButtonLoadingIndicator.js"}}
 
-#### Loading position
+### Loading position
 
 The `loadingPosition` prop sets the position of the Button's loading indicator.
 It supports three values:
@@ -96,13 +105,37 @@ It supports three values:
 import IconButton from '@mui/joy/IconButton';
 ```
 
-Use the Icon Button component for a square button to house an icon with no text contents.
+Use the Icon Button component for a square button to house an icon with no text content.
 
 {{"demo": "IconButtons.js"}}
 
-:::warning
-Icon Buttons must have a meaningful [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) so their purpose can be understood by users who require assistive technology.
-They've been omitted from the demo above for the sake of brevity, but an appropriate label would look like this:
+## Link Button
+
+Buttons let users take actions, but if that action is to navigate to a new page, then an anchor tag is generally preferable over a button tag.
+
+If you need the style of a button with the functionality of a link, then you can use the `component` prop to replace the default `<button>` with an `<a>`, as shown below:
+
+{{"demo": "ButtonLink.js"}}
+
+## CSS variable playground
+
+Play around with the CSS variables available to the Button and Icon Button components to see how the design changes.
+You can use these to customize the components with both the `sx` prop and the theme.
+
+### Button
+
+{{"demo": "ButtonVariables.js", "hideToolbar": true}}
+
+### Icon Button
+
+{{"demo": "IconButtonVariables.js", "hideToolbar": true}}
+
+## Accessibility
+
+All Buttons must have a meaningful [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) so their purpose can be understood by users who require assistive technology.
+
+This is especially important for [Icon Buttons](#icon-button) because they don't contain any text.
+For example, an Icon Button that displays a `<FavoriteBorder />` icon might have a label that looks like this:
 
 ```js
 <IconButton aria-label="Add to favorites">
@@ -110,28 +143,12 @@ They've been omitted from the demo above for the sake of brevity, but an appropr
 </IconButton>
 ```
 
-:::
-
-## Link Button
-
-Buttons let users take actions, but if that action is to navigate to a new page, then an anchor tag may be preferable over a button.
-
-If you need the style of a button with the functionality of a link, you can use the `component` prop to replace the default `<button>` with an `<a>` tag, as shown below:
-
-{{"demo": "ButtonLink.js"}}
-
-## CSS variables
-
-{{"demo": "ButtonVariables.js", "hideToolbar": true}}
-
-{{"demo": "IconButtonVariables.js", "hideToolbar": true}}
-
 ## Anatomy
 
-The Button component is composed of a single root `<button>` element:
+The Button component is composed of a single root `<button>` element that wraps around its contents:
 
 ```html
-<button>
+<button class="JoyButton-root" type="button">
   <!-- Button contents -->
 </button>
 ```


### PR DESCRIPTION
Part of #33998

This PR revises and expands the Joy UI Button doc. Notable changes include:

- rearranging and reformatting to match the latest style
- adding a couple basic demos
- accessibility and anatomy

While I was comparing this doc with its sister in the Base docs, I noticed that the Base page had a tiny inconsistency in how it's organized, so I went ahead and changed that here because it's not worth creating a PR for on its own.