### PR TITLE
[useAutocomplete] Fix `useAutocomplete` disabled prop not disabling the input

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -1095,6 +1095,7 @@ export default function useAutocomplete(props) {
       autoCapitalize: 'none',
       spellCheck: 'false',
       role: 'combobox',
+      disabled: disabledProp,
     }),
     getClearProps: () => ({
       tabIndex: -1,

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
@@ -317,6 +317,21 @@ describe('useAutocomplete', () => {
     });
   });
 
+  describe('getInputProps', () => {
+    it('should disable input element', () => {
+      function Test(props) {
+        const { options } = props;
+        const { getInputProps } = useAutocomplete({ options, disabled: true });
+
+        return <input {...getInputProps()} />;
+      }
+      render(<Test options={['foo', 'bar']} />);
+      const input = screen.getByRole('combobox');
+
+      expect(input).to.have.attribute('disabled');
+    });
+  });
+
   it('should allow tuples or arrays as value when multiple=false', () => {
     function Test() {
       const defaultValue = ['bar'];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/36055

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Before: https://codesandbox.io/s/suspicious-dust-yxwwst?file=/src/App.tsx

After: https://codesandbox.io/s/wizardly-hugle-rsin57
