### PR TITLE
[POC] Add the `slotClasses` prop

### DIFF
--- a/docs/pages/experiments/base/slotClasses.tsx
+++ b/docs/pages/experiments/base/slotClasses.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { styled } from '@mui/system';
+import SwitchUnstyled, {
+  SlotClasses,
+  switchUnstyledClasses,
+  SwitchUnstyledOwnerState,
+  SwitchUnstyledProps,
+} from '@mui/base/SwitchUnstyled';
+
+const blue = {
+  500: '#007FFF',
+};
+
+const grey = {
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+};
+
+const Root = styled('span')(
+  ({ theme }) => `
+  font-size: 0;
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 24px;
+  margin: 10px;
+  cursor: pointer;
+
+  &.${switchUnstyledClasses.disabled} {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  & .${switchUnstyledClasses.track} {
+    background: ${theme.palette.mode === 'dark' ? grey[600] : grey[400]};
+    border-radius: 16px;
+    display: block;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+
+  & .${switchUnstyledClasses.thumb} {
+    display: block;
+    width: 16px;
+    height: 16px;
+    top: 4px;
+    left: 4px;
+    border-radius: 16px;
+    background-color: #fff;
+    position: relative;
+    
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 120ms;
+  }
+
+  &.${switchUnstyledClasses.focusVisible} .${switchUnstyledClasses.thumb} {
+    background-color: ${grey[500]};
+    box-shadow: 0 0 1px 8px rgba(0, 0, 0, 0.25);
+  }
+
+  &.${switchUnstyledClasses.checked} {
+    .${switchUnstyledClasses.thumb} {
+      left: 20px;
+      top: 4px;
+      background-color: #fff;
+    }
+
+    .${switchUnstyledClasses.track} {
+      background: ${blue[500]};
+    }
+  }
+
+  & .${switchUnstyledClasses.input} {
+    cursor: inherit;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: 1;
+    margin: 0;
+  }
+  `,
+);
+
+export default function UnstyledSwitches() {
+  const slots = { root: Root };
+  const slotProps: SwitchUnstyledProps['slotProps'] = {
+    input: { 'aria-label': 'Demo switch' },
+  };
+
+  const slotClasses: SlotClasses<'root' | 'thumb', SwitchUnstyledOwnerState> = (
+    ownerState: SwitchUnstyledOwnerState,
+  ) => ({
+    root: ownerState.checked ? 'checked' : 'unchecked',
+    thumb: ownerState.focusVisible ? 'focusVisible' : 'focusNotVisible',
+  });
+
+  return <SwitchUnstyled slots={slots} slotProps={slotProps} slotClasses={slotClasses} />;
+}

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.tsx
@@ -59,6 +59,7 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     onFocusVisible,
     readOnly: readOnlyProp,
     required,
+    slotClasses = {},
     slotProps = {},
     slots = {},
     ...other
@@ -97,6 +98,8 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     },
     ownerState,
     className: classes.root,
+    slotClasses,
+    slotName: 'root',
   });
 
   const Thumb: React.ElementType = slots.thumb ?? 'span';
@@ -105,6 +108,8 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     externalSlotProps: slotProps.thumb,
     ownerState,
     className: classes.thumb,
+    slotClasses,
+    slotName: 'thumb',
   });
 
   const Input: React.ElementType = slots.input ?? 'input';
@@ -114,6 +119,8 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     externalSlotProps: slotProps.input,
     ownerState,
     className: classes.input,
+    slotClasses,
+    slotName: 'input',
   });
 
   const Track: React.ElementType = slots.track === null ? () => null : slots.track ?? 'span';
@@ -122,6 +129,8 @@ const SwitchUnstyled = React.forwardRef(function SwitchUnstyled<
     externalSlotProps: slotProps.track,
     ownerState,
     className: classes.track,
+    slotClasses,
+    slotName: 'track',
   });
 
   return (

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -4,11 +4,20 @@ import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types'
 
 export interface SwitchUnstyledComponentsPropsOverrides {}
 
+export type SlotClasses<SlotName extends string, OwnerState> =
+  | {
+      [key in SlotName]?: string;
+    }
+  | ((ownerState: OwnerState) => {
+      [key in SlotName]?: string;
+    });
+
 export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   /**
    * Class name applied to the root element.
    */
   className?: string;
+  slotClasses?: SlotClasses<'root' | 'thumb' | 'input' | 'track', SwitchUnstyledOwnerState>;
   /**
    * The components used for each slot inside the Switch.
    * Either a string to use a HTML element or a component.


### PR DESCRIPTION
**DO NOT MERGE**

This is a POC of the simpler className customization. The introduced `slotClasses` prop is an object with fields being shortcuts to `slotProps.*.className`