### PR TITLE
[website] Fix layout shift

### DIFF
--- a/docs/src/components/icon/IconImage.tsx
+++ b/docs/src/components/icon/IconImage.tsx
@@ -36,38 +36,43 @@ export type IconImageProps = {
     | 'ebay'
     | 'samsung'
     | 'volvo';
-  sx?: SxProps<Theme>;
+  height?: number;
   ref?: React.Ref<HTMLImageElement>;
+  sx?: SxProps<Theme>;
   title?: string;
+  width?: number;
 } & Omit<JSX.IntrinsicElements['img'], 'ref'>;
 
 const Img = styled('img')({ display: 'inline-block', verticalAlign: 'bottom' });
 
+let neverHydrated = true;
+
 export default function IconImage(props: IconImageProps) {
-  const { name, title, ...other } = props;
+  const { height: heightProp, name, title, width: widthProp, ...other } = props;
   const theme = useTheme();
   const [mounted, setMounted] = React.useState(false);
   React.useEffect(() => {
+    neverHydrated = false;
     setMounted(true);
   }, []);
-  let width;
-  let height;
+  let defaultWidth;
+  let defaultHeight;
   let category = '';
   let mode = `-${theme.palette.mode}`;
   if (name.startsWith('product-')) {
-    width = 36;
-    height = 36;
+    defaultWidth = 36;
+    defaultHeight = 36;
   }
   if (name.startsWith('block-')) {
     category = 'pricing/';
     mode = '';
-    width = 13;
-    height = 15;
+    defaultWidth = 13;
+    defaultHeight = 15;
   }
   if (['yes', 'no', 'time'].indexOf(name) !== -1) {
     category = 'pricing/';
-    width = 18;
-    height = 18;
+    defaultWidth = 18;
+    defaultHeight = 18;
   }
   if (
     [
@@ -94,7 +99,10 @@ export default function IconImage(props: IconImageProps) {
   ) {
     category = 'companies/';
   }
-  if (!mounted && !!theme.vars) {
+  const width = widthProp ?? defaultWidth;
+  const height = heightProp ?? defaultHeight;
+
+  if (!mounted && neverHydrated && !!theme.vars) {
     // Prevent hydration mismatch between the light and dark mode image source.
     return <Box component="span" sx={{ width, height, display: 'inline-block' }} />;
   }

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -1046,7 +1046,7 @@ export default function PricingTable({
           </Box>
         </Box>
       )}
-      <RowHead startIcon={<IconImage name="product-core" width="28" height="28" />}>
+      <RowHead startIcon={<IconImage name="product-core" width={28} height={28} />}>
         MUI Core (open-source)
       </RowHead>
       {renderRow('Material UI')}
@@ -1056,7 +1056,7 @@ export default function PricingTable({
       {renderRow('MUI Base')}
       {divider}
       {renderRow('MUI System')}
-      <RowHead startIcon={<IconImage name="product-advanced" width="28" height="28" />}>
+      <RowHead startIcon={<IconImage name="product-advanced" width={28} height={28} />}>
         MUI X (open-core)
       </RowHead>
       <Box

--- a/docs/src/components/productCore/CoreHero.tsx
+++ b/docs/src/components/productCore/CoreHero.tsx
@@ -223,13 +223,13 @@ export default function Hero() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: { xs: 'center', md: 'flex-start' },
-              '& > *': { mr: 1, width: 28, height: 28 },
+              '& > *': { mr: 1 },
               ...theme.applyDarkStyles({
                 color: 'primary.400',
               }),
             })}
           >
-            <IconImage name="product-core" /> MUI Core
+            <IconImage width={28} height={28} name="product-core" /> MUI Core
           </Typography>
           <Typography variant="h1" sx={{ my: 2, maxWidth: 500 }}>
             Ready to use components, <br />

--- a/docs/src/components/productDesignKit/DesignKitHero.tsx
+++ b/docs/src/components/productDesignKit/DesignKitHero.tsx
@@ -27,13 +27,13 @@ export default function TemplateHero() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: { xs: 'center', md: 'start' },
-              '& > *': { mr: 1, width: 28, height: 28 },
+              '& > *': { mr: 1 },
               ...theme.applyDarkStyles({
                 color: 'primary.400',
               }),
             })}
           >
-            <IconImage name="product-designkits" /> Design kits
+            <IconImage width={28} height={28} name="product-designkits" /> Design kits
           </Typography>
           <Typography variant="h1" sx={{ my: 2, maxWidth: 500 }}>
             MUI in your favorite

--- a/docs/src/components/productTemplate/TemplateHero.tsx
+++ b/docs/src/components/productTemplate/TemplateHero.tsx
@@ -24,14 +24,14 @@ export default function TemplateHero() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: { xs: 'center', md: 'start' },
-              '& > *': { mr: 1, width: 28, height: 28 },
+              '& > *': { mr: 1 },
               color: 'primary.600',
               ...theme.applyDarkStyles({
                 color: 'primary.400',
               }),
             })}
           >
-            <IconImage name="product-templates" /> Templates
+            <IconImage width={28} height={28} name="product-templates" /> Templates
           </Typography>
           <Typography variant="h1" sx={{ my: 2, maxWidth: 500 }}>
             <GradientText>Fully built</GradientText>

--- a/docs/src/components/productX/XHero.tsx
+++ b/docs/src/components/productX/XHero.tsx
@@ -44,13 +44,13 @@ export default function XHero() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: { xs: 'center', md: 'flex-start' },
-              '& > *': { mr: 1, width: 28, height: 28 },
+              '& > *': { mr: 1 },
               ...theme.applyDarkStyles({
                 color: 'primary.400',
               }),
             })}
           >
-            <IconImage name="product-advanced" /> MUI X
+            <IconImage width={28} height={28} name="product-advanced" /> MUI X
           </Typography>
           <Typography variant="h1" sx={{ my: 2, maxWidth: 500 }}>
             Performant


### PR DESCRIPTION
This layout shift was driving me crazy:

https://user-images.githubusercontent.com/3165635/216846962-d4302a3c-c530-4b2c-9184-f61978718ed9.mov

The issue was that `'& > *': { width: 28, height: 28 },` has no guarantees to win over the style rendered by its children with emotion (it used to be OK with JSS).

---

If you want help seeing it:

https://user-images.githubusercontent.com/3165635/216846956-e55772ef-180c-4f27-bbeb-63a0824549c0.mov

There is also one in the app bar that is annoying but it's outside of my scope.