### PR TITLE
[Tab] Add explicit return type to useTab

### DIFF
--- a/docs/pages/base/api/use-tab.json
+++ b/docs/pages/base/api/use-tab.json
@@ -17,7 +17,40 @@
       }
     }
   },
-  "returnValue": {},
+  "returnValue": {
+    "active": {
+      "type": { "name": "boolean", "description": "If `true`, the tab is active." },
+      "default": "false",
+      "required": true
+    },
+    "disabled": {
+      "type": { "name": "boolean", "description": "If `true`, the tab is disabled." },
+      "default": "false",
+      "required": true
+    },
+    "focusVisible": {
+      "type": { "name": "boolean", "description": "If `true`, the tab's focus is visible." },
+      "required": true
+    },
+    "getRootProps": {
+      "type": {
+        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseTabRootSlotProps<TOther>",
+        "description": "Resolver for the root slot's props."
+      },
+      "required": true
+    },
+    "selected": {
+      "type": { "name": "boolean", "description": "If `true`, the tab is disabled." },
+      "required": true
+    },
+    "setFocusVisible": {
+      "type": {
+        "name": "React.Dispatch<React.SetStateAction<boolean>>",
+        "description": "Callback for setting the `focusVisible` param."
+      },
+      "required": true
+    }
+  },
   "name": "useTab",
   "filename": "/packages/mui-base/src/TabUnstyled/useTab.ts",
   "demos": "<ul><li><a href=\"/base/react-tabs/#hooks\">Unstyled Tabs</a></li></ul>"

--- a/docs/pages/base/api/use-tab.json
+++ b/docs/pages/base/api/use-tab.json
@@ -19,17 +19,17 @@
   },
   "returnValue": {
     "active": {
-      "type": { "name": "boolean", "description": "If `true`, the tab is active." },
+      "type": { "name": "boolean", "description": "If `true`, the component will be active." },
       "default": "false",
       "required": true
     },
     "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the tab is disabled." },
+      "type": { "name": "boolean", "description": "If `true`, the component will be disabled." },
       "default": "false",
       "required": true
     },
     "focusVisible": {
-      "type": { "name": "boolean", "description": "If `true`, the tab's focus is visible." },
+      "type": { "name": "boolean", "description": "If `true`, the tab's focus will be visible." },
       "required": true
     },
     "getRootProps": {
@@ -40,7 +40,7 @@
       "required": true
     },
     "selected": {
-      "type": { "name": "boolean", "description": "If `true`, the tab is disabled." },
+      "type": { "name": "boolean", "description": "If `true`, the tab will be selected." },
       "required": true
     },
     "setFocusVisible": {

--- a/docs/translations/api-docs/use-tab/use-tab.json
+++ b/docs/translations/api-docs/use-tab/use-tab.json
@@ -4,5 +4,12 @@
     "onChange": "Callback invoked when new value is being set.",
     "value": "You can provide your own value. Otherwise, we fall back to the child position index."
   },
-  "returnValueDescriptions": {}
+  "returnValueDescriptions": {
+    "active": "If <code>true</code>, the tab is active.",
+    "disabled": "If <code>true</code>, the tab is disabled.",
+    "focusVisible": "If <code>true</code>, the tab's focus is visible.",
+    "getRootProps": "Resolver for the root slot's props.",
+    "selected": "If <code>true</code>, the tab is disabled.",
+    "setFocusVisible": "Callback for setting the <code>focusVisible</code> param."
+  }
 }

