### PR TITLE
[docs][joy] Improve the Slots Table in API docs

### DIFF
--- a/docs/pages/joy-ui/api/alert.json
+++ b/docs/pages/joy-ui/api/alert.json
@@ -36,19 +36,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiAlert-root"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiAlert-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiAlert-endDecorator"
     }

--- a/docs/pages/joy-ui/api/aspect-ratio.json
+++ b/docs/pages/joy-ui/api/aspect-ratio.json
@@ -40,13 +40,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiAspectRatio-root"
     },
     {
       "name": "content",
-      "description": "The component used to render the content.",
+      "description": "The component that renders the content.",
       "default": "'div'",
       "class": ".MuiAspectRatio-content"
     }

--- a/docs/pages/joy-ui/api/autocomplete.json
+++ b/docs/pages/joy-ui/api/autocomplete.json
@@ -91,73 +91,73 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiAutocomplete-root"
     },
     {
       "name": "wrapper",
-      "description": "The component used to render the wrapper.",
+      "description": "The component that renders the wrapper.",
       "default": "'div'",
       "class": ".MuiAutocomplete-wrapper"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiAutocomplete-input"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiAutocomplete-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiAutocomplete-endDecorator"
     },
     {
       "name": "clearIndicator",
-      "description": "The component used to render the clear indicator.",
+      "description": "The component that renders the clear indicator.",
       "default": "'button'",
       "class": ".MuiAutocomplete-clearIndicator"
     },
     {
       "name": "popupIndicator",
-      "description": "The component used to render the popup indicator.",
+      "description": "The component that renders the popup indicator.",
       "default": "'button'",
       "class": ".MuiAutocomplete-popupIndicator"
     },
     {
       "name": "listbox",
-      "description": "The component used to render the listbox.",
+      "description": "The component that renders the listbox.",
       "default": "'ul'",
       "class": ".MuiAutocomplete-listbox"
     },
     {
       "name": "option",
-      "description": "The component used to render the option.",
+      "description": "The component that renders the option.",
       "default": "'li'",
       "class": ".MuiAutocomplete-option"
     },
     {
       "name": "loading",
-      "description": "The component used to render the loading.",
+      "description": "The component that renders the loading.",
       "default": "'li'",
       "class": ".MuiAutocomplete-loading"
     },
     {
       "name": "noOptions",
-      "description": "The component used to render the no-options.",
+      "description": "The component that renders the no-options.",
       "default": "'li'",
       "class": ".MuiAutocomplete-noOptions"
     },
     {
       "name": "limitTag",
-      "description": "The component used to render the limit tag.",
+      "description": "The component that renders the limit tag.",
       "default": "'span'",
       "class": ".MuiAutocomplete-limitTag"
     }

--- a/docs/pages/joy-ui/api/avatar.json
+++ b/docs/pages/joy-ui/api/avatar.json
@@ -37,19 +37,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiAvatar-root"
     },
     {
       "name": "img",
-      "description": "The component used to render the img.",
+      "description": "The component that renders the img.",
       "default": "'img'",
       "class": ".MuiAvatar-img"
     },
     {
       "name": "fallback",
-      "description": "The component used to render the fallback.",
+      "description": "The component that renders the fallback.",
       "default": "'svg'",
       "class": ".MuiAvatar-fallback"
     }

--- a/docs/pages/joy-ui/api/badge.json
+++ b/docs/pages/joy-ui/api/badge.json
@@ -49,13 +49,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiBadge-root"
     },
     {
       "name": "badge",
-      "description": "The component used to render the badge.",
+      "description": "The component that renders the badge.",
       "default": "'div'",
       "class": ".MuiBadge-badge"
     }

--- a/docs/pages/joy-ui/api/breadcrumbs.json
+++ b/docs/pages/joy-ui/api/breadcrumbs.json
@@ -21,25 +21,25 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'nav'",
       "class": ".MuiBreadcrumbs-root"
     },
     {
       "name": "ol",
-      "description": "The component used to render the ol.",
+      "description": "The component that renders the ol.",
       "default": "'ol'",
       "class": ".MuiBreadcrumbs-ol"
     },
     {
       "name": "li",
-      "description": "The component used to render the li.",
+      "description": "The component that renders the li.",
       "default": "'li'",
       "class": ".MuiBreadcrumbs-li"
     },
     {
       "name": "separator",
-      "description": "The component used to render the separator.",
+      "description": "The component that renders the separator.",
       "default": "'li'",
       "class": ".MuiBreadcrumbs-separator"
     }

--- a/docs/pages/joy-ui/api/button.json
+++ b/docs/pages/joy-ui/api/button.json
@@ -52,25 +52,25 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'button'",
       "class": ".MuiButton-root"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiButton-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiButton-endDecorator"
     },
     {
       "name": "loadingIndicatorCenter",
-      "description": "The component used to render the loading indicator center.",
+      "description": "The component that renders the loading indicator center.",
       "default": "'span'",
       "class": ".MuiButton-loadingIndicatorCenter"
     }

