### PR TITLE
[docs] Apply mode-base color for default-theme <Switch /> label

### DIFF
--- a/docs/data/material/customization/default-theme/DefaultTheme.js
+++ b/docs/data/material/customization/default-theme/DefaultTheme.js
@@ -59,7 +59,12 @@ function DefaultTheme() {
   return (
     <Box sx={{ width: '100%' }}>
       <FormControlLabel
-        sx={{ pb: 1 }}
+        sx={{
+          pb: 1,
+          label: {
+            color: (theme) => theme.palette.text.primary,
+          },
+        }}
         control={
           <Switch
             checked={checked}
@@ -72,7 +77,12 @@ function DefaultTheme() {
         label={t('expandAll')}
       />
       <FormControlLabel
-        sx={{ pb: 1 }}
+        sx={{
+          pb: 1,
+          label: {
+            color: (theme) => theme.palette.text.primary,
+          },
+        }}
         control={
           <Switch
             checked={darkTheme}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Before: the label's color on page [Default theme viewer](https://mui.com/material-ui/customization/default-theme/) doesn't sync with whole site's color theme.

![default-theme-viewer-before](https://user-images.githubusercontent.com/47290304/216463982-f36a05d0-43ba-4664-b6bf-6eea9da49183.png)

After: use `theme.palette.text.primary` for `FormControlLabel.sx.label.color` to apply color from theme.

![default-theme-viewer-after](https://user-images.githubusercontent.com/47290304/216463985-b85609af-e3f6-4e7b-a1c2-b2675f46e5ee.png)


