### PR TITLE
[StyledEngineProvider] Fix issue with cache not being defined

### DIFF
--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.js
@@ -12,7 +12,7 @@ if (typeof document === 'object') {
 
 export default function StyledEngineProvider(props) {
   const { injectFirst, children } = props;
-  return injectFirst ? <CacheProvider value={cache}>{children}</CacheProvider> : children;
+  return injectFirst && cache ? <CacheProvider value={cache}>{children}</CacheProvider> : children;
 }
 
 StyledEngineProvider.propTypes = {


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/36096, a regression from https://github.com/mui/material-ui/pull/36001. The emotion cache provided previously could have been undefined, which was throwing an error. The changes were tested locally, the codesandboxes takes ages to load for me 😕 

Before: https://codesandbox.io/s/lucid-dan-n6hu29?file=/package.json
After: https://codesandbox.io/s/pensive-violet-on5wym?file=/package.json