### PR TITLE
[examples] Update curl link in `material-next-ts-v4-v5-migration` example README

### DIFF
--- a/examples/material-next-ts-v4-v5-migration/README.md
+++ b/examples/material-next-ts-v4-v5-migration/README.md
@@ -7,8 +7,8 @@ Download the example [or clone the repo](https://github.com/mui/material-ui):
 <!-- #default-branch-switch -->
 
 ```sh
-curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs-with-typescript
-cd nextjs-with-typescript
+curl https://codeload.github.com/mui/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/material-next-ts-v4-v5-migration
+cd material-next-ts-v4-v5-migration
 ```
 
 Install it and run:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This path was not updated in README. I noticed this while reviewing PR #36109.