### PR TITLE
[docs][base] Improve the Slots Table in API docs

### DIFF
--- a/docs/pages/base/api/badge-unstyled.json
+++ b/docs/pages/base/api/badge-unstyled.json
@@ -23,13 +23,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiBadge-root"
     },
     {
       "name": "badge",
-      "description": "The component used to render the badge.",
+      "description": "The component that renders the badge.",
       "default": "'span'",
       "class": ".MuiBadge-badge"
     }

--- a/docs/pages/base/api/button-unstyled.json
+++ b/docs/pages/base/api/button-unstyled.json
@@ -23,7 +23,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "props.href || props.to ? 'a' : 'button'",
       "class": ".MuiButton-root"
     }

--- a/docs/pages/base/api/input-unstyled.json
+++ b/docs/pages/base/api/input-unstyled.json
@@ -46,19 +46,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiInput-root"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiInput-input"
     },
     {
       "name": "textarea",
-      "description": "The component used to render the textarea.",
+      "description": "The component that renders the textarea.",
       "default": "'textarea'",
       "class": ".MuiInput-textarea"
     }

--- a/docs/pages/base/api/menu-item-unstyled.json
+++ b/docs/pages/base/api/menu-item-unstyled.json
@@ -17,7 +17,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'li'",
       "class": ".MuiMenuItem-root"
     }

--- a/docs/pages/base/api/menu-unstyled.json
+++ b/docs/pages/base/api/menu-unstyled.json
@@ -28,13 +28,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "PopperUnstyled",
       "class": ".MuiMenu-root"
     },
     {
       "name": "listbox",
-      "description": "The component used to render the listbox.",
+      "description": "The component that renders the listbox.",
       "default": "'ul'",
       "class": ".MuiMenu-listbox"
     }

--- a/docs/pages/base/api/modal-unstyled.json
+++ b/docs/pages/base/api/modal-unstyled.json
@@ -36,13 +36,13 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiModal-root"
     },
     {
       "name": "backdrop",
-      "description": "The component used to render the backdrop.",
+      "description": "The component that renders the backdrop.",
       "class": ".MuiModal-backdrop"
     }
   ],

--- a/docs/pages/base/api/option-group-unstyled.json
+++ b/docs/pages/base/api/option-group-unstyled.json
@@ -23,19 +23,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'li'",
       "class": ".MuiOptionGroup-root"
     },
     {
       "name": "label",
-      "description": "The component used to render the label.",
+      "description": "The component that renders the label.",
       "default": "'span'",
       "class": ".MuiOptionGroup-label"
     },
     {
       "name": "list",
-      "description": "The component used to render the list.",
+      "description": "The component that renders the list.",
       "default": "'ul'",
       "class": ".MuiOptionGroup-list"
     }

--- a/docs/pages/base/api/option-unstyled.json
+++ b/docs/pages/base/api/option-unstyled.json
@@ -18,7 +18,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'li'",
       "class": ".MuiOption-root"
     }

--- a/docs/pages/base/api/select-unstyled.json
+++ b/docs/pages/base/api/select-unstyled.json
@@ -35,19 +35,19 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'button'",
       "class": ".MuiSelect-root"
     },
     {
       "name": "listbox",
-      "description": "The component used to render the listbox.",
+      "description": "The component that renders the listbox.",
       "default": "'ul'",
       "class": ".MuiSelect-listbox"
     },
     {
       "name": "popper",
-      "description": "The component used to render the popper.",
+      "description": "The component that renders the popper.",
       "default": "PopperUnstyled",
       "class": ".MuiSelect-popper"
     }

--- a/docs/pages/base/api/slider-unstyled.json
+++ b/docs/pages/base/api/slider-unstyled.json
@@ -65,48 +65,48 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiSlider-root"
     },
     {
       "name": "track",
-      "description": "The component used to render the track.",
+      "description": "The component that renders the track.",
       "default": "'span'",
       "class": ".MuiSlider-track"
     },
     {
       "name": "rail",
-      "description": "The component used to render the rail.",
+      "description": "The component that renders the rail.",
       "default": "'span'",
       "class": ".MuiSlider-rail"
     },
     {
       "name": "thumb",
-      "description": "The component used to render the thumb.",
+      "description": "The component that renders the thumb.",
       "default": "'span'",
       "class": ".MuiSlider-thumb"
     },
     {
       "name": "mark",
-      "description": "The component used to render the mark.",
+      "description": "The component that renders the mark.",
       "default": "'span'",
       "class": ".MuiSlider-mark"
     },
     {
       "name": "markLabel",
-      "description": "The component used to render the mark label.",
+      "description": "The component that renders the mark label.",
       "default": "'span'",
       "class": ".MuiSlider-markLabel"
     },
     {
       "name": "valueLabel",
-      "description": "The component used to render the value label.",
+      "description": "The component that renders the value label.",
       "class": ".MuiSlider-valueLabel"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiSlider-input"
     }

