### PR TITLE
[docs] Fix @mui/styles example links

### DIFF
--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -400,15 +400,15 @@ Refer to the plugin's page for setup and usage instructions.
 
 <!-- #default-branch-switch -->
 
-Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/master/examples/material-gatsby) for an up-to-date usage example.
+Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/v4.x/examples/gatsby) for an usage example.
 
 ### Next.js
 
-You need to have a custom `pages/_document.js`, then copy [this logic](https://github.com/mui/material-ui/blob/814fb60bbd8e500517b2307b6a297a638838ca89/examples/material-next/pages/_document.js#L52-L59) to inject the server-side rendered styles into the `<head>` element.
+You need to have a custom `pages/_document.js`, then copy [this logic](https://github.com/mui/material-ui/blob/v4.x/examples/nextjs/pages/_document.js#L52-L59) to inject the server-side rendered styles into the `<head>` element.
 
 <!-- #default-branch-switch -->
 
-Refer to [this example project](https://github.com/mui/material-ui/tree/master/examples/material-next) for an up-to-date usage example.
+Refer to [this example project](https://github.com/mui/material-ui/tree/v4.x/examples/nextjs) for an up-to-date usage example.
 
 ## Class names
 


### PR DESCRIPTION
Fix a regression introduced in #36112 reported by the SEO crawl of ahrefs

- https://github.com/mui/material-ui/blob/814fb60bbd8e500517b2307b6a297a638838ca89/examples/material-next/pages/_document.js#L52-L59 is a 404.
- The other links are out of sync with the docs. Instead of showing how to use `@mui/system` with Material UI v5, I have updated the links to show how to use `@material-ui/styles` with Material UI v4. v5 is closer to v4 than `@mui/system` to `@mui/styles`.

Ideally, we would create new examples for `@mui/styles` but it's unlikely to be ever important enough to be on the priority list.

Preview: https://deploy-preview-36331--material-ui.netlify.app/system/styles/advanced/#server-side-rendering