### PR TITLE
[base] Remove `classes` prop from the Base components that have it

### DIFF
--- a/docs/pages/base/api/modal-unstyled.json
+++ b/docs/pages/base/api/modal-unstyled.json
@@ -2,7 +2,6 @@
   "props": {
     "children": { "type": { "name": "custom", "description": "element" }, "required": true },
     "open": { "type": { "name": "bool" }, "required": true },
-    "classes": { "type": { "name": "object" } },
     "closeAfterTransition": { "type": { "name": "bool" }, "default": "false" },
     "component": { "type": { "name": "elementType" } },
     "container": { "type": { "name": "union", "description": "HTML element<br>&#124;&nbsp;func" } },
@@ -33,11 +32,7 @@
     }
   },
   "name": "ModalUnstyled",
-  "styles": {
-    "classes": ["root", "hidden"],
-    "globalClasses": { "root": "MuiModal-root", "hidden": "MuiModal-hidden" },
-    "name": null
-  },
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
       "name": "backdrop",

--- a/docs/pages/base/api/slider-unstyled.json
+++ b/docs/pages/base/api/slider-unstyled.json
@@ -3,7 +3,6 @@
     "aria-label": { "type": { "name": "custom", "description": "string" } },
     "aria-labelledby": { "type": { "name": "string" } },
     "aria-valuetext": { "type": { "name": "custom", "description": "string" } },
-    "classes": { "type": { "name": "object" } },
     "component": { "type": { "name": "elementType" } },
     "defaultValue": {
       "type": { "name": "union", "description": "Array&lt;number&gt;<br>&#124;&nbsp;number" }
@@ -62,45 +61,7 @@
     }
   },
   "name": "SliderUnstyled",
-  "styles": {
-    "classes": [
-      "root",
-      "marked",
-      "vertical",
-      "disabled",
-      "dragging",
-      "rail",
-      "track",
-      "trackFalse",
-      "trackInverted",
-      "thumb",
-      "active",
-      "focusVisible",
-      "mark",
-      "markActive",
-      "markLabel",
-      "markLabelActive"
-    ],
-    "globalClasses": {
-      "root": "MuiSlider-root",
-      "marked": "MuiSlider-marked",
-      "vertical": "MuiSlider-vertical",
-      "disabled": "Mui-disabled",
-      "dragging": "MuiSlider-dragging",
-      "rail": "MuiSlider-rail",
-      "track": "MuiSlider-track",
-      "trackFalse": "MuiSlider-trackFalse",
-      "trackInverted": "MuiSlider-trackInverted",
-      "thumb": "MuiSlider-thumb",
-      "active": "Mui-active",
-      "focusVisible": "Mui-focusVisible",
-      "mark": "MuiSlider-mark",
-      "markActive": "MuiSlider-markActive",
-      "markLabel": "MuiSlider-markLabel",
-      "markLabelActive": "MuiSlider-markLabelActive"
-    },
-    "name": null
-  },
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
       "name": "input",

--- a/docs/pages/base/api/table-pagination-unstyled.json
+++ b/docs/pages/base/api/table-pagination-unstyled.json
@@ -40,35 +40,7 @@
     }
   },
   "name": "TablePaginationUnstyled",
-  "styles": {
-    "classes": [
-      "root",
-      "toolbar",
-      "spacer",
-      "selectLabel",
-      "selectRoot",
-      "select",
-      "selectIcon",
-      "input",
-      "menuItem",
-      "displayedRows",
-      "actions"
-    ],
-    "globalClasses": {
-      "root": "MuiTablePagination-root",
-      "toolbar": "MuiTablePagination-toolbar",
-      "spacer": "MuiTablePagination-spacer",
-      "selectLabel": "MuiTablePagination-selectLabel",
-      "selectRoot": "MuiTablePagination-selectRoot",
-      "select": "MuiTablePagination-select",
-      "selectIcon": "MuiTablePagination-selectIcon",
-      "input": "MuiTablePagination-input",
-      "menuItem": "MuiTablePagination-menuItem",
-      "displayedRows": "MuiTablePagination-displayedRows",
-      "actions": "MuiTablePagination-actions"
-    },
-    "name": null
-  },
+  "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
       "name": "actions",

--- a/docs/pages/material-ui/api/modal.json
+++ b/docs/pages/material-ui/api/modal.json
@@ -61,7 +61,7 @@
     }
   },
   "name": "Modal",
