### PR TITLE
[docs] Improve visual look of loose lists

### DIFF
--- a/docs/data/material/components/radio-buttons/radio-buttons.md
+++ b/docs/data/material/components/radio-buttons/radio-buttons.md
@@ -104,6 +104,7 @@ import { useRadioGroup } from '@mui/material/RadioGroup';
 (WAI-ARIA: https://www.w3.org/WAI/ARIA/apg/patterns/radio/)
 
 - All form controls should have labels, and this includes radio buttons, checkboxes, and switches. In most cases, this is done by using the `<label>` element ([FormControlLabel](/material-ui/api/form-control-label/)).
+
 - When a label can't be used, it's necessary to add an attribute directly to the input component.
   In this case, you can apply the additional attribute (e.g. `aria-label`, `aria-labelledby`, `title`) via the `inputProps` property.
 

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -434,9 +434,14 @@ const Root = styled('div')(
       },
     },
     '& li': {
+      // tight lists https://spec.commonmark.org/0.30/#tight
       marginBottom: 4,
       '& pre': {
         marginTop: theme.spacing(1),
+      },
+      // loose lists https://spec.commonmark.org/0.30/#loose
+      '& > p': {
+        marginBottom: theme.spacing(1),
       },
     },
   }),


### PR DESCRIPTION
This is a continuation of https://github.com/mui/mui-x/pull/7899 to solve the problem differently. Instead of removing the use of loose lists for only tight lists, we can improve how loose lists are displayed to not feel broken. Each would have its own use cases:

a tight list for: bullet points
a loose list for: list paragraphs

The style of the docs currently didn't take into account that [looses](https://spec.commonmark.org/0.30/#loose) lists could exist. The UX (visual design aspect of it) feels broken on https://next.mui.com/x/react-date-pickers/base-concepts/#responsiveness

## Tight list (no changes): 

<img width="690" alt="Screenshot 2023-02-16 at 19 55 18" src="https://user-images.githubusercontent.com/3165635/219460790-61de2b6a-c257-4cb7-b3d7-1f0ca1a75ae1.png">

## Loose list before:

<img width="793" alt="Screenshot 2023-02-16 at 19 52 51" src="https://user-images.githubusercontent.com/3165635/219460324-eac7c4b9-00e7-4fe0-aa29-89034304462d.png">

## Loose list after:

<img width="798" alt="Screenshot 2023-02-16 at 19 52 31" src="https://user-images.githubusercontent.com/3165635/219460296-24d00c72-e804-4e69-903c-7c33e712c8fc.png">

---

I'm also using a loose list in https://deploy-preview-36190--material-ui.netlify.app/material-ui/react-radio-button/#accessibility now, as it seems to make sense in this context.