--- a/docs/pages/base/api/snackbar-unstyled.json
+++ b/docs/pages/base/api/snackbar-unstyled.json
@@ -24,7 +24,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiSnackbar-root"
     }

--- a/docs/pages/base/api/switch-unstyled.json
+++ b/docs/pages/base/api/switch-unstyled.json
@@ -27,25 +27,25 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'span'",
       "class": ".MuiSwitch-root"
     },
     {
       "name": "input",
-      "description": "The component used to render the input.",
+      "description": "The component that renders the input.",
       "default": "'input'",
       "class": ".MuiSwitch-input"
     },
     {
       "name": "thumb",
-      "description": "The component used to render the thumb.",
+      "description": "The component that renders the thumb.",
       "default": "'span'",
       "class": ".MuiSwitch-thumb"
     },
     {
       "name": "track",
-      "description": "The component used to render the track.",
+      "description": "The component that renders the track.",
       "default": "'span'",
       "class": ".MuiSwitch-track"
     }

--- a/docs/pages/base/api/tab-panel-unstyled.json
+++ b/docs/pages/base/api/tab-panel-unstyled.json
@@ -20,7 +20,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiTabPanel-root"
     }

--- a/docs/pages/base/api/tab-unstyled.json
+++ b/docs/pages/base/api/tab-unstyled.json
@@ -24,7 +24,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'button'",
       "class": ".MuiTab-root"
     }

--- a/docs/pages/base/api/table-pagination-unstyled.json
+++ b/docs/pages/base/api/table-pagination-unstyled.json
@@ -44,49 +44,49 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'td'",
       "class": ".MuiTablePagination-root"
     },
     {
       "name": "actions",
-      "description": "The component used to render the actions.",
+      "description": "The component that renders the actions.",
       "default": "TablePaginationActionsUnstyled",
       "class": ".MuiTablePagination-actions"
     },
     {
       "name": "select",
-      "description": "The component used to render the select.",
+      "description": "The component that renders the select.",
       "default": "'select'",
       "class": ".MuiTablePagination-select"
     },
     {
       "name": "selectLabel",
-      "description": "The component used to render the select label.",
+      "description": "The component that renders the select label.",
       "default": "'p'",
       "class": ".MuiTablePagination-selectLabel"
     },
     {
       "name": "menuItem",
-      "description": "The component used to render the menu item.",
+      "description": "The component that renders the menu item.",
       "default": "'option'",
       "class": ".MuiTablePagination-menuItem"
     },
     {
       "name": "displayedRows",
-      "description": "The component used to render the displayed rows.",
+      "description": "The component that renders the displayed rows.",
       "default": "'p'",
       "class": ".MuiTablePagination-displayedRows"
     },
     {
       "name": "toolbar",
-      "description": "The component used to render the toolbar.",
+      "description": "The component that renders the toolbar.",
       "default": "'div'",
       "class": ".MuiTablePagination-toolbar"
     },
     {
       "name": "spacer",
-      "description": "The component used to render the spacer.",
+      "description": "The component that renders the spacer.",
       "default": "'div'",
       "class": ".MuiTablePagination-spacer"
     }

--- a/docs/pages/base/api/tabs-list-unstyled.json
+++ b/docs/pages/base/api/tabs-list-unstyled.json
@@ -16,7 +16,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiTabsList-root"
     }

--- a/docs/pages/base/api/tabs-unstyled.json
+++ b/docs/pages/base/api/tabs-unstyled.json
@@ -38,7 +38,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "The component used to render the root.",
+      "description": "The component that renders the root.",
       "default": "'div'",
       "class": ".MuiTabs-root"
     }

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -171,15 +171,20 @@ export default function ApiPage(props) {
   } = pageContent;
 
   const isJoyComponent = filename.includes('mui-joy');
+  const isBaseComponent = filename.includes('mui-base');
   const defaultPropsLink = isJoyComponent
     ? '/joy-ui/customization/themed-components/#default-props'
     : '/material-ui/customization/theme-components/#default-props';
   const styleOverridesLink = isJoyComponent
     ? '/joy-ui/customization/themed-components/#style-overrides'
     : '/material-ui/customization/theme-components/#global-style-overrides';
