### PR TITLE
[docs] Revise and expand Joy UI Checkbox doc

### DIFF
--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,5 +1,4 @@
 Broken links found by `yarn docs:link-check` that exist:
 
 - https://mui.com/blog/material-ui-v4-is-out/#premium-themes-store-✨
-- https://mui.com/joy-ui/react-box
 - https://mui.com/size-snapshot

--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,4 +1,5 @@
 Broken links found by `yarn docs:link-check` that exist:
 
 - https://mui.com/blog/material-ui-v4-is-out/#premium-themes-store-✨
+- https://mui.com/joy-ui/react-box
 - https://mui.com/size-snapshot

--- a/docs/data/joy/components/checkbox/CheckboxColors.js
+++ b/docs/data/joy/components/checkbox/CheckboxColors.js
@@ -4,9 +4,13 @@ import Checkbox from '@mui/joy/Checkbox';
 
 export default function CheckboxColors() {
   return (
-    <Box sx={{ display: 'flex', gap: 3 }}>
-      <Checkbox label="Label" />
-      <Checkbox label="Label" defaultChecked />
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 3 }}>
+      <Checkbox label="Primary" color="primary" defaultChecked />
+      <Checkbox label="Neutral" color="neutral" defaultChecked />
+      <Checkbox label="Danger" color="danger" defaultChecked />
+      <Checkbox label="Info" color="info" defaultChecked />
+      <Checkbox label="Success" color="success" defaultChecked />
+      <Checkbox label="Warning" color="warning" defaultChecked />
     </Box>
   );
 }

--- a/docs/data/joy/components/checkbox/CheckboxColors.js
+++ b/docs/data/joy/components/checkbox/CheckboxColors.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Checkbox from '@mui/joy/Checkbox';
+
+export default function CheckboxColors() {
+  return (
+    <Box sx={{ display: 'flex', gap: 3 }}>
+      <Checkbox label="Label" />
+      <Checkbox label="Label" defaultChecked />
+    </Box>
+  );
+}

--- a/docs/data/joy/components/checkbox/CheckboxSizes.js
+++ b/docs/data/joy/components/checkbox/CheckboxSizes.js
@@ -4,9 +4,10 @@ import Checkbox from '@mui/joy/Checkbox';
 
 export default function CheckboxSizes() {
   return (
-    <Box sx={{ display: 'flex', gap: 3 }}>
-      <Checkbox label="Label" />
-      <Checkbox label="Label" defaultChecked />
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 3 }}>
+      <Checkbox label="Small" size="sm" defaultChecked />
+      <Checkbox label="Medium" size="md" defaultChecked />
+      <Checkbox label="Large" size="lg" defaultChecked />
     </Box>
   );
 }

--- a/docs/data/joy/components/checkbox/CheckboxSizes.js
+++ b/docs/data/joy/components/checkbox/CheckboxSizes.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Checkbox from '@mui/joy/Checkbox';
+
+export default function CheckboxSizes() {
+  return (
+    <Box sx={{ display: 'flex', gap: 3 }}>
+      <Checkbox label="Label" />
+      <Checkbox label="Label" defaultChecked />
+    </Box>
+  );
+}

--- a/docs/data/joy/components/checkbox/CheckboxVariants.js
+++ b/docs/data/joy/components/checkbox/CheckboxVariants.js
@@ -5,8 +5,10 @@ import Checkbox from '@mui/joy/Checkbox';
 export default function CheckboxVariants() {
   return (
     <Box sx={{ display: 'flex', gap: 3 }}>
-      <Checkbox label="Label" />
-      <Checkbox label="Label" defaultChecked />
+      <Checkbox label="Solid" variant="solid" />
+      <Checkbox label="Soft" variant="soft" />
+      <Checkbox label="Outlined" variant="outlined" />
+      <Checkbox label="Plain" variant="plain" />
     </Box>
   );
 }

--- a/docs/data/joy/components/checkbox/CheckboxVariants.js
+++ b/docs/data/joy/components/checkbox/CheckboxVariants.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Checkbox from '@mui/joy/Checkbox';
+
+export default function CheckboxVariants() {
+  return (
+    <Box sx={{ display: 'flex', gap: 3 }}>
+      <Checkbox label="Label" />
+      <Checkbox label="Label" defaultChecked />
+    </Box>
+  );
+}

