### PR TITLE
[docs] Allow to pass page icon component

### DIFF
--- a/docs/src/MuiPage.ts
+++ b/docs/src/MuiPage.ts
@@ -4,6 +4,10 @@ export interface MuiPage {
   disableDrawer?: boolean;
   icon?: string;
   /**
+   * Icon component to use. Overrides `icon` if provided.
+   */
+  IconComponent?: React.ElementType;
+  /**
    * Indicates if the pages are regarding some legacy API.
    */
   legacy?: boolean;

--- a/docs/src/MuiPage.ts
+++ b/docs/src/MuiPage.ts
@@ -1,3 +1,5 @@
+import type { ElementType } from 'react';
+
 export interface MuiPage {
   pathname: string;
   children?: MuiPage[];
@@ -6,7 +8,7 @@ export interface MuiPage {
   /**
    * Icon component to use. Overrides `icon` if provided.
    */
-  IconComponent?: React.ElementType;
+  IconComponent?: ElementType;
   /**
    * Indicates if the pages are regarding some legacy API.
    */

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -241,6 +241,7 @@ function reduceChildRoutes(context) {
         newFeature={page.newFeature}
         plan={page.plan}
         icon={page.icon}
+        IconComponent={page.IconComponent}
         subheader={subheader}
         topLevel={topLevel && !page.subheader}
         openImmediately={topLevel || subheader}
@@ -268,6 +269,7 @@ function reduceChildRoutes(context) {
         newFeature={page.newFeature}
         plan={page.plan}
         icon={page.icon}
+        IconComponent={page.IconComponent}
         subheader={Boolean(page.subheader)}
         onClick={onClose}
       />,

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -17,9 +17,7 @@ import InvertColorsRoundedIcon from '@mui/icons-material/InvertColorsRounded';
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import BookRoundedIcon from '@mui/icons-material/BookRounded';
 import ChromeReaderModeRoundedIcon from '@mui/icons-material/ChromeReaderModeRounded';
-import TableViewRoundedIcon from '@mui/icons-material/TableViewRounded';
 import ScienceIcon from '@mui/icons-material/Science';
-import DateRangeRounded from '@mui/icons-material/DateRangeRounded';
 
 const iconsMap = {
   DescriptionIcon: ArticleRoundedIcon,
@@ -32,9 +30,7 @@ const iconsMap = {
   AddIcon: AddCircleRoundedIcon,
   BookIcon: BookRoundedIcon,
   ReaderIcon: ChromeReaderModeRoundedIcon,
-  TableViewIcon: TableViewRoundedIcon,
   ExperimentIcon: ScienceIcon,
-  DatePickerIcon: DateRangeRounded,
 };
 
 const Item = styled(
@@ -202,6 +198,7 @@ export default function AppNavDrawerItem(props) {
     depth,
     href,
     icon,
+    IconComponent: IconComponentProp,
     legacy,
     newFeature,
     linkProps,
@@ -231,8 +228,8 @@ export default function AppNavDrawerItem(props) {
     }
   };
 
-  const hasIcon = icon && iconsMap[icon];
-  const IconComponent = hasIcon ? iconsMap[icon] : null;
+  const hasIcon = !!IconComponentProp || (icon && iconsMap[icon]);
+  const IconComponent = IconComponentProp || iconsMap[icon] || null;
   const iconProps = hasIcon ? { fontSize: 'small', color: 'primary' } : {};
   const iconElement = hasIcon ? (
     <Box
@@ -289,6 +286,7 @@ AppNavDrawerItem.propTypes = {
   depth: PropTypes.number.isRequired,
   href: PropTypes.string,
   icon: PropTypes.string,
+  IconComponent: PropTypes.elementType,
   legacy: PropTypes.bool,
   linkProps: PropTypes.object,
   newFeature: PropTypes.bool,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In MUI X [we want to use an icon](https://github.com/mui/mui-x/pull/7820#discussion_r1100605866) that hasn't been added to the icons map:
https://github.com/mui/material-ui/blob/f800c835562da9cc8fa3f7615b32a8e6cc8b31d8/docs/src/modules/components/AppNavDrawerItem.js#L24-L26
To do this, we will need to update the icons map.
This PR adds the ability to pass the icon component instead.
