### PR TITLE
[core]  Migrate internal `docs-utilities` package to TypeScript

### DIFF
--- a/packages/docs-utilities/index.d.ts
+++ b/packages/docs-utilities/index.d.ts
@@ -1,7 +1,0 @@
-export function getLineFeed(source: string): string;
-
-export function fixBabelGeneratorIssues(source: string): string;
-
-export function fixLineEndings(source: string, target: string): string;
-
-export function getUnstyledFilename(filename: string, definitionFile?: boolean): string;

--- a/packages/docs-utilities/index.d.ts
+++ b/packages/docs-utilities/index.d.ts
@@ -4,4 +4,4 @@ export function fixBabelGeneratorIssues(source: string): string;
 
 export function fixLineEndings(source: string, target: string): string;
 
-export function getUnstyledFilename(filename: string, definitionFile: boolean = false): string;
+export function getUnstyledFilename(filename: string, definitionFile?: boolean): string;

--- a/packages/docs-utilities/index.ts
+++ b/packages/docs-utilities/index.ts
@@ -3,7 +3,7 @@ const { EOL } = require('os');
 /**
  * @param {string} source
  */
-function getLineFeed(source) {
+function getLineFeed(source: string): string {
   const match = source.match(/\r?\n/);
   return match === null ? EOL : match[0];
 }
@@ -12,7 +12,7 @@ const fixBabelIssuesRegExp = /(?<=(\/>)|,)(\r?\n){2}/g;
 /**
  * @param {string} source
  */
-function fixBabelGeneratorIssues(source) {
+function fixBabelGeneratorIssues(source: string): string {
   return source.replace(fixBabelIssuesRegExp, '\n');
 }
 
@@ -20,7 +20,7 @@ function fixBabelGeneratorIssues(source) {
  * @param {string} source
  * @param {string} target
  */
-function fixLineEndings(source, target) {
+function fixLineEndings(source: string, target: string): string {
   return target.replace(/\r?\n/g, getLineFeed(source));
 }
 
@@ -28,7 +28,7 @@ function fixLineEndings(source, target) {
  * Converts styled or regular component d.ts file to unstyled d.ts
  * @param {string} filename - the file of the styled or regular mui component
  */
-function getUnstyledFilename(filename, definitionFile = false) {
+function getUnstyledFilename(filename: string, definitionFile: boolean = false) {
   if (filename.indexOf('Unstyled') > -1) {
     return filename;
   }

--- a/packages/docs-utilities/package.json
+++ b/packages/docs-utilities/package.json
@@ -2,5 +2,5 @@
   "name": "@mui-internal/docs-utilities",
   "version": "1.0.0",
   "private": "true",
-  "main": "index.js"
+  "main": "index.ts"
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

It was throwing the following error:
> A parameter initializer is only allowed in a function or constructor implementation.

_Edit:_ I migrated the `docs-utilities` to TypeScript instead. 