### PR TITLE
[TextareaAutosize] Fix scroll jump when used in the `DataGrid`

### DIFF
--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.js
@@ -4,7 +4,6 @@ import { flushSync } from 'react-dom';
 import {
   unstable_debounce as debounce,
   unstable_useForkRef as useForkRef,
-  unstable_useEnhancedEffect as useEnhancedEffect,
   unstable_ownerWindow as ownerWindow,
 } from '@mui/utils';
 
@@ -182,7 +181,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
     };
   });
 
-  useEnhancedEffect(() => {
+  React.useEffect(() => {
     syncHeight();
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/35823

Before: https://codesandbox.io/s/nifty-tesla-6gx3lp?file=/src/datagrid.js
After: https://codesandbox.io/s/friendly-scooby-jw2bt8?file=/src/datagrid.js
