### PR TITLE
[TextField] Fix floating label position

### DIFF
--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -184,7 +184,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
             label != null && label !== '' && fcs.required ? (
               <React.Fragment>
                 {label}
-                &nbsp;{'*'}
+                &thinsp;{'*'}
               </React.Fragment>
             ) : (
               label

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -47,7 +47,7 @@ describe('<OutlinedInput />', () => {
       />,
     );
     const notchOutlined = container.querySelector('.notched-outlined legend');
-    expect(notchOutlined).to.have.text('label\xa0*');
+    expect(notchOutlined).to.have.text('label\u2009*');
   });
 
   it('should forward classes to InputBase', () => {

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -111,7 +111,7 @@ describe('<TextField />', () => {
       const [, fakeLabel] = getAllByTestId('label');
       const notch = container.querySelector('.notch legend');
       expect(notch).to.contain(fakeLabel);
-      expect(notch).to.have.text('label\u00a0*');
+      expect(notch).to.have.text('label\u2009*');
     });
 
     it('should set shrink prop on outline from label', () => {
@@ -127,7 +127,7 @@ describe('<TextField />', () => {
       );
 
       const notch = container.querySelector('.notch legend');
-      expect(notch).to.have.text('0\u00a0*');
+      expect(notch).to.have.text('0\u2009*');
     });
 
     it('should not set padding for empty, null or undefined label props', function test() {


### PR DESCRIPTION
I noticed this while I was checking out https://github.com/mui/mui-toolpad/pull/1695, something was looking off visually with the Name input:

<img width="507" alt="Screenshot 2023-02-21 at 22 34 18" src="https://user-images.githubusercontent.com/3165635/220463595-963feff2-0579-4246-b462-d8a709f31dd7.png">

as it turns out, the label displayed and the label used for the gutter in the outline don't match:

https://github.com/mui/material-ui/blob/17f9fc668df0feb16d14e268870f1cff2a709485/packages/mui-material/src/OutlinedInput/OutlinedInput.js#L187

https://github.com/mui/material-ui/blob/17f9fc668df0feb16d14e268870f1cff2a709485/packages/mui-material/src/FormLabel/FormLabel.js#L113

With this change, it feels better, the gap is more consistent 😌

<img width="511" alt="Screenshot 2023-02-21 at 22 36 39" src="https://user-images.githubusercontent.com/3165635/220463975-e79621be-21c0-445e-a7dd-c2c44bcf1e54.png">

I checked a bit the history, it was first spotted in https://github.com/mui/material-ui/pull/29630#discussion_r748176639.