### PR TITLE
[docs] Fix the prop type regression on the API pages

### DIFF
--- a/docs/pages/base/api/use-autocomplete.json
+++ b/docs/pages/base/api/use-autocomplete.json
@@ -1,232 +1,147 @@
 {
   "parameters": {
     "options": {
-      "type": { "name": "ReadonlyArray<T>", "description": "Array of options." },
+      "type": { "name": "ReadonlyArray&lt;T&gt", "description": "ReadonlyArray&lt;T&gt" },
       "required": true
     },
-    "autoComplete": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the portion of the selected suggestion that has not been typed by the user,\nknown as the completion string, appears inline after the input cursor in the textbox.\nThe inline completion string is visually highlighted and has a selected state."
-      },
-      "default": "false"
-    },
+    "autoComplete": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
     "autoHighlight": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the first option is automatically highlighted."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
-    "autoSelect": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the selected option becomes the value of the input\nwhen the Autocomplete loses focus unless the user chooses\na different option or changes the character string in the input."
-      },
-      "default": "false"
-    },
+    "autoSelect": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
     "blurOnSelect": {
       "type": {
-        "name": "'touch' | 'mouse' | true | false",
-        "description": "Control if the input should be blurred when an option is selected:\n\n- `false` the input is not blurred.\n- `true` the input is always blurred.\n- `touch` the input is blurred after a touch event.\n- `mouse` the input is blurred after a mouse event."
+        "name": "&#39;touch&#39; | &#39;mouse&#39; | true | false",
+        "description": "&#39;touch&#39; | &#39;mouse&#39; | true | false"
       },
       "default": "false"
     },
     "clearOnBlur": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the input's text is cleared on blur if no value is selected.\n\nSet to `true` if you want to help the user enter a new value.\nSet to `false` if you want to help the user resume their search."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "!props.freeSolo"
     },
     "clearOnEscape": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, clear all values when the user presses escape and the popup is closed."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
-    "componentName": {
-      "type": {
-        "name": "string",
-        "description": "The component name that is using this hook. Used for warnings."
-      }
-    },
+    "componentName": { "type": { "name": "string", "description": "string" } },
     "defaultValue": {
       "type": {
-        "name": "AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>",
-        "description": "The default value. Use when the component is not controlled."
+        "name": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt",
+        "description": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt"
       },
       "default": "props.multiple ? [] : null"
     },
     "disableClearable": {
-      "type": {
-        "name": "DisableClearable",
-        "description": "If `true`, the input can't be cleared."
-      },
+      "type": { "name": "DisableClearable", "description": "DisableClearable" },
       "default": "false"
     },
     "disableCloseOnSelect": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the popup won't close when a value is selected."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
-    "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component is disabled." },
-      "default": "false"
-    },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
     "disabledItemsFocusable": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, will allow focus on disabled items."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
     "disableListWrap": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the list box in the popup will not wrap focus."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
     "filterOptions": {
       "type": {
-        "name": "(options: T[], state: FilterOptionsState<T>) => T[]",
-        "description": "A function that determines the filtered options to be rendered on search."
+        "name": "(options: T[], state: FilterOptionsState&lt;T&gt) =&gt T[]",
+        "description": "(options: T[], state: FilterOptionsState&lt;T&gt) =&gt T[]"
       }
     },
     "filterSelectedOptions": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, hide the selected options from the list box."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
-    "freeSolo": {
-      "type": {
-        "name": "FreeSolo",
-        "description": "If `true`, the Autocomplete is free solo, meaning that the user input is not bound to provided options."
-      },
-      "default": "false"
-    },
+    "freeSolo": { "type": { "name": "FreeSolo", "description": "FreeSolo" }, "default": "false" },
     "getOptionDisabled": {
-      "type": {
-        "name": "(option: T) => boolean",
-        "description": "Used to determine the disabled state for a given option."
-      }
+      "type": { "name": "(option: T) =&gt boolean", "description": "(option: T) =&gt boolean" }
     },
     "getOptionLabel": {
       "type": {
-        "name": "(option: T | AutocompleteFreeSoloValueMapping<FreeSolo>) => string",
-        "description": "Used to determine the string value for a given option.\nIt's used to fill the input (and the list box options if `renderOption` is not provided).\n\nIf used in free solo mode, it must accept both the type of the options and a string."
+        "name": "(option: T | AutocompleteFreeSoloValueMapping&lt;FreeSolo&gt) =&gt string",
+        "description": "(option: T | AutocompleteFreeSoloValueMapping&lt;FreeSolo&gt) =&gt string"
       },
       "default": "(option) => option.label ?? option"
     },
     "groupBy": {
-      "type": {
-        "name": "(option: T) => string",
-        "description": "If provided, the options will be grouped under the returned string.\nThe groupBy value is also used as the text for group headings when `renderGroup` is not provided."
-      }
+      "type": { "name": "(option: T) =&gt string", "description": "(option: T) =&gt string" }
     },
     "handleHomeEndKeys": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the component handles the \"Home\" and \"End\" keys when the popup is open.\nIt should move focus to the first option and last option, respectively."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "!props.freeSolo"
     },
