### PR TITLE
Fix warnings introduced by latest React canary

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,12 @@
     "**/@types/react": "^18.0.26",
     "**/@types/react-is": "^17.0.3",
     "**/cross-fetch": "^3.1.5",
-    "**/react-is": "^18.2.0"
+    "**/react-is": "^18.2.0",
+    "react": "18.3.0-next-ee8509801-20230117",
+    "scheduler": "0.24.0-next-ee8509801-20230117",
+    "react-is": "18.3.0-next-ee8509801-20230117",
+    "react-test-renderer": "18.3.0-next-ee8509801-20230117",
+    "react-dom": "18.3.0-next-ee8509801-20230117"
   },
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -228,11 +228,11 @@
     "**/@types/react-is": "^17.0.3",
     "**/cross-fetch": "^3.1.5",
     "**/react-is": "^18.2.0",
-    "react": "18.3.0-next-ee8509801-20230117",
-    "scheduler": "0.24.0-next-ee8509801-20230117",
-    "react-is": "18.3.0-next-ee8509801-20230117",
-    "react-test-renderer": "18.3.0-next-ee8509801-20230117",
-    "react-dom": "18.3.0-next-ee8509801-20230117"
+    "react": "18.3.0-next-39a3b72c6-20230414",
+    "scheduler": "0.24.0-next-39a3b72c6-20230414",
+    "react-is": "18.3.0-next-39a3b72c6-20230414",
+    "react-test-renderer": "18.3.0-next-39a3b72c6-20230414",
+    "react-dom": "18.3.0-next-39a3b72c6-20230414"
   },
   "nyc": {
     "include": [

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -309,8 +309,12 @@ describe('<TextareaAutosize />', () => {
           forceUpdate();
         }).toErrorDev([
           'MUI: Too many re-renders.',
-          !strictModeDoubleLoggingSuppressed && 'MUI: Too many re-renders.',
-          !strictModeDoubleLoggingSuppressed && 'MUI: Too many re-renders.',
+          !strictModeDoubleLoggingSuppressed &&
+            !React.version.startsWith('18.3') &&
+            'MUI: Too many re-renders.',
+          !strictModeDoubleLoggingSuppressed &&
+            !React.version.startsWith('18.3') &&
+            'MUI: Too many re-renders.',
         ]);
       });
     });

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.test.js
@@ -31,7 +31,12 @@ describe('useAutocomplete', () => {
           {groupedOptions.length > 0 ? (
             <ul {...getListboxProps()}>
               {groupedOptions.map((option, index) => {
-                return <li {...getOptionProps({ option, index })}>{option}</li>;
+                const { key, ...listItemProps } = getOptionProps({ option, index });
+                return (
+                  <li key={key} {...listItemProps}>
+                    {option}
+                  </li>
+                );
               })}
             </ul>
           ) : null}
@@ -257,7 +262,12 @@ describe('useAutocomplete', () => {
           {groupedOptions.length > 0 ? (
             <ul {...getListboxProps()}>
               {groupedOptions.map((option, index) => {
-                return <li {...getOptionProps({ option, index })}>{option}</li>;
+                const { key, ...listItemProps } = getOptionProps({ option, index });
+                return (
+                  <li key={key} {...listItemProps}>
+                    {option}
+                  </li>
+                );
               })}
             </ul>
           ) : null}

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -485,11 +485,14 @@ describe('Joy <Autocomplete />', () => {
           renderTags={(value, getTagProps) =>
             value
               .filter((x, index) => index === 1)
-              .map((option, index) => (
-                <Chip key={index} endDecorator={<ChipDelete {...getTagProps({ index })} />}>
-                  {option.title}
-                </Chip>
-              ))
+              .map((option, index) => {
+                const { key: tagKey, ...tagProps } = getTagProps({ index });
+                return (
+                  <Chip key={index} endDecorator={<ChipDelete key={tagKey} {...tagProps} />}>
+                    {option.title}
+                  </Chip>
+                );
+              })
           }
           onChange={handleChange}
           autoFocus

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -423,13 +423,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(
       selectedOptions = renderTags(value as Array<unknown>, getCustomizedTagProps, ownerState);
     } else {
       selectedOptions = (value as Array<unknown>).map((option, index) => {
+        const { key, ...endDecoratorProps } = getCustomizedTagProps({ index });
         return (
           <Chip
             key={index}
             size={size}
             variant="soft"
             color={color === 'context' ? undefined : 'neutral'}
-            endDecorator={<ChipDelete {...getCustomizedTagProps({ index })} />}
+            endDecorator={<ChipDelete key={key} {...endDecoratorProps} />}
           >
             {getOptionLabel(option)}
           </Chip>
@@ -643,8 +644,10 @@ const Autocomplete = React.forwardRef(function Autocomplete(
     },
   });
 
-  const defaultRenderOption = (optionProps: any, option: unknown) => (
-    <SlotOption {...optionProps}>{getOptionLabel(option)}</SlotOption>
+  const defaultRenderOption = ({ key, ...optionProps }: any, option: unknown) => (
+    <SlotOption key={key} {...optionProps}>
+      {getOptionLabel(option)}
+    </SlotOption>
   );
 
   const renderOption = renderOptionProp || defaultRenderOption;

--- a/packages/mui-material-next/src/Tabs/Tabs.test.js
+++ b/packages/mui-material-next/src/Tabs/Tabs.test.js
@@ -338,11 +338,21 @@ describe('<Tabs />', () => {
 
           nodeEnv = process.env.NODE_ENV;
           // We can't use a regular assignment, because it causes a syntax error in Karma
-          Object.defineProperty(process.env, 'NODE_ENV', { value: 'development' });
+          Object.defineProperty(process.env, 'NODE_ENV', {
+            configurable: true,
+            writable: true,
+            enumerable: true,
+            value: 'development',
+          });
         });
 
         after(() => {
-          Object.defineProperty(process.env, 'NODE_ENV', { value: nodeEnv });
+          Object.defineProperty(process.env, 'NODE_ENV', {
+            configurable: true,
+            writable: true,
+            enumerable: true,
+            value: nodeEnv,
+          });
         });
 
         it('should warn if a Tab has display: none', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -502,14 +502,12 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
     if (renderTags) {
       startAdornment = renderTags(value, getCustomizedTagProps, ownerState);
     } else {
-      startAdornment = value.map((option, index) => (
-        <Chip
-          label={getOptionLabel(option)}
-          size={size}
-          {...getCustomizedTagProps({ index })}
-          {...ChipProps}
-        />
-      ));
+      startAdornment = value.map((option, index) => {
+        const { key, ...tagProps } = getCustomizedTagProps({ index });
+        return (
+          <Chip label={getOptionLabel(option)} size={size} key={key} {...tagProps} {...ChipProps} />
+        );
+      });
     }
   }
 
@@ -541,7 +539,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
   );
 
   const renderGroup = renderGroupProp || defaultRenderGroup;
-  const defaultRenderOption = (props2, option) => <li {...props2}>{getOptionLabel(option)}</li>;
+  const defaultRenderOption = (props2, option) => {
+    const { key, ...listItemProps } = props2;
+    return (
+      <li key={key} {...listItemProps}>
+        {getOptionLabel(option)}
+      </li>
+    );
+  };
   const renderOption = renderOptionProp || defaultRenderOption;
 
   const renderListOption = (option, index) => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -617,7 +617,10 @@ describe('<Autocomplete />', () => {
           renderTags={(value, getTagProps) =>
             value
               .filter((x, index) => index === 1)
-              .map((option, index) => <Chip label={option.title} {...getTagProps({ index })} />)
+              .map((option, index) => {
+                const { key, ...tagProps } = getTagProps({ index });
+                return <Chip key={key} label={option.title} {...tagProps} />;
+              })
           }
           onChange={handleChange}
           renderInput={(params) => <TextField {...params} autoFocus />}

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -375,11 +375,21 @@ describe('<Tabs />', () => {
 
           nodeEnv = process.env.NODE_ENV;
           // We can't use a regular assignment, because it causes a syntax error in Karma
-          Object.defineProperty(process.env, 'NODE_ENV', { value: 'development' });
+          Object.defineProperty(process.env, 'NODE_ENV', {
+            configurable: true,
+            writable: true,
+            enumerable: true,
+            value: 'development',
+          });
         });
 
         after(() => {
-          Object.defineProperty(process.env, 'NODE_ENV', { value: nodeEnv });
+          Object.defineProperty(process.env, 'NODE_ENV', {
+            configurable: true,
+            writable: true,
+            enumerable: true,
+            value: nodeEnv,
+          });
         });
 
         it('should warn if a `Tab` has display: none', function test() {

--- a/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/mui-material/src/useMediaQuery/useMediaQuery.test.js
@@ -197,7 +197,10 @@ describe('useMediaQuery', () => {
           );
         }
 
-        const { hydrate } = renderToString(<Test />);
+        const { hydrate } = renderToString(<Test />, {
+          // https://github.com/facebook/react/issues/26095
+          strict: false,
+        });
         hydrate();
         expect(screen.getByTestId('matches').textContent).to.equal('false');
         expect(getRenderCountRef.current()).to.equal(2);

--- a/packages/mui-styles/src/withStyles/withStyles.test.js
+++ b/packages/mui-styles/src/withStyles/withStyles.test.js
@@ -135,7 +135,15 @@ describe('withStyles', () => {
       const jssCallbackStub = stub().returns({});
       const styles = { root: jssCallbackStub };
       const StyledComponent = withStyles(styles)(MyComp);
-      render(<StyledComponent mySuppliedProp={222} />);
+      expect(() => {
+        render(<StyledComponent mySuppliedProp={222} />);
+      }).toErrorDev(
+        React.version.startsWith('18.3')
+          ? [
+              'Warning: MyComp: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
+            ]
+          : [],
+      );
 
       expect(jssCallbackStub.callCount).to.equal(1);
       expect(jssCallbackStub.args[0][0]).to.deep.equal({
@@ -179,20 +187,29 @@ describe('withStyles', () => {
       const styles = { root: { display: 'flex' } };
       const StyledComponent = withStyles(styles, { name: 'MuiFoo' })(MuiFoo);
 
-      const { container } = render(
-        <ThemeProvider
-          theme={createTheme({
-            components: {
-              MuiFoo: {
-                defaultProps: {
-                  foo: 'bar',
+      let container;
+      expect(() => {
+        container = render(
+          <ThemeProvider
+            theme={createTheme({
+              components: {
+                MuiFoo: {
+                  defaultProps: {
+                    foo: 'bar',
+                  },
                 },
               },
-            },
-          })}
-        >
-          <StyledComponent foo={undefined} />
-        </ThemeProvider>,
+            })}
+          >
+            <StyledComponent foo={undefined} />
+          </ThemeProvider>,
+        ).container;
+      }).toErrorDev(
+        React.version.startsWith('18.3')
+          ? [
+              'Warning: MuiFoo: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
+            ]
+          : [],
       );
 
       expect(container).to.have.text('bar');

--- a/packages/mui-utils/src/useControlled.js
+++ b/packages/mui-utils/src/useControlled.js
@@ -25,10 +25,27 @@ export default function useControlled({ controlled, default: defaultProp, name, 
       }
     }, [state, name, controlled]);
 
-    const { current: defaultValue } = React.useRef(defaultProp);
+    const appearedRef = React.useRef(false);
+    const initialDefaultPropRef = React.useRef();
 
     React.useEffect(() => {
-      if (!isControlled && defaultValue !== defaultProp) {
+      // first appearence will contain ref value of the first render but defaultProp will be from the second render
+      // thus always failing for values that change identities e.g. `[]` or `{}`
+      if (!appearedRef.current) {
+        initialDefaultPropRef.current = defaultProp;
+      }
+    }, []);
+
+    React.useEffect(() => {
+      appearedRef.current = true;
+
+      return () => {
+        appearedRef.current = false;
+      };
+    }, []);
+
+    React.useEffect(() => {
+      if (!isControlled && initialDefaultPropRef.current !== defaultProp) {
         console.error(
           [
             `MUI: A component is changing the default ${state} state of an uncontrolled ${name} after being initialized. ` +

--- a/test/utils/initMatchers.test.js
+++ b/test/utils/initMatchers.test.js
@@ -97,25 +97,6 @@ describe('custom matchers', () => {
       expect(() => {}).not.toErrorDev([]);
     });
 
-    it('fails if no arguments are used as a way of negating', () => {
-      expect(() => {
-        expect(() => {}).toErrorDev();
-      }).to.throw(
-        "Expected to call console.error but didn't provide messages. " +
-          "If you don't expect any messages prefer `expect().not.toErrorDev();",
-      );
-    });
-
-    it('fails if arguments are passed when negated', () => {
-      expect(() => {
-        expect(() => {}).not.toErrorDev('not unexpected?');
-      }).to.throw(
-        'Expected no call to console.error but provided messages. ' +
-          "If you want to make sure a certain message isn't logged prefer the positive. " +
-          'By expecting certain messages you automatically expect that no other messages are logged',
-      );
-    });
-
     it('ignores `false` messages', () => {
       const isReact16 = false;
       expect(() => {

--- a/test/utils/initMatchers.ts
+++ b/test/utils/initMatchers.ts
@@ -519,18 +519,6 @@ chai.use((chaiAPI, utils) => {
         // TODO Remove type once MUI X enables noImplicitAny
         let caughtError: unknown | null = null;
 
-        this.assert(
-          expectedMessages.length > 0,
-          `Expected to call console.${methodName} but didn't provide messages. ` +
-            `If you don't expect any messages prefer \`expect().not.${matcherName}();\`.`,
-          `Expected no call to console.${methodName} while also expecting messages.` +
-            'Expected no call to console.error but provided messages. ' +
-            "If you want to make sure a certain message isn't logged prefer the positive. " +
-            'By expecting certain messages you automatically expect that no other messages are logged',
-          // Not interested in a diff but the typings require the 4th parameter.
-          undefined,
-        );
-
         // Ignore skipped messages in e.g. `[condition && 'foo']`
         const remainingMessages = expectedMessages.filter((messageOrFalse) => {
           return messageOrFalse !== false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13773,13 +13773,13 @@ react-docgen@^5.4.3:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@18.3.0-next-ee8509801-20230117, react-dom@^18.2.0:
-  version "18.3.0-next-ee8509801-20230117"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.0-next-ee8509801-20230117.tgz#d14e4df874d4a9cd218ae7889c7b0ed8c3932a57"
-  integrity sha512-blD1rTRADFysokt9B/9KJnIei2PT4gUqQcjdFWb3lLYjJ7GunqNb7v+a0cKmJGhT6cf8kGPM2BsKhX/WxdYotw==
+react-dom@18.3.0-next-39a3b72c6-20230414, react-dom@^18.2.0:
+  version "18.3.0-next-39a3b72c6-20230414"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.0-next-39a3b72c6-20230414.tgz#73851f0f7134b7105bbd70f19291561fe44e404c"
+  integrity sha512-EvYOPBV0tJ/HGunfadbEl+F1hR7P0LXdlQ9ksfDsQzta0JYc+XX8mEor9vRVhFR8TlEdRDISlSu2u16TIO+VhQ==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "0.24.0-next-ee8509801-20230117"
+    scheduler "0.24.0-next-39a3b72c6-20230414"
 
 react-draggable@^4.4.5:
   version "4.4.5"
@@ -13823,7 +13823,7 @@ react-intersection-observer@^9.4.3:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz#ec84ce0c25cad548075130ea045ac5c7adf908f3"
   integrity sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==
 
-react-is@18.3.0-next-ee8509801-20230117, react-is@^16.10.2, "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
+react-is@18.3.0-next-39a3b72c6-20230414, react-is@^16.10.2, "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
@@ -13958,14 +13958,14 @@ react-swipeable-views@^0.14.0:
     react-swipeable-views-utils "^0.14.0"
     warning "^4.0.1"
 
-react-test-renderer@18.3.0-next-ee8509801-20230117, react-test-renderer@^18.0.0, react-test-renderer@^18.2.0:
-  version "18.3.0-next-ee8509801-20230117"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.3.0-next-ee8509801-20230117.tgz#d6eb070f03938ac93484cfe87f75c0a05beb5652"
-  integrity sha512-jth3LtJ3NSG/3DIdOlYROnvLISdHwgF+jgoj5xr2EKncddfQjpZ2GCgMp/kG2zz8DVdfzoyY+vftqy6EWr5XZA==
+react-test-renderer@18.3.0-next-39a3b72c6-20230414, react-test-renderer@^18.0.0, react-test-renderer@^18.2.0:
+  version "18.3.0-next-39a3b72c6-20230414"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.3.0-next-39a3b72c6-20230414.tgz#8e0da6b8481ecd3b15ea1e8ac707ce7019e917c8"
+  integrity sha512-UHkbTwSvScQb1EsNb3IV3+SDlaHoPVzeiEP9WU74EMFCCMt5QF36S07Q7Za+5Fvj6cA3TH0uYRtUDK2f0SDj+Q==
   dependencies:
-    react-is "18.3.0-next-ee8509801-20230117"
+    react-is "18.3.0-next-39a3b72c6-20230414"
     react-shallow-renderer "^16.15.0"
-    scheduler "0.24.0-next-ee8509801-20230117"
+    scheduler "0.24.0-next-39a3b72c6-20230414"
 
 react-transition-group@2.9.0:
   version "2.9.0"
@@ -14000,10 +14000,10 @@ react-window@^1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@18.3.0-next-ee8509801-20230117, react@^18.2.0:
-  version "18.3.0-next-ee8509801-20230117"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.3.0-next-ee8509801-20230117.tgz#7ace660ad4a81218ed3d6ec94dad12819d6b24dd"
-  integrity sha512-gmEF7K4tQKY9yH1iTglHYmOrf6do08XaECS8bTAdX3B8RXXls5JhqPVgOKgvKg1dVkLzt0qn6cAHE4GWP4+F3A==
+react@18.3.0-next-39a3b72c6-20230414, react@^18.2.0:
+  version "18.3.0-next-39a3b72c6-20230414"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.0-next-39a3b72c6-20230414.tgz#509c20e80887abe3bb5ce2fe99aedb8aa18429c9"
+  integrity sha512-7lAq8yabg268nJlT6U95sG3ed6AmDcO+0SXOcKdPclItXgSklk8nRMw2vY7yx552hY+p2Odw+DusnWvqfWcNEA==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -14761,10 +14761,10 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.24.0-next-ee8509801-20230117, scheduler@^0.23.0:
-  version "0.24.0-next-ee8509801-20230117"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.24.0-next-ee8509801-20230117.tgz#e461e6f3973b0bdef633743a28d36b190d07b867"
-  integrity sha512-WNterR0s5UDpOka2BUbfUQfXjA2GQJDsioeWcUYd551HePW8vHqoW3WDNBFcbNBT9Wf/YfUfweMdkJbRHCBalg==
+scheduler@0.24.0-next-39a3b72c6-20230414, scheduler@^0.23.0:
+  version "0.24.0-next-39a3b72c6-20230414"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.24.0-next-39a3b72c6-20230414.tgz#96693b41e7f2cdd18a114d7c419cf416e5d7d037"
+  integrity sha512-UvG14yKTH146Ygr94EBfjtpB4BJoWNgEWTeerMaB3KHDEO3yEeh8By7Aj27Gmy7u+AeZSin3zeAWO7sxnEOrEA==
   dependencies:
     loose-envify "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13773,13 +13773,13 @@ react-docgen@^5.4.3:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@18.3.0-next-ee8509801-20230117, react-dom@^18.2.0:
+  version "18.3.0-next-ee8509801-20230117"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.0-next-ee8509801-20230117.tgz#d14e4df874d4a9cd218ae7889c7b0ed8c3932a57"
+  integrity sha512-blD1rTRADFysokt9B/9KJnIei2PT4gUqQcjdFWb3lLYjJ7GunqNb7v+a0cKmJGhT6cf8kGPM2BsKhX/WxdYotw==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "0.24.0-next-ee8509801-20230117"
 
 react-draggable@^4.4.5:
   version "4.4.5"
@@ -13823,7 +13823,7 @@ react-intersection-observer@^9.4.3:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.4.3.tgz#ec84ce0c25cad548075130ea045ac5c7adf908f3"
   integrity sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==
 
-react-is@^16.10.2, "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
+react-is@18.3.0-next-ee8509801-20230117, react-is@^16.10.2, "react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^16.13.1, react-is@^16.7.0, react-is@^17.0.1, react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
@@ -13958,14 +13958,14 @@ react-swipeable-views@^0.14.0:
     react-swipeable-views-utils "^0.14.0"
     warning "^4.0.1"
 
-react-test-renderer@^18.0.0, react-test-renderer@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
-  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
+react-test-renderer@18.3.0-next-ee8509801-20230117, react-test-renderer@^18.0.0, react-test-renderer@^18.2.0:
+  version "18.3.0-next-ee8509801-20230117"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.3.0-next-ee8509801-20230117.tgz#d6eb070f03938ac93484cfe87f75c0a05beb5652"
+  integrity sha512-jth3LtJ3NSG/3DIdOlYROnvLISdHwgF+jgoj5xr2EKncddfQjpZ2GCgMp/kG2zz8DVdfzoyY+vftqy6EWr5XZA==
   dependencies:
-    react-is "^18.2.0"
+    react-is "18.3.0-next-ee8509801-20230117"
     react-shallow-renderer "^16.15.0"
-    scheduler "^0.23.0"
+    scheduler "0.24.0-next-ee8509801-20230117"
 
 react-transition-group@2.9.0:
   version "2.9.0"
@@ -14000,10 +14000,10 @@ react-window@^1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react@18.3.0-next-ee8509801-20230117, react@^18.2.0:
+  version "18.3.0-next-ee8509801-20230117"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.0-next-ee8509801-20230117.tgz#7ace660ad4a81218ed3d6ec94dad12819d6b24dd"
+  integrity sha512-gmEF7K4tQKY9yH1iTglHYmOrf6do08XaECS8bTAdX3B8RXXls5JhqPVgOKgvKg1dVkLzt0qn6cAHE4GWP4+F3A==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -14761,10 +14761,10 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@0.24.0-next-ee8509801-20230117, scheduler@^0.23.0:
+  version "0.24.0-next-ee8509801-20230117"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.24.0-next-ee8509801-20230117.tgz#e461e6f3973b0bdef633743a28d36b190d07b867"
+  integrity sha512-WNterR0s5UDpOka2BUbfUQfXjA2GQJDsioeWcUYd551HePW8vHqoW3WDNBFcbNBT9Wf/YfUfweMdkJbRHCBalg==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
I would recommend splitting these out into individual PRs since some changes affect shipped code. I won't have the time to do that though but it should be straig forward since I handled different warnings in different commits.

Notable React canary changes are the introduction of warnings for usage of `defaultProps` and spreading `key` (part of https://github.com/reactjs/rfcs/pull/107)

Part of https://github.com/mui/material-ui/issues/14761