-  "styles": { "classes": ["root", "hidden"], "globalClasses": {}, "name": "MuiModal" },
+  "styles": { "classes": ["root", "hidden", "backdrop"], "globalClasses": {}, "name": "MuiModal" },
   "spread": true,
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-material/src/Modal/Modal.js",

--- a/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
+++ b/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
@@ -2,7 +2,6 @@
   "componentDescription": "Modal is a lower-level construct that is leveraged by the following components:\n\n*   [Dialog](https://mui.com/material-ui/api/dialog/)\n*   [Drawer](https://mui.com/material-ui/api/drawer/)\n*   [Menu](https://mui.com/material-ui/api/menu/)\n*   [Popover](https://mui.com/material-ui/api/popover/)\n\nIf you are creating a modal dialog, you probably want to use the [Dialog](https://mui.com/material-ui/api/dialog/) component\nrather than directly using Modal.\n\nThis component shares many concepts with [react-overlays](https://react-bootstrap.github.io/react-overlays/#modals).",
   "propDescriptions": {
     "children": "A single child content element.<br>⚠️ <a href=\"/material-ui/guides/composition/#caveat-with-refs\">Needs to be able to hold a ref</a>.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "closeAfterTransition": "When set to true the Modal waits until a nested Transition is completed before closing.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "container": "An HTML element or function that returns one. The <code>container</code> will have the portal children appended to it.<br>By default, it uses the body of the top-level document object, so it&#39;s simply <code>document.body</code> most of the time.",
@@ -20,14 +19,7 @@
     "slotProps": "The props used for each slot inside the Modal.",
     "slots": "The components used for each slot inside the Modal. Either a string to use a HTML element or a component. See <a href=\"#slots\">Slots API</a> below for more details."
   },
-  "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
-    "hidden": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "the <code>Modal</code> has exited"
-    }
-  },
+  "classDescriptions": {},
   "slotDescriptions": {
     "backdrop": "The component used to render the backdrop.",
     "root": "The component used to render the root."

--- a/docs/translations/api-docs/modal/modal-zh.json
+++ b/docs/translations/api-docs/modal/modal-zh.json
@@ -25,12 +25,16 @@
   },
   "classDescriptions": {
     "root": {
-      "description": "Styles applied to the root element."
+      "description": "Class name applied to the root element."
     },
     "hidden": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "the <code>Modal</code> has exited"
+    },
+    "backdrop": {
+      "description": "Class name applied to {{nodeName}}.",
+      "nodeName": "the backdrop element"
     }
   }
 }

--- a/docs/translations/api-docs/modal/modal.json
+++ b/docs/translations/api-docs/modal/modal.json
@@ -31,6 +31,10 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "the <code>Modal</code> has exited"
+    },
+    "backdrop": {
+      "description": "Styles applied to {{nodeName}}.",
+      "nodeName": "the backdrop element"
     }
   }
 }

--- a/docs/translations/api-docs/modal/modal.json
+++ b/docs/translations/api-docs/modal/modal.json
@@ -26,14 +26,14 @@
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details."
   },
   "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
+    "root": { "description": "Class name applied to the root element." },
     "hidden": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "the <code>Modal</code> has exited"
     },
     "backdrop": {
-      "description": "Styles applied to {{nodeName}}.",
+      "description": "Class name applied to {{nodeName}}.",
       "nodeName": "the backdrop element"
     }
   }

--- a/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
+++ b/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
@@ -4,7 +4,6 @@
     "aria-label": "The label of the slider.",
     "aria-labelledby": "The id of the element containing a label for the slider.",
     "aria-valuetext": "A string value that provides a user-friendly name for the current value of the slider.",
-    "classes": "Override or extend the styles applied to the component. See <a href=\"#css\">CSS API</a> below for more details.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "defaultValue": "The default value. Use when the component is not controlled.",
     "disabled": "If <code>true</code>, the component is disabled.",
@@ -28,79 +27,7 @@
     "value": "The value of the slider. For ranged sliders, provide an array with two values.",
     "valueLabelFormat": "The format function the value label&#39;s value.<br>When a function is provided, it should have the following signature:<br>- {number} value The value label&#39;s value to format - {number} index The value label&#39;s index to format"
   },
