### PR TITLE
[examples] Update Next.js examples to use built-in font

### DIFF
--- a/examples/material-next-ts/package.json
+++ b/examples/material-next-ts/package.json
@@ -16,7 +16,6 @@
     "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
-    "@next/font": "latest",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/examples/material-next-ts/src/theme.ts
+++ b/examples/material-next-ts/src/theme.ts
@@ -1,4 +1,4 @@
-import { Roboto } from '@next/font/google';
+import { Roboto } from 'next/font/google';
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 

--- a/examples/material-next/package.json
+++ b/examples/material-next/package.json
@@ -16,7 +16,6 @@
     "@emotion/styled": "latest",
     "@mui/icons-material": "latest",
     "@mui/material": "latest",
-    "@next/font": "latest",
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",

--- a/examples/material-next/src/theme.js
+++ b/examples/material-next/src/theme.js
@@ -1,4 +1,4 @@
-import { Roboto } from '@next/font/google';
+import { Roboto } from 'next/font/google';
 import { createTheme } from '@mui/material/styles';
 import { red } from '@mui/material/colors';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Starting with Next.js 13.2, `@next/font` is now built-in to Next.js as `next/font`. We no longer need to install `@next/font` separately.

Reference: https://nextjs.org/blog/next-13-2#other-improvements
Reference: https://nextjs.org/docs/messages/built-in-next-font