### PR TITLE
[docs] Component API tabs with links

### DIFF
--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -11,6 +11,10 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 
 <p class="description">Tabs are UI elements for organizing and navigating between groups of related content.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
+{{"component": "modules/components/ComponentPageTabs.js"}}
+
 ## Introduction
 
 Tabs are implemented using a collection of related components:
@@ -21,8 +25,6 @@ Tabs are implemented using a collection of related components:
 - `<TabsUnstyled />` - the top-level component that wraps the Tabs List and Tab Panel components so that tabs and their panels can communicate with one another.
 
 {{"demo": "UnstyledTabsIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Components
 

--- a/docs/pages/base/react-tabs.js
+++ b/docs/pages/base/react-tabs.js
@@ -1,7 +1,102 @@
 import * as React from 'react';
-import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
 import * as pageProps from 'docs/data/base/components/tabs/tabs.md?@mui/markdown';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import tabApiJsonPageContent from './api/tab-unstyled.json';
+import tabsApiJsonPageContent from './api/tabs-unstyled.json';
+import tabsListApiJsonPageContent from './api/tabs-list-unstyled.json';
+import tabPanelApiJsonPageContent from './api/tab-panel-unstyled.json';
+import useTabApiJsonPageContent from './api/use-tab.json';
+import useTabsApiJsonPageContent from './api/use-tabs.json';
+import useTabsListApiJsonPageContent from './api/use-tabs-list.json';
+import useTabPanelApiJsonPageContent from './api/use-tab-panel.json';
 
-export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+export default function Page(props) {
+  const { userLanguage, ...other } = props;
+  return <MarkdownDocs {...pageProps} {...other} />;
 }
+
+Page.getInitialProps = () => {
+  const tabApiReq = require.context(
+    'docs/translations/api-docs/tab-unstyled',
+    false,
+    /tab-unstyled.*.json$/,
+  );
+  const tabApiDescriptions = mapApiPageTranslations(tabApiReq);
+
+  const tabsApiReq = require.context(
+    'docs/translations/api-docs/tabs-unstyled',
+    false,
+    /tabs-unstyled.*.json$/,
+  );
+  const tabsApiDescriptions = mapApiPageTranslations(tabsApiReq);
+
+  const tabsListApiReq = require.context(
+    'docs/translations/api-docs/tabs-list-unstyled',
+    false,
+    /tabs-list-unstyled.*.json$/,
+  );
+  const tabsListApiDescriptions = mapApiPageTranslations(tabsListApiReq);
+
+  const tabPanelApiReq = require.context(
+    'docs/translations/api-docs/tab-panel-unstyled',
+    false,
+    /tab-panel-unstyled.*.json$/,
+  );
+  const tabPanelApiDescriptions = mapApiPageTranslations(tabPanelApiReq);
+
+  const useTabApiReq = require.context(
+    'docs/translations/api-docs/use-tab',
+    false,
+    /use-tab.*.json$/,
+  );
+  const useTabApiDescriptions = mapApiPageTranslations(useTabApiReq);
+
+  const useTabsApiReq = require.context(
+    'docs/translations/api-docs/use-tabs',
+    false,
+    /use-tabs.*.json$/,
+  );
+  const useTabsApiDescriptions = mapApiPageTranslations(useTabsApiReq);
+
+  const useTabsListApiReq = require.context(
+    'docs/translations/api-docs/use-tabs-list',
+    false,
+    /use-tabs-list.*.json$/,
+  );
+  const useTabsListApiDescriptions = mapApiPageTranslations(useTabsListApiReq);
+
+  const useTabPanelApiReq = require.context(
+    'docs/translations/api-docs/use-tab-panel',
+    false,
+    /use-tab-panel.*.json$/,
+  );
+  const useTabPanelApiDescriptions = mapApiPageTranslations(useTabPanelApiReq);
+
+  return {
+    componentsApiDescriptions: {
+      tab: tabApiDescriptions,
+      tabs: tabsApiDescriptions,
+      tabsList: tabsListApiDescriptions,
+      tabPanel: tabPanelApiDescriptions,
+    },
+    componentsApiPageContents: {
+      tab: tabApiJsonPageContent,
+      tabs: tabsApiJsonPageContent,
+      tabsList: tabsListApiJsonPageContent,
+      tabPanel: tabPanelApiJsonPageContent,
+    },
+    hooksApiDescriptions: {
+      useTab: useTabApiDescriptions,
+      useTabs: useTabsApiDescriptions,
+      useTabPanel: useTabPanelApiDescriptions,
+      useTabsList: useTabsListApiDescriptions,
+    },
+    hooksApiPageContents: {
+      useTab: useTabApiJsonPageContent,
+      useTabs: useTabsApiJsonPageContent,
+      useTabsList: useTabsListApiJsonPageContent,
+      useTabPanel: useTabPanelApiJsonPageContent,
+    },
+  };
+};

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { useRouter } from 'next/router';
+import Box from '@mui/material/Box';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import Link from 'docs/src/modules/components/Link';
+import { useTranslate } from 'docs/src/modules/utils/i18n';
+import { alpha } from '@mui/material/styles';
+
+export default function ComponentPageTabs(props) {
+  const {
+    markdown: { headers },
+    activeTab,
+    setActiveTab,
+    children,
+  } = props;
+
+  return (
+    <Box className="component-tabs" sx={{ display: 'inline' }}>
+      <Tabs
+        value={activeTab}
+        onChange={(e, value) => setActiveTab(value)}
+        sx={{
+          position: 'sticky',
+          top: 65, // to be positioned below the app bar
+          mt: 3,
+          pt: 1,
+          mx: {
+            xs: -2,
+            sm: 0,
+          },
+          px: {
+            xs: 2,
+            sm: 0,
+          },
+          backgroundColor: (theme) =>
+            theme.palette.mode === 'dark'
+              ? alpha(theme.palette.primaryDark[900], 0.7)
+              : 'rgba(255,255,255,0.8)',
+          backdropFilter: 'blur(8px)',
+          borderBottom: 1,
+          borderColor: 'divider',
+          zIndex: 1000,
+        }}
+      >
+        <Tab label="Demos" value="" />
+        <Tab label="Component API" value="component-api" />
+        {headers.hooks && headers.hooks.length > 0 && <Tab label="Hook API" value="hook-api" />}
+      </Tabs>
+      {children}
+    </Box>
+  );
+}

--- a/docs/src/modules/components/DemosDocs.js
+++ b/docs/src/modules/components/DemosDocs.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import MarkdownElement from 'docs/src/modules/components/MarkdownElementV2';
+
+export default function DemosDocs(props) {
+  const { WrapperComponent: Wrapper, wrapperProps, rendered = [], ...rest } = props;
+  return (
+    <React.Fragment key="demos-docs">
+      {rendered.map((renderedMarkdownOrDemo, index) => {
+        return (
+          <MarkdownElement
+            renderedMarkdownOrDemo={renderedMarkdownOrDemo}
+            WrapperComponent={Wrapper}
+            wrapperProps={{ ...wrapperProps, key: `demos-docs-${index}` }}
+            {...rest}
+          />
+        );
+      })}
+    </React.Fragment>
+  );
+}

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -1,0 +1,246 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import path from 'path';
+import { useRouter } from 'next/router';
+import kebabCase from 'lodash/kebabCase';
+import upperFirst from 'lodash/upperFirst';
+import { useTheme } from '@mui/system';
+import { exactProp } from '@mui/utils';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { CssVarsProvider, useColorScheme } from '@mui/joy/styles';
+import { getTranslatedHeader as getHookTranslatedHeader } from 'docs/src/modules/components/HookApiPage';
+import { getTranslatedHeader as getComponentTranslatedHeader } from 'docs/src/modules/components/ApiPage';
+import MarkdownElement from 'docs/src/modules/components/MarkdownElementV2';
+import Link from 'docs/src/modules/components/Link';
+import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
+import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
+import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
+import BrandingProvider from 'docs/src/BrandingProvider';
+import Ad from 'docs/src/modules/components/Ad';
+import AdGuest from 'docs/src/modules/components/AdGuest';
+import DemosDocs from 'docs/src/modules/components/DemosDocs';
+
+function noComponent(moduleID) {
+  return function NoComponent() {
+    throw new Error(`No demo component provided for '${moduleID}'`);
+  };
+}
+
+function JoyModeObserver({ mode }) {
+  const { setMode } = useColorScheme();
+  React.useEffect(() => {
+    setMode(mode);
+  }, [mode, setMode]);
+  return null;
+}
+
+JoyModeObserver.propTypes = {
+  mode: PropTypes.oneOf(['light', 'dark']),
+};
+
+const ApiLink = styled(Link)(({ theme }) =>
+  theme.unstable_sx({
+    backgroundColor:
+      theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.primary[50],
+    fontWeight: 300,
+    fontSize: 12,
+    borderRadius: '6px',
+    lineHeight: 1.5,
+    fontFamily: 'Menlo,Consolas,"Droid Sans Mono",monospace',
+    fontWeight: 400,
+    px: 0.5,
+    mt: 1,
+  }),
+);
+
+export default function MarkdownDocs(props) {
+  const theme = useTheme();
+  const router = useRouter();
+  const [activeTab, setActiveTabState] = React.useState(router.query.docsTab ?? '');
+
+  let hash;
+  if (router.asPath.indexOf('#') >= 0) {
+    hash = router.asPath.split('#')[1];
+  }
+  const setActiveTab = (newValue) => {
+    const value = newValue ?? '';
+    setActiveTabState(newValue);
+    router
+      .push(
+        `${router.pathname}/${newValue !== '' ? `?docsTab=${newValue}` : ''}${
+          hash ? `#${hash}` : ''
+        }`,
+        undefined,
+        {
+          shallow: true,
+        },
+      )
+      .catch((e) => {
+        // workaround for https://github.com/vercel/next.js/issues/37362
+        if (!e.cancelled) {
+          throw e;
+        }
+      });
+  };
+
+  const { canonicalAs } = pathnameToLanguage(router.asPath);
+  const {
+    disableAd = false,
+    disableToc = false,
+    demos = {},
+    docs,
+    demoComponents,
+    srcComponents,
+    componentsApiDescriptions,
+    componentsApiPageContents,
+    hooksApiDescriptions,
+    hooksApiPageContents,
+  } = props;
+
+  const userLanguage = useUserLanguage();
+  const t = useTranslate();
+
+  React.useEffect(() => {
+    setActiveTab(router.query.docsTab ?? '');
+  }, [router.query.docsTab]);
+
+  const localizedDoc = docs[userLanguage] || docs.en;
+  // Generate the TOC based on the tab
+  const { description, location, rendered, title, toc } = localizedDoc;
+  const demosToc = toc.filter((item) => item.text !== 'API');
+
+  const isJoy = canonicalAs.startsWith('/joy-ui/');
+  const Provider = isJoy ? CssVarsProvider : React.Fragment;
+  const Wrapper = isJoy ? BrandingProvider : React.Fragment;
+
+  const commonElements = [];
+
+  let i = 0;
+  let done = false;
+
+  const wrapperProps = {
+    ...(isJoy && { mode: theme.palette.mode }),
+  };
+
+  // process the elements before the tabs component
+  while (i <= rendered.length && !done) {
+    const renderedMarkdownOrDemo = rendered[i];
+    if (renderedMarkdownOrDemo.component && renderedMarkdownOrDemo.component.indexOf('Tabs') >= 0) {
+      done = true;
+    }
+    commonElements.push(
+      <MarkdownElement
+        srcComponents={srcComponents}
+        renderedMarkdownOrDemo={renderedMarkdownOrDemo}
+        WrapperComponent={Wrapper}
+        key={`common-elements-${i}`}
+        wrapperProps={wrapperProps}
+        localizedDoc={localizedDoc}
+        demos={demos}
+        location={location}
+        theme={theme}
+        demoComponents={demoComponents}
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+        disableAd={disableAd}
+      />,
+    );
+    i++;
+  }
+
+  return (
+    <AppLayoutDocs
+      description={description}
+      disableAd={disableAd}
+      disableToc={disableToc}
+      location={location}
+      title={title}
+      toc={activeTab === 'hook-api' || activeTab === 'component-api' ? [] : demosToc}
+      hasTabs
+    >
+      <Provider>
+        {isJoy && <JoyModeObserver key="joy-provider" mode={theme.palette.mode} />}
+        {disableAd ? null : (
+          <Wrapper key="add">
+            <AdGuest classSelector=".component-tabs">
+              <Ad />
+            </AdGuest>
+          </Wrapper>
+        )}
+        {commonElements}
+        <Box {...(activeTab !== '' && { sx: { display: 'none' }, 'aria-hidden': true })}>
+          {rendered.slice(i, rendered.length - 1).map((renderedMarkdownOrDemo, index) => (
+            <MarkdownElement
+              key={`demos-section-${index}`}
+              renderedMarkdownOrDemo={renderedMarkdownOrDemo}
+              WrapperComponent={Wrapper}
+              wrapperProps={wrapperProps}
+              srcComponents={srcComponents}
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+              localizedDoc={localizedDoc}
+              demos={demos}
+              location={location}
+              theme={theme}
+              demoComponents={demoComponents}
+              disableAd={disableAd}
+            />
+          ))}
+        </Box>
+        <Box
+          {...(activeTab !== 'component-api' && { sx: { display: 'none' }, 'aria-hidden': true })}
+        >
+          <Box component="ul" sx={{ mt: 5 }}>
+            {Object.keys(componentsApiPageContents).map((component) => {
+              const product = router.pathname.split('/')[1];
+              const displayNameLink = upperFirst(component);
+              return (
+                <li>
+                  <ApiLink href={`/${product}/api/${kebabCase(component)}-unstyled`}>
+                    <code>
+                      {'<'}
+                      {displayNameLink}
+                      {' />'}
+                    </code>
+                  </ApiLink>
+                </li>
+              );
+            })}
+          </Box>
+        </Box>
+        <Box {...(activeTab !== 'hook-api' && { sx: { display: 'none' }, 'aria-hidden': true })}>
+          <Box component="ul" sx={{ mt: 5 }}>
+            {Object.keys(hooksApiPageContents).map((hook) => {
+              const product = router.pathname.split('/')[1];
+              return (
+                <li>
+                  <ApiLink href={`/${product}/api/${kebabCase(hook)}`}>
+                    <code>{hook}</code>
+                  </ApiLink>
+                </li>
+              );
+            })}
+          </Box>
+        </Box>
+      </Provider>
+    </AppLayoutDocs>
+  );
+}
+
+MarkdownDocs.propTypes = {
+  demoComponents: PropTypes.object,
+  demos: PropTypes.object,
+  disableAd: PropTypes.bool,
+  disableToc: PropTypes.bool,
+  docs: PropTypes.object.isRequired,
+  srcComponents: PropTypes.object,
+  componentsApiDescriptions: PropTypes.object,
+  componentsApiPageContents: PropTypes.object,
+  hooksApiDescriptions: PropTypes.object,
+  hooksApiPageContents: PropTypes.object,
+};
+
+if (process.env.NODE_ENV !== 'production') {
+  MarkdownDocs.propTypes = exactProp(MarkdownDocs.propTypes);
+}

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -191,36 +191,40 @@ export default function MarkdownDocs(props) {
         <Box
           {...(activeTab !== 'component-api' && { sx: { display: 'none' }, 'aria-hidden': true })}
         >
-          <Box component="ul" sx={{ mt: 5 }}>
-            {Object.keys(componentsApiPageContents).map((component) => {
-              const product = router.pathname.split('/')[1];
-              const displayNameLink = upperFirst(component);
-              return (
-                <li>
-                  <ApiLink href={`/${product}/api/${kebabCase(component)}-unstyled`}>
-                    <code>
-                      {'<'}
-                      {displayNameLink}
-                      {' />'}
-                    </code>
-                  </ApiLink>
-                </li>
-              );
-            })}
+          <Box sx={{ height: 'calc(100vh - 350px)' }}>
+            <Box component="ul" sx={{ mt: 5 }}>
+              {Object.keys(componentsApiPageContents).map((component) => {
+                const product = router.pathname.split('/')[1];
+                const displayNameLink = upperFirst(component);
+                return (
+                  <li>
+                    <ApiLink href={`/${product}/api/${kebabCase(component)}-unstyled`}>
+                      <code>
+                        {'<'}
+                        {displayNameLink}
+                        {' />'}
+                      </code>
+                    </ApiLink>
+                  </li>
+                );
+              })}
+            </Box>
           </Box>
         </Box>
         <Box {...(activeTab !== 'hook-api' && { sx: { display: 'none' }, 'aria-hidden': true })}>
-          <Box component="ul" sx={{ mt: 5 }}>
-            {Object.keys(hooksApiPageContents).map((hook) => {
-              const product = router.pathname.split('/')[1];
-              return (
-                <li>
-                  <ApiLink href={`/${product}/api/${kebabCase(hook)}`}>
-                    <code>{hook}</code>
-                  </ApiLink>
-                </li>
-              );
-            })}
+          <Box sx={{ height: 'calc(100vh - 350px)' }}>
+            <Box component="ul" sx={{ mt: 5 }}>
+              {Object.keys(hooksApiPageContents).map((hook) => {
+                const product = router.pathname.split('/')[1];
+                return (
+                  <li>
+                    <ApiLink href={`/${product}/api/${kebabCase(hook)}`}>
+                      <code>{hook}</code>
+                    </ApiLink>
+                  </li>
+                );
+              })}
+            </Box>
           </Box>
         </Box>
       </Provider>

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -43,8 +43,7 @@ const ApiLink = styled(Link)(({ theme }) =>
   theme.unstable_sx({
     backgroundColor:
       theme.palette.mode === 'dark' ? theme.palette.primaryDark[700] : theme.palette.primary[50],
-    fontWeight: 300,
-    fontSize: 12,
+    fontSize: 13,
     borderRadius: '6px',
     lineHeight: 1.5,
     fontFamily: 'Menlo,Consolas,"Droid Sans Mono",monospace',

--- a/docs/src/modules/components/MarkdownElementV2.js
+++ b/docs/src/modules/components/MarkdownElementV2.js
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
+import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
+import Demo from 'docs/src/modules/components/Demo';
+
+export default function MarkdownElementV2({
+  renderedMarkdownOrDemo,
+  WrapperComponent: Wrapper,
+  wrapperProps,
+  srcComponents,
+  activeTab,
+  setActiveTab,
+  localizedDoc,
+  demos = {},
+  location,
+  theme,
+  demoComponents,
+  disableAd,
+}) {
+  const userLanguage = useUserLanguage();
+  const t = useTranslate();
+
+  if (typeof renderedMarkdownOrDemo === 'string') {
+    return (
+      <Wrapper {...wrapperProps}>
+        <MarkdownElement renderedMarkdown={renderedMarkdownOrDemo} />
+      </Wrapper>
+    );
+  }
+
+  if (renderedMarkdownOrDemo.component) {
+    const name = renderedMarkdownOrDemo.component;
+    const Component = srcComponents?.[name];
+    const additionalProps = {};
+
+    if (Component === undefined) {
+      throw new Error(`No component found at the path ${path.join('docs/src', name)}`);
+    }
+    if (name.indexOf('Tabs') >= 0) {
+      additionalProps.activeTab = activeTab;
+      additionalProps.setActiveTab = setActiveTab;
+    }
+
+    return (
+      <Wrapper {...wrapperProps}>
+        <Component {...renderedMarkdownOrDemo} {...additionalProps} markdown={localizedDoc} />
+      </Wrapper>
+    );
+  }
+
+  const name = renderedMarkdownOrDemo.demo;
+  const demo = demos?.[name];
+  if (demo === undefined) {
+    const errorMessage = [
+      `Missing demo: ${name}. You can use one of the following:`,
+      Object.keys(demos),
+    ].join('\n');
+
+    if (userLanguage === 'en') {
+      throw new Error(errorMessage);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(errorMessage);
+    }
+
+    const warnIcon = (
+      <span role="img" aria-label={t('emojiWarning')}>
+        ⚠️
+      </span>
+    );
+    return (
+      <div key={index}>
+        {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
+        {warnIcon} Missing demo `{name}` {warnIcon}
+      </div>
+    );
+  }
+
+  const splitLocationBySlash = location.split('/');
+  splitLocationBySlash.pop();
+  const fileNameWithLocation = `${splitLocationBySlash.join('/')}/${name}`;
+
+  return (
+    <Demo
+      {...wrapperProps}
+      mode={theme.palette.mode}
+      demo={{
+        raw: demo.raw,
+        js: demoComponents[demo.module] ?? noComponent(demo.module),
+        scope: demos.scope,
+        jsxPreview: demo.jsxPreview,
+        rawTS: demo.rawTS,
+        tsx: demoComponents[demo.moduleTS] ?? null,
+      }}
+      disableAd={disableAd}
+      demoOptions={renderedMarkdownOrDemo}
+      githubLocation={`${process.env.SOURCE_CODE_REPO}/blob/v${process.env.LIB_VERSION}${fileNameWithLocation}`}
+    />
+  );
+}


### PR DESCRIPTION
Another alternative of how we may show API links, based on https://github.com/mui/material-ui/pull/35938#issuecomment-1428728061. 

Preview: https://deploy-preview-36178--material-ui.netlify.app/base/react-tabs/