### PR TITLE
[useInput] Add return value interface

### DIFF
--- a/docs/pages/base/api/use-input.json
+++ b/docs/pages/base/api/use-input.json
@@ -62,14 +62,14 @@
     "getInputProps": {
       "type": {
         "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputInputSlotProps<TOther>",
-        "description": "Resolver for the `input` slot's props."
+        "description": "Resolver for the input slot's props."
       },
       "required": true
     },
     "getRootProps": {
       "type": {
         "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputRootSlotProps<TOther>",
-        "description": "Resolver for the `root` slot's props."
+        "description": "Resolver for the root slot's props."
       },
       "required": true
     },

--- a/docs/pages/base/api/use-input.json
+++ b/docs/pages/base/api/use-input.json
@@ -35,10 +35,7 @@
   },
   "returnValue": {
     "disabled": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, it indicates that the component is disabled."
-      },
+      "type": { "name": "boolean", "description": "If `true`, the component will be disabled." },
       "default": "false",
       "required": true
     },
@@ -58,7 +55,7 @@
     "formControlContext": {
       "type": {
         "name": "FormControlUnstyledState | undefined",
-        "description": "Return value from `useFormControlUnstyledContext` hook."
+        "description": "Return value from the `useFormControlUnstyledContext` hook."
       },
       "required": true
     },
@@ -79,13 +76,13 @@
     "required": {
       "type": {
         "name": "boolean",
-        "description": "If `true`, it indicates that the `input` element is required."
+        "description": "If `true`, the `input` will indicate that it's required."
       },
       "default": "false",
       "required": true
     },
     "value": {
-      "type": { "name": "unknown", "description": "The `value` of input element." },
+      "type": { "name": "unknown", "description": "The `value` of the `input` element." },
       "required": true
     }
   },

--- a/docs/pages/base/api/use-input.json
+++ b/docs/pages/base/api/use-input.json
@@ -33,7 +33,56 @@
     },
     "value": { "type": { "name": "unknown", "description": "" } }
   },
-  "returnValue": {},
+  "returnValue": {
+    "disabled": {
+      "type": { "name": "boolean", "description": "If `true`, the component is disabled." },
+      "default": "false",
+      "required": true
+    },
+    "error": {
+      "type": {
+        "name": "boolean",
+        "description": "If `true`, the `input` will indicate an error by setting the `aria-invalid` attribute."
+      },
+      "default": "false",
+      "required": true
+    },
+    "focused": {
+      "type": { "name": "boolean", "description": "If `true`, the `input` will be focused." },
+      "default": "false",
+      "required": true
+    },
+    "formControlContext": {
+      "type": {
+        "name": "FormControlUnstyledState | undefined",
+        "description": "Return value from `useFormControlUnstyledContext` hook."
+      },
+      "required": true
+    },
+    "getInputProps": {
+      "type": {
+        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputInputSlotProps<TOther>",
+        "description": "Resolver for the input slot's props."
+      },
+      "required": true
+    },
+    "getRootProps": {
+      "type": {
+        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputRootSlotProps<TOther>",
+        "description": "Resolver for the root slot's props."
+      },
+      "required": true
+    },
+    "required": {
+      "type": { "name": "boolean", "description": "If `true`, the `input` element is required." },
+      "default": "false",
+      "required": true
+    },
+    "value": {
+      "type": { "name": "unknown", "description": "`value` of input element." },
+      "required": true
+    }
+  },
   "name": "useInput",
   "filename": "/packages/mui-base/src/InputUnstyled/useInput.ts",
   "demos": "<ul><li><a href=\"/base/react-input/#hook\">Unstyled Input</a></li></ul>"