-  const slotGuideLink = isJoyComponent
-    ? '/joy-ui/customization/themed-components/#component-identifier'
-    : '';
+  let slotGuideLink = '';
+  if (isJoyComponent) {
+    slotGuideLink = '/joy-ui/customization/themed-components/#component-identifier';
+  } else if (isBaseComponent) {
+    slotGuideLink = '/base/getting-started/customization/#overriding-subcomponent-slots';
+  }
+
   const {
     componentDescription,
     componentDescriptionToc = [],

--- a/docs/translations/api-docs/badge-unstyled/badge-unstyled.json
+++ b/docs/translations/api-docs/badge-unstyled/badge-unstyled.json
@@ -12,7 +12,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "badge": "The component used to render the badge."
+    "root": "The component that renders the root.",
+    "badge": "The component that renders the badge."
   }
 }

--- a/docs/translations/api-docs/button-unstyled/button-unstyled.json
+++ b/docs/translations/api-docs/button-unstyled/button-unstyled.json
@@ -9,5 +9,5 @@
     "slots": "The components used for each slot inside the Button. Either a string to use a HTML element or a component. See <a href=\"#slots\">Slots API</a> below for more details."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/input-unstyled/input-unstyled.json
+++ b/docs/translations/api-docs/input-unstyled/input-unstyled.json
@@ -26,8 +26,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "input": "The component used to render the input.",
-    "textarea": "The component used to render the textarea."
+    "root": "The component that renders the root.",
+    "input": "The component that renders the input.",
+    "textarea": "The component that renders the textarea."
   }
 }

--- a/docs/translations/api-docs/menu-item-unstyled/menu-item-unstyled.json
+++ b/docs/translations/api-docs/menu-item-unstyled/menu-item-unstyled.json
@@ -8,5 +8,5 @@
     "slots": "The components used for each slot inside the MenuItem. Either a string to use a HTML element or a component. See <a href=\"#slots\">Slots API</a> below for more details."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/menu-unstyled/menu-unstyled.json
+++ b/docs/translations/api-docs/menu-unstyled/menu-unstyled.json
@@ -12,7 +12,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "listbox": "The component used to render the listbox."
+    "root": "The component that renders the root.",
+    "listbox": "The component that renders the listbox."
   }
 }

--- a/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
+++ b/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
@@ -21,7 +21,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "backdrop": "The component used to render the backdrop."
+    "root": "The component that renders the root.",
+    "backdrop": "The component that renders the backdrop."
   }
 }

--- a/docs/translations/api-docs/option-group-unstyled/option-group-unstyled.json
+++ b/docs/translations/api-docs/option-group-unstyled/option-group-unstyled.json
@@ -9,8 +9,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "label": "The component used to render the label.",
-    "list": "The component used to render the list."
+    "root": "The component that renders the root.",
+    "label": "The component that renders the label.",
+    "list": "The component that renders the list."
   }
 }

--- a/docs/translations/api-docs/option-unstyled/option-unstyled.json
+++ b/docs/translations/api-docs/option-unstyled/option-unstyled.json
@@ -9,5 +9,5 @@
     "value": "The value of the option."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/select-unstyled/select-unstyled.json
+++ b/docs/translations/api-docs/select-unstyled/select-unstyled.json
@@ -21,8 +21,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "listbox": "The component used to render the listbox.",
-    "popper": "The component used to render the popper."
+    "root": "The component that renders the root.",
+    "listbox": "The component that renders the listbox.",
+    "popper": "The component that renders the popper."
   }
 }

--- a/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
+++ b/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
@@ -29,13 +29,13 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "track": "The component used to render the track.",
-    "rail": "The component used to render the rail.",
-    "thumb": "The component used to render the thumb.",
-    "mark": "The component used to render the mark.",
-    "markLabel": "The component used to render the mark label.",
-    "valueLabel": "The component used to render the value label.",
-    "input": "The component used to render the input."
+    "root": "The component that renders the root.",
+    "track": "The component that renders the track.",
+    "rail": "The component that renders the rail.",
+    "thumb": "The component that renders the thumb.",
+    "mark": "The component that renders the mark.",
+    "markLabel": "The component that renders the mark label.",
+    "valueLabel": "The component that renders the value label.",
+    "input": "The component that renders the input."
   }
 }

