### PR TITLE
ListItem: use CSS classes to reduce generated CSS

### DIFF
--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -12,7 +12,7 @@ import { styled, useThemeProps } from '../styles';
 import { useColorInversion } from '../styles/ColorInversion';
 import useSlot from '../utils/useSlot';
 import { ListItemOwnerState, ListItemTypeMap } from './ListItemProps';
-import { getListItemUtilityClass } from './listItemClasses';
+import listItemClasses, { getListItemUtilityClass } from './listItemClasses';
 import NestedListContext from '../List/NestedListContext';
 import RowListContext from '../List/RowListContext';
 import WrapListContext from '../List/WrapListContext';
@@ -98,13 +98,13 @@ const ListItemRoot = styled('li', {
     minBlockSize: 'var(--List-item-minHeight)',
     fontSize: 'var(--List-item-fontSize)',
     fontFamily: theme.vars.fontFamily.body,
-    ...(ownerState.sticky && {
+    [`&.${listItemClasses.sticky}`]: {
       // sticky in list item can be found in grouped options
       position: 'sticky',
       top: 'var(--List-item-stickyTop, 0px)', // integration with Menu and Select.
       zIndex: 1,
       background: 'var(--List-item-stickyBackground)',
-    }),
+    },
   },
   theme.variants[ownerState.variant!]?.[ownerState.color!],
 ]);

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -41,13 +41,14 @@ const useUtilityClasses = (ownerState: ListItemButtonOwnerState) => {
 export const StyledListItemButton = styled('div')<{ ownerState: ListItemButtonOwnerState }>(
   ({ theme, ownerState }) => [
     {
-      ...(ownerState.selected && {
+      [`&.${listItemButtonClasses.selected}`]: {
         '--List-decorator-color': 'initial',
-      }),
-      ...(ownerState.disabled && {
+        fontWeight: theme.vars.fontWeight.md,
+      },
+      [`&.${listItemButtonClasses.disabled}`]: {
         '--List-decorator-color':
           theme.variants?.[`${ownerState.variant!}Disabled`]?.[ownerState.color!]?.color,
-      }),
+      },
       WebkitTapHighlightColor: 'transparent',
       boxSizing: 'border-box',
       position: 'relative',
@@ -81,17 +82,14 @@ export const StyledListItemButton = styled('div')<{ ownerState: ListItemButtonOw
       minInlineSize: 0,
       fontSize: 'var(--List-item-fontSize)',
       fontFamily: theme.vars.fontFamily.body,
-      ...(ownerState.selected && {
-        fontWeight: theme.vars.fontWeight.md,
-      }),
       [theme.focus.selector]: theme.focus.default,
     },
     {
       ...theme.variants[ownerState.variant!]?.[ownerState.color!],
-      ...(!ownerState.selected && {
+      [`&:not(.${listItemButtonClasses.selected})`]: {
         '&:hover': theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
         '&:active': theme.variants[`${ownerState.variant!}Active`]?.[ownerState.color!],
-      }),
+      },
     },
     {
       [`&.${listItemButtonClasses.disabled}`]:


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This addresses / fixes #35984 as it relates to the `ListItem` and `ListItemButton` with some caveats:

- I only use existing CSS classes; none are added
  - `vertical` exists in classes, but doesn't seem to be added to `ListItemButton`
- I only use CSS classes when doing so would avoid eliminate that `ownerState` usage
- `row` and `wrap` states depend on the containing `List`
