### PR TITLE
[FormLabel] Export `FormLabelOwnProps` from `FormLabel` to fix type error

### DIFF
--- a/packages/mui-material/src/FormLabel/FormLabel.d.ts
+++ b/packages/mui-material/src/FormLabel/FormLabel.d.ts
@@ -7,7 +7,7 @@ import { FormLabelClasses } from './formLabelClasses';
 
 export interface FormLabelPropsColorOverrides {}
 
-interface FormLabelOwnProps {
+export interface FormLabelOwnProps {
   /**
    * The content of the component.
    */


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes https://github.com/mui/material-ui/issues/36035

This issue occurs on the same situation as https://github.com/mui/material-ui/issues/33165.
Explained on https://github.com/mui/material-ui/issues/36035#issuecomment-1415895742.


Before: https://codesandbox.io/s/sad-merkle-3swvv2?file=/src/Demo.tsx
After: https://codesandbox.io/s/nervous-morning-d5onc3?file=/src/Demo.tsx
  