### PR TITLE
[website] Update the Accessibility Engineer role

### DIFF
--- a/docs/src/pages/careers/accessibility-engineer.md
+++ b/docs/src/pages/careers/accessibility-engineer.md
@@ -62,14 +62,13 @@ Depending on the day, you'll:
 
 ### Skills you should have
 
+- **Strong grasp of accessibility techniques in web development** applying HTML5, CSS, ARIA, and JavaScript. You should have held a Front-end Engineer (or closely related) role in the past.
 - **A track record of accessibility experience with both consumer/enterprise products and assistive technologies, such as screen readers, eye control, and other accessibility technologies**.
   If you've been the accessibility champ in a previous company, pushing towards making sure the user interfaces can be used by disabled people, we want you in our team!
 - **Hands-on knowledge of accessibility guidelines and standards** (such as Section 508, WCAG, and EN 301 549) as well as technologies (such as UI Automation, IAccessible, ARIA, and related accessibility APIs)
   You would be the one who the team can go to with any a11y topics/questions.
 - **An advocate of continuous learning;** able to absorb and share new ideas, approaches, and techniques for achieving accessibility.
   Continuous learning is one of the most important parts of this field.
-- **Strong grasp of accessibility techniques in web development** applying HTML5, CSS, ARIA, and JavaScript.
-  We are creating products used on the web.
 - **Experience with assistive technologies across multiple platforms**, including screen readers, magnification, and read-aloud tools.
 
 ### What would be nice if you had, but isn't required


### PR DESCRIPTION
So we can move from reports like this https://www.notion.so/mui-org/Accessibility-Engineer-5fd51889c22c41ec80bacaeebe1c2bd7#a8d5508fa70c42eb9537cfe602a73187 to having them **cleanly** solved (and not half backed solution that degrades the product, overall)

I worked on this based on the applications that we receive https://app.ashbyhq.com/jobs/6df7339b-5cee-4d7d-ad69-701b39eb194b/candidate-pipeline/application-review, the applications are too biased toward candidates that have Accessibility testing experience. I think that it would work x10 better to have a Software Engineer that cares about Accessibility but never did the job than an Accessibility tester that never wrote code. In the former case, the person will grow with the feedback of the community, in the latter case, the person will be stuck.