-    "id": {
-      "type": {
-        "name": "string",
-        "description": "This prop is used to help implement the accessibility logic.\nIf you don't provide an id it will fall back to a randomly generated one."
-      }
-    },
+    "id": { "type": { "name": "string", "description": "string" } },
     "includeInputInList": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the highlight can move to the input."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
-    "inputValue": { "type": { "name": "string", "description": "The input value." } },
+    "inputValue": { "type": { "name": "string", "description": "string" } },
     "isOptionEqualToValue": {
       "type": {
-        "name": "(option: T, value: T) => boolean",
-        "description": "Used to determine if the option represents the given value.\nUses strict equality by default.\n⚠️ Both arguments need to be handled, an option can only match with one value."
+        "name": "(option: T, value: T) =&gt boolean",
+        "description": "(option: T, value: T) =&gt boolean"
       }
     },
-    "multiple": {
-      "type": {
-        "name": "Multiple",
-        "description": "If `true`, `value` must be an array and the menu will support multiple selections."
-      },
-      "default": "false"
-    },
+    "multiple": { "type": { "name": "Multiple", "description": "Multiple" }, "default": "false" },
     "onChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, value: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails<T>) => void",
-        "description": "Callback fired when the value changes."
+        "name": "(event: React.SyntheticEvent, value: AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails&lt;T&gt) =&gt void",
+        "description": "(event: React.SyntheticEvent, value: AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails&lt;T&gt) =&gt void"
       }
     },
     "onClose": {
       "type": {
-        "name": "(event: React.SyntheticEvent, reason: AutocompleteCloseReason) => void",
-        "description": "Callback fired when the popup requests to be closed.\nUse in controlled mode (see open)."
+        "name": "(event: React.SyntheticEvent, reason: AutocompleteCloseReason) =&gt void",
+        "description": "(event: React.SyntheticEvent, reason: AutocompleteCloseReason) =&gt void"
       }
     },
     "onHighlightChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, option: T | null, reason: AutocompleteHighlightChangeReason) => void",
-        "description": "Callback fired when the highlight option changes."
+        "name": "(event: React.SyntheticEvent, option: T | null, reason: AutocompleteHighlightChangeReason) =&gt void",
+        "description": "(event: React.SyntheticEvent, option: T | null, reason: AutocompleteHighlightChangeReason) =&gt void"
       }
     },
     "onInputChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, value: string, reason: AutocompleteInputChangeReason) => void",
-        "description": "Callback fired when the input value changes."
+        "name": "(event: React.SyntheticEvent, value: string, reason: AutocompleteInputChangeReason) =&gt void",
+        "description": "(event: React.SyntheticEvent, value: string, reason: AutocompleteInputChangeReason) =&gt void"
       }
     },
     "onOpen": {
       "type": {
-        "name": "(event: React.SyntheticEvent) => void",
-        "description": "Callback fired when the popup requests to be opened.\nUse in controlled mode (see open)."
+        "name": "(event: React.SyntheticEvent) =&gt void",
+        "description": "(event: React.SyntheticEvent) =&gt void"
       }
     },
-    "open": { "type": { "name": "boolean", "description": "If `true`, the component is shown." } },
-    "openOnFocus": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the popup will open on input focus."
-      },
-      "default": "false"
-    },
-    "readOnly": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the component becomes readonly. It is also supported for multiple tags where the tag cannot be deleted."
-      },
-      "default": "false"
-    },
+    "open": { "type": { "name": "boolean", "description": "boolean" } },
+    "openOnFocus": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
+    "readOnly": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
     "selectOnFocus": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the input's text is selected on focus.\nIt helps the user clear the selected value."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "!props.freeSolo"
     },
     "unstable_classNamePrefix": {
-      "type": { "name": "string", "description": "" },
+      "type": { "name": "string", "description": "string" },
       "default": "'Mui'"
     },
     "unstable_isActiveElementInListbox": {
-      "type": { "name": "(listbox: React.RefObject<HTMLElement>) => boolean", "description": "" }
+      "type": {
+        "name": "(listbox: React.RefObject&lt;HTMLElement&gt) =&gt boolean",
+        "description": "(listbox: React.RefObject&lt;HTMLElement&gt) =&gt boolean"
+      }
     },
     "value": {
       "type": {
-        "name": "AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>",
-        "description": "The value of the autocomplete.\n\nThe value must have reference equality with the option in order to be selected.\nYou can customize the equality behavior with the `isOptionEqualToValue` prop."
+        "name": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt",
+        "description": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt"
       }
     }
   },

