### PR TITLE
[docs] Fix Joy UI variables playground

### DIFF
--- a/docs/src/modules/components/JoyVariablesDemo.tsx
+++ b/docs/src/modules/components/JoyVariablesDemo.tsx
@@ -72,6 +72,7 @@ function SlotVariables({ slot, data, renderField, defaultOpen = false }: SlotVar
             display: 'flex',
             flexWrap: 'wrap',
             gap: 2,
+            '& > *': { flex: 1 },
           }}
         >
           {data.map((item) => renderField(item))}
@@ -179,21 +180,7 @@ export default function JoyVariablesDemo(props: {
                       variant="outlined"
                       value={Number(`${resolvedValue}`?.replace('px', '')) || ''}
                       slotProps={{
-                        input: {
-                          onKeyDown: (event) => {
-                            if (
-                              (event.ctrlKey || event.metaKey) &&
-                              event.key.toLowerCase() === 'z'
-                            ) {
-                              setSx((prevSx) => {
-                                const newSx = { ...prevSx };
-                                delete newSx[item.var];
-                                return newSx;
-                              });
-                            }
-                          },
-                          ...resolvedInputAttributes,
-                        },
+                        input: { ...resolvedInputAttributes },
                       }}
                       endDecorator={
                         <React.Fragment>
@@ -222,6 +209,15 @@ export default function JoyVariablesDemo(props: {
                         </React.Fragment>
                       }
                       type="number"
+                      onKeyDown={(event) => {
+                        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+                          setSx((prevSx) => {
+                            const newSx = { ...prevSx };
+                            delete newSx[item.var];
+                            return newSx;
+                          });
+                        }
+                      }}
                       onChange={(event) => {
                         const { value } = event.target;
                         setSx((prevSx) => {
@@ -234,7 +230,7 @@ export default function JoyVariablesDemo(props: {
                           return {
                             ...prevSx,
                             [item.var]:
-                              typeof resolvedValue === 'string' ? `${value}px` : Number(value),
+                              typeof resolvedValue === 'number' ? Number(value) : `${value}px`,
                           };
                         });
                       }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Before**
The field without a default value always returns a number when edited.

https://user-images.githubusercontent.com/18292247/214749444-bb0a951f-ae7a-4674-af99-f9e105f6035b.mov

**After**

https://user-images.githubusercontent.com/18292247/214749559-1c794d0a-e79b-4839-8b54-9ab06d779720.mov




- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
