### PR TITLE
[Select][base] Prevent unnecessary rerendering of Select options

### DIFF
--- a/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.test.ts
+++ b/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.test.ts
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  ActionTypes,
-  ListboxAction,
-  ListboxState,
-  UseListboxPropsWithDefaults,
-} from './useListbox.types';
+import { ActionTypes, ListboxReducerAction, ListboxState } from './useListbox.types';
 import defaultReducer from './defaultListboxReducer';
-
-type AugmentedListboxAction<T> = ListboxAction<T> & { props: UseListboxPropsWithDefaults<T> };
 
 describe('useListbox defaultReducer', () => {
   describe('action: setControlledValue', () => {
@@ -18,7 +11,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.setValue,
         value: 'foo',
         event: null,
@@ -44,7 +37,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.blur,
         event: {} as any, // not relevant
         props: {
@@ -70,7 +63,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.optionClick,
         event: {} as any, // not relevant
         props: {
@@ -95,7 +88,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: ['one'],
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.optionClick,
         event: {} as any, // not relevant
         props: {
@@ -120,7 +113,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: ['one', 'two'],
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.optionClick,
         event: {} as any, // not relevant
         props: {
@@ -148,7 +141,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'Home',
@@ -176,7 +169,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'End',
@@ -204,7 +197,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'ArrowUp',
@@ -232,7 +225,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'ArrowDown',
@@ -258,7 +251,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'ArrowDown',
@@ -286,7 +279,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'Enter',
@@ -312,7 +305,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: ['one'],
         };
 
-        const action: AugmentedListboxAction<string> = {
+        const action: ListboxReducerAction<string> = {
           type: ActionTypes.optionClick,
           event: {
             key: 'Enter',
@@ -342,7 +335,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 'th',
         event: {} as React.KeyboardEvent,
@@ -367,7 +360,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 'z',
         event: {} as React.KeyboardEvent,
@@ -392,7 +385,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 't',
         event: {} as React.KeyboardEvent,
@@ -417,7 +410,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 't',
         event: {} as React.KeyboardEvent,
@@ -442,7 +435,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: AugmentedListboxAction<string> = {
+      const action: ListboxReducerAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 'one',
         event: {} as React.KeyboardEvent,

--- a/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.test.ts
+++ b/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.test.ts
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { ActionTypes, ListboxAction, ListboxState } from './useListbox.types';
+import {
+  ActionTypes,
+  ListboxAction,
+  ListboxState,
+  UseListboxPropsWithDefaults,
+} from './useListbox.types';
 import defaultReducer from './defaultListboxReducer';
+
+type AugmentedListboxAction<T> = ListboxAction<T> & { props: UseListboxPropsWithDefaults<T> };
 
 describe('useListbox defaultReducer', () => {
   describe('action: setControlledValue', () => {
@@ -11,10 +18,19 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.setValue,
         value: 'foo',
         event: null,
+        props: {
+          options: ['foo', 'bar'],
+          disableListWrap: false,
+          disabledItemsFocusable: false,
+          isOptionDisabled: () => false,
+          optionComparer: (o, v) => o === v,
+          optionStringifier: (option) => option,
+          multiple: false,
+        },
       };
       const result = defaultReducer(state, action);
       expect(result.selectedValue).to.equal('foo');
@@ -28,7 +44,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.blur,
         event: {} as any, // not relevant
         props: {
@@ -54,7 +70,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.optionClick,
         event: {} as any, // not relevant
         props: {
@@ -79,7 +95,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: ['one'],
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.optionClick,
         event: {} as any, // not relevant
         props: {
@@ -104,7 +120,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: ['one', 'two'],
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.optionClick,
         event: {} as any, // not relevant
         props: {
@@ -132,7 +148,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'Home',
@@ -160,7 +176,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'End',
@@ -188,7 +204,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'ArrowUp',
@@ -216,7 +232,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'ArrowDown',
@@ -242,7 +258,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'ArrowDown',
@@ -270,7 +286,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: null,
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.keyDown,
           event: {
             key: 'Enter',
@@ -296,7 +312,7 @@ describe('useListbox defaultReducer', () => {
           selectedValue: ['one'],
         };
 
-        const action: ListboxAction<string> = {
+        const action: AugmentedListboxAction<string> = {
           type: ActionTypes.optionClick,
           event: {
             key: 'Enter',
@@ -326,7 +342,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 'th',
         event: {} as React.KeyboardEvent,
@@ -351,7 +367,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 'z',
         event: {} as React.KeyboardEvent,
@@ -376,7 +392,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 't',
         event: {} as React.KeyboardEvent,
@@ -401,7 +417,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 't',
         event: {} as React.KeyboardEvent,
@@ -426,7 +442,7 @@ describe('useListbox defaultReducer', () => {
         selectedValue: null,
       };
 
-      const action: ListboxAction<string> = {
+      const action: AugmentedListboxAction<string> = {
         type: ActionTypes.textNavigation,
         searchString: 'one',
         event: {} as React.KeyboardEvent,

--- a/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {
   ListboxState,
   UseListboxPropsWithDefaults,
-  ListboxAction,
   ActionTypes,
+  ListboxReducerAction,
 } from './useListbox.types';
 
 type OptionPredicate<TOption> = (option: TOption, index: number) => boolean;
@@ -338,7 +338,7 @@ function handleOptionsChange<TOption>(
 
 export default function defaultListboxReducer<TOption>(
   state: Readonly<ListboxState<TOption>>,
-  action: ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> },
+  action: ListboxReducerAction<TOption>,
 ): Readonly<ListboxState<TOption>> {
   const { type } = action;
 

--- a/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/defaultListboxReducer.ts
@@ -338,7 +338,7 @@ function handleOptionsChange<TOption>(
 
 export default function defaultListboxReducer<TOption>(
   state: Readonly<ListboxState<TOption>>,
-  action: ListboxAction<TOption>,
+  action: ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> },
 ): Readonly<ListboxState<TOption>> {
   const { type } = action;
 

--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.test.tsx
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.test.tsx
@@ -21,24 +21,25 @@ describe('useControllableReducer', () => {
       });
 
       const actionToDispatch = { type: ActionTypes.setValue as const, value: 'b', event: null };
+      const props: UseListboxPropsWithDefaults<string> = {
+        options: ['a', 'b', 'c'],
+        defaultValue: 'a',
+        isOptionDisabled: () => false,
+        disableListWrap: false,
+        disabledItemsFocusable: false,
+        optionComparer: (a, b) => a === b,
+        optionStringifier: (option) => option,
+        multiple: false,
+      };
+
       function TestComponent() {
-        const props: UseListboxPropsWithDefaults<string> = {
-          options: ['a', 'b', 'c'],
-          defaultValue: 'a',
-          isOptionDisabled: () => false,
-          disableListWrap: false,
-          disabledItemsFocusable: false,
-          optionComparer: (a, b) => a === b,
-          optionStringifier: (option) => option,
-          multiple: false,
-        };
         const [, dispatch] = useControllableReducer(reducer, undefined, { current: props });
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }
 
       render(<TestComponent />);
-      expect(reducer.getCalls()[0].args[1]).to.equal(actionToDispatch);
+      expect(reducer.getCalls()[0].args[1]).to.deep.equal({ ...actionToDispatch, props });
     });
 
     it('calls the provided external reducer', () => {
@@ -53,17 +54,18 @@ describe('useControllableReducer', () => {
       });
 
       const actionToDispatch = { type: ActionTypes.setValue as const, value: 'b', event: null };
+      const props: UseListboxPropsWithDefaults<string> = {
+        options: ['a', 'b', 'c'],
+        defaultValue: 'a',
+        isOptionDisabled: () => false,
+        disableListWrap: false,
+        disabledItemsFocusable: false,
+        optionComparer: (a, b) => a === b,
+        optionStringifier: (option) => option,
+        multiple: false,
+      };
+
       function TestComponent() {
-        const props: UseListboxPropsWithDefaults<string> = {
-          options: ['a', 'b', 'c'],
-          defaultValue: 'a',
-          isOptionDisabled: () => false,
-          disableListWrap: false,
-          disabledItemsFocusable: false,
-          optionComparer: (a, b) => a === b,
-          optionStringifier: (option) => option,
-          multiple: false,
-        };
         const [, dispatch] = useControllableReducer(internalReducer, externalReducer, {
           current: props,
         });
@@ -73,7 +75,7 @@ describe('useControllableReducer', () => {
 
       render(<TestComponent />);
       expect(internalReducer.notCalled).to.equal(true);
-      expect(externalReducer.getCalls()[0].args[1]).to.equal(actionToDispatch);
+      expect(externalReducer.getCalls()[0].args[1]).to.deep.equal({ ...actionToDispatch, props });
     });
 
     it('calls onChange when the reducer returns a modified selected value', () => {
@@ -84,7 +86,10 @@ describe('useControllableReducer', () => {
         };
       });
 
-      const actionToDispatch = { type: ActionTypes.setValue as const, value: 'b', event: null };
+      const actionToDispatch = {
+        type: ActionTypes.keyDown as const,
+        event: null as unknown as React.KeyboardEvent, // not relevant here
+      };
       const handleChange = spy();
       const handleHighlightChange = spy();
 
@@ -101,7 +106,9 @@ describe('useControllableReducer', () => {
           onChange: handleChange,
           onHighlightChange: handleHighlightChange,
         };
-        const [, dispatch] = useControllableReducer(reducer, undefined, { current: props });
+
+        const propsRef = React.useRef(props);
+        const [, dispatch] = useControllableReducer(reducer, undefined, propsRef);
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }
@@ -120,9 +127,8 @@ describe('useControllableReducer', () => {
       });
 
       const actionToDispatch = {
-        type: ActionTypes.setHighlight as const,
-        highlight: 'b',
-        event: null,
+        type: ActionTypes.keyDown as const,
+        event: null as unknown as React.KeyboardEvent, // not relevant here
       };
       const handleChange = spy();
       const handleHighlightChange = spy();
@@ -140,7 +146,9 @@ describe('useControllableReducer', () => {
           onChange: handleChange,
           onHighlightChange: handleHighlightChange,
         };
-        const [, dispatch] = useControllableReducer(reducer, undefined, { current: props });
+
+        const propsRef = React.useRef(props);
+        const [, dispatch] = useControllableReducer(reducer, undefined, propsRef);
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }

--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.test.tsx
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.test.tsx
@@ -32,7 +32,7 @@ describe('useControllableReducer', () => {
           optionStringifier: (option) => option,
           multiple: false,
         };
-        const [, dispatch] = useControllableReducer(reducer, undefined, props);
+        const [, dispatch] = useControllableReducer(reducer, undefined, { current: props });
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }
@@ -64,7 +64,9 @@ describe('useControllableReducer', () => {
           optionStringifier: (option) => option,
           multiple: false,
         };
-        const [, dispatch] = useControllableReducer(internalReducer, externalReducer, props);
+        const [, dispatch] = useControllableReducer(internalReducer, externalReducer, {
+          current: props,
+        });
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }
@@ -99,7 +101,7 @@ describe('useControllableReducer', () => {
           onChange: handleChange,
           onHighlightChange: handleHighlightChange,
         };
-        const [, dispatch] = useControllableReducer(reducer, undefined, props);
+        const [, dispatch] = useControllableReducer(reducer, undefined, { current: props });
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }
@@ -138,7 +140,7 @@ describe('useControllableReducer', () => {
           onChange: handleChange,
           onHighlightChange: handleHighlightChange,
         };
-        const [, dispatch] = useControllableReducer(reducer, undefined, props);
+        const [, dispatch] = useControllableReducer(reducer, undefined, { current: props });
         React.useEffect(() => dispatch(actionToDispatch), [dispatch]);
         return null;
       }

--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
@@ -3,6 +3,7 @@ import {
   ActionTypes,
   ListboxAction,
   ListboxReducer,
+  ListboxReducerAction,
   ListboxState,
   UseListboxPropsWithDefaults,
 } from './useListbox.types';
@@ -140,10 +141,7 @@ export default function useControllableReducer<TOption>(
   };
 
   const combinedReducer = React.useCallback(
-    (
-      state: ListboxState<TOption>,
-      action: ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> },
-    ) => {
+    (state: ListboxState<TOption>, action: ListboxReducerAction<TOption>) => {
       actionRef.current = action;
 
       if (externalReducer) {
@@ -162,7 +160,7 @@ export default function useControllableReducer<TOption>(
       dispatch({
         props: props.current,
         ...action,
-      } as ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> });
+      } as ListboxReducerAction<TOption>);
     },
     [dispatch, props],
   );

--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  ActionTypes,
   ListboxAction,
   ListboxReducer,
   ListboxState,
@@ -55,6 +56,14 @@ function useStateChangeDetection<TOption>(
   React.useEffect(() => {
     if (!propsRef.current || lastActionRef.current === null) {
       // Detect changes only if an action has been dispatched.
+      return;
+    }
+
+    if (
+      lastActionRef.current.type === ActionTypes.setValue ||
+      lastActionRef.current.type === ActionTypes.setHighlight
+    ) {
+      // Don't fire change events when the value has been changed externally (e.g. by changing the controlled prop).
       return;
     }
 

--- a/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useControllableReducer.ts
@@ -149,11 +149,12 @@ export default function useControllableReducer<TOption>(
   const [nextState, dispatch] = React.useReducer(combinedReducer, initialState);
 
   const dispatchWithProps = React.useCallback(
-    (action: ListboxAction<TOption>) =>
+    (action: ListboxAction<TOption>) => {
       dispatch({
         props: props.current,
         ...action,
-      } as ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> }),
+      } as ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> });
+    },
     [dispatch, props],
   );
 

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -113,9 +113,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
     });
 
     previousOptions.current = options;
-
-    // No need to re-run this effect if props change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, optionComparer, dispatch]);
 
   const setSelectedValue = React.useCallback(

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -64,7 +64,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
   const [{ highlightedValue, selectedValue }, dispatch] = useControllableReducer(
     defaultReducer,
     externalReducer,
-    propsWithDefaults.current!,
+    propsWithDefaults,
   );
 
   const handleTextNavigation = useTextNavigation((searchString, event) =>

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -13,7 +13,7 @@ import useControllableReducer from './useControllableReducer';
 import areArraysEqual from '../utils/areArraysEqual';
 import { EventHandlers } from '../utils/types';
 import useLatest from '../utils/useLatest';
-import useTextNavigation from './useTextNavigation';
+import useTextNavigation from '../utils/useTextNavigation';
 
 const defaultOptionComparer = <TOption>(optionA: TOption, optionB: TOption) => optionA === optionB;
 const defaultIsOptionDisabled = () => false;
@@ -74,7 +74,14 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
     propsWithDefaults.current,
   );
 
-  const handleTextNavigation = useTextNavigation(dispatch, propsWithDefaults);
+  const handleTextNavigation = useTextNavigation((searchString, event) =>
+    dispatch({
+      type: ActionTypes.textNavigation,
+      event,
+      searchString,
+      props: propsWithDefaults.current,
+    }),
+  );
 
   const highlightedIndexRef = React.useRef<number>(-1);
   const selectedValueRef = React.useRef<TOption | TOption[] | null>(null);
@@ -121,7 +128,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
   }, [options, optionComparer, dispatch]);
 
   const setSelectedValue = React.useCallback(
-    (option: TOption | TOption[] | null) => {
+    (option: TOption[]) => {
       dispatch({
         type: ActionTypes.setValue,
         event: null,

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -44,7 +44,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
 
   const optionIdGenerator = props.optionIdGenerator ?? defaultIdGenerator;
 
-  const propsWithDefaults: React.Ref<UseListboxPropsWithDefaults<TOption>> = useLatest(
+  const propsWithDefaults: React.RefObject<UseListboxPropsWithDefaults<TOption>> = useLatest(
     {
       ...props,
       disabledItemsFocusable,
@@ -55,23 +55,16 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       optionComparer,
       optionStringifier,
     },
-    [
-      props,
-      disabledItemsFocusable,
-      disableListWrap,
-      focusManagement,
-      isOptionDisabled,
-      optionComparer,
-      optionStringifier,
-    ],
+    [props],
   );
+
   const listboxRef = React.useRef<HTMLUListElement>(null);
   const handleRef = useForkRef(externalListboxRef, listboxRef);
 
   const [{ highlightedValue, selectedValue }, dispatch] = useControllableReducer(
     defaultReducer,
     externalReducer,
-    propsWithDefaults.current,
+    propsWithDefaults.current!,
   );
 
   const handleTextNavigation = useTextNavigation((searchString, event) =>
@@ -79,7 +72,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       type: ActionTypes.textNavigation,
       event,
       searchString,
-      props: propsWithDefaults.current,
     }),
   );
 
@@ -118,7 +110,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       event: null,
       options,
       previousOptions: previousOptions.current,
-      props: propsWithDefaults.current,
     });
 
     previousOptions.current = options;
@@ -163,7 +154,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
           type: ActionTypes.optionClick,
           option,
           event,
-          props: propsWithDefaults.current,
         });
       },
     [dispatch],
@@ -181,7 +171,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
           type: ActionTypes.optionHover,
           option,
           event,
-          props: propsWithDefaults.current,
         });
       },
     [dispatch],
@@ -213,7 +202,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       dispatch({
         type: ActionTypes.keyDown,
         event,
-        props: propsWithDefaults.current,
       });
 
       handleTextNavigation(event);
@@ -235,7 +223,6 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       dispatch({
         type: ActionTypes.blur,
         event,
-        props: propsWithDefaults.current,
       });
     };
 

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -79,7 +79,8 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
   const highlightedIndexRef = React.useRef<number>(-1);
 
   React.useEffect(() => {
-    if (valueParam !== selectedValue) {
+    // if a controlled value changes, we need to update the state to keep things in sync
+    if (valueParam !== undefined && valueParam !== selectedValue) {
       dispatch({
         type: ActionTypes.setValue,
         event: null,

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import { unstable_useForkRef as useForkRef, unstable_useId as useId } from '@mui/utils';
 import {
@@ -15,7 +16,7 @@ import { EventHandlers } from '../utils/types';
 
 const TEXT_NAVIGATION_RESET_TIMEOUT = 500; // milliseconds
 
-function useNotifyChanged(prop, propName) {
+function useNotifyChanged(prop: unknown, propName: string) {
   React.useEffect(() => {
     console.log(`${propName} changed (new value: ${prop}))`);
   }, [prop, propName]);
@@ -102,6 +103,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
   );
 
   const highlightedIndexRef = React.useRef<number>(-1);
+  const selectedValueRef = React.useRef<TOption | TOption[] | null>(null);
 
   React.useEffect(() => {
     if (highlightedValue == null) {
@@ -112,6 +114,10 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       );
     }
   }, [highlightedValue, options, optionComparer]);
+
+  React.useEffect(() => {
+    selectedValueRef.current = selectedValue;
+  }, [selectedValue]);
 
   const highlightedIndex = React.useMemo(() => {
     return highlightedValue == null
@@ -304,11 +310,11 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
       let selected: boolean;
       const index = options.findIndex((opt) => optionComparer(opt, option));
       if (multiple) {
-        selected = ((selectedValue as TOption[]) ?? []).some(
+        selected = ((selectedValueRef.current as TOption[]) ?? []).some(
           (value) => value != null && optionComparer(option, value),
         );
       } else {
-        selected = optionComparer(option, selectedValue as TOption);
+        selected = optionComparer(option, selectedValueRef.current as TOption);
       }
 
       const disabled = isOptionDisabled(option, index);
@@ -319,7 +325,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
         highlighted: highlightedIndexRef.current === index,
       };
     },
-    [options, selectedValue, multiple, isOptionDisabled, optionComparer],
+    [options, multiple, isOptionDisabled, optionComparer],
   );
 
   const getOptionTabIndex = React.useCallback(

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.ts
@@ -126,7 +126,7 @@ export default function useListbox<TOption>(props: UseListboxParameters<TOption>
   }, [options, optionComparer, dispatch]);
 
   const setSelectedValue = React.useCallback(
-    (option: TOption[]) => {
+    (option: TOption | TOption[] | null) => {
       dispatch({
         type: ActionTypes.setValue,
         event: null,

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -94,6 +94,8 @@ export type ListboxAction<TOption> =
   | SetValueAction<TOption>
   | OptionsChangeAction<TOption>;
 
+export type ListboxReducerAction<T> = ListboxAction<T> & { props: UseListboxPropsWithDefaults<T> };
+
 export interface ListboxState<TOption> {
   highlightedValue: TOption | null;
   selectedValue: TOption | TOption[] | null;
@@ -101,7 +103,7 @@ export interface ListboxState<TOption> {
 
 export type ListboxReducer<TOption> = (
   state: ListboxState<TOption>,
-  action: ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> },
+  action: ListboxReducerAction<TOption>,
 ) => ListboxState<TOption>;
 
 interface UseListboxCommonProps<TOption> {

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -35,32 +35,27 @@ interface OptionClickAction<TOption> {
   type: ActionTypes.optionClick;
   option: TOption;
   event: React.MouseEvent;
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface OptionHoverAction<TOption> {
   type: ActionTypes.optionHover;
   option: TOption;
   event: React.MouseEvent;
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
-interface FocusAction<TOption> {
+interface FocusAction {
   type: ActionTypes.focus;
   event: React.FocusEvent;
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
-interface BlurAction<TOption> {
+interface BlurAction {
   type: ActionTypes.blur;
   event: React.FocusEvent;
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
-interface KeyDownAction<TOption> {
+interface KeyDownAction {
   type: ActionTypes.keyDown;
   event: React.KeyboardEvent;
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface SetValueAction<TOption> {
@@ -75,11 +70,10 @@ interface SetHighlightAction<TOption> {
   highlight: TOption | null;
 }
 
-interface TextNavigationAction<TOption> {
+interface TextNavigationAction {
   type: ActionTypes.textNavigation;
   event: React.KeyboardEvent;
   searchString: string;
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 interface OptionsChangeAction<TOption> {
@@ -87,17 +81,16 @@ interface OptionsChangeAction<TOption> {
   event: null;
   options: TOption[];
   previousOptions: TOption[];
-  props: UseListboxPropsWithDefaults<TOption>;
 }
 
 export type ListboxAction<TOption> =
   | OptionClickAction<TOption>
   | OptionHoverAction<TOption>
-  | FocusAction<TOption>
-  | BlurAction<TOption>
-  | KeyDownAction<TOption>
+  | FocusAction
+  | BlurAction
+  | KeyDownAction
   | SetHighlightAction<TOption>
-  | TextNavigationAction<TOption>
+  | TextNavigationAction
   | SetValueAction<TOption>
   | OptionsChangeAction<TOption>;
 
@@ -106,9 +99,9 @@ export interface ListboxState<TOption> {
   selectedValue: TOption | TOption[] | null;
 }
 
-export type ListboxReducer<TOption> = (
+export type ListboxReducer<TOption, Props> = (
   state: ListboxState<TOption>,
-  action: ListboxAction<TOption>,
+  action: ListboxAction<TOption> & { props: Props },
 ) => ListboxState<TOption>;
 
 interface UseListboxCommonProps<TOption> {
@@ -165,7 +158,7 @@ interface UseListboxCommonProps<TOption> {
    * Custom state reducer function. It calculates the new state (highlighted and selected options)
    * based on the previous one and the performed action.
    */
-  stateReducer?: ListboxReducer<TOption>;
+  stateReducer?: ListboxReducer<TOption, UseListboxPropsWithDefaults<TOption>>;
 }
 
 interface UseSingleSelectListboxParameters<TOption> extends UseListboxCommonProps<TOption> {

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -174,7 +174,7 @@ interface UseSingleSelectListboxParameters<TOption> extends UseListboxCommonProp
   /**
    * The selected value. Use when the component is controlled.
    */
-  value?: TOption | null;
+  value: TOption | null;
   /**
    * Callback fired when the value changes.
    */
@@ -197,7 +197,7 @@ interface UseMultiSelectListboxParameters<TOption> extends UseListboxCommonProps
   /**
    * The selected value. Use when the component is controlled.
    */
-  value?: TOption[];
+  value: TOption[];
   /**
    * Callback fired when the value changes.
    */

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -163,18 +163,18 @@ interface UseListboxCommonProps<TOption> {
 
 interface UseSingleSelectListboxParameters<TOption> extends UseListboxCommonProps<TOption> {
   /**
-   * The default selected value. Use when the component is not controlled.
+   * The default selected value. Use when the listbox is not controlled.
    */
   defaultValue?: TOption | null;
   /**
-   * If `true`, the component will allow to select multiple options.
+   * If `true`, the listbox will allow to select multiple options.
    * @default false
    */
   multiple?: false;
   /**
-   * The selected value. Use when the component is controlled.
+   * The selected value. Use when the listbox is controlled.
    */
-  value: TOption | null;
+  value?: TOption | null;
   /**
    * Callback fired when the value changes.
    */
@@ -186,16 +186,16 @@ interface UseSingleSelectListboxParameters<TOption> extends UseListboxCommonProp
 
 interface UseMultiSelectListboxParameters<TOption> extends UseListboxCommonProps<TOption> {
   /**
-   * The default selected value. Use when the component is not controlled.
+   * The default selected value. Use when the listbox is not controlled.
    */
   defaultValue?: TOption[];
   /**
-   * If `true`, the component will allow to select multiple options.
+   * If `true`, the listbox will allow to select multiple options.
    * @default false
    */
   multiple: true;
   /**
-   * The selected value. Use when the component is controlled.
+   * The selected value. Use when the listbox is controlled.
    */
   value: TOption[];
   /**

--- a/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useListbox.types.ts
@@ -99,9 +99,9 @@ export interface ListboxState<TOption> {
   selectedValue: TOption | TOption[] | null;
 }
 
-export type ListboxReducer<TOption, Props> = (
+export type ListboxReducer<TOption> = (
   state: ListboxState<TOption>,
-  action: ListboxAction<TOption> & { props: Props },
+  action: ListboxAction<TOption> & { props: UseListboxPropsWithDefaults<TOption> },
 ) => ListboxState<TOption>;
 
 interface UseListboxCommonProps<TOption> {
@@ -158,7 +158,7 @@ interface UseListboxCommonProps<TOption> {
    * Custom state reducer function. It calculates the new state (highlighted and selected options)
    * based on the previous one and the performed action.
    */
-  stateReducer?: ListboxReducer<TOption, UseListboxPropsWithDefaults<TOption>>;
+  stateReducer?: ListboxReducer<TOption>;
 }
 
 interface UseSingleSelectListboxParameters<TOption> extends UseListboxCommonProps<TOption> {

--- a/packages/mui-base/src/ListboxUnstyled/useTextNavigation.ts
+++ b/packages/mui-base/src/ListboxUnstyled/useTextNavigation.ts
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { ActionTypes, ListboxAction, UseListboxPropsWithDefaults } from './useListbox.types';
+
+const TEXT_NAVIGATION_RESET_TIMEOUT = 500; // milliseconds
+
+/**
+ * Provides a handler for text navigation.
+ * It's used to navigate the listbox by typing the first letters of the options.
+ *
+ * @param dispatch The dispatch function from the reducer.
+ * @param propsWithDefaults Props with defaults applied.
+ * @returns A function to be used in a keydown event handler.
+ */
+export default function useTextNavigation<TOption>(
+  dispatch: (action: ListboxAction<TOption>) => void,
+  propsWithDefaults: React.RefObject<UseListboxPropsWithDefaults<TOption>>,
+) {
+  const textCriteriaRef = React.useRef<{
+    searchString: string;
+    lastTime: number | null;
+  }>({
+    searchString: '',
+    lastTime: null,
+  });
+
+  return React.useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key.length === 1 && event.key !== ' ') {
+        const textCriteria = textCriteriaRef.current;
+        const lowerKey = event.key.toLowerCase();
+        const currentTime = performance.now();
+        if (
+          textCriteria.searchString.length > 0 &&
+          textCriteria.lastTime &&
+          currentTime - textCriteria.lastTime > TEXT_NAVIGATION_RESET_TIMEOUT
+        ) {
+          textCriteria.searchString = lowerKey;
+        } else if (
+          textCriteria.searchString.length !== 1 ||
+          lowerKey !== textCriteria.searchString
+        ) {
+          // If there is just one character in the buffer and the key is the same, do not append
+          textCriteria.searchString += lowerKey;
+        }
+
+        textCriteria.lastTime = currentTime;
+
+        dispatch({
+          type: ActionTypes.textNavigation,
+          event,
+          searchString: textCriteria.searchString,
+          props: propsWithDefaults.current,
+        });
+      }
+    },
+    [dispatch, propsWithDefaults],
+  );
+}

--- a/packages/mui-base/src/MenuUnstyled/useMenu.ts
+++ b/packages/mui-base/src/MenuUnstyled/useMenu.ts
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import {
   defaultListboxReducer,
-  ListboxAction,
   ListboxState,
   useListbox,
   ActionTypes,
-  UseListboxPropsWithDefaults,
+  ListboxReducerAction,
 } from '../ListboxUnstyled';
 import {
   MenuItemMetadata,
@@ -18,7 +17,7 @@ import { EventHandlers } from '../utils';
 
 function stateReducer(
   state: ListboxState<string>,
-  action: ListboxAction<string> & { props: UseListboxPropsWithDefaults<string> },
+  action: ListboxReducerAction<string>,
 ): ListboxState<string> {
   if (
     action.type === ActionTypes.blur ||

--- a/packages/mui-base/src/MenuUnstyled/useMenu.ts
+++ b/packages/mui-base/src/MenuUnstyled/useMenu.ts
@@ -6,6 +6,7 @@ import {
   ListboxState,
   useListbox,
   ActionTypes,
+  UseListboxPropsWithDefaults,
 } from '../ListboxUnstyled';
 import {
   MenuItemMetadata,
@@ -17,7 +18,7 @@ import { EventHandlers } from '../utils';
 
 function stateReducer(
   state: ListboxState<string>,
-  action: ListboxAction<string>,
+  action: ListboxAction<string> & { props: UseListboxPropsWithDefaults<string> },
 ): ListboxState<string> {
   if (action.type === ActionTypes.blur || action.type === ActionTypes.setValue) {
     return state;

--- a/packages/mui-base/src/MenuUnstyled/useMenu.ts
+++ b/packages/mui-base/src/MenuUnstyled/useMenu.ts
@@ -20,7 +20,11 @@ function stateReducer(
   state: ListboxState<string>,
   action: ListboxAction<string> & { props: UseListboxPropsWithDefaults<string> },
 ): ListboxState<string> {
-  if (action.type === ActionTypes.blur || action.type === ActionTypes.setValue) {
+  if (
+    action.type === ActionTypes.blur ||
+    action.type === ActionTypes.optionHover ||
+    action.type === ActionTypes.setValue
+  ) {
     return state;
   }
 

--- a/packages/mui-base/src/MenuUnstyled/useMenu.ts
+++ b/packages/mui-base/src/MenuUnstyled/useMenu.ts
@@ -19,11 +19,7 @@ function stateReducer(
   state: ListboxState<string>,
   action: ListboxAction<string>,
 ): ListboxState<string> {
-  if (
-    action.type === ActionTypes.blur ||
-    action.type === ActionTypes.optionHover ||
-    action.type === ActionTypes.setValue
-  ) {
+  if (action.type === ActionTypes.blur || action.type === ActionTypes.setValue) {
     return state;
   }
 

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -15,7 +15,7 @@ import {
   screen,
 } from 'test/utils';
 
-describe('MultiSelectUnstyled', () => {
+describe.skip('MultiSelectUnstyled', () => {
   const mount = createMount();
   const { render } = createRenderer();
 

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.test.tsx
@@ -15,7 +15,7 @@ import {
   screen,
 } from 'test/utils';
 
-describe.skip('MultiSelectUnstyled', () => {
+describe('MultiSelectUnstyled', () => {
   const mount = createMount();
   const { render } = createRenderer();
 

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -148,6 +148,10 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
     getListboxProps,
     getOptionProps,
     getOptionState,
+    registerHighlightChangeHandler,
+    unregisterHighlightChangeHandler,
+    registerSelectionChangeHandler,
+    unregisterSelectionChangeHandler,
     value,
   } = useSelect<TValue>({
     buttonRef: handleButtonRef,
@@ -224,8 +228,19 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
       getOptionProps,
       getOptionState,
       listboxRef,
+      registerSelectionChangeHandler,
+      unregisterSelectionChangeHandler,
+      registerHighlightChangeHandler,
+      unregisterHighlightChangeHandler,
     }),
-    [getOptionProps, getOptionState],
+    [
+      getOptionProps,
+      getOptionState,
+      registerHighlightChangeHandler,
+      unregisterHighlightChangeHandler,
+      registerSelectionChangeHandler,
+      unregisterSelectionChangeHandler,
+    ],
   );
 
   return (

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -152,9 +152,7 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
     getOptionProps,
     getOptionState,
     registerHighlightChangeHandler,
-    unregisterHighlightChangeHandler,
     registerSelectionChangeHandler,
-    unregisterSelectionChangeHandler,
     value,
   } = useSelect<TValue>({
     buttonRef: handleButtonRef,
@@ -232,17 +230,13 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
       getOptionState,
       listboxRef,
       registerSelectionChangeHandler,
-      unregisterSelectionChangeHandler,
       registerHighlightChangeHandler,
-      unregisterHighlightChangeHandler,
     }),
     [
       getOptionProps,
       getOptionState,
       registerHighlightChangeHandler,
-      unregisterHighlightChangeHandler,
       registerSelectionChangeHandler,
-      unregisterSelectionChangeHandler,
     ],
   );
 

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.tsx
@@ -135,10 +135,13 @@ const MultiSelectUnstyled = React.forwardRef(function MultiSelectUnstyled<TValue
     }
   }, [autoFocus]);
 
-  const handleOpenChange = (isOpen: boolean) => {
-    setListboxOpen(isOpen);
-    onListboxOpenChange?.(isOpen);
-  };
+  const handleOpenChange = React.useCallback(
+    (isOpen: boolean) => {
+      setListboxOpen(isOpen);
+      onListboxOpenChange?.(isOpen);
+    },
+    [setListboxOpen, onListboxOpenChange],
+  );
 
   const {
     buttonActive,

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
@@ -32,6 +32,10 @@ describe('OptionUnstyled', () => {
             getOptionState: dummyGetOptionState,
             getOptionProps: dummyGetOptionProps,
             listboxRef: React.createRef(),
+            registerHighlightChangeHandler: () => {},
+            registerSelectionChangeHandler: () => {},
+            unregisterHighlightChangeHandler: () => {},
+            unregisterSelectionChangeHandler: () => {},
           }}
         >
           {node}
@@ -45,6 +49,10 @@ describe('OptionUnstyled', () => {
             getOptionState: dummyGetOptionState,
             getOptionProps: dummyGetOptionProps,
             listboxRef: React.createRef(),
+            registerHighlightChangeHandler: () => {},
+            registerSelectionChangeHandler: () => {},
+            unregisterHighlightChangeHandler: () => {},
+            unregisterSelectionChangeHandler: () => {},
           }}
         >
           {node}

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.test.tsx
@@ -32,10 +32,8 @@ describe('OptionUnstyled', () => {
             getOptionState: dummyGetOptionState,
             getOptionProps: dummyGetOptionProps,
             listboxRef: React.createRef(),
-            registerHighlightChangeHandler: () => {},
-            registerSelectionChangeHandler: () => {},
-            unregisterHighlightChangeHandler: () => {},
-            unregisterSelectionChangeHandler: () => {},
+            registerHighlightChangeHandler: () => () => {},
+            registerSelectionChangeHandler: () => () => {},
           }}
         >
           {node}
@@ -49,10 +47,8 @@ describe('OptionUnstyled', () => {
             getOptionState: dummyGetOptionState,
             getOptionProps: dummyGetOptionProps,
             listboxRef: React.createRef(),
-            registerHighlightChangeHandler: () => {},
-            registerSelectionChangeHandler: () => {},
-            unregisterHighlightChangeHandler: () => {},
-            unregisterSelectionChangeHandler: () => {},
+            registerHighlightChangeHandler: () => () => {},
+            registerSelectionChangeHandler: () => () => {},
           }}
         >
           {node}

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
@@ -42,10 +43,45 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
 
   console.log('rendering OptionUnstyled');
 
+  const [selected, setSelected] = React.useState(false);
+  const [highlighted, setHighlighted] = React.useState(false);
+
   const selectContext = React.useContext(SelectUnstyledContext);
   if (!selectContext) {
     throw new Error('OptionUnstyled must be used within a SelectUnstyled');
   }
+
+  React.useEffect(() => {
+    function updateSelectedState(e: unknown, newValue: TValue | null) {
+      // TODO: use option comparer
+      if (newValue === value && !selected) {
+        setSelected(true);
+      } else if (newValue !== value && selected) {
+        setSelected(false);
+      }
+    }
+
+    selectContext.registerSelectionChangeHandler(updateSelectedState);
+    return () => {
+      selectContext.unregisterSelectionChangeHandler(updateSelectedState);
+    };
+  }, [selectContext, selected, value]);
+
+  React.useEffect(() => {
+    function updateHighlightedState(e: unknown, newValue: TValue | null) {
+      // TODO: use option comparer
+      if (newValue === value && !highlighted) {
+        setHighlighted(true);
+      } else if (newValue !== value && highlighted) {
+        setHighlighted(false);
+      }
+    }
+
+    selectContext.registerHighlightChangeHandler(updateHighlightedState);
+    return () => {
+      selectContext.unregisterHighlightChangeHandler(updateHighlightedState);
+    };
+  }, [selectContext, highlighted, value]);
 
   const Root = component || slots.root || 'li';
 

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
@@ -40,6 +40,8 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
     ...other
   } = props;
 
+  console.log('rendering OptionUnstyled');
+
   const selectContext = React.useContext(SelectUnstyledContext);
   if (!selectContext) {
     throw new Error('OptionUnstyled must be used within a SelectUnstyled');

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
@@ -40,8 +39,6 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
     value,
     ...other
   } = props;
-
-  console.log('rendering OptionUnstyled');
 
   const [selected, setSelected] = React.useState(false);
   const [highlighted, setHighlighted] = React.useState(false);

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.tsx
@@ -45,14 +45,8 @@ const OptionUnstyled = React.forwardRef(function OptionUnstyled<TValue>(
     throw new Error('OptionUnstyled must be used within a SelectUnstyled');
   }
 
-  const selectOption = {
-    value,
-    label: label || children,
-    disabled,
-  };
-
-  const optionState = selectContext.getOptionState(selectOption);
-  const optionProps = selectContext.getOptionProps(selectOption);
+  const optionState = selectContext.getOptionState(value);
+  const optionProps = selectContext.getOptionProps(value);
 
   const [selected, setSelected] = React.useState(optionState.selected);
   const [highlighted, setHighlighted] = React.useState(optionState.highlighted);

--- a/packages/mui-base/src/OptionUnstyled/index.ts
+++ b/packages/mui-base/src/OptionUnstyled/index.ts
@@ -4,3 +4,6 @@ export * from './OptionUnstyled.types';
 
 export { default as optionUnstyledClasses } from './optionUnstyledClasses';
 export * from './optionUnstyledClasses';
+
+export { default as useOption } from './useOption';
+export * from './useOption.types';

--- a/packages/mui-base/src/OptionUnstyled/useOption.ts
+++ b/packages/mui-base/src/OptionUnstyled/useOption.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { SelectUnstyledContext } from '../SelectUnstyled';
+
+interface UseOptionParameters<Value> {
+  disabled: boolean;
+  value: Value;
+}
+
+interface UseOptionReturnValue {}
+
+export default function useOption<Value>(params: UseOptionParameters<Value>): UseOptionReturnValue {
+  const { value } = params;
+
+  const selectContext = React.useContext(SelectUnstyledContext);
+  if (!selectContext) {
+    throw new Error('OptionUnstyled must be used within a SelectUnstyled');
+  }
+
+  const optionState = selectContext.getOptionState(value);
+  const optionProps = selectContext.getOptionProps(value);
+
+  return {
+    getRootProps: () => optionProps,
+    selected: optionState.selected,
+    disabled: optionState.disabled,
+    highlighted: optionState.highlighted,
+  };
+}

--- a/packages/mui-base/src/OptionUnstyled/useOption.ts
+++ b/packages/mui-base/src/OptionUnstyled/useOption.ts
@@ -1,28 +1,111 @@
 import * as React from 'react';
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import { SelectUnstyledContext } from '../SelectUnstyled';
-
-interface UseOptionParameters<Value> {
-  disabled: boolean;
-  value: Value;
-}
-
-interface UseOptionReturnValue {}
+import { UseOptionParameters, UseOptionReturnValue } from './useOption.types';
+import { EventHandlers } from '../utils';
+import useForcedRerendering from '../utils/useForcedRerendering';
 
 export default function useOption<Value>(params: UseOptionParameters<Value>): UseOptionReturnValue {
-  const { value } = params;
+  const { value, optionRef: optionRefParam } = params;
 
   const selectContext = React.useContext(SelectUnstyledContext);
   if (!selectContext) {
-    throw new Error('OptionUnstyled must be used within a SelectUnstyled');
+    throw new Error(
+      'Option must have access to the SelectUnstyledContext (i.e., be used inside a SelectUnstyled component).',
+    );
   }
 
-  const optionState = selectContext.getOptionState(value);
-  const optionProps = selectContext.getOptionProps(value);
+  const {
+    getOptionProps,
+    getOptionState,
+    listboxRef,
+    registerHighlightChangeHandler,
+    unregisterHighlightChangeHandler,
+    registerSelectionChangeHandler,
+    unregisterSelectionChangeHandler,
+  } = selectContext;
+
+  const optionState = getOptionState(value);
+  const optionProps = getOptionProps(value);
+
+  const { selected, highlighted } = optionState;
+
+  const rerender = useForcedRerendering();
+
+  React.useEffect(() => {
+    function updateSelectedState(_: unknown, selectedValues: Value | Value[] | null) {
+      if (!selected) {
+        if (Array.isArray(selectedValues)) {
+          if (selectedValues.includes(value)) {
+            rerender();
+          }
+        } else if (selectedValues === value) {
+          rerender();
+        }
+      } else if (Array.isArray(selectedValues)) {
+        if (!selectedValues.includes(value)) {
+          rerender();
+        }
+      } else if (selectedValues !== value) {
+        rerender();
+      }
+    }
+
+    registerSelectionChangeHandler(updateSelectedState);
+
+    return () => {
+      unregisterSelectionChangeHandler(updateSelectedState);
+    };
+  }, [registerSelectionChangeHandler, unregisterSelectionChangeHandler, rerender, selected, value]);
+
+  React.useEffect(() => {
+    function updateHighlightedState(_: unknown, highlightedValue: Value | null) {
+      if (highlightedValue === value && !highlighted) {
+        rerender();
+      } else if (highlightedValue !== value && highlighted) {
+        rerender();
+      }
+    }
+
+    registerHighlightChangeHandler(updateHighlightedState);
+    return () => {
+      unregisterHighlightChangeHandler(updateHighlightedState);
+    };
+  }, [
+    registerHighlightChangeHandler,
+    unregisterHighlightChangeHandler,
+    rerender,
+    value,
+    highlighted,
+  ]);
+
+  const optionRef = React.useRef<HTMLLIElement>(null);
+  const handleRef = useForkRef(optionRefParam, optionRef);
+
+  React.useEffect(() => {
+    // Scroll to the currently highlighted option
+    if (highlighted) {
+      if (!listboxRef.current || !optionRef.current) {
+        return;
+      }
+      const listboxClientRect = listboxRef.current.getBoundingClientRect();
+      const optionClientRect = optionRef.current.getBoundingClientRect();
+
+      if (optionClientRect.top < listboxClientRect.top) {
+        listboxRef.current.scrollTop -= listboxClientRect.top - optionClientRect.top;
+      } else if (optionClientRect.bottom > listboxClientRect.bottom) {
+        listboxRef.current.scrollTop += optionClientRect.bottom - listboxClientRect.bottom;
+      }
+    }
+  }, [highlighted, listboxRef]);
 
   return {
-    getRootProps: () => optionProps,
-    selected: optionState.selected,
-    disabled: optionState.disabled,
-    highlighted: optionState.highlighted,
+    getRootProps: <Other extends EventHandlers = {}>(otherHandlers: Other = {} as Other) => ({
+      ...otherHandlers,
+      ...optionProps,
+      ref: handleRef,
+    }),
+    selected,
+    highlighted,
   };
 }

--- a/packages/mui-base/src/OptionUnstyled/useOption.ts
+++ b/packages/mui-base/src/OptionUnstyled/useOption.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
-import { SelectUnstyledContext } from '../SelectUnstyled';
+import { SelectUnstyledContext } from '../SelectUnstyled/SelectUnstyledContext';
 import { UseOptionParameters, UseOptionReturnValue } from './useOption.types';
 import { EventHandlers } from '../utils';
 import useForcedRerendering from '../utils/useForcedRerendering';
@@ -20,20 +20,17 @@ export default function useOption<Value>(params: UseOptionParameters<Value>): Us
     getOptionState,
     listboxRef,
     registerHighlightChangeHandler,
-    unregisterHighlightChangeHandler,
     registerSelectionChangeHandler,
-    unregisterSelectionChangeHandler,
   } = selectContext;
 
   const optionState = getOptionState(value);
-  const optionProps = getOptionProps(value);
 
   const { selected, highlighted } = optionState;
 
   const rerender = useForcedRerendering();
 
   React.useEffect(() => {
-    function updateSelectedState(_: unknown, selectedValues: Value | Value[] | null) {
+    function updateSelectedState(selectedValues: Value | Value[] | null) {
       if (!selected) {
         if (Array.isArray(selectedValues)) {
           if (selectedValues.includes(value)) {
@@ -51,15 +48,11 @@ export default function useOption<Value>(params: UseOptionParameters<Value>): Us
       }
     }
 
-    registerSelectionChangeHandler(updateSelectedState);
-
-    return () => {
-      unregisterSelectionChangeHandler(updateSelectedState);
-    };
-  }, [registerSelectionChangeHandler, unregisterSelectionChangeHandler, rerender, selected, value]);
+    return registerSelectionChangeHandler(updateSelectedState);
+  }, [registerSelectionChangeHandler, rerender, selected, value]);
 
   React.useEffect(() => {
-    function updateHighlightedState(_: unknown, highlightedValue: Value | null) {
+    function updateHighlightedState(highlightedValue: Value | null) {
       if (highlightedValue === value && !highlighted) {
         rerender();
       } else if (highlightedValue !== value && highlighted) {
@@ -67,17 +60,8 @@ export default function useOption<Value>(params: UseOptionParameters<Value>): Us
       }
     }
 
-    registerHighlightChangeHandler(updateHighlightedState);
-    return () => {
-      unregisterHighlightChangeHandler(updateHighlightedState);
-    };
-  }, [
-    registerHighlightChangeHandler,
-    unregisterHighlightChangeHandler,
-    rerender,
-    value,
-    highlighted,
-  ]);
+    return registerHighlightChangeHandler(updateHighlightedState);
+  }, [registerHighlightChangeHandler, rerender, value, highlighted]);
 
   const optionRef = React.useRef<HTMLLIElement>(null);
   const handleRef = useForkRef(optionRefParam, optionRef);
@@ -102,7 +86,7 @@ export default function useOption<Value>(params: UseOptionParameters<Value>): Us
   return {
     getRootProps: <Other extends EventHandlers = {}>(otherHandlers: Other = {} as Other) => ({
       ...otherHandlers,
-      ...optionProps,
+      ...getOptionProps(value, otherHandlers),
       ref: handleRef,
     }),
     selected,

--- a/packages/mui-base/src/OptionUnstyled/useOption.types.ts
+++ b/packages/mui-base/src/OptionUnstyled/useOption.types.ts
@@ -1,0 +1,20 @@
+import { UseSelectOptionSlotProps } from '../SelectUnstyled';
+import { EventHandlers } from '../utils';
+
+export interface UseOptionParameters<Value> {
+  disabled: boolean;
+  value: Value;
+  optionRef?: React.Ref<HTMLElement>;
+}
+
+export interface UseOptionReturnValue {
+  selected: boolean;
+  highlighted: boolean;
+  getRootProps: <Other extends EventHandlers>(
+    otherHandlers?: Other,
+  ) => UseOptionRootSlotProps<Other>;
+}
+
+export type UseOptionRootSlotProps<Other extends EventHandlers = {}> = UseSelectOptionSlotProps & {
+  ref?: React.Ref<HTMLElement>;
+} & Other;

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -14,7 +14,7 @@ import {
 } from './SelectUnstyled.types';
 import { flattenOptionGroups, getOptionsFromChildren } from './utils';
 import useSelect from './useSelect';
-import { SelectChangeEventType, SelectChild, SelectOption } from './useSelect.types';
+import { SelectChild, SelectOption } from './useSelect.types';
 import { useSlotProps, WithOptionalOwnerState } from '../utils';
 import PopperUnstyled from '../PopperUnstyled';
 import { SelectUnstyledContext, SelectUnstyledContextType } from './SelectUnstyledContext';
@@ -135,13 +135,6 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     [setListboxOpen, onListboxOpenChange],
   );
 
-  const handleChange = React.useCallback(
-    (event: SelectChangeEventType, newValue: TValue | null) => {
-      onChange?.(event, newValue);
-    },
-    [onChange],
-  );
-
   const {
     buttonActive,
     buttonFocusVisible,
@@ -162,7 +155,7 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     listboxId,
     multiple: false,
     open: listboxOpen,
-    onChange: handleChange,
+    onChange,
     onOpenChange: handleOpenChange,
     options,
     optionStringifier,

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -287,14 +286,6 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
       unregisterHighlightChangeHandler,
     ],
   );
-
-  React.useEffect(() => {
-    console.log('getOptionProps changed');
-  }, [getOptionProps]);
-
-  React.useEffect(() => {
-    console.log('getOptionState changed');
-  }, [getOptionState]);
 
   return (
     <React.Fragment>

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -127,10 +127,13 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     }
   }, [autoFocus]);
 
-  const handleOpenChange = (isOpen: boolean) => {
-    setListboxOpen(isOpen);
-    onListboxOpenChange?.(isOpen);
-  };
+  const handleOpenChange = React.useCallback(
+    (isOpen: boolean) => {
+      setListboxOpen(isOpen);
+      onListboxOpenChange?.(isOpen);
+    },
+    [setListboxOpen, onListboxOpenChange],
+  );
 
   const {
     buttonActive,
@@ -216,6 +219,14 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     }),
     [getOptionProps, getOptionState],
   );
+
+  React.useEffect(() => {
+    console.log('getOptionProps changed');
+  }, [getOptionProps]);
+
+  React.useEffect(() => {
+    console.log('getOptionState changed');
+  }, [getOptionState]);
 
   return (
     <React.Fragment>

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -14,7 +14,7 @@ import {
 } from './SelectUnstyled.types';
 import { flattenOptionGroups, getOptionsFromChildren } from './utils';
 import useSelect from './useSelect';
-import { SelectChild, SelectOption } from './useSelect.types';
+import { SelectChangeEventType, SelectChild, SelectOption } from './useSelect.types';
 import { useSlotProps, WithOptionalOwnerState } from '../utils';
 import PopperUnstyled from '../PopperUnstyled';
 import { SelectUnstyledContext, SelectUnstyledContextType } from './SelectUnstyledContext';
@@ -55,12 +55,6 @@ function useUtilityClasses(ownerState: SelectUnstyledOwnerState<any>) {
 
   return composeClasses(slots, getSelectUnstyledUtilityClass, {});
 }
-
-type ChangeEventType =
-  | React.MouseEvent<Element, MouseEvent>
-  | React.KeyboardEvent<Element>
-  | React.FocusEvent<Element, Element>
-  | null;
 
 /**
  * The foundation for building custom-styled select components.
@@ -141,25 +135,12 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     [setListboxOpen, onListboxOpenChange],
   );
 
-  const selectionChangeEventHandlers = React.useRef<
-    Set<(e: ChangeEventType, newValue: TValue | null) => void>
-  >(new Set());
-
-  const highlightChangeEventHandlers = React.useRef<
-    Set<(e: ChangeEventType, newValue: TValue | null) => void>
-  >(new Set());
-
   const handleChange = React.useCallback(
-    (e: ChangeEventType, newValue: TValue | null) => {
-      onChange?.(e, newValue);
-      selectionChangeEventHandlers.current.forEach((handler) => handler(e, newValue));
+    (event: SelectChangeEventType, newValue: TValue | null) => {
+      onChange?.(event, newValue);
     },
     [onChange],
   );
-
-  const handleHighlightChange = React.useCallback((e: ChangeEventType, newValue: TValue | null) => {
-    highlightChangeEventHandlers.current.forEach((handler) => handler(e, newValue));
-  }, []);
 
   const {
     buttonActive,
@@ -169,6 +150,10 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     getListboxProps,
     getOptionProps,
     getOptionState,
+    registerHighlightChangeHandler,
+    unregisterHighlightChangeHandler,
+    registerSelectionChangeHandler,
+    unregisterSelectionChangeHandler,
     value,
   } = useSelect({
     buttonRef: handleButtonRef,
@@ -176,10 +161,9 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     disabled: disabledProp,
     listboxId,
     multiple: false,
-    onChange: handleChange,
-    onHighlightChange: handleHighlightChange,
-    onOpenChange: handleOpenChange,
     open: listboxOpen,
+    onChange: handleChange,
+    onOpenChange: handleOpenChange,
     options,
     optionStringifier,
     value: valueProp,
@@ -237,34 +221,6 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     ownerState,
     className: classes.popper,
   });
-
-  const registerSelectionChangeHandler = React.useCallback(
-    (handler: (e: ChangeEventType, newValue: TValue | null) => void) => {
-      selectionChangeEventHandlers.current.add(handler);
-    },
-    [],
-  );
-
-  const unregisterSelectionChangeHandler = React.useCallback(
-    (handler: (e: ChangeEventType, newValue: TValue | null) => void) => {
-      selectionChangeEventHandlers.current.delete(handler);
-    },
-    [],
-  );
-
-  const registerHighlightChangeHandler = React.useCallback(
-    (handler: (e: ChangeEventType, newValue: TValue | null) => void) => {
-      highlightChangeEventHandlers.current.add(handler);
-    },
-    [],
-  );
-
-  const unregisterHighlightChangeHandler = React.useCallback(
-    (handler: (e: ChangeEventType, newValue: TValue | null) => void) => {
-      highlightChangeEventHandlers.current.delete(handler);
-    },
-    [],
-  );
 
   const context: SelectUnstyledContextType = React.useMemo(
     () => ({

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -144,9 +144,7 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
     getOptionProps,
     getOptionState,
     registerHighlightChangeHandler,
-    unregisterHighlightChangeHandler,
     registerSelectionChangeHandler,
-    unregisterSelectionChangeHandler,
     value,
   } = useSelect({
     buttonRef: handleButtonRef,
@@ -221,17 +219,13 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
       getOptionState,
       listboxRef,
       registerSelectionChangeHandler,
-      unregisterSelectionChangeHandler,
       registerHighlightChangeHandler,
-      unregisterHighlightChangeHandler,
     }),
     [
       getOptionProps,
       getOptionState,
       registerSelectionChangeHandler,
-      unregisterSelectionChangeHandler,
       registerHighlightChangeHandler,
-      unregisterHighlightChangeHandler,
     ],
   );
 

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.tsx
@@ -233,7 +233,6 @@ const SelectUnstyled = React.forwardRef(function SelectUnstyled<TValue extends {
       open: listboxOpen,
       placement: 'bottom-start' as const,
       role: undefined,
-      keepMounted: true,
     },
     ownerState,
     className: classes.popper,

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
@@ -6,6 +6,46 @@ export interface SelectUnstyledContextType {
   getOptionState: (value: SelectOption<any>) => OptionState;
   getOptionProps: (option: SelectOption<any>) => UseSelectOptionSlotProps;
   listboxRef: React.RefObject<HTMLElement>;
+  registerSelectionChangeHandler: (
+    handler: (
+      e:
+        | React.MouseEvent<Element, MouseEvent>
+        | React.KeyboardEvent<Element>
+        | React.FocusEvent<Element, Element>
+        | null,
+      newValue: any | any[],
+    ) => void,
+  ) => void;
+  unregisterSelectionChangeHandler: (
+    handler: (
+      e:
+        | React.MouseEvent<Element, MouseEvent>
+        | React.KeyboardEvent<Element>
+        | React.FocusEvent<Element, Element>
+        | null,
+      newValue: any | any[],
+    ) => void,
+  ) => void;
+  registerHighlightChangeHandler: (
+    handler: (
+      e:
+        | React.MouseEvent<Element, MouseEvent>
+        | React.KeyboardEvent<Element>
+        | React.FocusEvent<Element, Element>
+        | null,
+      newValue: any | null,
+    ) => void,
+  ) => void;
+  unregisterHighlightChangeHandler: (
+    handler: (
+      e:
+        | React.MouseEvent<Element, MouseEvent>
+        | React.KeyboardEvent<Element>
+        | React.FocusEvent<Element, Element>
+        | null,
+      newValue: any | null,
+    ) => void,
+  ) => void;
 }
 
 export const SelectUnstyledContext = React.createContext<SelectUnstyledContextType | undefined>(

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { OptionState } from '../ListboxUnstyled';
-import { SelectOption, UseSelectOptionSlotProps } from './useSelect.types';
+import { UseSelectOptionSlotProps } from './useSelect.types';
 
 export interface SelectUnstyledContextType {
-  getOptionState: (value: SelectOption<any>) => OptionState;
-  getOptionProps: (option: SelectOption<any>) => UseSelectOptionSlotProps;
+  getOptionState: (value: any) => OptionState;
+  getOptionProps: (value: any) => UseSelectOptionSlotProps;
   listboxRef: React.RefObject<HTMLElement>;
   registerSelectionChangeHandler: (
     handler: (

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyledContext.ts
@@ -1,51 +1,18 @@
 import * as React from 'react';
 import { OptionState } from '../ListboxUnstyled';
+import { EventHandlers } from '../utils';
 import { UseSelectOptionSlotProps } from './useSelect.types';
+import { SelectChangeNotifiers } from './useSelectChangeNotifiers';
 
 export interface SelectUnstyledContextType {
   getOptionState: (value: any) => OptionState;
-  getOptionProps: (value: any) => UseSelectOptionSlotProps;
+  getOptionProps: <OtherHandlers extends EventHandlers>(
+    value: any,
+    otherHandlers: OtherHandlers,
+  ) => UseSelectOptionSlotProps;
   listboxRef: React.RefObject<HTMLElement>;
-  registerSelectionChangeHandler: (
-    handler: (
-      e:
-        | React.MouseEvent<Element, MouseEvent>
-        | React.KeyboardEvent<Element>
-        | React.FocusEvent<Element, Element>
-        | null,
-      newValue: any | any[],
-    ) => void,
-  ) => void;
-  unregisterSelectionChangeHandler: (
-    handler: (
-      e:
-        | React.MouseEvent<Element, MouseEvent>
-        | React.KeyboardEvent<Element>
-        | React.FocusEvent<Element, Element>
-        | null,
-      newValue: any | any[],
-    ) => void,
-  ) => void;
-  registerHighlightChangeHandler: (
-    handler: (
-      e:
-        | React.MouseEvent<Element, MouseEvent>
-        | React.KeyboardEvent<Element>
-        | React.FocusEvent<Element, Element>
-        | null,
-      newValue: any | null,
-    ) => void,
-  ) => void;
-  unregisterHighlightChangeHandler: (
-    handler: (
-      e:
-        | React.MouseEvent<Element, MouseEvent>
-        | React.KeyboardEvent<Element>
-        | React.FocusEvent<Element, Element>
-        | null,
-      newValue: any | null,
-    ) => void,
-  ) => void;
+  registerSelectionChangeHandler: SelectChangeNotifiers<any>['registerSelectionChangeHandler'];
+  registerHighlightChangeHandler: SelectChangeNotifiers<any>['registerHighlightChangeHandler'];
 }
 
 export const SelectUnstyledContext = React.createContext<SelectUnstyledContextType | undefined>(

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -53,13 +53,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     defaultValue = multiple ? [] : null;
   }
 
-  /* const [value, setValue] = useControlled({
-    controlled: valueProp,
-    default: defaultValue,
-    name: 'SelectUnstyled',
-    state: 'value',
-  }); */
-
   const optionsMap = React.useMemo(() => {
     const map = new Map<TValue, SelectOption<TValue>>();
     options.forEach((option) => {

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -259,14 +259,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     ref: handleButtonRef,
   });
 
-  const selectedOption = React.useMemo(
-    () =>
-      props.multiple
-        ? props.options.filter((o) => (value as TValue[]).includes(o.value))
-        : props.options.find((o) => o.value === value) ?? null,
-    [props.multiple, props.options, value],
-  );
-
   const optionValues = React.useMemo(() => options.map((o) => o.value), [options]);
 
   let useListboxParameters: UseListboxParameters<TValue>;

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as React from 'react';
 import {
   unstable_useControlled as useControlled,
@@ -26,12 +25,6 @@ import {
 } from '../ListboxUnstyled';
 import { EventHandlers } from '../utils/types';
 import defaultOptionStringifier from './defaultOptionStringifier';
-
-function useNotifyChanged(prop: unknown, propName: string) {
-  React.useEffect(() => {
-    console.log(`${propName} changed (new value: ${prop}))`);
-  }, [prop, propName]);
-}
 
 function defaultOptionComparer<TValue>(o: SelectOption<TValue>, v: SelectOption<TValue>) {
   return o?.value === v?.value;
@@ -239,7 +232,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
         onChangeMultiple?.(e, newValues);
       },
       onHighlightChange: (e, newOption) => {
-        console.log('onHighlightChange', newOption);
         onHighlightChange?.(e, newOption?.value ?? null);
       },
       options,
@@ -262,8 +254,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
         onChangeSingle?.(e, option?.value ?? null);
       },
       onHighlightChange: (e, newOption) => {
-        console.log('onHighlightChange', newOption);
-
         onHighlightChange?.(e, newOption?.value ?? null);
       },
       options,
@@ -306,9 +296,6 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       onBlur: createHandleListboxBlur(otherHandlers),
       onKeyUp: createHandleListboxKeyUp(otherHandlers),
     });
-
-  useNotifyChanged(getListboxOptionProps, 'getListboxOptionProps');
-  useNotifyChanged(createHandleListboxItemClick, 'createHandleListboxItemClick');
 
   const getOptionProps = React.useCallback(
     <TOther extends EventHandlers>(

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -80,8 +80,12 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
 
   const handleListboxRef = useForkRef(listboxRefProp, listboxRef, focusListboxIfRequested);
 
-  const { notifySelectionChanged, notifyHighlightChanged, registrationFunctions } =
-    useSelectChangeNotifiers<TValue>();
+  const {
+    notifySelectionChanged,
+    notifyHighlightChanged,
+    registerHighlightChangeHandler,
+    registerSelectionChangeHandler,
+  } = useSelectChangeNotifiers<TValue>();
 
   React.useEffect(() => {
     focusListboxIfRequested();
@@ -284,11 +288,11 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
   } = useListbox(useListboxParameters);
 
   React.useEffect(() => {
-    notifySelectionChanged(null, selectedOption);
+    notifySelectionChanged(selectedOption);
   }, [selectedOption, notifySelectionChanged]);
 
   React.useEffect(() => {
-    notifyHighlightChanged(null, highlightedOption);
+    notifyHighlightChanged(highlightedOption);
   }, [highlightedOption, notifyHighlightChanged]);
 
   const getButtonProps = <TOther extends EventHandlers>(
@@ -345,7 +349,8 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     getOptionProps,
     getOptionState,
     open,
-    ...registrationFunctions,
+    registerHighlightChangeHandler,
+    registerSelectionChangeHandler,
     value: selectedOption,
     highlightedOption,
   };

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -312,7 +312,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       },
       options: optionValues,
       optionStringifier: stringifyOption,
-      value: selectedOption as TValue[],
+      value: value as TValue[],
     };
   } else {
     const onChangeSingle = onChange as (

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -1,9 +1,5 @@
 import * as React from 'react';
-import {
-  unstable_useControlled as useControlled,
-  unstable_useForkRef as useForkRef,
-  unstable_useId as useId,
-} from '@mui/utils';
+import { unstable_useForkRef as useForkRef, unstable_useId as useId } from '@mui/utils';
 import { useButton } from '../ButtonUnstyled';
 import {
   SelectOption,
@@ -57,12 +53,12 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     defaultValue = multiple ? [] : null;
   }
 
-  const [value, setValue] = useControlled({
+  /* const [value, setValue] = useControlled({
     controlled: valueProp,
     default: defaultValue,
     name: 'SelectUnstyled',
     state: 'value',
-  });
+  }); */
 
   const optionsMap = React.useMemo(() => {
     const map = new Map<TValue, SelectOption<TValue>>();
@@ -247,12 +243,12 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       value: TValue[],
     ) => void;
     useListboxParameters = {
+      defaultValue: defaultValue as TValue[],
       id: listboxId,
       isOptionDisabled,
       listboxRef: handleListboxRef,
       multiple: true,
       onChange: (e, newValues) => {
-        setValue(newValues);
         onChangeMultiple?.(e, newValues);
       },
       onHighlightChange: (e, newValue) => {
@@ -260,7 +256,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       },
       options: optionValues,
       optionStringifier: stringifyOption,
-      value: value as TValue[],
+      value: valueProp as TValue[],
     };
   } else {
     const onChangeSingle = onChange as (
@@ -268,12 +264,12 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       value: TValue | null,
     ) => void;
     useListboxParameters = {
+      defaultValue: defaultValue as TValue | null,
       id: listboxId,
       isOptionDisabled,
       listboxRef: handleListboxRef,
       multiple: false,
       onChange: (e, newValue: TValue | null) => {
-        setValue(newValue);
         onChangeSingle?.(e, newValue);
       },
       onHighlightChange: (e, newValue) => {
@@ -282,7 +278,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       options: optionValues,
       optionStringifier: stringifyOption,
       stateReducer: listboxReducer,
-      value: value as TValue | null,
+      value: valueProp as TValue | null,
     };
   }
 
@@ -291,12 +287,12 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     getOptionProps: getListboxOptionProps,
     getOptionState,
     highlightedOption,
-    selectedOption: listboxSelectedOption,
+    selectedOption,
   } = useListbox(useListboxParameters);
 
   React.useEffect(() => {
-    notifySelectionChanged(null, listboxSelectedOption);
-  }, [listboxSelectedOption, notifySelectionChanged]);
+    notifySelectionChanged(null, selectedOption);
+  }, [selectedOption, notifySelectionChanged]);
 
   React.useEffect(() => {
     notifyHighlightChanged(null, highlightedOption);
@@ -342,7 +338,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
   );
 
   React.useDebugValue({
-    selectedOption: listboxSelectedOption,
+    selectedOption,
     highlightedOption,
     open,
   });
@@ -357,7 +353,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     getOptionState,
     open,
     ...registrationFunctions,
-    value,
+    value: selectedOption,
     highlightedOption,
   };
 }

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -167,34 +167,37 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       }
     };
 
-  const listboxReducer: ListboxReducer<SelectOption<TValue>> = (state, action) => {
-    const newState = defaultListboxReducer(state, action);
+  const listboxReducer: ListboxReducer<SelectOption<TValue>> = React.useCallback(
+    (state, action) => {
+      const newState = defaultListboxReducer(state, action);
 
-    // change selection when listbox is closed
-    if (
-      action.type === ActionTypes.keyDown &&
-      !open &&
-      (action.event.key === 'ArrowUp' || action.event.key === 'ArrowDown')
-    ) {
-      return {
-        ...newState,
-        selectedValue: newState.highlightedValue,
-      };
-    }
+      // change selection when listbox is closed
+      if (
+        action.type === ActionTypes.keyDown &&
+        !open &&
+        (action.event.key === 'ArrowUp' || action.event.key === 'ArrowDown')
+      ) {
+        return {
+          ...newState,
+          selectedValue: newState.highlightedValue,
+        };
+      }
 
-    if (
-      action.type === ActionTypes.blur ||
-      action.type === ActionTypes.setValue ||
-      action.type === ActionTypes.optionsChange
-    ) {
-      return {
-        ...newState,
-        highlightedValue: newState.selectedValue as SelectOption<TValue>,
-      };
-    }
+      if (
+        action.type === ActionTypes.blur ||
+        action.type === ActionTypes.setValue ||
+        action.type === ActionTypes.optionsChange
+      ) {
+        return {
+          ...newState,
+          highlightedValue: newState.selectedValue as SelectOption<TValue>,
+        };
+      }
 
-    return newState;
-  };
+      return newState;
+    },
+    [open],
+  );
 
   const {
     getRootProps: getButtonRootProps,

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -326,6 +326,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     getOptionState,
     open,
     value,
+    highlightedOption,
   };
 }
 

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -32,7 +32,7 @@ function useSelect<TValue>(props: UseSelectMultiParameters<TValue>): UseSelectMu
 function useSelect<TValue>(props: UseSelectParameters<TValue>) {
   const {
     buttonRef: buttonRefProp,
-    defaultValue,
+    defaultValue: defaultValueProp,
     disabled = false,
     listboxId: listboxIdProp,
     listboxRef: listboxRefProp,
@@ -51,6 +51,11 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
 
   const listboxRef = React.useRef<HTMLElement | null>(null);
   const listboxId = useId(listboxIdProp);
+
+  let defaultValue = defaultValueProp;
+  if (valueProp === undefined && defaultValueProp === undefined) {
+    defaultValue = multiple ? [] : null;
+  }
 
   const [value, setValue] = useControlled({
     controlled: valueProp,
@@ -249,11 +254,9 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       onChange: (e, newValues) => {
         setValue(newValues);
         onChangeMultiple?.(e, newValues);
-        notifySelectionChanged(e, newValues);
       },
       onHighlightChange: (e, newValue) => {
         onHighlightChange?.(e, newValue ?? null);
-        notifyHighlightChanged(e, newValue ?? null);
       },
       options: optionValues,
       optionStringifier: stringifyOption,
@@ -272,11 +275,9 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       onChange: (e, newValue: TValue | null) => {
         setValue(newValue);
         onChangeSingle?.(e, newValue);
-        notifySelectionChanged(e, newValue);
       },
       onHighlightChange: (e, newValue) => {
         onHighlightChange?.(e, newValue);
-        notifyHighlightChanged(e, newValue);
       },
       options: optionValues,
       optionStringifier: stringifyOption,
@@ -292,6 +293,14 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     highlightedOption,
     selectedOption: listboxSelectedOption,
   } = useListbox(useListboxParameters);
+
+  React.useEffect(() => {
+    notifySelectionChanged(null, listboxSelectedOption);
+  }, [listboxSelectedOption, notifySelectionChanged]);
+
+  React.useEffect(() => {
+    notifyHighlightChanged(null, highlightedOption);
+  }, [highlightedOption, notifyHighlightChanged]);
 
   const getButtonProps = <TOther extends EventHandlers>(
     otherHandlers: TOther = {} as TOther,

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -22,7 +22,6 @@ import {
   defaultListboxReducer,
   ActionTypes,
   UseListboxParameters,
-  UseListboxPropsWithDefaults,
 } from '../ListboxUnstyled';
 import { EventHandlers } from '../utils/types';
 import defaultOptionStringifier from './defaultOptionStringifier';
@@ -168,10 +167,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       }
     };
 
-  const listboxReducer: ListboxReducer<
-    SelectOption<TValue>,
-    UseListboxPropsWithDefaults<SelectOption<TValue>>
-  > = (state, action) => {
+  const listboxReducer: ListboxReducer<SelectOption<TValue>> = (state, action) => {
     const newState = defaultListboxReducer(state, action);
 
     // change selection when listbox is closed

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -22,6 +22,7 @@ import {
   defaultListboxReducer,
   ActionTypes,
   UseListboxParameters,
+  UseListboxPropsWithDefaults,
 } from '../ListboxUnstyled';
 import { EventHandlers } from '../utils/types';
 import defaultOptionStringifier from './defaultOptionStringifier';
@@ -167,7 +168,10 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       }
     };
 
-  const listboxReducer: ListboxReducer<SelectOption<TValue>> = (state, action) => {
+  const listboxReducer: ListboxReducer<
+    SelectOption<TValue>,
+    UseListboxPropsWithDefaults<SelectOption<TValue>>
+  > = (state, action) => {
     const newState = defaultListboxReducer(state, action);
 
     // change selection when listbox is closed

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import {
   unstable_useControlled as useControlled,
@@ -26,7 +27,7 @@ import {
 import { EventHandlers } from '../utils/types';
 import defaultOptionStringifier from './defaultOptionStringifier';
 
-function useNotifyChanged(prop, propName) {
+function useNotifyChanged(prop: unknown, propName: string) {
   React.useEffect(() => {
     console.log(`${propName} changed (new value: ${prop}))`);
   }, [prop, propName]);
@@ -51,6 +52,7 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
     listboxRef: listboxRefProp,
     multiple = false,
     onChange,
+    onHighlightChange,
     onOpenChange,
     open = false,
     options,
@@ -236,6 +238,10 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
         setValue(newValues);
         onChangeMultiple?.(e, newValues);
       },
+      onHighlightChange: (e, newOption) => {
+        console.log('onHighlightChange', newOption);
+        onHighlightChange?.(e, newOption?.value ?? null);
+      },
       options,
       optionStringifier,
       value: selectedOption as SelectOption<TValue>[],
@@ -254,6 +260,11 @@ function useSelect<TValue>(props: UseSelectParameters<TValue>) {
       onChange: (e, option: SelectOption<TValue> | null) => {
         setValue(option?.value ?? null);
         onChangeSingle?.(e, option?.value ?? null);
+      },
+      onHighlightChange: (e, newOption) => {
+        console.log('onHighlightChange', newOption);
+
+        onHighlightChange?.(e, newOption?.value ?? null);
       },
       options,
       optionStringifier,

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -6,6 +6,7 @@ import {
   UseListboxRootSlotProps,
 } from '../ListboxUnstyled';
 import { EventHandlers } from '../utils/types';
+import { SelectChangeNotifiers } from './useSelectChangeNotifiers';
 
 export interface SelectOption<TValue> {
   value: TValue;
@@ -127,30 +128,12 @@ interface UseSelectCommonResult<TValue> {
    * Registers a handler for when the highlighted option changes.
    * @param handler A function that will be called with the new highlighted option.
    */
-  registerHighlightChangeHandler: (
-    handler: (event: SelectChangeEventType, newValue: TValue | null) => void,
-  ) => void;
+  registerHighlightChangeHandler: SelectChangeNotifiers<TValue>['registerHighlightChangeHandler'];
   /**
    * Registers a handler for when the selection changes.
    * @param handler A function that will be called with the new selected items.
    */
-  registerSelectionChangeHandler: (
-    handler: (event: SelectChangeEventType, newValue: TValue | TValue[] | null) => void,
-  ) => void;
-  /**
-   * Unregisters a handler for when the highlighted option changes.
-   * @param handler The handler to unregister.
-   */
-  unregisterHighlightChangeHandler: (
-    handler: (event: SelectChangeEventType, newValue: TValue | null) => void,
-  ) => void;
-  /**
-   * Unregisters a handler for when the selection changes.
-   * @param handler The handler to unregister.
-   */
-  unregisterSelectionChangeHandler: (
-    handler: (event: SelectChangeEventType, newValue: TValue | TValue[] | null) => void,
-  ) => void;
+  registerSelectionChangeHandler: SelectChangeNotifiers<TValue>['registerSelectionChangeHandler'];
 }
 
 export interface UseSelectSingleResult<TValue> extends UseSelectCommonResult<TValue> {

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -116,6 +116,7 @@ interface UseSelectCommonResult<TValue> {
   ) => UseSelectOptionSlotProps<TOther>;
   getOptionState: (option: SelectOption<TValue>) => OptionState;
   open: boolean;
+  highlightedOption: TValue | null;
 }
 
 export interface UseSelectSingleResult<TValue> extends UseSelectCommonResult<TValue> {

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -27,6 +27,12 @@ export function isOptionGroup<TValue>(
   return !!(child as SelectOptionGroup<TValue>).options;
 }
 
+export type SelectChangeEventType =
+  | React.MouseEvent<Element, MouseEvent>
+  | React.KeyboardEvent<Element>
+  | React.FocusEvent<Element, Element>
+  | null;
+
 interface UseSelectCommonProps<TValue> {
   buttonRef?: React.Ref<Element>;
   disabled?: boolean;
@@ -117,6 +123,34 @@ interface UseSelectCommonResult<TValue> {
   getOptionState: (option: SelectOption<TValue>) => OptionState;
   open: boolean;
   highlightedOption: TValue | null;
+  /**
+   * Registers a handler for when the highlighted option changes.
+   * @param handler A function that will be called with the new highlighted option.
+   */
+  registerHighlightChangeHandler: (
+    handler: (event: SelectChangeEventType, newValue: TValue | null) => void,
+  ) => void;
+  /**
+   * Registers a handler for when the selection changes.
+   * @param handler A function that will be called with the new selected items.
+   */
+  registerSelectionChangeHandler: (
+    handler: (event: SelectChangeEventType, newValue: TValue | TValue[] | null) => void,
+  ) => void;
+  /**
+   * Unregisters a handler for when the highlighted option changes.
+   * @param handler The handler to unregister.
+   */
+  unregisterHighlightChangeHandler: (
+    handler: (event: SelectChangeEventType, newValue: TValue | null) => void,
+  ) => void;
+  /**
+   * Unregisters a handler for when the selection changes.
+   * @param handler The handler to unregister.
+   */
+  unregisterSelectionChangeHandler: (
+    handler: (event: SelectChangeEventType, newValue: TValue | TValue[] | null) => void,
+  ) => void;
 }
 
 export interface UseSelectSingleResult<TValue> extends UseSelectCommonResult<TValue> {

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -33,6 +33,14 @@ interface UseSelectCommonProps<TValue> {
   listboxId?: string;
   listboxRef?: React.Ref<Element>;
   onOpenChange?: (open: boolean) => void;
+  onHighlightChange?: (
+    e:
+      | React.MouseEvent<Element, MouseEvent>
+      | React.KeyboardEvent<Element>
+      | React.FocusEvent<Element, Element>
+      | null,
+    highlighted: TValue | null,
+  ) => void;
   open?: boolean;
   options: SelectOption<TValue>[];
   optionStringifier?: (option: SelectOption<TValue>) => string;

--- a/packages/mui-base/src/SelectUnstyled/useSelectChangeNotifiers.test.tsx
+++ b/packages/mui-base/src/SelectUnstyled/useSelectChangeNotifiers.test.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { act, render } from 'test/utils';
+import useSelectChangeNotifiers from './useSelectChangeNotifiers';
+
+describe('useSelectChangeNotifiers', () => {
+  it('should call the registered handler when the value changes', () => {
+    const handler = spy();
+
+    function TestComponent() {
+      const { registrationFunctions, notifySelectionChanged } = useSelectChangeNotifiers();
+      registrationFunctions.registerSelectionChangeHandler(handler);
+      const [value, setValue] = React.useState(0);
+
+      const handleClick = (event: React.MouseEvent) => {
+        setValue((v) => v + 1);
+        notifySelectionChanged(event, value + 1);
+      };
+
+      return <button onClick={handleClick}>Update selection</button>;
+    }
+
+    const { getByRole } = render(<TestComponent />);
+    const button = getByRole('button');
+
+    act(() => {
+      button.click();
+    });
+
+    expect(handler.callCount).to.equal(1);
+    expect(handler.args[0][0]).to.have.property('type', 'click');
+    expect(handler.args[0][1]).to.equal(1);
+  });
+
+  it('should call the registered handler when the highlight changes', () => {
+    const handler = spy();
+
+    function TestComponent() {
+      const { registrationFunctions, notifyHighlightChanged } = useSelectChangeNotifiers();
+      registrationFunctions.registerHighlightChangeHandler(handler);
+      const [value, setValue] = React.useState(0);
+
+      const handleClick = (event: React.MouseEvent) => {
+        setValue((v) => v + 1);
+        notifyHighlightChanged(event, value + 1);
+      };
+
+      return <button onClick={handleClick}>Update highlight</button>;
+    }
+
+    const { getByRole } = render(<TestComponent />);
+    const button = getByRole('button');
+
+    act(() => {
+      button.click();
+    });
+
+    expect(handler.callCount).to.equal(1);
+    expect(handler.args[0][0]).to.have.property('type', 'click');
+    expect(handler.args[0][1]).to.equal(1);
+  });
+
+  it('should not call the handlers after they are unregistered', () => {
+    const changeHandler = spy();
+    const highlightChangeHandler = spy();
+
+    function TestComponent() {
+      const { registrationFunctions, notifySelectionChanged, notifyHighlightChanged } =
+        useSelectChangeNotifiers();
+      registrationFunctions.registerSelectionChangeHandler(changeHandler);
+      registrationFunctions.registerHighlightChangeHandler(highlightChangeHandler);
+
+      const [value, setValue] = React.useState(0);
+
+      const updateValue = (event: React.MouseEvent) => {
+        setValue((v) => v + 1);
+        notifySelectionChanged(event, value + 1);
+        notifyHighlightChanged(event, value + 1);
+      };
+
+      const clearHandlers = () => {
+        registrationFunctions.unregisterSelectionChangeHandler(changeHandler);
+        registrationFunctions.unregisterHighlightChangeHandler(highlightChangeHandler);
+      };
+
+      return (
+        <div>
+          <button onClick={updateValue}>Update selection</button>
+          <button onClick={clearHandlers}>Clear handlers</button>
+        </div>
+      );
+    }
+
+    const { getByText } = render(<TestComponent />);
+    const updateButton = getByText('Update selection');
+    const clearButton = getByText('Clear handlers');
+
+    act(() => {
+      updateButton.click();
+    });
+
+    expect(changeHandler.callCount).to.equal(1);
+    expect(highlightChangeHandler.callCount).to.equal(1);
+
+    act(() => {
+      clearButton.click();
+    });
+
+    act(() => {
+      updateButton.click();
+    });
+
+    expect(changeHandler.callCount).to.equal(1);
+    expect(highlightChangeHandler.callCount).to.equal(1);
+  });
+});

--- a/packages/mui-base/src/SelectUnstyled/useSelectChangeNotifiers.test.tsx
+++ b/packages/mui-base/src/SelectUnstyled/useSelectChangeNotifiers.test.tsx
@@ -9,13 +9,13 @@ describe('useSelectChangeNotifiers', () => {
     const handler = spy();
 
     function TestComponent() {
-      const { registrationFunctions, notifySelectionChanged } = useSelectChangeNotifiers();
-      registrationFunctions.registerSelectionChangeHandler(handler);
+      const { registerSelectionChangeHandler, notifySelectionChanged } = useSelectChangeNotifiers();
+      registerSelectionChangeHandler(handler);
       const [value, setValue] = React.useState(0);
 
-      const handleClick = (event: React.MouseEvent) => {
+      const handleClick = () => {
         setValue((v) => v + 1);
-        notifySelectionChanged(event, value + 1);
+        notifySelectionChanged(value + 1);
       };
 
       return <button onClick={handleClick}>Update selection</button>;
@@ -29,21 +29,20 @@ describe('useSelectChangeNotifiers', () => {
     });
 
     expect(handler.callCount).to.equal(1);
-    expect(handler.args[0][0]).to.have.property('type', 'click');
-    expect(handler.args[0][1]).to.equal(1);
+    expect(handler.args[0][0]).to.equal(1);
   });
 
   it('should call the registered handler when the highlight changes', () => {
     const handler = spy();
 
     function TestComponent() {
-      const { registrationFunctions, notifyHighlightChanged } = useSelectChangeNotifiers();
-      registrationFunctions.registerHighlightChangeHandler(handler);
+      const { registerHighlightChangeHandler, notifyHighlightChanged } = useSelectChangeNotifiers();
+      registerHighlightChangeHandler(handler);
       const [value, setValue] = React.useState(0);
 
-      const handleClick = (event: React.MouseEvent) => {
+      const handleClick = () => {
         setValue((v) => v + 1);
-        notifyHighlightChanged(event, value + 1);
+        notifyHighlightChanged(value + 1);
       };
 
       return <button onClick={handleClick}>Update highlight</button>;
@@ -57,8 +56,7 @@ describe('useSelectChangeNotifiers', () => {
     });
 
     expect(handler.callCount).to.equal(1);
-    expect(handler.args[0][0]).to.have.property('type', 'click');
-    expect(handler.args[0][1]).to.equal(1);
+    expect(handler.args[0][0]).to.equal(1);
   });
 
   it('should not call the handlers after they are unregistered', () => {
@@ -66,22 +64,28 @@ describe('useSelectChangeNotifiers', () => {
     const highlightChangeHandler = spy();
 
     function TestComponent() {
-      const { registrationFunctions, notifySelectionChanged, notifyHighlightChanged } =
-        useSelectChangeNotifiers();
-      registrationFunctions.registerSelectionChangeHandler(changeHandler);
-      registrationFunctions.registerHighlightChangeHandler(highlightChangeHandler);
+      const {
+        notifySelectionChanged,
+        notifyHighlightChanged,
+        registerSelectionChangeHandler,
+        registerHighlightChangeHandler,
+      } = useSelectChangeNotifiers();
+
+      const unregisterSelectionChangeHandler = registerSelectionChangeHandler(changeHandler);
+      const unregisterHighlightChangeHandler =
+        registerHighlightChangeHandler(highlightChangeHandler);
 
       const [value, setValue] = React.useState(0);
 
-      const updateValue = (event: React.MouseEvent) => {
+      const updateValue = () => {
         setValue((v) => v + 1);
-        notifySelectionChanged(event, value + 1);
-        notifyHighlightChanged(event, value + 1);
+        notifySelectionChanged(value + 1);
+        notifyHighlightChanged(value + 1);
       };
 
       const clearHandlers = () => {
-        registrationFunctions.unregisterSelectionChangeHandler(changeHandler);
-        registrationFunctions.unregisterHighlightChangeHandler(highlightChangeHandler);
+        unregisterSelectionChangeHandler();
+        unregisterHighlightChangeHandler();
       };
 
       return (

--- a/packages/mui-base/src/SelectUnstyled/useSelectChangeNotifiers.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelectChangeNotifiers.ts
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { SelectChangeEventType } from './useSelect.types';
+
+export interface SelectChangeNotifiers<TValue> {
+  /**
+   * Calls all the registered selection change handlers.
+   *
+   * @param event - The event that triggered the selection change.
+   * @param newValue - The newly selected value(s).
+   */
+  notifySelectionChanged: (
+    event: SelectChangeEventType,
+    newValue: TValue | TValue[] | null,
+  ) => void;
+  /**
+   * Calls all the registered highlight change handlers.
+   *
+   * @param event - The event that triggered the highlight change.
+   * @param newValue - The newly highlighted value.
+   */
+  notifyHighlightChanged: (event: SelectChangeEventType, newValue: TValue | null) => void;
+  /**
+   * Functions to register and unregister selection and highlight change handlers.
+   */
+  registrationFunctions: {
+    registerSelectionChangeHandler: (
+      handler: (event: SelectChangeEventType, newValue: TValue | TValue[] | null) => void,
+    ) => void;
+    unregisterSelectionChangeHandler: (
+      handler: (event: SelectChangeEventType, newValue: TValue | TValue[] | null) => void,
+    ) => void;
+    registerHighlightChangeHandler: (
+      handler: (event: SelectChangeEventType, newValue: TValue | null) => void,
+    ) => void;
+    unregisterHighlightChangeHandler: (
+      handler: (event: SelectChangeEventType, newValue: TValue | null) => void,
+    ) => void;
+  };
+}
+
+/**
+ * @ignore - internal hook.
+ *
+ * This hook is used to notify any interested components about changes in the Select's selection and highlight.
+ */
+export default function useSelectChangeNotifiers<TValue>(): SelectChangeNotifiers<TValue> {
+  const selectionChangeEventHandlers = React.useRef<
+    Set<(e: SelectChangeEventType, newValue: TValue | TValue[] | null) => void>
+  >(new Set());
+
+  const highlightChangeEventHandlers = React.useRef<
+    Set<(e: SelectChangeEventType, newValue: TValue | null) => void>
+  >(new Set());
+
+  const notifySelectionChanged = React.useCallback(
+    (e: SelectChangeEventType, newValue: TValue | TValue[] | null) => {
+      selectionChangeEventHandlers.current.forEach((handler) => handler(e, newValue));
+    },
+    [],
+  );
+
+  const notifyHighlightChanged = React.useCallback(
+    (e: SelectChangeEventType, newValue: TValue | null) => {
+      highlightChangeEventHandlers.current.forEach((handler) => handler(e, newValue));
+    },
+    [],
+  );
+
+  const registerSelectionChangeHandler = React.useCallback(
+    (handler: (e: SelectChangeEventType, newValue: TValue | TValue[] | null) => void) => {
+      selectionChangeEventHandlers.current.add(handler);
+    },
+    [],
+  );
+
+  const unregisterSelectionChangeHandler = React.useCallback(
+    (handler: (e: SelectChangeEventType, newValue: TValue | TValue[] | null) => void) => {
+      selectionChangeEventHandlers.current.delete(handler);
+    },
+    [],
+  );
+
+  const registerHighlightChangeHandler = React.useCallback(
+    (handler: (e: SelectChangeEventType, newValue: TValue | null) => void) => {
+      highlightChangeEventHandlers.current.add(handler);
+    },
+    [],
+  );
+
+  const unregisterHighlightChangeHandler = React.useCallback(
+    (handler: (e: SelectChangeEventType, newValue: TValue | null) => void) => {
+      highlightChangeEventHandlers.current.delete(handler);
+    },
+    [],
+  );
+
+  return {
+    notifySelectionChanged,
+    notifyHighlightChanged,
+    registrationFunctions: {
+      registerSelectionChangeHandler,
+      unregisterSelectionChangeHandler,
+      registerHighlightChangeHandler,
+      unregisterHighlightChangeHandler,
+    },
+  };
+}

--- a/packages/mui-base/src/SelectUnstyled/utils.tsx
+++ b/packages/mui-base/src/SelectUnstyled/utils.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { OptionUnstyledProps } from '../OptionUnstyled';
+import { OptionUnstyledProps } from '../OptionUnstyled/OptionUnstyled.types';
 import { OptionGroupUnstyledProps } from '../OptionGroupUnstyled';
 import { isOptionGroup, SelectChild, SelectOption, SelectOptionGroup } from './useSelect.types';
 

--- a/packages/mui-base/src/utils/messageBus/messageBus.test.ts
+++ b/packages/mui-base/src/utils/messageBus/messageBus.test.ts
@@ -1,0 +1,43 @@
+import { spy } from 'sinon';
+import { expect } from 'chai';
+import { createMessageBus } from './messageBus';
+
+describe('messageBus', () => {
+  it('should be able to subscribe to a message', () => {
+    const { subscribe, publish } = createMessageBus();
+    const callback = spy();
+    subscribe('test', callback);
+    publish('test', 'foo');
+    expect(callback.args[0][0]).to.equal('foo');
+  });
+
+  it('should be able to unsubscribe from a message', () => {
+    const { subscribe, publish } = createMessageBus();
+    const callback = spy();
+    const unsubscribe = subscribe('test', callback);
+    unsubscribe();
+    publish('test', 'foo');
+    expect(callback.callCount).to.equal(0);
+  });
+
+  it('should be able to publish multiple messages', () => {
+    const { subscribe, publish } = createMessageBus();
+    const callback = spy();
+    subscribe('test', callback);
+    subscribe('test2', callback);
+    publish('test', 'foo');
+    publish('test2', 'foo');
+    expect(callback.callCount).to.equal(2);
+  });
+
+  it('should be able to publish multiple messages with different arguments', () => {
+    const { subscribe, publish } = createMessageBus();
+    const callback = spy();
+    subscribe('test', callback);
+    subscribe('test2', callback);
+    publish('test', 'foo');
+    publish('test2', 'bar');
+    expect(callback.args[0][0]).to.equal('foo');
+    expect(callback.args[1][0]).to.equal('bar');
+  });
+});

--- a/packages/mui-base/src/utils/messageBus/messageBus.ts
+++ b/packages/mui-base/src/utils/messageBus/messageBus.ts
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+export interface MessageBus {
+  subscribe(topic: string, callback: Function): () => void;
+  publish(topic: string, ...args: unknown[]): void;
+}
+
+export function createMessageBus(): MessageBus {
+  const listeners = new Map<string, Set<Function>>();
+
+  function subscribe(topic: string, callback: Function) {
+    const topicListeners = listeners.get(topic);
+    if (topicListeners) {
+      topicListeners.add(callback);
+      return () => {
+        topicListeners.delete(callback);
+        if (topicListeners.size === 0) {
+          listeners.delete(topic);
+        }
+      };
+    }
+
+    const newTopicListeners = new Set([callback]);
+    listeners.set(topic, newTopicListeners);
+    return () => {
+      newTopicListeners.delete(callback);
+      if (newTopicListeners.size === 0) {
+        listeners.delete(topic);
+      }
+    };
+  }
+
+  function publish(topic: string, ...args: unknown[]) {
+    const topicListeners = listeners.get(topic);
+    if (topicListeners) {
+      topicListeners.forEach((callback) => callback(...args));
+    }
+  }
+
+  return { subscribe, publish };
+}
+
+export default function useMessageBus() {
+  const bus = React.useRef<MessageBus>();
+  if (!bus.current) {
+    bus.current = createMessageBus();
+  }
+
+  return bus.current;
+}

--- a/packages/mui-base/src/utils/useForcedRerendering.ts
+++ b/packages/mui-base/src/utils/useForcedRerendering.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export default function useForcedRerendering() {
+  const [, setState] = React.useState({});
+
+  return React.useCallback(() => {
+    setState({});
+  }, []);
+}

--- a/packages/mui-base/src/utils/useLatest.ts
+++ b/packages/mui-base/src/utils/useLatest.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export default function useLatest<T>(value: T, deps: React.DependencyList) {
+  const ref = React.useRef<T>(value);
+
+  React.useEffect(() => {
+    ref.current = value;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return ref;
+}

--- a/packages/mui-base/src/utils/useLatest.ts
+++ b/packages/mui-base/src/utils/useLatest.ts
@@ -1,12 +1,19 @@
 import * as React from 'react';
 
-export default function useLatest<T>(value: T, deps: React.DependencyList) {
+/**
+ * Initializes a ref with the given value and updates it when the value changes.
+ *
+ * @param value Value to store in the ref
+ * @param deps An optional array of dependencies to watch for changes. If not provided, the ref will be updated each time the `value` changes.
+ * @returns A React.RefObject containing the latest value
+ */
+export default function useLatest<T>(value: T, deps?: React.DependencyList) {
   const ref = React.useRef<T>(value);
 
   React.useEffect(() => {
     ref.current = value;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  }, deps ?? [value]);
 
   return ref;
 }

--- a/packages/mui-base/src/utils/useTextNavigation.ts
+++ b/packages/mui-base/src/utils/useTextNavigation.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ActionTypes, ListboxAction, UseListboxPropsWithDefaults } from './useListbox.types';
 
 const TEXT_NAVIGATION_RESET_TIMEOUT = 500; // milliseconds
 
@@ -7,13 +6,11 @@ const TEXT_NAVIGATION_RESET_TIMEOUT = 500; // milliseconds
  * Provides a handler for text navigation.
  * It's used to navigate the listbox by typing the first letters of the options.
  *
- * @param dispatch The dispatch function from the reducer.
- * @param propsWithDefaults Props with defaults applied.
+ * @param callback A function to be called when the navigation should be performed.
  * @returns A function to be used in a keydown event handler.
  */
-export default function useTextNavigation<TOption>(
-  dispatch: (action: ListboxAction<TOption>) => void,
-  propsWithDefaults: React.RefObject<UseListboxPropsWithDefaults<TOption>>,
+export default function useTextNavigation(
+  callback: (searchString: string, event: React.KeyboardEvent) => void,
 ) {
   const textCriteriaRef = React.useRef<{
     searchString: string;
@@ -45,14 +42,9 @@ export default function useTextNavigation<TOption>(
 
         textCriteria.lastTime = currentTime;
 
-        dispatch({
-          type: ActionTypes.textNavigation,
-          event,
-          searchString: textCriteria.searchString,
-          props: propsWithDefaults.current,
-        });
+        callback(textCriteria.searchString, event);
       }
     },
-    [dispatch, propsWithDefaults],
+    [callback],
   );
 }

--- a/packages/mui-joy/src/Option/Option.tsx
+++ b/packages/mui-joy/src/Option/Option.tsx
@@ -68,8 +68,44 @@ const Option = React.forwardRef(function Option(inProps, ref) {
   const optionProps = selectContext.getOptionProps(selectOption);
   const listboxRef = selectContext.listboxRef;
 
+  const [selected, setSelected] = React.useState(optionState.selected);
+  const [highlighted, setHighlighted] = React.useState(optionState.highlighted);
+
+  React.useEffect(() => {
+    function updateHighlightedState(event: unknown, newValue: any | null) {
+      // TODO: use option comparer
+      if (newValue === value && !highlighted) {
+        setHighlighted(true);
+      } else if (newValue !== value && highlighted) {
+        setHighlighted(false);
+      }
+    }
+
+    selectContext.registerHighlightChangeHandler(updateHighlightedState);
+    return () => {
+      selectContext.unregisterHighlightChangeHandler(updateHighlightedState);
+    };
+  }, [selectContext, highlighted, value]);
+
+  React.useEffect(() => {
+    function updateSelectedState(event: unknown, newValue: any | any[] | null) {
+      // TODO: use option comparer
+      if (newValue === value && !selected) {
+        setSelected(true);
+      } else if (newValue !== value && selected) {
+        setSelected(false);
+      }
+    }
+
+    selectContext.registerSelectionChangeHandler(updateSelectedState);
+
+    return () => {
+      selectContext.unregisterSelectionChangeHandler(updateSelectedState);
+    };
+  }, [selectContext, selected, value]);
+
   const { getColor } = useColorInversion(variant);
-  const color = getColor(inProps.color, optionState.selected ? 'primary' : colorProp);
+  const color = getColor(inProps.color, selected ? 'primary' : colorProp);
 
   const ownerState = {
     ...props,
@@ -85,7 +121,7 @@ const Option = React.forwardRef(function Option(inProps, ref) {
 
   React.useEffect(() => {
     // Scroll to the currently highlighted option
-    if (optionState.highlighted) {
+    if (highlighted) {
       if (!listboxRef.current || !optionRef.current) {
         return;
       }
@@ -98,7 +134,7 @@ const Option = React.forwardRef(function Option(inProps, ref) {
         listboxRef.current.scrollTop += optionClientRect.bottom - listboxClientRect.bottom;
       }
     }
-  }, [optionState.highlighted, listboxRef]);
+  }, [highlighted, listboxRef]);
 
   const classes = useUtilityClasses(ownerState);
 

--- a/packages/mui-joy/src/Option/Option.tsx
+++ b/packages/mui-joy/src/Option/Option.tsx
@@ -58,14 +58,8 @@ const Option = React.forwardRef(function Option(inProps, ref) {
     throw new Error('OptionUnstyled must be used within a SelectUnstyled');
   }
 
-  const selectOption = {
-    value,
-    label: label || children,
-    disabled,
-  };
-
-  const optionState = selectContext.getOptionState(selectOption);
-  const optionProps = selectContext.getOptionProps(selectOption);
+  const optionState = selectContext.getOptionState(value);
+  const optionProps = selectContext.getOptionProps(value);
   const listboxRef = selectContext.listboxRef;
 
   const [selected, setSelected] = React.useState(optionState.selected);

--- a/packages/mui-joy/src/Option/Option.tsx
+++ b/packages/mui-joy/src/Option/Option.tsx
@@ -67,7 +67,6 @@ const Option = React.forwardRef(function Option(inProps, ref) {
 
   React.useEffect(() => {
     function updateHighlightedState(event: unknown, newValue: any | null) {
-      // TODO: use option comparer
       if (newValue === value && !highlighted) {
         setHighlighted(true);
       } else if (newValue !== value && highlighted) {
@@ -83,7 +82,6 @@ const Option = React.forwardRef(function Option(inProps, ref) {
 
   React.useEffect(() => {
     function updateSelectedState(event: unknown, newValue: any | any[] | null) {
-      // TODO: use option comparer
       if (newValue === value && !selected) {
         setSelected(true);
       } else if (newValue !== value && selected) {

--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -11,7 +11,7 @@ import {
 } from 'test/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Select, { selectClasses as classes, SelectOption } from '@mui/joy/Select';
-import Option from '@mui/joy/Option';
+import Option, { optionClasses } from '@mui/joy/Option';
 import List from '@mui/joy/List';
 import ListItem from '@mui/joy/ListItem';
 import ListDivider from '@mui/joy/ListDivider';
@@ -378,7 +378,7 @@ describe('Joy <Select />', () => {
         fireEvent.keyDown(listbox, { key: 'ArrowDown' });
         fireEvent.keyDown(listbox, { key: 'Enter' });
 
-        expect(options[1]).to.have.attribute('aria-selected', 'true');
+        expect(options[1]).to.have.class(optionClasses.highlighted);
       });
     });
 

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -437,8 +437,6 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
     value,
     registerHighlightChangeHandler,
     registerSelectionChangeHandler,
-    unregisterHighlightChangeHandler,
-    unregisterSelectionChangeHandler,
   } = useSelect({
     buttonRef,
     defaultValue,
@@ -567,8 +565,6 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
       color,
       registerHighlightChangeHandler,
       registerSelectionChangeHandler,
-      unregisterHighlightChangeHandler,
-      unregisterSelectionChangeHandler,
     }),
     [
       color,
@@ -576,8 +572,6 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
       getOptionState,
       registerHighlightChangeHandler,
       registerSelectionChangeHandler,
-      unregisterHighlightChangeHandler,
-      unregisterSelectionChangeHandler,
     ],
   );
 

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -435,6 +435,10 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
     getOptionProps,
     getOptionState,
     value,
+    registerHighlightChangeHandler,
+    registerSelectionChangeHandler,
+    unregisterHighlightChangeHandler,
+    unregisterSelectionChangeHandler,
   } = useSelect({
     buttonRef,
     defaultValue,
@@ -561,8 +565,20 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
       getOptionState,
       listboxRef,
       color,
+      registerHighlightChangeHandler,
+      registerSelectionChangeHandler,
+      unregisterHighlightChangeHandler,
+      unregisterSelectionChangeHandler,
     }),
-    [color, getOptionProps, getOptionState],
+    [
+      color,
+      getOptionProps,
+      getOptionState,
+      registerHighlightChangeHandler,
+      registerSelectionChangeHandler,
+      unregisterHighlightChangeHandler,
+      unregisterSelectionChangeHandler,
+    ],
   );
 
   const modifiers = React.useMemo(


### PR DESCRIPTION
This PR solves a performance issue with SelectUnstyled and dependent components (Joy's Select).

The root of the problem was that every `mouseover` event fired on an option caused rerendering of all options. The event correctly dispatches the `optionHover` action in the listbox reducer, but the surrounding logic caused some functions to be recreated, which caused the SelectUnstyledContext to be updated. This, in turn, caused all the options to detect the changes and rerender themselves.

A couple of optimizations were made:
1. Functions that don't need to be recreated every render were wrapped in `useCallback`
2. The SelectUnstyledContext value does not change when the selected or highlighted items change. Instead, a new way of notifying the options about changes was introduced. The options subscribe to updates in the select, and when an update event is fired, they can decide if the change concerns them and rerender accordingly.

The introduction of the lightweight event bus was necessary to update only the options that were changed. The Material UI implementation doesn't have this problem, as it uses `cloneElement`, so that the Select can set props directly on its MenuItems. This, however, can cause issues when grouping is used and prevents from using non-MenuItem components (or even Fragments) as Select's children. The discussion about removing cloneElement usage took place in #14943.
