### PR TITLE
[base] Export all slot prop overrides interfaces

### DIFF
--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
@@ -6,7 +6,7 @@ import { SlotComponentProps } from '../utils';
 
 export type PopperPlacementType = Options['placement'];
 
-interface PopperUnstyledRootSlotPropsOverrides {}
+export interface PopperUnstyledRootSlotPropsOverrides {}
 
 export interface PopperUnstyledTransitionProps {
   in: boolean;

--- a/packages/mui-base/src/PopperUnstyled/index.ts
+++ b/packages/mui-base/src/PopperUnstyled/index.ts
@@ -8,6 +8,7 @@ export type {
   PopperUnstyledTypeMap,
   PopperUnstyledProps,
   PopperUnstyledRootSlotProps,
+  PopperUnstyledRootSlotPropsOverrides,
 } from './PopperUnstyled.types';
 export {
   default as popperUnstyledClasses,

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
@@ -3,7 +3,7 @@ import { OverrideProps } from '@mui/types';
 import { UseTabPanelRootSlotProps } from '../useTabPanel';
 import { SlotComponentProps } from '../utils';
 
-interface TabPanelUnstyledRootSlotPropsOverrides {}
+export interface TabPanelUnstyledRootSlotPropsOverrides {}
 
 export interface TabPanelUnstyledOwnProps {
   /**

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
@@ -4,7 +4,7 @@ import { ButtonUnstyledOwnProps } from '../ButtonUnstyled';
 import { SlotComponentProps } from '../utils';
 import { UseTabRootSlotProps } from '../useTab';
 
-interface TabUnstyledRootSlotPropsOverrides {}
+export interface TabUnstyledRootSlotPropsOverrides {}
 
 export interface TabUnstyledOwnProps
   extends Omit<ButtonUnstyledOwnProps, 'onChange' | 'slots' | 'slotProps'> {

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
@@ -3,7 +3,7 @@ import { OverrideProps } from '@mui/types';
 import { UseTabsListRootSlotProps } from '../useTabsList';
 import { SlotComponentProps } from '../utils';
 
-interface TabsListUnstyledRootSlotPropsOverrides {}
+export interface TabsListUnstyledRootSlotPropsOverrides {}
 
 export interface TabsListUnstyledOwnProps {
   /**

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
-interface TabsUnstyledRootSlotPropsOverrides {}
+export interface TabsUnstyledRootSlotPropsOverrides {}
 
 type TabsUnstyledOrientation = 'horizontal' | 'vertical';
 


### PR DESCRIPTION
As noted in https://github.com/mui/material-ui/pull/35964#discussion_r1117542959, some of the slot prop override interfaces were not exported. This PR exports all of them.