### PR TITLE
[ListboxUnstyled] Fix option state highlighted to prevent unnecessary focus

### DIFF
--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -267,7 +267,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
     return {
       selected,
       disabled,
-      highlighted: highlightedIndex === index,
+      highlighted: highlightedIndex === index && index !== -1,
     };
   };
 

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.test.tsx
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.test.tsx
@@ -41,10 +41,6 @@ describe('MenuUnstyled', () => {
   describe('after initialization', () => {
     const spyFocus = spy();
 
-    afterEach(() => {
-      spyFocus.resetHistory();
-    });
-
     const Test = () => {
       React.useEffect(() => {
         document.addEventListener('focus', spyFocus, true);

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.test.tsx
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.test.tsx
@@ -51,16 +51,16 @@ describe('MenuUnstyled', () => {
 
       return (
         <MenuUnstyled {...defaultProps}>
-          <MenuItemUnstyled data-testid="item-1">1</MenuItemUnstyled>
-          <MenuItemUnstyled data-testid="item-2">2</MenuItemUnstyled>
-          <MenuItemUnstyled data-testid="item-3">3</MenuItemUnstyled>
+          <MenuItemUnstyled>1</MenuItemUnstyled>
+          <MenuItemUnstyled>2</MenuItemUnstyled>
+          <MenuItemUnstyled>3</MenuItemUnstyled>
         </MenuUnstyled>
       );
     }
 
-    it('when menu is opened it highlights one item and it must be the first one', () => {
-      const { getAllByTestId } = render(<Test />);
-      const [firstItem, ...otherItems] = getAllByTestId(/^item-/);
+    it('highlights the first item when the menu is opened', () => {
+      const { getAllByRole } = render(<Test />);
+      const [firstItem, ...otherItems] = getAllByRole('menuitem');
 
       expect(firstItem.tabIndex).to.equal(0);
       otherItems.forEach((item) => {

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.test.tsx
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.test.tsx
@@ -41,7 +41,7 @@ describe('MenuUnstyled', () => {
   describe('after initialization', () => {
     const spyFocus = spy();
 
-    const Test = () => {
+    function Test() {
       React.useEffect(() => {
         document.addEventListener('focus', spyFocus, true);
         return () => {
@@ -56,7 +56,7 @@ describe('MenuUnstyled', () => {
           <MenuItemUnstyled data-testid="item-3">3</MenuItemUnstyled>
         </MenuUnstyled>
       );
-    };
+    }
 
     it('when menu is opened it highlights one item and it must be the first one', () => {
       const { getAllByTestId } = render(<Test />);


### PR DESCRIPTION
close #35780

This fix the bad focus on options when the list is initialized, In this case the findIndex will always return -1 for the index of the option because the array options is not filled yet.

**before:** https://codesandbox.io/s/k0zipv?file=/demo.js:0-1083
**after:** https://codesandbox.io/s/fix-listbox-uvx06z?file=/demo.js

### Problem
`highlighted: highlightedIndex === index, // this will be always true as long as the options array is empty`

### Fix
Force condition by checking index is not equal to -1 when the options is empty

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).