### PR TITLE
[docs][joy] Update Customization section code example to use the correct API

### DIFF
--- a/docs/data/joy/customization/approaches/approaches.md
+++ b/docs/data/joy/customization/approaches/approaches.md
@@ -80,10 +80,12 @@ const theme = extendTheme({
   components: {
     // The component identifier always start with `Joy${ComponentName}`.
     JoyButton: {
-      styleOverrides: ({ theme }) => ({
-        // theme.vars.* return the CSS variables.
-        fontSize: theme.vars.fontSize.lg, // 'var(--joy-fontSize-lg)'
-      }),
+      styleOverrides: {
+        root: ({theme}) => {
+          // theme.vars.* return the CSS variables.
+          fontSize: theme.vars.fontSize.lg, // 'var(--joy-fontSize-lg)'
+        },
+      },
     },
   },
 });

--- a/docs/data/joy/customization/approaches/approaches.md
+++ b/docs/data/joy/customization/approaches/approaches.md
@@ -81,7 +81,7 @@ const theme = extendTheme({
     // The component identifier always start with `Joy${ComponentName}`.
     JoyButton: {
       styleOverrides: {
-        root: ({theme}) => {
+        root: ({ theme }) => {
           // theme.vars.* return the CSS variables.
           fontSize: theme.vars.fontSize.lg, // 'var(--joy-fontSize-lg)'
         },


### PR DESCRIPTION
Existing code example is invalid. Added a `root` block inside the styleOverrides to fix it

Signed-off-by: Pubudu Dodangoda <pubudu.dodan@gmail.com>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