--- a/docs/translations/api-docs/use-tab/use-tab.json
+++ b/docs/translations/api-docs/use-tab/use-tab.json
@@ -5,11 +5,11 @@
     "value": "You can provide your own value. Otherwise, we fall back to the child position index."
   },
   "returnValueDescriptions": {
-    "active": "If <code>true</code>, the tab is active.",
-    "disabled": "If <code>true</code>, the tab is disabled.",
-    "focusVisible": "If <code>true</code>, the tab's focus is visible.",
+    "active": "If <code>true</code>, the component will be active.",
+    "disabled": "If <code>true</code>, the component will be disabled.",
+    "focusVisible": "If <code>true</code>, the tab's focus will be visible.",
     "getRootProps": "Resolver for the root slot's props.",
-    "selected": "If <code>true</code>, the tab is disabled.",
+    "selected": "If <code>true</code>, the tab will be selected.",
     "setFocusVisible": "Callback for setting the <code>focusVisible</code> param."
   }
 }

--- a/packages/mui-base/src/TabUnstyled/useTab.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.ts
@@ -1,6 +1,6 @@
 import { useTabContext, getTabId, getPanelId } from '../TabsUnstyled';
 import { useButton } from '../ButtonUnstyled';
-import { UseTabParameters, UseTabRootSlotProps } from './useTab.types';
+import { UseTabParameters, UseTabReturnValue, UseTabRootSlotProps } from './useTab.types';
 import { EventHandlers } from '../utils';
 /**
  *
@@ -12,7 +12,7 @@ import { EventHandlers } from '../utils';
  *
  * - [useTab API](https://mui.com/base/api/use-tab/)
  */
-function useTab(parameters: UseTabParameters) {
+function useTab(parameters: UseTabParameters): UseTabReturnValue {
   const { value: valueProp, onChange, onClick, onFocus } = parameters;
 
   const { getRootProps: getRootPropsButton, ...otherButtonProps } = useButton(parameters);

--- a/packages/mui-base/src/TabUnstyled/useTab.types.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.types.ts
@@ -30,3 +30,36 @@ export type UseTabRootSlotProps<TOther = {}> = UseButtonRootSlotProps<
   id: string | undefined;
   role: React.AriaRole;
 };
+
+export interface UseTabReturnValue {
+  /**
+   * If `true`, the tab is disabled.
+   */
+  selected: boolean;
+  /**
+   * If `true`, the tab's focus is visible.
+   */
+  focusVisible: boolean;
+  /**
+   * Callback for setting the `focusVisible` param.
+   */
+  setFocusVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  /**
+   * If `true`, the tab is disabled.
+   * @default false
+   */
+  disabled: boolean;
+  /**
+   * If `true`, the tab is active.
+   * @default false
+   */
+  active: boolean;
+  /**
+   * Resolver for the root slot's props.
+   * @param externalProps props for the root slot
+   * @returns props that should be spread on the root slot
+   */
+  getRootProps: <TOther extends Record<string, any> = {}>(
+    externalProps?: TOther,
+  ) => UseTabRootSlotProps<TOther>;
+}

--- a/packages/mui-base/src/TabUnstyled/useTab.types.ts
+++ b/packages/mui-base/src/TabUnstyled/useTab.types.ts
@@ -33,11 +33,11 @@ export type UseTabRootSlotProps<TOther = {}> = UseButtonRootSlotProps<
 
 export interface UseTabReturnValue {
   /**
-   * If `true`, the tab is disabled.
+   * If `true`, the tab will be selected.
    */
   selected: boolean;
   /**
-   * If `true`, the tab's focus is visible.
+   * If `true`, the tab's focus will be visible.
    */
   focusVisible: boolean;
   /**
@@ -45,12 +45,12 @@ export interface UseTabReturnValue {
    */
   setFocusVisible: React.Dispatch<React.SetStateAction<boolean>>;
   /**
-   * If `true`, the tab is disabled.
+   * If `true`, the component will be disabled.
    * @default false
    */
   disabled: boolean;
   /**
-   * If `true`, the tab is active.
+   * If `true`, the component will be active.
    * @default false
    */
   active: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

UseTab return value interface

closes: useTab in https://github.com/mui/material-ui/issues/35933

preview: https://deploy-preview-36046--material-ui.netlify.app/base/api/use-tab/#return-value

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
