### PR TITLE
[Avatar] Fix ownerState usage with styleOverrides when fallback is used

### DIFF
--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -176,7 +176,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
   } else if (hasImg && alt) {
     children = alt[0];
   } else {
-    children = <AvatarFallback className={classes.fallback} />;
+    children = <AvatarFallback ownerState={ownerState} className={classes.fallback} />;
   }
 
   return (

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { createRenderer, fireEvent, describeConformance } from 'test/utils';
 import { spy } from 'sinon';
 import Avatar, { avatarClasses as classes } from '@mui/material/Avatar';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CancelIcon from '../internal/svg-icons/Cancel';
 
 describe('<Avatar />', () => {
@@ -211,5 +212,29 @@ describe('<Avatar />', () => {
 
       expect(avatar).to.have.class(classes.colorDefault);
     });
+  });
+
+  it('should not error when ownerState is used in styleOverrides', () => {
+    const theme = createTheme({
+      components: {
+        MuiAvatar: {
+          styleOverrides: {
+            root: ({ ownerState }) => ({
+              ...(ownerState.variant === 'rounded' && {
+                color: 'red',
+              }),
+            }),
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      render(
+        <ThemeProvider theme={theme}>
+          <Avatar variant="rounded" />
+        </ThemeProvider>,
+      ),
+    ).not.toErrorDev();
   });
 });

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -214,7 +214,7 @@ describe('<Avatar />', () => {
     });
   });
 
-  it('should not error when ownerState is used in styleOverrides', () => {
+  it('should not throw error when ownerState is used in styleOverrides', () => {
     const theme = createTheme({
       components: {
         MuiAvatar: {
@@ -235,6 +235,6 @@ describe('<Avatar />', () => {
           <Avatar variant="rounded" />
         </ThemeProvider>,
       ),
-    ).not.toErrorDev();
+    ).not.to.throw();
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/36223

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
