### PR TITLE
[useAutocomplete] Changed default disabledProp to false

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -90,7 +90,7 @@ export default function useAutocomplete(props) {
     defaultValue = props.multiple ? [] : null,
     disableClearable = false,
     disableCloseOnSelect = false,
-    disabled: disabledProp,
+    disabled: disabledProp = false,
     disabledItemsFocusable = false,
     disableListWrap = false,
     filterOptions = defaultFilterOptions,


### PR DESCRIPTION
Fixed Issue: [useAutocomplete disabled prop does not disable component #36055](https://github.com/mui/material-ui/issues/36055)


