### PR TITLE
[docs] Add an option to force DemoEditor contents to wrap

### DIFF
--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -51,4 +51,4 @@ Use the `minRows` prop to define the minimum height of the component:
 
 Use the `maxRows` prop to define the maximum height of the component:
 
-{{"demo": "MaxHeightTextarea.js"}}
+{{"demo": "MaxHeightTextarea.js", "noHorizontalScroll": true}}

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -51,4 +51,4 @@ Use the `minRows` prop to define the minimum height of the component:
 
 Use the `maxRows` prop to define the maximum height of the component:
 
-{{"demo": "MaxHeightTextarea.js", "noHorizontalScroll": true}}
+{{"demo": "MaxHeightTextarea.js"}}

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -539,7 +539,7 @@ export default function Demo(props) {
                 'data-ga-event-label': demo.gaLabel,
                 'data-ga-event-action': 'copy-click',
               }}
-              noHorizontalScroll={demoOptions.noHorizontalScroll}
+              wrapLines={demoOptions.wrapLines}
             >
               <DemoEditorError>{debouncedError}</DemoEditorError>
             </DemoEditor>

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -539,6 +539,7 @@ export default function Demo(props) {
                 'data-ga-event-label': demo.gaLabel,
                 'data-ga-event-action': 'copy-click',
               }}
+              noHorizontalScroll={demoOptions.noHorizontalScroll}
             >
               <DemoEditorError>{debouncedError}</DemoEditorError>
             </DemoEditor>

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -55,6 +55,9 @@ const StyledSimpleCodeEditor = styled(SimpleCodeEditor)(({ theme }) => ({
     // Override inline-style
     whiteSpace: 'pre !important',
   },
+  '& .no-horizontal-scroll > [class^=language]': {
+    whiteSpace: 'pre-wrap !important',
+  },
 }));
 
 interface DemoEditorProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -64,10 +67,20 @@ interface DemoEditorProps extends React.HTMLAttributes<HTMLDivElement> {
   language: string;
   onChange: () => {};
   value: string;
+  noHorizontalScroll?: boolean;
 }
 
 export default function DemoEditor(props: DemoEditorProps) {
-  const { language, value, onChange, copyButtonProps, children, id, ...other } = props;
+  const {
+    language,
+    value,
+    onChange,
+    copyButtonProps,
+    children,
+    id,
+    noHorizontalScroll = false,
+    ...other
+  } = props;
   const t = useTranslate();
   const contextTheme = useTheme();
   const wrapperRef = React.useRef<HTMLElement | null>(null);
@@ -112,6 +125,7 @@ export default function DemoEditor(props: DemoEditorProps) {
             id={id}
             value={value}
             onValueChange={onChange}
+            preClassName={noHorizontalScroll ? 'no-horizontal-scroll' : undefined}
           />
         </div>
         <Box

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -51,12 +51,11 @@ const StyledSimpleCodeEditor = styled(SimpleCodeEditor)(({ theme }) => ({
   '& textarea': {
     outline: 0,
   },
-  '& > textarea, & > pre': {
-    // Override inline-style
-    whiteSpace: 'pre !important',
+  '& [class^=language]': {
+    whiteSpace: 'pre-wrap',
   },
-  '& .no-horizontal-scroll > [class^=language]': {
-    whiteSpace: 'pre-wrap !important',
+  '& .no-wrap > [class^=language]': {
+    whiteSpace: 'pre',
   },
 }));
 
@@ -67,7 +66,7 @@ interface DemoEditorProps extends React.HTMLAttributes<HTMLDivElement> {
   language: string;
   onChange: () => {};
   value: string;
-  noHorizontalScroll?: boolean;
+  wrapLines?: boolean;
 }
 
 export default function DemoEditor(props: DemoEditorProps) {
@@ -78,7 +77,7 @@ export default function DemoEditor(props: DemoEditorProps) {
     copyButtonProps,
     children,
     id,
-    noHorizontalScroll = false,
+    wrapLines = true,
     ...other
   } = props;
   const t = useTranslate();
@@ -125,7 +124,7 @@ export default function DemoEditor(props: DemoEditorProps) {
             id={id}
             value={value}
             onValueChange={onChange}
-            preClassName={noHorizontalScroll ? 'no-horizontal-scroll' : undefined}
+            preClassName={wrapLines ? undefined : 'no-wrap'}
           />
         </div>
         <Box


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds the ability to disable the horizontal scrollbars of a Demo and force long lines in the content to always wrap. It could be useful for other cases where we want to suppress a little bit of overflow (e.g. long dummy text thats not worth the effort for user to scroll sideways) to make it look better (no scrollbar!) so I added it to `demoOptions`.

#### Before

![Screenshot 2023-02-15 at 1 18 23 PM](https://user-images.githubusercontent.com/4997971/218939595-b8809434-4a87-4977-a3e2-d3a01de0cf58.png)

#### After

![Screenshot 2023-02-15 at 1 18 20 PM](https://user-images.githubusercontent.com/4997971/218939650-7270128d-5f26-43eb-ba66-3f141d95f1e6.png)

Preview link: https://deploy-preview-36191--material-ui.netlify.app/base/react-textarea-autosize/#maximum-height
