### PR TITLE
[docs] Allow to pass navigation bar banner from outside

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -154,7 +154,7 @@ const StyledAppNavDrawer = styled(AppNavDrawer)(({ disablePermanent, theme }) =>
 });
 
 export default function AppFrame(props) {
-  const { children, disableDrawer = false, className, BannerComponent } = props;
+  const { children, disableDrawer = false, className, BannerComponent = AppFrameBanner } = props;
   const t = useTranslate();
 
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -239,8 +239,4 @@ AppFrame.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   disableDrawer: PropTypes.bool,
-};
-
-AppFrame.defaultProps = {
-  BannerComponent: AppFrameBanner,
 };

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -154,7 +154,7 @@ const StyledAppNavDrawer = styled(AppNavDrawer)(({ disablePermanent, theme }) =>
 });
 
 export default function AppFrame(props) {
-  const { children, disableDrawer = false, className } = props;
+  const { children, disableDrawer = false, className, BannerComponent } = props;
   const t = useTranslate();
 
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -200,7 +200,7 @@ export default function AppFrame(props) {
           </NextLink>
           <GrowingDiv />
           <Stack direction="row" spacing="10px">
-            <AppFrameBanner />
+            <BannerComponent />
             <DeferredAppSearch />
             <Tooltip title={t('appFrame.github')} enterDelay={300}>
               <IconButton
@@ -235,7 +235,12 @@ export default function AppFrame(props) {
 }
 
 AppFrame.propTypes = {
+  BannerComponent: PropTypes.elementType,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   disableDrawer: PropTypes.bool,
+};
+
+AppFrame.defaultProps = {
+  BannerComponent: AppFrameBanner,
 };

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -71,6 +71,7 @@ const ActionsDiv = styled('div')(({ theme }) => ({
 function AppLayoutDocs(props) {
   const router = useRouter();
   const {
+    BannerComponent,
     children,
     description,
     disableAd = false,
@@ -101,7 +102,7 @@ function AppLayoutDocs(props) {
   }
 
   return (
-    <AppFrame>
+    <AppFrame BannerComponent={BannerComponent}>
       <GlobalStyles
         styles={{
           ':root': {
@@ -139,6 +140,7 @@ function AppLayoutDocs(props) {
 }
 
 AppLayoutDocs.propTypes = {
+  BannerComponent: PropTypes.elementType,
   children: PropTypes.node.isRequired,
   description: PropTypes.string.isRequired,
   disableAd: PropTypes.bool.isRequired,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Motivation

After a stable MUI X release, in MUI X v5 docs, a notification for v6 is needed to be shown similar to the one [here](https://v4.mui.com/) for v5.

Exposing a prop from `AppLayoutDocs` which receives `Banner` component will allow to:
- Control banner visibility directly from MUI X docs
- Show banner only on MUI X docs (as needed for v5 because both `v5.mui.com` and `mui.com` will point to the same version of MUI Core but different of MUI X, so adding a banner like today won't do the need full.)
- Not have to bump monorepo everytime a new banner is needed in X

This PR will be accompanied by update in docs-v5 adding banner on MUI-X stable release.