### PR TITLE
[core] Make it easier to find who is importing specific files

### DIFF
--- a/docs/data/base/pages.ts
+++ b/docs/data/base/pages.ts
@@ -1,4 +1,4 @@
-import pagesApi from './pagesApi';
+import pagesApi from 'docs/data/base/pagesApi';
 
 const pages = [
   {

--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -1,5 +1,5 @@
-import pagesApi from './pagesApi';
-import { MuiPage } from '../../src/MuiPage';
+import pagesApi from 'docs/data/material/pagesApi';
+import { MuiPage } from 'docs/src/MuiPage';
 
 const pages: MuiPage[] = [
   {

--- a/docs/data/system/pages.ts
+++ b/docs/data/system/pages.ts
@@ -1,4 +1,4 @@
-import pagesApi from './pagesApi';
+import pagesApi from 'docs/data/system/pagesApi';
 
 const pages = [
   {

--- a/docs/src/pages.ts
+++ b/docs/src/pages.ts
@@ -1,5 +1,5 @@
-import pagesApi from './pagesApi';
-import type { MuiPage, OrderedMuiPage } from './MuiPage';
+import pagesApi from 'docs/src/pagesApi';
+import type { MuiPage, OrderedMuiPage } from 'docs/src/MuiPage';
 
 const pages: readonly MuiPage[] = [
   {


### PR DESCRIPTION
I was trying to understand who uses https://github.com/mui/material-ui/blob/master/docs/data/base/pagesApi.js in the review of #35828. but I got no match for searching the import of `base/pagesApi` and many matches for `/pagesApi`. With this change, I can have a direct search hit.

@Janpot "Find all references" in VS Code doesn't work in this case. It seems that it only works with ESM.
Beyond it, 2. to make "Find all references" work, we first have to find where it's defined. The user flow: see it on GitHub and direct search doesn't work. 3. when we copy & paste files around, the import path break.
So overall, I think that we should use absolute imports as much as possible. However, with packages we publish on npm, the imports must be relative in the final pkg, having the imports relative in the first place can simplify the pkg preparation. So maybe an exception worth having.