### PR TITLE
[docs] Turn off job banner on docs

### DIFF
--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -3,4 +3,5 @@ module.exports = {
   enable_website_banner: false,
   enable_toc_banner: true,
   enable_docsnav_banner: true,
+  enable_job_banner: false,
 };

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -9,6 +9,7 @@ import Link from 'docs/src/modules/components/Link';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import { shouldHandleLinkClick } from 'docs/src/modules/components/MarkdownLinks';
 import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBanner';
+import featureToggle from 'docs/src/featureToggle';
 
 const Nav = styled('nav')(({ theme }) => ({
   top: 0,
@@ -131,7 +132,7 @@ function flatten(headings) {
   return itemsWithNode;
 }
 
-const shouldShowJobAd = () => {
+function shouldShowJobAd() {
   const date = new Date();
   const timeZoneOffset = date.getTimezoneOffset();
   // Hide for time zones UT+5.5 - UTC+14 & UTC-8 - UTC-12
@@ -139,13 +140,14 @@ const shouldShowJobAd = () => {
     return false;
   }
   return true;
-};
+}
+
+const showSurveyBanner = false;
+const showJobAd = featureToggle.enable_job_banner && shouldShowJobAd();
 
 export default function AppTableOfContents(props) {
   const { toc } = props;
   const t = useTranslate();
-  const showSurveyBanner = false;
-  const showAddJob = shouldShowJobAd() && !showSurveyBanner;
 
   const items = React.useMemo(() => flatten(toc), [toc]);
   const [activeState, setActiveState] = React.useState(null);
@@ -280,7 +282,7 @@ export default function AppTableOfContents(props) {
             </Typography>
           </Link>
         )}
-        {showAddJob && (
+        {!showSurveyBanner && showJobAd && (
           <Link
             href="https://jobs.ashbyhq.com/MUI?utm_source=2vOWXNv1PE"
             target="_blank"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

- Add a toggle variable to turn off/on the Job ad.
- Set the toggle to "off"

Follow up on https://github.com/mui/material-ui/pull/36074#discussion_r1097632956

## Preview (after)

https://deploy-preview-36080--material-ui.netlify.app/material-ui/getting-started/overview/

### Before

<img width="255" alt="image" src="https://user-images.githubusercontent.com/550141/217033926-83e36a53-eb13-40d8-9df2-45c9e885a8a2.png">