### PR TITLE
[Card] Fix Card focus effect overflowing parent card

### DIFF
--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -25,6 +25,7 @@ const CardActionAreaRoot = styled(ButtonBase, {
 })(({ theme }) => ({
   display: 'block',
   textAlign: 'inherit',
+  borderRadius: 'inherit',
   width: '100%',
   [`&:hover .${cardActionAreaClasses.focusHighlight}`]: {
     opacity: (theme.vars || theme).palette.action.hoverOpacity,

--- a/packages/mui-material/src/CardActionArea/CardActionArea.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.js
@@ -25,7 +25,7 @@ const CardActionAreaRoot = styled(ButtonBase, {
 })(({ theme }) => ({
   display: 'block',
   textAlign: 'inherit',
-  borderRadius: 'inherit',
+  borderRadius: 'inherit', // for Safari to work https://github.com/mui/material-ui/issues/36285.
   width: '100%',
   [`&:hover .${cardActionAreaClasses.focusHighlight}`]: {
     opacity: (theme.vars || theme).palette.action.hoverOpacity,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes https://github.com/mui/material-ui/issues/36285

Fixes this in Safari:
<img width="718" alt="Screenshot 2023-03-29 at 7 44 42 PM" src="https://user-images.githubusercontent.com/4997971/228525922-8214c7c6-867a-4ec4-8a80-39eeb6c12b10.png">

Demo: mouseover the card here - https://deploy-preview-36329--material-ui.netlify.app/material-ui/react-card/#primary-action

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
