### PR TITLE
[docs] Update community theme builder to forked updated one

### DIFF
--- a/docs/data/material/customization/color/color.md
+++ b/docs/data/material/customization/color/color.md
@@ -71,7 +71,7 @@ If you are using the default primary and / or secondary shades then by providing
 
 ### Tools by the community
 
-- [mui-theme-creator](https://bareynol.github.io/mui-theme-creator/): A tool to help design and customize themes for the MUI component library. Includes basic site templates to show various components and how they are affected by the theme
+- [mui-theme-creator](https://zenoo.github.io/mui-theme-creator/): A tool to help design and customize themes for the MUI component library. Includes basic site templates to show various components and how they are affected by the theme
 - [Material palette generator](https://m2.material.io/inline-tools/color/): The Material palette generator can be used to generate a palette for any color you input.
 
 ## 2014 Material Design color palettes

--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -80,7 +80,7 @@ declare module '@mui/material/styles' {
 
 The community has built great tools to build a theme:
 
-- [mui-theme-creator](https://bareynol.github.io/mui-theme-creator/): A tool to help design and customize themes for the MUI component library. Includes basic site templates to show various components and how they are affected by the theme
+- [mui-theme-creator](https://zenoo.github.io/mui-theme-creator/): A tool to help design and customize themes for the MUI component library. Includes basic site templates to show various components and how they are affected by the theme
 - [Material palette generator](https://m2.material.io/inline-tools/color/): The Material palette generator can be used to generate a palette for any color you input.
 
 ## Accessing the theme in a component


### PR DESCRIPTION
This PR simply just changes a suggested community theme builder in the docs from the current to a forked and more up to date one:

- The current: [https://bareynol.github.io/mui-theme-creator/](https://bareynol.github.io/mui-theme-creator/)
- Forked and more up to date one: [https://zenoo.github.io/mui-theme-creator/](https://zenoo.github.io/mui-theme-creator/)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
