### PR TITLE
[docs][material-ui] Fix broken links in Working with Tailwind CSS documentation

### DIFF
--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
@@ -308,7 +308,7 @@ Let's add the `Slider` into the `Player` component now:
 
 You should see this:
 
-<img src="/static/base/with-tailwind-css/player-slider.png" alt="Screenshot of the media player used as example in the guide, designed by the Tailwind Labs team" style="width: 745px; margin-top: 8px; margin-bottom: 8px;" />
+<img src="../../../../../docs/public/static/base/with-tailwind-css/player-slider.png" alt="Screenshot of the media player used as example in the guide, designed by the Tailwind Labs team" style="width: 745px; margin-top: 8px; margin-bottom: 8px;" />
 
 ### Customize the slider thumb
 

--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
@@ -379,7 +379,7 @@ We'll create a custom Button component that uses the `focusVisible` state from t
 
 This is what it'll look like:
 
-<img src="/static/base/with-tailwind-css/player-buttons.png" alt="Screenshot of a button used as example in the guide, designed by the Tailwind Labs team" style="width: 745px; margin-top: 8px; margin-bottom: 8px;" />
+<img src="../../../../../docs/public/static/base/with-tailwind-css/player-buttons.png" alt="Screenshot of a button used as example in the guide, designed by the Tailwind Labs team" style="width: 745px; margin-top: 8px; margin-bottom: 8px;" />
 
 Create a `Button.tsx` file and copy the following code:
 


### PR DESCRIPTION
Fixed 2 broken image links in [Working with Tailwind CSS doc](https://github.com/mui/material-ui/blob/fe348b969eea012bbb39c26b89f3cb4254c0bdf4/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md). Relative URL paths for both images were incomplete.

### First fix - Player-slider.png (Line 311)
Before:
![image](https://user-images.githubusercontent.com/24467345/213818282-99772df7-daca-43ab-8342-8e56bc095cd5.png)
After:
![image](https://user-images.githubusercontent.com/24467345/213818304-a6336794-44f4-49fd-a46d-d68fb2bc3a08.png)

### Second fix - Player-buttons.png (Line 382)
Before:
![image](https://user-images.githubusercontent.com/24467345/213818358-96b09e10-e671-46f8-9ea6-67ac2ecf56c5.png)
After:
![image](https://user-images.githubusercontent.com/24467345/213818371-02cad207-b7a8-489e-b597-bbeba7e5b085.png)

Note: This is my first pull request in this repository. I have read the contribution guidelines. However, please let me know if there's anything that needs to be done differently. I would greatly appreciate any feedback and guidance on how to improve my submission.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
