### PR TITLE
[docs] Fix demos showing TypeScript instead of JavaScript

### DIFF
--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -17,7 +17,7 @@ It typically sits on or near an element and indicates the status of that element
 
 The Unstyled Badge component creates a badge that is applied to its child element.
 
-{{"demo": "UnstyledBadgeIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledBadgeIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -15,7 +15,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 
 The Unstyled Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
 
-{{"demo": "UnstyledButtonIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledButtonIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/input/input.md
+++ b/docs/data/base/components/input/input.md
@@ -16,7 +16,7 @@ An input is a UI element that accepts text data from the user.
 The Unstyled Input component replaces the native HTML `<input>` tag, and offers expanded customization and accessibility features.
 It can also be transformed into a `<textarea>` as needed.
 
-{{"demo": "UnstyledInputIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledInputIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -19,7 +19,7 @@ It renders an unordered list (`<ul>`) by default.
 Use the Unstyled Menu Item to add items to the menu.
 These are rendered as `<li>` elements.
 
-{{"demo": "UnstyledMenuIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledMenuIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -18,7 +18,7 @@ A select is a UI element that gives users a list of options to choose from.
 MUI Base offers two components to replace the native HTML `<select>` tag: Unstyled Select and Unstyled Multi-Select.
 It also includes Unstyled Option for creating the options on the list, and Unstyled Option Group for grouping those options.
 
-{{"demo": "UnstyledSelectIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledSelectIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 ### Features
 

--- a/docs/data/base/components/slider/slider.md
+++ b/docs/data/base/components/slider/slider.md
@@ -18,7 +18,7 @@ The Unstyled Slider component lets users make selections from a range of values 
 
 Sliders are ideal for interface controls that benefit from a visual representation of adjustable content, such as volume or brightness settings, or for applying image filters such as gradients or saturation.
 
-{{"demo": "UnstyledSliderIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledSliderIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/switch/switch.md
+++ b/docs/data/base/components/switch/switch.md
@@ -15,7 +15,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/switch/
 
 The Unstyled Switch component provides users with a switch for toggling between two mutually exclusive states.
 
-{{"demo": "UnstyledSwitchIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledSwitchIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -21,7 +21,7 @@ Table Pagination renders its internal elements in a `<td>` tag by default so it 
 You can use the `component` or `slots.root` prop to render a different root element—for example, if you need to place the pagination controls outside of the table.
 See the [Slot props section](#slot-props) for details.
 
-{{"demo": "UnstyledPaginationIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledPaginationIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -20,7 +20,7 @@ Tabs are implemented using a collection of related components:
 - `<TabPanelUnstyled />` - the card that hosts the content associated with a tab.
 - `<TabsUnstyled />` - the top-level component that wraps the Tabs List and Tab Panel components so that tabs and their panels can communicate with one another.
 
-{{"demo": "UnstyledTabsIntroduction.tsx", "defaultCodeOpen": false, "bg": "gradient"}}
+{{"demo": "UnstyledTabsIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -330,6 +330,20 @@ export default function Demo(props) {
     }
   }
 
+  if (!demoOptions.demo.endsWith('.js') && demoOptions.hideToolbar !== true) {
+    throw new Error(
+      [
+        `The following demos use TS directly: ${demoOptions.demo}.`,
+        '',
+        'Please run "yarn docs:typescript:formatted" to generate a JS version and reference it:',
+        `{{"demo": "${demoOptions.demo.replace(/\.(.*)$/, '.js')}", …}}.`,
+        '',
+        "Otherwise, if it's not a code demo hide the toolbar:",
+        `{{"demo": "${demoOptions.demo}", "hideToolbar": true, …}}.`,
+      ].join('\n'),
+    );
+  }
+
   const t = useTranslate();
   const codeVariant = useCodeVariant();
   const demoData = useDemoData(codeVariant, demo, githubLocation);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Originally raised in https://github.com/mui/material-ui/pull/35741#issuecomment-1377939041, the bug: https://mui.com/base/react-input/#introduction shows TypeScript while the developer is asking for JavaScript:

<img width="502" alt="Screenshot 2023-02-06 at 15 54 46" src="https://user-images.githubusercontent.com/3165635/217004838-7d16fe46-c6f3-4ce9-970f-c432ddd4109f.png">

This PR fixes these bugs and throws an error if a TS demo is used directly instead of plain JS. It also fixes the export to CodeSandbox.