### PR TITLE
[docs] Fix typos in base components docs

### DIFF
--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -66,7 +66,7 @@ Use the `component` prop to override the root slot with a custom element:
 
 If you provide a non-interactive element such as a `<span>`, the Unstyled Button component will automatically add the necessary accessibility attributes.
 
-Compare the attributes on the `<span>` in this demo with the Button from the previous demo—try inspecting them both with your brower's dev tools:
+Compare the attributes on the `<span>` in this demo with the Button from the previous demo—try inspecting them both with your browser's dev tools:
 
 {{"demo": "UnstyledButtonsSpan.js"}}
 

--- a/docs/data/base/components/form-control/form-control-pt.md
+++ b/docs/data/base/components/form-control/form-control-pt.md
@@ -7,7 +7,7 @@ githubLabel: 'component: FormControl'
 
 # Unstyled form control
 
-<p class="description">The FormControlUnstyled component is a utility that lets you associate a form input with auxillary components, such as labels, error indicators, or helper text.</p>
+<p class="description">The FormControlUnstyled component is a utility that lets you associate a form input with auxiliary components, such as labels, error indicators, or helper text.</p>
 
 ## Introduction
 

--- a/docs/data/base/components/form-control/form-control-zh.md
+++ b/docs/data/base/components/form-control/form-control-zh.md
@@ -7,7 +7,7 @@ githubLabel: 'component: FormControl'
 
 # Unstyled form control
 
-<p class="description">The FormControlUnstyled component is a utility that lets you associate a form input with auxillary components, such as labels, error indicators, or helper text.</p>
+<p class="description">The FormControlUnstyled component is a utility that lets you associate a form input with auxiliary components, such as labels, error indicators, or helper text.</p>
 
 ## Introduction
 

--- a/docs/data/base/components/modal/modal-pt.md
+++ b/docs/data/base/components/modal/modal-pt.md
@@ -76,7 +76,7 @@ The following demo shows how to nest one modal within another:
 
 You can animate the open and close states of a modal using a transition component, as long as that component fulfills the following requirements:
 
-- Is a direct child descendent of the modal
+- Is a direct child descendant of the modal
 - Has an `in` prop—this corresponds to the open/close state
 - Calls the `onEnter` callback prop when the enter transition starts
 - Calls the `onExited` callback prop when the exit transition is completed

--- a/docs/data/base/components/modal/modal-zh.md
+++ b/docs/data/base/components/modal/modal-zh.md
@@ -76,7 +76,7 @@ The following demo shows how to nest one modal within another:
 
 You can animate the open and close states of a modal using a transition component, as long as that component fulfills the following requirements:
 
-- Is a direct child descendent of the modal
+- Is a direct child descendant of the modal
 - Has an `in` prop—this corresponds to the open/close state
 - Calls the `onEnter` callback prop when the enter transition starts
 - Calls the `onExited` callback prop when the exit transition is completed

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -82,7 +82,7 @@ The following demo shows how to nest one Modal within another:
 
 You can animate the open and close states of a Modal using a transition component, as long as that component fulfills the following requirements:
 
-- Is a direct child descendent of the modal
+- Is a direct child descendant of the modal
 - Has an `in` prop—this corresponds to the open/close state
 - Calls the `onEnter` callback prop when the enter transition starts
 - Calls the `onExited` callback prop when the exit transition is completed

--- a/docs/data/base/components/popper/popper-pt.md
+++ b/docs/data/base/components/popper/popper-pt.md
@@ -56,7 +56,7 @@ The popper's default placement is `bottom`. You can change it using the `placeme
 
 You can animate the open and close states of the popper with a render prop child and a transition component, as long as the component meets these conditions:
 
-- Is a direct child descendent of the popper
+- Is a direct child descendant of the popper
 - Calls the `onEnter` callback prop when the enter transition starts
 - Calls the `onExited` callback prop when the exit transition is completed
 

--- a/docs/data/base/components/popper/popper-zh.md
+++ b/docs/data/base/components/popper/popper-zh.md
@@ -56,7 +56,7 @@ The popper's default placement is `bottom`. You can change it using the `placeme
 
 You can animate the open and close states of the popper with a render prop child and a transition component, as long as the component meets these conditions:
 
