### PR TITLE
[Material You] Use `md` as a CSS var prefix

### DIFF
--- a/docs/src/modules/components/MaterialYouUsageDemo.tsx
+++ b/docs/src/modules/components/MaterialYouUsageDemo.tsx
@@ -93,11 +93,11 @@ export const prependLinesSpace = (code: string, size: number = 2) => {
   return newCode.join('\n');
 };
 
-function ModeSwitcher({ md2Mode }: { md2Mode: Mode | undefined }) {
-  const { mode, setMode } = useColorScheme();
-  if (md2Mode && mode !== md2Mode) {
-    setMode(md2Mode ?? mode);
-  }
+function ModeSwitcher({ md2Mode }: { md2Mode: Mode }) {
+  const { setMode } = useColorScheme();
+  React.useEffect(() => {
+    setMode(md2Mode);
+  }, [md2Mode, setMode]);
   return null;
 }
 

--- a/packages/mui-material-next/src/styles/extendTheme.test.ts
+++ b/packages/mui-material-next/src/styles/extendTheme.test.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import { extendTheme } from '@mui/material-next/styles';
+
+describe('Material You — extendTheme', () => {
+  it('should have default cssVarPrefix', () => {
+    expect(extendTheme().cssVarPrefix).to.equal('md');
+  });
+
+  it('`getCssVar` return default prefix', () => {
+    expect(extendTheme().getCssVar('palette-primary-main')).to.equal(
+      'var(--md-palette-primary-main)',
+    );
+  });
+});

--- a/packages/mui-material-next/src/styles/extendTheme.ts
+++ b/packages/mui-material-next/src/styles/extendTheme.ts
@@ -49,10 +49,10 @@ function setColor(obj: any, key: string, defaultValue: any) {
   obj[key] = obj[key] || defaultValue;
 }
 
-export const createGetCssVar = (cssVarPrefix = 'mui') => systemCreateGetCssVar(cssVarPrefix);
+export const createGetCssVar = (cssVarPrefix = 'md') => systemCreateGetCssVar(cssVarPrefix);
 
 export default function extendTheme(options: CssVarsThemeOptions = {}, ...args: any[]) {
-  const { colorSchemes: colorSchemesInput = {}, cssVarPrefix = 'mui', ...input } = options;
+  const { colorSchemes: colorSchemesInput = {}, cssVarPrefix = 'md', ...input } = options;
   const getCssVar = createGetCssVar(cssVarPrefix);
 
   const md3LightColors = createMd3LightColorScheme(getCssVar, md3CommonPalette);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**Preview**: https://deploy-preview-36177--material-ui.netlify.app/material-ui/react-button/#material-you-version

## Why

- To follow the [spec](https://m3.material.io/styles/color/the-color-system/tokens) and leverage the official Figma tool for exporting the theme.

Below is what I get from the [Material Theme Builder](https://www.figma.com/community/plugin/1034969338659738588/Material-Theme-Builder).

<img width="363" alt="Screen Shot 2566-02-14 at 14 40 39" src="https://user-images.githubusercontent.com/18292247/218670799-800d19d4-7e7d-4a3b-92fc-a9e768003731.png">

- This will also ensure that Material UI and Material You can coexist on the same page without clashing due to different prefixes.


---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
