### PR TITLE
[docs] Standardize "no longer" / "not documented" callouts in Material UI docs

### DIFF
--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -16,7 +16,7 @@ An accordion is a lightweight container that may either be used standalone, or b
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-Accordions are no longer documented in the [Material Design guidelines](https://material.io/), but MUI will continue to support them.
+Accordions are no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support them.
 :::
 
 ## Basic accordion

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -16,7 +16,7 @@ An accordion is a lightweight container that may either be used standalone, or b
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-Accordions are no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support them.
+This component is longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support it.
 :::
 
 ## Basic accordion

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -16,7 +16,7 @@ An accordion is a lightweight container that may either be used standalone, or b
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-This component is longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support it.
+This component is no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support it.
 :::
 
 ## Basic accordion

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -16,7 +16,7 @@ An accordion is a lightweight container that may either be used standalone, or b
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-Accordions are no longer documented in the [Material Design guidelines](https://m2.material.io/), but MUI will continue to support them. It was formerly known as the "expansion panel".
+Accordions are no longer documented in the [Material Design guidelines](https://material.io/), but MUI will continue to support them.
 :::
 
 ## Basic accordion

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -16,7 +16,7 @@ An accordion is a lightweight container that may either be used standalone, or b
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-This component is no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support it.
+This component is no longer documented in the [Material Design guidelines](https://m2.material.io/), but Material UI will continue to support it.
 :::
 
 ## Basic accordion

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -11,7 +11,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 <p class="description">An alert displays a short, important message in a way that attracts the user's attention without interrupting the user's task.</p>
 
 :::info
-This component is not documented in the [Material Design guidelines](https://material.io/), but MUI supports it.
+This component is not documented in the [Material Design guidelines](https://material.io/), but it is available in Material UI.
 :::
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -11,7 +11,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 <p class="description">An alert displays a short, important message in a way that attracts the user's attention without interrupting the user's task.</p>
 
 :::info
-This component is not documented in the [Material Design guidelines](https://material.io/), but it is available in Material UI.
+This component is not documented in the [Material Design guidelines](https://m2.material.io/), but it is available in Material UI.
 :::
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}

--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -10,7 +10,9 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 
 <p class="description">An alert displays a short, important message in a way that attracts the user's attention without interrupting the user's task.</p>
 
-**Note:** This component is not documented in the [Material Design guidelines](https://m2.material.io/), but MUI supports it.
+:::info
+This component is not documented in the [Material Design guidelines](https://material.io/), but MUI supports it.
+:::
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 

--- a/docs/data/material/components/steppers/steppers.md
+++ b/docs/data/material/components/steppers/steppers.md
@@ -19,7 +19,7 @@ Steppers may display a transient feedback message after a step is saved.
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-Steppers are no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support them.
+This component is no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support it.
 :::
 
 ## Horizontal stepper

--- a/docs/data/material/components/steppers/steppers.md
+++ b/docs/data/material/components/steppers/steppers.md
@@ -19,7 +19,7 @@ Steppers may display a transient feedback message after a step is saved.
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 :::info
-This component is no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support it.
+This component is no longer documented in the [Material Design guidelines](https://m2.material.io/), but Material UI will continue to support it.
 :::
 
 ## Horizontal stepper

--- a/docs/data/material/components/steppers/steppers.md
+++ b/docs/data/material/components/steppers/steppers.md
@@ -18,8 +18,8 @@ Steppers may display a transient feedback message after a step is saved.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
-:::warning
-Steppers are no longer documented in the [Material Design guidelines](https://m2.material.io/), but Material UI will continue to support them.
+:::info
+Steppers are no longer documented in the [Material Design guidelines](https://material.io/), but Material UI will continue to support them.
 :::
 
 ## Horizontal stepper

--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -25,7 +25,7 @@ It comes with three variants: outlined (default), filled, and standard.
 :::info
 The standard variant of the Text Field is no longer documented in the [Material Design guidelines](https://material.io/)
 ([this article explains why](https://medium.com/google-design/the-evolution-of-material-designs-text-fields-603688b3fe03)),
-but MUI will continue to support it.
+but Material UI will continue to support it.
 :::
 
 ## Form props

--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -23,7 +23,7 @@ It comes with three variants: outlined (default), filled, and standard.
 {{"demo": "BasicTextFields.js"}}
 
 :::info
-The standard variant of the Text Field is no longer documented in the [Material Design guidelines](https://material.io/)
+The standard variant of the Text Field is no longer documented in the [Material Design guidelines](https://m2.material.io/)
 ([this article explains why](https://medium.com/google-design/the-evolution-of-material-designs-text-fields-603688b3fe03)),
 but Material UI will continue to support it.
 :::

--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -22,9 +22,11 @@ It comes with three variants: outlined (default), filled, and standard.
 
 {{"demo": "BasicTextFields.js"}}
 
-**Note:** The standard variant of the `TextField` is no longer documented in the [Material Design guidelines](https://m2.material.io/)
-([here's why](https://medium.com/google-design/the-evolution-of-material-designs-text-fields-603688b3fe03)),
+:::info
+The standard variant of the Text Field is no longer documented in the [Material Design guidelines](https://material.io/)
+([this article explains why](https://medium.com/google-design/the-evolution-of-material-designs-text-fields-603688b3fe03)),
 but MUI will continue to support it.
+:::
 
 ## Form props
 

--- a/docs/data/material/components/timeline/timeline.md
+++ b/docs/data/material/components/timeline/timeline.md
@@ -11,7 +11,7 @@ packageName: '@mui/lab'
 <p class="description">The timeline displays a list of events in chronological order.</p>
 
 :::info
-This component is not documented in the [Material Design guidelines](https://material.io/), but it is available in Material UI.
+This component is not documented in the [Material Design guidelines](https://m2.material.io/), but it is available in Material UI.
 :::
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}

--- a/docs/data/material/components/timeline/timeline.md
+++ b/docs/data/material/components/timeline/timeline.md
@@ -11,7 +11,7 @@ packageName: '@mui/lab'
 <p class="description">The timeline displays a list of events in chronological order.</p>
 
 :::info
-This component is not documented in the [Material Design guidelines](https://material.io/), but MUI supports it.
+This component is not documented in the [Material Design guidelines](https://material.io/), but it is available in Material UI.
 :::
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}

--- a/docs/data/material/components/timeline/timeline.md
+++ b/docs/data/material/components/timeline/timeline.md
@@ -10,7 +10,9 @@ packageName: '@mui/lab'
 
 <p class="description">The timeline displays a list of events in chronological order.</p>
 
-**Note:** This component is not documented in the [Material Design guidelines](https://m2.material.io/), but MUI supports it.
+:::info
+This component is not documented in the [Material Design guidelines](https://material.io/), but MUI supports it.
+:::
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 


### PR DESCRIPTION
Closes #35385

This PR standardizes the callouts on the following pages:

Components no longer documented by Material Design:
- Accordion
- Stepper
- standard variant of Text Field

<img width="657" alt="Screenshot 2023-01-26 at 10 02 23 AM" src="https://user-images.githubusercontent.com/71297412/214885716-b9e04cf4-37a5-4e78-92a9-aabefc49bc04.png">


Components not documented by Material Design:
- Alert
- Timeline

<img width="637" alt="Screenshot 2023-01-26 at 10 02 18 AM" src="https://user-images.githubusercontent.com/71297412/214885802-5fbb6a16-957f-4eb1-8601-973a921dd17a.png">


I've also changed the MD link from m2.material.io to simply material.io, so (ideally) we won't have to worry about updating them in the future when we eventually support MD3.