### PR TITLE
[typescript] Explicitly define the component return types

### DIFF
--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -131,7 +131,7 @@ function defaultIsEnabled(): boolean {
  *
  * - [FocusTrap API](https://mui.com/base/api/focus-trap/)
  */
-function FocusTrap(props: FocusTrapProps) {
+function FocusTrap(props: FocusTrapProps): JSX.Element {
   const {
     children,
     disableAutoFocus = false,

--- a/packages/mui-base/src/NoSsr/NoSsr.tsx
+++ b/packages/mui-base/src/NoSsr/NoSsr.tsx
@@ -21,7 +21,7 @@ import { NoSsrProps } from './NoSsr.types';
  *
  * - [NoSsr API](https://mui.com/base/api/no-ssr/)
  */
-function NoSsr(props: NoSsrProps) {
+function NoSsr(props: NoSsrProps): JSX.Element {
   const { children, defer = false, fallback = null } = props;
   const [mountedState, setMountedState] = React.useState(false);
 

--- a/packages/mui-base/src/Portal/Portal.tsx
+++ b/packages/mui-base/src/Portal/Portal.tsx
@@ -66,8 +66,10 @@ const Portal = React.forwardRef(function Portal(
     <React.Fragment>
       {mountNode ? ReactDOM.createPortal(children, mountNode) : mountNode}
     </React.Fragment>
-  ) as JSX.Element;
-}) as ((props: PortalProps) => JSX.Element) & { propTypes?: any };
+  );
+}) as React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<PortalProps> & React.RefAttributes<Element>
+>;
 
 Portal.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-base/src/Portal/Portal.tsx
+++ b/packages/mui-base/src/Portal/Portal.tsx
@@ -67,9 +67,7 @@ const Portal = React.forwardRef(function Portal(
       {mountNode ? ReactDOM.createPortal(children, mountNode) : mountNode}
     </React.Fragment>
   );
-}) as React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<PortalProps> & React.RefAttributes<Element>
->;
+}) as React.ForwardRefExoticComponent<PortalProps & React.RefAttributes<Element>>;
 
 Portal.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-base/src/Portal/Portal.tsx
+++ b/packages/mui-base/src/Portal/Portal.tsx
@@ -66,8 +66,8 @@ const Portal = React.forwardRef(function Portal(
     <React.Fragment>
       {mountNode ? ReactDOM.createPortal(children, mountNode) : mountNode}
     </React.Fragment>
-  );
-});
+  ) as JSX.Element;
+}) as ((props: PortalProps) => JSX.Element) & { propTypes?: any };
 
 Portal.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-base/src/Portal/Portal.types.ts
+++ b/packages/mui-base/src/Portal/Portal.types.ts
@@ -18,4 +18,5 @@ export interface PortalProps {
    * @default false
    */
   disablePortal?: boolean;
+  ref?: React.Ref<Element>;
 }

--- a/packages/mui-base/src/Portal/Portal.types.ts
+++ b/packages/mui-base/src/Portal/Portal.types.ts
@@ -18,5 +18,4 @@ export interface PortalProps {
    * @default false
    */
   disablePortal?: boolean;
-  ref?: React.Ref<Element>;
 }

--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -105,7 +105,9 @@ const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(function Time
       />
     </TimelineContext.Provider>
   );
-}) as ((props: TimelineProps) => JSX.Element) & { propTypes?: any };
+}) as React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<TimelineProps> & React.RefAttributes<HTMLUListElement>
+>;
 
 Timeline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -105,7 +105,7 @@ const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(function Time
       />
     </TimelineContext.Provider>
   );
-});
+}) as ((props: TimelineProps) => JSX.Element) & { propTypes?: any };
 
 Timeline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -105,9 +105,7 @@ const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>(function Time
       />
     </TimelineContext.Provider>
   );
-}) as React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<TimelineProps> & React.RefAttributes<HTMLUListElement>
->;
+}) as React.ForwardRefExoticComponent<TimelineProps & React.RefAttributes<HTMLUListElement>>;
 
 Timeline.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -19,7 +19,6 @@ export type PopperProps = Omit<PopperUnstyledProps, 'direction'> & {
    * @default {}
    */
   componentsProps?: PopperUnstyledProps['slotProps'];
-  ref?: React.Ref<HTMLDivElement>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
@@ -67,7 +66,9 @@ const Popper = React.forwardRef(function Popper(
       ref={ref}
     />
   );
-}) as ((props: PopperProps) => JSX.Element) & { propTypes?: any };
+}) as React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<PopperProps & React.RefAttributes<HTMLDivElement>>
+>;
 
 Popper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -14,12 +14,12 @@ export type PopperProps = Omit<PopperUnstyledProps, 'direction'> & {
   components?: {
     Root?: React.ElementType;
   };
-
   /**
    * The props used for each slot inside the Popper.
    * @default {}
    */
   componentsProps?: PopperUnstyledProps['slotProps'];
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -66,9 +66,7 @@ const Popper = React.forwardRef(function Popper(
       ref={ref}
     />
   );
-}) as React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<PopperProps & React.RefAttributes<HTMLDivElement>>
->;
+}) as React.ForwardRefExoticComponent<PopperProps & React.RefAttributes<HTMLDivElement>>;
 
 Popper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-material/src/Popper/Popper.tsx
+++ b/packages/mui-material/src/Popper/Popper.tsx
@@ -67,7 +67,7 @@ const Popper = React.forwardRef(function Popper(
       ref={ref}
     />
   );
-});
+}) as ((props: PopperProps) => JSX.Element) & { propTypes?: any };
 
 Popper.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------


### PR DESCRIPTION
Add return type annotations so that Typescript doesn't have to infer it, as suggested in https://github.com/mui/material-ui/issues/35287#issuecomment-1408870399

Before: https://codesandbox.io/s/popper-missing-props-3l97zo?file=/src/App.tsx
After: https://codesandbox.io/s/popper-missing-props-fixed-b0rj7h?file=/src/App.tsx

Fixes #35287