--- a/docs/pages/base/api/use-input.json
+++ b/docs/pages/base/api/use-input.json
@@ -62,14 +62,14 @@
     "getInputProps": {
       "type": {
         "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputInputSlotProps<TOther>",
-        "description": "Resolver for the input slot's props."
+        "description": "Resolver for the `input` slot's props."
       },
       "required": true
     },
     "getRootProps": {
       "type": {
         "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputRootSlotProps<TOther>",
-        "description": "Resolver for the root slot's props."
+        "description": "Resolver for the `root` slot's props."
       },
       "required": true
     },

--- a/docs/pages/base/api/use-input.json
+++ b/docs/pages/base/api/use-input.json
@@ -35,7 +35,10 @@
   },
   "returnValue": {
     "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component is disabled." },
+      "type": {
+        "name": "boolean",
+        "description": "If `true`, it indicates that the component is disabled."
+      },
       "default": "false",
       "required": true
     },
@@ -74,12 +77,15 @@
       "required": true
     },
     "required": {
-      "type": { "name": "boolean", "description": "If `true`, the `input` element is required." },
+      "type": {
+        "name": "boolean",
+        "description": "If `true`, it indicates that the `input` element is required."
+      },
       "default": "false",
       "required": true
     },
     "value": {
-      "type": { "name": "unknown", "description": "`value` of input element." },
+      "type": { "name": "unknown", "description": "The `value` of input element." },
       "required": true
     }
   },

--- a/docs/translations/api-docs/use-input/use-input.json
+++ b/docs/translations/api-docs/use-input/use-input.json
@@ -7,13 +7,13 @@
     "required": "If <code>true</code>, the <code>input</code> element is required.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
   },
   "returnValueDescriptions": {
-    "disabled": "If <code>true</code>, the component is disabled.",
+    "disabled": "If <code>true</code>, it indicates that the component is disabled.",
     "error": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.",
     "focused": "If <code>true</code>, the <code>input</code> will be focused.",
     "formControlContext": "Return value from <code>useFormControlUnstyledContext</code> hook.",
     "getInputProps": "Resolver for the input slot's props.",
     "getRootProps": "Resolver for the root slot's props.",
-    "required": "If <code>true</code>, the <code>input</code> element is required.",
-    "value": "<code>value</code> of input element."
+    "required": "If <code>true</code>, it indicates that the <code>input</code> element is required.",
+    "value": "The <code>value</code> of input element."
   }
 }

--- a/docs/translations/api-docs/use-input/use-input.json
+++ b/docs/translations/api-docs/use-input/use-input.json
@@ -6,5 +6,14 @@
     "error": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component.",
     "required": "If <code>true</code>, the <code>input</code> element is required.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
   },
-  "returnValueDescriptions": {}
+  "returnValueDescriptions": {
+    "disabled": "If <code>true</code>, the component is disabled.",
+    "error": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.",
+    "focused": "If <code>true</code>, the <code>input</code> will be focused.",
+    "formControlContext": "Return value from <code>useFormControlUnstyledContext</code> hook.",
+    "getInputProps": "Resolver for the input slot's props.",
+    "getRootProps": "Resolver for the root slot's props.",
+    "required": "If <code>true</code>, the <code>input</code> element is required.",
+    "value": "<code>value</code> of input element."
+  }
 }

--- a/docs/translations/api-docs/use-input/use-input.json
+++ b/docs/translations/api-docs/use-input/use-input.json
@@ -11,8 +11,8 @@
     "error": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.",
     "focused": "If <code>true</code>, the <code>input</code> will be focused.",
     "formControlContext": "Return value from the <code>useFormControlUnstyledContext</code> hook.",
-    "getInputProps": "Resolver for the input slot's props.",
-    "getRootProps": "Resolver for the root slot's props.",
+    "getInputProps": "Resolver for the <code>input</code> slot's props.",
+    "getRootProps": "Resolver for the <code>root</code> slot's props.",
     "required": "If <code>true</code>, the <code>input</code> will indicate that it's required.",
     "value": "The <code>value</code> of the <code>input</code> element."
   }