-- Is a direct child descendent of the popper
+- Is a direct child descendant of the popper
 - Calls the `onEnter` callback prop when the enter transition starts
 - Calls the `onExited` callback prop when the exit transition is completed
 

--- a/docs/data/base/components/popper/popper.md
+++ b/docs/data/base/components/popper/popper.md
@@ -63,7 +63,7 @@ Try changing this value to `top` in the interactive demo below to see how it wor
 
 You can animate the open and close states of the popper with a render prop child and a transition component, as long as the component meets these conditions:
 
-- Is a direct child descendent of the popper
+- Is a direct child descendant of the popper
 - Calls the `onEnter` callback prop when the enter transition starts
 - Calls the `onExited` callback prop when the exit transition is completed
 

--- a/docs/data/base/components/snackbar/snackbar-pt.md
+++ b/docs/data/base/components/snackbar/snackbar-pt.md
@@ -127,7 +127,7 @@ For the sake of simplicity, demos and code snippets primarily feature components
 
 You can animate the open and close states of the snackbar with a render prop child and a transition component, as long as the component meets these conditions:
 
-- Is a direct child descendent of the snackbar
+- Is a direct child descendant of the snackbar
 - Has an `in` prop—this corresponds to the open state
 - Passes the `exited` prop to `SnackbarUnstyled`
 - Calls the `onEnter` callback prop when the enter transition starts—sets `exited` to false

--- a/docs/data/base/components/snackbar/snackbar-zh.md
+++ b/docs/data/base/components/snackbar/snackbar-zh.md
@@ -127,7 +127,7 @@ For the sake of simplicity, demos and code snippets primarily feature components
 
 You can animate the open and close states of the snackbar with a render prop child and a transition component, as long as the component meets these conditions:
 
-- Is a direct child descendent of the snackbar
+- Is a direct child descendant of the snackbar
 - Has an `in` prop—this corresponds to the open state
 - Passes the `exited` prop to `SnackbarUnstyled`
 - Calls the `onEnter` callback prop when the enter transition starts—sets `exited` to false

--- a/docs/data/base/components/snackbar/snackbar.md
+++ b/docs/data/base/components/snackbar/snackbar.md
@@ -106,7 +106,7 @@ For the sake of simplicity, demos and code snippets primarily feature components
 
 You can animate the open and close states of the snackbar with a render prop child and a transition component, as long as the component meets these conditions:
 
-- Is a direct child descendent of the snackbar
+- Is a direct child descendant of the snackbar
 - Has an `in` prop—this corresponds to the open state
 - Passes the `exited` prop to Unstyled Snackbar
 - Calls the `onEnter` callback prop when the enter transition starts—sets `exited` to false

--- a/docs/data/base/components/tabs/tabs-pt.md
+++ b/docs/data/base/components/tabs/tabs-pt.md
@@ -135,7 +135,7 @@ The demos below illustrate the proper use of ARIA labels.
 
 By default, when using keyboard navigation, the tab components open via **manual activation**—that is, the next panel is displayed only after the user activates the tab with either <kbd class="key">Space</kbd>, <kbd class="key">Enter</kbd>, or a mouse click.
 
-This is the preferable behavior for tabs in most cases, acccording to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
+This is the preferable behavior for tabs in most cases, according to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 Alternatively, you can set the panels to be displayed automatically when their corresponding tabs are in focus—this behavior of the selection following the focus is known as **automatic activation**.
 

--- a/docs/data/base/components/tabs/tabs-zh.md
+++ b/docs/data/base/components/tabs/tabs-zh.md
@@ -135,7 +135,7 @@ The demos below illustrate the proper use of ARIA labels.
 
 By default, when using keyboard navigation, the tab components open via **manual activation**—that is, the next panel is displayed only after the user activates the tab with either <kbd class="key">Space</kbd>, <kbd class="key">Enter</kbd>, or a mouse click.
 
-This is the preferable behavior for tabs in most cases, acccording to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
+This is the preferable behavior for tabs in most cases, according to [the WAI-ARIA authoring practices](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 Alternatively, you can set the panels to be displayed automatically when their corresponding tabs are in focus—this behavior of the selection following the focus is known as **automatic activation**.
 


### PR DESCRIPTION
Fixing some typos in the base component docs

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
