### PR TITLE
[Box] Fix usage of not supported features in TypeScript 3.5

### DIFF
--- a/packages/mui-material/src/Box/Box.d.ts
+++ b/packages/mui-material/src/Box/Box.d.ts
@@ -1,4 +1,5 @@
-import { createBox, BoxTypeMap } from '@mui/system';
+import { BoxTypeMap } from '@mui/system';
+import { OverridableComponent } from '@mui/types';
 import { OverrideProps } from '../OverridableComponent';
 import { Theme as MaterialTheme } from '../styles';
 
@@ -12,7 +13,7 @@ import { Theme as MaterialTheme } from '../styles';
  *
  * - [Box API](https://mui.com/material-ui/api/box/)
  */
-declare const Box: ReturnType<typeof createBox<MaterialTheme>>;
+declare const Box: OverridableComponent<BoxTypeMap<{}, 'div', MaterialTheme>>;
 
 export type BoxProps<
   D extends React.ElementType = BoxTypeMap['defaultComponent'],


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/35860. This is a regression from https://github.com/mui/material-ui/pull/35532, as `ReturnType` is not supported in TypeScript 3.5