### PR TITLE
[docs] Small color tweaks to the docs search bar

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -27,7 +27,7 @@ const SearchButton = styled('button')(({ theme }) => [
     display: 'flex',
     alignItems: 'center',
     margin: 0,
-    paddingLeft: theme.spacing(1),
+    paddingLeft: theme.spacing(0.6),
     [theme.breakpoints.only('xs')]: {
       backgroundColor: 'transparent',
       padding: 0,
@@ -38,7 +38,7 @@ const SearchButton = styled('button')(({ theme }) => [
       },
     },
     [theme.breakpoints.up('sm')]: {
-      minWidth: 200,
+      minWidth: 150,
     },
     fontFamily: theme.typography.fontFamily,
     position: 'relative',
@@ -51,15 +51,15 @@ const SearchButton = styled('button')(({ theme }) => [
     transitionProperty: 'all',
     transitionDuration: '150ms',
     '&:hover': {
-      background: alpha(theme.palette.grey[100], 0.7),
+      background: theme.palette.grey[100],
       borderColor: (theme.vars || theme).palette.grey[300],
     },
   },
   theme.applyDarkStyles({
-    backgroundColor: (theme.vars || theme).palette.primaryDark[900],
+    backgroundColor: alpha(theme.palette.primaryDark[700], 0.4),
     borderColor: (theme.vars || theme).palette.primaryDark[700],
     '&:hover': {
-      background: alpha(theme.palette.primaryDark[700], 0.4),
+      background: theme.palette.primaryDark[700],
       borderColor: (theme.vars || theme).palette.primaryDark[600],
     },
   }),
@@ -80,10 +80,10 @@ const Shortcut = styled('div')(({ theme }) => {
     marginLeft: theme.spacing(0.5),
     border: `1px solid ${(theme.vars || theme).palette.grey[200]}`,
     backgroundColor: '#FFF',
-    padding: theme.spacing(0, 0.8),
-    borderRadius: 5,
+    padding: theme.spacing(0, 0.5),
+    borderRadius: 7,
     ...theme.applyDarkStyles({
-      borderColor: (theme.vars || theme).palette.primaryDark[500],
+      borderColor: (theme.vars || theme).palette.primaryDark[600],
       backgroundColor: (theme.vars || theme).palette.primaryDark[800],
     }),
   };

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -51,7 +51,7 @@ const SearchButton = styled('button')(({ theme }) => [
     transitionProperty: 'all',
     transitionDuration: '150ms',
     '&:hover': {
-      background: theme.palette.grey[100],
+      background: (theme.vars || theme).palette.grey[100],
       borderColor: (theme.vars || theme).palette.grey[300],
     },
   },
@@ -59,7 +59,7 @@ const SearchButton = styled('button')(({ theme }) => [
     backgroundColor: alpha(theme.palette.primaryDark[700], 0.4),
     borderColor: (theme.vars || theme).palette.primaryDark[700],
     '&:hover': {
-      background: theme.palette.primaryDark[700],
+      background: (theme.vars || theme).palette.primaryDark[700],
       borderColor: (theme.vars || theme).palette.primaryDark[600],
     },
   }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

That's basically it! Some small tweaks in colors for that component, just to fine-tune a bit more. Also reduced slightly the `minWidth` so we gain a bit more space, especially when there are banners on the side of it.
