### PR TITLE
[docs] Rename `v6-alpha` to `v6-next` in navigation

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -456,7 +456,7 @@ export default function AppNavDrawer(props) {
               versionSelector={renderVersionSelector([
                 // DATA_GRID_VERSION is set from the X repo
                 {
-                  text: 'v6-alpha',
+                  text: 'v6-next',
                   ...(process.env.DATA_GRID_VERSION.startsWith('6')
                     ? {
                         text: `v${process.env.DATA_GRID_VERSION}`,
@@ -495,7 +495,7 @@ export default function AppNavDrawer(props) {
                         current: true,
                       }
                     : {
-                        text: `v6-alpha`,
+                        text: `v6-next`,
                         href: `https://next.mui.com${languagePrefix}/components/data-grid/`,
                       }),
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

We are already on `beta`, having `v6-alpha` on navigation no longer makes sense.
