### PR TITLE
[core] Enforce namespace import for ReactDOM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -167,23 +167,27 @@ module.exports = {
       ...baseStyleRules['no-restricted-syntax'],
       {
         message:
-          "Do not import default from React. Use a namespace import (import * as React from 'react';) instead.",
-        selector: 'ImportDeclaration[source.value="react"] ImportDefaultSpecifier',
+          "Do not import default or named exports from React. Use a namespace import (import * as React from 'react';) instead.",
+        selector:
+          'ImportDeclaration[source.value="react"] ImportDefaultSpecifier, ImportDeclaration[source.value="react"] ImportSpecifier',
       },
       {
         message:
-          "Do not import default from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom';) instead.",
-        selector: 'ImportDeclaration[source.value="react-dom"] ImportDefaultSpecifier',
+          "Do not import default or named exports from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom';) instead.",
+        selector:
+          'ImportDeclaration[source.value="react-dom"] ImportDefaultSpecifier, ImportDeclaration[source.value="react-dom"] ImportSpecifier',
       },
       {
         message:
-          "Do not import default from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom/client';) instead.",
-        selector: 'ImportDeclaration[source.value="react-dom/client"] ImportDefaultSpecifier',
+          "Do not import default or named exports from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom/client';) instead.",
+        selector:
+          'ImportDeclaration[source.value="react-dom/client"] ImportDefaultSpecifier, ImportDeclaration[source.value="react-dom/client"] ImportSpecifier',
       },
       {
         message:
-          "Do not import default from ReactDOMServer. Use a namespace import (import * as ReactDOM from 'react-dom/server';) instead.",
-        selector: 'ImportDeclaration[source.value="react-dom/server"] ImportDefaultSpecifier',
+          "Do not import default or named exports from ReactDOMServer. Use a namespace import (import * as ReactDOM from 'react-dom/server';) instead.",
+        selector:
+          'ImportDeclaration[source.value="react-dom/server"] ImportDefaultSpecifier, ImportDeclaration[source.value="react-dom/server"] ImportSpecifier',
       },
     ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -170,6 +170,11 @@ module.exports = {
           "Do not import default from React. Use a namespace import (import * as React from 'react';) instead.",
         selector: 'ImportDeclaration[source.value="react"] ImportDefaultSpecifier',
       },
+      {
+        message:
+          "Do not import default from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom';) instead.",
+        selector: 'ImportDeclaration[source.value="react-dom"] ImportDefaultSpecifier',
+      },
     ],
 
     // We re-export default in many places, remove when https://github.com/airbnb/javascript/issues/2500 gets resolved

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -173,7 +173,8 @@ module.exports = {
       {
         message:
           "Do not import default from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom';) instead.",
-        selector: 'ImportDeclaration[source.value="react-dom"] ImportDefaultSpecifier',
+        selector:
+          'ImportDeclaration[source.value=/^react-dom(\\u002F(server|client))?$/] ImportDefaultSpecifier',
       },
     ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -173,8 +173,17 @@ module.exports = {
       {
         message:
           "Do not import default from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom';) instead.",
-        selector:
-          'ImportDeclaration[source.value=/^react-dom(\\u002F(server|client))?$/] ImportDefaultSpecifier',
+        selector: 'ImportDeclaration[source.value="react-dom"] ImportDefaultSpecifier',
+      },
+      {
+        message:
+          "Do not import default from ReactDOM. Use a namespace import (import * as ReactDOM from 'react-dom/client';) instead.",
+        selector: 'ImportDeclaration[source.value="react-dom/client"] ImportDefaultSpecifier',
+      },
+      {
+        message:
+          "Do not import default from ReactDOMServer. Use a namespace import (import * as ReactDOM from 'react-dom/server';) instead.",
+        selector: 'ImportDeclaration[source.value="react-dom/server"] ImportDefaultSpecifier',
       },
     ],
 

--- a/benchmark/browser/index.js
+++ b/benchmark/browser/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { logReactMetrics } from './utils';
 

--- a/benchmark/server/scenarios/core.js
+++ b/benchmark/server/scenarios/core.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import Benchmark from 'benchmark';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { StylesProvider } from '@mui/styles';
 import ButtonBase from '@mui/material/ButtonBase';
 

--- a/benchmark/server/scenarios/docs.js
+++ b/benchmark/server/scenarios/docs.js
@@ -3,7 +3,7 @@ import Benchmark from 'benchmark';
 import fs from 'fs';
 import path from 'path';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import Markdown from 'docs/data/material/getting-started/templates/blog/Markdown';
 import { createStore } from 'redux';

--- a/benchmark/server/scenarios/server.js
+++ b/benchmark/server/scenarios/server.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import express from 'express';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { SheetsRegistry } from 'jss';
 import { createTheme } from '@mui/material/styles';
 import {

--- a/benchmark/server/scenarios/styles.js
+++ b/benchmark/server/scenarios/styles.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import Benchmark from 'benchmark';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import styledComponents, { ServerStyleSheet } from 'styled-components';
 import styledEmotion from '@emotion/styled';
 import { css } from '@emotion/react';

--- a/docs/data/joy/getting-started/templates/order-dashboard/useScript.ts
+++ b/docs/data/joy/getting-started/templates/order-dashboard/useScript.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import * as React from 'react';
 
 export type UseScriptStatus = 'idle' | 'loading' | 'ready' | 'error';
 
@@ -19,7 +19,7 @@ function getScriptNode(src: string) {
 }
 
 function useScript(src: string): UseScriptStatus {
-  const [status, setStatus] = useState<UseScriptStatus>(() => {
+  const [status, setStatus] = React.useState<UseScriptStatus>(() => {
     if (typeof window === 'undefined') {
       // SSR Handling - always return 'loading'
       return 'loading';
@@ -28,7 +28,7 @@ function useScript(src: string): UseScriptStatus {
     return cachedScriptStatuses[src] ?? 'loading';
   });
 
-  useEffect(() => {
+  React.useEffect(() => {
     const cachedScriptStatus = cachedScriptStatuses[src];
     if (cachedScriptStatus === 'ready' || cachedScriptStatus === 'error') {
       // If the script is already cached, set its status immediately

--- a/docs/data/material/components/use-media-query/use-media-query-pt.md
+++ b/docs/data/material/components/use-media-query/use-media-query-pt.md
@@ -134,7 +134,7 @@ Finally, you need to provide an implementation of [matchMedia](https://developer
 For instance on the server-side:
 
 ```js
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import parser from 'ua-parser-js';
 import mediaQuery from 'css-mediaquery';
 import { ThemeProvider } from '@material-ui/core/styles';

--- a/docs/data/material/components/use-media-query/use-media-query-zh.md
+++ b/docs/data/material/components/use-media-query/use-media-query-zh.md
@@ -136,7 +136,7 @@ Finally, you need to provide an implementation of [matchMedia](https://developer
 For instance on the server-side:
 
 ```js
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import parser from 'ua-parser-js';
 import mediaQuery from 'css-mediaquery';
 import { ThemeProvider } from '@mui/core/styles';

--- a/docs/data/material/components/use-media-query/use-media-query.md
+++ b/docs/data/material/components/use-media-query/use-media-query.md
@@ -144,7 +144,7 @@ Using [css-mediaquery](https://github.com/ericf/css-mediaquery) to emulate match
 For instance on the server-side:
 
 ```js
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import parser from 'ua-parser-js';
 import mediaQuery from 'css-mediaquery';
 import { createTheme, ThemeProvider } from '@mui/material/styles';

--- a/docs/data/material/experimental-api/classname-generator/classname-generator-pt.md
+++ b/docs/data/material/experimental-api/classname-generator/classname-generator-pt.md
@@ -160,7 +160,7 @@ Import the initializer in `/src/index.js`.
 ```diff
 +import './MuiClassNameSetup';
  import * as React from 'react';
- import ReactDOM from 'react-dom';
+ import * as ReactDOM from 'react-dom';
  import App from './App';
 
  ReactDOM.render(<App />);

--- a/docs/data/material/experimental-api/classname-generator/classname-generator-zh.md
+++ b/docs/data/material/experimental-api/classname-generator/classname-generator-zh.md
@@ -160,7 +160,7 @@ Import the initializer in `/src/index.js`.
 ```diff
 +import './MuiClassNameSetup';
  import * as React from 'react';
- import ReactDOM from 'react-dom';
+ import * as ReactDOM from 'react-dom';
  import App from './App';
 
  ReactDOM.render(<App />);

--- a/docs/data/material/experimental-api/classname-generator/classname-generator.md
+++ b/docs/data/material/experimental-api/classname-generator/classname-generator.md
@@ -160,7 +160,7 @@ Import the initializer in `/src/index.js`.
 ```diff
 +import './MuiClassNameSetup';
  import * as React from 'react';
- import ReactDOM from 'react-dom';
+ import * as ReactDOM from 'react-dom';
  import App from './App';
 
  ReactDOM.render(<App />);

--- a/docs/data/material/guides/server-rendering/server-rendering-pt.md
+++ b/docs/data/material/guides/server-rendering/server-rendering-pt.md
@@ -103,7 +103,7 @@ Vamos ver como isso é passado na função `renderFullPage`.
 ```jsx
 import express from 'express';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import createEmotionServer from '@emotion/server/create-instance';
@@ -181,7 +181,7 @@ The client-side is straightforward. All we need to do is use the same cache conf
 
 ```jsx
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { CacheProvider } from '@emotion/react';

--- a/docs/data/material/guides/server-rendering/server-rendering-zh.md
+++ b/docs/data/material/guides/server-rendering/server-rendering-zh.md
@@ -107,7 +107,7 @@ With this we are creating a new Emotion cache instance and using this to extract
 ```jsx
 import express from 'express';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { CacheProvider } from '@emotion/react';
@@ -150,7 +150,7 @@ app.use(handleRender);
 const port = 3000;
 app.listen(port); import express from 'express';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import CssBaseline from '@mui/core/CssBaseline';
 import { ThemeProvider } from '@mui/core/styles';
 import createEmotionServer from '@emotion/server/create-instance';
@@ -220,7 +220,7 @@ The client-side is straightforward. All we need to do is use the same cache conf
 
 ```jsx
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import CssBaseline from '@mui/core/CssBaseline';
 import { ThemeProvider } from '@mui/core/styles';
 import { CacheProvider } from '@emotion/react';

--- a/docs/data/material/guides/server-rendering/server-rendering.md
+++ b/docs/data/material/guides/server-rendering/server-rendering.md
@@ -109,7 +109,7 @@ We will see how this is passed along in the `renderFullPage` function.
 ```jsx
 import express from 'express';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { CacheProvider } from '@emotion/react';
@@ -186,7 +186,7 @@ Let's take a look at the client file:
 
 ```jsx
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { CacheProvider } from '@emotion/react';

--- a/docs/data/styles/advanced/advanced-pt.md
+++ b/docs/data/styles/advanced/advanced-pt.md
@@ -363,7 +363,7 @@ export default function App() {
 This example returns a string of HTML and inlines the critical CSS required, right before it's used:
 
 ```jsx
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheets } from '@material-ui/styles';
 
 function render() {

--- a/docs/data/styles/advanced/advanced-zh.md
+++ b/docs/data/styles/advanced/advanced-zh.md
@@ -376,7 +376,7 @@ const jss = create({
 这个例子返回一个HTML字符串，并在使用前将所需的关键CSS内联。
 
 ```jsx
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheets } from '@mui/styles';
 
 function render() {

--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -368,7 +368,7 @@ export default function App() {
 This example returns a string of HTML and inlines the critical CSS required, right before it's used:
 
 ```jsx
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheets } from '@mui/styles';
 
 function render() {

--- a/docs/data/styles/api/api-pt.md
+++ b/docs/data/styles/api/api-pt.md
@@ -115,7 +115,7 @@ export default function MyComponent(props) {
 Esta é uma classe auxiliar para manipular a renderização do lado do servidor. [You can follow this guide for a practical approach](/material-ui/guides/server-rendering/).
 
 ```jsx
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheets } from '@material-ui/styles';
 
 const sheets = new ServerStyleSheets();

--- a/docs/data/styles/api/api-zh.md
+++ b/docs/data/styles/api/api-zh.md
@@ -115,7 +115,7 @@ export default function MyComponent(props) {
 这是一个处理服务器端渲染的类助手（class helper）。 [你可以遵循本指南的实用方法](/material-ui/guides/server-rendering/)
 
 ```jsx
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheets } from '@mui/styles';
 
 const sheets = new ServerStyleSheets();

--- a/docs/data/styles/api/api.md
+++ b/docs/data/styles/api/api.md
@@ -129,7 +129,7 @@ export default function MyComponent(props) {
 This is a class helper to handle server-side rendering. [You can follow this guide for a practical approach](/material-ui/guides/server-rendering/).
 
 ```jsx
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheets } from '@mui/styles';
 
 const sheets = new ServerStyleSheets();

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createPortal } from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import * as ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
@@ -309,7 +309,7 @@ export default function AppSearch() {
         </Shortcut>
       </SearchButton>
       {isOpen &&
-        createPortal(
+        ReactDOM.createPortal(
           <DocSearchModal
             initialQuery={initialQuery}
             appId={'TZGZ85B9TB'}

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';

--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import { create } from 'jss';

--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -53,7 +53,7 @@ describe('CodeSandbox', () => {
       },
       'index.js': {
         content:
-          "import * as React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
       },
     });
   });
@@ -101,7 +101,7 @@ describe('CodeSandbox', () => {
       },
       'index.tsx': {
         content:
-          "import * as React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
       },
       'tsconfig.json': {
         content:

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -66,7 +66,7 @@ const createJoyTemplate = (demo: {
     },
     [`index.${ext}`]: {
       content: `import * as React from 'react';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/joy/styles';
 import App from './App';
 

--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -23,7 +23,7 @@ export const getHtml = ({ title, language }: { title: string; language: string }
 export const getRootIndex = (product?: 'joy-ui' | 'base') => {
   if (product === 'joy-ui') {
     return `import * as React from 'react';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider, CssVarsProvider } from '@mui/joy/styles';
 import Demo from './demo';
 
@@ -39,7 +39,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
   }
   if (product === 'base') {
     return `import * as React from 'react';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import Demo from './demo';
 
 ReactDOM.createRoot(document.querySelector("#root")).render(
@@ -49,7 +49,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
 );`;
   }
   return `import * as React from 'react';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';
 import Demo from './demo';
 

--- a/docs/src/modules/sandbox/StackBlitz.test.js
+++ b/docs/src/modules/sandbox/StackBlitz.test.js
@@ -36,7 +36,7 @@ describe('StackBlitz', () => {
         'demo.js':
           'import * as React from \'react\';\nimport Stack from \'@mui/material/Stack\';\nimport Button from \'@mui/material/Button\';\n\nexport default function BasicButtons() {\n  return (\n    <Stack spacing={2} direction="row">\n      <Button variant="text">Text</Button>\n      <Button variant="contained">Contained</Button>\n      <Button variant="outlined">Outlined</Button>\n    </Stack>\n  );\n}\n',
         'index.js':
-          "import * as React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
       },
       dependencies: {
         react: 'latest',
@@ -67,7 +67,7 @@ describe('StackBlitz', () => {
         'demo.tsx':
           'import * as React from \'react\';\nimport Stack from \'@mui/material/Stack\';\nimport Button from \'@mui/material/Button\';\n\nexport default function BasicButtons() {\n  return (\n    <Stack spacing={2} direction="row">\n      <Button variant="text">Text</Button>\n      <Button variant="contained">Contained</Button>\n      <Button variant="outlined">Outlined</Button>\n    </Stack>\n  );\n}\n',
         'index.tsx':
-          "import * as React from 'react';\nimport ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
         'tsconfig.json':
           '{\n  "compilerOptions": {\n    "target": "es5",\n    "lib": [\n      "dom",\n      "dom.iterable",\n      "esnext"\n    ],\n    "allowJs": true,\n    "skipLibCheck": true,\n    "esModuleInterop": true,\n    "allowSyntheticDefaultImports": true,\n    "strict": true,\n    "forceConsistentCasingInFileNames": true,\n    "module": "esnext",\n    "moduleResolution": "node",\n    "resolveJsonModule": true,\n    "isolatedModules": true,\n    "noEmit": true,\n    "jsx": "react"\n  },\n  "include": [\n    "src"\n  ]\n}\n',
       },

--- a/examples/base-cra-tailwind-ts/src/index.tsx
+++ b/examples/base-cra-tailwind-ts/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 

--- a/examples/base-cra-ts/src/index.tsx
+++ b/examples/base-cra-ts/src/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import App from './App';
 
 const rootElement = document.getElementById('root');
-const root = createRoot(rootElement!);
+const root = ReactDOM.createRoot(rootElement!);
 
 root.render(<App />);

--- a/examples/joy-cra-ts/src/index.tsx
+++ b/examples/joy-cra-ts/src/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import App from './App';
 
 const rootElement = document.getElementById('root');
-const root = createRoot(rootElement!);
+const root = ReactDOM.createRoot(rootElement!);
 
 root.render(<App />);

--- a/examples/material-cra-styled-components-ts/src/index.tsx
+++ b/examples/material-cra-styled-components-ts/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import CssBaseline from '@mui/material/CssBaseline';
 import App from './App';
 

--- a/examples/material-cra-styled-components/src/index.js
+++ b/examples/material-cra-styled-components/src/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import CssBaseline from '@mui/material/CssBaseline';
 import App from './App';
 import * as serviceWorker from './serviceWorker';

--- a/examples/material-cra-tailwind-ts/src/index.tsx
+++ b/examples/material-cra-tailwind-ts/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import { createTheme, StyledEngineProvider, ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 import './index.css';
@@ -7,7 +7,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const rootElement = document.getElementById('root');
-const root = createRoot(rootElement!);
+const root = ReactDOM.createRoot(rootElement!);
 
 // All `Portal`-related components need to have the the main app wrapper element as a container
 // so that the are in the subtree under the element used in the `important` option of the Tailwind's config.

--- a/examples/material-cra-ts/src/index.tsx
+++ b/examples/material-cra-ts/src/index.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import App from './App';
 import theme from './theme';
 
 const rootElement = document.getElementById('root');
-const root = createRoot(rootElement!);
+const root = ReactDOM.createRoot(rootElement!);
 
 root.render(
   <ThemeProvider theme={theme}>

--- a/examples/material-cra/src/index.js
+++ b/examples/material-cra/src/index.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import App from './App';
 import theme from './theme';
 
 const rootElement = document.getElementById('root');
-const root = createRoot(rootElement);
+const root = ReactDOM.createRoot(rootElement);
 
 root.render(
   <ThemeProvider theme={theme}>

--- a/examples/material-express-ssr/client.js
+++ b/examples/material-express-ssr/client.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { CacheProvider } from '@emotion/react';

--- a/examples/material-express-ssr/server.js
+++ b/examples/material-express-ssr/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { CacheProvider } from '@emotion/react';

--- a/examples/material-preact/src/index.js
+++ b/examples/material-preact/src/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import App from './App';
 
 ReactDOM.render(

--- a/examples/material-remix-ts/app/entry.client.tsx
+++ b/examples/material-remix-ts/app/entry.client.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
-import { startTransition } from 'react';
-import { hydrateRoot } from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import { RemixBrowser } from 'remix';
 import { CacheProvider } from '@emotion/react';
 import { ThemeProvider } from '@mui/material/styles';
@@ -14,7 +12,7 @@ interface ClientCacheProviderProps {
   children: React.ReactNode;
 }
 function ClientCacheProvider({ children }: ClientCacheProviderProps) {
-  const [cache, setCache] = useState(createEmotionCache());
+  const [cache, setCache] = React.useState(createEmotionCache());
 
   const clientStyleContextValue = React.useMemo(
     () => ({
@@ -33,8 +31,8 @@ function ClientCacheProvider({ children }: ClientCacheProviderProps) {
 }
 
 const hydrate = () => {
-  startTransition(() => {
-    hydrateRoot(
+  React.startTransition(() => {
+    ReactDOM.hydrateRoot(
       document,
       <ClientCacheProvider>
         <ThemeProvider theme={theme}>

--- a/examples/material-remix-ts/app/entry.server.tsx
+++ b/examples/material-remix-ts/app/entry.server.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderToString } from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { RemixServer } from 'remix';
 import type { EntryContext } from 'remix';
 import createEmotionCache from './src/createEmotionCache';
@@ -31,7 +31,7 @@ export default function handleRequest(
   }
 
   // Render the component to a string.
-  const html = renderToString(<MuiRemixServer />);
+  const html = ReactDOMServer.renderToString(<MuiRemixServer />);
 
   // Grab the CSS from emotion
   const { styles } = extractCriticalToChunks(html);

--- a/examples/material-remix-ts/app/src/ClientStyleContext.tsx
+++ b/examples/material-remix-ts/app/src/ClientStyleContext.tsx
@@ -1,9 +1,9 @@
-import { createContext } from 'react';
+import * as React from 'react';
 
 export interface ClientStyleContextData {
   reset: () => void;
 }
 
-export default createContext<ClientStyleContextData>({
+export default React.createContext<ClientStyleContextData>({
   reset: () => {},
 });

--- a/examples/material-vite-ts/src/main.tsx
+++ b/examples/material-vite-ts/src/main.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom/client';
+import * as ReactDOM from 'react-dom/client';
 import { ThemeProvider } from '@emotion/react';
 import { CssBaseline } from '@mui/material';
 import theme from './theme';

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { flushSync } from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import {
   unstable_debounce as debounce,
   unstable_useForkRef as useForkRef,
@@ -177,7 +177,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
     // In React 18, state updates in a ResizeObserver's callback are happening after the paint which causes flickering
     // when doing some visual updates in it. Using flushSync ensures that the dom will be painted after the states updates happen
     // Related issue - https://github.com/facebook/react/issues/24331
-    flushSync(() => {
+    ReactDOM.flushSync(() => {
       setState((prevState) => {
         return updateState(prevState, newState);
       });

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-actual.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-actual.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';

--- a/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
+++ b/packages/mui-codemod/src/v5.0.0/theme-spacing.test/large-expected.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -1,5 +1,5 @@
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { flushSync } from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { styled, useThemeProps } from '@mui/material/styles';
 import {
   createUnarySpacing,
@@ -265,7 +265,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
       // In React 18, state updates in a ResizeObserver's callback are happening after the paint which causes flickering
       // when doing some visual updates in it. Using flushSync ensures that the dom will be painted after the states updates happen
       // Related issue - https://github.com/facebook/react/issues/24331
-      flushSync(() => {
+      ReactDOM.flushSync(() => {
         setMaxColumnHeight(Math.max(...columnHeights));
         setNumberOfLineBreaks(currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0);
       });

--- a/packages/mui-lab/src/TabContext/TabContext.test.js
+++ b/packages/mui-lab/src/TabContext/TabContext.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
 import { createRenderer } from 'test/utils';
 import TabContext, { getPanelId, getTabId, useTabContext } from './TabContext';

--- a/packages/mui-material/src/Dialog/DialogContext.ts
+++ b/packages/mui-material/src/Dialog/DialogContext.ts
@@ -1,10 +1,10 @@
-import { createContext } from 'react';
+import * as React from 'react';
 
 interface DialogContextValue {
   titleId?: string;
 }
 
-const DialogContext = createContext<DialogContextValue>({});
+const DialogContext = React.createContext<DialogContextValue>({});
 
 if (process.env.NODE_ENV !== 'production') {
   DialogContext.displayName = 'DialogContext';

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { flushSync } from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { elementTypeAcceptingRef } from '@mui/utils';
 import { useThemeProps } from '@mui/system';
@@ -239,7 +239,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
     }
     claimedSwipeInstance = null;
     touchDetected.current = false;
-    flushSync(() => {
+    ReactDOM.flushSync(() => {
       setMaybeSwiping(false);
     });
 
@@ -308,7 +308,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(inProps, ref) 
       // this is because Safari Mobile will not fire any mouse events (still fires touch though) if the DOM changes during mousemove.
       // so do this change on first touchmove instead of touchstart
       if (force || !(disableDiscovery && allowSwipeInChildren)) {
-        flushSync(() => {
+        ReactDOM.flushSync(() => {
           setMaybeSwiping(true);
         });
       }

--- a/packages/mui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/mui-styles/src/StylesProvider/StylesProvider.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import * as ReactDOMServer from 'react-dom/server';
 import { expect } from 'chai';
 import { create, SheetsRegistry } from 'jss';
 import { createMount, strictModeDoubleLoggingSupressed } from 'test/utils';

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import * as DomTestingLibrary from '@testing-library/dom';

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { createRoot } from 'react-dom/client';
+import * as ReactDOMClient from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import * as DomTestingLibrary from '@testing-library/dom';
 import TestViewer from './TestViewer';
@@ -108,7 +108,7 @@ if (typeof ReactDOM.unstable_createRoot === 'function') {
   const root = ReactDOM.unstable_createRoot(container);
   root.render(children);
 } else {
-  const root = createRoot(container);
+  const root = ReactDOMClient.createRoot(container);
   root.render(children);
 }
 

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import webfontloader from 'webfontloader';
 import TestViewer from './TestViewer';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes https://github.com/mui/material-ui/issues/36198

This PR updates the eslint `no-restricted-syntax` rule to enforce `import * as ReactDOM` (`react-dom`, `react-dom/client`, `react-dom/server`) and give an error for:
  - default imports (`import ReactDOM from 'react-dom'`)
  - named imports (`import { createPortal } from 'react-dom'`)

Example lint step: https://app.circleci.com/pipelines/github/mui/material-ui/91534/workflows/63fb99e1-8ccd-4c53-9106-401ead3f8c2d/jobs/485842/parallel-runs/0/steps/0-108

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
