### PR TITLE
[docs] Fix event's label reported to GA

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -122,7 +122,9 @@ function AppLayoutDocs(props) {
             See https://jakearchibald.com/2014/dont-use-flexbox-for-page-layout/ for more details.
           */}
           <StyledAppContainer disableAd={disableAd}>
-            <ActionsDiv>{location && <EditPage markdownLocation={location} />}</ActionsDiv>
+            <ActionsDiv>
+              <EditPage markdownLocation={location} />
+            </ActionsDiv>
             {children}
             <NoSsr>
               <AppLayoutDocsFooter tableOfContents={toc} />
@@ -141,7 +143,7 @@ AppLayoutDocs.propTypes = {
   description: PropTypes.string.isRequired,
   disableAd: PropTypes.bool.isRequired,
   disableToc: PropTypes.bool.isRequired,
-  location: PropTypes.string,
+  location: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   toc: PropTypes.array.isRequired,
 };

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -431,7 +431,7 @@ export default function Demo(props) {
 
   return (
     <Root>
-      <AnchorLink id={`${demoName}`} />
+      <AnchorLink id={demoName} />
       <DemoRoot
         hiddenToolbar={demoOptions.hideToolbar}
         bg={demoOptions.bg}

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -494,7 +494,7 @@ export default function Demo(props) {
               language={demoData.sourceLanguage}
               copyButtonProps={{
                 'data-ga-event-category': codeOpen ? 'demo-expand' : 'demo',
-                'data-ga-event-label': demoOptions.demo,
+                'data-ga-event-label': demo.gaLabel,
                 'data-ga-event-action': 'copy-click',
               }}
             />
@@ -516,7 +516,7 @@ export default function Demo(props) {
               language={demoData.sourceLanguage}
               copyButtonProps={{
                 'data-ga-event-category': codeOpen ? 'demo-expand' : 'demo',
-                'data-ga-event-label': demoOptions.demo,
+                'data-ga-event-label': demo.gaLabel,
                 'data-ga-event-action': 'copy-click',
               }}
             >
@@ -532,6 +532,9 @@ export default function Demo(props) {
 
 Demo.propTypes = {
   demo: PropTypes.object.isRequired,
+  /**
+   * The options provided with: {{"demo": "Name.js", …demoOptions}}
+   */
   demoOptions: PropTypes.object.isRequired,
   disableAd: PropTypes.bool.isRequired,
   githubLocation: PropTypes.string.isRequired,

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -401,7 +401,7 @@ export default function DemoToolbar(props) {
         <MenuItem
           key="link-deploy-preview"
           data-ga-event-category="demo"
-          data-ga-event-label={demoOptions.demo}
+          data-ga-event-label={demo.gaLabel}
           data-ga-event-action="link-deploy-preview"
           component="a"
           href={`https://deploy-preview-${process.env.PULL_REQUEST_ID}--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
@@ -418,7 +418,7 @@ export default function DemoToolbar(props) {
       <MenuItem
         key="link-next"
         data-ga-event-category="demo"
-        data-ga-event-label={demoOptions.demo}
+        data-ga-event-label={demo.gaLabel}
         data-ga-event-action="link-next"
         component="a"
         href={`https://next--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
@@ -431,7 +431,7 @@ export default function DemoToolbar(props) {
       <MenuItem
         key="permalink"
         data-ga-event-category="demo"
-        data-ga-event-label={demoOptions.demo}
+        data-ga-event-label={demo.gaLabel}
         data-ga-event-action="permalink"
         component="a"
         href={`${process.env.NETLIFY_DEPLOY_URL}${router.route}#${demoName}`}
@@ -444,7 +444,7 @@ export default function DemoToolbar(props) {
       <MenuItem
         key="link-master"
         data-ga-event-category="demo"
-        data-ga-event-label={demoOptions.demo}
+        data-ga-event-label={demo.gaLabel}
         data-ga-event-action="link-master"
         component="a"
         href={`https://master--${process.env.NETLIFY_SITE_NAME}.netlify.app${router.route}/#${demoName}`}
@@ -481,7 +481,7 @@ export default function DemoToolbar(props) {
               aria-label={t('showJSSource')}
               data-ga-event-category="demo"
               data-ga-event-action="source-js"
-              data-ga-event-label={demoOptions.demo}
+              data-ga-event-label={demo.gaLabel}
               {...getControlProps(0)}
             >
               <JavaScriptIcon sx={{ fontSize: 20 }} />
@@ -503,7 +503,7 @@ export default function DemoToolbar(props) {
               aria-label={t('showTSSource')}
               data-ga-event-category="demo"
               data-ga-event-action="source-ts"
-              data-ga-event-label={demoOptions.demo}
+              data-ga-event-label={demo.gaLabel}
               {...getControlProps(1)}
             >
               <TypeScriptIcon sx={{ fontSize: 20 }} />
@@ -521,7 +521,7 @@ export default function DemoToolbar(props) {
               size="large"
               aria-controls={openDemoSource ? demoSourceId : null}
               data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
+              data-ga-event-label={demo.gaLabel}
               data-ga-event-action="expand"
               onClick={handleCodeOpenClick}
               color="default"
@@ -536,7 +536,7 @@ export default function DemoToolbar(props) {
                 <IconButton
                   size="large"
                   data-ga-event-category="demo"
-                  data-ga-event-label={demoOptions.demo}
+                  data-ga-event-label={demo.gaLabel}
                   data-ga-event-action="codesandbox"
                   onClick={handleCodeSandboxClick}
                   {...getControlProps(3)}
@@ -550,7 +550,7 @@ export default function DemoToolbar(props) {
                 <IconButton
                   size="large"
                   data-ga-event-category="demo"
-                  data-ga-event-label={demoOptions.demo}
+                  data-ga-event-label={demo.gaLabel}
                   data-ga-event-action="stackblitz"
                   onClick={handleStackBlitzClick}
                   {...getControlProps(4)}
@@ -566,7 +566,7 @@ export default function DemoToolbar(props) {
             <IconButton
               size="large"
               data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
+              data-ga-event-label={demo.gaLabel}
               data-ga-event-action="copy"
               onClick={handleCopyClick}
               {...getControlProps(5)}
@@ -578,7 +578,7 @@ export default function DemoToolbar(props) {
             <IconButton
               size="large"
               data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
+              data-ga-event-label={demo.gaLabel}
               data-ga-event-action="reset-focus"
               onClick={handleResetFocusClick}
               {...getControlProps(6)}
@@ -591,7 +591,7 @@ export default function DemoToolbar(props) {
               size="large"
               aria-controls={demoId}
               data-ga-event-category="demo"
-              data-ga-event-label={demoOptions.demo}
+              data-ga-event-label={demo.gaLabel}
               data-ga-event-action="reset"
               onClick={onResetDemoClick}
               {...getControlProps(7)}
@@ -627,7 +627,7 @@ export default function DemoToolbar(props) {
       >
         <MenuItem
           data-ga-event-category="demo"
-          data-ga-event-label={demoOptions.demo}
+          data-ga-event-label={demo.gaLabel}
           data-ga-event-action="github"
           component="a"
           href={demoData.githubLocation}
@@ -639,7 +639,7 @@ export default function DemoToolbar(props) {
         </MenuItem>
         <MenuItem
           data-ga-event-category="demo"
-          data-ga-event-label={demoOptions.demo}
+          data-ga-event-label={demo.gaLabel}
           data-ga-event-action="copy-js-source-link"
           onClick={createHandleCodeSourceLink(`${demoName}.js`)}
         >
@@ -647,7 +647,7 @@ export default function DemoToolbar(props) {
         </MenuItem>
         <MenuItem
           data-ga-event-category="demo"
-          data-ga-event-label={demoOptions.demo}
+          data-ga-event-label={demo.gaLabel}
           data-ga-event-action="copy-ts-source-link"
           onClick={createHandleCodeSourceLink(`${demoName}.tsx`)}
         >

--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -6,8 +6,8 @@ import { useTheme } from '@mui/material/styles';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
 
 export default function EditPage(props) {
-  const theme = useTheme();
   const { markdownLocation } = props;
+  const theme = useTheme();
   const t = useTranslate();
   const userLanguage = useUserLanguage();
   const LOCALES = { zh: 'zh-CN', pt: 'pt-BR', es: 'es-ES' };

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -141,6 +141,7 @@ export default function MarkdownDocs(props) {
                 jsxPreview: demo.jsxPreview,
                 rawTS: demo.rawTS,
                 tsx: demoComponents[demo.moduleTS] ?? null,
+                gaLabel: fileNameWithLocation.replace(/^\/docs\/data\//, ''),
               }}
               disableAd={disableAd}
               demoOptions={renderedMarkdownOrDemo}


### PR DESCRIPTION
Solve frustration in https://github.com/mui/material-ui/pull/35872#pullrequestreview-1266540707. It's hard to filter the events for a given page.

<img width="554" alt="Screenshot 2023-01-24 at 00 11 50" src="https://user-images.githubusercontent.com/3165635/214173148-f80acc16-af53-406f-8f24-e5766fc2f749.png">

https://analytics.google.com/analytics/web/#/report/content-event-events/a106598593w159022482p160376982/explorer-segmentExplorer.segmentId=analytics.eventLabel&_r.drilldown=analytics.eventAction:expand&explorer-table.plotKeys=%5B%5D&explorer-table.rowStart=0&explorer-table.rowCount=50

The fix is to expand the path:

```diff
 <button
-  data-ga-event-label="BasicAlerts.js"
+  data-ga-event-label="material/components/alert/BasicAlerts.js"
```

This is a regression from #30757.