### PR TITLE
[docs] Clarify where to find docs for MUI Base components in Material UI

### DIFF
--- a/docs/data/material/components/click-away-listener/click-away-listener.md
+++ b/docs/data/material/components/click-away-listener/click-away-listener.md
@@ -9,11 +9,11 @@ githubLabel: 'component: ClickAwayListener'
 
 <p class="description">The Click-Away Listener component detects when a click event happens outside of its child element.</p>
 
-## MUI Base
+## This document has moved
 
-:::info
+:::warning
+Please refer to the [Click-Away Listener](/base/react-click-away-listener/) component page in the MUI Base docs for demos and details on usage.
+
 Click-Away Listener is a part of the standalone [MUI Base](/base/getting-started/overview/) component library.
 It is currently re-exported from `@mui/material` for your convenience, but it will be removed from this package in a future major version, after `@mui/base` gets a stable release.
-
-Please refer to the [Click-Away Listener](/base/react-click-away-listener/) component page in the MUI Base docs for examples and details on usage.
 :::

--- a/docs/data/material/components/no-ssr/no-ssr.md
+++ b/docs/data/material/components/no-ssr/no-ssr.md
@@ -8,11 +8,11 @@ components: NoSsr
 
 <p class="description">The No-SSR component defers the rendering of children components from the server to the client.</p>
 
-## MUI Base
+## This document has moved
 
-:::info
+:::warning
+Please refer to the [No-SSR](/base/react-no-ssr/) component page in the MUI Base docs for demos and details on usage.
+
 No-SSR is a part of the standalone [MUI Base](/base/getting-started/overview/) component library.
 It is currently re-exported from `@mui/material` for your convenience, but it will be removed from this package in a future major version, after `@mui/base` gets a stable release.
-
-Please refer to the [No-SSR](/base/react-no-ssr/) component page in the MUI Base docs for examples and details on usage.
 :::

--- a/docs/data/material/components/portal/portal.md
+++ b/docs/data/material/components/portal/portal.md
@@ -9,11 +9,11 @@ githubLabel: 'component: Portal'
 
 <p class="description">The Portal component lets you render its children into a DOM node that exists outside of the Portal's own DOM hierarchy.</p>
 
-## MUI Base
+## This document has moved
 
-:::info
+:::warning
+Please refer to the [Portal](/base/react-portal/) component page in the MUI Base docs for demos and details on usage.
+
 Portal is a part of the standalone [MUI Base](/base/getting-started/overview/) component library.
 It is currently re-exported from `@mui/material` for your convenience, but it will be removed from this package in a future major version, after `@mui/base` gets a stable release.
-
-Please refer to the [Portal](/base/react-portal/) component page in the MUI Base docs for examples and details on usage.
 :::

--- a/docs/data/material/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/material/components/textarea-autosize/textarea-autosize.md
@@ -9,11 +9,11 @@ githubLabel: 'component: TextareaAutosize'
 
 <p class="description">The Textarea Autosize component gives you a textarea HTML element that automatically adjusts its height to match the length of the content within.</p>
 
-## MUI Base
+## This document has moved
 
-:::info
+:::warning
+Please refer to the [Textarea Autosize](/base/react-textarea-autosize/) component page in the MUI Base docs for demos and details on usage.
+
 Textarea Autosize is a part of the standalone [MUI Base](/base/getting-started/overview/) component library.
 It is currently re-exported from `@mui/material` for your convenience, but it will be removed from this package in a future major version, after `@mui/base` gets a stable release.
-
-Please refer to the [Textarea Autosize](/base/react-textarea-autosize/) component page in the MUI Base docs for examples and details on usage.
 :::


### PR DESCRIPTION
https://deploy-preview-35799--material-ui.netlify.app/material-ui/react-portal/

Iterating on doc feedback following #35293, part of #35077.

We received feedback from a user that suggested that they did not understand where to find demos for the MUI Base components that are re-exported in Material UI. 

This PR attempts to make things more clear and obvious by:

- changing the headline on these pages from **MUI Base** to **This document has moved**
- bumping up the callout severity from `info` to `warning` so it's more eye-catching
- moving the most important link—the corresponding MUI Base doc—to the top of the callout

Before:
<img width="880" alt="Screen Shot 2023-01-11 at 12 56 06 PM" src="https://user-images.githubusercontent.com/71297412/211894005-931d7bfb-9ca0-4416-aa03-7ec88d47820d.png">

After:
<img width="875" alt="Screen Shot 2023-01-11 at 12 56 37 PM" src="https://user-images.githubusercontent.com/71297412/211893999-b2544b89-c430-4ff9-8851-bccd6ec703eb.png">
