### PR TITLE
Handle changes in TypeScript 5.0 beta

### DIFF
--- a/docs/data/material/components/slider/InputSlider.js
+++ b/docs/data/material/components/slider/InputSlider.js
@@ -19,7 +19,7 @@ export default function InputSlider() {
   };
 
   const handleInputChange = (event) => {
-    setValue(event.target.value === '' ? '' : Number(event.target.value));
+    setValue(event.target.value === '' ? 0 : Number(event.target.value));
   };
 
   const handleBlur = () => {
@@ -41,7 +41,7 @@ export default function InputSlider() {
         </Grid>
         <Grid item xs>
           <Slider
-            value={typeof value === 'number' ? value : 0}
+            value={value}
             onChange={handleSliderChange}
             aria-labelledby="input-slider"
           />

--- a/docs/data/material/components/slider/InputSlider.tsx
+++ b/docs/data/material/components/slider/InputSlider.tsx
@@ -12,16 +12,14 @@ const Input = styled(MuiInput)`
 `;
 
 export default function InputSlider() {
-  const [value, setValue] = React.useState<number | string | Array<number | string>>(
-    30,
-  );
+  const [value, setValue] = React.useState(30);
 
   const handleSliderChange = (event: Event, newValue: number | number[]) => {
-    setValue(newValue);
+    setValue(newValue as number);
   };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value === '' ? '' : Number(event.target.value));
+    setValue(event.target.value === '' ? 0 : Number(event.target.value));
   };
 
   const handleBlur = () => {
@@ -43,7 +41,7 @@ export default function InputSlider() {
         </Grid>
         <Grid item xs>
           <Slider
-            value={typeof value === 'number' ? value : 0}
+            value={value}
             onChange={handleSliderChange}
             aria-labelledby="input-slider"
           />

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "thenify": "3.3.1",
     "ts-node": "^10.9.1",
     "tslint": "5.14.0",
-    "typescript": "^4.9.4",
+    "typescript": "5.0.0-dev.20230129",
     "unist-util-visit": "^2.0.3",
     "util": "^0.12.5",
     "webpack": "^5.75.0",
@@ -224,7 +224,8 @@
     "**/@types/react": "^18.0.26",
     "**/@types/react-is": "^17.0.3",
     "**/cross-fetch": "^3.1.5",
-    "**/react-is": "^18.2.0"
+    "**/react-is": "^18.2.0",
+    "**/dtslint/typescript": "5.0.0-dev.20230129"
   },
   "nyc": {
     "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -15656,6 +15656,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+typescript@5.0.0-dev.20230129:
+  version "5.0.0-dev.20230129"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20230129.tgz#de37bbd919b9140a1bff707a1d4a73ca3e4893a3"
+  integrity sha512-RXkuG13JCg/g2OYnaLg7HiYfwpUzE7auAPSV2OcaW5VhJn1rESec8GbojVaxNoaQra4eANBVyMXx4SbJYYC2Yg==
+
 "typescript@^3 || ^4", typescript@^4.9.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"


### PR DESCRIPTION
Handles [changes in TypeScript 5.0 beta](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#forbidden-implicit-coercions-in-relational-operators)

Something changed with spread/Omit semantics. I've seen several similar errors in other codebases. Trying to figure out what changed/how to minimally reproduce.

## Test plan

- [ ] green TypeScript job with `@typescript@next`
- [ ] green TypeScript job with currently installed TypeScript version