### PR TITLE
add return value interfaces for MUI Base hook

### DIFF
--- a/packages/mui-base/src/BadgeUnstyled/useBadge.ts
+++ b/packages/mui-base/src/BadgeUnstyled/useBadge.ts
@@ -8,7 +8,14 @@ export interface UseBadgeParameters {
   showZero?: boolean;
 }
 
-export default function useBadge(parameters: UseBadgeParameters) {
+export interface UseBadgeReturnValue {
+  badgeContent: React.ReactNode;
+  invisible: boolean;
+  max: number;
+  displayValue: React.ReactNode;
+}
+
+export default function useBadge(parameters: UseBadgeParameters): UseBadgeReturnValue {
   const {
     badgeContent: badgeContentProp,
     invisible: invisibleProp = false,

--- a/packages/mui-base/src/ButtonUnstyled/useButton.ts
+++ b/packages/mui-base/src/ButtonUnstyled/useButton.ts
@@ -3,11 +3,15 @@ import {
   unstable_useForkRef as useForkRef,
   unstable_useIsFocusVisible as useIsFocusVisible,
 } from '@mui/utils';
-import { UseButtonParameters, UseButtonRootSlotProps } from './useButton.types';
+import {
+  UseButtonParameters,
+  UseButtonReturnValue,
+  UseButtonRootSlotProps,
+} from './useButton.types';
 import extractEventHandlers from '../utils/extractEventHandlers';
 import { EventHandlers } from '../utils/types';
 
-export default function useButton(parameters: UseButtonParameters) {
+export default function useButton(parameters: UseButtonParameters): UseButtonReturnValue {
   const {
     disabled = false,
     focusableWhenDisabled,

--- a/packages/mui-base/src/ButtonUnstyled/useButton.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/useButton.types.ts
@@ -39,3 +39,11 @@ export interface UseButtonParameters {
    */
   type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
+
+export interface UseButtonReturnValue {
+  getRootProps: () => UseButtonRootSlotProps;
+  focusVisible: boolean;
+  setFocusVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  disabled: boolean;
+  active: boolean;
+}

--- a/packages/mui-base/src/FormControlUnstyled/useFormControlUnstyledContext.ts
+++ b/packages/mui-base/src/FormControlUnstyled/useFormControlUnstyledContext.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import FormControlUnstyledContext from './FormControlUnstyledContext';
 
-export default function useFormControlUnstyledContext() {
+export default function useFormControlUnstyledContext(): React.ContextType<
+  typeof FormControlUnstyledContext
+> {
   return React.useContext(FormControlUnstyledContext);
 }

--- a/packages/mui-base/src/InputUnstyled/useInput.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.ts
@@ -7,9 +7,10 @@ import {
   UseInputInputSlotProps,
   UseInputParameters,
   UseInputRootSlotProps,
+  UseInputReturnValue,
 } from './useInput.types';
 
-export default function useInput(parameters: UseInputParameters) {
+export default function useInput(parameters: UseInputParameters):UseInputReturnValue {
   const {
     defaultValue: defaultValueProp,
     disabled: disabledProp = false,

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FormControlUnstyledState } from '../FormControlUnstyled';
 
 export interface UseInputParameters {
   /**
@@ -52,3 +53,14 @@ export interface UseInputInputSlotOwnProps {
 
 export type UseInputInputSlotProps<TOther = {}> = Omit<TOther, keyof UseInputInputSlotOwnProps> &
   UseInputInputSlotOwnProps;
+
+export interface UseInputReturnValue {
+  disabled: boolean;
+  error: boolean;
+  focused: boolean;
+  formControlContext: FormControlUnstyledState | undefined;
+  getInputProps: () => UseInputInputSlotProps;
+  getRootProps: () => UseInputRootSlotProps;
+  required: boolean;
+  value: unknown;
+}

--- a/packages/mui-base/src/MenuItemUnstyled/useMenuItem.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/useMenuItem.ts
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { unstable_useId as useId, unstable_useForkRef as useForkRef } from '@mui/utils';
 import { MenuUnstyledContext } from '../MenuUnstyled';
 import { useButton } from '../ButtonUnstyled';
-import { UseMenuItemParameters } from './useMenuItem.types';
+import { UseMenuItemParameters, UseMenuItemReturnValue } from './useMenuItem.types';
 
-export default function useMenuItem(props: UseMenuItemParameters) {
+export default function useMenuItem(props: UseMenuItemParameters):UseMenuItemReturnValue {
   const { disabled = false, ref, label } = props;
 
   const id = useId();

--- a/packages/mui-base/src/MenuItemUnstyled/useMenuItem.types.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/useMenuItem.types.ts
@@ -1,6 +1,15 @@
+import { UseButtonRootSlotProps } from '../ButtonUnstyled';
+
+
 export interface UseMenuItemParameters {
   disabled?: boolean;
   onClick?: React.MouseEventHandler<any>;
   ref: React.Ref<any>;
   label?: string;
+}
+
+export interface UseMenuItemReturnValue {
+  getRootProps: (other?: Record<string, any>) => UseButtonRootSlotProps;
+  disabled: boolean;
+  focusVisible: boolean;
 }

--- a/packages/mui-base/src/MenuUnstyled/useMenu.ts
+++ b/packages/mui-base/src/MenuUnstyled/useMenu.ts
@@ -12,6 +12,7 @@ import {
   MenuItemState,
   UseMenuListboxSlotProps,
   UseMenuParameters,
+  UseMenuReturnValue,
 } from './useMenu.types';
 import { EventHandlers } from '../utils';
 
@@ -43,7 +44,7 @@ function stateReducer(
   return newState;
 }
 
-export default function useMenu(parameters: UseMenuParameters = {}) {
+export default function useMenu(parameters: UseMenuParameters = {}): UseMenuReturnValue {
   const { listboxRef: listboxRefProp, open = false, onClose, listboxId } = parameters;
 
   const [menuItems, setMenuItems] = React.useState<Record<string, MenuItemMetadata>>({});

--- a/packages/mui-base/src/MenuUnstyled/useMenu.types.ts
+++ b/packages/mui-base/src/MenuUnstyled/useMenu.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { UseListboxRootSlotProps } from '../ListboxUnstyled';
+import { UseListboxRootSlotProps, UseListboxOptionSlotProps } from '../ListboxUnstyled';
+import { EventHandlers } from '../utils';
 
 export interface MenuItemMetadata {
   id: string;
@@ -31,3 +32,20 @@ export type UseMenuListboxSlotProps<TOther = {}> = UseListboxRootSlotProps<
   ref: React.Ref<any>;
   role: React.AriaRole;
 };
+
+export interface UseMenuReturnValue {
+  registerItem: (id: string, metadata: MenuItemMetadata) => void;
+  unregisterItem: (id: string) => void;
+  menuItems: Record<string, MenuItemMetadata>;
+  getListboxProps: <TOther extends EventHandlers>(
+    otherHandlers?: TOther,
+  ) => UseMenuListboxSlotProps;
+  getItemState: (id: string) => MenuItemState;
+  getItemProps: <TOther extends EventHandlers = {}>(
+    option: string,
+    otherHandlers?: TOther,
+  ) => UseListboxOptionSlotProps<TOther>;
+  highlightedOption: string | null;
+  highlightFirstItem: () => void;
+  highlightLastItem: () => void;
+}

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -15,6 +15,7 @@ import {
   UseSelectParameters,
   UseSelectSingleParameters,
   UseSelectSingleResult,
+  UseSelectReturnValue,
 } from './useSelect.types';
 import {
   ListboxReducer,
@@ -28,7 +29,7 @@ import defaultOptionStringifier from './defaultOptionStringifier';
 
 function useSelect<TValue>(props: UseSelectSingleParameters<TValue>): UseSelectSingleResult<TValue>;
 function useSelect<TValue>(props: UseSelectMultiParameters<TValue>): UseSelectMultiResult<TValue>;
-function useSelect<TValue>(props: UseSelectParameters<TValue>) {
+function useSelect<TValue>(props: UseSelectParameters<TValue>): UseSelectReturnValue<TValue> {
   const {
     buttonRef: buttonRefProp,
     defaultValue,

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -117,3 +117,22 @@ export interface UseSelectSingleResult<TValue> extends UseSelectCommonResult<TVa
 export interface UseSelectMultiResult<TValue> extends UseSelectCommonResult<TValue> {
   value: TValue[];
 }
+
+export interface UseSelectReturnValue<TValue> {
+  buttonActive: boolean;
+  buttonFocusVisible: boolean;
+  disabled: boolean;
+  getButtonProps: <TOther extends EventHandlers>(
+    otherHandlers?: TOther,
+  ) => UseSelectButtonSlotProps<TOther>;
+  getListboxProps: <TOther extends EventHandlers>(
+    otherHandlers?: TOther,
+  ) => UseSelectListboxSlotProps<TOther>;
+  getOptionProps: <TOther extends EventHandlers>(
+    option: SelectOption<TValue>,
+    otherHandlers?: TOther,
+  ) => UseSelectOptionSlotProps<TOther>;
+  getOptionState: (option: SelectOption<TValue>) => OptionState;
+  open: boolean;
+  value: TValue | TValue[] | null;
+}

--- a/packages/mui-base/src/SliderUnstyled/useSlider.ts
+++ b/packages/mui-base/src/SliderUnstyled/useSlider.ts
@@ -14,6 +14,7 @@ import {
   UseSliderParameters,
   UseSliderRootSlotProps,
   UseSliderThumbSlotProps,
+  UseSliderReturnValue,
 } from './useSlider.types';
 import { EventHandlers } from '../utils';
 
@@ -139,7 +140,7 @@ function focusThumb({
   }
 }
 
-const axisProps = {
+export const axisProps = {
   horizontal: {
     offset: (percent: number) => ({ left: `${percent}%` }),
     leap: (percent: number) => ({ width: `${percent}%` }),
@@ -178,7 +179,7 @@ function doesSupportTouchActionNone() {
   return cachedSupportsTouchActionNone;
 }
 
-export default function useSlider(parameters: UseSliderParameters) {
+export default function useSlider(parameters: UseSliderParameters): UseSliderReturnValue {
   const {
     'aria-labelledby': ariaLabelledby,
     defaultValue,

--- a/packages/mui-base/src/SliderUnstyled/useSlider.types.ts
+++ b/packages/mui-base/src/SliderUnstyled/useSlider.types.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { EventHandlers } from '../utils';
+import { axisProps } from './useSlider';
 
 export interface UseSliderParameters {
   'aria-labelledby'?: string;
@@ -62,3 +64,26 @@ export type UseSliderHiddenInputProps<TOther = {}> = Omit<
   keyof UseSliderHiddenInputOwnProps
 > &
   UseSliderHiddenInputOwnProps;
+
+export interface UseSliderReturnValue {
+  active: number;
+  axis: keyof typeof axisProps;
+  axisProps: typeof axisProps;
+  dragging: boolean;
+  focusedThumbIndex: number;
+  getHiddenInputProps: <TOther extends EventHandlers = {}>(
+    otherHandlers?: TOther,
+  ) => UseSliderHiddenInputProps<TOther>;
+  getRootProps: <TOther extends EventHandlers = {}>(
+    otherHandlers?: TOther,
+  ) => UseSliderRootSlotProps<TOther>;
+  getThumbProps: <TOther extends EventHandlers = {}>(
+    otherHandlers?: TOther,
+  ) => UseSliderThumbSlotProps<TOther>;
+  marks: Mark[];
+  open: number;
+  range: boolean;
+  trackLeap: number;
+  trackOffset: number;
+  values: number[];
+}

--- a/packages/mui-base/src/SnackbarUnstyled/useSnackbar.ts
+++ b/packages/mui-base/src/SnackbarUnstyled/useSnackbar.ts
@@ -4,6 +4,7 @@ import {
   UseSnackbarParameters,
   SnackbarCloseReason,
   UseSnackbarRootSlotProps,
+  UseSnackbarReturnValue,
 } from './useSnackbar.types';
 import extractEventHandlers from '../utils/extractEventHandlers';
 
@@ -14,7 +15,7 @@ import extractEventHandlers from '../utils/extractEventHandlers';
  *
  * - [Snackbar](https://mui.com/base/react-snackbar/)
  */
-export default function useSnackbar(parameters: UseSnackbarParameters) {
+export default function useSnackbar(parameters: UseSnackbarParameters): UseSnackbarReturnValue {
   const {
     autoHideDuration = null,
     disableWindowBlurListener = false,

--- a/packages/mui-base/src/SnackbarUnstyled/useSnackbar.types.ts
+++ b/packages/mui-base/src/SnackbarUnstyled/useSnackbar.types.ts
@@ -49,3 +49,10 @@ export interface UseSnackbarRootSlotOwnProps {
   ref?: React.Ref<any>;
   role: React.AriaRole;
 }
+
+export interface UseSnackbarReturnValue {
+  getRootProps: <TOther extends Record<string, ((event: any) => void) | undefined> = {}>(
+    otherHandlers?: TOther,
+  ) => UseSnackbarRootSlotProps<TOther>;
+  onClickAway: (event: React.SyntheticEvent<any> | Event) => void;
+}

--- a/packages/mui-base/src/SwitchUnstyled/useSwitch.ts
+++ b/packages/mui-base/src/SwitchUnstyled/useSwitch.ts
@@ -4,7 +4,11 @@ import {
   unstable_useForkRef as useForkRef,
   unstable_useIsFocusVisible as useIsFocusVisible,
 } from '@mui/utils';
-import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types';
+import {
+  UseSwitchInputSlotProps,
+  UseSwitchParameters,
+  UseSwitchReturnValue,
+} from './useSwitch.types';
 
 /**
  * The basic building block for creating custom switches.
@@ -13,7 +17,7 @@ import { UseSwitchInputSlotProps, UseSwitchParameters } from './useSwitch.types'
  *
  * - [Switches](https://mui.com/components/switches/)
  */
-export default function useSwitch(props: UseSwitchParameters) {
+export default function useSwitch(props: UseSwitchParameters): UseSwitchReturnValue {
   const {
     checked: checkedProp,
     defaultChecked,

--- a/packages/mui-base/src/SwitchUnstyled/useSwitch.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/useSwitch.types.ts
@@ -49,3 +49,11 @@ interface UseSwitchInputSlotOwnProps {
 
 export type UseSwitchInputSlotProps<TOther = {}> = Omit<TOther, keyof UseSwitchInputSlotOwnProps> &
   UseSwitchInputSlotOwnProps;
+
+export interface UseSwitchReturnValue {
+  checked: boolean;
+  disabled: boolean;
+  focusVisible: boolean;
+  getInputProps: (otherProps?: React.HTMLAttributes<HTMLInputElement>) => UseSwitchInputSlotProps;
+  readOnly: boolean;
+}

--- a/packages/mui-base/src/TabPanelUnstyled/useTabPanel.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/useTabPanel.ts
@@ -1,7 +1,7 @@
 import { useTabContext, getPanelId, getTabId } from '../TabsUnstyled';
-import { UseTabPanelParameters } from './useTabPanel.types';
+import { UseTabPanelParameters, UseTabPanelReturnValue } from './useTabPanel.types';
 
-const useTabPanel = (parameters: UseTabPanelParameters) => {
+const useTabPanel = (parameters: UseTabPanelParameters): UseTabPanelReturnValue => {
   const { value } = parameters;
 
   const context = useTabContext();

--- a/packages/mui-base/src/TabPanelUnstyled/useTabPanel.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/useTabPanel.types.ts
@@ -10,3 +10,12 @@ export interface UseTabPanelRootSlotProps {
   hidden?: boolean;
   id?: string;
 }
+
+export interface UseTabPanelReturnValue {
+  hidden: boolean;
+  getRootProps: () => {
+    'aria-labelledby': string | undefined;
+    hidden: boolean;
+    id: string | undefined;
+  };
+}

--- a/packages/mui-base/src/TabUnstyled/useTab.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.ts
@@ -1,9 +1,9 @@
 import { useTabContext, getTabId, getPanelId } from '../TabsUnstyled';
 import { useButton } from '../ButtonUnstyled';
-import { UseTabParameters, UseTabRootSlotProps } from './useTab.types';
+import { UseTabParameters, UseTabReturnValue, UseTabRootSlotProps } from './useTab.types';
 import { EventHandlers } from '../utils';
 
-const useTab = (parameters: UseTabParameters) => {
+const useTab = (parameters: UseTabParameters): UseTabReturnValue => {
   const { value: valueProp, onChange, onClick, onFocus } = parameters;
 
   const { getRootProps: getRootPropsButton, ...otherButtonProps } = useButton(parameters);

--- a/packages/mui-base/src/TabUnstyled/useTab.types.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { UseButtonRootSlotProps } from '../ButtonUnstyled';
+import { UseButtonRootSlotProps, UseButtonReturnValue } from '../ButtonUnstyled';
+import { EventHandlers } from '../utils';
 
 export interface UseTabParameters {
   /**
@@ -30,3 +31,11 @@ export type UseTabRootSlotProps<TOther = {}> = UseButtonRootSlotProps<
   id: string | undefined;
   role: React.AriaRole;
 };
+
+type UseTabOtherButtonProps = Omit<UseButtonReturnValue, 'getRootProps'>;
+export interface UseTabReturnValue extends UseTabOtherButtonProps {
+  getRootProps: <TOther extends EventHandlers>(
+    otherHandlers?: TOther,
+  ) => UseTabRootSlotProps<TOther>;
+  selected: boolean;
+}

--- a/packages/mui-base/src/TabsListUnstyled/useTabsList.types.ts
+++ b/packages/mui-base/src/TabsListUnstyled/useTabsList.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { EventHandlers } from '../utils';
 
 export interface UseTabsListParameters {
   'aria-label'?: string;
@@ -18,3 +19,16 @@ export type UseTabsListRootSlotProps<TOther = {}> = TOther & {
   ref: React.Ref<any>;
   onKeyDown?: React.KeyboardEventHandler<HTMLElement>;
 };
+
+export interface UseTabsListReturnValue {
+  isRtl: boolean;
+  orientation: 'horizontal' | 'vertical';
+  value: string | number | false;
+  processChildren: () =>
+    | React.ReactElement<any, string | React.JSXElementConstructor<any>>[]
+    | null
+    | undefined;
+  getRootProps: <TOther extends EventHandlers = {}>(
+    otherHandlers?: TOther,
+  ) => UseTabsListRootSlotProps<TOther>;
+}

--- a/packages/mui-base/src/TabsUnstyled/useTabs.ts
+++ b/packages/mui-base/src/TabsUnstyled/useTabs.ts
@@ -32,7 +32,18 @@ export interface UseTabsParameters {
   selectionFollowsFocus?: boolean;
 }
 
-const useTabs = (parameters: UseTabsParameters) => {
+export interface UseTabsReturnValue {
+  tabsContextValue: {
+    idPrefix: string | undefined;
+    value: string | number | false;
+    onSelected: (e: React.SyntheticEvent, newValue: string | number | false) => void;
+    orientation: 'horizontal' | 'vertical' | undefined;
+    direction: 'ltr' | 'rtl' | undefined;
+    selectionFollowsFocus: boolean | undefined;
+  };
+}
+
+const useTabs = (parameters: UseTabsParameters): UseTabsReturnValue => {
   const {
     value: valueProp,
     defaultValue,


### PR DESCRIPTION
This PR may fix this issue [#35933](https://github.com/mui/material-ui/issues/35933)
I tried to add return interface to all MUI Base Hooks (Those hooks are defined in this issue  [#35933](https://github.com/mui/material-ui/issues/35933)) without useAutocomplete Hook.
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