--- a/docs/translations/api-docs/use-input/use-input.json
+++ b/docs/translations/api-docs/use-input/use-input.json
@@ -7,13 +7,13 @@
     "required": "If <code>true</code>, the <code>input</code> element is required.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
   },
   "returnValueDescriptions": {
-    "disabled": "If <code>true</code>, it indicates that the component is disabled.",
+    "disabled": "If <code>true</code>, the component will be disabled.",
     "error": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.",
     "focused": "If <code>true</code>, the <code>input</code> will be focused.",
-    "formControlContext": "Return value from <code>useFormControlUnstyledContext</code> hook.",
+    "formControlContext": "Return value from the <code>useFormControlUnstyledContext</code> hook.",
     "getInputProps": "Resolver for the input slot's props.",
     "getRootProps": "Resolver for the root slot's props.",
-    "required": "If <code>true</code>, it indicates that the <code>input</code> element is required.",
-    "value": "The <code>value</code> of input element."
+    "required": "If <code>true</code>, the <code>input</code> will indicate that it's required.",
+    "value": "The <code>value</code> of the <code>input</code> element."
   }
 }

--- a/docs/translations/api-docs/use-input/use-input.json
+++ b/docs/translations/api-docs/use-input/use-input.json
@@ -11,8 +11,8 @@
     "error": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.",
     "focused": "If <code>true</code>, the <code>input</code> will be focused.",
     "formControlContext": "Return value from the <code>useFormControlUnstyledContext</code> hook.",
-    "getInputProps": "Resolver for the <code>input</code> slot's props.",
-    "getRootProps": "Resolver for the <code>root</code> slot's props.",
+    "getInputProps": "Resolver for the input slot's props.",
+    "getRootProps": "Resolver for the root slot's props.",
     "required": "If <code>true</code>, the <code>input</code> will indicate that it's required.",
     "value": "The <code>value</code> of the <code>input</code> element."
   }

--- a/packages/mui-base/src/InputUnstyled/useInput.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.ts
@@ -7,6 +7,7 @@ import {
   UseInputInputSlotProps,
   UseInputParameters,
   UseInputRootSlotProps,
+  UseInputReturnValue,
 } from './useInput.types';
 /**
  *
@@ -18,7 +19,7 @@ import {
  *
  * - [useInput API](https://mui.com/base/api/use-input/)
  */
