### PR TITLE
[docs] Correct the version, MUI X is in beta

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -456,7 +456,7 @@ export default function AppNavDrawer(props) {
               versionSelector={renderVersionSelector([
                 // DATA_GRID_VERSION is set from the X repo
                 {
-                  text: 'v6-alpha',
+                  text: 'v6-beta',
                   ...(process.env.DATA_GRID_VERSION.startsWith('6')
                     ? {
                         text: `v${process.env.DATA_GRID_VERSION}`,
@@ -495,7 +495,7 @@ export default function AppNavDrawer(props) {
                         current: true,
                       }
                     : {
-                        text: `v6-alpha`,
+                        text: `v6-beta`,
                         href: `https://next.mui.com${languagePrefix}/components/data-grid/`,
                       }),
                 },


### PR DESCRIPTION
Help boost the adoption and to fix the inconsistency in https://mui.com/x/react-data-grid/ 

<img width="328" alt="Screenshot 2023-02-08 at 00 02 01" src="https://user-images.githubusercontent.com/3165635/217386555-67bb1326-4024-452a-9447-f500a4bc33b6.png">

We say it's a beta and an alpha at the same time #36074.