-  "classDescriptions": {
-    "root": { "description": "Class name applied to the root element." },
-    "marked": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>marks</code> is provided with at least one label"
-    },
-    "vertical": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>orientation=\"vertical\"</code>"
-    },
-    "disabled": {
-      "description": "State class applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root and thumb element",
-      "conditions": "<code>disabled={true}</code>"
-    },
-    "dragging": {
-      "description": "State class applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root",
-      "conditions": "a thumb is being dragged"
-    },
-    "rail": {
-      "description": "Class name applied to {{nodeName}}.",
-      "nodeName": "the rail element"
-    },
-    "track": {
-      "description": "Class name applied to {{nodeName}}.",
-      "nodeName": "the track element"
-    },
-    "trackFalse": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>track={false}</code>"
-    },
-    "trackInverted": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>track=\"inverted\"</code>"
-    },
-    "thumb": {
-      "description": "Class name applied to {{nodeName}}.",
-      "nodeName": "the thumb element"
-    },
-    "active": {
-      "description": "State class applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "it's active"
-    },
-    "focusVisible": {
-      "description": "State class applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the thumb element",
-      "conditions": "keyboard focused"
-    },
-    "mark": {
-      "description": "Class name applied to {{nodeName}}.",
-      "nodeName": "the mark element"
-    },
-    "markActive": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the mark element",
-      "conditions": "active (depending on the value)"
-    },
-    "markLabel": {
-      "description": "Class name applied to {{nodeName}}.",
-      "nodeName": "the mark label element"
-    },
-    "markLabelActive": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the mark label element",
-      "conditions": "active (depending on the value)"
-    }
-  },
+  "classDescriptions": {},
   "slotDescriptions": {
     "input": "The component used to render the input.",
     "mark": "The component used to render the mark.",

--- a/docs/translations/api-docs/table-pagination-unstyled/table-pagination-unstyled.json
+++ b/docs/translations/api-docs/table-pagination-unstyled/table-pagination-unstyled.json
@@ -16,49 +16,7 @@
     "slotProps": "The props used for each slot inside the TablePagination.",
     "slots": "The components used for each slot inside the TablePagination. Either a string to use a HTML element or a component. See <a href=\"#slots\">Slots API</a> below for more details."
   },
