### PR TITLE
[docs] Add banner pointing to "Whats new" in MUI X page

### DIFF
--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -40,7 +40,7 @@ export default function AppFrameBanner() {
         },
       })}
     >
-      🚀&#160;&#160;MUI X v6-beta is out! Discover what's new and get started now with the new major version!&nbsp;
+      🚀 MUI X v6-beta is out! Discover what&apos;s new and get started now!
       <br />
     </Link>
   ) : null;

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -7,7 +7,7 @@ import { alpha } from '@mui/material/styles';
 export default function AppFrameBanner() {
   return FEATURE_TOGGLE.enable_docsnav_banner ? (
     <Link
-      href={'/x/whats-new'} //href={ROUTES.careers} // Fix me!
+      href={ROUTES.advancedComponentsWhatsNew}
       target="_blank"
       variant="caption"
       sx={(theme) => ({
@@ -40,7 +40,7 @@ export default function AppFrameBanner() {
         },
       })}
     >
-      🚀&#160;&#160;MUI X v6-beta is out! Check out what's new in this major version!&nbsp;
+      🚀&#160;&#160;MUI X v6-beta is out! Discover what's new in this major version!&nbsp;
       <br />
     </Link>
   ) : null;

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -40,7 +40,7 @@ export default function AppFrameBanner() {
         },
       })}
     >
-      🚀&#160;&#160;MUI X v6-beta is out! Discover what's new in this major version!&nbsp;
+      🚀&#160;&#160;MUI X v6-beta is out! Discover what's new and get started now with the new major version!&nbsp;
       <br />
     </Link>
   ) : null;

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import Link from 'docs/src/modules/components/Link';
-import ROUTES from 'docs/src/route';
 import FEATURE_TOGGLE from 'docs/src/featureToggle';
 import { alpha } from '@mui/material/styles';
 
 export default function AppFrameBanner() {
   return FEATURE_TOGGLE.enable_docsnav_banner ? (
     <Link
-      href={ROUTES.advancedComponentsWhatsNew}
+      href="https://next.mui.com/x/whats-new/"
       target="_blank"
       variant="caption"
       sx={(theme) => ({

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -7,7 +7,7 @@ import { alpha } from '@mui/material/styles';
 export default function AppFrameBanner() {
   return FEATURE_TOGGLE.enable_docsnav_banner ? (
     <Link
-      href={ROUTES.careers} // Fix me!
+      href={'/x/whats-new'} //href={ROUTES.careers} // Fix me!
       target="_blank"
       variant="caption"
       sx={(theme) => ({
@@ -40,8 +40,7 @@ export default function AppFrameBanner() {
         },
       })}
     >
-      🚀&#160;&#160;We&apos;re hiring a Designer, Full-stack Engineer, React Support Engineer, and
-      more!&nbsp;
+      🚀&#160;&#160;MUI X v6-beta is out! Check out what's new in this major version!&nbsp;
       <br />
     </Link>
   ) : null;

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -2,5 +2,5 @@
 module.exports = {
   enable_website_banner: false,
   enable_toc_banner: true,
-  enable_docsnav_banner: false,
+  enable_docsnav_banner: true,
 };

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -31,7 +31,7 @@ const ROUTES = {
   goldSponsor: '/material-ui/discover-more/backers/#gold',
   store: 'https://mui.com/store/',
   advancedComponents: '/x/introduction/',
-  advancedComponentsWhatsNew: '/x/whats-new',
+  advancedComponentsWhatsNew: 'https://next.mui.com/x/whats-new/',
   toolpadDocs: '/toolpad/getting-started/overview/',
   dataGridSpace: '/x/react-data-grid/getting-started/',
   dataGridDocs: '/x/react-data-grid/getting-started/',

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -31,7 +31,6 @@ const ROUTES = {
   goldSponsor: '/material-ui/discover-more/backers/#gold',
   store: 'https://mui.com/store/',
   advancedComponents: '/x/introduction/',
-  advancedComponentsWhatsNew: 'https://next.mui.com/x/whats-new/',
   toolpadDocs: '/toolpad/getting-started/overview/',
   dataGridSpace: '/x/react-data-grid/getting-started/',
   dataGridDocs: '/x/react-data-grid/getting-started/',

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -31,6 +31,7 @@ const ROUTES = {
   goldSponsor: '/material-ui/discover-more/backers/#gold',
   store: 'https://mui.com/store/',
   advancedComponents: '/x/introduction/',
+  advancedComponentsWhatsNew: '/x/whats-new',
   toolpadDocs: '/toolpad/getting-started/overview/',
   dataGridSpace: '/x/react-data-grid/getting-started/',
   dataGridDocs: '/x/react-data-grid/getting-started/',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

Add a banner to the main navigation bar on our docs linking to MUI X v6.

## Preview

https://deploy-preview-36074--material-ui.netlify.app/material-ui/getting-started/overview/

<img width="750" alt="image" src="https://user-images.githubusercontent.com/550141/217031542-8e33ca0d-2977-4880-83e1-bb16dc71d88f.png">