--- a/docs/pages/joy-ui/api/checkbox.json
+++ b/docs/pages/joy-ui/api/checkbox.json
@@ -51,31 +51,31 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiCheckbox-root"
     },
     {
       "name": "checkbox",
-      "description": "The component used to render the checkbox.",
+      "description": "The component that renders the checkbox.",
       "default": "'span'",
       "class": ".MuiCheckbox-checkbox"
     },
     {
       "name": "action",
-      "description": "The component used to render the action.",
+      "description": "The component that renders the action.",
       "default": "'span'",
       "class": ".MuiCheckbox-action"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiCheckbox-input"
     },
     {
       "name": "label",
-      "description": "The component used to render the label.",
+      "description": "The component that renders the label.",
       "default": "'label'",
       "class": ".MuiCheckbox-label"
     }

--- a/docs/pages/joy-ui/api/chip.json
+++ b/docs/pages/joy-ui/api/chip.json
@@ -38,31 +38,31 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiChip-root"
     },
     {
       "name": "label",
-      "description": "The component used to render the label.",
+      "description": "The component that renders the label.",
       "default": "'span'",
       "class": ".MuiChip-label"
     },
     {
       "name": "action",
-      "description": "The component used to render the action.",
+      "description": "The component that renders the action.",
       "default": "'button'",
       "class": ".MuiChip-action"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiChip-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiChip-endDecorator"
     }

--- a/docs/pages/joy-ui/api/circular-progress.json
+++ b/docs/pages/joy-ui/api/circular-progress.json
@@ -36,25 +36,25 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiCircularProgress-root"
     },
     {
       "name": "svg",
-      "description": "The component used to render the svg.",
+      "description": "The component that renders the svg.",
       "default": "'svg'",
       "class": ".MuiCircularProgress-svg"
     },
     {
       "name": "track",
-      "description": "The component used to render the track.",
+      "description": "The component that renders the track.",
       "default": "'circle'",
       "class": ".MuiCircularProgress-track"
     },
     {
       "name": "progress",
-      "description": "The component used to render the progress.",
+      "description": "The component that renders the progress.",
       "default": "'circle'",
       "class": ".MuiCircularProgress-progress"
     }

--- a/docs/pages/joy-ui/api/form-label.json
+++ b/docs/pages/joy-ui/api/form-label.json
@@ -15,13 +15,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'label'",
       "class": ".MuiFormLabel-root"
     },
     {
       "name": "asterisk",
-      "description": "The component used to render the asterisk.",
+      "description": "The component that renders the asterisk.",
       "default": "'span'",
       "class": ".MuiFormLabel-asterisk"
     }

--- a/docs/pages/joy-ui/api/input.json
+++ b/docs/pages/joy-ui/api/input.json
@@ -35,25 +35,25 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiInput-root"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiInput-input"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiInput-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiInput-endDecorator"
     }

--- a/docs/pages/joy-ui/api/link.json
+++ b/docs/pages/joy-ui/api/link.json
@@ -46,19 +46,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'a'",
       "class": ".MuiLink-root"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiLink-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiLink-endDecorator"
     }

--- a/docs/pages/joy-ui/api/list-item.json
+++ b/docs/pages/joy-ui/api/list-item.json
@@ -32,19 +32,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'li'",
       "class": ".MuiListItem-root"
     },
     {
       "name": "startAction",
-      "description": "The component used to render the start action.",
+      "description": "The component that renders the start action.",
       "default": "'div'",
       "class": ".MuiListItem-startAction"
     },
     {
       "name": "endAction",
-      "description": "The component used to render the end action.",
+      "description": "The component that renders the end action.",
       "default": "'div'",
       "class": ".MuiListItem-endAction"
     }

--- a/docs/pages/joy-ui/api/modal.json
+++ b/docs/pages/joy-ui/api/modal.json
@@ -24,13 +24,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiModal-root"
     },
     {
       "name": "backdrop",
-      "description": "The component used to render the backdrop.",
+      "description": "The component that renders the backdrop.",
       "default": "'div'",
       "class": ".MuiModal-backdrop"
     }

--- a/docs/pages/joy-ui/api/radio.json
+++ b/docs/pages/joy-ui/api/radio.json
@@ -47,37 +47,37 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiRadio-root"
     },
     {
       "name": "radio",
-      "description": "The component used to render the radio.",
+      "description": "The component that renders the radio.",
       "default": "'span'",
       "class": ".MuiRadio-radio"
     },
     {
       "name": "icon",
-      "description": "The component used to render the icon.",
+      "description": "The component that renders the icon.",
       "default": "'span'",
       "class": ".MuiRadio-icon"
     },
     {
       "name": "action",
-      "description": "The component used to render the action.",
+      "description": "The component that renders the action.",
       "default": "'span'",
       "class": ".MuiRadio-action"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiRadio-input"
     },
     {
       "name": "label",
-      "description": "The component used to render the label.",
+      "description": "The component that renders the label.",
       "default": "'label'",
       "class": ".MuiRadio-label"
     }