--- a/docs/pages/base/api/use-badge.json
+++ b/docs/pages/base/api/use-badge.json
@@ -1,9 +1,9 @@
 {
   "parameters": {
-    "badgeContent": { "type": { "name": "React.ReactNode", "description": "" } },
-    "invisible": { "type": { "name": "boolean", "description": "" } },
-    "max": { "type": { "name": "number", "description": "" } },
-    "showZero": { "type": { "name": "boolean", "description": "" } }
+    "badgeContent": { "type": { "name": "React.ReactNode", "description": "React.ReactNode" } },
+    "invisible": { "type": { "name": "boolean", "description": "boolean" } },
+    "max": { "type": { "name": "number", "description": "number" } },
+    "showZero": { "type": { "name": "boolean", "description": "boolean" } }
   },
   "returnValue": {},
   "name": "useBadge",

--- a/docs/pages/base/api/use-button.json
+++ b/docs/pages/base/api/use-button.json
@@ -1,61 +1,57 @@
 {
   "parameters": {
-    "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component is disabled." },
-      "default": "false"
-    },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
     "focusableWhenDisabled": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, allows a disabled button to receive focus."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
-    "href": { "type": { "name": "string", "description": "" } },
-    "onFocusVisible": { "type": { "name": "React.FocusEventHandler", "description": "" } },
-    "ref": { "type": { "name": "React.Ref<any>", "description": "" } },
-    "tabIndex": {
-      "type": { "name": "NonNullable<React.HTMLAttributes<any>['tabIndex']>", "description": "" }
+    "href": { "type": { "name": "string", "description": "string" } },
+    "onFocusVisible": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
     },
-    "to": { "type": { "name": "string", "description": "" } },
+    "ref": { "type": { "name": "React.Ref&lt;any&gt", "description": "React.Ref&lt;any&gt" } },
+    "tabIndex": {
+      "type": {
+        "name": "NonNullable&lt;React.HTMLAttributes&lt;any&gt[&#39;tabIndex&#39;]&gt",
+        "description": "NonNullable&lt;React.HTMLAttributes&lt;any&gt[&#39;tabIndex&#39;]&gt"
+      }
+    },
+    "to": { "type": { "name": "string", "description": "string" } },
     "type": {
       "type": {
-        "name": "React.ButtonHTMLAttributes<HTMLButtonElement>['type']",
-        "description": "Type attribute applied when the `component` is `button`."
+        "name": "React.ButtonHTMLAttributes&lt;HTMLButtonElement&gt[&#39;type&#39;]",
+        "description": "React.ButtonHTMLAttributes&lt;HTMLButtonElement&gt[&#39;type&#39;]"
       },
       "default": "'button'"
     }
   },
   "returnValue": {
     "active": {
-      "type": { "name": "boolean", "description": "If `true`, the component is active (pressed)." },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component is disabled." },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "focusVisible": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the component is being focused using keyboard."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "getRootProps": {
       "type": {
-        "name": "<TOther extends EventHandlers = {}>(otherHandlers?: TOther) => UseButtonRootSlotProps<TOther>",
-        "description": "Resolver for the root slot's props."
+        "name": "&lt;TOther extends EventHandlers = {}&gt(otherHandlers?: TOther) =&gt UseButtonRootSlotProps&lt;TOther&gt",
+        "description": "&lt;TOther extends EventHandlers = {}&gt(otherHandlers?: TOther) =&gt UseButtonRootSlotProps&lt;TOther&gt"
       },
       "required": true
     },
     "setFocusVisible": {
       "type": {
-        "name": "React.Dispatch<React.SetStateAction<boolean>>",
-        "description": "Callback for setting the `focusVisible` param."
+        "name": "React.Dispatch&lt;React.SetStateAction&lt;boolean&gt&gt",
+        "description": "React.Dispatch&lt;React.SetStateAction&lt;boolean&gt&gt"
       },
       "required": true
     }

--- a/docs/pages/base/api/use-input.json
+++ b/docs/pages/base/api/use-input.json
@@ -1,90 +1,75 @@
 {
   "parameters": {
-    "defaultValue": {
+    "defaultValue": { "type": { "name": "unknown", "description": "unknown" } },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" } },
+    "error": { "type": { "name": "boolean", "description": "boolean" } },
+    "inputRef": {
       "type": {
-        "name": "unknown",
-        "description": "The default value. Use when the component is not controlled."
+        "name": "React.Ref&lt;HTMLInputElement&gt",
+        "description": "React.Ref&lt;HTMLInputElement&gt"
       }
     },
-    "disabled": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the component is disabled.\nThe prop defaults to the value (`false`) inherited from the parent FormControl component."
-      }
+    "onBlur": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
     },
-    "error": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the `input` will indicate an error by setting the `aria-invalid` attribute.\nThe prop defaults to the value (`false`) inherited from the parent FormControl component."
-      }
-    },
-    "inputRef": { "type": { "name": "React.Ref<HTMLInputElement>", "description": "" } },
-    "onBlur": { "type": { "name": "React.FocusEventHandler", "description": "" } },
     "onChange": {
-      "type": { "name": "React.ChangeEventHandler<HTMLInputElement>", "description": "" }
-    },
-    "onClick": { "type": { "name": "React.MouseEventHandler", "description": "" } },
-    "onFocus": { "type": { "name": "React.FocusEventHandler", "description": "" } },
-    "required": {
       "type": {
-        "name": "boolean",
-        "description": "If `true`, the `input` element is required.\nThe prop defaults to the value (`false`) inherited from the parent FormControl component."
+        "name": "React.ChangeEventHandler&lt;HTMLInputElement&gt",
+        "description": "React.ChangeEventHandler&lt;HTMLInputElement&gt"
       }
     },
-    "value": { "type": { "name": "unknown", "description": "" } }
+    "onClick": {
+      "type": { "name": "React.MouseEventHandler", "description": "React.MouseEventHandler" }
+    },
+    "onFocus": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
+    },
+    "required": { "type": { "name": "boolean", "description": "boolean" } },
+    "value": { "type": { "name": "unknown", "description": "unknown" } }
   },
   "returnValue": {
     "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component will be disabled." },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "error": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the `input` will indicate an error by setting the `aria-invalid` attribute."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "focused": {
