### PR TITLE
[Joy] Fix `ListDivider` to change semantic based on `List`

### DIFF
--- a/packages/mui-joy/src/Divider/Divider.tsx
+++ b/packages/mui-joy/src/Divider/Divider.tsx
@@ -17,7 +17,7 @@ const useUtilityClasses = (ownerState: DividerOwnerState) => {
   return composeClasses(slots, getDividerUtilityClass, {});
 };
 
-const DividerRoot = styled('hr', {
+export const DividerRoot = styled('hr', {
   name: 'JoyDivider',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,

--- a/packages/mui-joy/src/ListDivider/ListDivider.test.js
+++ b/packages/mui-joy/src/ListDivider/ListDivider.test.js
@@ -54,4 +54,32 @@ describe('Joy <ListDivider />', () => {
       expect(screen.getByRole('presentation')).not.to.have.attribute('aria-orientation');
     });
   });
+
+  describe('semantics', () => {
+    it('should be `li` with role `separator` by default', () => {
+      render(<ListDivider />);
+
+      expect(screen.getByRole('separator')).to.have.tagName('li');
+    });
+
+    it('should still be `li` if List is a `ul` with role `menu`', () => {
+      render(
+        <List role="menu">
+          <ListDivider />
+        </List>,
+      );
+
+      expect(screen.getByRole('separator')).to.have.tagName('li');
+    });
+
+    it('should be `div` if `List` is not one of `ol, ul, menu`', () => {
+      const { container } = render(
+        <List component="div" role="menu">
+          <ListDivider />
+        </List>,
+      );
+      expect(screen.queryByRole('separator')).to.equal(null);
+      expect(container.firstChild.firstChild).to.have.tagName('div');
+    });
+  });
 });

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -5,10 +5,11 @@ import { unstable_capitalize as capitalize } from '@mui/utils';
 import { OverridableComponent } from '@mui/types';
 import composeClasses from '@mui/base/composeClasses';
 import { styled, useThemeProps } from '../styles';
-import Divider from '../Divider/Divider';
+import { DividerRoot } from '../Divider/Divider';
 import { ListDividerOwnerState, ListDividerTypeMap } from './ListDividerProps';
 import { getListDividerUtilityClass } from './listDividerClasses';
 import RowListContext from '../List/RowListContext';
+import ComponentListContext from '../List/ComponentListContext';
 
 const useUtilityClasses = (ownerState: ListDividerOwnerState) => {
   const { orientation, inset } = ownerState;
@@ -24,7 +25,7 @@ const useUtilityClasses = (ownerState: ListDividerOwnerState) => {
   return composeClasses(slots, getListDividerUtilityClass, {});
 };
 
-const ListDividerRoot = styled(Divider, {
+const ListDividerRoot = styled(DividerRoot as unknown as 'li', {
   name: 'JoyListDivider',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
@@ -70,9 +71,11 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
   });
 
   const row = React.useContext(RowListContext);
+  const listComponent = React.useContext(ComponentListContext);
 
   const {
-    component = 'li',
+    component: componentProp,
+    role: roleProp,
     className,
     children,
     inset = 'context',
@@ -80,24 +83,34 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
     ...other
   } = props;
 
+  const [listElement] = listComponent?.split(':') || ['', ''];
+  const component =
+    componentProp || (listElement && !listElement.match(/^(ul|ol|menu)$/) ? 'div' : 'li');
+  const role = roleProp || (component === 'li' ? 'separator' : undefined);
+
   const ownerState = {
     ...props,
     inset,
     row,
     orientation,
+    role,
   };
 
   const classes = useUtilityClasses(ownerState);
 
   return (
     <ListDividerRoot
-      // @ts-ignore
       ref={ref}
-      {...(inset === 'context' && { inset })}
-      component={component}
+      as={component}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
-      orientation={orientation}
+      role={role}
+      {...(role === 'separator' &&
+        orientation === 'vertical' && {
+          // The implicit aria-orientation of separator is 'horizontal'
+          // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
+          'aria-orientation': 'vertical',
+        })}
       {...other}
     >
       {children}
@@ -127,9 +140,10 @@ ListDivider.propTypes /* remove-proptypes */ = {
    * The empty space on the side(s) of the divider in a vertical list.
    *
    * For horizontal list (the nearest parent List has `row` prop set to `true`), only `inset="gutter"` affects the list divider.
+   * @default 'context'
    */
   inset: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
-    PropTypes.oneOf(['gutter', 'startDecorator', 'startContent']),
+    PropTypes.oneOf(['context', 'gutter', 'startDecorator', 'startContent']),
     PropTypes.string,
   ]),
   /**
@@ -137,6 +151,10 @@ ListDivider.propTypes /* remove-proptypes */ = {
    * @default 'horizontal'
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
+   * @ignore
+   */
+  role: PropTypes /* @typescript-to-proptypes-ignore */.string,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -93,6 +93,7 @@ const ListDivider = React.forwardRef(function ListDivider(inProps, ref) {
     inset,
     row,
     orientation,
+    component,
     role,
   };
 

--- a/packages/mui-joy/src/ListDivider/ListDividerProps.ts
+++ b/packages/mui-joy/src/ListDivider/ListDividerProps.ts
@@ -16,6 +16,7 @@ export interface ListDividerTypeMap<P = {}, D extends React.ElementType = 'li'> 
      * The empty space on the side(s) of the divider in a vertical list.
      *
      * For horizontal list (the nearest parent List has `row` prop set to `true`), only `inset="gutter"` affects the list divider.
+     * @default 'context'
      */
     inset?: OverridableStringUnion<
       'context' | 'gutter' | 'startDecorator' | 'startContent',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From https://codesandbox.io/s/joy-ui-feat-radix-accordion-4n2p04?file=/demo.tsx, the `ListDivider` does not change from `li` to `div` when List has a custom component.

```js
<List component="div">
  <ListDivider /> // => should be `div` without `role`.
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
