### PR TITLE
[useAutocomplete] Pass only valid values for the getOptionLabel prop

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -466,8 +466,8 @@ export default function useAutocomplete(props) {
 
   const checkHighlightedOptionExists = () => {
     const isSameValue = (value1, value2) => {
-      const label1 = value1 === null ? '' : getOptionLabel(value1);
-      const label2 = value2 === null ? '' : getOptionLabel(value2);
+      const label1 = value1 ? getOptionLabel(value1) : '';
+      const label2 = value2 ? getOptionLabel(value2) : '';
       return label1 === label2;
     };
 

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -464,13 +464,13 @@ export default function useAutocomplete(props) {
     },
   );
 
-  const isSameValue = (value1, value2) => {
-    const label1 = value1 === null ? '' : getOptionLabel(value1);
-    const label2 = value2 === null ? '' : getOptionLabel(value2);
-    return label1 === label2;
-  };
-
   const checkHighlightedOptionExists = () => {
+    const isSameValue = (value1, value2) => {
+      const label1 = value1 === null ? '' : getOptionLabel(value1);
+      const label2 = value2 === null ? '' : getOptionLabel(value2);
+      return label1 === label2;
+    };
+
     if (
       highlightedIndexRef.current !== -1 &&
       previousProps.filteredOptions &&

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -464,6 +464,12 @@ export default function useAutocomplete(props) {
     },
   );
 
+  const isSameValue = (value1, value2) => {
+    const label1 = value1 === null ? '' : getOptionLabel(value1);
+    const label2 = value2 === null ? '' : getOptionLabel(value2);
+    return label1 === label2;
+  };
+
   const checkHighlightedOptionExists = () => {
     if (
       highlightedIndexRef.current !== -1 &&
@@ -472,7 +478,7 @@ export default function useAutocomplete(props) {
       (multiple
         ? value.length === previousProps.value.length &&
           previousProps.value.every((val, i) => getOptionLabel(value[i]) === getOptionLabel(val))
-        : getOptionLabel(previousProps.value ?? '') === getOptionLabel(value ?? ''))
+        : isSameValue(previousProps.value, value))
     ) {
       const previousHighlightedOption = previousProps.filteredOptions[highlightedIndexRef.current];
 

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
@@ -366,4 +366,48 @@ describe('useAutocomplete', () => {
       fireEvent.click(button);
     }).not.to.throw();
   });
+
+  it('should call getOptionLabel only with existing options on filtered options change', () => {
+    function Test(props) {
+      const { options, getOptionLabel, filtered } = props;
+      const {
+        groupedOptions,
+        getRootProps,
+        getInputLabelProps,
+        getInputProps,
+        getListboxProps,
+        getOptionProps,
+      } = useAutocomplete({
+        options,
+        getOptionLabel,
+        filterOptions: (list) => list.filter((option) => filtered.includes(option)),
+        filterSelectedOptions: true,
+        autoHighlight: true,
+        open: true,
+      });
+
+      return (
+        <div>
+          <div {...getRootProps()}>
+            <label {...getInputLabelProps()}>useAutocomplete</label>
+            <input {...getInputProps()} />
+          </div>
+          <ul {...getListboxProps()}>
+            {groupedOptions.map((option, index) => {
+              return <li {...getOptionProps({ option, index })}>{option}</li>;
+            })}
+          </ul>
+        </div>
+      );
+    }
+
+    const getOptionLabel = spy((x) => x);
+    const options = ['foo', 'bar'];
+
+    const { setProps } = render(<Test {...{ getOptionLabel, options }} filtered={options} />);
+    setProps({ filtered: options.slice(1) }); // filter out some options
+
+    const calledOptions = getOptionLabel.getCalls().map(({ args: [option] }) => option);
+    expect(options).to.include.members(calledOptions);
+  });
 });

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
@@ -366,47 +366,4 @@ describe('useAutocomplete', () => {
       fireEvent.click(button);
     }).not.to.throw();
   });