-      "type": { "name": "boolean", "description": "If `true`, the `input` will be focused." },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "formControlContext": {
       "type": {
         "name": "FormControlUnstyledState | undefined",
-        "description": "Return value from the `useFormControlUnstyledContext` hook."
+        "description": "FormControlUnstyledState | undefined"
       },
       "required": true
     },
     "getInputProps": {
       "type": {
-        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputInputSlotProps<TOther>",
-        "description": "Resolver for the input slot's props."
+        "name": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseInputInputSlotProps&lt;TOther&gt",
+        "description": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseInputInputSlotProps&lt;TOther&gt"
       },
       "required": true
     },
     "getRootProps": {
       "type": {
-        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseInputRootSlotProps<TOther>",
-        "description": "Resolver for the root slot's props."
+        "name": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseInputRootSlotProps&lt;TOther&gt",
+        "description": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseInputRootSlotProps&lt;TOther&gt"
       },
       "required": true
     },
     "required": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the `input` will indicate that it's required."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
-    "value": {
-      "type": { "name": "unknown", "description": "The `value` of the `input` element." },
-      "required": true
-    }
+    "value": { "type": { "name": "unknown", "description": "unknown" }, "required": true }
   },
   "name": "useInput",
   "filename": "/packages/mui-base/src/InputUnstyled/useInput.ts",

