### PR TITLE
[Button] Fix border color for secondary disabled button

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -153,10 +153,6 @@ const ButtonRoot = styled(ButtonBase, {
       ...(ownerState.variant === 'outlined' && {
         border: `1px solid ${(theme.vars || theme).palette.action.disabledBackground}`,
       }),
-      ...(ownerState.variant === 'outlined' &&
-        ownerState.color === 'secondary' && {
-          border: `1px solid ${(theme.vars || theme).palette.action.disabled}`,
-        }),
       ...(ownerState.variant === 'contained' && {
         color: (theme.vars || theme).palette.action.disabled,
         boxShadow: (theme.vars || theme).shadows[0],


### PR DESCRIPTION
Fixes: #35851 

Standardize the border color for secondary button when it is disabled.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
