### PR TITLE
[Grid][Stack] classNames prefixed with Mui

### DIFF
--- a/packages/mui-joy/src/Box/Box.test.js
+++ b/packages/mui-joy/src/Box/Box.test.js
@@ -50,9 +50,9 @@ describe('Joy <Box />', () => {
 
     it('get custom className', () => {
       const { container, rerender } = render(<Box />);
-      expect(container.firstChild).to.have.class('JoyBox-root');
+      expect(container.firstChild).to.have.class('MuiBox-root');
 
-      ClassNameGenerator.configure((name) => name.replace('Joy', 'Company'));
+      ClassNameGenerator.configure((name) => name.replace('Mui', 'Company'));
 
       rerender(<Box />);
 

--- a/packages/mui-joy/src/Box/Box.tsx
+++ b/packages/mui-joy/src/Box/Box.tsx
@@ -6,7 +6,7 @@ import defaultTheme from '../styles/defaultTheme';
 
 const Box = createBox<Theme>({
   defaultTheme,
-  defaultClassName: 'JoyBox-root',
+  defaultClassName: 'MuiBox-root',
   generateClassName: ClassNameGenerator.generate,
 });
 

--- a/packages/mui-joy/src/Grid/Grid.test.js
+++ b/packages/mui-joy/src/Grid/Grid.test.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { describeConformance, createRenderer } from 'test/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Grid, { gridClasses as classes } from '@mui/joy/Grid';
@@ -20,4 +21,9 @@ describe('Joy UI <Grid />', () => {
     testVariantProps: { container: true, spacing: 5 },
     skip: ['componentsProp', 'classesRoot', 'rootClass'],
   }));
+
+  it('className should be prefixed with Mui', () => {
+    const { container } = render(<Grid />);
+    expect(container.firstChild).to.have.class('MuiGrid-root');
+  });
 });

--- a/packages/mui-joy/src/Grid/Grid.tsx
+++ b/packages/mui-joy/src/Grid/Grid.tsx
@@ -9,7 +9,6 @@ const Grid = createGrid({
     name: 'JoyGrid',
     overridesResolver: (props, styles) => styles.root,
   }),
-  componentName: 'JoyGrid',
   useThemeProps: (inProps) => useThemeProps({ props: inProps, name: 'JoyGrid' }),
 }) as OverridableComponent<GridTypeMap>;
 

--- a/packages/mui-joy/src/Stack/Stack.test.js
+++ b/packages/mui-joy/src/Stack/Stack.test.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { describeConformance, createRenderer } from 'test/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Stack, { stackClasses as classes } from '@mui/joy/Stack';
@@ -20,4 +21,9 @@ describe('Joy <Stack />', () => {
     skip: ['componentsProp', 'rootClass'],
     testVariantProps: { direction: 'row' },
   }));
+
+  it('className should be prefixed with Mui', () => {
+    const { container } = render(<Stack />);
+    expect(container.firstChild).to.have.class('MuiStack-root');
+  });
 });

--- a/packages/mui-joy/src/Stack/Stack.tsx
+++ b/packages/mui-joy/src/Stack/Stack.tsx
@@ -6,7 +6,6 @@ import styled from '../styles/styled';
 import { useThemeProps } from '../styles';
 
 const Stack = createStack({
-  componentName: 'JoyStack',
   createStyledComponent: styled('div', {
     name: 'JoyStack',
     slot: 'Root',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes part of : https://github.com/mui/material-ui/issues/36082

tried changing classnames of Box from JoyBox-root to MuiBox-root but some existing tests were failing and i was bit spectical on changes introduced

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