--- a/docs/pages/base/api/use-menu-item.json
+++ b/docs/pages/base/api/use-menu-item.json
@@ -1,9 +1,17 @@
 {
   "parameters": {
-    "ref": { "type": { "name": "React.Ref<any>", "description": "" }, "required": true },
-    "disabled": { "type": { "name": "boolean", "description": "" } },
-    "label": { "type": { "name": "string", "description": "" } },
-    "onClick": { "type": { "name": "React.MouseEventHandler<any>", "description": "" } }
+    "ref": {
+      "type": { "name": "React.Ref&lt;any&gt", "description": "React.Ref&lt;any&gt" },
+      "required": true
+    },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" } },
+    "label": { "type": { "name": "string", "description": "string" } },
+    "onClick": {
+      "type": {
+        "name": "React.MouseEventHandler&lt;any&gt",
+        "description": "React.MouseEventHandler&lt;any&gt"
+      }
+    }
   },
   "returnValue": {},
   "name": "useMenuItem",

--- a/docs/pages/base/api/use-menu.json
+++ b/docs/pages/base/api/use-menu.json
@@ -1,9 +1,11 @@
 {
   "parameters": {
-    "listboxId": { "type": { "name": "string", "description": "" } },
-    "listboxRef": { "type": { "name": "React.Ref<any>", "description": "" } },
-    "onClose": { "type": { "name": "() => void", "description": "" } },
-    "open": { "type": { "name": "boolean", "description": "" } }
+    "listboxId": { "type": { "name": "string", "description": "string" } },
+    "listboxRef": {
+      "type": { "name": "React.Ref&lt;any&gt", "description": "React.Ref&lt;any&gt" }
+    },
+    "onClose": { "type": { "name": "() =&gt void", "description": "() =&gt void" } },
+    "open": { "type": { "name": "boolean", "description": "boolean" } }
   },
   "returnValue": {},
   "name": "useMenu",

--- a/docs/pages/base/api/use-slider.json
+++ b/docs/pages/base/api/use-slider.json
@@ -1,32 +1,45 @@
 {
   "parameters": {
-    "ref": { "type": { "name": "React.Ref<any>", "description": "" }, "required": true },
-    "aria-labelledby": { "type": { "name": "string", "description": "" } },
-    "defaultValue": { "type": { "name": "number | number[]", "description": "" } },
-    "disabled": { "type": { "name": "boolean", "description": "" } },
-    "disableSwap": { "type": { "name": "boolean", "description": "" } },
-    "isRtl": { "type": { "name": "boolean", "description": "" } },
-    "marks": { "type": { "name": "boolean | Mark[]", "description": "" } },
-    "max": { "type": { "name": "number", "description": "" } },
-    "min": { "type": { "name": "number", "description": "" } },
-    "name": { "type": { "name": "string", "description": "" } },
+    "ref": {
+      "type": { "name": "React.Ref&lt;any&gt", "description": "React.Ref&lt;any&gt" },
+      "required": true
+    },
+    "aria-labelledby": { "type": { "name": "string", "description": "string" } },
+    "defaultValue": { "type": { "name": "number | number[]", "description": "number | number[]" } },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" } },
+    "disableSwap": { "type": { "name": "boolean", "description": "boolean" } },
+    "isRtl": { "type": { "name": "boolean", "description": "boolean" } },
+    "marks": { "type": { "name": "boolean | Mark[]", "description": "boolean | Mark[]" } },
+    "max": { "type": { "name": "number", "description": "number" } },
+    "min": { "type": { "name": "number", "description": "number" } },
+    "name": { "type": { "name": "string", "description": "string" } },
     "onChange": {
       "type": {
-        "name": "(event: Event, value: number | number[], activeThumb: number) => void",
-        "description": ""
+        "name": "(event: Event, value: number | number[], activeThumb: number) =&gt void",
+        "description": "(event: Event, value: number | number[], activeThumb: number) =&gt void"
       }
     },
     "onChangeCommitted": {
       "type": {
-        "name": "(event: React.SyntheticEvent | Event, value: number | number[]) => void",
-        "description": ""
+        "name": "(event: React.SyntheticEvent | Event, value: number | number[]) =&gt void",
+        "description": "(event: React.SyntheticEvent | Event, value: number | number[]) =&gt void"
       }
     },
-    "orientation": { "type": { "name": "'horizontal' | 'vertical'", "description": "" } },
-    "scale": { "type": { "name": "(value: number) => number", "description": "" } },
-    "step": { "type": { "name": "number | null", "description": "" } },
-    "tabIndex": { "type": { "name": "number", "description": "" } },
-    "value": { "type": { "name": "number | number[]", "description": "" } }
+    "orientation": {
+      "type": {
+        "name": "&#39;horizontal&#39; | &#39;vertical&#39;",
+        "description": "&#39;horizontal&#39; | &#39;vertical&#39;"
+      }
+    },
+    "scale": {
+      "type": {
+        "name": "(value: number) =&gt number",
+        "description": "(value: number) =&gt number"
+      }
+    },
+    "step": { "type": { "name": "number | null", "description": "number | null" } },
+    "tabIndex": { "type": { "name": "number", "description": "number" } },
+    "value": { "type": { "name": "number | number[]", "description": "number | number[]" } }
   },
   "returnValue": {},
   "name": "useSlider",

--- a/docs/pages/base/api/use-snackbar.json
+++ b/docs/pages/base/api/use-snackbar.json
@@ -1,33 +1,22 @@
 {
   "parameters": {
     "autoHideDuration": {
-      "type": {
-        "name": "number | null",
-        "description": "The number of milliseconds to wait before automatically calling the\n`onClose` function. `onClose` should then set the state of the `open`\nprop to hide the Snackbar. This behavior is disabled by default with\nthe `null` value."
-      },
+      "type": { "name": "number | null", "description": "number | null" },
       "default": "null"
     },
     "disableWindowBlurListener": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, the `autoHideDuration` timer will expire even if the window is not focused."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false"
     },
     "onClose": {
       "type": {
-        "name": "(event: React.SyntheticEvent<any> | Event | null, reason: SnackbarCloseReason) => void",
-        "description": "Callback fired when the component requests to be closed.\nTypically `onClose` is used to set state in the parent component,\nwhich is used to control the `Snackbar` `open` prop.\nThe `reason` parameter can optionally be used to control the response to `onClose`,\nfor example ignoring `clickaway`."
+        "name": "(event: React.SyntheticEvent&lt;any&gt | Event | null, reason: SnackbarCloseReason) =&gt void",
+        "description": "(event: React.SyntheticEvent&lt;any&gt | Event | null, reason: SnackbarCloseReason) =&gt void"
       }
     },
-    "open": { "type": { "name": "boolean", "description": "If `true`, the component is shown." } },
-    "ref": { "type": { "name": "React.Ref<any>", "description": "" } },
-    "resumeHideDuration": {
-      "type": {
-        "name": "number",
-        "description": "The number of milliseconds to wait before dismissing after user interaction.\nIf `autoHideDuration` prop isn't specified, it does nothing.\nIf `autoHideDuration` prop is specified but `resumeHideDuration` isn't,\nwe default to `autoHideDuration / 2` ms."
-      }
-    }
+    "open": { "type": { "name": "boolean", "description": "boolean" } },
+    "ref": { "type": { "name": "React.Ref&lt;any&gt", "description": "React.Ref&lt;any&gt" } },
+    "resumeHideDuration": { "type": { "name": "number", "description": "number" } }
   },
   "returnValue": {},
   "name": "useSnackbar",

--- a/docs/pages/base/api/use-switch.json
+++ b/docs/pages/base/api/use-switch.json
@@ -1,32 +1,25 @@
 {
   "parameters": {
-    "checked": {
-      "type": { "name": "boolean", "description": "If `true`, the component is checked." }
+    "checked": { "type": { "name": "boolean", "description": "boolean" } },
+    "defaultChecked": { "type": { "name": "boolean", "description": "boolean" } },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" } },
+    "onBlur": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
     },
-    "defaultChecked": {
-      "type": {
-        "name": "boolean",
-        "description": "The default checked state. Use when the component is not controlled."
-      }
-    },
-    "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component is disabled." }
-    },
-    "onBlur": { "type": { "name": "React.FocusEventHandler", "description": "" } },
     "onChange": {
       "type": {
-        "name": "React.ChangeEventHandler<HTMLInputElement>",
-        "description": "Callback fired when the state is changed."
+        "name": "React.ChangeEventHandler&lt;HTMLInputElement&gt",
+        "description": "React.ChangeEventHandler&lt;HTMLInputElement&gt"
       }
     },
-    "onFocus": { "type": { "name": "React.FocusEventHandler", "description": "" } },
-    "onFocusVisible": { "type": { "name": "React.FocusEventHandler", "description": "" } },
-    "readOnly": {
-      "type": { "name": "boolean", "description": "If `true`, the component is read only." }
+    "onFocus": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
     },
-    "required": {
-      "type": { "name": "boolean", "description": "If `true`, the `input` element is required." }
-    }
+    "onFocusVisible": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
+    },
+    "readOnly": { "type": { "name": "boolean", "description": "boolean" } },
+    "required": { "type": { "name": "boolean", "description": "boolean" } }
   },
   "returnValue": {},
   "name": "useSwitch",

--- a/docs/pages/base/api/use-tab-panel.json
+++ b/docs/pages/base/api/use-tab-panel.json
@@ -1,26 +1,20 @@
 {
   "parameters": {
     "value": {
-      "type": {
-        "name": "number | string",
-        "description": "The value of the TabPanel. It will be shown when the Tab with the corresponding value is selected."
-      },
+      "type": { "name": "number | string", "description": "number | string" },
       "required": true
     }
   },
   "returnValue": {
     "getRootProps": {
       "type": {
-        "name": "() => {\n  'aria-labelledby': string | undefined\n  hidden: boolean\n  id: string | undefined\n}",
-        "description": "Resolver for the root slot's props."
+        "name": "() =&gt {\n  &#39;aria-labelledby&#39;: string | undefined\n  hidden: boolean\n  id: string | undefined\n}",
+        "description": "() =&gt {\n  &#39;aria-labelledby&#39;: string | undefined\n  hidden: boolean\n  id: string | undefined\n}"
       },
       "required": true
     },
     "hidden": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, it indicates that the tab panel will be hidden."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     }

--- a/docs/pages/base/api/use-tab.json
+++ b/docs/pages/base/api/use-tab.json
@@ -1,52 +1,48 @@
 {
   "parameters": {
-    "ref": { "type": { "name": "React.Ref<any>", "description": "" }, "required": true },
-    "disabled": { "type": { "name": "boolean", "description": "" } },
+    "ref": {
+      "type": { "name": "React.Ref&lt;any&gt", "description": "React.Ref&lt;any&gt" },
+      "required": true
+    },
+    "disabled": { "type": { "name": "boolean", "description": "boolean" } },
     "onChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, value: number | string) => void",
-        "description": "Callback invoked when new value is being set."
+        "name": "(event: React.SyntheticEvent, value: number | string) =&gt void",
+        "description": "(event: React.SyntheticEvent, value: number | string) =&gt void"
       }
     },
-    "onClick": { "type": { "name": "React.MouseEventHandler", "description": "" } },
-    "onFocus": { "type": { "name": "React.FocusEventHandler", "description": "" } },
-    "value": {
-      "type": {
-        "name": "number | string",
-        "description": "You can provide your own value. Otherwise, we fall back to the child position index."
-      }
-    }
+    "onClick": {
+      "type": { "name": "React.MouseEventHandler", "description": "React.MouseEventHandler" }
+    },
+    "onFocus": {
+      "type": { "name": "React.FocusEventHandler", "description": "React.FocusEventHandler" }
+    },
+    "value": { "type": { "name": "number | string", "description": "number | string" } }
   },
   "returnValue": {
     "active": {
-      "type": { "name": "boolean", "description": "If `true`, the component will be active." },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "disabled": {
-      "type": { "name": "boolean", "description": "If `true`, the component will be disabled." },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
-    "focusVisible": {
-      "type": { "name": "boolean", "description": "If `true`, the tab's focus will be visible." },
-      "required": true
-    },
+    "focusVisible": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "getRootProps": {
       "type": {
-        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseTabRootSlotProps<TOther>",
-        "description": "Resolver for the root slot's props."
+        "name": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseTabRootSlotProps&lt;TOther&gt",
+        "description": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseTabRootSlotProps&lt;TOther&gt"
       },
       "required": true
     },
-    "selected": {
-      "type": { "name": "boolean", "description": "If `true`, the tab will be selected." },
-      "required": true
-    },
+    "selected": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "setFocusVisible": {
       "type": {
-        "name": "React.Dispatch<React.SetStateAction<boolean>>",
-        "description": "Callback for setting the `focusVisible` param."
+        "name": "React.Dispatch&lt;React.SetStateAction&lt;boolean&gt&gt",
+        "description": "React.Dispatch&lt;React.SetStateAction&lt;boolean&gt&gt"
       },
       "required": true
     }

--- a/docs/pages/base/api/use-tabs-list.json
+++ b/docs/pages/base/api/use-tabs-list.json
@@ -1,48 +1,43 @@
 {
   "parameters": {
-    "ref": { "type": { "name": "React.Ref<unknown>", "description": "" }, "required": true },
-    "aria-label": { "type": { "name": "string", "description": "" } },
-    "aria-labelledby": { "type": { "name": "string", "description": "" } },
-    "children": {
-      "type": { "name": "React.ReactNode", "description": "The content of the component." }
-    }
+    "ref": {
+      "type": { "name": "React.Ref&lt;unknown&gt", "description": "React.Ref&lt;unknown&gt" },
+      "required": true
+    },
+    "aria-label": { "type": { "name": "string", "description": "string" } },
+    "aria-labelledby": { "type": { "name": "string", "description": "string" } },
+    "children": { "type": { "name": "React.ReactNode", "description": "React.ReactNode" } }
   },
   "returnValue": {
     "getRootProps": {
       "type": {
-        "name": "<TOther extends Record<string, any> = {}>(externalProps?: TOther) => UseTabsListRootSlotProps<TOther>",
-        "description": "Resolver for the root slot's props."
+        "name": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseTabsListRootSlotProps&lt;TOther&gt",
+        "description": "&lt;TOther extends Record&lt;string, any&gt = {}&gt(externalProps?: TOther) =&gt UseTabsListRootSlotProps&lt;TOther&gt"
       },
       "required": true
     },
     "isRtl": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true`, it will indicate that the text's direction in right-to-left."
-      },
+      "type": { "name": "boolean", "description": "boolean" },
       "default": "false",
       "required": true
     },
     "orientation": {
       "type": {
-        "name": "'horizontal' | 'vertical'",
-        "description": "The component orientation (layout flow direction)."
+        "name": "&#39;horizontal&#39; | &#39;vertical&#39;",
+        "description": "&#39;horizontal&#39; | &#39;vertical&#39;"
       },
       "default": "'horizontal'",
       "required": true
     },
     "processChildren": {
       "type": {
-        "name": "() => React.ReactElement<any, string | React.JSXElementConstructor<any>>[] | null | undefined",
-        "description": "Callback for processing the children of the tabs list. It adds the necessary attributes for correct a11y and navigation."
+        "name": "() =&gt React.ReactElement&lt;any, string | React.JSXElementConstructor&lt;any&gt&gt[] | null | undefined",
+        "description": "() =&gt React.ReactElement&lt;any, string | React.JSXElementConstructor&lt;any&gt&gt[] | null | undefined"
       },
       "required": true
     },
     "value": {
-      "type": {
-        "name": "string | number | false",
-        "description": "The value of the currently selected `Tab`."
-      },
+      "type": { "name": "string | number | false", "description": "string | number | false" },
       "required": true
     }
   },

--- a/docs/pages/base/api/use-tabs.json
+++ b/docs/pages/base/api/use-tabs.json
@@ -1,39 +1,31 @@
 {
   "parameters": {
     "defaultValue": {
-      "type": {
-        "name": "string | number | false",
-        "description": "The default value. Use when the component is not controlled."
-      }
+      "type": { "name": "string | number | false", "description": "string | number | false" }
     },
     "direction": {
-      "type": { "name": "'ltr' | 'rtl'", "description": "The direction of the text." },
+      "type": {
+        "name": "&#39;ltr&#39; | &#39;rtl&#39;",
+        "description": "&#39;ltr&#39; | &#39;rtl&#39;"
+      },
       "default": "'ltr'"
     },
     "onChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, value: number | string | boolean) => void",
-        "description": "Callback invoked when new value is being set."
+        "name": "(event: React.SyntheticEvent, value: number | string | boolean) =&gt void",
+        "description": "(event: React.SyntheticEvent, value: number | string | boolean) =&gt void"
       }
     },
     "orientation": {
       "type": {
-        "name": "'horizontal' | 'vertical'",
-        "description": "The component orientation (layout flow direction)."
+        "name": "&#39;horizontal&#39; | &#39;vertical&#39;",
+        "description": "&#39;horizontal&#39; | &#39;vertical&#39;"
       },
       "default": "'horizontal'"
     },
-    "selectionFollowsFocus": {
-      "type": {
-        "name": "boolean",
-        "description": "If `true` the selected tab changes on focus. Otherwise it only\nchanges on activation."
-      }
-    },
+    "selectionFollowsFocus": { "type": { "name": "boolean", "description": "boolean" } },
     "value": {
-      "type": {
-        "name": "string | number | false",
-        "description": "The value of the currently selected `Tab`.\nIf you don't want any selected `Tab`, you can set this prop to `false`."
-      }
+      "type": { "name": "string | number | false", "description": "string | number | false" }
     }
   },
   "returnValue": {},

--- a/docs/src/modules/components/PropertiesTable.js
+++ b/docs/src/modules/components/PropertiesTable.js
@@ -53,13 +53,7 @@ export default function PropertiesTable(props) {
         </thead>
         <tbody>
           {Object.entries(properties).map(([propName, propData]) => {
-            let typeName = propData.type.name;
-            typeName = typeName
-              .replace(/&/g, '&amp;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt')
-              .replace(/"/g, '&quot;')
-              .replace(/'/g, '&#39;');
+            const typeName = propData.type.description || propData.type.name;
             const propDefault = propData.default;
             return (
               propData.description !== '@ignore' && (

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -264,12 +264,17 @@ const attachTable = (
       const requiredProp = prop.required;
 
       const deprecation = (propDescriptor.description || '').match(/@deprecated(\s+(?<info>.*))?/);
-
+      const typeDescription = (propDescriptor.typeStr ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
       return {
         [propName]: {
           type: {
-            name: propDescriptor.typeStr,
-            description: propDescriptor.description ?? undefined,
+            name: typeDescription,
+            description: typeDescription,
           },
           default: defaultValue,
           // undefined values are not serialized => saving some bytes

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -273,6 +273,8 @@ const attachTable = (
       return {
         [propName]: {
           type: {
+            // The docgen generates this structure for the components. For consistency in the structure
+            // we are adding the same value in both the name and the description
             name: typeDescription,
             description: typeDescription,
           },


### PR DESCRIPTION
Fixes regression from https://github.com/mui/material-ui/pull/35828 on the component's API prop types.

Before: https://mui.com/base/api/tab-unstyled/
![image](https://user-images.githubusercontent.com/4512430/218470157-900dd54e-1701-45fe-a2b2-0ee119812378.png)

After: https://deploy-preview-36168--material-ui.netlify.app/base/api/tab-unstyled/
![image](https://user-images.githubusercontent.com/4512430/218470353-2074565f-539e-4dd4-9d43-d108c9388559.png)

Hooks pages are not affected by the change:

Before: https://master--material-ui.netlify.app/base/api/use-tab/
After: https://deploy-preview-36168--material-ui.netlify.app/base/api/use-tab/