### PR TITLE
[core] Fix release changelog to handle commits with empty author field

### DIFF
--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -117,7 +117,6 @@ async function main(argv) {
       }),
     ),
   );
-
   const contributorHandles = authors
     .sort((a, b) => a.localeCompare(b))
     .map((author) => `@${author}`)

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -105,7 +105,7 @@ async function main(argv) {
         );
       }
       warnedOnce = true;
-      return chalk.red('TODO INSERT AUTHOR\'S USERNAME');
+      return chalk.red("TODO INSERT AUTHOR'S USERNAME");
     }
 
     return commit.author?.login;

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 import { Octokit } from '@octokit/rest';
+import chalk from 'chalk';
 import childProcess from 'child_process';
 import { promisify } from 'util';
 import yargs from 'yargs';
@@ -104,7 +105,7 @@ async function main(argv) {
         );
       }
       warnedOnce = true;
-      return 'TODO add the author username';
+      return chalk.red('TODO INSERT AUTHOR\'S USERNAME');
     }
 
     return commit.author?.login;

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -94,7 +94,16 @@ async function main(argv) {
     commitsItems.push(...compareCommits.commits.filter(filterCommit));
   }
 
-  const getAuthor = (commit) => commit.author?.login ?? commit.committer?.login;
+  const getAuthor = (commit) => {
+    if (!commit.author) {
+      console.warn(
+        `The author of the commit: ${commit.commit.tree.url} cannot be retrieved. Please add the github username manually.`,
+      );
+      return null;
+    }
+
+    return commit.author?.login;
+  };
 
   const authors = Array.from(
     new Set(
@@ -102,7 +111,8 @@ async function main(argv) {
         return getAuthor(commitsItem);
       }),
     ),
-  );
+  ).filter((author) => author != null);
+
   const contributorHandles = authors
     .sort((a, b) => a.localeCompare(b))
     .map((author) => `@${author}`)
@@ -130,7 +140,7 @@ async function main(argv) {
       // i.e. we can sort the lines alphanumerically
       .padStart(Math.floor(Math.log10(commitsItemsByDateDesc.length)) + 1, '0')} -->`;
     const shortMessage = commitsItem.commit.message.split('\n')[0];
-    return `- ${dateSortMarker}${shortMessage} @${getAuthor(commitsItem)}`;
+    return `- ${dateSortMarker}${shortMessage} @${commitsItem.author?.login}`;
   });
   const nowFormatted = new Date().toLocaleDateString('en-US', {
     month: 'short',

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -94,10 +94,12 @@ async function main(argv) {
     commitsItems.push(...compareCommits.commits.filter(filterCommit));
   }
 
+  const getAuthor = (commit) => commit.author?.login ?? commit.committer?.login;
+
   const authors = Array.from(
     new Set(
       commitsItems.map((commitsItem) => {
-        return commitsItem.author.login;
+        return getAuthor(commitsItem);
       }),
     ),
   );
@@ -128,7 +130,7 @@ async function main(argv) {
       // i.e. we can sort the lines alphanumerically
       .padStart(Math.floor(Math.log10(commitsItemsByDateDesc.length)) + 1, '0')} -->`;
     const shortMessage = commitsItem.commit.message.split('\n')[0];
-    return `- ${dateSortMarker}${shortMessage} @${commitsItem.author.login}`;
+    return `- ${dateSortMarker}${shortMessage} @${getAuthor(commitsItem)}`;
   });
   const nowFormatted = new Date().toLocaleDateString('en-US', {
     month: 'short',

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -94,12 +94,17 @@ async function main(argv) {
     commitsItems.push(...compareCommits.commits.filter(filterCommit));
   }
 
+  let warnedOnce = false;
+
   const getAuthor = (commit) => {
     if (!commit.author) {
-      console.warn(
-        `The author of the commit: ${commit.commit.tree.url} cannot be retrieved. Please add the github username manually.`,
-      );
-      return null;
+      if (!warnedOnce) {
+        console.warn(
+          `The author of the commit: ${commit.commit.tree.url} cannot be retrieved. Please add the github username manually.`,
+        );
+      }
+      warnedOnce = true;
+      return 'TODO add the author username';
     }
 
     return commit.author?.login;
@@ -140,7 +145,7 @@ async function main(argv) {
       // i.e. we can sort the lines alphanumerically
       .padStart(Math.floor(Math.log10(commitsItemsByDateDesc.length)) + 1, '0')} -->`;
     const shortMessage = commitsItem.commit.message.split('\n')[0];
-    return `- ${dateSortMarker}${shortMessage} @${commitsItem.author?.login}`;
+    return `- ${dateSortMarker}${shortMessage} @${getAuthor(commitsItem)}`;
   });
   const nowFormatted = new Date().toLocaleDateString('en-US', {
     month: 'short',

--- a/scripts/releaseChangelog.mjs
+++ b/scripts/releaseChangelog.mjs
@@ -116,7 +116,7 @@ async function main(argv) {
         return getAuthor(commitsItem);
       }),
     ),
-  ).filter((author) => author != null);
+  );
 
   const contributorHandles = authors
     .sort((a, b) => a.localeCompare(b))


### PR DESCRIPTION
After https://github.com/mui/material-ui/pull/35876 was merged the `releaseChangelog` script was failing because the `author` field was empty. I am not sure how the pull request was created.