-  "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
-    "toolbar": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the Toolbar component"
-    },
-    "spacer": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the spacer element"
-    },
-    "selectLabel": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the select label Typography element"
-    },
-    "selectRoot": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the Select component `root` element"
-    },
-    "select": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the Select component `select` class"
-    },
-    "selectIcon": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the Select component `icon` class"
-    },
-    "input": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the Select component `root` element"
-    },
-    "menuItem": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the MenuItem component"
-    },
-    "displayedRows": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the displayed rows Typography element"
-    },
-    "actions": {
-      "description": "Styles applied to {{nodeName}}.",
-      "nodeName": "the internal `TablePaginationUnstyledActions` component"
-    }
-  },
+  "classDescriptions": {},
   "slotDescriptions": {
     "actions": "The component used to render the actions.",
     "displayedRows": "The component used to render the displayed rows.",

--- a/packages/mui-base/src/InputUnstyled/inputUnstyledClasses.ts
+++ b/packages/mui-base/src/InputUnstyled/inputUnstyledClasses.ts
@@ -2,27 +2,27 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface InputUnstyledClasses {
-  /** Styles applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Styles applied to the root element if the component is a descendant of `FormControl`. */
+  /** Class name applied to the root element if the component is a descendant of `FormControl`. */
   formControl: string;
-  /** Styles applied to the root element if `startAdornment` is provided. */
+  /** Class name applied to the root element if `startAdornment` is provided. */
   adornedStart: string;
-  /** Styles applied to the root element if `endAdornment` is provided. */
+  /** Class name applied to the root element if `endAdornment` is provided. */
   adornedEnd: string;
-  /** Styles applied to the root element if the component is focused. */
+  /** Class name applied to the root element if the component is focused. */
   focused: string;
-  /** Styles applied to the root element if `disabled={true}`. */
+  /** Class name applied to the root element if `disabled={true}`. */
   disabled: string;
   /** State class applied to the root element if `error={true}`. */
   error: string;
-  /** Styles applied to the root element if `multiline={true}`. */
+  /** Class name applied to the root element if `multiline={true}`. */
   multiline: string;
-  /** Styles applied to the input element. */
+  /** Class name applied to the input element. */
   input: string;
-  /** Styles applied to the input element if `multiline={true}`. */
+  /** Class name applied to the input element if `multiline={true}`. */
   inputMultiline: string;
-  /** Styles applied to the input element if `type="search"`. */
+  /** Class name applied to the input element if `type="search"`. */
   inputTypeSearch: string;
 }
 

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
@@ -30,7 +30,7 @@ const useUtilityClasses = (ownerState: ModalUnstyledOwnerState) => {
     backdrop: ['backdrop'],
   };
 
-  return composeClasses(slots, getModalUtilityClass, {});
+  return composeClasses(slots, getModalUtilityClass);
 };
 
 function getContainer(container: ModalUnstyledOwnProps['container']) {

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
@@ -23,14 +23,14 @@ import { getModalUtilityClass } from './modalUnstyledClasses';
 import { useSlotProps } from '../utils';
 
 const useUtilityClasses = (ownerState: ModalUnstyledOwnerState) => {
-  const { open, exited, classes } = ownerState;
+  const { open, exited } = ownerState;
 
   const slots = {
     root: ['root', !open && exited && 'hidden'],
     backdrop: ['backdrop'],
   };
 
-  return composeClasses(slots, getModalUtilityClass, classes);
+  return composeClasses(slots, getModalUtilityClass, {});
 };
 
 function getContainer(container: ModalUnstyledOwnProps['container']) {
@@ -71,7 +71,6 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled<
 >(props: ModalUnstyledProps<BaseComponentType>, forwardedRef: React.Ref<Element> | undefined) {
   const {
     children,
-    classes: classesProp,
     closeAfterTransition = false,
     component,
     container,
@@ -171,7 +170,6 @@ const ModalUnstyled = React.forwardRef(function ModalUnstyled<
 
   const ownerState: ModalUnstyledOwnerState = {
     ...props,
-    classes: classesProp,
     closeAfterTransition,
     disableAutoFocus,
     disableEnforceFocus,

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
@@ -328,10 +328,6 @@ ModalUnstyled.propTypes /* remove-proptypes */ = {
    */
   children: elementAcceptingRef.isRequired,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * When set to true the Modal waits until a nested Transition is completed before closing.
    * @default false
    */

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.tsx
@@ -30,7 +30,7 @@ const useUtilityClasses = (ownerState: ModalUnstyledOwnerState) => {
     backdrop: ['backdrop'],
   };
 
-  return composeClasses(slots, getModalUtilityClass);
+  return composeClasses(slots, getModalUtilityClass, undefined);
 };
 
 function getContainer(container: ModalUnstyledOwnProps['container']) {

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
@@ -2,7 +2,6 @@ import { OverridableComponent, OverridableTypeMap, OverrideProps } from '@mui/ty
 import * as React from 'react';
 import { PortalProps } from '../Portal';
 import { SlotComponentProps } from '../utils';
-import { ModalUnstyledClasses } from './modalUnstyledClasses';
 
 export interface ModalUnstyledRootSlotPropsOverrides {}
 export interface ModalUnstyledBackdropSlotPropsOverrides {}
@@ -12,10 +11,6 @@ export interface ModalUnstyledOwnProps {
    * A single child content element.
    */
   children: React.ReactElement;
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<ModalUnstyledClasses>;
   /**
    * When set to true the Modal waits until a nested Transition is completed before closing.
    * @default false

--- a/packages/mui-base/src/ModalUnstyled/index.ts
+++ b/packages/mui-base/src/ModalUnstyled/index.ts
@@ -5,4 +5,5 @@ export * from './ModalUnstyled.types';
 export { default as ModalManager } from './ModalManager';
 export * from './ModalManager';
 
-export { default as modalUnstyledClasses, getModalUtilityClass } from './modalUnstyledClasses';
+export { default as modalUnstyledClasses } from './modalUnstyledClasses';
+export * from './modalUnstyledClasses';

--- a/packages/mui-base/src/ModalUnstyled/modalUnstyledClasses.ts
+++ b/packages/mui-base/src/ModalUnstyled/modalUnstyledClasses.ts
@@ -6,6 +6,8 @@ export interface ModalUnstyledClasses {
   root: string;
   /** Styles applied to the root element if the `Modal` has exited. */
   hidden: string;
+  /** Styles applied to the backdrop element. */
+  backdrop: string;
 }
 
 export type ModalUnstyledClassKey = keyof ModalUnstyledClasses;
@@ -17,6 +19,7 @@ export function getModalUtilityClass(slot: string): string {
 const modalUnstyledClasses: ModalUnstyledClasses = generateUtilityClasses('MuiModal', [
   'root',
   'hidden',
+  'backdrop',
 ]);
 
 export default modalUnstyledClasses;

--- a/packages/mui-base/src/ModalUnstyled/modalUnstyledClasses.ts
+++ b/packages/mui-base/src/ModalUnstyled/modalUnstyledClasses.ts
@@ -2,11 +2,11 @@ import generateUtilityClasses from '../generateUtilityClasses';
 import generateUtilityClass from '../generateUtilityClass';
 
 export interface ModalUnstyledClasses {
-  /** Styles applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Styles applied to the root element if the `Modal` has exited. */
+  /** Class name applied to the root element if the `Modal` has exited. */
   hidden: string;
-  /** Styles applied to the backdrop element. */
+  /** Class name applied to the backdrop element. */
   backdrop: string;
 }
 

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.tsx
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.tsx
@@ -356,10 +356,6 @@ SliderUnstyled.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.tsx
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.tsx
@@ -20,7 +20,7 @@ function Identity(x) {
 }
 
 const useUtilityClasses = (ownerState: SliderUnstyledOwnerState) => {
-  const { disabled, dragging, marked, orientation, track, classes } = ownerState;
+  const { disabled, dragging, marked, orientation, track } = ownerState;
 
   const slots = {
     root: [
@@ -45,7 +45,7 @@ const useUtilityClasses = (ownerState: SliderUnstyledOwnerState) => {
     focusVisible: ['focusVisible'],
   };
 
-  return composeClasses(slots, getSliderUtilityClass, classes);
+  return composeClasses(slots, getSliderUtilityClass, {});
 };
 
 /**
@@ -67,7 +67,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled<
     'aria-labelledby': ariaLabelledby,
     className,
     component,
-    classes: classesProp,
     disableSwap = false,
     disabled = false,
     getAriaLabel,
@@ -100,7 +99,6 @@ const SliderUnstyled = React.forwardRef(function SliderUnstyled<
   > = {
     ...props,
     marks: marksProp,
-    classes: classesProp,
     disabled,
     isRtl,
     defaultValue,

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
@@ -1,7 +1,6 @@
 import { OverridableComponent, OverridableTypeMap, OverrideProps } from '@mui/types';
 import * as React from 'react';
 import { SlotComponentProps } from '../utils';
-import { SliderUnstyledClasses } from './sliderUnstyledClasses';
 import {
   UseSliderHiddenInputProps,
   UseSliderRootSlotProps,
@@ -46,10 +45,6 @@ export interface SliderUnstyledOwnProps {
    * A string value that provides a user-friendly name for the current value of the slider.
    */
   'aria-valuetext'?: string;
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<SliderUnstyledClasses>;
   /**
    * The default value. Use when the component is not controlled.
    */

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
@@ -9,10 +9,6 @@ export interface TablePaginationActionsUnstyledNextButtonSlotPropsOverrides {}
 export interface TablePaginationActionsUnstyledBackButtonSlotPropsOverrides {}
 
 export interface TablePaginationActionsUnstyledOwnProps {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: {};
   count: number;
   /**
    * The components used for each slot inside the TablePagination.

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { OverrideProps } from '@mui/types';
-import { TablePaginationUnstyledClasses } from './tablePaginationUnstyledClasses';
 import { SlotComponentProps } from '../utils';
 
 export interface LabelDisplayedRowsArgs {
@@ -22,10 +21,6 @@ export interface TablePaginationUnstyledToolbarSlotPropsOverrides {}
 export interface TablePaginationUnstyledSpacerSlotPropsOverrides {}
 
 export interface TablePaginationUnstyledOwnProps {
-  /**
-   * Override or extend the styles applied to the component.
-   */
-  classes?: Partial<TablePaginationUnstyledClasses>;
   /**
    * @ignore
    */

--- a/packages/mui-base/src/TablePaginationUnstyled/tablePaginationUnstyledClasses.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/tablePaginationUnstyledClasses.ts
@@ -2,27 +2,27 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface TablePaginationUnstyledClasses {
-  /** Styles applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Styles applied to the Toolbar component. */
+  /** Class name applied to the Toolbar component. */
   toolbar: string;
-  /** Styles applied to the spacer element. */
+  /** Class name applied to the spacer element. */
   spacer: string;
-  /** Styles applied to the select label Typography element. */
+  /** Class name applied to the select label Typography element. */
   selectLabel: string;
-  /** Styles applied to the Select component `root` element. */
+  /** Class name applied to the Select component `root` element. */
   selectRoot: string;
-  /** Styles applied to the Select component `select` class. */
+  /** Class name applied to the Select component `select` class. */
   select: string;
-  /** Styles applied to the Select component `icon` class. */
+  /** Class name applied to the Select component `icon` class. */
   selectIcon: string;
-  /** Styles applied to the Select component `root` element. */
+  /** Class name applied to the Select component `root` element. */
   input: string;
-  /** Styles applied to the MenuItem component. */
+  /** Class name applied to the MenuItem component. */
   menuItem: string;
-  /** Styles applied to the displayed rows Typography element. */
+  /** Class name applied to the displayed rows Typography element. */
   displayedRows: string;
-  /** Styles applied to the internal `TablePaginationUnstyledActions` component. */
+  /** Class name applied to the internal `TablePaginationUnstyledActions` component. */
   actions: string;
 }
 

--- a/packages/mui-joy/src/Slider/SliderProps.ts
+++ b/packages/mui-joy/src/Slider/SliderProps.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SliderUnstyledOwnProps } from '@mui/base/SliderUnstyled';
+import { SliderUnstyledClasses, SliderUnstyledOwnProps } from '@mui/base/SliderUnstyled';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { ColorPaletteProp, SxProps, VariantProp, ApplyColorInversion } from '../styles/types';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
@@ -36,6 +36,10 @@ export type SliderTypeMap<D extends React.ElementType = 'span', P = {}> = {
   props: P &
     Omit<SliderUnstyledOwnProps, 'slots' | 'slotProps'> &
     SliderSlotsAndSlotProps & {
+      /**
+       * Override or extend the styles applied to the component.
+       */
+      classes?: Partial<SliderUnstyledClasses>;
       /**
        * The color of the component. It supports those theme colors that make sense for this component.
        * @default 'primary'

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -40,6 +40,10 @@ export interface ModalTypeMap<D extends React.ElementType = 'div', P = {}> {
      */
     classes?: Partial<ModalUnstyledClasses>;
     /**
+     * @ignore
+     */
+    className?: string;
+    /**
      * The components used for each slot inside.
      *
      * This prop is an alias for the `slots` prop.

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps } from '@mui/base';
-import { ModalUnstyledTypeMap } from '@mui/base/ModalUnstyled';
+import { ModalUnstyledTypeMap, ModalUnstyledClasses } from '@mui/base/ModalUnstyled';
 import { Theme } from '../styles';
 import Backdrop, { BackdropProps } from '../Backdrop';
 import { OverridableComponent } from '../OverridableComponent';
@@ -35,6 +35,10 @@ export interface ModalTypeMap<D extends React.ElementType = 'div', P = {}> {
      * @deprecated Use `slotProps.backdrop` instead.
      */
     BackdropProps?: Partial<BackdropProps>;
+    /**
+     * Override or extend the styles applied to the component.
+     */
+    classes?: Partial<ModalUnstyledClasses>;
     /**
      * The components used for each slot inside.
      *

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import clsx from 'clsx';
 import ModalUnstyled, { modalUnstyledClasses } from '@mui/base/ModalUnstyled';
 import { isHostComponent, resolveComponentProps } from '@mui/base/utils';
 import { elementAcceptingRef, HTMLElementType } from '@mui/utils';
@@ -8,10 +9,6 @@ import useThemeProps from '../styles/useThemeProps';
 import Backdrop from '../Backdrop';
 
 export const modalClasses = modalUnstyledClasses;
-
-const extendUtilityClasses = (ownerState) => {
-  return ownerState.classes;
-};
 
 const ModalRoot = styled('div', {
   name: 'MuiModal',
@@ -62,6 +59,8 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   const {
     BackdropComponent = ModalBackdrop,
     BackdropProps,
+    classes,
+    className,
     closeAfterTransition = false,
     children,
     component,
@@ -102,8 +101,6 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     exited,
   };
 
-  const classes = extendUtilityClasses(ownerState);
-
   const RootSlot = slots?.root ?? components.Root ?? ModalRoot;
   const BackdropSlot = slots?.backdrop ?? components.Backdrop ?? BackdropComponent;
 
@@ -120,17 +117,23 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
         root: () => ({
           ...resolveComponentProps(rootSlotProps, ownerState),
           ...(!isHostComponent(RootSlot) && { as: component, theme }),
+          className: clsx(
+            className,
+            rootSlotProps?.className,
+            classes?.root,
+            !ownerState.open && ownerState.exited && classes?.hidden,
+          ),
         }),
         backdrop: () => ({
           ...BackdropProps,
           ...resolveComponentProps(backdropSlotProps, ownerState),
+          className: clsx(backdropSlotProps?.className, classes?.backdrop),
         }),
       }}
       onTransitionEnter={() => setExited(false)}
       onTransitionExited={() => setExited(true)}
       ref={ref}
       {...other}
-      classes={classes}
       {...commonProps}
     >
       {children}
@@ -171,6 +174,10 @@ Modal.propTypes /* remove-proptypes */ = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
   /**
    * When set to true the Modal waits until a nested Transition is completed before closing.
    * @default false

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -74,6 +74,19 @@ describe('<Modal />', () => {
     });
   });
 
+  describe('prop: classes', () => {
+    it('adds custom classes to the component', () => {
+      const { getByTestId } = render(
+        <Modal data-testid="Portal" open classes={{ root: 'custom-root', hidden: 'custom-hidden' }}>
+          <div />
+        </Modal>,
+      );
+      expect(getByTestId('Portal')).to.have.class(classes.root);
+      expect(getByTestId('Portal')).to.have.class('custom-root');
+      expect(getByTestId('Portal')).not.to.have.class('custom-hidden');
+    });
+  });
+
   describe('prop: open', () => {
     it('should not render the children by default', () => {
       const { queryByTestId } = render(

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -87,6 +87,10 @@ export interface SliderTypeMap<D extends React.ElementType = 'span', P = {}> {
      */
     classes?: Partial<SliderClasses>;
     /**
+     * @ignore
+     */
+    className?: string;
+    /**
      * The default value. Use when the component is not controlled.
      */
     defaultValue?: number | number[];

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -642,6 +642,7 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
       ...ownerState,
       ...thumbSlotProps?.ownerState,
     },
+    className: classes.thumb,
   });
 
   const valueLabelProps = useSlotProps({
@@ -665,6 +666,7 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
     elementType: MarkLabelSlot,
     externalSlotProps: markLabelSlotProps,
     ownerState,
+    className: classes.markLabel,
   });
 
   const inputSliderProps = useSlotProps({

--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -508,7 +508,6 @@ const Slider = React.forwardRef(function Slider(inputProps, ref) {
     componentsProps = {},
     color = 'primary',
     classes: classesProp,
-    // eslint-disable-next-line react/prop-types
     className,
     disableSwap = false,
     disabled = false,
@@ -833,6 +832,10 @@ Slider.propTypes /* remove-proptypes */ = {
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
   /**
    * The color of the component.
    * It supports both default and custom theme colors, which can be added as shown in the

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -197,6 +197,30 @@ describe('<Slider />', () => {
     expect(handleChange.args[1][1]).to.deep.equal(22);
   });
 
+  describe('prop: classes', () => {
+    it('adds custom classes to the component', () => {
+      const selectedClasses = ['root', 'rail', 'track', 'mark'];
+      const customClasses = selectedClasses.reduce((acc, curr) => {
+        acc[curr] = `custom-${curr}`;
+        return acc;
+      }, {});
+
+      const { container } = render(
+        <Slider
+          marks={[{ value: 0 }, { value: 20 }, { value: 30 }]}
+          defaultValue={0}
+          classes={customClasses}
+        />,
+      );
+
+      expect(container.firstChild).to.have.class(classes.root);
+      expect(container.firstChild).to.have.class('custom-root');
+      selectedClasses.slice(1).forEach((className, index) => {
+        expect(container.firstChild.children[index]).to.have.class(`custom-${className}`);
+      });
+    });
+  });
+
   describe('prop: orientation', () => {
     it('should render with the vertical classes', () => {
       const { container, getByRole } = render(<Slider orientation="vertical" value={0} />);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/36129

### Changes:
`ModalUnstyled`, `SliderUnstyled`, `TablePaginationUnstyled` and `TablePaginationActionsUnstyled` still support `classes` prop. This PR drops the prop from these components.