### PR TITLE
[docs] Fix incorrectly named AccessibleTable demo component

### DIFF
--- a/docs/data/material/components/tables/AccessibleTable.js
+++ b/docs/data/material/components/tables/AccessibleTable.js
@@ -17,7 +17,7 @@ const rows = [
   createData('Eclair', 262, 16.0, 24, 6.0),
 ];
 
-export default function AcccessibleTable() {
+export default function AccessibleTable() {
   return (
     <TableContainer component={Paper}>
       <Table sx={{ minWidth: 650 }} aria-label="caption table">

--- a/docs/data/material/components/tables/AccessibleTable.tsx
+++ b/docs/data/material/components/tables/AccessibleTable.tsx
@@ -23,7 +23,7 @@ const rows = [
   createData('Eclair', 262, 16.0, 24, 6.0),
 ];
 
-export default function AcccessibleTable() {
+export default function AccessibleTable() {
   return (
     <TableContainer component={Paper}>
       <Table sx={{ minWidth: 650 }} aria-label="caption table">

--- a/docs/data/material/components/tables/tables-pt.md
+++ b/docs/data/material/components/tables/tables-pt.md
@@ -120,7 +120,7 @@ No exemplo a seguir, nós demonstramos como usar [react-virtualized](https://git
 
 A caption functions like a heading for a table. Most screen readers announce the content of captions. Captions help users to find a table and understand what it's about and decide if they want to read it.
 
-{{"demo": "AcccessibleTable.js", "bg": true}}
+{{"demo": "AccessibleTable.js", "bg": true}}
 
 ## Unstyled
 

--- a/docs/data/material/components/tables/tables-zh.md
+++ b/docs/data/material/components/tables/tables-zh.md
@@ -120,7 +120,7 @@ Here is an example of a table with scrollable rows and fixed column headers. It 
 
 A caption functions like a heading for a table. Most screen readers announce the content of captions. Captions help users to find a table and understand what it's about and decide if they want to read it.
 
-{{"demo": "AcccessibleTable.js", "bg": true}}
+{{"demo": "AccessibleTable.js", "bg": true}}
 
 ## Unstyled
 

--- a/docs/data/material/components/tables/tables.md
+++ b/docs/data/material/components/tables/tables.md
@@ -129,7 +129,7 @@ Virtualization helps with performance issues.
 
 A caption functions like a heading for a table. Most screen readers announce the content of captions. Captions help users to find a table and understand what it's about and decide if they want to read it.
 
-{{"demo": "AcccessibleTable.js", "bg": true}}
+{{"demo": "AccessibleTable.js", "bg": true}}
 
 ## Unstyled
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Noticed there was a misspelling for `AccessibleTable` so wanted to put a fix in

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
