### PR TITLE
[docs] Add missing sandbox adapter deps resolving

### DIFF
--- a/docs/src/modules/sandbox/Dependencies.test.js
+++ b/docs/src/modules/sandbox/Dependencies.test.js
@@ -258,7 +258,7 @@ import * as Utils from '@mui/utils';
     });
   });
 
-  it('should date adapters', () => {
+  it('should handle date adapters', () => {
     const source = `
 import * as React from 'react';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
@@ -291,9 +291,12 @@ import AdapterMoment from '@mui/lab/AdapterMoment';
 import * as React from 'react';
 import TextField from '@mui/material/TextField';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDateFnsJalali } from '@mui/x-date-pickers/AdapterDateFnsJalali';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
+import { AdapterMomentHijri } from '@mui/x-date-pickers/AdapterMomentHijri';
+import { AdapterMomentJalaali } from '@mui/x-date-pickers/AdapterMomentJalaali';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';`;
 
@@ -310,9 +313,12 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';`;
       '@mui/material': 'latest',
       '@mui/x-date-pickers': 'latest',
       'date-fns': 'latest',
+      'date-fns-jalali': 'latest',
       dayjs: 'latest',
       luxon: 'latest',
       moment: 'latest',
+      'moment-hijri': 'latest',
+      'moment-jalaali': 'latest',
     });
   });
 
@@ -401,7 +407,7 @@ const ColorSchemeToggle = () => {
     </IconButton>
   );
 };
-    
+
 export default function EmailExample() {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   return (

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -134,14 +134,17 @@ export default function SandboxDependencies(
       if (dateAdapterMatch !== null) {
         /**
          * Mapping from the date adapter sub-packages to the npm packages they require.
-         * @example `@mui/lab/AdapterDateFns` has a peer dependency on `date-fns`.
+         * @example `@mui/x-date-pickers/AdapterDayjs` has a peer dependency on `dayjs`.
          */
         const packageName = (
           {
             AdapterDateFns: 'date-fns',
+            AdapterDateFnsJalali: 'date-fns-jalali',
             AdapterDayjs: 'dayjs',
             AdapterLuxon: 'luxon',
             AdapterMoment: 'moment',
+            AdapterMomentHijri: 'moment-hijri',
+            AdapterMomentJalaali: 'moment-jalaali',
           } as Record<string, string>
         )[dateAdapterMatch.groups?.adapterName || ''];
         if (packageName === undefined) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Add missing adapter dependencies resolving.
Noticed the issue when trying to open demos from [this page](https://next.mui.com/x/react-date-pickers/calendar-systems/).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
