### PR TITLE
[UseFormControlUnstyledContext] add return type 

### DIFF
--- a/packages/mui-base/src/FormControlUnstyled/useFormControlUnstyledContext.ts
+++ b/packages/mui-base/src/FormControlUnstyled/useFormControlUnstyledContext.ts
@@ -10,6 +10,8 @@ import FormControlUnstyledContext from './FormControlUnstyledContext';
  *
  * - [useFormControlUnstyledContext API](https://mui.com/base/api/use-form-control-unstyled-context/)
  */
-export default function useFormControlUnstyledContext() {
+export default function useFormControlUnstyledContext(): React.ContextType<
+  typeof FormControlUnstyledContext
+> {
   return React.useContext(FormControlUnstyledContext);
 }


### PR DESCRIPTION
Add typescript return type for this useFormControlUnstyledContext hook. it's related to this issue [#35933](https://github.com/mui/material-ui/issues/35933)

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
