### PR TITLE
[docs] Update custom Typography variants example

### DIFF
--- a/docs/data/material/components/typography/typography.md
+++ b/docs/data/material/components/typography/typography.md
@@ -88,7 +88,7 @@ It's important to realize that the style of a typography component is independen
 </Typography>;
 ```
 
-- You can change the mapping [globally using the theme](/material-ui/customization/theme-components/#default-props):
+- You can change the mapping [globally using the theme](/material-ui/customization/typography/#adding-amp-disabling-variants):
 
 ```js
 const theme = createTheme({

--- a/docs/data/material/customization/typography/TypographyCustomVariant.js
+++ b/docs/data/material/customization/typography/TypographyCustomVariant.js
@@ -7,10 +7,34 @@ const theme = createTheme({
   typography: {
     // @ts-ignore
     poster: {
-      color: 'red',
+      fontSize: '4rem',
+      color: 'indianred',
     },
     // Disable v3 variant
     h3: undefined,
+  },
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          // we have to provide the default variantMapping first because currently
+          // custom entries will replace this whole object instead of being merged
+          h1: 'h1',
+          h2: 'h2',
+          h3: 'h3',
+          h4: 'h4',
+          h5: 'h5',
+          h6: 'h6',
+          subtitle1: 'h6',
+          subtitle2: 'h6',
+          body1: 'p',
+          body2: 'p',
+          inherit: 'p',
+          // @ts-ignore
+          poster: 'h1', // map our new variant to render a <h1> by default
+        },
+      },
+    },
   },
 });
 

--- a/docs/data/material/customization/typography/TypographyCustomVariant.js
+++ b/docs/data/material/customization/typography/TypographyCustomVariant.js
@@ -31,7 +31,7 @@ const theme = createTheme({
           body2: 'p',
           inherit: 'p',
           // @ts-ignore
-          poster: 'h1', // map our new variant to render a <h1> by default
+          poster: 'h1', // map our new variant to render an <h1> by default
         },
       },
     },

--- a/docs/data/material/customization/typography/TypographyCustomVariant.js
+++ b/docs/data/material/customization/typography/TypographyCustomVariant.js
@@ -17,19 +17,6 @@ const theme = createTheme({
     MuiTypography: {
       defaultProps: {
         variantMapping: {
-          // we have to provide the default variantMapping first because currently
-          // custom entries will replace this whole object instead of being merged
-          h1: 'h1',
-          h2: 'h2',
-          h3: 'h3',
-          h4: 'h4',
-          h5: 'h5',
-          h6: 'h6',
-          subtitle1: 'h6',
-          subtitle2: 'h6',
-          body1: 'p',
-          body2: 'p',
-          inherit: 'p',
           // @ts-ignore
           poster: 'h1', // map our new variant to render an <h1> by default
         },

--- a/docs/data/material/customization/typography/TypographyCustomVariant.tsx
+++ b/docs/data/material/customization/typography/TypographyCustomVariant.tsx
@@ -7,10 +7,34 @@ const theme = createTheme({
   typography: {
     // @ts-ignore
     poster: {
-      color: 'red',
+      fontSize: '4rem',
+      color: 'indianred',
     },
     // Disable v3 variant
     h3: undefined,
+  },
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          // we have to provide the default variantMapping first because currently
+          // custom entries will replace this whole object instead of being merged
+          h1: 'h1',
+          h2: 'h2',
+          h3: 'h3',
+          h4: 'h4',
+          h5: 'h5',
+          h6: 'h6',
+          subtitle1: 'h6',
+          subtitle2: 'h6',
+          body1: 'p',
+          body2: 'p',
+          inherit: 'p',
+          // @ts-ignore
+          poster: 'h1', // map our new variant to render a <h1> by default
+        },
+      },
+    },
   },
 });
 

--- a/docs/data/material/customization/typography/TypographyCustomVariant.tsx
+++ b/docs/data/material/customization/typography/TypographyCustomVariant.tsx
@@ -31,7 +31,7 @@ const theme = createTheme({
           body2: 'p',
           inherit: 'p',
           // @ts-ignore
-          poster: 'h1', // map our new variant to render a <h1> by default
+          poster: 'h1', // map our new variant to render an <h1> by default
         },
       },
     },

