### PR TITLE
[docs] Update MUI X banner to reflect stable release

### DIFF
--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -6,7 +6,7 @@ import { alpha } from '@mui/material/styles';
 export default function AppFrameBanner() {
   return FEATURE_TOGGLE.enable_docsnav_banner ? (
     <Link
-      href="https://next.mui.com/x/whats-new/"
+      href="https://mui.com/x/whats-new/"
       target="_blank"
       variant="caption"
       sx={(theme) => ({
@@ -39,7 +39,7 @@ export default function AppFrameBanner() {
         },
       })}
     >
-      🚀 MUI X v6-beta is out! Discover what&apos;s new and get started now!
+      🚀 MUI X v6 is out! Discover what&apos;s new and get started now!
       <br />
     </Link>
   ) : null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Context: See https://github.com/mui/material-ui/pull/36299#discussion_r1115212728

Should be merged after MUI X stable release, followed by docs redeploy as mentioned in #36301