### PR TITLE
[usePreviousProps] Improve types for usePreviousProps

### DIFF
--- a/packages/mui-base/src/BadgeUnstyled/useBadge.ts
+++ b/packages/mui-base/src/BadgeUnstyled/useBadge.ts
@@ -16,7 +16,7 @@ export default function useBadge(parameters: UseBadgeParameters) {
     showZero = false,
   } = parameters;
 
-  const prevProps: Partial<UseBadgeParameters> = usePreviousProps({
+  const prevProps = usePreviousProps({
     badgeContent: badgeContentProp,
     max: maxProp,
   });

--- a/packages/mui-joy/src/Badge/Badge.tsx
+++ b/packages/mui-joy/src/Badge/Badge.tsx
@@ -163,7 +163,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
     badgeInset: badgeInsetProp,
     color: colorProp,
     variant: variantProp,
-  }) as BadgeProps;
+  });
 
   let invisible = invisibleProp;
 

--- a/packages/mui-utils/src/usePreviousProps.ts
+++ b/packages/mui-utils/src/usePreviousProps.ts
@@ -1,11 +1,15 @@
 import * as React from 'react';
 
+type AddUndefined<Value> = {
+  [Property in keyof Value]: Value[Property] | undefined;
+};
+
 const usePreviousProps = <T>(value: T) => {
   const ref = React.useRef<T | {}>({});
   React.useEffect(() => {
     ref.current = value;
   });
-  return ref.current;
+  return ref.current as AddUndefined<T>;
 };
 
 export default usePreviousProps;

--- a/packages/mui-utils/src/usePreviousProps.ts
+++ b/packages/mui-utils/src/usePreviousProps.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type AddUndefined<T> = {
+type PartialProps<T> = {
   [Property in keyof T]?: T[Property];
 };
 
@@ -9,7 +9,7 @@ const usePreviousProps = <T>(value: T) => {
   React.useEffect(() => {
     ref.current = value;
   });
-  return ref.current as AddUndefined<T>;
+  return ref.current as PartialProps<T>;
 };
 
 export default usePreviousProps;

--- a/packages/mui-utils/src/usePreviousProps.ts
+++ b/packages/mui-utils/src/usePreviousProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 type AddUndefined<T> = {
-  [Property in keyof T]: T[Property] | undefined;
+  [Property in keyof T]?: T[Property];
 };
 
 const usePreviousProps = <T>(value: T) => {

--- a/packages/mui-utils/src/usePreviousProps.ts
+++ b/packages/mui-utils/src/usePreviousProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-const usePreviousProps = (value: object): object => {
-  const ref = React.useRef({});
+const usePreviousProps = <T>(value: T) => {
+  const ref = React.useRef<T | {}>({});
   React.useEffect(() => {
     ref.current = value;
   });

--- a/packages/mui-utils/src/usePreviousProps.ts
+++ b/packages/mui-utils/src/usePreviousProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-type AddUndefined<Value> = {
-  [Property in keyof Value]: Value[Property] | undefined;
+type AddUndefined<T> = {
+  [Property in keyof T]: T[Property] | undefined;
 };
 
 const usePreviousProps = <T>(value: T) => {

--- a/packages/mui-utils/src/usePreviousProps.ts
+++ b/packages/mui-utils/src/usePreviousProps.ts
@@ -1,15 +1,11 @@
 import * as React from 'react';
 
-type PartialProps<T> = {
-  [Property in keyof T]?: T[Property];
-};
-
 const usePreviousProps = <T>(value: T) => {
   const ref = React.useRef<T | {}>({});
   React.useEffect(() => {
     ref.current = value;
   });
-  return ref.current as PartialProps<T>;
+  return ref.current as Partial<T>;
 };
 
 export default usePreviousProps;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Also removed unnessary casting 

https://github.com/mui/material-ui/pull/35833/files#diff-725c98d6ab0aa97869894d8da37e4e2c0e9c01bc80c1d0068632eabeacf8367fL166

**_Ignore unnessary suggestions in before picture, those are generated by vscode_**

Before: 
<img width="774" alt="Screenshot 2023-01-15 at 9 54 04 AM" src="https://user-images.githubusercontent.com/60743144/212522883-1a26ca49-20dd-4f99-8bfc-033f11f22d51.png">

After: 
<img width="772" alt="Screenshot 2023-01-15 at 9 54 24 AM" src="https://user-images.githubusercontent.com/60743144/212522890-d4470c9d-1cb8-4be4-ae5b-db82c95c9bde.png">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