--- a/docs/data/material/customization/typography/TypographyCustomVariant.tsx
+++ b/docs/data/material/customization/typography/TypographyCustomVariant.tsx
@@ -17,19 +17,6 @@ const theme = createTheme({
     MuiTypography: {
       defaultProps: {
         variantMapping: {
-          // we have to provide the default variantMapping first because currently
-          // custom entries will replace this whole object instead of being merged
-          h1: 'h1',
-          h2: 'h2',
-          h3: 'h3',
-          h4: 'h4',
-          h5: 'h5',
-          h6: 'h6',
-          subtitle1: 'h6',
-          subtitle2: 'h6',
-          body1: 'p',
-          body2: 'p',
-          inherit: 'p',
           // @ts-ignore
           poster: 'h1', // map our new variant to render an <h1> by default
         },

--- a/docs/data/material/customization/typography/typography.md
+++ b/docs/data/material/customization/typography/typography.md
@@ -229,7 +229,7 @@ In addition to using the default typography variants, you can add custom ones, o
 
 **Step 1. Update the theme's typography object**
 
-Let's add a variant called "poster", and get rid the "h3" variant:
+The code snippet below adds a custom variant to the theme called `poster`, and removes the default `h3` variant:
 
 ```js
 const theme = createTheme({
@@ -246,9 +246,10 @@ const theme = createTheme({
 
 **Step 2. (Optional) Set the default semantic element for your new variant**
 
-At this point, you can already use the new `poster` variant, which will render a `<span>` by default with your custom styles. Sometimes you may want to default to a different HTML element for semantic purposes, or to replace the inline `<span>` with a block-level element for styling purposes.
+At this point, you can already use the new `poster` variant, which will render a `<span>` by default with your custom styles.
+Sometimes you may want to default to a different HTML element for semantic purposes, or to replace the inline `<span>` with a block-level element for styling purposes.
 
-To do this we need to update the `variantMapping` prop of the `Typography` globally in the theme:
+To do this, update the `variantMapping` prop of the `Typography` component globally, at the theme level:
 
 ```js
 const theme = createTheme({
@@ -324,7 +325,7 @@ declare module '@mui/material/Typography' {
 ```jsx
 <Typography variant="poster">poster</Typography>;
 
-/* This variant is no longer supported, if you are using TypeScript it will give an error */
+/* This variant is no longer supported. If you are using TypeScript it will give an error */
 <Typography variant="h3">h3</Typography>;
 ```
 

--- a/docs/data/material/customization/typography/typography.md
+++ b/docs/data/material/customization/typography/typography.md
@@ -265,20 +265,7 @@ const theme = createTheme({
     MuiTypography: {
       defaultProps: {
         variantMapping: {
-          // we have to provide the default variantMapping first because currently
-          // custom entries will replace this whole object instead of merging
-          h1: 'h1',
-          h2: 'h2',
-          h3: 'h3',
-          h4: 'h4',
-          h5: 'h5',
-          h6: 'h6',
-          subtitle1: 'h6',
-          subtitle2: 'h6',
-          body1: 'p',
-          body2: 'p',
-          inherit: 'p',
-          // map our new variant to render a <h1> by default
+          // Map the new variant to render a <h1> by default
           poster: 'h1',
         },
       },

--- a/docs/data/material/customization/typography/typography.md
+++ b/docs/data/material/customization/typography/typography.md
@@ -229,10 +229,13 @@ In addition to using the default typography variants, you can add custom ones, o
 
 **Step 1. Update the theme's typography object**
 
+Let's add a variant called "poster", and get rid the "h3" variant:
+
 ```js
 const theme = createTheme({
   typography: {
     poster: {
+      fontSize: '4rem',
       color: 'red',
     },
     // Disable h3 variant
@@ -241,7 +244,49 @@ const theme = createTheme({
 });
 ```
 
-**Step 2. Update the necessary typings (if you are using TypeScript)**
+**Step 2. (Optional) Set the default semantic element for your new variant**
+
+At this point, you can already use the new `poster` variant, which will render a `<span>` by default with your custom styles. Sometimes you may want to default to a different HTML element for semantic purposes, or to replace the inline `<span>` with a block-level element for styling purposes.
+
+To do this we need to update the `variantMapping` prop of the `Typography` globally in the theme:
+
+```js
+const theme = createTheme({
+  typography: {
+    poster: {
+      fontSize: 64,
+      color: 'red',
+    },
+    // Disable h3 variant
+    h3: undefined,
+  },
+  components: {
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          // we have to provide the default variantMapping first because currently
+          // custom entries will replace this whole object instead of merging
+          h1: 'h1',
+          h2: 'h2',
+          h3: 'h3',
+          h4: 'h4',
+          h5: 'h5',
+          h6: 'h6',
+          subtitle1: 'h6',
+          subtitle2: 'h6',
+          body1: 'p',
+          body2: 'p',
+          inherit: 'p',
+          // map our new variant to render a <h1> by default
+          poster: 'h1',
+        },
+      },
+    },
+  },
+});
+```
+
+**Step 3. Update the necessary typings (if you are using TypeScript)**
 
 :::info
 If you aren't using TypeScript you should skip this step.
@@ -272,14 +317,14 @@ declare module '@mui/material/Typography' {
 }
 ```
 
-**Step 3. You can now use the new variant**
+**Step 4. You can now use the new variant**
 
 {{"demo": "TypographyCustomVariant.js", "hideToolbar": true}}
 
 ```jsx
 <Typography variant="poster">poster</Typography>;
 
-/* This variant is no longer supported */
+/* This variant is no longer supported, if you are using TypeScript it will give an error */
 <Typography variant="h3">h3</Typography>;
 ```
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow up to: https://github.com/mui/material-ui/issues/36005#issuecomment-1418452661

Preview: https://deploy-preview-36185--material-ui.netlify.app/material-ui/customization/typography/#adding-amp-disabling-variants

This PR expands a little more on how to add custom Typography variants to material-ui.

I am assuming that its very likely a user would want to (or want to know how to) specify the default HTML element for custom Typography variants if they are on this part of the docs, and it's not obvious (at least I completely missed it 🤦 ) that this is the way to do it until Jun pointed it out.

The most related existing doc about this is [here](https://mui.com/material-ui/react-typography/#changing-the-semantic-element) but it's not linked to from that page, and doesn't directly address using `variantMapping` and custom variants together – also I think a page called "Customization/Typography" should be a one-stop shop for all of this instead of having to hop to another page!