### PR TITLE
[Stepper] Add missing state classes for `Step` and `StepLabel` components

### DIFF
--- a/docs/pages/material-ui/api/step.json
+++ b/docs/pages/material-ui/api/step.json
@@ -18,8 +18,20 @@
   },
   "name": "Step",
   "styles": {
-    "classes": ["root", "horizontal", "vertical", "alternativeLabel", "completed"],
-    "globalClasses": { "completed": "Mui-completed" },
+    "classes": [
+      "root",
+      "horizontal",
+      "vertical",
+      "alternativeLabel",
+      "active",
+      "completed",
+      "disabled"
+    ],
+    "globalClasses": {
+      "active": "Mui-active",
+      "completed": "Mui-completed",
+      "disabled": "Mui-disabled"
+    },
     "name": "MuiStep"
   },
   "spread": true,

--- a/docs/translations/api-docs/step/step.json
+++ b/docs/translations/api-docs/step/step.json
@@ -29,10 +29,20 @@
       "nodeName": "the root element",
       "conditions": "<code>alternativeLabel={true}</code>"
     },
+    "active": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>active={true}</code>"
+    },
     "completed": {
       "description": "State class applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>completed={true}</code>"
+    },
+    "disabled": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>disabled={true}</code>"
     }
   }
 }

--- a/packages/mui-material/src/Step/Step.js
+++ b/packages/mui-material/src/Step/Step.js
@@ -10,10 +10,17 @@ import styled from '../styles/styled';
 import { getStepUtilityClass } from './stepClasses';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, orientation, alternativeLabel, completed } = ownerState;
+  const { classes, orientation, alternativeLabel, active, completed, disabled } = ownerState;
 
   const slots = {
-    root: ['root', orientation, alternativeLabel && 'alternativeLabel', completed && 'completed'],
+    root: [
+      'root',
+      orientation,
+      alternativeLabel && 'alternativeLabel',
+      active && 'active',
+      completed && 'completed',
+      disabled && 'disabled',
+    ],
   };
 
   return composeClasses(slots, getStepUtilityClass, classes);

--- a/packages/mui-material/src/Step/Step.test.js
+++ b/packages/mui-material/src/Step/Step.test.js
@@ -121,4 +121,45 @@ describe('<Step />', () => {
       expect(stepLabels[1]).to.have.class(stepLabelClasses.disabled);
     });
   });
+
+  describe('reflects props in classNames', () => {
+    it('renders with "active" className when active', () => {
+      const { container } = render(
+        <Step active>
+          <StepLabel>Step 1</StepLabel>
+        </Step>,
+      );
+
+      const root = container.querySelector(`.${classes.root}`);
+      const label = container.querySelector(`.${stepLabelClasses.root}`);
+      expect(root).to.have.class(classes.active);
+      expect(label).to.have.class(stepLabelClasses.active);
+    });
+
+    it('renders with "completed" className when completed', () => {
+      const { container } = render(
+        <Step completed>
+          <StepLabel>Step 1</StepLabel>
+        </Step>,
+      );
+
+      const root = container.querySelector(`.${classes.root}`);
+      const label = container.querySelector(`.${stepLabelClasses.root}`);
+      expect(root).to.have.class(classes.completed);
+      expect(label).to.have.class(stepLabelClasses.completed);
+    });
+
+    it('renders with "disabled" className when disabled', () => {
+      const { container } = render(
+        <Step disabled>
+          <StepLabel>Step 1</StepLabel>
+        </Step>,
+      );
+
+      const root = container.querySelector(`.${classes.root}`);
+      const label = container.querySelector(`.${stepLabelClasses.root}`);
+      expect(root).to.have.class(classes.disabled);
+      expect(label).to.have.class(stepLabelClasses.disabled);
+    });
+  });
 });

--- a/packages/mui-material/src/Step/stepClasses.ts
+++ b/packages/mui-material/src/Step/stepClasses.ts
@@ -10,8 +10,12 @@ export interface StepClasses {
   vertical: string;
   /** Styles applied to the root element if `alternativeLabel={true}`. */
   alternativeLabel: string;
+  /** State class applied to the root element if `active={true}`. */
+  active: string;
   /** State class applied to the root element if `completed={true}`. */
   completed: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
 }
 
 export type StepClassKey = keyof StepClasses;
@@ -25,7 +29,9 @@ const stepClasses: StepClasses = generateUtilityClasses('MuiStep', [
   'horizontal',
   'vertical',
   'alternativeLabel',
+  'active',
   'completed',
+  'disabled',
 ]);
 
 export default stepClasses;

--- a/packages/mui-material/src/StepLabel/StepLabel.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.js
@@ -16,6 +16,8 @@ const useUtilityClasses = (ownerState) => {
     root: [
       'root',
       orientation,
+      active && 'active',
+      completed && 'completed',
       error && 'error',
       disabled && 'disabled',
       alternativeLabel && 'alternativeLabel',

--- a/packages/mui-material/src/StepLabel/StepLabel.test.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.test.js
@@ -86,6 +86,17 @@ describe('<StepLabel />', () => {
   });
 
   describe('<Step /> prop: active', () => {
+    it('renders <StepLabel> with the className active', () => {
+      const { container } = render(
+        <Step active>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
+      );
+
+      const root = container.querySelector(`.${classes.root}`);
+      expect(root).to.have.class(classes.active);
+    });
+
     it('renders <Typography> with the className active', () => {
       const { container } = render(
         <Step active>
@@ -123,6 +134,17 @@ describe('<StepLabel />', () => {
   });
 
   describe('<Step /> prop: completed', () => {
+    it('renders <StepLabel> with the className completed', () => {
+      const { container } = render(
+        <Step completed>
+          <StepLabel>Step One</StepLabel>
+        </Step>,
+      );
+
+      const root = container.querySelector(`.${classes.root}`);
+      expect(root).to.have.class(classes.active);
+    });
+
     it('renders <Typography> with the className completed', () => {
       const { container } = render(
         <Step completed>


### PR DESCRIPTION
add `active`, `disabled` classes for `Step` component, add `active` class for `StepLabel` root, update tests

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I have tested this fix locally and also tested using a preview package on CodeSandbox.

Some additional stuff to previously closed issues https://github.com/mui/material-ui/issues/33410
