### PR TITLE
[Joy] Fix modal dialog overflow viewport

### DIFF
--- a/docs/data/joy/components/divider/divider.md
+++ b/docs/data/joy/components/divider/divider.md
@@ -70,7 +70,7 @@ To control the position of the content, override the CSS variable `--Divider-chi
 
 ## Automatic adjustment
 
-When the `Divider` is a direct child of either a [Card](/joy-ui/react-card/) or [ModalDialog](/joy-ui/react-modal/#dialog), it will automatically adapt to their spacing and orientation.
+When the `Divider` is a direct child of either a [Card](/joy-ui/react-card/) or [ModalDialog](/joy-ui/react-modal/#modal-dialog), it will automatically adapt to their spacing and orientation.
 
 ### Card
 

--- a/docs/data/joy/components/modal/DialogVerticalScroll.js
+++ b/docs/data/joy/components/modal/DialogVerticalScroll.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import Button from '@mui/joy/Button';
+import List from '@mui/joy/List';
+import ListItem from '@mui/joy/ListItem';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import Switch from '@mui/joy/Switch';
+import Modal from '@mui/joy/Modal';
+import ModalDialog from '@mui/joy/ModalDialog';
+import ModalClose from '@mui/joy/ModalClose';
+import Typography from '@mui/joy/Typography';
+import Stack from '@mui/joy/Stack';
+
+export default function DialogVerticalScroll() {
+  const [open, setOpen] = React.useState('');
+  const [scroll, setScroll] = React.useState(true);
+  return (
+    <React.Fragment>
+      <Stack direction="row" spacing={1}>
+        <Button variant="outlined" color="neutral" onClick={() => setOpen('center')}>
+          Center
+        </Button>
+        <Button
+          variant="outlined"
+          color="neutral"
+          onClick={() => setOpen('fullscreen')}
+        >
+          Full screen
+        </Button>
+      </Stack>
+      <Modal open={!!open} onClose={() => setOpen('')}>
+        <ModalDialog
+          aria-labelledby="dialog-vertical-scroll-title"
+          aria-describedby="dialog-vertical-scroll-description"
+          layout={open || undefined}
+        >
+          <ModalClose />
+          <Typography id="dialog-vertical-scroll-title" component="h2">
+            Vertical scroll example
+          </Typography>
+          <FormControl
+            orientation="horizontal"
+            sx={{ bgcolor: 'background.level2', p: 1, borderRadius: 'sm' }}
+          >
+            <FormLabel>Container overflow</FormLabel>
+            <Switch
+              checked={scroll}
+              onChange={(event) => setScroll(event.target.checked)}
+              sx={{ ml: 'auto' }}
+            />
+          </FormControl>
+          <List
+            sx={{
+              overflow: scroll ? 'scroll' : 'initial',
+              mx: 'calc(-1 * var(--ModalDialog-padding))',
+              px: 'var(--ModalDialog-padding)',
+            }}
+          >
+            {[...Array(100)].map((item, index) => (
+              <ListItem key={index}>I&apos;m in a scrollable area.</ListItem>
+            ))}
+          </List>
+        </ModalDialog>
+      </Modal>
+    </React.Fragment>
+  );
+}

--- a/docs/data/joy/components/modal/modal.md
+++ b/docs/data/joy/components/modal/modal.md
@@ -74,7 +74,7 @@ The possible values are:
 
 {{"demo": "CloseModal.js"}}
 
-### Dialog
+### Modal Dialog
 
 To create a modal dialog, renders the `ModalDialog` component inside the `Modal`.
 
@@ -147,6 +147,14 @@ The `ModalClose` and `ModalDialogTitle` inherits the size from the `ModalDialog`
 Use `role="alertdialog"` to create an [alert dialog](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/) that interrupts the user's workflow.
 
 {{"demo": "AlertDialogModal.js"}}
+
+### Vertical scroll
+
+By default, `ModalDialog` will not overflow the screen when the content is longer than the viewport.
+
+You have to apply CSS [`overflow="scroll | auto"`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow) to the content.
+
+{{"demo": "DialogVerticalScroll.js"}}
 
 ### Nested modals
 

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -89,8 +89,8 @@ const ModalDialogRoot = styled(SheetRoot, {
   ...(ownerState.layout === 'center' && {
     top: '50%',
     left: '50%',
-    transform: 'translate(-50%, max(-50%, -50vh + var(--ModalDialog-padding)))',
-    maxHeight: 'calc(100vh - 2 * var(--ModalDialog-padding))',
+    transform: 'translate(-50%, -50%)',
+    maxHeight: 'calc(94vh)',
   }),
   [`& [id="${ownerState['aria-labelledby']}"]`]: {
     '--Typography-margin': 'calc(-1 * var(--ModalDialog-titleOffset)) 0 var(--ModalDialog-gap) 0',

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -90,7 +90,7 @@ const ModalDialogRoot = styled(SheetRoot, {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxHeight: 94vh,
+    maxHeight: '94vh',
   }),
   [`& [id="${ownerState['aria-labelledby']}"]`]: {
     '--Typography-margin': 'calc(-1 * var(--ModalDialog-titleOffset)) 0 var(--ModalDialog-gap) 0',

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -90,7 +90,7 @@ const ModalDialogRoot = styled(SheetRoot, {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxHeight: 'calc(94vh)',
+    maxHeight: 94vh,
   }),
   [`& [id="${ownerState['aria-labelledby']}"]`]: {
     '--Typography-margin': 'calc(-1 * var(--ModalDialog-titleOffset)) 0 var(--ModalDialog-gap) 0',

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -90,7 +90,7 @@ const ModalDialogRoot = styled(SheetRoot, {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxHeight: '94vh',
+    maxHeight: 'calc(100% - 2 * var(--ModalDialog-padding))',
   }),
   [`& [id="${ownerState['aria-labelledby']}"]`]: {
     '--Typography-margin': 'calc(-1 * var(--ModalDialog-titleOffset)) 0 var(--ModalDialog-gap) 0',

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -76,6 +76,8 @@ const ModalDialogRoot = styled(SheetRoot, {
   minWidth: 'min(calc(100vw - 2 * var(--ModalDialog-padding)), var(--ModalDialog-minWidth, 300px))',
   outline: 0,
   position: 'absolute',
+  display: 'flex',
+  flexDirection: 'column',
   ...(ownerState.layout === 'fullscreen' && {
     top: 0,
     left: 0,
@@ -87,7 +89,8 @@ const ModalDialogRoot = styled(SheetRoot, {
   ...(ownerState.layout === 'center' && {
     top: '50%',
     left: '50%',
-    transform: 'translate(-50%, -50%)',
+    transform: 'translate(-50%, max(-50%, -50vh + var(--ModalDialog-padding)))',
+    maxHeight: 'calc(100vh - 2 * var(--ModalDialog-padding))',
   }),
   [`& [id="${ownerState['aria-labelledby']}"]`]: {
     '--Typography-margin': 'calc(-1 * var(--ModalDialog-titleOffset)) 0 var(--ModalDialog-gap) 0',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

close #36094

## Fix
Fixed by setting `maxHeight` and making the ModalDialog a flex column by default, so that the children with long content can be full height overflow

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
