### PR TITLE
[docs] Add a warning about to clear the local storage when `defaultMode` changes

### DIFF
--- a/docs/data/joy/customization/dark-mode/dark-mode.md
+++ b/docs/data/joy/customization/dark-mode/dark-mode.md
@@ -7,7 +7,7 @@
 To set dark mode as the default for your app, add `defaultMode: 'dark'` to your `<CssVarsProvider>` wrapper component:
 
 :::warning
-When you change the `defaultMode` to another value, you have to always clear the local storage to take effect.
+When you change the `defaultMode` to another value, you must clear the local storage for it to take effect.
 :::
 
 {{"demo": "DarkModeByDefault.js"}}

--- a/docs/data/joy/customization/dark-mode/dark-mode.md
+++ b/docs/data/joy/customization/dark-mode/dark-mode.md
@@ -6,6 +6,10 @@
 
 To set dark mode as the default for your app, add `defaultMode: 'dark'` to your `<CssVarsProvider>` wrapper component:
 
+:::warning
+Note that when you change the defaultMode to another value, you have to always clear the local storage.
+:::
+
 {{"demo": "DarkModeByDefault.js"}}
 
 For server-side applications, check out the framework setup in [the section below](#server-side-rendering) and provide the same value to the `getInitColorSchemeScript` function:

--- a/docs/data/joy/customization/dark-mode/dark-mode.md
+++ b/docs/data/joy/customization/dark-mode/dark-mode.md
@@ -7,7 +7,7 @@
 To set dark mode as the default for your app, add `defaultMode: 'dark'` to your `<CssVarsProvider>` wrapper component:
 
 :::warning
-Note that when you change the defaultMode to another value, you have to always clear the local storage.
+When you change the `defaultMode` to another value, you have to always clear the local storage to take effect.
 :::
 
 {{"demo": "DarkModeByDefault.js"}}


### PR DESCRIPTION
Signed-off-by: Arthur Pedroti <arthurpedroti@gmail.com>

Context and closes: #35888

Add a warning to clear the local storage when change the defaultMode to another value.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
