### PR TITLE
[TreeView] Fix Tree View inside shadow root crashes

### DIFF
--- a/packages/mui-lab/src/TreeItem/TreeItem.js
+++ b/packages/mui-lab/src/TreeItem/TreeItem.js
@@ -272,7 +272,15 @@ const TreeItem = React.forwardRef(function TreeItem(inProps, ref) {
   function handleFocus(event) {
     // DOM focus stays on the tree which manages focus with aria-activedescendant
     if (event.target === event.currentTarget) {
-      ownerDocument(event.target).getElementById(treeId).focus({ preventScroll: true });
+      let rootElement;
+
+      if (typeof event.target.getRootNode === 'function') {
+        rootElement = event.target.getRootNode();
+      } else {
+        rootElement = ownerDocument(event.target);
+      }
+
+      rootElement.getElementById(treeId).focus({ preventScroll: true });
     }
 
     const unfocusable = !disabledItemsFocusable && disabled;


### PR DESCRIPTION
Checks if the Node.getRootNode() function is available and use it in handleFocus to prevent a crash when running inside a shadow root.

Fixes #36224

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
