### PR TITLE
[Select][base] Update the generated docs

### DIFF
--- a/docs/pages/base/api/use-option.json
+++ b/docs/pages/base/api/use-option.json
@@ -1,20 +1,25 @@
 {
   "parameters": {
-    "disabled": { "type": { "name": "boolean", "description": "" }, "required": true },
-    "value": { "type": { "name": "Value", "description": "" }, "required": true },
-    "optionRef": { "type": { "name": "React.Ref<HTMLElement>", "description": "" } }
+    "disabled": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
+    "value": { "type": { "name": "Value", "description": "Value" }, "required": true },
+    "optionRef": {
+      "type": {
+        "name": "React.Ref&lt;HTMLElement&gt",
+        "description": "React.Ref&lt;HTMLElement&gt"
+      }
+    }
   },
   "returnValue": {
     "getRootProps": {
       "type": {
-        "name": "<Other extends EventHandlers>(otherHandlers?: Other) => UseOptionRootSlotProps<Other>",
-        "description": ""
+        "name": "&lt;Other extends EventHandlers&gt(otherHandlers?: Other) =&gt UseOptionRootSlotProps&lt;Other&gt",
+        "description": "&lt;Other extends EventHandlers&gt(otherHandlers?: Other) =&gt UseOptionRootSlotProps&lt;Other&gt"
       },
       "required": true
     },
-    "highlighted": { "type": { "name": "boolean", "description": "" }, "required": true },
-    "index": { "type": { "name": "number", "description": "" }, "required": true },
-    "selected": { "type": { "name": "boolean", "description": "" }, "required": true }
+    "highlighted": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
+    "index": { "type": { "name": "number", "description": "number" }, "required": true },
+    "selected": { "type": { "name": "boolean", "description": "boolean" }, "required": true }
   },
   "name": "useOption",
   "filename": "/packages/mui-base/src/OptionUnstyled/useOption.ts",


### PR DESCRIPTION
Ran `yarn docs:api` to regenerate the docs. This was necessary after #36168 was merged without considering the changes from #35946