### PR TITLE
[InputLabel] Change size prop option from normal to medium

### DIFF
--- a/docs/pages/material-ui/api/input-label.json
+++ b/docs/pages/material-ui/api/input-label.json
@@ -18,9 +18,9 @@
     "size": {
       "type": {
         "name": "union",
-        "description": "'normal'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       },
-      "default": "'normal'"
+      "default": "'medium'"
     },
     "sx": {
       "type": {

--- a/packages/mui-material/src/InputLabel/InputLabel.d.ts
+++ b/packages/mui-material/src/InputLabel/InputLabel.d.ts
@@ -54,9 +54,9 @@ export type InputLabelTypeMap<
     shrink?: boolean;
     /**
      * The size of the component.
-     * @default 'normal'
+     * @default 'medium'
      */
-    size?: OverridableStringUnion<'small' | 'normal', InputLabelPropsSizeOverrides>;
+    size?: OverridableStringUnion<'small' | 'medium', InputLabelPropsSizeOverrides>;
     /**
      * The system prop that allows defining system overrides as well as additional CSS styles.
      */

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -222,10 +222,10 @@ InputLabel.propTypes /* remove-proptypes */ = {
   shrink: PropTypes.bool,
   /**
    * The size of the component.
-   * @default 'normal'
+   * @default 'medium'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['normal', 'small']),
+    PropTypes.oneOf(['medium', 'small']),
     PropTypes.string,
   ]),
   /**


### PR DESCRIPTION
- Replaces `normal` with `medium`
- More in line with size props in the rest of the package(s)
- As far as I can tell, this is the only component that uses `small`/`normal` as the size options, opposed to `small`/`medium`

I didn't leave it "backwards compatible" since the size prop is not used when it's set to default/`normal` anyway, but I can adjust that if `normal` should be type supported until the next major version. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
