### PR TITLE
[Autocomplete] Fix tag removal regression

### DIFF
--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -471,14 +471,14 @@ export default function useAutocomplete(props) {
       previousProps.filteredOptions.length !== filteredOptions.length &&
       (multiple
         ? value.length === previousProps.value.length &&
-          previousProps.value.every((val, i) => isOptionEqualToValue(value[i], val))
-        : isOptionEqualToValue(previousProps.value ?? '', value ?? ''))
+          previousProps.value.every((val, i) => getOptionLabel(value[i]) === getOptionLabel(val))
+        : getOptionLabel(previousProps.value ?? '') === getOptionLabel(value ?? ''))
     ) {
       const previousHighlightedOption = previousProps.filteredOptions[highlightedIndexRef.current];
 
       if (previousHighlightedOption) {
         const previousHighlightedOptionExists = filteredOptions.some((option) => {
-          return isOptionEqualToValue(option, previousHighlightedOption);
+          return getOptionLabel(option) === getOptionLabel(previousHighlightedOption);
         });
 
         if (previousHighlightedOptionExists) {

--- a/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
+++ b/packages/mui-base/src/AutocompleteUnstyled/useAutocomplete.js
@@ -470,14 +470,15 @@ export default function useAutocomplete(props) {
       previousProps.filteredOptions &&
       previousProps.filteredOptions.length !== filteredOptions.length &&
       (multiple
-        ? previousProps.value.every((val, i) => getOptionLabel(value[i]) === getOptionLabel(val))
-        : getOptionLabel(previousProps.value ?? '') === getOptionLabel(value ?? ''))
+        ? value.length === previousProps.value.length &&
+          previousProps.value.every((val, i) => isOptionEqualToValue(value[i], val))
+        : isOptionEqualToValue(previousProps.value ?? '', value ?? ''))
     ) {
       const previousHighlightedOption = previousProps.filteredOptions[highlightedIndexRef.current];
 
       if (previousHighlightedOption) {
         const previousHighlightedOptionExists = filteredOptions.some((option) => {
-          return getOptionLabel(option) === getOptionLabel(previousHighlightedOption);
+          return isOptionEqualToValue(option, previousHighlightedOption);
         });
 
         if (previousHighlightedOptionExists) {

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -1325,12 +1325,7 @@ describe('Joy <Autocomplete />', () => {
 
     it('should keep focus on selected option when options updates and when options are provided as objects', () => {
       const { setProps } = render(
-        <Autocomplete
-          open
-          options={[{ label: 'one' }, { label: 'two' }]}
-          autoFocus
-          isOptionEqualToValue={(option, value) => option.label === value.label}
-        />,
+        <Autocomplete open options={[{ label: 'one' }, { label: 'two' }]} autoFocus />,
       );
       const textbox = screen.getByRole('combobox');
       const listbox = screen.getByRole('listbox');

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -1325,7 +1325,12 @@ describe('Joy <Autocomplete />', () => {
 
     it('should keep focus on selected option when options updates and when options are provided as objects', () => {
       const { setProps } = render(
-        <Autocomplete open options={[{ label: 'one' }, { label: 'two' }]} autoFocus />,
+        <Autocomplete
+          open
+          options={[{ label: 'one' }, { label: 'two' }]}
+          autoFocus
+          isOptionEqualToValue={(option, value) => option.label === value.label}
+        />,
       );
       const textbox = screen.getByRole('combobox');
       const listbox = screen.getByRole('listbox');

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1667,7 +1667,6 @@ describe('<Autocomplete />', () => {
           open
           options={[{ label: 'one' }, { label: 'two' }]}
           renderInput={(params) => <TextField {...params} autoFocus />}
-          isOptionEqualToValue={(o, v) => o.label === v.label}
         />,
       );
       const textbox = screen.getByRole('combobox');
@@ -2858,7 +2857,6 @@ describe('<Autocomplete />', () => {
           disableCloseOnSelect
           filterSelectedOptions
           options={[{ label: 'one' }, { label: 'two' }, { label: 'three' }]}
-          isOptionEqualToValue={(opt, val) => opt.label === val.label}
           renderInput={(params) => <TextField {...params} autoFocus />}
         />,
       );

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2798,29 +2798,29 @@ describe('<Autocomplete />', () => {
       fireEvent.mouseDown(textbox);
       expect(screen.queryByRole('listbox')).to.equal(null);
     });
-  });
 
-  it('should not be able to delete the tag when multiple=true', () => {
-    const { container } = render(
-      <Autocomplete
-        readOnly
-        multiple
-        defaultValue={['one', 'two']}
-        options={['one', 'two', 'three']}
-        renderInput={(params) => <TextField {...params} />}
-      />,
-    );
+    it('should not be able to delete the tag when multiple=true', () => {
+      const { container } = render(
+        <Autocomplete
+          readOnly
+          multiple
+          defaultValue={['one', 'two']}
+          options={['one', 'two', 'three']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
 
-    const chip = container.querySelector(`.${chipClasses.root}`);
-    expect(chip).not.to.have.class(chipClasses.deletable);
+      const chip = container.querySelector(`.${chipClasses.root}`);
+      expect(chip).not.to.have.class(chipClasses.deletable);
 
-    const textbox = screen.getByRole('combobox');
-    act(() => {
-      textbox.focus();
+      const textbox = screen.getByRole('combobox');
+      act(() => {
+        textbox.focus();
+      });
+      expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(2);
+      fireEvent.keyDown(textbox, { key: 'Backspace' });
+      expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(2);
     });
-    expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(2);
-    fireEvent.keyDown(textbox, { key: 'Backspace' });
-    expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(2);
   });
 
   // https://github.com/mui/material-ui/issues/36114

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2825,54 +2825,56 @@ describe('<Autocomplete />', () => {
   });
 
   // https://github.com/mui/material-ui/issues/36114
-  it('should allow deleting a tag immediately after adding it while the listbox is still open', () => {
-    const { container } = render(
-      <Autocomplete
-        multiple
-        disableCloseOnSelect
-        filterSelectedOptions
-        options={['one', 'two', 'three']}
-        renderInput={(params) => <TextField {...params} autoFocus />}
-      />,
-    );
+  describe('deleting a tag immediately after adding it while the listbox is still open', () => {
+    it('should allow it, given that options are primitive values', () => {
+      const { container } = render(
+        <Autocomplete
+          multiple
+          disableCloseOnSelect
+          filterSelectedOptions
+          options={['one', 'two', 'three']}
+          renderInput={(params) => <TextField {...params} autoFocus />}
+        />,
+      );
 
-    const textbox = screen.getByRole('combobox');
+      const textbox = screen.getByRole('combobox');
 
-    fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-    fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight the first option...
-    fireEvent.keyDown(textbox, { key: 'Enter' }); // ...and select it
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight the first option...
+      fireEvent.keyDown(textbox, { key: 'Enter' }); // ...and select it
 
-    fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight another option
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight another option
 
-    expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(1);
+      expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(1);
 
-    fireEvent.keyDown(textbox, { key: 'Backspace' });
-    expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(0);
-  });
+      fireEvent.keyDown(textbox, { key: 'Backspace' });
+      expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(0);
+    });
 
-  it('should allow deleting a tag immediately after adding it while the listbox is still open 2', () => {
-    const { container } = render(
-      <Autocomplete
-        multiple
-        disableCloseOnSelect
-        filterSelectedOptions
-        options={[{ label: 'one' }, { label: 'two' }, { label: 'three' }]}
-        isOptionEqualToValue={(opt, val) => opt.label === val.label}
-        renderInput={(params) => <TextField {...params} autoFocus />}
-      />,
-    );
+    it('should allow it, given that options are objects', () => {
+      const { container } = render(
+        <Autocomplete
+          multiple
+          disableCloseOnSelect
+          filterSelectedOptions
+          options={[{ label: 'one' }, { label: 'two' }, { label: 'three' }]}
+          isOptionEqualToValue={(opt, val) => opt.label === val.label}
+          renderInput={(params) => <TextField {...params} autoFocus />}
+        />,
+      );
 
-    const textbox = screen.getByRole('combobox');
+      const textbox = screen.getByRole('combobox');
 
-    fireEvent.keyDown(textbox, { key: 'ArrowDown' });
-    fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight the first option...
-    fireEvent.keyDown(textbox, { key: 'Enter' }); // ...and select it
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight the first option...
+      fireEvent.keyDown(textbox, { key: 'Enter' }); // ...and select it
 
-    fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight another option
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' }); // highlight another option
 
-    expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(1);
+      expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(1);
 
-    fireEvent.keyDown(textbox, { key: 'Backspace' });
-    expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(0);
+      fireEvent.keyDown(textbox, { key: 'Backspace' });
+      expect(container.querySelectorAll(`.${chipClasses.root}`)).to.have.length(0);
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the regression introduced in #35735 and described in #36114.
It makes sure the options that are compared exist.

Before: https://codesandbox.io/s/recursing-snyder-ybg6m5?file=/demo.tsx
After: https://codesandbox.io/s/hardcore-einstein-yx1xwr?file=/demo.tsx
(see the linked issue for repro steps)

Fixes #36114.