### PR TITLE
[docs] Fix modal transition demos

### DIFF
--- a/docs/data/base/components/modal/NestedModal.js
+++ b/docs/data/base/components/modal/NestedModal.js
@@ -68,11 +68,11 @@ function ChildModal() {
     <React.Fragment>
       <Button onClick={handleOpen}>Open Child Modal</Button>
       <Modal
-        hideBackdrop
         open={open}
         onClose={handleClose}
         aria-labelledby="child-modal-title"
         aria-describedby="child-modal-description"
+        slots={{ backdrop: Backdrop }}
       >
         <Box sx={[style, { width: '200px' }]}>
           <h2 id="child-modal-title">Text in a child modal</h2>

--- a/docs/data/base/components/modal/NestedModal.tsx
+++ b/docs/data/base/components/modal/NestedModal.tsx
@@ -65,11 +65,11 @@ function ChildModal() {
     <React.Fragment>
       <Button onClick={handleOpen}>Open Child Modal</Button>
       <Modal
-        hideBackdrop
         open={open}
         onClose={handleClose}
         aria-labelledby="child-modal-title"
         aria-describedby="child-modal-description"
+        slots={{ backdrop: Backdrop }}
       >
         <Box sx={[style, { width: '200px' }]}>
           <h2 id="child-modal-title">Text in a child modal</h2>

--- a/docs/data/base/components/modal/SpringModal.js
+++ b/docs/data/base/components/modal/SpringModal.js
@@ -1,25 +1,17 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { Box, styled } from '@mui/system';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
 import Button from '@mui/base/ButtonUnstyled';
 import { useSpring, animated } from '@react-spring/web';
 
 const BackdropUnstyled = React.forwardRef((props, ref) => {
-  const { open, className, ...other } = props;
-  return (
-    <div
-      className={clsx({ 'MuiBackdrop-open': open }, className)}
-      ref={ref}
-      {...other}
-    />
-  );
+  const { open, ...other } = props;
+  return <Fade ref={ref} in={open} {...other} />;
 });
 
 BackdropUnstyled.propTypes = {
-  className: PropTypes.string.isRequired,
-  open: PropTypes.bool,
+  open: PropTypes.bool.isRequired,
 };
 
 const Modal = styled(ModalUnstyled)`
@@ -52,12 +44,12 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     to: { opacity: open ? 1 : 0 },
     onStart: () => {
       if (open && onEnter) {
-        onEnter();
+        onEnter(null, true);
       }
     },
     onRest: () => {
       if (!open && onExited) {
-        onExited();
+        onExited(null, true);
       }
     },
   });
@@ -70,8 +62,8 @@ const Fade = React.forwardRef(function Fade(props, ref) {
 });
 
 Fade.propTypes = {
-  children: PropTypes.element,
-  in: PropTypes.bool.isRequired,
+  children: PropTypes.element.isRequired,
+  in: PropTypes.bool,
   onEnter: PropTypes.func,
   onExited: PropTypes.func,
 };
@@ -107,7 +99,7 @@ export default function SpringModal() {
         <Fade in={open}>
           <Box sx={style}>
             <h2 id="spring-modal-title">Text in a modal</h2>
-            <span id="spring-modal-description" style={{ marginTop: '16px' }}>
+            <span id="spring-modal-description" style={{ marginTop: 16 }}>
               Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
             </span>
           </Box>

--- a/docs/data/base/components/modal/SpringModal.tsx
+++ b/docs/data/base/components/modal/SpringModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import clsx from 'clsx';
 import { Box, styled, Theme } from '@mui/system';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
 import Button from '@mui/base/ButtonUnstyled';
@@ -7,16 +6,10 @@ import { useSpring, animated } from '@react-spring/web';
 
 const BackdropUnstyled = React.forwardRef<
   HTMLDivElement,
-  { open?: boolean; className: string }
+  { children: React.ReactElement; open: boolean }
 >((props, ref) => {
-  const { open, className, ...other } = props;
-  return (
-    <div
-      className={clsx({ 'MuiBackdrop-open': open }, className)}
-      ref={ref}
-      {...other}
-    />
-  );
+  const { open, ...other } = props;
+  return <Fade ref={ref} in={open} {...other} />;
 });
 
 const Modal = styled(ModalUnstyled)`
@@ -43,10 +36,11 @@ const Backdrop = styled(BackdropUnstyled)`
 `;
 
 interface FadeProps {
-  children?: React.ReactElement;
-  in: boolean;
-  onEnter?: () => {};
-  onExited?: () => {};
+  children: React.ReactElement;
+  in?: boolean;
+  onClick?: any;
+  onEnter?: (node: HTMLElement, isAppearing: boolean) => void;
+  onExited?: (node: HTMLElement, isAppearing: boolean) => void;
 }
 
 const Fade = React.forwardRef<HTMLDivElement, FadeProps>(function Fade(props, ref) {
@@ -56,12 +50,12 @@ const Fade = React.forwardRef<HTMLDivElement, FadeProps>(function Fade(props, re
     to: { opacity: open ? 1 : 0 },
     onStart: () => {
       if (open && onEnter) {
-        onEnter();
+        onEnter(null as any, true);
       }
     },
     onRest: () => {
       if (!open && onExited) {
-        onExited();
+        onExited(null as any, true);
       }
     },
   });
@@ -104,7 +98,7 @@ export default function SpringModal() {
         <Fade in={open}>
           <Box sx={style}>
             <h2 id="spring-modal-title">Text in a modal</h2>
-            <span id="spring-modal-description" style={{ marginTop: '16px' }}>
+            <span id="spring-modal-description" style={{ marginTop: 16 }}>
               Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
             </span>
           </Box>

--- a/docs/data/base/components/modal/TransitionsModal.js
+++ b/docs/data/base/components/modal/TransitionsModal.js
@@ -1,24 +1,20 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { Box, styled } from '@mui/system';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
 import Fade from '@mui/material/Fade';
 import Button from '@mui/base/ButtonUnstyled';
 
 const BackdropUnstyled = React.forwardRef((props, ref) => {
-  const { open, className, ...other } = props;
+  const { open, ...other } = props;
   return (
-    <div
-      className={clsx({ 'MuiBackdrop-open': open }, className)}
-      ref={ref}
-      {...other}
-    />
+    <Fade in={open}>
+      <div ref={ref} {...other} />
+    </Fade>
   );
 });
 
 BackdropUnstyled.propTypes = {
-  className: PropTypes.string.isRequired,
   open: PropTypes.bool,
 };
 
@@ -73,10 +69,10 @@ export default function TransitionsModal() {
         closeAfterTransition
         slots={{ backdrop: Backdrop }}
       >
-        <Fade in={open} timeout={300}>
+        <Fade in={open}>
           <Box sx={style}>
             <h2 id="transition-modal-title">Text in a modal</h2>
-            <span id="transition-modal-description" style={{ marginTop: '16px' }}>
+            <span id="transition-modal-description" style={{ marginTop: 16 }}>
               Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
             </span>
           </Box>

--- a/docs/data/base/components/modal/TransitionsModal.tsx
+++ b/docs/data/base/components/modal/TransitionsModal.tsx
@@ -1,23 +1,19 @@
 import * as React from 'react';
-import clsx from 'clsx';
 import { Box, styled, Theme } from '@mui/system';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
 import Fade from '@mui/material/Fade';
 import Button from '@mui/base/ButtonUnstyled';
 
-const BackdropUnstyled = React.forwardRef<
-  HTMLDivElement,
-  { open?: boolean; className: string }
->((props, ref) => {
-  const { open, className, ...other } = props;
-  return (
-    <div
-      className={clsx({ 'MuiBackdrop-open': open }, className)}
-      ref={ref}
-      {...other}
-    />
-  );
-});
+const BackdropUnstyled = React.forwardRef<HTMLDivElement, { open?: boolean }>(
+  (props, ref) => {
+    const { open, ...other } = props;
+    return (
+      <Fade in={open}>
+        <div ref={ref} {...other} />
+      </Fade>
+    );
+  },
+);
 
 const Modal = styled(ModalUnstyled)`
   position: fixed;
@@ -70,10 +66,10 @@ export default function TransitionsModal() {
         closeAfterTransition
         slots={{ backdrop: Backdrop }}
       >
-        <Fade in={open} timeout={300}>
+        <Fade in={open}>
           <Box sx={style}>
             <h2 id="transition-modal-title">Text in a modal</h2>
-            <span id="transition-modal-description" style={{ marginTop: '16px' }}>
+            <span id="transition-modal-description" style={{ marginTop: 16 }}>
               Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
             </span>
           </Box>

--- a/docs/data/material/components/modal/NestedModal.js
+++ b/docs/data/material/components/modal/NestedModal.js
@@ -30,7 +30,6 @@ function ChildModal() {
     <React.Fragment>
       <Button onClick={handleOpen}>Open Child Modal</Button>
       <Modal
-        hideBackdrop
         open={open}
         onClose={handleClose}
         aria-labelledby="child-modal-title"

--- a/docs/data/material/components/modal/NestedModal.tsx
+++ b/docs/data/material/components/modal/NestedModal.tsx
@@ -30,7 +30,6 @@ function ChildModal() {
     <React.Fragment>
       <Button onClick={handleOpen}>Open Child Modal</Button>
       <Modal
-        hideBackdrop
         open={open}
         onClose={handleClose}
         aria-labelledby="child-modal-title"

--- a/docs/data/material/components/modal/SpringModal.js
+++ b/docs/data/material/components/modal/SpringModal.js
@@ -9,11 +9,11 @@ import { useSpring, animated } from '@react-spring/web';
 
 const Fade = React.forwardRef(function Fade(props, ref) {
   const {
-    in: open,
     children,
+    in: open,
+    onClick,
     onEnter,
     onExited,
-    onClick,
     ownerState,
     ...other
   } = props;

--- a/docs/data/material/components/modal/SpringModal.js
+++ b/docs/data/material/components/modal/SpringModal.js
@@ -8,34 +8,44 @@ import Typography from '@mui/material/Typography';
 import { useSpring, animated } from '@react-spring/web';
 
 const Fade = React.forwardRef(function Fade(props, ref) {
-  const { in: open, children, onEnter, onExited, ...other } = props;
+  const {
+    in: open,
+    children,
+    onEnter,
+    onExited,
+    onClick,
+    ownerState,
+    ...other
+  } = props;
   const style = useSpring({
     from: { opacity: 0 },
     to: { opacity: open ? 1 : 0 },
     onStart: () => {
       if (open && onEnter) {
-        onEnter();
+        onEnter(null, true);
       }
     },
     onRest: () => {
       if (!open && onExited) {
-        onExited();
+        onExited(null, true);
       }
     },
   });
 
   return (
     <animated.div ref={ref} style={style} {...other}>
-      {children}
+      {React.cloneElement(children, { onClick })}
     </animated.div>
   );
 });
 
 Fade.propTypes = {
-  children: PropTypes.element,
-  in: PropTypes.bool.isRequired,
+  children: PropTypes.element.isRequired,
+  in: PropTypes.bool,
+  onClick: PropTypes.any,
   onEnter: PropTypes.func,
   onExited: PropTypes.func,
+  ownerState: PropTypes.any,
 };
 
 const style = {
@@ -64,9 +74,11 @@ export default function SpringModal() {
         open={open}
         onClose={handleClose}
         closeAfterTransition
-        BackdropComponent={Backdrop}
-        BackdropProps={{
-          timeout: 500,
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            TransitionComponent: Fade,
+          },
         }}
       >
         <Fade in={open}>

--- a/docs/data/material/components/modal/SpringModal.tsx
+++ b/docs/data/material/components/modal/SpringModal.tsx
@@ -7,32 +7,42 @@ import Typography from '@mui/material/Typography';
 import { useSpring, animated } from '@react-spring/web';
 
 interface FadeProps {
-  children?: React.ReactElement;
-  in: boolean;
-  onEnter?: () => {};
-  onExited?: () => {};
+  children: React.ReactElement;
+  in?: boolean;
+  onClick?: any;
+  onEnter?: (node: HTMLElement, isAppearing: boolean) => void;
+  onExited?: (node: HTMLElement, isAppearing: boolean) => void;
+  ownerState?: any;
 }
 
 const Fade = React.forwardRef<HTMLDivElement, FadeProps>(function Fade(props, ref) {
-  const { in: open, children, onEnter, onExited, ...other } = props;
+  const {
+    children,
+    in: open,
+    onClick,
+    onEnter,
+    onExited,
+    ownerState,
+    ...other
+  } = props;
   const style = useSpring({
     from: { opacity: 0 },
     to: { opacity: open ? 1 : 0 },
     onStart: () => {
       if (open && onEnter) {
-        onEnter();
+        onEnter(null as any, true);
       }
     },
     onRest: () => {
       if (!open && onExited) {
-        onExited();
+        onExited(null as any, true);
       }
     },
   });
 
   return (
     <animated.div ref={ref} style={style} {...other}>
-      {children}
+      {React.cloneElement(children, { onClick })}
     </animated.div>
   );
 });
@@ -63,9 +73,11 @@ export default function SpringModal() {
         open={open}
         onClose={handleClose}
         closeAfterTransition
-        BackdropComponent={Backdrop}
-        BackdropProps={{
-          timeout: 500,
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            TransitionComponent: Fade,
+          },
         }}
       >
         <Fade in={open}>

--- a/docs/data/material/components/modal/TransitionsModal.js
+++ b/docs/data/material/components/modal/TransitionsModal.js
@@ -32,9 +32,11 @@ export default function TransitionsModal() {
         open={open}
         onClose={handleClose}
         closeAfterTransition
-        BackdropComponent={Backdrop}
-        BackdropProps={{
-          timeout: 500,
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            timeout: 500,
+          },
         }}
       >
         <Fade in={open}>

--- a/docs/data/material/components/modal/TransitionsModal.tsx
+++ b/docs/data/material/components/modal/TransitionsModal.tsx
@@ -32,9 +32,11 @@ export default function TransitionsModal() {
         open={open}
         onClose={handleClose}
         closeAfterTransition
-        BackdropComponent={Backdrop}
-        BackdropProps={{
-          timeout: 500,
+        slots={{ backdrop: Backdrop }}
+        slotProps={{
+          backdrop: {
+            timeout: 500,
+          },
         }}
       >
         <Fade in={open}>

--- a/docs/pages/material-ui/api/backdrop.json
+++ b/docs/pages/material-ui/api/backdrop.json
@@ -27,6 +27,7 @@
         "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
       }
     },
+    "TransitionComponent": { "type": { "name": "elementType" }, "default": "Fade" },
     "transitionDuration": {
       "type": {
         "name": "union",

--- a/docs/translations/api-docs/backdrop/backdrop.json
+++ b/docs/translations/api-docs/backdrop/backdrop.json
@@ -11,6 +11,7 @@
     "slotProps": "The extra props for the slot components. You can override the existing props or add new ones.<br>This prop is an alias for the <code>componentsProps</code> prop, which will be deprecated in the future.",
     "slots": "The components used for each slot inside.<br>This prop is an alias for the <code>components</code> prop, which will be deprecated in the future.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details.",
+    "TransitionComponent": "The component used for the transition. <a href=\"/material-ui/transitions/#transitioncomponent-prop\">Follow this guide</a> to learn more about the requirements for this component.",
     "transitionDuration": "The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object."
   },
   "classDescriptions": {

--- a/packages/mui-base/src/utils/isHostComponent.ts
+++ b/packages/mui-base/src/utils/isHostComponent.ts
@@ -3,8 +3,6 @@ import * as React from 'react';
 /**
  * Determines if a given element is a DOM element name (i.e. not a React component).
  */
-function isHostComponent(element: React.ElementType) {
+export default function isHostComponent(element: React.ElementType) {
   return typeof element === 'string';
 }
-
-export default isHostComponent;

--- a/packages/mui-base/src/utils/mergeSlotProps.ts
+++ b/packages/mui-base/src/utils/mergeSlotProps.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import clsx, { ClassValue } from 'clsx';
 import { Simplify } from '@mui/types';
 import { EventHandlers } from './types';

--- a/packages/mui-base/src/utils/types.ts
+++ b/packages/mui-base/src/utils/types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export type EventHandlers = Record<string, React.EventHandler<any>>;
 
 export type WithOptionalOwnerState<T extends { ownerState: unknown }> = Omit<T, 'ownerState'> &

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -83,6 +83,14 @@ export interface BackdropTypeMap<P = {}, D extends React.ElementType = 'div'> {
        * You may specify a single timeout for all transitions, or individually with an object.
        */
       transitionDuration?: TransitionProps['timeout'];
+      /**
+       * The component used for the transition.
+       * [Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
+       * @default Fade
+       */
+      TransitionComponent?: React.JSXElementConstructor<
+        TransitionProps & { children: React.ReactElement<any, any> }
+      >;
     };
   defaultComponent: D;
 }

--- a/packages/mui-material/src/Backdrop/Backdrop.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.js
@@ -45,17 +45,16 @@ const Backdrop = React.forwardRef(function Backdrop(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiBackdrop' });
   const {
     children,
+    className,
     component = 'div',
     components = {},
     componentsProps = {},
-    className,
     invisible = false,
     open,
     slotProps = {},
     slots = {},
-    transitionDuration,
-    // eslint-disable-next-line react/prop-types
     TransitionComponent = Fade,
+    transitionDuration,
     ...other
   } = props;
 
@@ -170,6 +169,12 @@ Backdrop.propTypes /* remove-proptypes */ = {
     PropTypes.func,
     PropTypes.object,
   ]),
+  /**
+   * The component used for the transition.
+   * [Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
+   * @default Fade
+   */
+  TransitionComponent: PropTypes.elementType,
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.


### PR DESCRIPTION
The two demos in https://mui.com/base/react-modal/#transitions have broken animations. It feels all off.

I noticed this in #36023.

https://deploy-preview-36137--material-ui.netlify.app/base/react-modal/#transitions