### PR TITLE
[Joy] Remove classes prop from the components that have it

### DIFF
--- a/packages/mui-joy/src/Divider/Divider.tsx
+++ b/packages/mui-joy/src/Divider/Divider.tsx
@@ -144,10 +144,6 @@ Divider.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/mui-joy/src/Divider/DividerProps.ts
+++ b/packages/mui-joy/src/Divider/DividerProps.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/types';
-import { DividerClasses } from './dividerClasses';
 
 export type DividerSlot = 'root';
 
@@ -13,10 +12,6 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<DividerClasses>;
     /**
      * The styles applied to the divider to shrink or stretch the line based on the orientation.
      */

--- a/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
+++ b/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
@@ -86,10 +86,6 @@ FormHelperText.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * The component used for the root node.
    * Either a string to use a HTML element or a component.
    */

--- a/packages/mui-joy/src/FormHelperText/FormHelperTextProps.ts
+++ b/packages/mui-joy/src/FormHelperText/FormHelperTextProps.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/types';
-import { FormHelperTextClasses } from './formHelperTextClasses';
 
 export type FormHelperTextSlot = 'root';
 
@@ -11,10 +10,6 @@ export interface FormHelperTextTypeMap<P = {}, D extends React.ElementType = 'p'
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<FormHelperTextClasses>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -115,10 +115,6 @@ ListDivider.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/mui-joy/src/ListDivider/ListDividerProps.ts
+++ b/packages/mui-joy/src/ListDivider/ListDividerProps.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/types';
-import { ListDividerClasses } from './listDividerClasses';
 
 export type ListDividerSlot = 'root';
 
@@ -13,10 +12,6 @@ export interface ListDividerTypeMap<P = {}, D extends React.ElementType = 'li'> 
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<ListDividerClasses>;
     /**
      * The empty space on the side(s) of the divider in a vertical list.
      *

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -210,10 +210,6 @@ ListItemButton.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/mui-joy/src/ListItemButton/ListItemButtonProps.ts
+++ b/packages/mui-joy/src/ListItemButton/ListItemButtonProps.ts
@@ -6,7 +6,6 @@ import {
   OverrideProps,
 } from '@mui/types';
 import { ColorPaletteProp, VariantProp, SxProps, ApplyColorInversion } from '../styles/types';
-import { ListItemButtonClasses } from './listItemButtonClasses';
 
 export type ListItemButtonSlot = 'root';
 
@@ -37,10 +36,6 @@ export interface ListItemButtonTypeMap<P = {}, D extends React.ElementType = 'di
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<ListItemButtonClasses>;
     /**
      * If `true`, the component is disabled.
      * @default false

--- a/packages/mui-joy/src/ListItemContent/ListItemContent.tsx
+++ b/packages/mui-joy/src/ListItemContent/ListItemContent.tsx
@@ -61,10 +61,6 @@ ListItemContent.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/mui-joy/src/ListItemContent/ListItemContentProps.ts
+++ b/packages/mui-joy/src/ListItemContent/ListItemContentProps.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/types';
-import { ListItemContentClasses } from './listItemContentClasses';
 
 export type ListItemContentSlot = 'root';
 
@@ -11,10 +10,6 @@ export interface ListItemContentTypeMap<P = {}, D extends React.ElementType = 'd
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<ListItemContentClasses>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
+++ b/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
@@ -73,10 +73,6 @@ ListItemDecorator.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
-   * Override or extend the styles applied to the component.
-   */
-  classes: PropTypes.object,
-  /**
    * @ignore
    */
   className: PropTypes.string,

--- a/packages/mui-joy/src/ListItemDecorator/ListItemDecoratorProps.ts
+++ b/packages/mui-joy/src/ListItemDecorator/ListItemDecoratorProps.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/types';
-import { ListItemDecoratorClasses } from './listItemDecoratorClasses';
 
 export type ListItemDecoratorSlot = 'root';
 
@@ -11,10 +10,6 @@ export interface ListItemDecoratorTypeMap<P = {}, D extends React.ElementType = 
      * The content of the component.
      */
     children?: React.ReactNode;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<ListItemDecoratorClasses>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Changes
- Many Joy components still support `classes` prop. This PR drops the prop from these components.

It would be easier to merge this only after we merge https://github.com/mui/material-ui/pull/36008 to have less conflict