### PR TITLE
Bump JSDOM to 21.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "fs-extra": "^10.1.0",
     "globby": "^13.1.3",
     "html-webpack-plugin": "^5.5.0",
-    "jsdom": "^20.0.3",
+    "jsdom": "^21.1.0",
     "karma": "^6.4.1",
     "karma-browserstack-launcher": "~1.6.0",
     "karma-chrome-launcher": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9988,10 +9988,10 @@ jscodeshift@^0.13.1:
     temp "^0.8.4"
     write-file-atomic "^2.3.0"
 
-jsdom@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.3.tgz#886a41ba1d4726f67a8858028c99489fed6ad4db"
-  integrity sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==
+jsdom@^21.1.0:
+  version "21.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-21.1.0.tgz#d56ba4a84ed478260d83bd53dc181775f2d8e6ef"
+  integrity sha512-m0lzlP7qOtthD918nenK3hdItSd2I+V3W9IrBcB36sqDwG+KnUs66IF5GY7laGWUnlM9vTsD0W1QwSEBYWWcJg==
   dependencies:
     abab "^2.0.6"
     acorn "^8.8.1"


### PR DESCRIPTION
Adds caching to `getComputedStyles` for perf. Want to check if this didn't break anything

If I remember correctly `test_unit` had quite the range but [336.15s (branch)](https://app.circleci.com/pipelines/github/mui/material-ui/90080/workflows/20c89d60-e939-4afa-a267-5e7b56b35a0a/jobs/477404) vs [538.74s (master)](https://app.circleci.com/pipelines/github/mui/material-ui/90037/workflows/85c4282d-660f-44db-a1d3-0e23357cb3bb/jobs/477172) looks promising.

jsdom changelog: https://github.com/jsdom/jsdom/blob/master/Changelog.md#2110.