### PR TITLE
[Badge][material] Replace `BadgeUnstyled` with `useBadge` hook

### DIFF
--- a/docs/pages/material-ui/api/badge.json
+++ b/docs/pages/material-ui/api/badge.json
@@ -96,7 +96,7 @@
   "spread": true,
   "forwardsRefTo": "HTMLSpanElement",
   "filename": "/packages/mui-material/src/Badge/Badge.js",
-  "inheritance": { "component": "BadgeUnstyled", "pathname": "/base/api/badge-unstyled/" },
+  "inheritance": null,
   "demos": "<ul><li><a href=\"/material-ui/react-avatar/\">Avatar</a></li>\n<li><a href=\"/material-ui/react-badge/\">Badge</a></li></ul>",
   "cssComponent": false
 }

--- a/packages/mui-material/src/Badge/Badge.d.ts
+++ b/packages/mui-material/src/Badge/Badge.d.ts
@@ -102,7 +102,6 @@ export declare const BadgeMark: React.FC<BadgeBadgeProps>;
  * API:
  *
  * - [Badge API](https://mui.com/material-ui/api/badge/)
- * - inherits [BadgeUnstyled API](https://mui.com/base/api/badge-unstyled/)
  */
 declare const Badge: OverridableComponent<BadgeTypeMap>;
 

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -285,7 +285,6 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
   const badgeProps = useSlotProps({
     elementType: BadgeSlot,
     externalSlotProps: badgeSlotProps,
-    externalForwardedProps: other,
     ownerState,
     className: clsx(classes.badge, badgeSlotProps?.className),
   });

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -7,7 +7,6 @@ import { useBadge } from '@mui/base/BadgeUnstyled';
 import { useSlotProps } from '@mui/base';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
-import shouldSpreadAdditionalProps from '../utils/shouldSpreadAdditionalProps';
 import capitalize from '../utils/capitalize';
 import badgeClasses, { getBadgeUtilityClass } from './badgeClasses';
 

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -264,7 +264,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   // support both `slots` and `components` for backward compatibility
-  const RootSlot = component ?? slots?.root ?? components.Root ?? BadgeRoot;
+  const RootSlot = slots?.root ?? components.Root ?? BadgeRoot;
   const BadgeSlot = slots?.badge ?? components.Badge ?? BadgeBadge;
 
   const rootSlotProps = slotProps?.root ?? componentsProps.root;
@@ -276,6 +276,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
     externalForwardedProps: other,
     additionalProps: {
       ref,
+      as: component,
     },
     ownerState,
     className: clsx(rootSlotProps?.className, classes.root, className),

--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -265,7 +265,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
   const classes = useUtilityClasses(ownerState);
 
   // support both `slots` and `components` for backward compatibility
-  const RootSlot = slots?.root ?? components.Root ?? BadgeRoot;
+  const RootSlot = component ?? slots?.root ?? components.Root ?? BadgeRoot;
   const BadgeSlot = slots?.badge ?? components.Badge ?? BadgeBadge;
 
   const rootSlotProps = slotProps?.root ?? componentsProps.root;
@@ -276,10 +276,7 @@ const Badge = React.forwardRef(function Badge(inProps, ref) {
     externalSlotProps: rootSlotProps,
     externalForwardedProps: other,
     additionalProps: {
-      ...(shouldSpreadAdditionalProps(RootSlot) && {
-        as: component,
-        ref,
-      }),
+      ref,
     },
     ownerState,
     className: clsx(rootSlotProps?.className, classes.root, className),

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { BadgeUnstyled } from '@mui/base';
 import { createRenderer, describeConformance } from 'test/utils';
 import Badge, { badgeClasses as classes } from '@mui/material/Badge';
 
@@ -30,7 +29,7 @@ describe('<Badge />', () => {
     </Badge>,
     () => ({
       classes,
-      inheritComponent: BadgeUnstyled,
+      inheritComponent: 'span',
       render,
       refInstanceof: window.HTMLSpanElement,
       muiName: 'MuiBadge',
@@ -38,7 +37,7 @@ describe('<Badge />', () => {
     }),
   );
 
-  it('renders children and badgeContent', () => {
+  it('renderapps children and badgeContent', () => {
     const children = <div id="child" data-testid="child" />;
     const badge = <div id="badge" data-testid="badge" />;
     const { container, getByTestId } = render(<Badge badgeContent={badge}>{children}</Badge>);

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -37,7 +37,7 @@ describe('<Badge />', () => {
     }),
   );
 
-  it('renderapps children and badgeContent', () => {
+  it('renders children and badgeContent', () => {
     const children = <div id="child" data-testid="child" />;
     const badge = <div id="badge" data-testid="badge" />;
     const { container, getByTestId } = render(<Badge badgeContent={badge}>{children}</Badge>);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/36130
Solves part of https://github.com/mui/material-ui/issues/34502

### Changes
- Material `Badge` is implemented using `BadgeUnstyled` at the moment. It is replaced with `useBadge` hook in this PR since we want to implement design system components with hooks.