--- a/docs/pages/joy-ui/api/select.json
+++ b/docs/pages/joy-ui/api/select.json
@@ -54,37 +54,37 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiSelect-root"
     },
     {
       "name": "button",
-      "description": "The component used to render the button.",
+      "description": "The component that renders the button.",
       "default": "'button'",
       "class": ".MuiSelect-button"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiSelect-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiSelect-endDecorator"
     },
     {
       "name": "indicator",
-      "description": "The component used to render the indicator.",
+      "description": "The component that renders the indicator.",
       "default": "'span'",
       "class": ".MuiSelect-indicator"
     },
     {
       "name": "listbox",
-      "description": "The component used to render the listbox.",
+      "description": "The component that renders the listbox.",
       "default": "'ul'",
       "class": ".MuiSelect-listbox"
     }

--- a/docs/pages/joy-ui/api/slider.json
+++ b/docs/pages/joy-ui/api/slider.json
@@ -106,49 +106,49 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiSlider-root"
     },
     {
       "name": "track",
-      "description": "The component used to render the track.",
+      "description": "The component that renders the track.",
       "default": "'span'",
       "class": ".MuiSlider-track"
     },
     {
       "name": "rail",
-      "description": "The component used to render the rail.",
+      "description": "The component that renders the rail.",
       "default": "'span'",
       "class": ".MuiSlider-rail"
     },
     {
       "name": "thumb",
-      "description": "The component used to render the thumb.",
+      "description": "The component that renders the thumb.",
       "default": "'span'",
       "class": ".MuiSlider-thumb"
     },
     {
       "name": "mark",
-      "description": "The component used to render the mark.",
+      "description": "The component that renders the mark.",
       "default": "'span'",
       "class": ".MuiSlider-mark"
     },
     {
       "name": "markLabel",
-      "description": "The component used to render the mark label.",
+      "description": "The component that renders the mark label.",
       "default": "'span'",
       "class": ".MuiSlider-markLabel"
     },
     {
       "name": "valueLabel",
-      "description": "The component used to render the value label.",
+      "description": "The component that renders the value label.",
       "default": "'span'",
       "class": ".MuiSlider-valueLabel"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiSlider-input"
     }

--- a/docs/pages/joy-ui/api/switch.json
+++ b/docs/pages/joy-ui/api/switch.json
@@ -41,43 +41,43 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiSwitch-root"
     },
     {
       "name": "thumb",
-      "description": "The component used to render the thumb.",
+      "description": "The component that renders the thumb.",
       "default": "'span'",
       "class": ".MuiSwitch-thumb"
     },
     {
       "name": "action",
-      "description": "The component used to render the action.",
+      "description": "The component that renders the action.",
       "default": "'div'",
       "class": ".MuiSwitch-action"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiSwitch-input"
     },
     {
       "name": "track",
-      "description": "The component used to render the track.",
+      "description": "The component that renders the track.",
       "default": "'span'",
       "class": ".MuiSwitch-track"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiSwitch-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiSwitch-endDecorator"
     }

--- a/docs/pages/joy-ui/api/textarea.json
+++ b/docs/pages/joy-ui/api/textarea.json
@@ -35,25 +35,25 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiTextarea-root"
     },
     {
       "name": "textarea",
-      "description": "The component used to render the textarea.",
+      "description": "The component that renders the textarea.",
       "default": "'textarea'",
       "class": ".MuiTextarea-textarea"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'div'",
       "class": ".MuiTextarea-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'div'",
       "class": ".MuiTextarea-endDecorator"
     }

--- a/docs/pages/joy-ui/api/tooltip.json
+++ b/docs/pages/joy-ui/api/tooltip.json
@@ -67,13 +67,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiTooltip-root"
     },
     {
       "name": "arrow",
-      "description": "The component used to render the arrow.",
+      "description": "The component that renders the arrow.",
       "default": "'span'",
       "class": ".MuiTooltip-arrow"
     }

