### PR TITLE
[docs] Support Google Analytics 4

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -138,9 +138,7 @@ const Icons = React.memo(function Icons(props) {
         eventAction: 'click',
         eventLabel: icon.name,
       });
-      window.gtag('send', {
-        hitType: 'event',
-        eventCategory: 'material-icons',
+      window.gtag('event', 'material-icons', {
         eventAction: 'click',
         eventLabel: icon.name,
       });
@@ -150,9 +148,7 @@ const Icons = React.memo(function Icons(props) {
         eventAction: 'click',
         eventLabel: icon.theme,
       });
-      window.gtag('send', {
-        hitType: 'event',
-        eventCategory: 'material-icons-theme',
+      window.gtag('event', 'material-icons-theme', {
         eventAction: 'click',
         eventLabel: icon.theme,
       });
@@ -511,9 +507,7 @@ export default function SearchIcons() {
                 eventAction: 'no-results',
                 eventLabel: value,
               });
-              window.gtag('send', {
-                hitType: 'event',
-                eventCategory: 'material-icons',
+              window.gtag('event', 'material-icons', {
                 eventAction: 'no-results',
                 eventLabel: value,
               });

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -138,7 +138,19 @@ const Icons = React.memo(function Icons(props) {
         eventAction: 'click',
         eventLabel: icon.name,
       });
+      window.gtag('send', {
+        hitType: 'event',
+        eventCategory: 'material-icons',
+        eventAction: 'click',
+        eventLabel: icon.name,
+      });
       window.ga('send', {
+        hitType: 'event',
+        eventCategory: 'material-icons-theme',
+        eventAction: 'click',
+        eventLabel: icon.theme,
+      });
+      window.gtag('send', {
         hitType: 'event',
         eventCategory: 'material-icons-theme',
         eventAction: 'click',
@@ -494,6 +506,12 @@ export default function SearchIcons() {
             // Keep track of the no results so we can add synonyms in the future.
             if (value.length >= 4 && results.length === 0) {
               window.ga('send', {
+                hitType: 'event',
+                eventCategory: 'material-icons',
+                eventAction: 'no-results',
+                eventLabel: value,
+              });
+              window.gtag('send', {
                 hitType: 'event',
                 eventCategory: 'material-icons',
                 eventAction: 'no-results',

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -243,4 +243,11 @@ export function reportWebVitals({ id, name, label, value }) {
     eventLabel: id, // id unique to current page load
     nonInteraction: true, // avoids affecting bounce rate.
   });
+  window.gtag('send', 'event', {
+    eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    eventAction: name,
+    eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
+    eventLabel: id, // id unique to current page load
+    nonInteraction: true, // avoids affecting bounce rate.
+  });
 }

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -230,6 +230,7 @@ MyApp.getInitialProps = async ({ ctx, Component }) => {
 
 // Track fraction of actual events to prevent exceeding event quota.
 // Filter sessions instead of individual events so that we can track multiple metrics per device.
+// See https://github.com/GoogleChromeLabs/web-vitals-report to use this data
 const disableWebVitalsReporting = Math.random() > 0.0001;
 export function reportWebVitals({ id, name, label, delta, value }) {
   if (disableWebVitalsReporting) {
@@ -245,9 +246,9 @@ export function reportWebVitals({ id, name, label, delta, value }) {
   });
   window.gtag('event', name, {
     value: delta,
-    metricLabel: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
-    metricValue: value,
-    metricDetla: delta,
-    metricId: id, // id unique to current page load
+    metric_label: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    metric_value: value,
+    metric_delta: delta,
+    metric_id: id, // id unique to current page load
   });
 }

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -231,7 +231,7 @@ MyApp.getInitialProps = async ({ ctx, Component }) => {
 // Track fraction of actual events to prevent exceeding event quota.
 // Filter sessions instead of individual events so that we can track multiple metrics per device.
 const disableWebVitalsReporting = Math.random() > 0.0001;
-export function reportWebVitals({ id, name, label, value }) {
+export function reportWebVitals({ id, name, label, delta, value }) {
   if (disableWebVitalsReporting) {
     return;
   }
@@ -243,11 +243,11 @@ export function reportWebVitals({ id, name, label, value }) {
     eventLabel: id, // id unique to current page load
     nonInteraction: true, // avoids affecting bounce rate.
   });
-  window.gtag('send', 'event', {
-    eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
-    eventAction: name,
-    eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
-    eventLabel: id, // id unique to current page load
-    nonInteraction: true, // avoids affecting bounce rate.
+  window.gtag('event', name, {
+    value: delta,
+    metricLabel: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
+    metricValue: value,
+    metricDetla: delta,
+    metricId: id, // id unique to current page load
   });
 }

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -179,6 +179,9 @@ function gtag(){dataLayer.push(arguments);}
 window.gtag = gtag;
 gtag('js', new Date());
 gtag('config', '${GOOGLE_ANALYTICS_ID_V4}');
+gtag('config', 'TAG_ID', {
+  send_page_view: false
+});
 `,
             }}
           />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -34,6 +34,7 @@ const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 
 const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
+const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-5NXDQLC2ZK';
 
 export default class MyDocument extends Document {
   render() {
@@ -158,6 +159,22 @@ export default class MyDocument extends Document {
                   sampleRate: ${PRODUCTION_GA ? 80 : 100},
                 });
               `,
+            }}
+          />
+          <script async src="https://www.googletagmanager.com/gtag/js?id=G-5NXDQLC2ZK" />
+          <script
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){
+                  console.log({a: arguments });
+                  dataLayer.push(arguments);}
+                window.gtag = gtag;
+                gtag('js', new Date());
+
+                gtag('config', '${GOOGLE_ANALYTICS_ID_V4}');
+                `,
             }}
           />
           <NextScript />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -174,14 +174,12 @@ export default class MyDocument extends Document {
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){
-                  dataLayer.push(arguments);}
-                window.gtag = gtag;
-                gtag('js', new Date());
-
-                gtag('config', '${GOOGLE_ANALYTICS_ID_V4}');
-                `,
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+window.gtag = gtag;
+gtag('js', new Date());
+gtag('config', '${GOOGLE_ANALYTICS_ID_V4}');
+`,
             }}
           />
           <NextScript />

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -178,9 +178,8 @@ window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 window.gtag = gtag;
 gtag('js', new Date());
-gtag('config', '${GOOGLE_ANALYTICS_ID_V4}');
-gtag('config', 'TAG_ID', {
-  send_page_view: false
+gtag('config', '${GOOGLE_ANALYTICS_ID_V4}', {
+  send_page_view: false,
 });
 `,
             }}

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -161,7 +161,10 @@ export default class MyDocument extends Document {
               `,
             }}
           />
-          <script async src="https://www.googletagmanager.com/gtag/js?id=G-5NXDQLC2ZK" />
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID_V4}`}
+          />
           <script
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -168,7 +168,6 @@ export default class MyDocument extends Document {
               __html: `
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){
-                  console.log({a: arguments });
                   dataLayer.push(arguments);}
                 window.gtag = gtag;
                 gtag('js', new Date());

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -34,7 +34,7 @@ const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 
 const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
-const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-5NXDQLC2ZK';
+const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-XJ83JQEK7J';
 
 export default class MyDocument extends Document {
   render() {

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Script from 'next/script';
 import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import { ServerStyleSheet } from 'styled-components';
 import createEmotionServer from '@emotion/server/create-instance';
@@ -161,8 +162,12 @@ export default class MyDocument extends Document {
               `,
             }}
           />
-          <script
-            async
+          {/**
+           * A better alternative to <script async>, to delay its execution
+           * https://developer.chrome.com/blog/script-component/
+           */}
+          <Script
+            strategy="afterInteractive"
             src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID_V4}`}
           />
           <script

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -34,7 +34,9 @@ if (process.env.NODE_ENV === 'production') {
 const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 
+// TODO remove https://support.google.com/analytics/answer/11986666
 const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
+
 const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-XJ83JQEK7J';
 
 export default class MyDocument extends Document {
@@ -155,25 +157,11 @@ export default class MyDocument extends Document {
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
-                window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-                window.ga('create','${GOOGLE_ANALYTICS_ID}',{
-                  sampleRate: ${PRODUCTION_GA ? 80 : 100},
-                });
-              `,
-            }}
-          />
-          {/**
-           * A better alternative to <script async>, to delay its execution
-           * https://developer.chrome.com/blog/script-component/
-           */}
-          <Script
-            strategy="afterInteractive"
-            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID_V4}`}
-          />
-          <script
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{
-              __html: `
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+window.ga('create','${GOOGLE_ANALYTICS_ID}',{
+  sampleRate: ${PRODUCTION_GA ? 80 : 100},
+});
+
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 window.gtag = gtag;
@@ -183,6 +171,14 @@ gtag('config', '${GOOGLE_ANALYTICS_ID_V4}', {
 });
 `,
             }}
+          />
+          {/**
+           * A better alternative to <script async>, to delay its execution
+           * https://developer.chrome.com/blog/script-component/
+           */}
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID_V4}`}
           />
           <NextScript />
         </body>

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -94,6 +94,12 @@ class AdErrorBoundary extends React.Component {
       eventAction: 'crash',
       eventLabel,
     });
+    window.gtag('send', {
+      hitType: 'event',
+      eventCategory: 'ad',
+      eventAction: 'crash',
+      eventLabel,
+    });
   }
 
   render() {
@@ -192,6 +198,12 @@ function Ad() {
 
     const delay = setTimeout(() => {
       window.ga('send', {
+        hitType: 'event',
+        eventCategory: 'ad',
+        eventAction: 'display',
+        eventLabel,
+      });
+      window.gtag('send', {
         hitType: 'event',
         eventCategory: 'ad',
         eventAction: 'display',

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -94,9 +94,7 @@ class AdErrorBoundary extends React.Component {
       eventAction: 'crash',
       eventLabel,
     });
-    window.gtag('send', {
-      hitType: 'event',
-      eventCategory: 'ad',
+    window.gtag('event', 'ad', {
       eventAction: 'crash',
       eventLabel,
     });
@@ -203,9 +201,7 @@ function Ad() {
         eventAction: 'display',
         eventLabel,
       });
-      window.gtag('send', {
-        hitType: 'event',
-        eventCategory: 'ad',
+      window.gtag('event', 'ad', {
         eventAction: 'display',
         eventLabel,
       });

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -35,6 +35,12 @@ function handleClick(event) {
         eventAction: element.getAttribute('data-ga-event-action'),
         eventLabel: element.getAttribute('data-ga-event-label'),
       });
+      window.gtag('send', {
+        hitType: 'event',
+        eventCategory: category,
+        eventAction: element.getAttribute('data-ga-event-action'),
+        eventLabel: element.getAttribute('data-ga-event-label'),
+      });
       break;
     }
 
@@ -47,7 +53,7 @@ let boundDataGaListener = false;
 const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 
-const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
+const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? '' : 'G-5NXDQLC2ZK';
 
 /**
  * basically just a `useAnalytics` hook.
@@ -55,24 +61,14 @@ const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
  * in the same component this "hook" is used.
  */
 function GoogleAnalytics() {
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-    // eslint-disable-next-line prefer-rest-params
-    window.dataLayer.push(arguments);
-  }
-  
   React.useEffect(() => {
     loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
-    loadScript(
-      `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`,
-      document.querySelector('head'),
-      );
-      
-      if (!boundDataGaListener) {
-        boundDataGaListener = true;
-        document.addEventListener('click', handleClick);
-        gtag('js', new Date());
-        gtag('config', GOOGLE_ANALYTICS_ID);
+
+    if (!boundDataGaListener) {
+      boundDataGaListener = true;
+      document.addEventListener('click', handleClick);
+      window.gtag('js', new Date());
+      window.gtag('config', GOOGLE_ANALYTICS_ID_V4);
     }
   }, []);
 
@@ -83,18 +79,22 @@ function GoogleAnalytics() {
     setTimeout(() => {
       const { canonicalAsServer } = pathnameToLanguage(window.location.pathname);
       window.ga('set', { page: canonicalAsServer });
+      window.gtag('set', { page: canonicalAsServer });
       window.ga('send', { hitType: 'pageview' });
+      window.gtag('send', { hitType: 'pageview' });
     });
   }, [router.route]);
 
   const codeVariant = useNoSsrCodeVariant();
   React.useEffect(() => {
     window.ga('set', 'dimension1', codeVariant);
+    window.gtag('set', 'dimension1', codeVariant);
   }, [codeVariant]);
 
   const userLanguage = useUserLanguage();
   React.useEffect(() => {
     window.ga('set', 'dimension2', userLanguage);
+    window.gtag('set', 'dimension2', userLanguage);
   }, [userLanguage]);
 
   React.useEffect(() => {
@@ -105,6 +105,7 @@ function GoogleAnalytics() {
     function trackDevicePixelRation() {
       const devicePixelRatio = Math.round(window.devicePixelRatio * 10) / 10;
       window.ga('set', 'dimension3', devicePixelRatio);
+      window.gtag('set', 'dimension3', devicePixelRatio);
     }
 
     trackDevicePixelRation();
@@ -128,7 +129,9 @@ function GoogleAnalytics() {
 
   React.useEffect(() => {
     window.ga('set', 'dimension4', colorSchemeOS);
+    window.gtag('set', 'dimension4', colorSchemeOS);
     window.ga('set', 'dimension5', colorScheme);
+    window.gtag('set', 'dimension5', colorScheme);
   }, [colorSchemeOS, colorScheme]);
 
   return null;

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -64,10 +64,13 @@ function GoogleAnalytics() {
   }, []);
 
   const router = useRouter();
+  const timeout = React.useRef();
 
   React.useEffect(() => {
     // Wait for the title to be updated.
-    setTimeout(() => {
+    // React fires useEffect twice in dev mode
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
       const { canonicalAsServer } = pathnameToLanguage(window.location.pathname);
       window.ga('set', { page: canonicalAsServer });
       window.ga('send', { hitType: 'pageview' });

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -136,11 +136,14 @@ function GoogleAnalytics() {
     window.gtag('set', 'user_properties', {
       colorSchemeOS,
     });
+  }, [colorSchemeOS]);
+
+  React.useEffect(() => {
     window.ga('set', 'dimension5', colorScheme);
     window.gtag('set', 'user_properties', {
       colorScheme,
     });
-  }, [colorSchemeOS, colorScheme]);
+  }, [colorScheme]);
 
   return null;
 }

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -72,9 +72,12 @@ function GoogleAnalytics() {
     setTimeout(() => {
       const { canonicalAsServer } = pathnameToLanguage(window.location.pathname);
       window.ga('set', { page: canonicalAsServer });
-      window.gtag('set', { page: canonicalAsServer });
       window.ga('send', { hitType: 'pageview' });
-      window.gtag('send', { hitType: 'pageview' });
+
+      window.gtag('event', 'page_view', {
+        page_title: document.title,
+        page_location: canonicalAsServer,
+      });
     });
   }, [router.route]);
 

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -86,13 +86,17 @@ function GoogleAnalytics() {
   const codeVariant = useNoSsrCodeVariant();
   React.useEffect(() => {
     window.ga('set', 'dimension1', codeVariant);
-    window.gtag('set', 'dimension1', codeVariant);
+    window.gtag('set', 'user_properties', {
+      codeVariant,
+    });
   }, [codeVariant]);
 
   const userLanguage = useUserLanguage();
   React.useEffect(() => {
     window.ga('set', 'dimension2', userLanguage);
-    window.gtag('set', 'dimension2', userLanguage);
+    window.gtag('set', 'user_properties', {
+      userLanguage,
+    });
   }, [userLanguage]);
 
   React.useEffect(() => {
@@ -103,7 +107,9 @@ function GoogleAnalytics() {
     function trackDevicePixelRation() {
       const devicePixelRatio = Math.round(window.devicePixelRatio * 10) / 10;
       window.ga('set', 'dimension3', devicePixelRatio);
-      window.gtag('set', 'dimension3', devicePixelRatio);
+      window.gtag('set', 'user_properties', {
+        devicePixelRatio,
+      });
     }
 
     trackDevicePixelRation();
@@ -127,9 +133,13 @@ function GoogleAnalytics() {
 
   React.useEffect(() => {
     window.ga('set', 'dimension4', colorSchemeOS);
-    window.gtag('set', 'dimension4', colorSchemeOS);
+    window.gtag('set', 'user_properties', {
+      colorSchemeOS,
+    });
     window.ga('set', 'dimension5', colorScheme);
-    window.gtag('set', 'dimension5', colorScheme);
+    window.gtag('set', 'user_properties', {
+      colorScheme,
+    });
   }, [colorSchemeOS, colorScheme]);
 
   return null;

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -50,11 +50,6 @@ function handleClick(event) {
 
 let boundDataGaListener = false;
 
-const PRODUCTION_GA =
-  process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
-
-const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-XJ83JQEK7J';
-
 /**
  * basically just a `useAnalytics` hook.
  * However, it needs the redux store which is created
@@ -67,8 +62,6 @@ function GoogleAnalytics() {
     if (!boundDataGaListener) {
       boundDataGaListener = true;
       document.addEventListener('click', handleClick);
-      window.gtag('js', new Date());
-      window.gtag('config', GOOGLE_ANALYTICS_ID_V4);
     }
   }, []);
 

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -75,6 +75,7 @@ function GoogleAnalytics() {
       window.ga('set', { page: canonicalAsServer });
       window.ga('send', { hitType: 'pageview' });
 
+      // https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag
       window.gtag('event', 'page_view', {
         page_title: document.title,
         page_location: canonicalAsServer,

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -35,9 +35,7 @@ function handleClick(event) {
         eventAction: element.getAttribute('data-ga-event-action'),
         eventLabel: element.getAttribute('data-ga-event-label'),
       });
-      window.gtag('send', {
-        hitType: 'event',
-        eventCategory: category,
+      window.gtag('event', category, {
         eventAction: element.getAttribute('data-ga-event-action'),
         eventLabel: element.getAttribute('data-ga-event-label'),
       });

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -44,18 +44,35 @@ function handleClick(event) {
 
 let boundDataGaListener = false;
 
+const PRODUCTION_GA =
+  process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
+
+const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
+
 /**
  * basically just a `useAnalytics` hook.
  * However, it needs the redux store which is created
  * in the same component this "hook" is used.
  */
 function GoogleAnalytics() {
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer.push(arguments);
+  }
+  
   React.useEffect(() => {
     loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
-
-    if (!boundDataGaListener) {
-      boundDataGaListener = true;
-      document.addEventListener('click', handleClick);
+    loadScript(
+      `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`,
+      document.querySelector('head'),
+      );
+      
+      if (!boundDataGaListener) {
+        boundDataGaListener = true;
+        document.addEventListener('click', handleClick);
+        gtag('js', new Date());
+        gtag('config', GOOGLE_ANALYTICS_ID);
     }
   }, []);
 

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -53,7 +53,7 @@ let boundDataGaListener = false;
 const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 
-const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? '' : 'G-5NXDQLC2ZK';
+const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-XJ83JQEK7J';
 
 /**
  * basically just a `useAnalytics` hook.


### PR DESCRIPTION
Seems to be working. Maybe it can be merged, to get time to check all the metrics are the same between UA token and GA4 token

- dev: https://analytics.google.com/analytics/web/#/p354125369/reports/intelligenthome
- prod: https://analytics.google.com/analytics/web/#/p353089763/reports/intelligenthome

If I'm correct, the behavior is to push events in `window.dataLayer` which will be used by the script from `https://www.googletagmanager.com/gtag/js` to send data to Google Analytics

The few visitors in prod before merging, it's me doing tests :)