--- a/docs/translations/api-docs/snackbar-unstyled/snackbar-unstyled.json
+++ b/docs/translations/api-docs/snackbar-unstyled/snackbar-unstyled.json
@@ -12,5 +12,5 @@
     "slots": "The components used for each slot inside the Snackbar. Either a string to use a HTML element or a component. See <a href=\"#slots\">Slots API</a> below for more details."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/switch-unstyled/switch-unstyled.json
+++ b/docs/translations/api-docs/switch-unstyled/switch-unstyled.json
@@ -13,9 +13,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "input": "The component used to render the input.",
-    "thumb": "The component used to render the thumb.",
-    "track": "The component used to render the track."
+    "root": "The component that renders the root.",
+    "input": "The component that renders the input.",
+    "thumb": "The component that renders the thumb.",
+    "track": "The component that renders the track."
   }
 }

--- a/docs/translations/api-docs/tab-panel-unstyled/tab-panel-unstyled.json
+++ b/docs/translations/api-docs/tab-panel-unstyled/tab-panel-unstyled.json
@@ -8,5 +8,5 @@
     "value": "The value of the TabPanel. It will be shown when the Tab with the corresponding value is selected."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/tab-unstyled/tab-unstyled.json
+++ b/docs/translations/api-docs/tab-unstyled/tab-unstyled.json
@@ -10,5 +10,5 @@
     "value": "You can provide your own value. Otherwise, we fall back to the child position index."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/table-pagination-unstyled/table-pagination-unstyled.json
+++ b/docs/translations/api-docs/table-pagination-unstyled/table-pagination-unstyled.json
@@ -18,13 +18,13 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "root": "The component used to render the root.",
-    "actions": "The component used to render the actions.",
-    "select": "The component used to render the select.",
-    "selectLabel": "The component used to render the select label.",
-    "menuItem": "The component used to render the menu item.",
-    "displayedRows": "The component used to render the displayed rows.",
-    "toolbar": "The component used to render the toolbar.",
-    "spacer": "The component used to render the spacer."
+    "root": "The component that renders the root.",
+    "actions": "The component that renders the actions.",
+    "select": "The component that renders the select.",
+    "selectLabel": "The component that renders the select label.",
+    "menuItem": "The component that renders the menu item.",
+    "displayedRows": "The component that renders the displayed rows.",
+    "toolbar": "The component that renders the toolbar.",
+    "spacer": "The component that renders the spacer."
   }
 }

--- a/docs/translations/api-docs/tabs-list-unstyled/tabs-list-unstyled.json
+++ b/docs/translations/api-docs/tabs-list-unstyled/tabs-list-unstyled.json
@@ -7,5 +7,5 @@
     "slots": "The components used for each slot inside the TabsList. Either a string to use a HTML element or a component. See <a href=\"#slots\">Slots API</a> below for more details."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/docs/translations/api-docs/tabs-unstyled/tabs-unstyled.json
+++ b/docs/translations/api-docs/tabs-unstyled/tabs-unstyled.json
@@ -13,5 +13,5 @@
     "value": "The value of the currently selected <code>Tab</code>. If you don&#39;t want any selected <code>Tab</code>, you can set this prop to <code>false</code>."
   },
   "classDescriptions": {},
-  "slotDescriptions": { "root": "The component used to render the root." }
+  "slotDescriptions": { "root": "The component that renders the root." }
 }

