### PR TITLE
[Autocomplete] Prevents Autocomplete menu from opening on right click

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1029,7 +1029,8 @@ export default function useAutocomplete(props) {
       if (open) {
         handlePopupIndicator(event);
         return;
-      }if(!open){
+      }
+      if (!open) {
         return;
       }
     }

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -766,7 +766,7 @@ export default function useAutocomplete(props) {
   const handleClear = (event) => {
     ignoreFocus.current = true;
     setInputValueState('');
-
+    
     if (onInputChange) {
       onInputChange(event, '', 'clear');
     }
@@ -1011,10 +1011,6 @@ export default function useAutocomplete(props) {
   const handleClick = (event) => {
     inputRef.current.focus();
 
-    if (event.type === 'click' || inputValue === '') {
-      handlePopupIndicator(event);
-    }
-
     if (
       selectOnFocus &&
       firstFocus.current &&
@@ -1024,6 +1020,23 @@ export default function useAutocomplete(props) {
     }
 
     firstFocus.current = false;
+
+    const isCloseIconClicked = event.target?.dataset?.testid === 'CloseIcon';
+    const isPathClicked = !!event.target?.getElementsByTagName('path').length
+    const shouldClose = isCloseIconClicked || isPathClicked;
+
+    if (shouldClose){
+      if (open){
+        handlePopupIndicator(event);
+        return;
+      }else{
+        return;
+      }
+    } 
+
+    if (inputValue === '' || !open) {
+      handlePopupIndicator(event);
+    }
   };
 
   let dirty = freeSolo && inputValue.length > 0;

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1029,7 +1029,7 @@ export default function useAutocomplete(props) {
       if (open) {
         handlePopupIndicator(event);
         return;
-      } else {
+      }if(!open){
         return;
       }
     }

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1023,18 +1023,14 @@ export default function useAutocomplete(props) {
 
     // Check if should open/close combo list upon clear click
 
-    const isCloseIconClicked = event.target?.dataset?.testid === 'CloseIcon';
-    const isPathClicked = !!event.target?.getElementsByTagName('path').length;
-    const shouldClose = isCloseIconClicked || isPathClicked;
+    const shouldClose =
+      event.target?.dataset?.testid === 'CloseIcon' ||
+      event.target?.querySelectorAll('path').length > 0;
 
-    if (shouldClose) {
-      if (open) {
-        handlePopupIndicator(event);
-        return;
-      }
-      if (!open) {
-        return;
-      }
+    if (shouldClose && open) {
+      handlePopupIndicator(event);
+    } else if (shouldClose && !open) {
+      return;
     }
 
     if (inputValue === '' || !open) {

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -766,7 +766,7 @@ export default function useAutocomplete(props) {
   const handleClear = (event) => {
     ignoreFocus.current = true;
     setInputValueState('');
-    
+
     if (onInputChange) {
       onInputChange(event, '', 'clear');
     }
@@ -1022,17 +1022,17 @@ export default function useAutocomplete(props) {
     firstFocus.current = false;
 
     const isCloseIconClicked = event.target?.dataset?.testid === 'CloseIcon';
-    const isPathClicked = !!event.target?.getElementsByTagName('path').length
+    const isPathClicked = !!event.target?.getElementsByTagName('path').length;
     const shouldClose = isCloseIconClicked || isPathClicked;
 
-    if (shouldClose){
-      if (open){
+    if (shouldClose) {
+      if (open) {
         handlePopupIndicator(event);
         return;
-      }else{
+      } else {
         return;
       }
-    } 
+    }
 
     if (inputValue === '' || !open) {
       handlePopupIndicator(event);

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1022,14 +1022,15 @@ export default function useAutocomplete(props) {
     firstFocus.current = false;
 
     // Check if should open/close combo list upon clear click
+    const isCloseIconClicked = event.target?.dataset?.testid === 'CloseIcon';
+    const isPathClicked = !!event.target?.getElementsByTagName('path').length;
+    const shouldClose = isCloseIconClicked || isPathClicked;
 
-    const shouldClose =
-      event.target?.dataset?.testid === 'CloseIcon' ||
-      event.target?.querySelectorAll('path').length > 0;
-
-    if (shouldClose && open) {
-      handlePopupIndicator(event);
-    } else if (shouldClose && !open) {
+    if (shouldClose) {
+      if (open) {
+        handlePopupIndicator(event);
+        return;
+      }
       return;
     }
 

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1008,8 +1008,12 @@ export default function useAutocomplete(props) {
   };
 
   // Focus the input when interacting with the combobox
-  const handleClick = () => {
+  const handleClick = (event) => {
     inputRef.current.focus();
+
+    if (event.type === 'click' || inputValue === '') {
+      handlePopupIndicator(event);
+    }
 
     if (
       selectOnFocus &&
@@ -1020,12 +1024,6 @@ export default function useAutocomplete(props) {
     }
 
     firstFocus.current = false;
-  };
-
-  const handleInputMouseDown = (event) => {
-    if (inputValue === '' || !open) {
-      handlePopupIndicator(event);
-    }
   };
 
   let dirty = freeSolo && inputValue.length > 0;
@@ -1088,7 +1086,6 @@ export default function useAutocomplete(props) {
       onBlur: handleBlur,
       onFocus: handleFocus,
       onChange: handleInputChange,
-      onMouseDown: handleInputMouseDown,
       // if open then this is handled imperativeley so don't let react override
       // only have an opinion about this when closed
       'aria-activedescendant': popupOpen ? '' : null,

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1021,6 +1021,8 @@ export default function useAutocomplete(props) {
 
     firstFocus.current = false;
 
+    // Check if should open/close combo list upon clear click
+
     const isCloseIconClicked = event.target?.dataset?.testid === 'CloseIcon';
     const isPathClicked = !!event.target?.getElementsByTagName('path').length;
     const shouldClose = isCloseIconClicked || isPathClicked;

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -425,7 +425,7 @@ describe('Joy <Autocomplete />', () => {
 
       const textbox = getByRole('combobox');
 
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
 
       expect(handleClose.callCount).to.equal(0);
@@ -441,7 +441,7 @@ describe('Joy <Autocomplete />', () => {
 
       const textbox = getByRole('combobox');
 
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
 
       expect(handleClose.callCount).to.equal(1);
@@ -931,7 +931,6 @@ describe('Joy <Autocomplete />', () => {
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       expect(textbox).toHaveFocus();
 
-      fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
 
@@ -942,12 +941,10 @@ describe('Joy <Autocomplete />', () => {
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       expect(textbox).not.toHaveFocus();
 
-      fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       expect(textbox).toHaveFocus();
 
-      fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
     });
@@ -1472,9 +1469,9 @@ describe('Joy <Autocomplete />', () => {
       const textbox = getByRole('combobox');
       const combobox = getByRole('combobox');
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
     });
 
@@ -1509,14 +1506,14 @@ describe('Joy <Autocomplete />', () => {
       const textbox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.click(textbox); // Open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       const options = getAllByRole('option');
       fireEvent.click(options[0]);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.click(textbox); // Open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox); // Remain open listbox
+      fireEvent.click(textbox); // Remain open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
 
@@ -1526,9 +1523,9 @@ describe('Joy <Autocomplete />', () => {
       const textbox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
   });
@@ -2271,7 +2268,7 @@ describe('Joy <Autocomplete />', () => {
     it('should not open the popup', () => {
       render(<Autocomplete readOnly options={['one', 'two', 'three']} />);
       const textbox = screen.getByRole('combobox');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(screen.queryByRole('listbox')).to.equal(null);
     });
 

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -578,7 +578,7 @@ describe('<Autocomplete />', () => {
 
       const textbox = getByRole('combobox');
 
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
 
       expect(handleClose.callCount).to.equal(0);
@@ -599,7 +599,7 @@ describe('<Autocomplete />', () => {
 
       const textbox = getByRole('combobox');
 
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       fireEvent.keyDown(textbox, { key: 'ArrowLeft' });
 
       expect(handleClose.callCount).to.equal(1);
@@ -1179,7 +1179,6 @@ describe('<Autocomplete />', () => {
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       expect(textbox).toHaveFocus();
 
-      fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
 
@@ -1190,12 +1189,10 @@ describe('<Autocomplete />', () => {
       expect(combobox).to.have.attribute('aria-expanded', 'false');
       expect(textbox).not.toHaveFocus();
 
-      fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       expect(textbox).toHaveFocus();
 
-      fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
     });
@@ -1850,9 +1847,9 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('combobox');
       const combobox = getByRole('combobox');
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
     });
 
@@ -1899,14 +1896,14 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.click(textbox); // Open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
       const options = getAllByRole('option');
       fireEvent.click(options[0]);
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.click(textbox); // Open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox); // Remain open listbox
+      fireEvent.click(textbox); // Remain open listbox
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
 
@@ -1922,9 +1919,7 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox);
-      expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
   });
@@ -2815,7 +2810,7 @@ describe('<Autocomplete />', () => {
         />,
       );
       const textbox = screen.getByRole('combobox');
-      fireEvent.mouseDown(textbox);
+      fireEvent.click(textbox);
       expect(screen.queryByRole('listbox')).to.equal(null);
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

@sp-reach opened this issue #36075 and I decided to fix it.

Old behaviour: 

<img width="1238" alt="autocomplete opening on right clic" src="https://user-images.githubusercontent.com/23372428/222262668-a696ec61-be72-4d0c-b824-79634ec01368.png">


New Behaviour:

<img width="1238" alt="autocomplete after fix" src="https://user-images.githubusercontent.com/23372428/222262934-7909ec2b-f89b-416f-bfca-8c26fd017fb3.png">



