### PR TITLE
[core] Revert `docs-utilities` migration to TypeScript and fix type

### DIFF
--- a/packages/docs-utilities/index.d.ts
+++ b/packages/docs-utilities/index.d.ts
@@ -4,4 +4,4 @@ export function fixBabelGeneratorIssues(source: string): string;
 
 export function fixLineEndings(source: string, target: string): string;
 
-export function getUnstyledFilename(filename: string, definitionFile: boolean = false): string;
+export function getUnstyledFilename(filename: string, definitionFile?: boolean): string;

--- a/packages/docs-utilities/index.d.ts
+++ b/packages/docs-utilities/index.d.ts
@@ -1,0 +1,7 @@
+export function getLineFeed(source: string): string;
+
+export function fixBabelGeneratorIssues(source: string): string;
+
+export function fixLineEndings(source: string, target: string): string;
+
+export function getUnstyledFilename(filename: string, definitionFile: boolean = false): string;

--- a/packages/docs-utilities/index.js
+++ b/packages/docs-utilities/index.js
@@ -3,7 +3,7 @@ const { EOL } = require('os');
 /**
  * @param {string} source
  */
-function getLineFeed(source: string): string {
+function getLineFeed(source) {
   const match = source.match(/\r?\n/);
   return match === null ? EOL : match[0];
 }
@@ -12,7 +12,7 @@ const fixBabelIssuesRegExp = /(?<=(\/>)|,)(\r?\n){2}/g;
 /**
  * @param {string} source
  */
-function fixBabelGeneratorIssues(source: string): string {
+function fixBabelGeneratorIssues(source) {
   return source.replace(fixBabelIssuesRegExp, '\n');
 }
 
@@ -20,7 +20,7 @@ function fixBabelGeneratorIssues(source: string): string {
  * @param {string} source
  * @param {string} target
  */
-function fixLineEndings(source: string, target: string): string {
+function fixLineEndings(source, target) {
   return target.replace(/\r?\n/g, getLineFeed(source));
 }
 
@@ -28,7 +28,7 @@ function fixLineEndings(source: string, target: string): string {
  * Converts styled or regular component d.ts file to unstyled d.ts
  * @param {string} filename - the file of the styled or regular mui component
  */
-function getUnstyledFilename(filename: string, definitionFile: boolean = false) {
+function getUnstyledFilename(filename, definitionFile = false) {
   if (filename.indexOf('Unstyled') > -1) {
     return filename;
   }

--- a/packages/docs-utilities/package.json
+++ b/packages/docs-utilities/package.json
@@ -2,5 +2,5 @@
   "name": "@mui-internal/docs-utilities",
   "version": "1.0.0",
   "private": "true",
-  "main": "index.ts"
+  "main": "index.js"
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-u/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Reverting the migration to TypeScript and only keeping the fix of the `getUnstyledFilename` method type (https://github.com/mui/material-ui/commit/6235c1dae7de454708bfbd70f396307fead3f927) as discussed in #35846.