-export default function useInput(parameters: UseInputParameters) {
+export default function useInput(parameters: UseInputParameters): UseInputReturnValue {
   const {
     defaultValue: defaultValueProp,
     disabled: disabledProp = false,

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -96,7 +96,7 @@ export interface UseInputReturnValue {
    */
   required: boolean;
   /**
-   * TThe `value` of the `input` element.
+   * The `value` of the `input` element.
    */
   value: unknown;
 }

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -75,7 +75,7 @@ export interface UseInputReturnValue {
    */
   formControlContext: FormControlUnstyledState | undefined;
   /**
-   * Resolver for the `input` slot's props.
+   * Resolver for the input slot's props.
    * @param externalProps props for the input slot
    * @returns props that should be spread on the input slot
    */
@@ -83,7 +83,7 @@ export interface UseInputReturnValue {
     externalProps?: TOther,
   ) => UseInputInputSlotProps<TOther>;
   /**
-   * Resolver for the `root` slot's props.
+   * Resolver for the root slot's props.
    * @param externalProps props for the root slot
    * @returns props that should be spread on the root slot
    */

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -56,7 +56,7 @@ export type UseInputInputSlotProps<TOther = {}> = Omit<TOther, keyof UseInputInp
 
 export interface UseInputReturnValue {
   /**
-   * If `true`, the component is disabled.
+   * If `true`, it indicates that the component is disabled.
    * @default false
    */
   disabled: boolean;
@@ -91,12 +91,12 @@ export interface UseInputReturnValue {
     externalProps?: TOther,
   ) => UseInputRootSlotProps<TOther>;
   /**
-   * If `true`, the `input` element is required.
+   * If `true`, it indicates that the `input` element is required.
    * @default false
    */
   required: boolean;
   /**
-   * `value` of input element.
+   * The `value` of input element.
    */
   value: unknown;
 }

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FormControlUnstyledState } from '../FormControlUnstyled';
 
 export interface UseInputParameters {
   /**
@@ -52,3 +53,50 @@ export interface UseInputInputSlotOwnProps {
 
 export type UseInputInputSlotProps<TOther = {}> = Omit<TOther, keyof UseInputInputSlotOwnProps> &
   UseInputInputSlotOwnProps;
+
+export interface UseInputReturnValue {
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: boolean;
+  /**
+   * If `true`, the `input` will indicate an error by setting the `aria-invalid` attribute.
+   * @default false
+   */
+  error: boolean;
+  /**
+   * If `true`, the `input` will be focused.
+   * @default false
+   */
+  focused: boolean;
+  /**
+   * Return value from `useFormControlUnstyledContext` hook.
+   */
+  formControlContext: FormControlUnstyledState | undefined;
+  /**
+   * Resolver for the input slot's props.
+   * @param externalProps props for the input slot
+   * @returns props that should be spread on the input slot
+   */
+  getInputProps: <TOther extends Record<string, any> = {}>(
+    externalProps?: TOther,
+  ) => UseInputInputSlotProps<TOther>;
+  /**
+   * Resolver for the root slot's props.
+   * @param externalProps props for the root slot
+   * @returns props that should be spread on the root slot
+   */
+  getRootProps: <TOther extends Record<string, any> = {}>(
+    externalProps?: TOther,
+  ) => UseInputRootSlotProps<TOther>;
+  /**
+   * If `true`, the `input` element is required.
+   * @default false
+   */
+  required: boolean;
+  /**
+   * `value` of input element.
+   */
+  value: unknown;
+}

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -56,7 +56,7 @@ export type UseInputInputSlotProps<TOther = {}> = Omit<TOther, keyof UseInputInp
 
 export interface UseInputReturnValue {
   /**
-   * If `true`, it indicates that the component is disabled.
+   * If `true`, the component will be disabled.
    * @default false
    */
   disabled: boolean;
@@ -71,7 +71,7 @@ export interface UseInputReturnValue {
    */
   focused: boolean;
   /**
-   * Return value from `useFormControlUnstyledContext` hook.
+   * Return value from the `useFormControlUnstyledContext` hook.
    */
   formControlContext: FormControlUnstyledState | undefined;
   /**
@@ -91,12 +91,12 @@ export interface UseInputReturnValue {
     externalProps?: TOther,
   ) => UseInputRootSlotProps<TOther>;
   /**
-   * If `true`, it indicates that the `input` element is required.
+   * If `true`, the `input` will indicate that it's required.
    * @default false
    */
   required: boolean;
   /**
-   * The `value` of input element.
+   * TThe `value` of the `input` element.
    */
   value: unknown;
 }

--- a/packages/mui-base/src/InputUnstyled/useInput.types.ts
+++ b/packages/mui-base/src/InputUnstyled/useInput.types.ts
@@ -75,7 +75,7 @@ export interface UseInputReturnValue {
    */
   formControlContext: FormControlUnstyledState | undefined;
   /**
-   * Resolver for the input slot's props.
+   * Resolver for the `input` slot's props.
    * @param externalProps props for the input slot
    * @returns props that should be spread on the input slot
    */
@@ -83,7 +83,7 @@ export interface UseInputReturnValue {
     externalProps?: TOther,
   ) => UseInputInputSlotProps<TOther>;
   /**
-   * Resolver for the root slot's props.
+   * Resolver for the `root` slot's props.
    * @param externalProps props for the root slot
    * @returns props that should be spread on the root slot
    */


### PR DESCRIPTION
### UseInput return value interface
I tried to add a return interface to  UseInput MUI Base Hooks (Those hooks are defined in this issue https://github.com/mui/material-ui/issues/35933).
- added return value type 

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