--- a/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
+++ b/packages/mui-base/src/BadgeUnstyled/BadgeUnstyled.types.ts
@@ -58,12 +58,12 @@ export interface BadgeUnstyledOwnProps {
 
 export interface BadgeUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the badge.
+   * The component that renders the badge.
    * @default 'span'
    */
   badge?: React.ElementType;

--- a/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
+++ b/packages/mui-base/src/ButtonUnstyled/ButtonUnstyled.types.ts
@@ -37,7 +37,7 @@ export interface ButtonUnstyledOwnProps extends Omit<UseButtonParameters, 'ref'>
 
 export interface ButtonUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default props.href || props.to ? 'a' : 'button'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.types.ts
+++ b/packages/mui-base/src/FormControlUnstyled/FormControlUnstyled.types.ts
@@ -54,7 +54,7 @@ export interface FormControlUnstyledOwnProps {
 
 export interface FormControlUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
+++ b/packages/mui-base/src/InputUnstyled/InputUnstyled.types.ts
@@ -138,17 +138,17 @@ export type InputUnstyledOwnProps = (SingleLineInputUnstyledProps | MultiLineInp
 
 export interface InputUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input?: React.ElementType;
   /**
-   * The component used to render the textarea.
+   * The component that renders the textarea.
    * @default 'textarea'
    */
   textarea?: React.ElementType;

--- a/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/MenuItemUnstyled.types.ts
@@ -45,7 +45,7 @@ export interface MenuItemUnstyledOwnProps {
 
 export interface MenuItemUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'li'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
+++ b/packages/mui-base/src/MenuUnstyled/MenuUnstyled.types.ts
@@ -69,12 +69,12 @@ export interface MenuUnstyledOwnProps {
 
 export interface MenuUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default PopperUnstyled
    */
   root?: React.ElementType;
   /**
-   * The component used to render the listbox.
+   * The component that renders the listbox.
    * @default 'ul'
    */
   listbox?: React.ElementType;

--- a/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
+++ b/packages/mui-base/src/ModalUnstyled/ModalUnstyled.types.ts
@@ -116,12 +116,12 @@ export interface ModalUnstyledOwnProps {
 
 export interface ModalUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the backdrop.
+   * The component that renders the backdrop.
    */
   backdrop?: React.ElementType;
 }

--- a/packages/mui-base/src/OptionGroupUnstyled/OptionGroupUnstyled.types.ts
+++ b/packages/mui-base/src/OptionGroupUnstyled/OptionGroupUnstyled.types.ts
@@ -49,17 +49,17 @@ export interface OptionGroupUnstyledOwnProps {
 
 export interface OptionGroupUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'li'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the label.
+   * The component that renders the label.
    * @default 'span'
    */
   label?: React.ElementType;
   /**
-   * The component used to render the list.
+   * The component that renders the list.
    * @default 'ul'
    */
   list?: React.ElementType;

--- a/packages/mui-base/src/OptionUnstyled/OptionUnstyled.types.ts
+++ b/packages/mui-base/src/OptionUnstyled/OptionUnstyled.types.ts
@@ -44,7 +44,7 @@ export interface OptionUnstyledOwnProps<TValue> {
 
 export interface OptionUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'li'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
+++ b/packages/mui-base/src/PopperUnstyled/PopperUnstyled.types.ts
@@ -112,7 +112,7 @@ export interface PopperUnstyledOwnProps {
 
 export interface PopperUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
+++ b/packages/mui-base/src/SelectUnstyled/SelectUnstyled.types.ts
@@ -124,17 +124,17 @@ export interface SelectUnstyledOwnProps<TValue extends {}, Multiple extends bool
 
 export interface SelectUnstyledSlots<TValue extends {}, Multiple extends boolean> {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'button'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the listbox.
+   * The component that renders the listbox.
    * @default 'ul'
    */
   listbox?: React.ElementType;
   /**
-   * The component used to render the popper.
+   * The component that renders the popper.
    * @default PopperUnstyled
    */
   popper?: React.ComponentType<SelectUnstyledPopperSlotProps<TValue, Multiple>>;

--- a/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
+++ b/packages/mui-base/src/SliderUnstyled/SliderUnstyled.types.ts
@@ -230,41 +230,41 @@ export interface SliderUnstyledOwnProps {
 
 export interface SliderUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the track.
+   * The component that renders the track.
    * @default 'span'
    */
   track?: React.ElementType;
   /**
-   * The component used to render the rail.
+   * The component that renders the rail.
    * @default 'span'
    */
   rail?: React.ElementType;
   /**
-   * The component used to render the thumb.
+   * The component that renders the thumb.
    * @default 'span'
    */
   thumb?: React.ElementType;
   /**
-   * The component used to render the mark.
+   * The component that renders the mark.
    * @default 'span'
    */
   mark?: React.ElementType;
   /**
-   * The component used to render the mark label.
+   * The component that renders the mark label.
    * @default 'span'
    */
   markLabel?: React.ElementType;
   /**
-   * The component used to render the value label.
+   * The component that renders the value label.
    */
   valueLabel?: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input?: React.ElementType;

--- a/packages/mui-base/src/SnackbarUnstyled/SnackbarUnstyled.types.ts
+++ b/packages/mui-base/src/SnackbarUnstyled/SnackbarUnstyled.types.ts
@@ -40,7 +40,7 @@ export interface SnackbarUnstyledOwnProps extends Omit<UseSnackbarParameters, 'r
 
 export interface SnackbarUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
+++ b/packages/mui-base/src/SwitchUnstyled/SwitchUnstyled.types.ts
@@ -48,22 +48,22 @@ export interface SwitchUnstyledOwnProps extends UseSwitchParameters {
 
 export interface SwitchUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'span'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the input.
+   * The component that renders the input.
    * @default 'input'
    */
   input?: React.ElementType;
   /**
-   * The component used to render the thumb.
+   * The component that renders the thumb.
    * @default 'span'
    */
   thumb?: React.ElementType;
   /**
-   * The component used to render the track.
+   * The component that renders the track.
    * @default 'span'
    */
   track?: React.ElementType | null;

--- a/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/TabPanelUnstyled.types.ts
@@ -36,7 +36,7 @@ export interface TabPanelUnstyledOwnProps {
 
 export interface TabPanelUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
+++ b/packages/mui-base/src/TabUnstyled/TabUnstyled.types.ts
@@ -33,7 +33,7 @@ export interface TabUnstyledOwnProps
 
 export interface TabUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'button'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationActionsUnstyled.types.ts
@@ -70,47 +70,47 @@ export interface TablePaginationActionsUnstyledOwnProps {
 
 export interface TablePaginationActionsUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the first button.
+   * The component that renders the first button.
    * @default 'button'
    */
   firstButton?: React.ElementType;
   /**
-   * The component used to render the last button.
+   * The component that renders the last button.
    * @default 'button'
    */
   lastButton?: React.ElementType;
   /**
-   * The component used to render the next button.
+   * The component that renders the next button.
    * @default 'button'
    */
   nextButton?: React.ElementType;
   /**
-   * The component used to render the back button.
+   * The component that renders the back button.
    * @default 'button'
    */
   backButton?: React.ElementType;
   /**
-   * The component used to render the first page icon.
+   * The component that renders the first page icon.
    * @default FirstPageIconDefault
    */
   firstPageIcon?: React.ElementType;
   /**
-   * The component used to render the last page icon.
+   * The component that renders the last page icon.
    * @default LastPageIconDefault
    */
   lastPageIcon?: React.ElementType;
   /**
-   * The component used to render the next page icon.
+   * The component that renders the next page icon.
    * @default NextPageIconDefault
    */
   nextPageIcon?: React.ElementType;
   /**
-   * The component used to render the back page icon.
+   * The component that renders the back page icon.
    * @default BackPageIconDefault
    */
   backPageIcon?: React.ElementType;

--- a/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
+++ b/packages/mui-base/src/TablePaginationUnstyled/TablePaginationUnstyled.types.ts
@@ -154,42 +154,42 @@ export interface TablePaginationUnstyledOwnProps {
 
 export interface TablePaginationUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'td'
    */
   root?: React.ElementType;
   /**
-   * The component used to render the actions.
+   * The component that renders the actions.
    * @default TablePaginationActionsUnstyled
    */
   actions?: React.ElementType;
   /**
-   * The component used to render the select.
+   * The component that renders the select.
    * @default 'select'
    */
   select?: React.ElementType;
   /**
-   * The component used to render the select label.
+   * The component that renders the select label.
    * @default 'p'
    */
   selectLabel?: React.ElementType;
   /**
-   * The component used to render the menu item.
+   * The component that renders the menu item.
    * @default 'option'
    */
   menuItem?: React.ElementType;
   /**
-   * The component used to render the displayed rows.
+   * The component that renders the displayed rows.
    * @default 'p'
    */
   displayedRows?: React.ElementType;
   /**
-   * The component used to render the toolbar.
+   * The component that renders the toolbar.
    * @default 'div'
    */
   toolbar?: React.ElementType;
   /**
-   * The component used to render the spacer.
+   * The component that renders the spacer.
    * @default 'div'
    */
   spacer?: React.ElementType;

--- a/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
+++ b/packages/mui-base/src/TabsListUnstyled/TabsListUnstyled.types.ts
@@ -32,7 +32,7 @@ export interface TabsListUnstyledOwnProps {
 
 export interface TabsListUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;

--- a/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
+++ b/packages/mui-base/src/TabsUnstyled/TabsUnstyled.types.ts
@@ -59,7 +59,7 @@ export interface TabsUnstyledOwnProps {
 
 export interface TabsUnstyledSlots {
   /**
-   * The component used to render the root.
+   * The component that renders the root.
    * @default 'div'
    */
   root?: React.ElementType;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR's motivation is to keep consistency with Joy. (Relevant PR: https://github.com/mui/material-ui/pull/36328), on which This PR is on top of. The independently relevant commits for Base are the last 4 commits.

**Preview**: https://deploy-preview-36330--material-ui.netlify.app/base/api/badge-unstyled/#slots