--- a/docs/pages/joy-ui/api/typography.json
+++ b/docs/pages/joy-ui/api/typography.json
@@ -42,19 +42,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'a'",
       "class": ".MuiTypography-root"
     },
     {
       "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "description": "The component that renders the start decorator.",
       "default": "'span'",
       "class": ".MuiTypography-startDecorator"
     },
     {
       "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
+      "description": "The component that renders the end decorator.",
       "default": "'span'",
       "class": ".MuiTypography-endDecorator"
     }

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -58,7 +58,7 @@ ClassesTable.propTypes = {
 };
 
 function SlotsTable(props) {
-  const { componentSlots, slotDescriptions } = props;
+  const { slotDefaultHeader, componentSlots, slotDescriptions } = props;
   const t = useTranslate();
 
   return (
@@ -67,7 +67,7 @@ function SlotsTable(props) {
         <tr>
           <th align="left">{t('api-docs.name')}</th>
           <th align="left">{t('api-docs.defaultClass')}</th>
-          <th align="left">{t('api-docs.defaultValue')}</th>
+          <th align="left">{slotDefaultHeader || t('api-docs.defaultValue')}</th>
           <th align="left">{t('api-docs.description')}</th>
         </tr>
       </thead>
@@ -104,6 +104,7 @@ function SlotsTable(props) {
 
 SlotsTable.propTypes = {
   componentSlots: PropTypes.array.isRequired,
+  slotDefaultHeader: PropTypes.string,
   slotDescriptions: PropTypes.object.isRequired,
 };
 
@@ -176,8 +177,8 @@ export default function ApiPage(props) {
   const styleOverridesLink = isJoyComponent
     ? '/joy-ui/customization/themed-components/#style-overrides'
     : '/material-ui/customization/theme-components/#global-style-overrides';
-  const extendVariantsLink = isJoyComponent
-    ? '/joy-ui/customization/themed-components/#extend-variants'
+  const slotGuideLink = isJoyComponent
+    ? '/joy-ui/customization/themed-components/#component-identifier'
     : '';
   const {
     componentDescription,
@@ -187,8 +188,8 @@ export default function ApiPage(props) {
     slotDescriptions,
   } = descriptions[userLanguage];
   const description = t('api-docs.pageDescription').replace(/{{name}}/, componentName);
-  const slotExtraDescription = extendVariantsLink
-    ? t('api-docs.slotDescription').replace(/{{extendVariantsLink}}/, extendVariantsLink)
+  const slotExtraDescription = slotGuideLink
+    ? t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
     : '';
   if (slotDescriptions && slotExtraDescription) {
     Object.keys(slotDescriptions).forEach((slot) => {
@@ -360,7 +361,11 @@ import { ${componentName} } from '${source}';`}
         {componentSlots?.length ? (
           <React.Fragment>
             <Heading hash="slots" />
-            <SlotsTable componentSlots={componentSlots} slotDescriptions={slotDescriptions} />
+            <SlotsTable
+              componentSlots={componentSlots}
+              slotDescriptions={slotDescriptions}
+              slotDefaultHeader={isJoyComponent ? t('api-docs.defaultHTMLTag') : ''}
+            />
             <br />
           </React.Fragment>
         ) : null}

--- a/docs/translations/api-docs-joy/alert/alert.json
+++ b/docs/translations/api-docs-joy/alert/alert.json
@@ -11,8 +11,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/aspect-ratio/aspect-ratio.json
+++ b/docs/translations/api-docs-joy/aspect-ratio/aspect-ratio.json
@@ -12,7 +12,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "content": "The component used to render the content."
+    "root": "The component that renders the root.",
+    "content": "The component that renders the content."
   }
 }

--- a/docs/translations/api-docs-joy/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs-joy/autocomplete/autocomplete.json
@@ -54,17 +54,17 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "wrapper": "The component used to render the wrapper.",
-    "input": "The component used to render the input.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator.",
-    "clearIndicator": "The component used to render the clear indicator.",
-    "popupIndicator": "The component used to render the popup indicator.",
-    "listbox": "The component used to render the listbox.",
-    "option": "The component used to render the option.",
-    "loading": "The component used to render the loading.",
-    "noOptions": "The component used to render the no-options.",
-    "limitTag": "The component used to render the limit tag."
+    "root": "The component that renders the root.",
+    "wrapper": "The component that renders the wrapper.",
+    "input": "The component that renders the input.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator.",
+    "clearIndicator": "The component that renders the clear indicator.",
+    "popupIndicator": "The component that renders the popup indicator.",
+    "listbox": "The component that renders the listbox.",
+    "option": "The component that renders the option.",
+    "loading": "The component that renders the loading.",
+    "noOptions": "The component that renders the no-options.",
+    "limitTag": "The component that renders the limit tag."
   }
 }

--- a/docs/translations/api-docs-joy/avatar/avatar.json
+++ b/docs/translations/api-docs-joy/avatar/avatar.json
@@ -12,8 +12,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "img": "The component used to render the img.",
-    "fallback": "The component used to render the fallback."
+    "root": "The component that renders the root.",
+    "img": "The component that renders the img.",
+    "fallback": "The component that renders the fallback."
   }
 }

--- a/docs/translations/api-docs-joy/badge/badge.json
+++ b/docs/translations/api-docs-joy/badge/badge.json
@@ -15,7 +15,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "badge": "The component used to render the badge."
+    "root": "The component that renders the root.",
+    "badge": "The component that renders the badge."
   }
 }

--- a/docs/translations/api-docs-joy/breadcrumbs/breadcrumbs.json
+++ b/docs/translations/api-docs-joy/breadcrumbs/breadcrumbs.json
@@ -8,9 +8,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "ol": "The component used to render the ol.",
-    "li": "The component used to render the li.",
-    "separator": "The component used to render the separator."
+    "root": "The component that renders the root.",
+    "ol": "The component that renders the ol.",
+    "li": "The component that renders the li.",
+    "separator": "The component that renders the separator."
   }
 }

--- a/docs/translations/api-docs-joy/button/button.json
+++ b/docs/translations/api-docs-joy/button/button.json
@@ -16,9 +16,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator.",
-    "loadingIndicatorCenter": "The component used to render the loading indicator center."
+    "root": "The component that renders the root.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator.",
+    "loadingIndicatorCenter": "The component that renders the loading indicator center."
   }
 }

--- a/docs/translations/api-docs-joy/checkbox/checkbox.json
+++ b/docs/translations/api-docs-joy/checkbox/checkbox.json
@@ -24,10 +24,10 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "checkbox": "The component used to render the checkbox.",
-    "action": "The component used to render the action.",
-    "input": "The component used to render the input.",
-    "label": "The component used to render the label."
+    "root": "The component that renders the root.",
+    "checkbox": "The component that renders the checkbox.",
+    "action": "The component that renders the action.",
+    "input": "The component that renders the input.",
+    "label": "The component that renders the label."
   }
 }

--- a/docs/translations/api-docs-joy/chip/chip.json
+++ b/docs/translations/api-docs-joy/chip/chip.json
@@ -13,10 +13,10 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "label": "The component used to render the label.",
-    "action": "The component used to render the action.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "label": "The component that renders the label.",
+    "action": "The component that renders the action.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/circular-progress/circular-progress.json
+++ b/docs/translations/api-docs-joy/circular-progress/circular-progress.json
@@ -11,9 +11,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "svg": "The component used to render the svg.",
-    "track": "The component used to render the track.",
-    "progress": "The component used to render the progress."
+    "root": "The component that renders the root.",
+    "svg": "The component that renders the svg.",
+    "track": "The component that renders the track.",
+    "progress": "The component that renders the progress."
   }
 }

--- a/docs/translations/api-docs-joy/form-label/form-label.json
+++ b/docs/translations/api-docs-joy/form-label/form-label.json
@@ -8,7 +8,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "asterisk": "The component used to render the asterisk."
+    "root": "The component that renders the root.",
+    "asterisk": "The component that renders the asterisk."
   }
 }

--- a/docs/translations/api-docs-joy/input/input.json
+++ b/docs/translations/api-docs-joy/input/input.json
@@ -13,9 +13,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "input": "The component used to render the input.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "input": "The component that renders the input.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/link/link.json
+++ b/docs/translations/api-docs-joy/link/link.json
@@ -15,8 +15,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/list-item/list-item.json
+++ b/docs/translations/api-docs-joy/list-item/list-item.json
@@ -13,8 +13,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "startAction": "The component used to render the start action.",
-    "endAction": "The component used to render the end action."
+    "root": "The component that renders the root.",
+    "startAction": "The component that renders the start action.",
+    "endAction": "The component that renders the end action."
   }
 }

--- a/docs/translations/api-docs-joy/modal/modal.json
+++ b/docs/translations/api-docs-joy/modal/modal.json
@@ -17,7 +17,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "backdrop": "The component used to render the backdrop."
+    "root": "The component that renders the root.",
+    "backdrop": "The component that renders the backdrop."
   }
 }

--- a/docs/translations/api-docs-joy/radio/radio.json
+++ b/docs/translations/api-docs-joy/radio/radio.json
@@ -22,11 +22,11 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "radio": "The component used to render the radio.",
-    "icon": "The component used to render the icon.",
-    "action": "The component used to render the action.",
-    "input": "The component used to render the input.",
-    "label": "The component used to render the label."
+    "root": "The component that renders the root.",
+    "radio": "The component that renders the radio.",
+    "icon": "The component that renders the icon.",
+    "action": "The component that renders the action.",
+    "input": "The component that renders the input.",
+    "label": "The component that renders the label."
   }
 }

--- a/docs/translations/api-docs-joy/select/select.json
+++ b/docs/translations/api-docs-joy/select/select.json
@@ -27,11 +27,11 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "button": "The component used to render the button.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator.",
-    "indicator": "The component used to render the indicator.",
-    "listbox": "The component used to render the listbox."
+    "root": "The component that renders the root.",
+    "button": "The component that renders the button.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator.",
+    "indicator": "The component that renders the indicator.",
+    "listbox": "The component that renders the listbox."
   }
 }

--- a/docs/translations/api-docs-joy/slider/slider.json
+++ b/docs/translations/api-docs-joy/slider/slider.json
@@ -103,13 +103,13 @@
     }
   },
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "track": "The component used to render the track.",
-    "rail": "The component used to render the rail.",
-    "thumb": "The component used to render the thumb.",
-    "mark": "The component used to render the mark.",
-    "markLabel": "The component used to render the mark label.",
-    "valueLabel": "The component used to render the value label.",
-    "input": "The component used to render the input."
+    "root": "The component that renders the root.",
+    "track": "The component that renders the track.",
+    "rail": "The component that renders the rail.",
+    "thumb": "The component that renders the thumb.",
+    "mark": "The component that renders the mark.",
+    "markLabel": "The component that renders the mark label.",
+    "valueLabel": "The component that renders the value label.",
+    "input": "The component that renders the input."
   }
 }

--- a/docs/translations/api-docs-joy/switch/switch.json
+++ b/docs/translations/api-docs-joy/switch/switch.json
@@ -16,12 +16,12 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "thumb": "The component used to render the thumb.",
-    "action": "The component used to render the action.",
-    "input": "The component used to render the input.",
-    "track": "The component used to render the track.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "thumb": "The component that renders the thumb.",
+    "action": "The component that renders the action.",
+    "input": "The component that renders the input.",
+    "track": "The component that renders the track.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/textarea/textarea.json
+++ b/docs/translations/api-docs-joy/textarea/textarea.json
@@ -13,9 +13,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "textarea": "The component used to render the textarea.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "textarea": "The component that renders the textarea.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/tooltip/tooltip.json
+++ b/docs/translations/api-docs-joy/tooltip/tooltip.json
@@ -31,7 +31,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "arrow": "The component used to render the arrow."
+    "root": "The component that renders the root.",
+    "arrow": "The component that renders the arrow."
   }
 }

--- a/docs/translations/api-docs-joy/typography/typography.json
+++ b/docs/translations/api-docs-joy/typography/typography.json
@@ -16,8 +16,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator.",
-    "endDecorator": "The component used to render the end decorator."
+    "root": "The component that renders the root.",
+    "startDecorator": "The component that renders the start decorator.",
+    "endDecorator": "The component that renders the end decorator."
   }
 }

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -6,6 +6,7 @@
     "cssComponent": "As a CSS utility, the {{name}} component also supports all <a href=\"/system/properties/\"><code>system</code></a> properties. You can use them as props directly on the component.",
     "default": "Default",
     "defaultValue": "Default value",
+    "defaultHTMLTag": "Default HTML tag",
     "demos": "Demos",
     "deprecated": "Deprecated",
     "description": "Description",
@@ -31,7 +32,7 @@
     "slots": "Slots",
     "spreadHint": "Props of the {{spreadHintElement}} component are also available.",
     "styleOverrides": "The name <code>{{componentStyles.name}}</code> can be used when providing <a href={{defaultPropsLink}}>default props</a> or <a href={{styleOverridesLink}}>style overrides</a> in the theme.",
-    "slotDescription": "You can use this slot in <code>slotProps</code> prop or in <code>extendTheme</code> function to customize its style or <a href={{extendVariantsLink}}>extend variants</a>.",
+    "slotDescription": "To learn how to customize the slot, check out this guide--<a href={{slotGuideLink}}>Overriding component structure</a>.",
     "type": "Type"
   },
   "albumDescr": "A responsive album / gallery page layout with a hero unit and footer.",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -32,7 +32,7 @@
     "slots": "Slots",
     "spreadHint": "Props of the {{spreadHintElement}} component are also available.",
     "styleOverrides": "The name <code>{{componentStyles.name}}</code> can be used when providing <a href={{defaultPropsLink}}>default props</a> or <a href={{styleOverridesLink}}>style overrides</a> in the theme.",
-    "slotDescription": "To learn how to customize the slot, check out this guide--<a href={{slotGuideLink}}>Overriding component structure</a>.",
+    "slotDescription": "To learn how to customize the slot, check out the <a href={{slotGuideLink}}>Overriding component structure</a> guide.",
     "type": "Type"
   },
   "albumDescr": "A responsive album / gallery page layout with a hero unit and footer.",

--- a/packages/mui-joy/src/Alert/AlertProps.ts
+++ b/packages/mui-joy/src/Alert/AlertProps.ts
@@ -7,17 +7,17 @@ export type AlertSlot = 'root' | 'startDecorator' | 'endDecorator';
 
 export interface AlertSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;

--- a/packages/mui-joy/src/AspectRatio/AspectRatioProps.ts
+++ b/packages/mui-joy/src/AspectRatio/AspectRatioProps.ts
@@ -7,12 +7,12 @@ export type AspectRatioSlot = 'root' | 'content';
 
 export interface AspectRatioSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the content.
+   * The component that renders the content.
    * @default 'div'
    */
   content: React.ElementType;

--- a/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts
+++ b/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts
@@ -28,62 +28,62 @@ export type AutocompleteSlot =
 
 export interface AutocompleteSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the wrapper.
+   * The component that renders the wrapper.
    * @default 'div'
    */
   wrapper: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;
   /**
-   * The component used to render the clear indicator.
+   * The component that renders the clear indicator.
    * @default 'button'
    */
   clearIndicator: React.ElementType;
   /**
-   * The component used to render the popup indicator.
+   * The component that renders the popup indicator.
    * @default 'button'
    */
   popupIndicator: React.ElementType;
   /**
-   * The component used to render the listbox.
+   * The component that renders the listbox.
    * @default 'ul'
    */
   listbox: React.ElementType;
   /**
-   * The component used to render the option.
+   * The component that renders the option.
    * @default 'li'
    */
   option: React.ElementType;
   /**
-   * The component used to render the loading.
+   * The component that renders the loading.
    * @default 'li'
    */
   loading: React.ElementType;
   /**
-   * The component used to render the no-options.
+   * The component that renders the no-options.
    * @default 'li'
    */
   noOptions: React.ElementType;
   /**
-   * The component used to render the limit tag.
+   * The component that renders the limit tag.
    * @default 'span'
    */
   limitTag: React.ElementType;

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -7,17 +7,17 @@ export type AvatarSlot = 'root' | 'img' | 'fallback';
 
 export interface AvatarSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the img.
+   * The component that renders the img.
    * @default 'img'
    */
   img: React.ElementType;
   /**
-   * The component used to render the fallback.
+   * The component that renders the fallback.
    * @default 'svg'
    */
   fallback: React.ElementType;

--- a/packages/mui-joy/src/Badge/BadgeProps.ts
+++ b/packages/mui-joy/src/Badge/BadgeProps.ts
@@ -7,12 +7,12 @@ export type BadgeSlot = 'root' | 'badge';
 
 export interface BadgeSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the badge.
+   * The component that renders the badge.
    * @default 'div'
    */
   badge: React.ElementType;

--- a/packages/mui-joy/src/Breadcrumbs/BreadcrumbsProps.ts
+++ b/packages/mui-joy/src/Breadcrumbs/BreadcrumbsProps.ts
@@ -7,22 +7,22 @@ export type BreadcrumbsSlot = 'root' | 'ol' | 'li' | 'separator';
 
 export interface BreadcrumbsSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'nav'
    */
   root: React.ElementType;
   /**
-   * The component used to render the ol.
+   * The component that renders the ol.
    * @default 'ol'
    */
   ol: React.ElementType;
   /**
-   * The component used to render the li.
+   * The component that renders the li.
    * @default 'li'
    */
   li: React.ElementType;
   /**
-   * The component used to render the separator.
+   * The component that renders the separator.
    * @default 'li'
    */
   separator: React.ElementType;

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -12,22 +12,22 @@ export type ButtonSlot = 'root' | 'startDecorator' | 'endDecorator' | 'loadingIn
 
 export interface ButtonSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'button'
    */
   root: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;
   /**
-   * The component used to render the loading indicator center.
+   * The component that renders the loading indicator center.
    * @default 'span'
    */
   loadingIndicatorCenter: React.ElementType;

--- a/packages/mui-joy/src/Checkbox/CheckboxProps.ts
+++ b/packages/mui-joy/src/Checkbox/CheckboxProps.ts
@@ -8,27 +8,27 @@ export type CheckboxSlot = 'root' | 'checkbox' | 'action' | 'input' | 'label';
 
 export interface CheckboxSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root: React.ElementType;
   /**
-   * The component used to render the checkbox.
+   * The component that renders the checkbox.
    * @default 'span'
    */
   checkbox: React.ElementType;
   /**
-   * The component used to render the action.
+   * The component that renders the action.
    * @default 'span'
    */
   action: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input: React.ElementType;
   /**
-   * The component used to render the label.
+   * The component that renders the label.
    * @default 'label'
    */
   label: React.ElementType;

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -7,27 +7,27 @@ export type ChipSlot = 'root' | 'label' | 'action' | 'startDecorator' | 'endDeco
 
 export interface ChipSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the label.
+   * The component that renders the label.
    * @default 'span'
    */
   label: React.ElementType;
   /**
-   * The component used to render the action.
+   * The component that renders the action.
    * @default 'button'
    */
   action: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;

--- a/packages/mui-joy/src/CircularProgress/CircularProgressProps.ts
+++ b/packages/mui-joy/src/CircularProgress/CircularProgressProps.ts
@@ -7,22 +7,22 @@ export type CircularProgressSlot = 'root' | 'svg' | 'track' | 'progress';
 
 export interface CircularProgressSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root: React.ElementType;
   /**
-   * The component used to render the svg.
+   * The component that renders the svg.
    * @default 'svg'
    */
   svg: React.ElementType;
   /**
-   * The component used to render the track.
+   * The component that renders the track.
    * @default 'circle'
    */
   track: React.ElementType;
   /**
-   * The component used to render the progress.
+   * The component that renders the progress.
    * @default 'circle'
    */
   progress: React.ElementType;

--- a/packages/mui-joy/src/FormLabel/FormLabelProps.ts
+++ b/packages/mui-joy/src/FormLabel/FormLabelProps.ts
@@ -7,12 +7,12 @@ export type FormLabelSlot = 'root' | 'asterisk';
 
 export interface FormLabelSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'label'
    */
   root: React.ElementType;
   /**
-   * The component used to render the asterisk.
+   * The component that renders the asterisk.
    * @default 'span'
    */
   asterisk: React.ElementType;

--- a/packages/mui-joy/src/Input/InputProps.ts
+++ b/packages/mui-joy/src/Input/InputProps.ts
@@ -7,22 +7,22 @@ export type InputSlot = 'root' | 'input' | 'startDecorator' | 'endDecorator';
 
 export interface InputSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;

--- a/packages/mui-joy/src/Link/LinkProps.ts
+++ b/packages/mui-joy/src/Link/LinkProps.ts
@@ -15,17 +15,17 @@ export type LinkSlot = 'root' | 'startDecorator' | 'endDecorator';
 
 export interface LinkSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'a'
    */
   root: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;

--- a/packages/mui-joy/src/ListItem/ListItemProps.ts
+++ b/packages/mui-joy/src/ListItem/ListItemProps.ts
@@ -7,17 +7,17 @@ export type ListItemSlot = 'root' | 'startAction' | 'endAction';
 
 export interface ListItemSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'li'
    */
   root: React.ElementType;
   /**
-   * The component used to render the start action.
+   * The component that renders the start action.
    * @default 'div'
    */
   startAction: React.ElementType;
   /**
-   * The component used to render the end action.
+   * The component that renders the end action.
    * @default 'div'
    */
   endAction: React.ElementType;

--- a/packages/mui-joy/src/Modal/ModalProps.ts
+++ b/packages/mui-joy/src/Modal/ModalProps.ts
@@ -8,12 +8,12 @@ export type ModalSlot = 'root' | 'backdrop';
 
 export interface ModalSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the backdrop.
+   * The component that renders the backdrop.
    * @default 'div'
    */
   backdrop: React.ElementType;

--- a/packages/mui-joy/src/Radio/RadioProps.ts
+++ b/packages/mui-joy/src/Radio/RadioProps.ts
@@ -8,32 +8,32 @@ export type RadioSlot = 'root' | 'radio' | 'icon' | 'action' | 'input' | 'label'
 
 export interface RadioSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root: React.ElementType;
   /**
-   * The component used to render the radio.
+   * The component that renders the radio.
    * @default 'span'
    */
   radio: React.ElementType;
   /**
-   * The component used to render the icon.
+   * The component that renders the icon.
    * @default 'span'
    */
   icon: React.ElementType;
   /**
-   * The component used to render the action.
+   * The component that renders the action.
    * @default 'span'
    */
   action: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input: React.ElementType;
   /**
-   * The component used to render the label.
+   * The component that renders the label.
    * @default 'label'
    */
   label: React.ElementType;

--- a/packages/mui-joy/src/Select/SelectProps.ts
+++ b/packages/mui-joy/src/Select/SelectProps.ts
@@ -17,32 +17,32 @@ export type SelectSlot =
 
 export interface SelectSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the button.
+   * The component that renders the button.
    * @default 'button'
    */
   button: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;
   /**
-   * The component used to render the indicator.
+   * The component that renders the indicator.
    * @default 'span'
    */
   indicator: React.ElementType;
   /**
-   * The component used to render the listbox.
+   * The component that renders the listbox.
    * @default 'ul'
    */
   listbox: React.ElementType;

--- a/packages/mui-joy/src/Slider/SliderProps.ts
+++ b/packages/mui-joy/src/Slider/SliderProps.ts
@@ -16,42 +16,42 @@ export type SliderSlot =
 
 export interface SliderSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root: React.ElementType;
   /**
-   * The component used to render the track.
+   * The component that renders the track.
    * @default 'span'
    */
   track: React.ElementType;
   /**
-   * The component used to render the rail.
+   * The component that renders the rail.
    * @default 'span'
    */
   rail: React.ElementType;
   /**
-   * The component used to render the thumb.
+   * The component that renders the thumb.
    * @default 'span'
    */
   thumb: React.ElementType;
   /**
-   * The component used to render the mark.
+   * The component that renders the mark.
    * @default 'span'
    */
   mark: React.ElementType;
   /**
-   * The component used to render the mark label.
+   * The component that renders the mark label.
    * @default 'span'
    */
   markLabel: React.ElementType;
   /**
-   * The component used to render the value label.
+   * The component that renders the value label.
    * @default 'span'
    */
   valueLabel: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input: React.ElementType;

--- a/packages/mui-joy/src/Switch/SwitchProps.ts
+++ b/packages/mui-joy/src/Switch/SwitchProps.ts
@@ -15,37 +15,37 @@ export type SwitchSlot =
 
 export interface SwitchSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the thumb.
+   * The component that renders the thumb.
    * @default 'span'
    */
   thumb: React.ElementType;
   /**
-   * The component used to render the action.
+   * The component that renders the action.
    * @default 'div'
    */
   action: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input: React.ElementType;
   /**
-   * The component used to render the track.
+   * The component that renders the track.
    * @default 'span'
    */
   track: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;

--- a/packages/mui-joy/src/Textarea/TextareaProps.ts
+++ b/packages/mui-joy/src/Textarea/TextareaProps.ts
@@ -7,22 +7,22 @@ export type TextareaSlot = 'root' | 'textarea' | 'startDecorator' | 'endDecorato
 
 export interface TextareaSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the textarea.
+   * The component that renders the textarea.
    * @default 'textarea'
    */
   textarea: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'div'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'div'
    */
   endDecorator: React.ElementType;

--- a/packages/mui-joy/src/Tooltip/TooltipProps.ts
+++ b/packages/mui-joy/src/Tooltip/TooltipProps.ts
@@ -8,12 +8,12 @@ export type TooltipSlot = 'root' | 'arrow';
 
 export interface TooltipSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root: React.ElementType;
   /**
-   * The component used to render the arrow.
+   * The component that renders the arrow.
    * @default 'span'
    */
   arrow: React.ElementType;

--- a/packages/mui-joy/src/Typography/TypographyProps.ts
+++ b/packages/mui-joy/src/Typography/TypographyProps.ts
@@ -15,17 +15,17 @@ export type TypographySlot = 'root' | 'startDecorator' | 'endDecorator';
 
 export interface TypographySlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'a'
    */
   root: React.ElementType;
   /**
-   * The component used to render the start decorator.
+   * The component that renders the start decorator.
    * @default 'span'
    */
   startDecorator: React.ElementType;
   /**
-   * The component used to render the end decorator.
+   * The component that renders the end decorator.
    * @default 'span'
    */
   endDecorator: React.ElementType;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Follow-up** on https://github.com/mui/material-ui/pull/36307


## Changes

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/18292247/221109310-7d577eec-d7b6-4ba7-8313-c1d3fd89a60c.png">

**Preview**: https://deploy-preview-36328--material-ui.netlify.app/joy-ui/api/alert/#slots