### PR TITLE
[TextField] Fix floating label position

### DIFF
--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -110,7 +110,9 @@ const InputLabelRoot = styled(FormLabel, {
     ...(ownerState.shrink && {
       userSelect: 'none',
       pointerEvents: 'auto',
-      maxWidth: 'calc(133% - 24px)',
+      // Theoretically, we should have (8+5)*2/0.75 = 34px
+      // but it feels a better when it bleeds a bit on the left, so 32px.
+      maxWidth: 'calc(133% - 32px)',
       transform: 'translate(14px, -9px) scale(0.75)',
     }),
   }),


### PR DESCRIPTION
I never thought that there would still be bugs opportunities in this outline input 😁. You can reproduce this on https://codesandbox.io/s/muddy-leaf-t4y7z5?file=/package.json

```jsx
import * as React from "react";
import Box from "@mui/material/Box";
import TextField from "@mui/material/TextField";

export default function BasicTextFields() {
  return (
    <Box sx={{ m: 2 }}>
      <TextField
        id="outlined-basic"
        InputLabelProps={{ shrink: true }}
        label="Foo Foo Foo Foo Foo Foo Foo F"
        variant="outlined"
      />
    </Box>
  );
}
```

Before:

<img width="219" alt="Screenshot 2023-02-19 at 00 55 10" src="https://user-images.githubusercontent.com/3165635/219904784-940e036b-d926-4b7f-84a7-3fa71282491c.png">

After:

<img width="224" alt="Screenshot 2023-02-19 at 01 02 16" src="https://user-images.githubusercontent.com/3165635/219904951-c0d0e810-ba09-45d0-8e39-10217f9e3714.png">

---

I have noticed this on https://next.mui.com/x/react-date-pickers/getting-started/#installation, it's broken:

<img width="330" alt="Screenshot 2023-02-19 at 00 57 29" src="https://user-images.githubusercontent.com/3165635/219904840-f18a0ed8-88f5-4ad3-b649-9904d5680413.png">