### PR TITLE
[website] Add job listing for Technical Writer role

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -209,6 +209,12 @@ const openRolesData = [
           'You will build a thriving and connected developer community around our suite of products.',
         url: '/careers/developer-advocate/',
       },
+      {
+        title: 'Technical Writer',
+        description:
+          'You will own the documentation and technical content strategy for our products.',
+        url: '/careers/technical-writer/',
+      },
     ],
   },
   {

--- a/docs/pages/careers/technical-writer.js
+++ b/docs/pages/careers/technical-writer.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
+import * as pageProps from 'docs/src/pages/careers/technical-writer.md?@mui/markdown';
+
+export default function Page() {
+  return <TopLayoutCareers {...pageProps} />;
+}

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -27,7 +27,7 @@ For additional details about the MUI team and culture, you can check our [career
 
 ## Why we're hiring
 
-Our documentation is crucial to the success of our products, and until recently, there has not been a unifying editorial strategy behind what gets published.
+Our documentation is crucial to the success of our products, and until recently, there has not been a unifying editorial strategy behind how our docs get published.
 This means we have a massive backlog of existing technical content to be audited and revised.
 Your mission will be to be to own the vision and strategy for our docs.
 We are looking for someone who can contribute to the following outcomes:
@@ -46,7 +46,7 @@ We are looking for an experienced writer-developer to join us as a Technical Wri
 ### Why this is interesting
 
 Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month.
-As the next hire for our Developer Experience team, you will work closely with our Developer Advocate to collaborate on educational resources, and oversee the publishing of new docs written by our engineers.
+As the next hire for our Developer Experience team, you will work closely with our Developer Advocate to collaborate on educational resources, and oversee the editing and publishing of new docs written by our engineers across all product teams.
 You could have a big impact in this role if you bring a solid vision for the documentation experience.
 There is an endless number of improvements to be made by a competent editor and strategist.
 
@@ -88,12 +88,13 @@ For the right candidate:
 - You are fluent in English (both written and spoken) and have a strong portfolio of published technical content.
 - You are passionate about helping other developers solve problems and have an educational mindset.
 - You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
-- Engineering background: you should be comfortable building React component demos from scratch to illustrate key concepts in the docs.
+- You should be comfortable building React component demos from scratch to illustrate key concepts in the docs.
 - You are passionate about UI development.
 
 ### What would be nice if you had, but isn't required
 
 - Experience as an editor or content lead.
+- Experience as a front-end developer.
 - Experience working with open-source.
 - Experience using MUI.
 

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -87,8 +87,7 @@ For the right candidate:
 
 - You are fluent in English (both written and spoken) and have a strong portfolio of published technical content.
 - You are passionate about helping other developers solve problems and have an educational mindset.
-- You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
-- You should be comfortable building React component demos from scratch to illustrate key concepts in the docs.
+- You are comfortable building React component demos from scratch to illustrate key concepts in the docs.
 - You are passionate about UI development.
 
 ### What would be nice if you had, but isn't required

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -1,0 +1,113 @@
+# Technical Writer
+
+<p class="description">You will own the documentation and technical content strategy for our suite of products.</p>
+
+## Details of the Role
+
+Location: Remote (strong requirement for UTC-8 to UTC+2).
+
+Type of work: Full-time (contractor or employee depending on circumstances).
+
+We're a remote company, we prefer asynchronous communication over meetings.
+
+We work independently, the rest of us won't know what you're doing day-to-day unless you tell us.
+
+## About the company
+
+MUI started with Material UI, the most successful React implementation of Google's Material Design. We have gained a large following, thanks to our focus on Material Design fidelity, our obsession with details, on offering a large number of components, our community engagement, and by carefully improving the DX. Today, countless teams and organizations rely on our open-source libraries to build their design system.
+
+A couple of years ago, we started to expand our suite of products. We released MUI X, a collection of advanced components; MUI Design kits, the MUI components available for Figma, Sketch, etc.; and also host Templates, a set of pre-built UI kits. We've seen rapid growth with all of them (2-3x per year) and we have more to come. We are building a low-code platform for developers to significantly increase the speed and lower the barrier for creating simple CRUD/dashboard UIs with MUI.
+
+We are a fully distributed team, spread across multiple time zones. We work mainly asynchronously, relying mostly on written collaboration. Every contributor has the freedom to define how they work — the rest of us won't know what you're doing day-to-day unless you tell us. For additional details about the MUI team and culture, you can check our careers and about pages and also our public Handbook.
+
+## Why we're hiring
+
+Our documentation is crucial to the success of our products, and until now, there has never been a unifying editorial strategy. Your mission will be to be to own the vision, strategy, and execution of our docs. We are looking for someone who can contribute to the following outcomes:
+
+Bring consistent style, structure, formatting, and information architecture to the documentation—both new and existing.
+
+Improve the overall developer experience by contributing to the docs infrastructure.
+
+Make our docs more beginner-friendly by suggesting and creating new technical guides to help users succeed.
+
+Both our open-source community and our premium products are growing fast (x2 YoY). We need talented people to keep that going!
+
+## About the role
+
+We are looking for an experienced writer-developer to join us as a Technical Writer to lead documentation projects.
+
+Why this is interesting
+
+Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month. There is an endless number of improvements to be made by a competent editor and strategist.
+
+### What you'll do on a day-to-day basis
+
+Depending on the day, you'll work on:
+
+Content.
+
+Revise and expand existing product documentation for consistency and comprehensiveness.
+
+Review and edit new docs from engineers as they're written.
+
+Create new documentation and technical guides as needed.
+
+Contribute to the company blog and oversee the editorial calendar.
+
+Community.
+
+Work with the open source community to bring docs contributions up to MUI's standards.
+
+Find freelance writers to work with to publish more technical content.
+
+Technical.
+
+Write code where required to support how-to content and blog posts.
+
+Create inspiring sample applications, documentation, and tutorials.
+
+Follow GitHub issues to understand where developers face frustration with our docs and develop strategies to overcome these. This could be suggesting or implementing documentation updates, or proposing or contributing code changes that solve the core issue.
+
+For the right candidate:
+
+Working with the Leadership to construct and execute on a hiring plan to grow the Developer Experience team.
+
+Here are a few initiatives you might work on
+
+Edit and revise the Material UI component documentation
+
+Create a docs portal / "how to use our docs" section for info shared across all MUI products.
+
+Start a writer's program to solicit technical content from the community.
+
+Create a learning section in the documentation for written tutorials.
+
+Own the Algolia search experience, improving the content on the most frequent search queries.
+
+Analyze user feedback on the docs to prioritize and delegate improvements where needed.
+
+## About you
+
+### Skills you should have
+
+You are fluent in English (both written and spoken) and have a strong portfolio of published technical writing.
+
+You are passionate about helping other developers solve problems and have an educational mindset.
+
+You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
+
+Engineering background: you should be comfortable building React component demos from scratch to illustrate key concepts in the docs.
+
+You are passionate about UI development.
+
+### What would be nice if you had, but isn't required
+
+Experience as an editor or content lead.
+
+Experience working with open-source.
+
+Experience using MUI.
+
+## Benefits & Compensation
+
+Competitive compensation depending on the profile and location. We are ready to pay top market rates for a person that can clearly exceed the role's expectations. You can find the other perks & benefits on the careers page.

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -27,7 +27,7 @@ For additional details about the MUI team and culture, you can check our [career
 
 ## Why we're hiring
 
-Our documentation is crucial to the success of our products, and until now, there has never been a unifying editorial strategy behind what gets published.
+Our documentation is crucial to the success of our products, and until recently, there has not been a unifying editorial strategy behind what gets published.
 Your mission will be to be to own the vision and strategy for our docs.
 We are looking for someone who can contribute to the following outcomes:
 

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -77,7 +77,7 @@ For the right candidate:
 - Write the MUI Toolpad documentation.
 - Create a docs portal for information shared across all MUI products.
 - Start a writer's program to solicit technical content from the community.
-- Create a learning section in the documentation for written tutorials.
+- Create a learning hub in the documentation for tutorials.
 - Own the Algolia search experience, improving the content on the most frequent search queries.
 - Analyze user feedback on the docs to prioritize and delegate improvements where needed.
 

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -46,7 +46,7 @@ We are looking for an experienced writer-developer to join us as a Technical Wri
 ### Why this is interesting
 
 Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month.
-As the next hire for our Developer Experience team, you will work closely with our Developer Advocate to collaborate on educational resources for developers.
+As the next hire for our Developer Experience team, you will work closely with our Developer Advocate to collaborate on educational resources, and oversee the publishing of new docs written by our engineers.
 You could have a big impact in this role if you bring a solid vision for the documentation experience.
 There is an endless number of improvements to be made by a competent editor and strategist.
 

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -28,14 +28,14 @@ For additional details about the MUI team and culture, you can check our [career
 ## Why we're hiring
 
 Our documentation is crucial to the success of our products, and until now, there has never been a unifying editorial strategy behind what gets published.
-Your mission will be to be to own the vision and strategy for our docs. 
+Your mission will be to be to own the vision and strategy for our docs.
 We are looking for someone who can contribute to the following outcomes:
 
 - Implement consistent and high-quality style, structure, formatting, and information architecture across the docs.
 - Improve the developer experience by contributing to the docs infrastructure.
 - Help make our docs more beginner-friendly by creating new technical content.
 
-Both our open-source community and our premium products are growing fast (x2 YoY). 
+Both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 
 ## About the role
@@ -44,77 +44,62 @@ We are looking for an experienced writer-developer to join us as a Technical Wri
 
 ### Why this is interesting
 
-Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month. 
+Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month.
+As the next hire for our Developer Experience team, you will work closely with our Developer Advocate to collaborate on educational resources for developers.
+You could have a massive impact in this role if you bring a solid vision for the documentation experience.
 There is an endless number of improvements to be made by a competent editor and strategist.
 
 ### What you'll do on a day-to-day basis
 
 Depending on the day, you'll work on:
 
-Content.
-
-Revise and expand existing product documentation for consistency and comprehensiveness.
-
-Review and edit new docs from engineers as they're written.
-
-Create new documentation and technical guides as needed.
-
-Contribute to the company blog and oversee the editorial calendar.
-
-Community.
-
-Work with the open source community to bring docs contributions up to MUI's standards.
-
-Find freelance writers to work with to publish more technical content.
-
-Technical.
-
-Write code where required to support how-to content and blog posts.
-
-Create inspiring sample applications, documentation, and tutorials.
-
-Follow GitHub issues to understand where developers face frustration with our docs and develop strategies to overcome these. This could be suggesting or implementing documentation updates, or proposing or contributing code changes that solve the core issue.
+- **Content**.
+  - Revise and expand existing product documentation for consistency and comprehensiveness.
+  - Review and edit new docs from engineers as they're written.
+  - Create new documentation and technical guides as needed.
+  - Contribute to the company blog and oversee the editorial calendar.
+- **Community**.
+  - Work with the open source community to solicit docs contributions and bring them up to MUI's standards.
+  - Find freelance writers to work with to publish more technical content.
+- **Technical**.
+  - Write code where required to support how-to content and blog posts.
+  - Create inspiring sample applications, documentation, and tutorials.
+  - Follow GitHub issues to understand where developers face frustrations with our docs and develop strategies to overcome these.
 
 For the right candidate:
 
-Working with the Leadership to construct and execute on a hiring plan to grow the Developer Experience team.
+- Working with the Leadership to construct and execute on a hiring plan to grow the Developer Experience team.
 
-Here are a few initiatives you might work on
+### Here are a few initiatives you might work on
 
-Edit and revise the Material UI component documentation
-
-Create a docs portal / "how to use our docs" section for info shared across all MUI products.
-
-Start a writer's program to solicit technical content from the community.
-
-Create a learning section in the documentation for written tutorials.
-
-Own the Algolia search experience, improving the content on the most frequent search queries.
-
-Analyze user feedback on the docs to prioritize and delegate improvements where needed.
+- Edit and revise the Material UI and MUI X documentation.
+- Write the MUI Toolpad documentation.
+- Create a docs portal for information shared across all MUI products.
+- Start a writer's program to solicit technical content from the community.
+- Create a learning section in the documentation for written tutorials.
+- Own the Algolia search experience, improving the content on the most frequent search queries.
+- Analyze user feedback on the docs to prioritize and delegate improvements where needed.
 
 ## About you
 
 ### Skills you should have
 
-You are fluent in English (both written and spoken) and have a strong portfolio of published technical writing.
-
-You are passionate about helping other developers solve problems and have an educational mindset.
-
-You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
-
-Engineering background: you should be comfortable building React component demos from scratch to illustrate key concepts in the docs.
-
-You are passionate about UI development.
+- You are fluent in English (both written and spoken) and have a strong portfolio of published technical content.
+- You are passionate about helping other developers solve problems and have an educational mindset.
+- You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
+- Engineering background: you should be comfortable building React component demos from scratch to illustrate key concepts in the docs.
+- You are passionate about UI development.
 
 ### What would be nice if you had, but isn't required
 
-Experience as an editor or content lead.
-
-Experience working with open-source.
-
-Experience using MUI.
+- Experience as an editor or content lead.
+- Experience working with open-source.
+- Experience using MUI.
 
 ## Benefits & Compensation
 
 Competitive compensation depending on the profile and location. We are ready to pay top market rates for a person that can clearly exceed the role's expectations. You can find the other perks & benefits on the careers page.
+
+## How to apply?
+
+[Apply now for this position 📮](link-to-role)

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -28,6 +28,7 @@ For additional details about the MUI team and culture, you can check our [career
 ## Why we're hiring
 
 Our documentation is crucial to the success of our products, and until recently, there has not been a unifying editorial strategy behind what gets published.
+This means we have a massive backlog of existing technical content to be audited and revised.
 Your mission will be to be to own the vision and strategy for our docs.
 We are looking for someone who can contribute to the following outcomes:
 
@@ -46,7 +47,7 @@ We are looking for an experienced writer-developer to join us as a Technical Wri
 
 Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month.
 As the next hire for our Developer Experience team, you will work closely with our Developer Advocate to collaborate on educational resources for developers.
-You could have a massive impact in this role if you bring a solid vision for the documentation experience.
+You could have a big impact in this role if you bring a solid vision for the documentation experience.
 There is an endless number of improvements to be made by a competent editor and strategist.
 
 ### What you'll do on a day-to-day basis

--- a/docs/src/pages/careers/technical-writer.md
+++ b/docs/src/pages/careers/technical-writer.md
@@ -4,41 +4,48 @@
 
 ## Details of the Role
 
-Location: Remote (strong requirement for UTC-8 to UTC+2).
-
-Type of work: Full-time (contractor or employee depending on circumstances).
-
-We're a remote company, we prefer asynchronous communication over meetings.
-
-We work independently, the rest of us won't know what you're doing day-to-day unless you tell us.
+- Location: Remote (strong requirement for UTC-8 to UTC+2).
+- Type of work: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501#494af1f358794028beb4b7697b5d3102)).
+- We're a remote company, we prefer asynchronous communication over meetings.
+- We work independently, the rest of us won't know what you're doing day-to-day unless you tell us.
 
 ## About the company
 
-MUI started with Material UI, the most successful React implementation of Google's Material Design. We have gained a large following, thanks to our focus on Material Design fidelity, our obsession with details, on offering a large number of components, our community engagement, and by carefully improving the DX. Today, countless teams and organizations rely on our open-source libraries to build their design system.
+MUI started with Material UI, the most successful React implementation of Google's Material Design.
+We have gained a large following, thanks to our focus on Material Design fidelity, our obsession with details, on offering a large number of components, our community engagement, and by carefully improving the DX.
+Today, countless teams and organizations rely on our open-source libraries to build their design system.
 
-A couple of years ago, we started to expand our suite of products. We released MUI X, a collection of advanced components; MUI Design kits, the MUI components available for Figma, Sketch, etc.; and also host Templates, a set of pre-built UI kits. We've seen rapid growth with all of them (2-3x per year) and we have more to come. We are building a low-code platform for developers to significantly increase the speed and lower the barrier for creating simple CRUD/dashboard UIs with MUI.
+A couple of years ago, we started to expand our suite of products.
+We released [MUI X](/x/), a collection of advanced components; [MUI Design kits](/design-kits/), the MUI components available for Figma, Sketch, etc.; and also host [Templates](/templates/), a set of pre-built UI kits.
+We've seen rapid growth with all of them (2-3x per year) and we have more to come.
+We are building [a low-code platform](https://mui.com/toolpad/) for developers to significantly increase the speed and lower the barrier for creating simple CRUD/dashboard UIs with MUI.
 
-We are a fully distributed team, spread across multiple time zones. We work mainly asynchronously, relying mostly on written collaboration. Every contributor has the freedom to define how they work — the rest of us won't know what you're doing day-to-day unless you tell us. For additional details about the MUI team and culture, you can check our careers and about pages and also our public Handbook.
+We are a fully distributed team, spread across multiple time zones.
+We work mainly asynchronously, relying mostly on written collaboration.
+Every contributor has the freedom to define how they work — the rest of us won't know what you're doing day-to-day unless you tell us.
+For additional details about the MUI team and culture, you can check our [careers](/careers/) and [about](/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 
-Our documentation is crucial to the success of our products, and until now, there has never been a unifying editorial strategy. Your mission will be to be to own the vision, strategy, and execution of our docs. We are looking for someone who can contribute to the following outcomes:
+Our documentation is crucial to the success of our products, and until now, there has never been a unifying editorial strategy behind what gets published.
+Your mission will be to be to own the vision and strategy for our docs. 
+We are looking for someone who can contribute to the following outcomes:
 
-Bring consistent style, structure, formatting, and information architecture to the documentation—both new and existing.
+- Implement consistent and high-quality style, structure, formatting, and information architecture across the docs.
+- Improve the developer experience by contributing to the docs infrastructure.
+- Help make our docs more beginner-friendly by creating new technical content.
 
-Improve the overall developer experience by contributing to the docs infrastructure.
-
-Make our docs more beginner-friendly by suggesting and creating new technical guides to help users succeed.
-
-Both our open-source community and our premium products are growing fast (x2 YoY). We need talented people to keep that going!
+Both our open-source community and our premium products are growing fast (x2 YoY). 
+We need talented people to keep that going!
 
 ## About the role
 
 We are looking for an experienced writer-developer to join us as a Technical Writer to lead documentation projects.
 
-Why this is interesting
+### Why this is interesting
 
-Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month. There is an endless number of improvements to be made by a competent editor and strategist.
+Our solutions empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month. 
+There is an endless number of improvements to be made by a competent editor and strategist.
 
 ### What you'll do on a day-to-day basis
 


### PR DESCRIPTION
This PR adds a listing for the Technical Writer role that we've been discussing internally. This person would potentially be the next hire on the DevEx team, and they would take over for me as the primary editor of the MUI docs and blog. The thought is that this position might be easier to hire for than a second Developer Advocate, and it would free me up to focus on other tasks that are uniquely suited to the advocate role, like multimedia educational content and community building.

Preview: https://deploy-preview-36099--material-ui.netlify.app/careers/technical-writer/