### PR TITLE
[Autocomplete][joy] Add disabled class to the popup indicator

### DIFF
--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -209,6 +209,9 @@ const AutocompletePopupIndicator = styled(StyledIconButton as unknown as 'button
   ...(ownerState.popupOpen && {
     transform: 'rotate(180deg)',
   }),
+  ...(ownerState.disabled && {
+    opacity: 0.3,
+  }),
 }));
 
 const AutocompleteListbox = styled(StyledAutocompleteListbox, {

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -68,8 +68,17 @@ const defaultVariantMapping = {
 };
 
 const useUtilityClasses = (ownerState: OwnerState) => {
-  const { focused, hasClearIcon, hasPopupIcon, popupOpen, variant, color, size, multiple } =
-    ownerState;
+  const {
+    disabled,
+    focused,
+    hasClearIcon,
+    hasPopupIcon,
+    popupOpen,
+    variant,
+    color,
+    size,
+    multiple,
+  } = ownerState;
 
   const slots = {
     root: [
@@ -86,7 +95,7 @@ const useUtilityClasses = (ownerState: OwnerState) => {
     startDecorator: ['startDecorator'],
     endDecorator: ['endDecorator'],
     clearIndicator: ['clearIndicator'],
-    popupIndicator: ['popupIndicator', popupOpen && 'popupIndicatorOpen'],
+    popupIndicator: ['popupIndicator', popupOpen && 'popupIndicatorOpen', disabled && 'disabled'],
     listbox: ['listbox'],
     option: ['option'],
     loading: ['loading'],
@@ -208,9 +217,6 @@ const AutocompletePopupIndicator = styled(StyledIconButton as unknown as 'button
   marginInlineEnd: 'calc(var(--Input-decorator-childOffset) * -1)',
   ...(ownerState.popupOpen && {
     transform: 'rotate(180deg)',
-  }),
-  ...(ownerState.disabled && {
-    opacity: 0.3,
   }),
 }));
 
@@ -381,6 +387,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(
   const ownerState = {
     ...props,
     value,
+    disabled,
     focused,
     hasOptions: !!groupedOptions.length,
     hasClearIcon,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #36395

**Preview**: https://deploy-preview-36397--material-ui.netlify.app/joy-ui/react-autocomplete