### PR TITLE
redirect next.mui.com/x/* to mui.com/x/*

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -6,8 +6,8 @@
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/master/latest/size-snapshot.json 200
 
-# To add when we finish work on v6
-# https://next.mui.com/* https://mui.com/:splat 301!
+# To comment when we start working on v6
+https://next.mui.com/* https://mui.com/:splat 302!
 
 # For links that we can't edit later on, e.g. hosted in the code published on npm
 /r/styles-instance-warning /material-ui/getting-started/faq/#i-have-several-instances-of-styles-on-the-page 302
@@ -417,5 +417,3 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /toolpad/_next/* https://mui-toolpad-docs.netlify.app/_next/:splat 200
 /toolpad/* https://mui-toolpad-docs.netlify.app/toolpad/:splat 200
 /r/toolpad-* https://mui-toolpad-docs.netlify.app/r/toolpad-:splat 200
-
-/* https://mui.com/:splat 302!

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -418,4 +418,4 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /toolpad/* https://mui-toolpad-docs.netlify.app/toolpad/:splat 200
 /r/toolpad-* https://mui-toolpad-docs.netlify.app/r/toolpad-:splat 200
 
-/* https://mui.com/:splat 301!
+/* https://mui.com/:splat 302!

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -400,6 +400,9 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /r/legal-* https://mui-store.netlify.app/r/legal-:splat 200
 
 ## MUI X
+## Once MUI X v6 is released, we want next.mui.com/x/* to redirect to mui.com/x/*
+## TODO: remove this redirect once we start deploying v7 docs to next.mui.com/x/*
+/x/* https://mui.com/x/:splat 302!
 ## Unlike the store that expect to be hosted under a subfolder,
 ## MUI X is configured to be hosted at the root.
 /static/x/* https://docs-next--material-ui-x.netlify.app/static/x/:splat 200

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -178,7 +178,7 @@ test.describe('Material docs', () => {
 
       const anchor = page.locator('.DocSearch-Hits a:has-text("Card")');
 
-      await expect(anchor.first()).toHaveAttribute('href', '/material-ui/react-card/#main-content');
+      await expect(anchor.first()).toHaveAttribute('href', '/material-ui/react-card/');
     });
 
     test('should have correct link when searching API', async ({ page }) => {
@@ -192,7 +192,7 @@ test.describe('Material docs', () => {
 
       const anchor = page.locator('.DocSearch-Hits a:has-text("Card API")');
 
-      await expect(anchor.first()).toHaveAttribute('href', '/material-ui/api/card/#main-content');
+      await expect(anchor.first()).toHaveAttribute('href', '/material-ui/api/card/');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Currently, MUI X v6 docs are available under https://next.mui.com/x/whats-new/
But once we release the v6 stable, we want to redirect to mui.com/x/* where the v6 stable docs will be deployed.