### PR TITLE
[examples] Remove `next-env.d.ts` from Next.js examples

### DIFF
--- a/examples/nextjs-with-typescript-v4-migration/.gitignore
+++ b/examples/nextjs-with-typescript-v4-migration/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/nextjs-with-typescript-v4-migration/next-env.d.ts
+++ b/examples/nextjs-with-typescript-v4-migration/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/nextjs-with-typescript/.gitignore
+++ b/examples/nextjs-with-typescript/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts

--- a/examples/nextjs-with-typescript/next-env.d.ts
+++ b/examples/nextjs-with-typescript/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


`next-env.d.ts` should not be committed and should be ignored by version control.

![image](https://user-images.githubusercontent.com/20135478/211303938-f0a7cbac-3e26-4982-9a7f-f95c706f1c3e.png)

Source: https://nextjs.org/docs/basic-features/typescript#existing-projects

---

The default `.gitignore` template for `create-next-app` has also been updated to ignore `next-env.d.ts` in this PR: https://github.com/vercel/next.js/pull/39051