### PR TITLE
[examples] Refactor to have better types in the Next.js + TypeScript examples

### DIFF
--- a/examples/material-next-ts-v4-v5-migration/pages/_app.tsx
+++ b/examples/material-next-ts-v4-v5-migration/pages/_app.tsx
@@ -10,7 +10,7 @@ import createEmotionCache from '../src/createEmotionCache';
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
 
-interface MyAppProps extends AppProps {
+export interface MyAppProps extends AppProps {
   emotionCache?: EmotionCache;
 }
 

--- a/examples/material-next-ts-v4-v5-migration/pages/_document.tsx
+++ b/examples/material-next-ts-v4-v5-migration/pages/_document.tsx
@@ -8,13 +8,14 @@ import Document, {
   DocumentContext,
 } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { AppType } from 'next/app';
 import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import theme from '../src/theme';
 import createEmotionCache from '../src/createEmotionCache';
+import { MyAppProps } from './_app';
 
 interface MyDocumentProps extends DocumentProps {
-  emotionStyleTags: EmotionJSX.Element[];
+  emotionStyleTags: JSX.Element[];
 }
 
 export default function MyDocument({ emotionStyleTags }: MyDocumentProps) {
@@ -94,7 +95,7 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
 
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App: any) =>
+      enhanceApp: (App: React.ComponentType<React.ComponentProps<AppType> & MyAppProps>) =>
         function EnhanceApp(props) {
           return jssSheets.collect(<App emotionCache={cache} {...props} />);
         },

--- a/examples/material-next-ts/pages/_app.tsx
+++ b/examples/material-next-ts/pages/_app.tsx
@@ -10,7 +10,7 @@ import createEmotionCache from '../src/createEmotionCache';
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
 
-interface MyAppProps extends AppProps {
+export interface MyAppProps extends AppProps {
   emotionCache?: EmotionCache;
 }
 

--- a/examples/material-next-ts/pages/_document.tsx
+++ b/examples/material-next-ts/pages/_document.tsx
@@ -8,12 +8,13 @@ import Document, {
   DocumentContext,
 } from 'next/document';
 import createEmotionServer from '@emotion/server/create-instance';
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { AppType } from 'next/app';
 import theme, { roboto } from '../src/theme';
 import createEmotionCache from '../src/createEmotionCache';
+import { MyAppProps } from './_app';
 
 interface MyDocumentProps extends DocumentProps {
-  emotionStyleTags: EmotionJSX.Element[];
+  emotionStyleTags: JSX.Element;
 }
 
 export default function MyDocument({ emotionStyleTags }: MyDocumentProps) {
@@ -68,7 +69,7 @@ MyDocument.getInitialProps = async (ctx: DocumentContext) => {
 
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App: any) =>
+      enhanceApp: (App: React.ComponentType<React.ComponentProps<AppType> & MyAppProps>) =>
         function EnhanceApp(props) {
           return <App emotionCache={cache} {...props} />;
         },

--- a/examples/material-next-ts/pages/_document.tsx
+++ b/examples/material-next-ts/pages/_document.tsx
@@ -14,7 +14,7 @@ import createEmotionCache from '../src/createEmotionCache';
 import { MyAppProps } from './_app';
 
 interface MyDocumentProps extends DocumentProps {
-  emotionStyleTags: JSX.Element;
+  emotionStyleTags: JSX.Element[];
 }
 
 export default function MyDocument({ emotionStyleTags }: MyDocumentProps) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Two minor typing changes in this example:

- instead of using `any` as the type for the `App` component just so we don't get an error when using the `emotionCache` prop, we define a new component with the right props (the props from Next.js' `AppType` component, plus our `MyAppProps` defined in the `_app.tsx` file)
- the `EmotionJSX.Element` type is just an alias for `JSX.Element`, so I think we can avoid this import here