### PR TITLE
[website] Fix homepage MD theme demo

### DIFF
--- a/docs/src/components/home/MaterialDesignComponents.tsx
+++ b/docs/src/components/home/MaterialDesignComponents.tsx
@@ -172,21 +172,13 @@ function Demo({
         className="mui-default-theme"
         sx={{ flexGrow: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
       >
-        {props.theme ? (
-          <CssVarsProvider disableStyleSheetGeneration theme={props.theme}>
-            {React.cloneElement(children, {
-              ...(control && {
-                [control.prop]: propValue,
-              }),
-            })}
-          </CssVarsProvider>
-        ) : (
-          React.cloneElement(children, {
+        <CssVarsProvider theme={props.theme}>
+          {React.cloneElement(children, {
             ...(control && {
               [control.prop]: propValue,
             }),
-          })
-        )}
+          })}
+        </CssVarsProvider>
       </Box>
       <Typography fontWeight="semiBold" variant="body2">
         {name}


### PR DESCRIPTION
I could pinpoint the origin of this migration to v5.11.0 See https://6398768e1aba5f000883fb24--material-ui-docs.netlify.app/, and more specifically, it was broken in: #35366. This is not MD:

<img width="410" alt="Screenshot 2023-02-02 at 13 42 39" src="https://user-images.githubusercontent.com/3165635/216328072-85991fa6-49a3-4f94-8343-1f8ab565ab0f.png">

https://mui.com/

---

With this fix:

<img width="409" alt="Screenshot 2023-02-02 at 13 43 19" src="https://user-images.githubusercontent.com/3165635/216328206-54a3bfae-5616-4846-83d5-31f429e90350.png">