--- a/docs/data/joy/components/checkbox/CheckboxVariants.js
+++ b/docs/data/joy/components/checkbox/CheckboxVariants.js
@@ -5,10 +5,10 @@ import Checkbox from '@mui/joy/Checkbox';
 export default function CheckboxVariants() {
   return (
     <Box sx={{ display: 'flex', gap: 3 }}>
-      <Checkbox label="Solid" variant="solid" />
-      <Checkbox label="Soft" variant="soft" />
-      <Checkbox label="Outlined" variant="outlined" />
-      <Checkbox label="Plain" variant="plain" />
+      <Checkbox label="Solid" variant="solid" defaultChecked />
+      <Checkbox label="Soft" variant="soft" defaultChecked />
+      <Checkbox label="Outlined" variant="outlined" defaultChecked />
+      <Checkbox label="Plain" variant="plain" defaultChecked />
     </Box>
   );
 }

--- a/docs/data/joy/components/checkbox/FocusCheckbox.js
+++ b/docs/data/joy/components/checkbox/FocusCheckbox.js
@@ -6,13 +6,13 @@ export default function FocusCheckbox() {
   return (
     <Box sx={{ display: 'flex', gap: 3 }}>
       <Checkbox
-        label="Label"
+        label="Fully wrapped"
         defaultChecked
         // to demonstrate the focus outline
         slotProps={{ action: { className: checkboxClasses.focusVisible } }}
       />
       <Checkbox
-        label="Label"
+        label="Input wrapped"
         defaultChecked
         sx={{ [`& > .${checkboxClasses.checkbox}`]: { position: 'relative' } }}
         // to demonstrate the focus outline

--- a/docs/data/joy/components/checkbox/GroupCheckboxes.js
+++ b/docs/data/joy/components/checkbox/GroupCheckboxes.js
@@ -9,7 +9,7 @@ export default function GroupCheckboxes() {
   return (
     <Box>
       <Typography id="sandwich-group" level="body2" fontWeight="lg" mb={1}>
-        Sandwich Condiments
+        Sandwich Dressings
       </Typography>
       <Box role="group" aria-labelledby="sandwich-group">
         <List size="sm">

--- a/docs/data/joy/components/checkbox/HelperTextCheckbox.js
+++ b/docs/data/joy/components/checkbox/HelperTextCheckbox.js
@@ -7,7 +7,7 @@ export default function HelperTextCheckbox() {
   return (
     <FormControl>
       <Checkbox label="Label" />
-      <FormHelperText>A description for the checkbox.</FormHelperText>
+      <FormHelperText>A description for the Checkbox.</FormHelperText>
     </FormControl>
   );
 }

--- a/docs/data/joy/components/checkbox/HoverCheckbox.js
+++ b/docs/data/joy/components/checkbox/HoverCheckbox.js
@@ -6,16 +6,16 @@ export default function HoverCheckbox() {
   return (
     <Checkbox
       uncheckedIcon={<Done />}
-      label="Label"
+      label="My unchecked icon appears on hover"
       slotProps={{
         root: ({ checked, focusVisible }) => ({
           sx: !checked
             ? {
-                '& svg': { opacity: focusVisible ? 0.32 : 0 },
-                '&:hover svg': {
-                  opacity: 0.32,
-                },
-              }
+              '& svg': { opacity: focusVisible ? 0.32 : 0 },
+              '&:hover svg': {
+                opacity: 0.32,
+              },
+            }
             : {},
         }),
       }}

--- a/docs/data/joy/components/checkbox/HoverCheckbox.js
+++ b/docs/data/joy/components/checkbox/HoverCheckbox.js
@@ -11,11 +11,11 @@ export default function HoverCheckbox() {
         root: ({ checked, focusVisible }) => ({
           sx: !checked
             ? {
-              '& svg': { opacity: focusVisible ? 0.32 : 0 },
-              '&:hover svg': {
-                opacity: 0.32,
-              },
-            }
+                '& svg': { opacity: focusVisible ? 0.32 : 0 },
+                '&:hover svg': {
+                  opacity: 0.32,
+                },
+              }
             : {},
         }),
       }}

--- a/docs/data/joy/components/checkbox/IconlessCheckbox.js
+++ b/docs/data/joy/components/checkbox/IconlessCheckbox.js
@@ -21,7 +21,7 @@ export default function IconlessCheckbox() {
           }}
         >
           {[
-            'Perpperoni',
+            'Pepperoni',
             'Cheese',
             'Olives',
             'Tomatoes',

--- a/docs/data/joy/components/checkbox/IconsCheckbox.js
+++ b/docs/data/joy/components/checkbox/IconsCheckbox.js
@@ -3,5 +3,7 @@ import Checkbox from '@mui/joy/Checkbox';
 import Close from '@mui/icons-material/Close';
 
 export default function IconsCheckbox() {
-  return <Checkbox uncheckedIcon={<Close />} label="I have an icon when unchecked" />;
+  return (
+    <Checkbox uncheckedIcon={<Close />} label="I have an icon when unchecked" />
+  );
 }

--- a/docs/data/joy/components/checkbox/IconsCheckbox.js
+++ b/docs/data/joy/components/checkbox/IconsCheckbox.js
@@ -3,5 +3,5 @@ import Checkbox from '@mui/joy/Checkbox';
 import Close from '@mui/icons-material/Close';
 
 export default function IconsCheckbox() {
-  return <Checkbox uncheckedIcon={<Close />} label="Label" />;
+  return <Checkbox uncheckedIcon={<Close />} label="I have an icon when unchecked" />;
 }

--- a/docs/data/joy/components/checkbox/OverlayCheckbox.js
+++ b/docs/data/joy/components/checkbox/OverlayCheckbox.js
@@ -15,11 +15,11 @@ export default function OverlayCheckbox() {
       }}
     >
       <Sheet variant="outlined" sx={{ bgcolor: 'background.body' }}>
-        <Checkbox overlay label="It works with any parent" />
+        <Checkbox overlay label="Focus on me" />
       </Sheet>
       <Sheet variant="outlined" sx={{ bgcolor: 'background.body' }}>
         <Checkbox
-          label="Focus outline covers the parent!"
+          label="My parent receives focus"
           overlay
           // Force the outline to appear in the demo. Usually, you don't need this in your project.
           slotProps={{ action: { className: checkboxClasses.focusVisible } }}

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -104,7 +104,7 @@ To set the focus outline so that it only wraps the input, target the `checkboxCl
 ### Clickable container
 
 Use the `overlay` prop to shift the focus outline from the Checkbox to its container, making the entire container clickable to toggle the state of the Checkbox.
-This works with any wrapper element—the demo below uses [Sheet](/joy-ui/react-sheet/):
+This works with any wrapper element with [positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning)—the demo below uses [Sheet](/joy-ui/react-sheet/) (by default, it has `relative` position):
 
 {{"demo": "OverlayCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -42,9 +42,10 @@ Use the `label` prop to provide text, and add `defaultChecked` when the input sh
 
 ### Variants
 
-The Checkbox component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid`, `soft`, `outlined`, and `plain`.
-When unchecked, the Checkbox is set to `outlined`.
-When checked, the variant changes to `solid`. 
+The Checkbox component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid`, `soft`, `outlined`, and `plain`. By default, when unchecked, the Checkbox is set to `outlined`;
+when checked, the variant changes to `solid`.
+
+Adding the `variant` prop to your Checkbox overrides this default behavior. Try checking and unchecking the Checkboxes in the demo below to see the differences:
 
 {{"demo": "CheckboxVariants.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -67,7 +67,6 @@ To learn how to add custom sizes to the component, check out [Themed componentsâ
 ### Colors
 
 Every palette included in the theme is available via the `color` prop.
-Play around combining different colors with different variants.
 
 {{"demo": "CheckboxColors.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -75,8 +75,8 @@ Try clicking on the Checkbox labels in the demo below to see how this works:
 
 ### Focus outline
 
-The focus outline, by default, wraps both the checkbox itself and its label.
-To change that, target the `checkboxClasses.checkbox` class and add `position: 'relative'`.
+By default, the focus outline wraps both the Checkbox input and its label.
+To set the focus outline so that it only wraps the input, target the `checkboxClasses.checkbox` class and add `position: 'relative'`, as shown in the demo below:
 
 {{"demo": "FocusCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -94,7 +94,7 @@ The default Checkbox is _dual-state:_ the user can toggle between checked and un
 There is, however, the option for a _tri-state_ or indeterminate Checkbox that supports a state known as "partially checked."
 
 This indeterminate state is often used to communicate the fact that only some out of a set of Checkboxes are checked.
-As such, it's usually reserved for parent Checkboxes that can control the the state of their children.
+As such, it's usually reserved for parent Checkboxes that can control the states of their children.
 
 The demo below shows how to implement the `indeterminate` prop on a parent Checkbox that watches for the checked state in its children.
 If only one child is checked, the parent will display the indeterminate state.

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -59,7 +59,9 @@ You can also use `checkedIcon` to customize the checked state.
 
 #### Appear on hover
 
-Target the icon by using the `svg` selector and then use `opacity` to show the unchecked icon when hovering over the Checkbox.
+You can use the `uncheckedIcon` as a "preview" of the checked state by making it appear when the user hovers over the empty Checkbox.
+
+The demo below shows how to target the icon by using the `svg` selector and apply `opacity` for a smooth effect:
 
 {{"demo": "HoverCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -101,6 +101,11 @@ It has no accessibility or UX implications.
 
 ### Helper text
 
+```jsx
+import FormControl from '@mui/joy/FormControl';
+import FormHelperText from '@mui/joy/FormHelperText';
+```
+
 Use the Form Control and Form Helper Text components add a description to the Checkbox. 
 The Checkbox will be linked to the helper text via the `aria-describedby` attribute.
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -80,12 +80,21 @@ To set the focus outline so that it only wraps the input, target the `checkboxCl
 
 {{"demo": "FocusCheckbox.js"}}
 
+### Clickable container
+
+Use the `overlay` prop to shift the focus outline from the Checkbox to its container, making the entire container clickable to toggle the state of the Checkbox.
+This works with any wrapper element—the demo below uses [Sheet](/joy-ui/react-sheet/):
+
+{{"demo": "OverlayCheckbox.js"}}
+
 ### Indeterminate
 
-Technically, the Checkbox component has only two states: checked or unchecked.
-Visually, however, there is an alternate checked state possible called _indeterminate_, which you might think of as an "in-between" state.
+The default Checkbox is _dual-state:_ the user can toggle between checked and unchecked.
 
-The indeterminate state is often used to communicate the fact that only some out of a set of Checkboxes are checked.
+There is, however, the option for a _tri-state_ or indeterminate Checkbox that supports a state known as "partially checked."
+
+This indeterminate state is often used to communicate the fact that only some out of a set of Checkboxes are checked.
+As such, it's usually reserved for parent Checkboxes that can control the the state of their children.
 
 The demo below shows how to implement the `indeterminate` prop on a parent Checkbox that watches for the checked state in its children.
 If only one child is checked, the parent will display the indeterminate state.
@@ -96,7 +105,6 @@ When the indeterminate state is set, the value of the `checked` prop only impact
 It has no accessibility or UX implications.
 :::
 
-
 {{"demo": "IndeterminateCheckbox.js"}}
 
 ### Helper text
@@ -106,7 +114,7 @@ import FormControl from '@mui/joy/FormControl';
 import FormHelperText from '@mui/joy/FormHelperText';
 ```
 
-Use the Form Control and Form Helper Text components add a description to the Checkbox. 
+Use the Form Control and Form Helper Text components add a description to the Checkbox.
 The Checkbox will be linked to the helper text via the `aria-describedby` attribute.
 
 {{"demo": "HelperTextCheckbox.js"}}
@@ -119,12 +127,6 @@ Combine with the [List](/joy-ui/react-list/) component to ensure consistent spac
 Learn more about accessible design patterns for checkboxes [in the W3C documentation](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox.html).
 
 {{"demo": "GroupCheckboxes.js"}}
-
-### Overlay
-
-Use the `overlay` prop to make the entire surface of the wrapper container the checkbox is in clickable.
-
-{{"demo": "OverlayCheckbox.js"}}
 
 ## Common examples
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -21,7 +21,7 @@ When should you use checkboxes rather than switches or radio buttons?
 
 - Use a switch to provide the user with **a single binary choice**—checkboxes are preferable when you need to give the user multiple binary choices.
 - Use radio buttons to give the user **mutually exclusive options**—checkboxes are preferable when you need to let the user select one, some, all, or none from a series of options.
-:::
+  :::
 
 {{"demo": "CheckboxUsage.js", "hideToolbar": true, "bg": "gradient"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -113,10 +113,10 @@ The Checkbox will be linked to the helper text via the `aria-describedby` attrib
 
 ### Group
 
-To group multiple checkboxes, use `role="group"` on the wrapper component.
+To group multiple Checkboxes, wrap them in a container component like [Box](/joy-ui/react-box/) with `role="group"`.
 
-Combine with the [`List`](/joy-ui/react-list/) component to ensure consistent spacing and enable screen readers to interpret the checkbox group as a list.
-Learn more about checkbox accessible design patters [in the W3C documentation](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox.html).
+Combine with the [List](/joy-ui/react-list/) component to ensure consistent spacing and enable screen readers to interpret the Checkbox group as a list.
+Learn more about accessible design patterns for checkboxes [in the W3C documentation](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox.html).
 
 {{"demo": "GroupCheckboxes.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -166,7 +166,7 @@ Don't forget to use the `label` prop to ensure proper Checkbox accessibility.
 
 ### Choice chips
 
-You can use Checkbox to recreate a kind of [Chip](/material-ui/react-chip/) component, which is commonly implemented in the form of a group of filtering options.
+You can use Checkbox to recreate a kind of [Chip](/joy-ui/react-chip/) component, which is commonly implemented in the form of a group of filtering options.
 
 {{"demo": "ExampleChoiceChipCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -42,12 +42,33 @@ Use the `label` prop to provide text, and add `defaultChecked` when the input sh
 
 ### Variants
 
-When unchecked, the checkbox component uses the `outlined` variant.
-When checked, the variant changes to `solid`. See [Variants](#variants) for more details.
+The Checkbox component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid`, `soft`, `outlined`, and `plain`.
+When unchecked, the Checkbox is set to `outlined`.
+When checked, the variant changes to `solid`. 
+
+{{"demo": "CheckboxVariants.js"}}
+
+:::info
+To learn how to add your own variants, check out [Themed components—Extend variants](/joy-ui/customization/themed-components/#extend-variants).
+Note that you lose the global variants when you add custom variants.
+:::
 
 ### Sizes
 
+The Checkbox component comes in three sizes: `sm`, `md` (default), and `lg`.
+
+{{"demo": "CheckboxSizes.js"}}
+
+:::info
+To learn how to add custom sizes to the component, check out [Themed components—Extend sizes](/joy-ui/customization/themed-components/#extend-sizes).
+:::
+
 ### Colors
+
+Every palette included in the theme is available via the `color` prop.
+Play around combining different colors with different variants.
+
+{{"demo": "CheckboxColors.js"}}
 
 ### Icons
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -142,7 +142,7 @@ The Checkbox will be linked to the helper text via the `aria-describedby` attrib
 
 ### Group
 
-To group multiple Checkboxes, wrap them in a container component like [Box](/joy-ui/react-box/) with `role="group"`.
+To group multiple Checkboxes, wrap them in a container component like Box with `role="group"`.
 
 Combine with the [List](/joy-ui/react-list/) component to ensure consistent spacing and enable screen readers to interpret the Checkbox group as a list.
 Learn more about accessible design patterns for checkboxes [in the W3C documentation](https://www.w3.org/WAI/ARIA/apg/example-index/checkbox/checkbox.html).

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -82,22 +82,27 @@ To set the focus outline so that it only wraps the input, target the `checkboxCl
 
 ### Indeterminate
 
-Technically, the checkbox component only has two states: checked or unchecked.
-However, visually, there is a third state called _indeterminate_.
+Technically, the Checkbox component has only two states: checked or unchecked.
+Visually, however, there is an alternate checked state possible called _indeterminate_, which you might think of as an "in-between" state.
 
-It's common to find it in tables where you have one checkbox that selects every table row.
-Use the `indeterminate` prop to circle around these states.
+The indeterminate state is often used to communicate the fact that only some out of a set of Checkboxes are checked.
+
+The demo below shows how to implement the `indeterminate` prop on a parent Checkbox that watches for the checked state in its children.
+If only one child is checked, the parent will display the indeterminate state.
+Clicking on the parent Checkbox toggles selecting and deselecting all children.
 
 :::warning
 When the indeterminate state is set, the value of the `checked` prop only impacts the form submitted values.
 It has no accessibility or UX implications.
 :::
 
+
 {{"demo": "IndeterminateCheckbox.js"}}
 
 ### Helper text
 
-To add a description to the checkbox, use `FormControl` and `FormHelperText`. The checkbox will be linked to the helper text via `aria-describedby` attribute.
+Use the Form Control and Form Helper Text components add a description to the Checkbox. 
+The Checkbox will be linked to the helper text via the `aria-describedby` attribute.
 
 {{"demo": "HelperTextCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -173,3 +173,21 @@ You can use Checkbox to recreate a kind of [Chip](/material-ui/react-chip/) comp
 ### Viewport checklist
 
 {{"demo": "ExampleButtonCheckbox.js"}}
+
+## Anatomy
+
+The Checkbox component is composed of a root `<span>` that wraps the input and `<label>` (if present).
+Note that the actual `<input type="checkbox">` is doubly nested within `<span>` elements that represent the `checkbox` and `action` slots, respectively.
+
+```html
+<span class="JoyCheckbox-root">
+  <span class="JoyCheckbox-checkbox">
+    <span class="JoyCheckbox-action">
+      <input type="checkbox" class="JoyCheckbox-input" value />
+    </span>
+  </span>
+  <label class="JoyCheckbox-label">
+    <!-- label text -->
+  </label>
+</span>
+```

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -91,17 +91,17 @@ This works with any wrapper element—the demo below uses [Sheet](/joy-ui/react-
 
 The default Checkbox is _dual-state:_ the user can toggle between checked and unchecked.
 
-There is, however, the option for a _tri-state_ or indeterminate Checkbox that supports a state known as "partially checked."
+There is also the option for a _tri-state_ or indeterminate Checkbox that supports a state known as "partially checked."
 
 This indeterminate state is often used to communicate the fact that only some out of a set of Checkboxes are checked.
 As such, it's usually reserved for parent Checkboxes that can control the states of their children.
 
 The demo below shows how to implement the `indeterminate` prop on a parent Checkbox that watches for the checked state in its children.
-If only one child is checked, the parent will display the indeterminate state.
+If only one child is checked, then the parent displays the indeterminate state.
 Clicking on the parent Checkbox toggles selecting and deselecting all children.
 
 :::warning
-When the indeterminate state is set, the value of the `checked` prop only impacts the form submitted values.
+When the indeterminate state is set, the value of the `checked` prop only impacts form-submitted values.
 It has no accessibility or UX implications.
 :::
 
@@ -132,21 +132,20 @@ Learn more about accessible design patterns for checkboxes [in the W3C documenta
 
 ### Filtering status
 
-In this example, we're using variants _and_ colors, within the `ListItem` and `Checkbox` component, to communicate state changes
+This example uses variants and colors available to the List Item and Checkbox components to communicate state changes.
 
 {{"demo": "ExampleFilterStatusCheckbox.js"}}
 
 ### Filtering members
 
-Note that in this example, we're using the CSS `flexDirection: 'rowReverse'` property to properly position the label and icon.
-
-Don't forget to use the `label` prop to ensure proper checkbox accessibility.
+This example uses the CSS `flexDirection: 'rowReverse'` property to position the label and icon.
+Don't forget to use the `label` prop to ensure proper Checkbox accessibility.
 
 {{"demo": "ExampleFilterMemberCheckbox.js"}}
 
 ### Choice chips
 
-You can use checkboxes to create a chip alike design, most often used to filter between different options.
+You can use Checkbox to recreate a kind of [Chip](/material-ui/react-chip/) component, which is commonly implemented in the form of a group of filtering options.
 
 {{"demo": "ExampleChoiceChipCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -25,52 +25,49 @@ When should you use checkboxes rather than switches or radio buttons?
 
 {{"demo": "CheckboxUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
-:::info
-To learn how to add more variants or sizes to the component, check out the [Themed components](/joy-ui/customization/themed-components/) page.
-:::
-
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
-## Component
-
-After [installation](/joy-ui/getting-started/installation/), you can start building with this component using the following basic elements:
+## Basics
 
 ```jsx
-import Box from '@mui/joy/Box';
 import Checkbox from '@mui/joy/Checkbox';
-
-export default function MyApp() {
-  return (
-    <Box>
-      <Checkbox label="Hello world!" />
-    </Box>
-  );
-}
 ```
 
-### Checked
-
-When unchecked, the checkbox component uses the `outlined` variant.
-When checked, the variant changes to `solid`.
+The basic Checkbox component is a single input set to the unchecked state.
+Use the `label` prop to provide text, and add `defaultChecked` when the input should be checked by default.
 
 {{"demo": "BasicCheckbox.js"}}
 
-### Icon
+## Customization
 
-`Checkbox`, by default, comes without an unchecked component.
-To add an icon to both uncheck and checked states, use the `uncheckedIcon` and `checkedIcon` props.
+### Variants
+
+When unchecked, the checkbox component uses the `outlined` variant.
+When checked, the variant changes to `solid`. See [Variants](#variants) for more details.
+
+### Sizes
+
+### Colors
+
+### Icons
+
+By default, the Checkbox component is empty when unchecked.
+Use the `uncheckedIcon` prop to add a custom icon for the unchecked state.
+You can also use `checkedIcon` to customize the checked state.
 
 {{"demo": "IconsCheckbox.js"}}
 
 #### Appear on hover
 
-Target the icon by using the `svg` selector and then use `opacity` to show the unchecked icon when hovering the checkbox.
+Target the icon by using the `svg` selector and then use `opacity` to show the unchecked icon when hovering over the Checkbox.
 
 {{"demo": "HoverCheckbox.js"}}
 
-#### Without an icon
+#### No icons
 
-To rely only on variants to communicate the checkbox state change, use the `disableIcon` prop to remove the icon.
+Use the `disableIcon` prop to remove the icon entirely.
+In this case, the state of the Checkbox is communicated through the type of variant applied to the label.
+Try clicking on the Checkbox labels in the demo below to see how this works:
 
 {{"demo": "IconlessCheckbox.js"}}
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -7,12 +7,21 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 
 # Checkbox
 
-<p class="description">Checkboxes allow the user to select one or more items from a set.</p>
+<p class="description">Checkboxes give users binary choices when presented with multiple options in a series.</p>
 
 ## Introduction
 
-The `Checkbox` component is the one to be used when you want to allow users to select multiple options.
-For toggling between on and off or single option selection, consider using a switch or radio button, respectively.
+Checkboxes provide users with a graphical representation of a binary choice (yes or no, on or off).
+They are most commonly presented in a series, giving the user multiple choices to make.
+
+The Joy UI Checkbox component replaces the native HTML `<input type="checkbox">` element, and offers expanded options for styling and accessibility.
+
+:::success
+When should you use checkboxes rather than switches or radio buttons?
+
+- Use a switch to provide the user with **a single binary choice**—checkboxes are preferable when you need to give the user multiple binary choices.
+- Use radio buttons to give the user **mutually exclusive options**—checkboxes are preferable when you need to let the user select one, some, all, or none from a series of options.
+:::
 
 {{"demo": "CheckboxUsage.js", "hideToolbar": true, "bg": "gradient"}}
 


### PR DESCRIPTION
Part of #33998 

This PR revises and expands the Joy UI Checkbox component doc.

Notable changes include:

- expanded Introduction with guidance on usage vs Switches and Radio Buttons
- details on Variants, Sizes, and Colors, along with demos showing off all options
- more descriptive Label text for demos
- clarifying the "indeterminate" state
- additional details throughout all sections
- anatomy

https://deploy-preview-35817--material-ui.netlify.app/joy-ui/react-checkbox/