-
-  it('should call getOptionLabel when computing highlight', () => {
-    function Test(props) {
-      const { options, getOptionLabel, open } = props;
-      const {
-        groupedOptions,
-        getRootProps,
-        getInputLabelProps,
-        getInputProps,
-        getListboxProps,
-        getOptionProps,
-      } = useAutocomplete({
-        options,
-        getOptionLabel,
-        autoHighlight: true,
-        open,
-      });
-
-      return (
-        <div>
-          <div {...getRootProps()}>
-            <label {...getInputLabelProps()}>useAutocomplete</label>
-            <input {...getInputProps()} />
-          </div>
-          <ul {...getListboxProps()}>
-            {groupedOptions.map((option, index) => {
-              return <li {...getOptionProps({ option, index })}>{option}</li>;
-            })}
-          </ul>
-        </div>
-      );
-    }
-
-    const getOptionLabel = spy((x) => x);
-    const options = ['foo', 'bar'];
-
-    const { setProps } = render(<Test options={options} getOptionLabel={getOptionLabel} open />);
-    setProps({ open: false });
-    setProps({ open: true });
-
-    const calledOptions = getOptionLabel.getCalls().map(({ args: [option] }) => option);
-    expect(options).to.include.members(calledOptions);
-  });
 });

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.test.js
@@ -367,9 +367,9 @@ describe('useAutocomplete', () => {
     }).not.to.throw();
   });
 
-  it('should call getOptionLabel only with existing options on filtered options change', () => {
+  it('should call getOptionLabel when computing highlight', () => {
     function Test(props) {
-      const { options, getOptionLabel, filtered } = props;
+      const { options, getOptionLabel, open } = props;
       const {
         groupedOptions,
         getRootProps,
@@ -380,10 +380,8 @@ describe('useAutocomplete', () => {
       } = useAutocomplete({
         options,
         getOptionLabel,
-        filterOptions: (list) => list.filter((option) => filtered.includes(option)),
-        filterSelectedOptions: true,
         autoHighlight: true,
-        open: true,
+        open,
       });
 
       return (
@@ -404,8 +402,9 @@ describe('useAutocomplete', () => {
     const getOptionLabel = spy((x) => x);
     const options = ['foo', 'bar'];
 
-    const { setProps } = render(<Test {...{ getOptionLabel, options }} filtered={options} />);
-    setProps({ filtered: options.slice(1) }); // filter out some options
+    const { setProps } = render(<Test options={options} getOptionLabel={getOptionLabel} open />);
+    setProps({ open: false });
+    setProps({ open: true });
 
     const calledOptions = getOptionLabel.getCalls().map(({ args: [option] }) => option);
     expect(options).to.include.members(calledOptions);

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -1975,6 +1975,25 @@ describe('Joy <Autocomplete />', () => {
       });
       expect(textbox).to.have.property('value', 'a');
     });
+
+    it('should not throw error when nested options are provided', () => {
+      const { getByRole } = render(
+        <Autocomplete
+          openOnFocus
+          autoHighlight
+          options={[
+            { property: { name: 'one' } },
+            { property: { name: 'two' } },
+            { property: { name: 'three' } },
+          ]}
+          getOptionLabel={(option) => option.property.name}
+        />,
+      );
+
+      expect(() => {
+        fireEvent.focus(getByRole('combobox'));
+      }).not.to.throw();
+    });
   });
 
   describe('prop: onHighlightChange', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2418,6 +2418,26 @@ describe('<Autocomplete />', () => {
       });
       expect(textbox).to.have.property('value', 'a');
     });
+
+    it('should not call getOptionLabel with unknown values when computing highlight', () => {
+      const { getByRole } = render(
+        <Autocomplete
+          openOnFocus
+          autoHighlight
+          options={[
+            { property: { name: 'one' } },
+            { property: { name: 'two' } },
+            { property: { name: 'three' } },
+          ]}
+          getOptionLabel={(option) => option.property.name}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+
+      expect(() => {
+        fireEvent.focus(getByRole('combobox'));
+      }).not.to.throw();
+    });
   });
 
   describe('prop: fullWidth', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2419,7 +2419,7 @@ describe('<Autocomplete />', () => {
       expect(textbox).to.have.property('value', 'a');
     });
 
-    it('should not call getOptionLabel with unknown values when computing highlight', () => {
+    it('should not throw error when nested options are provided', () => {
       const { getByRole } = render(
         <Autocomplete
           openOnFocus


### PR DESCRIPTION
The `getOptionLabel` prop shouldn't be called with fallback values, as it will not match the TypeScript's contract for generic `getOptionLabel` value.

Fixes #36045

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Before: https://codesandbox.io/s/angry-tree-2jcp3o?file=/src/App.tsx

After: https://codesandbox.io/s/frosty-tdd-euyttl?file=/src/App.tsx