### PR TITLE
[base] Override the types of `slotProps` per slot

### DIFF
--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
@@ -36,16 +36,8 @@ export interface BadgeUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'span',
-      BadgeUnstyledRootSlotOverrides,
-      BadgeUnstyledOwnerState
-    >;
-    badge?: SlotComponentProps<
-      'span',
-      BadgeUnstyledBadgeSlotOverrides,
-      BadgeUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'span', BadgeUnstyledRootSlotOverrides, BadgeUnstyledOwnerState>;
+    badge?: SlotComponentProps<'span', BadgeUnstyledBadgeSlotOverrides, BadgeUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Badge.

--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { OverrideProps, OverridableTypeMap, OverridableComponent } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-export interface BadgeUnstyledComponentsPropsOverrides {}
+export interface BadgeUnstyledRootSlotOverrides {}
+export interface BadgeUnstyledBadgeSlotOverrides {}
 
 export type BadgeUnstyledOwnerState = BadgeUnstyledProps & {
   badgeContent: React.ReactNode;
@@ -37,12 +38,12 @@ export interface BadgeUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'span',
-      BadgeUnstyledComponentsPropsOverrides,
+      BadgeUnstyledRootSlotOverrides,
       BadgeUnstyledOwnerState
     >;
     badge?: SlotComponentProps<
       'span',
-      BadgeUnstyledComponentsPropsOverrides,
+      BadgeUnstyledBadgeSlotOverrides,
       BadgeUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { OverrideProps, OverridableTypeMap, OverridableComponent } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-export interface BadgeUnstyledRootSlotOverrides {}
-export interface BadgeUnstyledBadgeSlotOverrides {}
+export interface BadgeUnstyledRootSlotPropsOverrides {}
+export interface BadgeUnstyledBadgeSlotPropsOverrides {}
 
 export type BadgeUnstyledOwnerState = BadgeUnstyledProps & {
   badgeContent: React.ReactNode;
@@ -36,8 +36,12 @@ export interface BadgeUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'span', BadgeUnstyledRootSlotOverrides, BadgeUnstyledOwnerState>;
-    badge?: SlotComponentProps<'span', BadgeUnstyledBadgeSlotOverrides, BadgeUnstyledOwnerState>;
+    root?: SlotComponentProps<'span', BadgeUnstyledRootSlotPropsOverrides, BadgeUnstyledOwnerState>;
+    badge?: SlotComponentProps<
+      'span',
+      BadgeUnstyledBadgeSlotPropsOverrides,
+      BadgeUnstyledOwnerState
+    >;
   };
   /**
    * The components used for each slot inside the Badge.

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
@@ -7,7 +7,7 @@ export interface ButtonUnstyledActions {
   focusVisible(): void;
 }
 
-export interface ButtonUnstyledRootSlotOverrides {}
+export interface ButtonUnstyledRootSlotPropsOverrides {}
 
 export interface ButtonUnstyledOwnProps extends Omit<UseButtonParameters, 'ref'> {
   /**
@@ -21,7 +21,11 @@ export interface ButtonUnstyledOwnProps extends Omit<UseButtonParameters, 'ref'>
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'button', ButtonUnstyledRootSlotOverrides, ButtonUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'button',
+      ButtonUnstyledRootSlotPropsOverrides,
+      ButtonUnstyledOwnerState
+    >;
   };
   /**
    * The components used for each slot inside the Button.

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
@@ -21,11 +21,7 @@ export interface ButtonUnstyledOwnProps extends Omit<UseButtonParameters, 'ref'>
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'button',
-      ButtonUnstyledRootSlotOverrides,
-      ButtonUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'button', ButtonUnstyledRootSlotOverrides, ButtonUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Button.

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
@@ -7,7 +7,7 @@ export interface ButtonUnstyledActions {
   focusVisible(): void;
 }
 
-export interface ButtonUnstyledComponentsPropsOverrides {}
+export interface ButtonUnstyledRootSlotOverrides {}
 
 export interface ButtonUnstyledOwnProps extends Omit<UseButtonParameters, 'ref'> {
   /**
@@ -23,7 +23,7 @@ export interface ButtonUnstyledOwnProps extends Omit<UseButtonParameters, 'ref'>
   slotProps?: {
     root?: SlotComponentProps<
       'button',
-      ButtonUnstyledComponentsPropsOverrides,
+      ButtonUnstyledRootSlotOverrides,
       ButtonUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.types.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.types.ts
@@ -4,7 +4,7 @@ import { SlotComponentProps } from '../utils';
 
 export type NativeFormControlElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
-export interface FormControlUnstyledComponentsPropsOverrides {}
+export interface FormControlUnstyledRootSlotOverrides {}
 
 export interface FormControlUnstyledOwnProps {
   /**
@@ -39,7 +39,7 @@ export interface FormControlUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      FormControlUnstyledComponentsPropsOverrides,
+      FormControlUnstyledRootSlotOverrides,
       FormControlUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.types.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.types.ts
@@ -4,7 +4,7 @@ import { SlotComponentProps } from '../utils';
 
 export type NativeFormControlElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
-export interface FormControlUnstyledRootSlotOverrides {}
+export interface FormControlUnstyledRootSlotPropsOverrides {}
 
 export interface FormControlUnstyledOwnProps {
   /**
@@ -39,7 +39,7 @@ export interface FormControlUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      FormControlUnstyledRootSlotOverrides,
+      FormControlUnstyledRootSlotPropsOverrides,
       FormControlUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/FormControlUnstyled/index.ts
+++ b/packages/mui-base/src/FormControlUnstyled/index.ts
@@ -4,7 +4,7 @@ export { default as FormControlUnstyledContext } from './FormControlUnstyledCont
 
 export type {
   FormControlUnstyledProps,
-  FormControlUnstyledRootSlotOverrides,
+  FormControlUnstyledRootSlotPropsOverrides,
   FormControlUnstyledState,
 } from './FormControlUnstyled.types';
 

--- a/packages/mui-base/src/FormControlUnstyled/index.ts
+++ b/packages/mui-base/src/FormControlUnstyled/index.ts
@@ -4,7 +4,7 @@ export { default as FormControlUnstyledContext } from './FormControlUnstyledCont
 
 export type {
   FormControlUnstyledProps,
-  FormControlUnstyledComponentsPropsOverrides,
+  FormControlUnstyledRootSlotOverrides,
   FormControlUnstyledState,
 } from './FormControlUnstyled.types';
 

--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
@@ -4,7 +4,8 @@ import { FormControlUnstyledState } from '../FormControlUnstyled';
 import { UseInputParameters, UseInputRootSlotProps } from './useInput.types';
 import { SlotComponentProps } from '../utils';
 
-export interface InputUnstyledComponentsPropsOverrides {}
+export interface InputUnstyledRootSlotOverrides {}
+export interface InputUnstyledInputSlotOverrides {}
 
 export interface SingleLineInputUnstyledProps {
   /**
@@ -110,12 +111,12 @@ export type InputUnstyledOwnProps = (SingleLineInputUnstyledProps | MultiLineInp
     slotProps?: {
       root?: SlotComponentProps<
         'div',
-        InputUnstyledComponentsPropsOverrides,
+        InputUnstyledRootSlotOverrides,
         InputUnstyledOwnerState
       >;
       input?: SlotComponentProps<
         'input',
-        InputUnstyledComponentsPropsOverrides,
+        InputUnstyledInputSlotOverrides,
         InputUnstyledOwnerState
       >;
     };

--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
@@ -4,8 +4,8 @@ import { FormControlUnstyledState } from '../FormControlUnstyled';
 import { UseInputParameters, UseInputRootSlotProps } from './useInput.types';
 import { SlotComponentProps } from '../utils';
 
-export interface InputUnstyledRootSlotOverrides {}
-export interface InputUnstyledInputSlotOverrides {}
+export interface InputUnstyledRootSlotPropsOverrides {}
+export interface InputUnstyledInputSlotPropsOverrides {}
 
 export interface SingleLineInputUnstyledProps {
   /**
@@ -109,8 +109,16 @@ export type InputUnstyledOwnProps = (SingleLineInputUnstyledProps | MultiLineInp
      * @default {}
      */
     slotProps?: {
-      root?: SlotComponentProps<'div', InputUnstyledRootSlotOverrides, InputUnstyledOwnerState>;
-      input?: SlotComponentProps<'input', InputUnstyledInputSlotOverrides, InputUnstyledOwnerState>;
+      root?: SlotComponentProps<
+        'div',
+        InputUnstyledRootSlotPropsOverrides,
+        InputUnstyledOwnerState
+      >;
+      input?: SlotComponentProps<
+        'input',
+        InputUnstyledInputSlotPropsOverrides,
+        InputUnstyledOwnerState
+      >;
     };
     /**
      * The components used for each slot inside the InputBase.

--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
@@ -109,16 +109,8 @@ export type InputUnstyledOwnProps = (SingleLineInputUnstyledProps | MultiLineInp
      * @default {}
      */
     slotProps?: {
-      root?: SlotComponentProps<
-        'div',
-        InputUnstyledRootSlotOverrides,
-        InputUnstyledOwnerState
-      >;
-      input?: SlotComponentProps<
-        'input',
-        InputUnstyledInputSlotOverrides,
-        InputUnstyledOwnerState
-      >;
+      root?: SlotComponentProps<'div', InputUnstyledRootSlotOverrides, InputUnstyledOwnerState>;
+      input?: SlotComponentProps<'input', InputUnstyledInputSlotOverrides, InputUnstyledOwnerState>;
     };
     /**
      * The components used for each slot inside the InputBase.

--- a/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
@@ -2,7 +2,7 @@ import { OverrideProps } from '@mui/types';
 import * as React from 'react';
 import { SlotComponentProps } from '../utils';
 
-export interface MenuItemUnstyledRootSlotOverrides {}
+export interface MenuItemUnstyledRootSlotPropsOverrides {}
 
 export interface MenuItemUnstyledOwnerState extends MenuItemUnstyledOwnProps {
   disabled: boolean;
@@ -31,7 +31,11 @@ export interface MenuItemUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'li', MenuItemUnstyledRootSlotOverrides, MenuItemUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'li',
+      MenuItemUnstyledRootSlotPropsOverrides,
+      MenuItemUnstyledOwnerState
+    >;
   };
   /**
    * A text representation of the menu item's content.

--- a/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
@@ -2,7 +2,7 @@ import { OverrideProps } from '@mui/types';
 import * as React from 'react';
 import { SlotComponentProps } from '../utils';
 
-export interface MenuItemUnstyledComponentsPropsOverrides {}
+export interface MenuItemUnstyledRootSlotOverrides {}
 
 export interface MenuItemUnstyledOwnerState extends MenuItemUnstyledOwnProps {
   disabled: boolean;
@@ -33,7 +33,7 @@ export interface MenuItemUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'li',
-      MenuItemUnstyledComponentsPropsOverrides,
+      MenuItemUnstyledRootSlotOverrides,
       MenuItemUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
@@ -31,11 +31,7 @@ export interface MenuItemUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'li',
-      MenuItemUnstyledRootSlotOverrides,
-      MenuItemUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'li', MenuItemUnstyledRootSlotOverrides, MenuItemUnstyledOwnerState>;
   };
   /**
    * A text representation of the menu item's content.

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
@@ -4,7 +4,8 @@ import PopperUnstyled, { PopperUnstyledProps } from '../PopperUnstyled';
 import { SlotComponentProps } from '../utils';
 import { UseMenuListboxSlotProps } from './useMenu.types';
 
-export interface MenuUnstyledComponentsPropsOverrides {}
+export interface MenuUnstyledRootSlotOverrides {}
+export interface MenuUnstyledListboxSlotOverrides {}
 
 export interface MenuUnstyledActions {
   highlightFirstItem: () => void;
@@ -49,12 +50,12 @@ export interface MenuUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       typeof PopperUnstyled,
-      MenuUnstyledComponentsPropsOverrides,
+      MenuUnstyledRootSlotOverrides,
       MenuUnstyledOwnerState
     >;
     listbox?: SlotComponentProps<
       'ul',
-      MenuUnstyledComponentsPropsOverrides,
+      MenuUnstyledListboxSlotOverrides,
       MenuUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
@@ -53,11 +53,7 @@ export interface MenuUnstyledOwnProps {
       MenuUnstyledRootSlotOverrides,
       MenuUnstyledOwnerState
     >;
-    listbox?: SlotComponentProps<
-      'ul',
-      MenuUnstyledListboxSlotOverrides,
-      MenuUnstyledOwnerState
-    >;
+    listbox?: SlotComponentProps<'ul', MenuUnstyledListboxSlotOverrides, MenuUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Menu.

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
@@ -4,8 +4,8 @@ import PopperUnstyled, { PopperUnstyledProps } from '../PopperUnstyled';
 import { SlotComponentProps } from '../utils';
 import { UseMenuListboxSlotProps } from './useMenu.types';
 
-export interface MenuUnstyledRootSlotOverrides {}
-export interface MenuUnstyledListboxSlotOverrides {}
+export interface MenuUnstyledRootSlotPropsOverrides {}
+export interface MenuUnstyledListboxSlotPropsOverrides {}
 
 export interface MenuUnstyledActions {
   highlightFirstItem: () => void;
@@ -50,10 +50,14 @@ export interface MenuUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       typeof PopperUnstyled,
-      MenuUnstyledRootSlotOverrides,
+      MenuUnstyledRootSlotPropsOverrides,
       MenuUnstyledOwnerState
     >;
-    listbox?: SlotComponentProps<'ul', MenuUnstyledListboxSlotOverrides, MenuUnstyledOwnerState>;
+    listbox?: SlotComponentProps<
+      'ul',
+      MenuUnstyledListboxSlotPropsOverrides,
+      MenuUnstyledOwnerState
+    >;
   };
   /**
    * The components used for each slot inside the Menu.

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
@@ -4,8 +4,8 @@ import { PortalProps } from '../Portal';
 import { SlotComponentProps } from '../utils';
 import { ModalUnstyledClasses } from './modalUnstyledClasses';
 
-export interface ModalUnstyledRootSlotOverrides {}
-export interface ModalUnstyledBackdropSlotOverrides {}
+export interface ModalUnstyledRootSlotPropsOverrides {}
+export interface ModalUnstyledBackdropSlotPropsOverrides {}
 
 export interface ModalUnstyledOwnProps {
   /**
@@ -104,10 +104,10 @@ export interface ModalUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', ModalUnstyledRootSlotOverrides, ModalUnstyledOwnerState>;
+    root?: SlotComponentProps<'div', ModalUnstyledRootSlotPropsOverrides, ModalUnstyledOwnerState>;
     backdrop?: SlotComponentProps<
       'div',
-      ModalUnstyledBackdropSlotOverrides,
+      ModalUnstyledBackdropSlotPropsOverrides,
       ModalUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
@@ -104,11 +104,7 @@ export interface ModalUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'div',
-      ModalUnstyledRootSlotOverrides,
-      ModalUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'div', ModalUnstyledRootSlotOverrides, ModalUnstyledOwnerState>;
     backdrop?: SlotComponentProps<
       'div',
       ModalUnstyledBackdropSlotOverrides,

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
@@ -4,7 +4,8 @@ import { PortalProps } from '../Portal';
 import { SlotComponentProps } from '../utils';
 import { ModalUnstyledClasses } from './modalUnstyledClasses';
 
-export interface ModalUnstyledComponentsPropsOverrides {}
+export interface ModalUnstyledRootSlotOverrides {}
+export interface ModalUnstyledBackdropSlotOverrides {}
 
 export interface ModalUnstyledOwnProps {
   /**
@@ -105,12 +106,12 @@ export interface ModalUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      ModalUnstyledComponentsPropsOverrides,
+      ModalUnstyledRootSlotOverrides,
       ModalUnstyledOwnerState
     >;
     backdrop?: SlotComponentProps<
       'div',
-      ModalUnstyledComponentsPropsOverrides,
+      ModalUnstyledBackdropSlotOverrides,
       ModalUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.spec.tsx
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.spec.tsx
@@ -7,7 +7,7 @@ import {
   PopperUnstyled,
 } from '@mui/base';
 
-const MultiSelectUnstyledComponentsPropsOverridesTest = (
+const MultiSelectUnstyledSlotPropsOverridesTest = (
   <MultiSelectUnstyled
     slotProps={{
       root: {
@@ -59,7 +59,7 @@ function InvalidPopper({ requiredProp }: { requiredProp: string }) {
   return <div />;
 }
 
-const MultiSelectUnstyledComponentsOverridesUsingInvalidComponentTest = (
+const MultiSelectUnstyledSlotsOverridesUsingInvalidComponentTest = (
   <MultiSelectUnstyled
     slots={{
       // @ts-expect-error - provided a component that requires a prop MultiSelectUnstyled does not provide
@@ -68,7 +68,7 @@ const MultiSelectUnstyledComponentsOverridesUsingInvalidComponentTest = (
   />
 );
 
-const MultiSelectUnstyledComponentsOverridesUsingHostComponentTest = (
+const MultiSelectUnstyledSlotsOverridesUsingHostComponentTest = (
   <MultiSelectUnstyled
     slots={{
       // @ts-expect-error - provided a host element instead of a component

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
@@ -9,9 +9,9 @@ import {
 } from '../SelectUnstyled';
 import { SlotComponentProps } from '../utils';
 
-export interface MultiSelectUnstyledRootSlotOverrides {}
-export interface MultiSelectUnstyledListboxSlotOverrides {}
-export interface MultiSelectUnstyledPopperSlotOverrides {}
+export interface MultiSelectUnstyledRootSlotPropsOverrides {}
+export interface MultiSelectUnstyledListboxSlotPropsOverrides {}
+export interface MultiSelectUnstyledPopperSlotPropsOverrides {}
 
 export interface MultiSelectUnstyledOwnProps<TValue extends {}> extends SelectUnstyledCommonProps {
   /**
@@ -53,17 +53,17 @@ export interface MultiSelectUnstyledOwnProps<TValue extends {}> extends SelectUn
   slotProps?: {
     root?: SlotComponentProps<
       'button',
-      MultiSelectUnstyledRootSlotOverrides,
+      MultiSelectUnstyledRootSlotPropsOverrides,
       MultiSelectUnstyledOwnerState<TValue>
     >;
     listbox?: SlotComponentProps<
       'button',
-      MultiSelectUnstyledListboxSlotOverrides,
+      MultiSelectUnstyledListboxSlotPropsOverrides,
       MultiSelectUnstyledOwnerState<TValue>
     >;
     popper?: SlotComponentProps<
       typeof PopperUnstyled,
-      MultiSelectUnstyledPopperSlotOverrides,
+      MultiSelectUnstyledPopperSlotPropsOverrides,
       MultiSelectUnstyledOwnerState<TValue>
     >;
   };

--- a/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
+++ b/packages/mui-base/src/MultiSelectUnstyled/MultiSelectUnstyled.types.ts
@@ -9,7 +9,9 @@ import {
 } from '../SelectUnstyled';
 import { SlotComponentProps } from '../utils';
 
-export interface MultiSelectUnstyledComponentsPropsOverrides {}
+export interface MultiSelectUnstyledRootSlotOverrides {}
+export interface MultiSelectUnstyledListboxSlotOverrides {}
+export interface MultiSelectUnstyledPopperSlotOverrides {}
 
 export interface MultiSelectUnstyledOwnProps<TValue extends {}> extends SelectUnstyledCommonProps {
   /**
@@ -51,17 +53,17 @@ export interface MultiSelectUnstyledOwnProps<TValue extends {}> extends SelectUn
   slotProps?: {
     root?: SlotComponentProps<
       'button',
-      MultiSelectUnstyledComponentsPropsOverrides,
+      MultiSelectUnstyledRootSlotOverrides,
       MultiSelectUnstyledOwnerState<TValue>
     >;
     listbox?: SlotComponentProps<
       'button',
-      MultiSelectUnstyledComponentsPropsOverrides,
+      MultiSelectUnstyledListboxSlotOverrides,
       MultiSelectUnstyledOwnerState<TValue>
     >;
     popper?: SlotComponentProps<
       typeof PopperUnstyled,
-      MultiSelectUnstyledComponentsPropsOverrides,
+      MultiSelectUnstyledPopperSlotOverrides,
       MultiSelectUnstyledOwnerState<TValue>
     >;
   };

--- a/packages/mui-base/src/OptionGroupUnstyled/OptionGroupUnstyled.types.ts
+++ b/packages/mui-base/src/OptionGroupUnstyled/OptionGroupUnstyled.types.ts
@@ -2,7 +2,9 @@ import { OverrideProps } from '@mui/types';
 import * as React from 'react';
 import { SlotComponentProps } from '../utils';
 
-export interface OptionGroupUnstyledComponentsPropsOverrides {}
+export interface OptionGroupUnstyledRootSlotOverrides {}
+export interface OptionGroupUnstyledLabelSlotOverrides {}
+export interface OptionGroupUnstyledListSlotOverrides {}
 
 export interface OptionGroupUnstyledOwnProps {
   /**
@@ -33,17 +35,17 @@ export interface OptionGroupUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'li',
-      OptionGroupUnstyledComponentsPropsOverrides,
+      OptionGroupUnstyledRootSlotOverrides,
       OptionGroupUnstyledOwnerState
     >;
     label?: SlotComponentProps<
       'span',
-      OptionGroupUnstyledComponentsPropsOverrides,
+      OptionGroupUnstyledLabelSlotOverrides,
       OptionGroupUnstyledOwnerState
     >;
     list?: SlotComponentProps<
       'ul',
-      OptionGroupUnstyledComponentsPropsOverrides,
+      OptionGroupUnstyledListSlotOverrides,
       OptionGroupUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/OptionGroupUnstyled/OptionGroupUnstyled.types.ts
+++ b/packages/mui-base/src/OptionGroupUnstyled/OptionGroupUnstyled.types.ts
@@ -2,9 +2,9 @@ import { OverrideProps } from '@mui/types';
 import * as React from 'react';
 import { SlotComponentProps } from '../utils';
 
-export interface OptionGroupUnstyledRootSlotOverrides {}
-export interface OptionGroupUnstyledLabelSlotOverrides {}
-export interface OptionGroupUnstyledListSlotOverrides {}
+export interface OptionGroupUnstyledRootSlotPropsOverrides {}
+export interface OptionGroupUnstyledLabelSlotPropsOverrides {}
+export interface OptionGroupUnstyledListSlotPropsOverrides {}
 
 export interface OptionGroupUnstyledOwnProps {
   /**
@@ -35,17 +35,17 @@ export interface OptionGroupUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'li',
-      OptionGroupUnstyledRootSlotOverrides,
+      OptionGroupUnstyledRootSlotPropsOverrides,
       OptionGroupUnstyledOwnerState
     >;
     label?: SlotComponentProps<
       'span',
-      OptionGroupUnstyledLabelSlotOverrides,
+      OptionGroupUnstyledLabelSlotPropsOverrides,
       OptionGroupUnstyledOwnerState
     >;
     list?: SlotComponentProps<
       'ul',
-      OptionGroupUnstyledListSlotOverrides,
+      OptionGroupUnstyledListSlotPropsOverrides,
       OptionGroupUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.types.ts
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.types.ts
@@ -4,7 +4,7 @@ import { OptionState } from '../ListboxUnstyled';
 import { UseSelectOptionSlotProps } from '../SelectUnstyled/useSelect.types';
 import { SlotComponentProps } from '../utils';
 
-export interface OptionUnstyledRootSlotOverrides {}
+export interface OptionUnstyledRootSlotPropsOverrides {}
 
 export interface OptionUnstyledOwnProps<TValue> {
   /**
@@ -25,7 +25,7 @@ export interface OptionUnstyledOwnProps<TValue> {
   slotProps?: {
     root?: SlotComponentProps<
       'li',
-      OptionUnstyledRootSlotOverrides,
+      OptionUnstyledRootSlotPropsOverrides,
       OptionUnstyledOwnerState<TValue>
     >;
   };

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.types.ts
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.types.ts
@@ -4,7 +4,7 @@ import { OptionState } from '../ListboxUnstyled';
 import { UseSelectOptionSlotProps } from '../SelectUnstyled/useSelect.types';
 import { SlotComponentProps } from '../utils';
 
-export interface OptionUnstyledComponentsPropsOverrides {}
+export interface OptionUnstyledRootSlotOverrides {}
 
 export interface OptionUnstyledOwnProps<TValue> {
   /**
@@ -25,7 +25,7 @@ export interface OptionUnstyledOwnProps<TValue> {
   slotProps?: {
     root?: SlotComponentProps<
       'li',
-      OptionUnstyledComponentsPropsOverrides,
+      OptionUnstyledRootSlotOverrides,
       OptionUnstyledOwnerState<TValue>
     >;
   };

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
@@ -6,7 +6,7 @@ import { SlotComponentProps } from '../utils';
 
 export type PopperPlacementType = Options['placement'];
 
-interface PopperUnstyledComponentsPropsOverrides {}
+interface PopperUnstyledRootSlotOverrides {}
 
 export interface PopperUnstyledTransitionProps {
   in: boolean;
@@ -91,7 +91,7 @@ export interface PopperUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      PopperUnstyledComponentsPropsOverrides,
+      PopperUnstyledRootSlotOverrides,
       PopperUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
@@ -89,11 +89,7 @@ export interface PopperUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'div',
-      PopperUnstyledRootSlotOverrides,
-      PopperUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'div', PopperUnstyledRootSlotOverrides, PopperUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Popper.

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
@@ -6,7 +6,7 @@ import { SlotComponentProps } from '../utils';
 
 export type PopperPlacementType = Options['placement'];
 
-interface PopperUnstyledRootSlotOverrides {}
+interface PopperUnstyledRootSlotPropsOverrides {}
 
 export interface PopperUnstyledTransitionProps {
   in: boolean;
@@ -89,7 +89,11 @@ export interface PopperUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', PopperUnstyledRootSlotOverrides, PopperUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'div',
+      PopperUnstyledRootSlotPropsOverrides,
+      PopperUnstyledOwnerState
+    >;
   };
   /**
    * The components used for each slot inside the Popper.

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.spec.tsx
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.spec.tsx
@@ -7,7 +7,7 @@ import {
   PopperUnstyled,
 } from '@mui/base';
 
-const SelectUnstyledComponentsPropsOverridesTest = (
+const SelectUnstyledSlotPropsOverridesTest = (
   <SelectUnstyled
     slotProps={{
       root: {
@@ -59,7 +59,7 @@ function InvalidPopper({ requiredProp }: { requiredProp: string }) {
   return <div />;
 }
 
-const SelectUnstyledComponentsOverridesUsingInvalidComponentTest = (
+const SelectUnstyledSlotsOverridesUsingInvalidComponentTest = (
   <SelectUnstyled
     slots={{
       // @ts-expect-error - provided a component that requires a prop SelectUnstyled does not provide
@@ -68,7 +68,7 @@ const SelectUnstyledComponentsOverridesUsingInvalidComponentTest = (
   />
 );
 
-const SelectUnstyledComponentsOverridesUsingHostComponentTest = (
+const SelectUnstyledSlotsOverridesUsingHostComponentTest = (
   <SelectUnstyled
     slots={{
       // @ts-expect-error - provided a host element instead of a component

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
@@ -8,7 +8,9 @@ import {
 import PopperUnstyled, { PopperUnstyledProps } from '../PopperUnstyled';
 import { SlotComponentProps } from '../utils';
 
-export interface SelectUnstyledComponentsPropsOverrides {}
+export interface SelectUnstyledRootSlotOverrides {}
+export interface SelectUnstyledListboxSlotOverrides {}
+export interface SelectUnstyledPopperSlotOverrides {}
 
 export interface SelectUnstyledCommonProps {
   /**
@@ -89,17 +91,17 @@ export interface SelectUnstyledOwnProps<TValue extends {}> extends SelectUnstyle
   slotProps?: {
     root?: SlotComponentProps<
       'button',
-      SelectUnstyledComponentsPropsOverrides,
+      SelectUnstyledRootSlotOverrides,
       SelectUnstyledOwnerState<TValue>
     >;
     listbox?: SlotComponentProps<
       'button',
-      SelectUnstyledComponentsPropsOverrides,
+      SelectUnstyledListboxSlotOverrides,
       SelectUnstyledOwnerState<TValue>
     >;
     popper?: SlotComponentProps<
       typeof PopperUnstyled,
-      SelectUnstyledComponentsPropsOverrides,
+      SelectUnstyledPopperSlotOverrides,
       SelectUnstyledOwnerState<TValue>
     >;
   };

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
@@ -8,9 +8,9 @@ import {
 import PopperUnstyled, { PopperUnstyledProps } from '../PopperUnstyled';
 import { SlotComponentProps } from '../utils';
 
-export interface SelectUnstyledRootSlotOverrides {}
-export interface SelectUnstyledListboxSlotOverrides {}
-export interface SelectUnstyledPopperSlotOverrides {}
+export interface SelectUnstyledRootSlotPropsOverrides {}
+export interface SelectUnstyledListboxSlotPropsOverrides {}
+export interface SelectUnstyledPopperSlotPropsOverrides {}
 
 export interface SelectUnstyledCommonProps {
   /**
@@ -91,17 +91,17 @@ export interface SelectUnstyledOwnProps<TValue extends {}> extends SelectUnstyle
   slotProps?: {
     root?: SlotComponentProps<
       'button',
-      SelectUnstyledRootSlotOverrides,
+      SelectUnstyledRootSlotPropsOverrides,
       SelectUnstyledOwnerState<TValue>
     >;
     listbox?: SlotComponentProps<
       'button',
-      SelectUnstyledListboxSlotOverrides,
+      SelectUnstyledListboxSlotPropsOverrides,
       SelectUnstyledOwnerState<TValue>
     >;
     popper?: SlotComponentProps<
       typeof PopperUnstyled,
-      SelectUnstyledPopperSlotOverrides,
+      SelectUnstyledPopperSlotPropsOverrides,
       SelectUnstyledOwnerState<TValue>
     >;
   };

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
@@ -24,14 +24,14 @@ export interface SliderUnstyledOwnerState extends SliderUnstyledOwnProps {
   valueLabelFormat: string | ((value: number, index: number) => React.ReactNode);
 }
 
-export interface SliderUnstyledRootSlotOverrides {}
-export interface SliderUnstyledTrackSlotOverrides {}
-export interface SliderUnstyledRailSlotOverrides {}
-export interface SliderUnstyledThumbSlotOverrides {}
-export interface SliderUnstyledMarkSlotOverrides {}
-export interface SliderUnstyledMarkLabelSlotOverrides {}
-export interface SliderUnstyledValueLabelSlotOverrides {}
-export interface SliderUnstyledInputSlotOverrides {}
+export interface SliderUnstyledRootSlotPropsOverrides {}
+export interface SliderUnstyledTrackSlotPropsOverrides {}
+export interface SliderUnstyledRailSlotPropsOverrides {}
+export interface SliderUnstyledThumbSlotPropsOverrides {}
+export interface SliderUnstyledMarkSlotPropsOverrides {}
+export interface SliderUnstyledMarkLabelSlotPropsOverrides {}
+export interface SliderUnstyledValueLabelSlotPropsOverrides {}
+export interface SliderUnstyledInputSlotPropsOverrides {}
 
 export interface SliderUnstyledOwnProps {
   /**
@@ -143,22 +143,46 @@ export interface SliderUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'span', SliderUnstyledRootSlotOverrides, SliderUnstyledOwnerState>;
-    track?: SlotComponentProps<'span', SliderUnstyledTrackSlotOverrides, SliderUnstyledOwnerState>;
-    rail?: SlotComponentProps<'span', SliderUnstyledRailSlotOverrides, SliderUnstyledOwnerState>;
-    thumb?: SlotComponentProps<'span', SliderUnstyledThumbSlotOverrides, SliderUnstyledOwnerState>;
-    mark?: SlotComponentProps<'span', SliderUnstyledMarkSlotOverrides, SliderUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'span',
+      SliderUnstyledRootSlotPropsOverrides,
+      SliderUnstyledOwnerState
+    >;
+    track?: SlotComponentProps<
+      'span',
+      SliderUnstyledTrackSlotPropsOverrides,
+      SliderUnstyledOwnerState
+    >;
+    rail?: SlotComponentProps<
+      'span',
+      SliderUnstyledRailSlotPropsOverrides,
+      SliderUnstyledOwnerState
+    >;
+    thumb?: SlotComponentProps<
+      'span',
+      SliderUnstyledThumbSlotPropsOverrides,
+      SliderUnstyledOwnerState
+    >;
+    mark?: SlotComponentProps<
+      'span',
+      SliderUnstyledMarkSlotPropsOverrides,
+      SliderUnstyledOwnerState
+    >;
     markLabel?: SlotComponentProps<
       'span',
-      SliderUnstyledMarkLabelSlotOverrides,
+      SliderUnstyledMarkLabelSlotPropsOverrides,
       SliderUnstyledOwnerState
     >;
     valueLabel?: SlotComponentProps<
       React.ElementType,
-      SliderUnstyledValueLabelSlotOverrides,
+      SliderUnstyledValueLabelSlotPropsOverrides,
       SliderUnstyledOwnerState
     >;
-    input?: SlotComponentProps<'input', SliderUnstyledInputSlotOverrides, SliderUnstyledOwnerState>;
+    input?: SlotComponentProps<
+      'input',
+      SliderUnstyledInputSlotPropsOverrides,
+      SliderUnstyledOwnerState
+    >;
   };
   /**
    * The components used for each slot inside the Slider.

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
@@ -24,7 +24,14 @@ export interface SliderUnstyledOwnerState extends SliderUnstyledOwnProps {
   valueLabelFormat: string | ((value: number, index: number) => React.ReactNode);
 }
 
-export interface SliderUnstyledComponentsPropsOverrides {}
+export interface SliderUnstyledRootSlotOverrides {}
+export interface SliderUnstyledTrackSlotOverrides {}
+export interface SliderUnstyledRailSlotOverrides {}
+export interface SliderUnstyledThumbSlotOverrides {}
+export interface SliderUnstyledMarkSlotOverrides {}
+export interface SliderUnstyledMarkLabelSlotOverrides {}
+export interface SliderUnstyledValueLabelSlotOverrides {}
+export interface SliderUnstyledInputSlotOverrides {}
 
 export interface SliderUnstyledOwnProps {
   /**
@@ -136,47 +143,22 @@ export interface SliderUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'span',
-      SliderUnstyledComponentsPropsOverrides,
-      SliderUnstyledOwnerState
-    >;
-    track?: SlotComponentProps<
-      'span',
-      SliderUnstyledComponentsPropsOverrides,
-      SliderUnstyledOwnerState
-    >;
-    rail?: SlotComponentProps<
-      'span',
-      SliderUnstyledComponentsPropsOverrides,
-      SliderUnstyledOwnerState
-    >;
-    thumb?: SlotComponentProps<
-      'span',
-      SliderUnstyledComponentsPropsOverrides,
-      SliderUnstyledOwnerState
-    >;
-    mark?: SlotComponentProps<
-      'span',
-      SliderUnstyledComponentsPropsOverrides,
-      SliderUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'span', SliderUnstyledRootSlotOverrides, SliderUnstyledOwnerState>;
+    track?: SlotComponentProps<'span', SliderUnstyledTrackSlotOverrides, SliderUnstyledOwnerState>;
+    rail?: SlotComponentProps<'span', SliderUnstyledRailSlotOverrides, SliderUnstyledOwnerState>;
+    thumb?: SlotComponentProps<'span', SliderUnstyledThumbSlotOverrides, SliderUnstyledOwnerState>;
+    mark?: SlotComponentProps<'span', SliderUnstyledMarkSlotOverrides, SliderUnstyledOwnerState>;
     markLabel?: SlotComponentProps<
       'span',
-      SliderUnstyledComponentsPropsOverrides,
+      SliderUnstyledMarkLabelSlotOverrides,
       SliderUnstyledOwnerState
     >;
     valueLabel?: SlotComponentProps<
       React.ElementType,
-      SliderUnstyledComponentsPropsOverrides,
+      SliderUnstyledValueLabelSlotOverrides,
       SliderUnstyledOwnerState
     >;
-
-    input?: SlotComponentProps<
-      'input',
-      SliderUnstyledComponentsPropsOverrides,
-      SliderUnstyledOwnerState
-    >;
+    input?: SlotComponentProps<'input', SliderUnstyledInputSlotOverrides, SliderUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Slider.

--- a/packages/mui-base/src/SnackbarUnstyled/SnackbarUnstyled.types.ts
+++ b/packages/mui-base/src/SnackbarUnstyled/SnackbarUnstyled.types.ts
@@ -4,8 +4,8 @@ import ClickAwayListener, { ClickAwayListenerProps } from '../ClickAwayListener'
 import { UseSnackbarParameters } from './useSnackbar.types';
 import { SlotComponentProps } from '../utils';
 
-export interface SnackbarUnstyledRootSlotOverrides {}
-export interface SnackbarUnstyledClickAwayListenerSlotOverrides {}
+export interface SnackbarUnstyledRootSlotPropsOverrides {}
+export interface SnackbarUnstyledClickAwayListenerSlotPropsOverrides {}
 
 export interface SnackbarUnstyledOwnProps extends Omit<UseSnackbarParameters, 'ref'> {
   children?: React.ReactNode;
@@ -24,10 +24,14 @@ export interface SnackbarUnstyledOwnProps extends Omit<UseSnackbarParameters, 'r
   slotProps?: {
     clickAwayListener?: SlotComponentProps<
       typeof ClickAwayListener,
-      SnackbarUnstyledClickAwayListenerSlotOverrides,
+      SnackbarUnstyledClickAwayListenerSlotPropsOverrides,
       SnackbarUnstyledOwnerState
     >;
-    root?: SlotComponentProps<'div', SnackbarUnstyledRootSlotOverrides, SnackbarUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'div',
+      SnackbarUnstyledRootSlotPropsOverrides,
+      SnackbarUnstyledOwnerState
+    >;
   };
   /**
    * The prop used to handle exited transition and unmount the component.

--- a/packages/mui-base/src/SnackbarUnstyled/SnackbarUnstyled.types.ts
+++ b/packages/mui-base/src/SnackbarUnstyled/SnackbarUnstyled.types.ts
@@ -4,7 +4,8 @@ import ClickAwayListener, { ClickAwayListenerProps } from '../ClickAwayListener'
 import { UseSnackbarParameters } from './useSnackbar.types';
 import { SlotComponentProps } from '../utils';
 
-export interface SnackbarUnstyledComponentsPropsOverrides {}
+export interface SnackbarUnstyledRootSlotOverrides {}
+export interface SnackbarUnstyledClickAwayListenerSlotOverrides {}
 
 export interface SnackbarUnstyledOwnProps extends Omit<UseSnackbarParameters, 'ref'> {
   children?: React.ReactNode;
@@ -23,14 +24,10 @@ export interface SnackbarUnstyledOwnProps extends Omit<UseSnackbarParameters, 'r
   slotProps?: {
     clickAwayListener?: SlotComponentProps<
       typeof ClickAwayListener,
-      SnackbarUnstyledComponentsPropsOverrides,
+      SnackbarUnstyledClickAwayListenerSlotOverrides,
       SnackbarUnstyledOwnerState
     >;
-    root?: SlotComponentProps<
-      'div',
-      SnackbarUnstyledComponentsPropsOverrides,
-      SnackbarUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'div', SnackbarUnstyledRootSlotOverrides, SnackbarUnstyledOwnerState>;
   };
   /**
    * The prop used to handle exited transition and unmount the component.

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -2,10 +2,10 @@ import { OverrideProps, Simplify } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types';
 
-export interface SwitchUnstyledRootSlotOverrides {}
-export interface SwitchUnstyledThumbSlotOverrides {}
-export interface SwitchUnstyledInputSlotOverrides {}
-export interface SwitchUnstyledTrackSlotOverrides {}
+export interface SwitchUnstyledRootSlotPropsOverrides {}
+export interface SwitchUnstyledThumbSlotPropsOverrides {}
+export interface SwitchUnstyledInputSlotPropsOverrides {}
+export interface SwitchUnstyledTrackSlotPropsOverrides {}
 
 export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   /**
@@ -29,10 +29,26 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'span', SwitchUnstyledRootSlotOverrides, SwitchUnstyledOwnerState>;
-    thumb?: SlotComponentProps<'span', SwitchUnstyledThumbSlotOverrides, SwitchUnstyledOwnerState>;
-    input?: SlotComponentProps<'input', SwitchUnstyledInputSlotOverrides, SwitchUnstyledOwnerState>;
-    track?: SlotComponentProps<'span', SwitchUnstyledTrackSlotOverrides, SwitchUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'span',
+      SwitchUnstyledRootSlotPropsOverrides,
+      SwitchUnstyledOwnerState
+    >;
+    thumb?: SlotComponentProps<
+      'span',
+      SwitchUnstyledThumbSlotPropsOverrides,
+      SwitchUnstyledOwnerState
+    >;
+    input?: SlotComponentProps<
+      'input',
+      SwitchUnstyledInputSlotPropsOverrides,
+      SwitchUnstyledOwnerState
+    >;
+    track?: SlotComponentProps<
+      'span',
+      SwitchUnstyledTrackSlotPropsOverrides,
+      SwitchUnstyledOwnerState
+    >;
   };
 }
 

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -2,7 +2,10 @@ import { OverrideProps, Simplify } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types';
 
-export interface SwitchUnstyledComponentsPropsOverrides {}
+export interface SwitchUnstyledRootSlotOverrides {}
+export interface SwitchUnstyledThumbSlotOverrides {}
+export interface SwitchUnstyledInputSlotOverrides {}
+export interface SwitchUnstyledTrackSlotOverrides {}
 
 export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
   /**
@@ -26,26 +29,10 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'span',
-      SwitchUnstyledComponentsPropsOverrides,
-      SwitchUnstyledOwnerState
-    >;
-    thumb?: SlotComponentProps<
-      'span',
-      SwitchUnstyledComponentsPropsOverrides,
-      SwitchUnstyledOwnerState
-    >;
-    input?: SlotComponentProps<
-      'input',
-      SwitchUnstyledComponentsPropsOverrides,
-      SwitchUnstyledOwnerState
-    >;
-    track?: SlotComponentProps<
-      'span',
-      SwitchUnstyledComponentsPropsOverrides,
-      SwitchUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'span', SwitchUnstyledRootSlotOverrides, SwitchUnstyledOwnerState>;
+    thumb?: SlotComponentProps<'span', SwitchUnstyledThumbSlotOverrides, SwitchUnstyledOwnerState>;
+    input?: SlotComponentProps<'input', SwitchUnstyledInputSlotOverrides, SwitchUnstyledOwnerState>;
+    track?: SlotComponentProps<'span', SwitchUnstyledTrackSlotOverrides, SwitchUnstyledOwnerState>;
   };
 }
 

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
@@ -3,7 +3,7 @@ import { OverrideProps } from '@mui/types';
 import { UseTabPanelRootSlotProps } from './useTabPanel.types';
 import { SlotComponentProps } from '../utils';
 
-interface TabPanelUnstyledRootSlotOverrides {}
+interface TabPanelUnstyledRootSlotPropsOverrides {}
 
 export interface TabPanelUnstyledOwnProps {
   /**
@@ -28,7 +28,11 @@ export interface TabPanelUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', TabPanelUnstyledRootSlotOverrides, TabPanelUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'div',
+      TabPanelUnstyledRootSlotPropsOverrides,
+      TabPanelUnstyledOwnerState
+    >;
   };
 }
 

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
@@ -28,11 +28,7 @@ export interface TabPanelUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'div',
-      TabPanelUnstyledRootSlotOverrides,
-      TabPanelUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'div', TabPanelUnstyledRootSlotOverrides, TabPanelUnstyledOwnerState>;
   };
 }
 

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
@@ -3,7 +3,7 @@ import { OverrideProps } from '@mui/types';
 import { UseTabPanelRootSlotProps } from './useTabPanel.types';
 import { SlotComponentProps } from '../utils';
 
-interface TabPanelUnstyledComponentsPropsOverrides {}
+interface TabPanelUnstyledRootSlotOverrides {}
 
 export interface TabPanelUnstyledOwnProps {
   /**
@@ -30,7 +30,7 @@ export interface TabPanelUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      TabPanelUnstyledComponentsPropsOverrides,
+      TabPanelUnstyledRootSlotOverrides,
       TabPanelUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
@@ -4,7 +4,7 @@ import { ButtonUnstyledOwnProps } from '../ButtonUnstyled';
 import { SlotComponentProps } from '../utils';
 import { UseTabRootSlotProps } from './useTab.types';
 
-interface TabUnstyledRootSlotOverrides {}
+interface TabUnstyledRootSlotPropsOverrides {}
 
 export interface TabUnstyledOwnProps
   extends Omit<ButtonUnstyledOwnProps, 'onChange' | 'slots' | 'slotProps'> {
@@ -29,7 +29,7 @@ export interface TabUnstyledOwnProps
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', TabUnstyledRootSlotOverrides, TabUnstyledOwnerState>;
+    root?: SlotComponentProps<'div', TabUnstyledRootSlotPropsOverrides, TabUnstyledOwnerState>;
   };
 }
 

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
@@ -4,7 +4,7 @@ import { ButtonUnstyledOwnProps } from '../ButtonUnstyled';
 import { SlotComponentProps } from '../utils';
 import { UseTabRootSlotProps } from './useTab.types';
 
-interface TabUnstyledComponentsPropsOverrides {}
+interface TabUnstyledRootSlotOverrides {}
 
 export interface TabUnstyledOwnProps
   extends Omit<ButtonUnstyledOwnProps, 'onChange' | 'slots' | 'slotProps'> {
@@ -29,7 +29,7 @@ export interface TabUnstyledOwnProps
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', TabUnstyledComponentsPropsOverrides, TabUnstyledOwnerState>;
+    root?: SlotComponentProps<'div', TabUnstyledRootSlotOverrides, TabUnstyledOwnerState>;
   };
 }
 

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-export interface TablePaginationActionsUnstyledRootSlotOverrides {}
-export interface TablePaginationActionsUnstyledFirstButtonSlotOverrides {}
-export interface TablePaginationActionsUnstyledLastButtonSlotOverrides {}
-export interface TablePaginationActionsUnstyledNextButtonSlotOverrides {}
-export interface TablePaginationActionsUnstyledBackButtonSlotOverrides {}
+export interface TablePaginationActionsUnstyledRootSlotPropsOverrides {}
+export interface TablePaginationActionsUnstyledFirstButtonSlotPropsOverrides {}
+export interface TablePaginationActionsUnstyledLastButtonSlotPropsOverrides {}
+export interface TablePaginationActionsUnstyledNextButtonSlotPropsOverrides {}
+export interface TablePaginationActionsUnstyledBackButtonSlotPropsOverrides {}
 
 export interface TablePaginationActionsUnstyledOwnProps {
   /**
@@ -37,27 +37,27 @@ export interface TablePaginationActionsUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      TablePaginationActionsUnstyledRootSlotOverrides,
+      TablePaginationActionsUnstyledRootSlotPropsOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     firstButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledFirstButtonSlotOverrides,
+      TablePaginationActionsUnstyledFirstButtonSlotPropsOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     lastButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledLastButtonSlotOverrides,
+      TablePaginationActionsUnstyledLastButtonSlotPropsOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     nextButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledNextButtonSlotOverrides,
+      TablePaginationActionsUnstyledNextButtonSlotPropsOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     backButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledBackButtonSlotOverrides,
+      TablePaginationActionsUnstyledBackButtonSlotPropsOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-export interface TablePaginationActionsUnstyledComponentsPropsOverrides {}
+export interface TablePaginationActionsUnstyledRootSlotOverrides {}
+export interface TablePaginationActionsUnstyledFirstButtonSlotOverrides {}
+export interface TablePaginationActionsUnstyledLastButtonSlotOverrides {}
+export interface TablePaginationActionsUnstyledNextButtonSlotOverrides {}
+export interface TablePaginationActionsUnstyledBackButtonSlotOverrides {}
 
 export interface TablePaginationActionsUnstyledOwnProps {
   /**
@@ -33,27 +37,27 @@ export interface TablePaginationActionsUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      TablePaginationActionsUnstyledComponentsPropsOverrides,
+      TablePaginationActionsUnstyledRootSlotOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     firstButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledComponentsPropsOverrides,
+      TablePaginationActionsUnstyledFirstButtonSlotOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     lastButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledComponentsPropsOverrides,
+      TablePaginationActionsUnstyledLastButtonSlotOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     nextButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledComponentsPropsOverrides,
+      TablePaginationActionsUnstyledNextButtonSlotOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
     backButton?: SlotComponentProps<
       'button',
-      TablePaginationActionsUnstyledComponentsPropsOverrides,
+      TablePaginationActionsUnstyledBackButtonSlotOverrides,
       TablePaginationActionsUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
@@ -12,14 +12,14 @@ export interface LabelDisplayedRowsArgs {
 
 export type ItemAriaLabelType = 'first' | 'last' | 'next' | 'previous';
 
-export interface TablePaginationUnstyledRootSlotOverrides {}
-export interface TablePaginationUnstyledActionsSlotOverrides {}
-export interface TablePaginationUnstyledSelectSlotOverrides {}
-export interface TablePaginationUnstyledSelectLabelSlotOverrides {}
-export interface TablePaginationUnstyledMenuItemSlotOverrides {}
-export interface TablePaginationUnstyledDisplayedRowsSlotOverrides {}
-export interface TablePaginationUnstyledToolbarSlotOverrides {}
-export interface TablePaginationUnstyledSpacerSlotOverrides {}
+export interface TablePaginationUnstyledRootSlotPropsOverrides {}
+export interface TablePaginationUnstyledActionsSlotPropsOverrides {}
+export interface TablePaginationUnstyledSelectSlotPropsOverrides {}
+export interface TablePaginationUnstyledSelectLabelSlotPropsOverrides {}
+export interface TablePaginationUnstyledMenuItemSlotPropsOverrides {}
+export interface TablePaginationUnstyledDisplayedRowsSlotPropsOverrides {}
+export interface TablePaginationUnstyledToolbarSlotPropsOverrides {}
+export interface TablePaginationUnstyledSpacerSlotPropsOverrides {}
 
 export interface TablePaginationUnstyledOwnProps {
   /**
@@ -52,42 +52,42 @@ export interface TablePaginationUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledRootSlotOverrides,
+      TablePaginationUnstyledRootSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     actions?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledActionsSlotOverrides,
+      TablePaginationUnstyledActionsSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     select?: SlotComponentProps<
       'select',
-      TablePaginationUnstyledSelectSlotOverrides,
+      TablePaginationUnstyledSelectSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     selectLabel?: SlotComponentProps<
       'p',
-      TablePaginationUnstyledSelectLabelSlotOverrides,
+      TablePaginationUnstyledSelectLabelSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     menuItem?: SlotComponentProps<
       'option',
-      TablePaginationUnstyledMenuItemSlotOverrides,
+      TablePaginationUnstyledMenuItemSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     displayedRows?: SlotComponentProps<
       'p',
-      TablePaginationUnstyledDisplayedRowsSlotOverrides,
+      TablePaginationUnstyledDisplayedRowsSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     toolbar?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledToolbarSlotOverrides,
+      TablePaginationUnstyledToolbarSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
     spacer?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledSpacerSlotOverrides,
+      TablePaginationUnstyledSpacerSlotPropsOverrides,
       TablePaginationUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
@@ -12,7 +12,14 @@ export interface LabelDisplayedRowsArgs {
 
 export type ItemAriaLabelType = 'first' | 'last' | 'next' | 'previous';
 
-export interface TablePaginationUnstyledComponentsPropsOverrides {}
+export interface TablePaginationUnstyledRootSlotOverrides {}
+export interface TablePaginationUnstyledActionsSlotOverrides {}
+export interface TablePaginationUnstyledSelectSlotOverrides {}
+export interface TablePaginationUnstyledSelectLabelSlotOverrides {}
+export interface TablePaginationUnstyledMenuItemSlotOverrides {}
+export interface TablePaginationUnstyledDisplayedRowsSlotOverrides {}
+export interface TablePaginationUnstyledToolbarSlotOverrides {}
+export interface TablePaginationUnstyledSpacerSlotOverrides {}
 
 export interface TablePaginationUnstyledOwnProps {
   /**
@@ -45,42 +52,42 @@ export interface TablePaginationUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledRootSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     actions?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledActionsSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     select?: SlotComponentProps<
       'select',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledSelectSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     selectLabel?: SlotComponentProps<
       'p',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledSelectLabelSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     menuItem?: SlotComponentProps<
       'option',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledMenuItemSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     displayedRows?: SlotComponentProps<
       'p',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledDisplayedRowsSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     toolbar?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledToolbarSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
     spacer?: SlotComponentProps<
       'div',
-      TablePaginationUnstyledComponentsPropsOverrides,
+      TablePaginationUnstyledSpacerSlotOverrides,
       TablePaginationUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
@@ -16,11 +16,7 @@ export interface TabsListUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<
-      'div',
-      TabsListUnstyledRootSlotOverrides,
-      TabsListUnstyledOwnerState
-    >;
+    root?: SlotComponentProps<'div', TabsListUnstyledRootSlotOverrides, TabsListUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the TabsList.

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
@@ -3,7 +3,7 @@ import { OverrideProps } from '@mui/types';
 import { UseTabsListRootSlotProps } from './useTabsList.types';
 import { SlotComponentProps } from '../utils';
 
-interface TabsListUnstyledRootSlotOverrides {}
+interface TabsListUnstyledRootSlotPropsOverrides {}
 
 export interface TabsListUnstyledOwnProps {
   /**
@@ -16,7 +16,11 @@ export interface TabsListUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', TabsListUnstyledRootSlotOverrides, TabsListUnstyledOwnerState>;
+    root?: SlotComponentProps<
+      'div',
+      TabsListUnstyledRootSlotPropsOverrides,
+      TabsListUnstyledOwnerState
+    >;
   };
   /**
    * The components used for each slot inside the TabsList.

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
@@ -3,7 +3,7 @@ import { OverrideProps } from '@mui/types';
 import { UseTabsListRootSlotProps } from './useTabsList.types';
 import { SlotComponentProps } from '../utils';
 
-interface TabsListUnstyledComponentsPropsOverrides {}
+interface TabsListUnstyledRootSlotOverrides {}
 
 export interface TabsListUnstyledOwnProps {
   /**
@@ -18,7 +18,7 @@ export interface TabsListUnstyledOwnProps {
   slotProps?: {
     root?: SlotComponentProps<
       'div',
-      TabsListUnstyledComponentsPropsOverrides,
+      TabsListUnstyledRootSlotOverrides,
       TabsListUnstyledOwnerState
     >;
   };

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-interface TabsUnstyledRootSlotOverrides {}
+interface TabsUnstyledRootSlotPropsOverrides {}
 
 type TabsUnstyledOrientation = 'horizontal' | 'vertical';
 
@@ -47,7 +47,7 @@ export interface TabsUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', TabsUnstyledRootSlotOverrides, TabsUnstyledOwnerState>;
+    root?: SlotComponentProps<'div', TabsUnstyledRootSlotPropsOverrides, TabsUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Tabs.

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-interface TabsUnstyledComponentsPropsOverrides {}
+interface TabsUnstyledRootSlotOverrides {}
 
 type TabsUnstyledOrientation = 'horizontal' | 'vertical';
 
@@ -47,7 +47,7 @@ export interface TabsUnstyledOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', TabsUnstyledComponentsPropsOverrides, TabsUnstyledOwnerState>;
+    root?: SlotComponentProps<'div', TabsUnstyledRootSlotOverrides, TabsUnstyledOwnerState>;
   };
   /**
    * The components used for each slot inside the Tabs.

--- a/packages/mui-base/test/typescript/moduleAugmentation/selectUnstyledComponentsProps.spec.tsx
+++ b/packages/mui-base/test/typescript/moduleAugmentation/selectUnstyledComponentsProps.spec.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { SelectUnstyled, MultiSelectUnstyled } from '@mui/base';
 
 declare module '@mui/base' {
-  interface SelectUnstyledComponentsPropsOverrides {
+  interface SelectUnstyledRootSlotOverrides {
     variant?: 'one' | 'two';
   }
 
-  interface MultiSelectUnstyledComponentsPropsOverrides {
+  interface MultiSelectUnstyledRootSlotOverrides {
     variant?: 'a' | 'b';
   }
 }

--- a/packages/mui-base/test/typescript/moduleAugmentation/selectUnstyledComponentsProps.spec.tsx
+++ b/packages/mui-base/test/typescript/moduleAugmentation/selectUnstyledComponentsProps.spec.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { SelectUnstyled, MultiSelectUnstyled } from '@mui/base';
 
 declare module '@mui/base' {
-  interface SelectUnstyledRootSlotOverrides {
+  interface SelectUnstyledRootSlotPropsOverrides {
     variant?: 'one' | 'two';
   }
 
-  interface MultiSelectUnstyledRootSlotOverrides {
+  interface MultiSelectUnstyledRootSlotPropsOverrides {
     variant?: 'a' | 'b';
   }
 }

--- a/packages/mui-base/test/typescript/moduleAugmentation/sliderComponentsProps.spec.tsx
+++ b/packages/mui-base/test/typescript/moduleAugmentation/sliderComponentsProps.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SliderUnstyled } from '@mui/base';
 
 declare module '@mui/base' {
-  interface SliderUnstyledComponentsPropsOverrides {
+  interface SliderUnstyledRootSlotOverrides {
     variant?: 'one' | 'two';
   }
 }

--- a/packages/mui-base/test/typescript/moduleAugmentation/sliderComponentsProps.spec.tsx
+++ b/packages/mui-base/test/typescript/moduleAugmentation/sliderComponentsProps.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SliderUnstyled } from '@mui/base';
 
 declare module '@mui/base' {
-  interface SliderUnstyledRootSlotOverrides {
+  interface SliderUnstyledRootSlotPropsOverrides {
     variant?: 'one' | 'two';
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/34906

This PR goes with option 1 described in the issue above

> 1. Have a separate type for each slot override (see #35662)
   
   ```ts
   export interface BadgeUnstyledRootSlotPropsOverrides {}
   export interface BadgeUnstyledBadgeSlotPropsOverrides {}

   export interface BadgeUnstyledOwnProps {
     // ...
     slotProps?: {
       root?: SlotComponentProps<
         'span',
         BadgeUnstyledRootSlotPropsOverrides,
         BadgeUnstyledOwnerState
       >;
       badge?: SlotComponentProps<
         'span',
         BadgeUnstyledBadgeSlotPropsOverrides,
         BadgeUnstyledOwnerState
       >;
     };
   }
   ```

>  This could be slightly easier to use for developers. They would augment the required interface and the changes will apply only to one slot.
  It would be slightly more cumbersome to implement, though, and would create many new types (up to 8 in case of SliderUnstyled).

---

### Note to be added to CHANGELOG in the upcoming release

### Breaking Changes for MUI Base:

 - The way of overriding the types of `slotProps` prop has changed. Developers can now override them per slot.
 - The naming convention of `${ComponentName}ComponentsPropsOverrides` is replaced with `${ComponentName}${SlotName}SlotPropsOverrides`.

```diff
 declare module '@mui/base/SwitchUnstyled' {
-  interface SwitchUnstyledComponentsPropsOverrides {
+  interface SwitchUnstyledRootSlotPropsOverrides {
     'data-a'?: string;
+  }
+
+  interface SwitchUnstyledInputSlotPropsOverrides {
     'data-b'?: string;
+  }
+
+  interface SwitchUnstyledThumbSlotPropsOverrides {
     'data-c'?: string;
+  }
+
+  interface SwitchUnstyledTrackSlotPropsOverrides {
     'data-d'?: string;
   }
 }
```