### PR TITLE
[docs] Fix wrong v5 migration instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7363,7 +7363,7 @@ A big thanks to the 26 contributors who made this release possible. Here are som
 
   ```diff
   -<Tabs />
-  +<Tabs indicatorColor="primary" textColor="inherit" />
+  +<Tabs indicatorColor="secondary" textColor="inherit" />
   ```
 
 #### Changes

--- a/docs/data/material/migration/migration-v4/v5-component-changes-pt.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes-pt.md
@@ -1567,7 +1567,7 @@ This is done to match the most common use cases with Material Design.
 
 ```diff
 -<Tabs />
-+<Tabs indicatorColor="primary" textColor="inherit" />
++<Tabs indicatorColor="secondary" textColor="inherit" />
 ```
 
 ### Update event type (TypeScript)

--- a/docs/data/material/migration/migration-v4/v5-component-changes-zh.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes-zh.md
@@ -1567,7 +1567,7 @@ This is done to match the most common use cases with Material Design.
 
 ```diff
 -<Tabs />
-+<Tabs indicatorColor="primary" textColor="inherit" />
++<Tabs indicatorColor="secondary" textColor="inherit" />
 ```
 
 ### Update event type (TypeScript)

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -1592,7 +1592,7 @@ This is done to match the most common use cases with Material Design.
 
 ```diff
 -<Tabs />
-+<Tabs indicatorColor="primary" textColor="inherit" />
++<Tabs indicatorColor="secondary" textColor="inherit" />
 ```
 
 ### Update event type (TypeScript)


### PR DESCRIPTION
I had it wrong in #25063.

Context: https://mui-org.slack.com/archives/C041SDSF32L/p1675141428308229

> It should be indicatorColor="secondary" textColor="inherit"
