### PR TITLE
[useSelect] Add return value interface

### DIFF
--- a/docs/pages/base/api/use-select.json
+++ b/docs/pages/base/api/use-select.json
@@ -1,6 +1,65 @@
 {
   "parameters": {},
-  "returnValue": {},
+  "returnValue": {
+    "buttonActive": {
+      "type": {
+        "name": "boolean",
+        "description": "If `true`, the select's button is active (pressed)."
+      },
+      "default": "false",
+      "required": true
+    },
+    "buttonFocusVisible": {
+      "type": {
+        "name": "boolean",
+        "description": "If `true`, the select's button is being focused using keyboard."
+      },
+      "default": "false",
+      "required": true
+    },
+    "disabled": {
+      "type": { "name": "boolean", "description": "If `true`, the component will be disabled." },
+      "default": "false",
+      "required": true
+    },
+    "getButtonProps": {
+      "type": {
+        "name": "<TOther extends EventHandlers>(otherHandlers?: TOther) => UseSelectButtonSlotProps<TOther>",
+        "description": "Resolver for the button slot's props."
+      },
+      "required": true
+    },
+    "getListboxProps": {
+      "type": {
+        "name": "<TOther extends EventHandlers>(otherHandlers?: TOther) => UseSelectListboxSlotProps<TOther>",
+        "description": "Resolver for the listbox slot's props."
+      },
+      "required": true
+    },
+    "getOptionProps": {
+      "type": {
+        "name": "<TOther extends EventHandlers>(option: SelectOption<TValue>, otherHandlers?: TOther) => UseSelectOptionSlotProps<TOther>",
+        "description": "Resolver for the specified option's props."
+      },
+      "required": true
+    },
+    "getOptionState": {
+      "type": {
+        "name": "(option: SelectOption<TValue>) => OptionState",
+        "description": "Resolver for the specified option's state."
+      },
+      "required": true
+    },
+    "open": {
+      "type": { "name": "boolean", "description": "If `true`, the select dropdown is open." },
+      "default": "false",
+      "required": true
+    },
+    "value": {
+      "type": { "name": "TValue | TValue[] | null", "description": "The selected value." },
+      "required": true
+    }
+  },
   "name": "useSelect",
   "filename": "/packages/mui-base/src/SelectUnstyled/useSelect.ts",
   "demos": "<ul><li><a href=\"/base/react-select/#hook\">Unstyled Select</a></li></ul>"

--- a/docs/translations/api-docs/use-select/use-select.json
+++ b/docs/translations/api-docs/use-select/use-select.json
@@ -1,1 +1,15 @@
-{ "hookDescription": "", "parametersDescriptions": {}, "returnValueDescriptions": {} }
+{
+  "hookDescription": "",
+  "parametersDescriptions": {},
+  "returnValueDescriptions": {
+    "buttonActive": "If <code>true</code>, the select's button is active (pressed).",
+    "buttonFocusVisible": "If <code>true</code>, the select's button is being focused using keyboard.",
+    "disabled": "If <code>true</code>, the component will be disabled.",
+    "getButtonProps": "Resolver for the button slot's props.",
+    "getListboxProps": "Resolver for the listbox slot's props.",
+    "getOptionProps": "Resolver for the specified option's props.",
+    "getOptionState": "Resolver for the specified option's state.",
+    "open": "If <code>true</code>, the select dropdown is open.",
+    "value": "The selected value."
+  }
+}

--- a/packages/mui-base/src/SelectUnstyled/useSelect.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.ts
@@ -13,6 +13,7 @@ import {
   UseSelectMultiResult,
   UseSelectOptionSlotProps,
   UseSelectParameters,
+  UseSelectReturnValue,
   UseSelectSingleParameters,
   UseSelectSingleResult,
 } from './useSelect.types';
@@ -38,7 +39,7 @@ function useSelect<TValue>(props: UseSelectMultiParameters<TValue>): UseSelectMu
  *
  * - [useSelect API](https://mui.com/base/api/use-select/)
  */
-function useSelect<TValue>(props: UseSelectParameters<TValue>) {
+function useSelect<TValue>(props: UseSelectParameters<TValue>): UseSelectReturnValue<TValue> {
   const {
     buttonRef: buttonRefProp,
     defaultValue,

--- a/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/useSelect.types.ts
@@ -117,3 +117,63 @@ export interface UseSelectSingleResult<TValue> extends UseSelectCommonResult<TVa
 export interface UseSelectMultiResult<TValue> extends UseSelectCommonResult<TValue> {
   value: TValue[];
 }
+
+export interface UseSelectReturnValue<TValue> {
+  /**
+   * If `true`, the select's button is active (pressed).
+   * @default false
+   */
+  buttonActive: boolean;
+  /**
+   * If `true`, the select's button is being focused using keyboard.
+   * @default false
+   */
+  buttonFocusVisible: boolean;
+  /**
+   * If `true`, the component will be disabled.
+   * @default false
+   */
+  disabled: boolean;
+  /**
+   * Resolver for the button slot's props.
+   * @param otherHandlers event handlers for the root button slot
+   * @returns props that should be spread on the root button slot
+   */
+  getButtonProps: <TOther extends EventHandlers>(
+    otherHandlers?: TOther,
+  ) => UseSelectButtonSlotProps<TOther>;
+  /**
+   * Resolver for the listbox slot's props.
+   * @param otherHandlers event handlers for the listbox slot
+   * @returns props that should be spread on the root button slot
+   */
+  getListboxProps: <TOther extends EventHandlers>(
+    otherHandlers?: TOther,
+  ) => UseSelectListboxSlotProps<TOther>;
+  /**
+   * Resolver for the specified option's props.
+   * @param option the select's option for which the props are resolved
+   * @param otherHandlers event handlers for the specified option slot
+   * @returns props that should be spread on the specified option slot
+   */
+  getOptionProps: <TOther extends EventHandlers>(
+    option: SelectOption<TValue>,
+    otherHandlers?: TOther,
+  ) => UseSelectOptionSlotProps<TOther>;
+  /**
+   * Resolver for the specified option's state.
+   * @param option the select's option which state is resolved
+   * @param otherHandlers event handlers for the specified option slot
+   * @returns props that should be spread on the specified option slot
+   */
+  getOptionState: (option: SelectOption<TValue>) => OptionState;
+  /**
+   * If `true`, the select dropdown is open.
+   * @default false
+   */
+  open: boolean;
+  /**
+   * The selected value.
+   */
+  value: TValue | TValue[] | null;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes (part of) #35933 
## Summary
Add an explicit interface for the return values of the `useSelect` hook.