### PR TITLE
[docs] Improve inline preview's information

### DIFF
--- a/docs/data/material/components/text-fields/StateTextFields.js
+++ b/docs/data/material/components/text-fields/StateTextFields.js
@@ -4,9 +4,6 @@ import TextField from '@mui/material/TextField';
 
 export default function StateTextFields() {
   const [name, setName] = React.useState('Cat in the Hat');
-  const handleChange = (event) => {
-    setName(event.target.value);
-  };
 
   return (
     <Box
@@ -18,10 +15,12 @@ export default function StateTextFields() {
       autoComplete="off"
     >
       <TextField
-        id="outlined-name"
-        label="Name"
+        id="outlined-controlled"
+        label="Controlled"
         value={name}
-        onChange={handleChange}
+        onChange={(event) => {
+          setName(event.target.value);
+        }}
       />
       <TextField
         id="outlined-uncontrolled"

--- a/docs/data/material/components/text-fields/StateTextFields.tsx
+++ b/docs/data/material/components/text-fields/StateTextFields.tsx
@@ -4,9 +4,6 @@ import TextField from '@mui/material/TextField';
 
 export default function StateTextFields() {
   const [name, setName] = React.useState('Cat in the Hat');
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setName(event.target.value);
-  };
 
   return (
     <Box
@@ -18,10 +15,12 @@ export default function StateTextFields() {
       autoComplete="off"
     >
       <TextField
-        id="outlined-name"
-        label="Name"
+        id="outlined-controlled"
+        label="Controlled"
         value={name}
-        onChange={handleChange}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          setName(event.target.value);
+        }}
       />
       <TextField
         id="outlined-uncontrolled"

--- a/docs/data/material/components/text-fields/StateTextFields.tsx.preview
+++ b/docs/data/material/components/text-fields/StateTextFields.tsx.preview
@@ -1,8 +1,10 @@
 <TextField
-  id="outlined-name"
-  label="Name"
+  id="outlined-controlled"
+  label="Controlled"
   value={name}
-  onChange={handleChange}
+  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  }}
 />
 <TextField
   id="outlined-uncontrolled"


### PR DESCRIPTION
See the change in the `tsx.preview`, you do no longer need to expand the demo to understand how to get the value in the change handler.

https://mui.com/material-ui/react-text-field/#uncontrolled-vs-controlled
https://deploy-preview-35974--material-ui.netlify.app/material-ui/react-text-field/#uncontrolled-vs-controlled