### PR TITLE
[Grid2] Support dynamic nested columns

### DIFF
--- a/docs/data/material/components/grid2/NestedGridColumns.js
+++ b/docs/data/material/components/grid2/NestedGridColumns.js
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Grid from '@mui/material/Unstable_Grid2';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function NestedGrid() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Grid container spacing={2} columns={24}>
+        <Grid xs={8}>
+          <Item>xs=8/24</Item>
+        </Grid>
+        <Grid container xs={16}>
+          <Grid xs={12}>
+            <Item>nested xs=12/24</Item>
+          </Grid>
+          <Grid xs={12}>
+            <Item>nested xs=12/24</Item>
+          </Grid>
+        </Grid>
+        <Grid xs={8}>
+          <Item>xs=8/24</Item>
+        </Grid>
+        <Grid container xs={16} columns={12}>
+          <Grid xs={6}>
+            <Item>nested xs=6/12</Item>
+          </Grid>
+          <Grid xs={6}>
+            <Item>nested xs=6/12</Item>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/docs/data/material/components/grid2/NestedGridColumns.tsx
+++ b/docs/data/material/components/grid2/NestedGridColumns.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Grid from '@mui/material/Unstable_Grid2';
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function NestedGrid() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Grid container spacing={2} columns={24}>
+        <Grid xs={8}>
+          <Item>xs=8/24</Item>
+        </Grid>
+        <Grid container xs={16}>
+          <Grid xs={12}>
+            <Item>nested xs=12/24</Item>
+          </Grid>
+          <Grid xs={12}>
+            <Item>nested xs=12/24</Item>
+          </Grid>
+        </Grid>
+        <Grid xs={8}>
+          <Item>xs=8/24</Item>
+        </Grid>
+        <Grid container xs={16} columns={12}>
+          <Grid xs={6}>
+            <Item>nested xs=6/12</Item>
+          </Grid>
+          <Grid xs={6}>
+            <Item>nested xs=6/12</Item>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/docs/data/material/components/grid2/grid2.md
+++ b/docs/data/material/components/grid2/grid2.md
@@ -133,7 +133,15 @@ The demo below shows how this works:
 The grid container that renders inside another grid container is a nested grid that inherits its [`columns`](#columns) and [`spacing`](#spacing) from the top level.
 It will also inherit the props of the top-level grid if it receives those props.
 
-Check out the demo below to see what this looks like:
+### Inheriting columns
+
+A nested grid container will inherits the columns from its parent unless the `columns` prop is specified to the instance.
+
+{{"demo": "NestedGridColumns.js", "bg": true}}
+
+### Inheriting spacing
+
+A nested grid container will inherits the row and column spacing from its parent unless the `spacing` prop is specified to the instance.
 
 {{"demo": "NestedGrid.js", "bg": true}}
 

--- a/packages/mui-system/src/Unstable_Grid/gridGenerator.test.js
+++ b/packages/mui-system/src/Unstable_Grid/gridGenerator.test.js
@@ -252,7 +252,7 @@ describe('grid generator', () => {
     it('nested container level 1', () => {
       const result = generateGridStyles({ ownerState: { container: true, level: 1 } });
       sinon.assert.match(result, {
-        margin: `calc(var(--Grid-rowSpacing1) / -2) calc(var(--Grid-columnSpacing1) / -2)`,
+        margin: `calc(var(--Grid-rowSpacingLevel1) / -2) calc(var(--Grid-columnSpacingLevel1) / -2)`,
         padding: `calc(var(--Grid-rowSpacing) / 2) calc(var(--Grid-columnSpacing) / 2)`,
       });
     });
@@ -260,8 +260,8 @@ describe('grid generator', () => {
     it('nested container level 2', () => {
       const result = generateGridStyles({ ownerState: { container: true, level: 2 } });
       sinon.assert.match(result, {
-        margin: `calc(var(--Grid-rowSpacing2) / -2) calc(var(--Grid-columnSpacing2) / -2)`,
-        padding: `calc(var(--Grid-rowSpacing1) / 2) calc(var(--Grid-columnSpacing1) / 2)`,
+        margin: `calc(var(--Grid-rowSpacingLevel2) / -2) calc(var(--Grid-columnSpacingLevel2) / -2)`,
+        padding: `calc(var(--Grid-rowSpacingLevel1) / 2) calc(var(--Grid-columnSpacingLevel1) / 2)`,
       });
     });
 
@@ -270,7 +270,7 @@ describe('grid generator', () => {
         ownerState: { container: true, level: 1, disableEqualOverflow: true },
       });
       sinon.assert.match(result, {
-        margin: `calc(var(--Grid-rowSpacing1) * -1) 0px 0px calc(var(--Grid-columnSpacing1) * -1)`,
+        margin: `calc(var(--Grid-rowSpacingLevel1) * -1) 0px 0px calc(var(--Grid-columnSpacingLevel1) * -1)`,
         padding: `var(--Grid-rowSpacing) 0px 0px var(--Grid-columnSpacing)`,
       });
     });
@@ -285,7 +285,7 @@ describe('grid generator', () => {
         },
       });
       sinon.assert.match(result, {
-        margin: `calc(var(--Grid-rowSpacing1) / -2) calc(var(--Grid-columnSpacing1) / -2)`,
+        margin: `calc(var(--Grid-rowSpacingLevel1) / -2) calc(var(--Grid-columnSpacingLevel1) / -2)`,
         padding: `var(--Grid-rowSpacing) 0px 0px var(--Grid-columnSpacing)`,
       });
     });
@@ -313,7 +313,7 @@ describe('grid generator', () => {
         ownerState: { container: false, disableEqualOverflow: true, level: 2 },
       });
       sinon.assert.match(result, {
-        padding: `var(--Grid-rowSpacing1) 0px 0px var(--Grid-columnSpacing1)`,
+        padding: `var(--Grid-rowSpacingLevel1) 0px 0px var(--Grid-columnSpacingLevel1)`,
       });
     });
   });
@@ -475,7 +475,7 @@ describe('grid generator', () => {
         theme: { breakpoints },
         ownerState: { container: true, level: 1 },
       });
-      expect(result['--Grid-rowSpacing1']).to.equal('var(--Grid-rowSpacing)');
+      expect(result['--Grid-rowSpacingLevel1']).to.equal('var(--Grid-rowSpacing)');
     });
   });
 
@@ -539,7 +539,7 @@ describe('grid generator', () => {
         theme: { breakpoints },
         ownerState: { container: true, level: 1 },
       });
-      expect(result['--Grid-columnSpacing1']).to.equal('var(--Grid-columnSpacing)');
+      expect(result['--Grid-columnSpacingLevel1']).to.equal('var(--Grid-columnSpacing)');
     });
   });
 

--- a/packages/mui-system/src/Unstable_Grid/gridGenerator.ts
+++ b/packages/mui-system/src/Unstable_Grid/gridGenerator.ts
@@ -12,8 +12,8 @@ interface Iterator<T> {
   (appendStyle: (responsiveStyles: Record<string, any>, style: object) => void, value: T): void;
 }
 
-function appendLevel(level: number) {
-  if (level === 0) {
+function appendLevel(level: number | undefined) {
+  if (!level) {
     return '';
   }
   return `Level${level}`;

--- a/packages/mui-system/src/Unstable_Grid/gridGenerator.ts
+++ b/packages/mui-system/src/Unstable_Grid/gridGenerator.ts
@@ -12,13 +12,20 @@ interface Iterator<T> {
   (appendStyle: (responsiveStyles: Record<string, any>, style: object) => void, value: T): void;
 }
 
+function appendLevel(level: number) {
+  if (level === 0) {
+    return '';
+  }
+  return `Level${level}`;
+}
+
 function isNestedContainer(ownerState: Props['ownerState']) {
   return ownerState.level > 0 && ownerState.container;
 }
 
 function createGetSelfSpacing(ownerState: Props['ownerState']) {
   return function getSelfSpacing(axis: 'row' | 'column') {
-    return `var(--Grid-${axis}Spacing${ownerState.level || ''})`;
+    return `var(--Grid-${axis}Spacing${appendLevel(ownerState.level)})`;
   };
 }
 
@@ -27,7 +34,7 @@ function createGetParentSpacing(ownerState: Props['ownerState']) {
     if (ownerState.level === 0) {
       return `var(--Grid-${axis}Spacing)`;
     }
-    return `var(--Grid-${axis}Spacing${ownerState.level - 1 || ''})`;
+    return `var(--Grid-${axis}Spacing${appendLevel(ownerState.level - 1)})`;
   };
 }
 
@@ -35,7 +42,7 @@ function getParentColumns(ownerState: Props['ownerState']) {
   if (ownerState.level === 0) {
     return `var(--Grid-columns)`;
   }
-  return `var(--Grid-columns${ownerState.level - 1 || ''})`;
+  return `var(--Grid-columns${appendLevel(ownerState.level - 1)})`;
 }
 
 export const filterBreakpointKeys = (breakpointsKeys: Breakpoint[], responsiveKeys: string[]) =>
@@ -159,10 +166,10 @@ export const generateGridColumnsStyles = ({ theme, ownerState }: Props) => {
     return {};
   }
   const styles = isNestedContainer(ownerState)
-    ? { [`--Grid-columns${ownerState.level || ''}`]: getParentColumns(ownerState) }
+    ? { [`--Grid-columns${appendLevel(ownerState.level)}`]: getParentColumns(ownerState) }
     : { '--Grid-columns': 12 };
   traverseBreakpoints<number>(theme.breakpoints, ownerState.columns, (appendStyle, value) => {
-    appendStyle(styles, { [`--Grid-columns${ownerState.level || ''}`]: value });
+    appendStyle(styles, { [`--Grid-columns${appendLevel(ownerState.level)}`]: value });
   });
   return styles;
 };
@@ -176,7 +183,7 @@ export const generateGridRowSpacingStyles = ({ theme, ownerState }: Props) => {
     ? {
         // Set the default spacing as its parent spacing.
         // It will be overridden if spacing props are provided
-        [`--Grid-rowSpacing${ownerState.level || ''}`]: getParentSpacing('row'),
+        [`--Grid-rowSpacing${appendLevel(ownerState.level)}`]: getParentSpacing('row'),
       }
     : {};
   traverseBreakpoints<number | string>(
@@ -184,7 +191,7 @@ export const generateGridRowSpacingStyles = ({ theme, ownerState }: Props) => {
     ownerState.rowSpacing,
     (appendStyle, value) => {
       appendStyle(styles, {
-        [`--Grid-rowSpacing${ownerState.level || ''}`]:
+        [`--Grid-rowSpacing${appendLevel(ownerState.level)}`]:
           typeof value === 'string' ? value : theme.spacing?.(value),
       });
     },
@@ -201,7 +208,7 @@ export const generateGridColumnSpacingStyles = ({ theme, ownerState }: Props) =>
     ? {
         // Set the default spacing as its parent spacing.
         // It will be overridden if spacing props are provided
-        [`--Grid-columnSpacing${ownerState.level || ''}`]: getParentSpacing('column'),
+        [`--Grid-columnSpacing${appendLevel(ownerState.level)}`]: getParentSpacing('column'),
       }
     : {};
   traverseBreakpoints<number | string>(
@@ -209,7 +216,7 @@ export const generateGridColumnSpacingStyles = ({ theme, ownerState }: Props) =>
     ownerState.columnSpacing,
     (appendStyle, value) => {
       appendStyle(styles, {
-        [`--Grid-columnSpacing${ownerState.level || ''}`]:
+        [`--Grid-columnSpacing${appendLevel(ownerState.level)}`]:
           typeof value === 'string' ? value : theme.spacing?.(value),
       });
     },

--- a/packages/mui-system/src/Unstable_Grid/gridGenerator.ts
+++ b/packages/mui-system/src/Unstable_Grid/gridGenerator.ts
@@ -31,6 +31,13 @@ function createGetParentSpacing(ownerState: Props['ownerState']) {
   };
 }
 
+function getParentColumns(ownerState: Props['ownerState']) {
+  if (ownerState.level === 0) {
+    return `var(--Grid-columns)`;
+  }
+  return `var(--Grid-columns${ownerState.level - 1 || ''})`;
+}
+
 export const filterBreakpointKeys = (breakpointsKeys: Breakpoint[], responsiveKeys: string[]) =>
   breakpointsKeys.filter((key: string) => responsiveKeys.includes(key));
 
@@ -112,7 +119,7 @@ export const generateGridSizeStyles = ({ theme, ownerState }: Props) => {
         style = {
           flexGrow: 0,
           flexBasis: 'auto',
-          width: `calc(100% * ${value} / var(--Grid-columns)${
+          width: `calc(100% * ${value} / ${getParentColumns(ownerState)}${
             isNestedContainer(ownerState) ? ` + ${getSelfSpacing('column')}` : ''
           })`,
         };
@@ -137,7 +144,8 @@ export const generateGridOffsetStyles = ({ theme, ownerState }: Props) => {
       }
       if (typeof value === 'number') {
         style = {
-          marginLeft: value === 0 ? '0px' : `calc(100% * ${value} / var(--Grid-columns))`,
+          marginLeft:
+            value === 0 ? '0px' : `calc(100% * ${value} / ${getParentColumns(ownerState)})`,
         };
       }
       appendStyle(styles, style);
@@ -150,9 +158,11 @@ export const generateGridColumnsStyles = ({ theme, ownerState }: Props) => {
   if (!ownerState.container) {
     return {};
   }
-  const styles = { '--Grid-columns': 12 };
+  const styles = isNestedContainer(ownerState)
+    ? { [`--Grid-columns${ownerState.level || ''}`]: getParentColumns(ownerState) }
+    : { '--Grid-columns': 12 };
   traverseBreakpoints<number>(theme.breakpoints, ownerState.columns, (appendStyle, value) => {
-    appendStyle(styles, { '--Grid-columns': value });
+    appendStyle(styles, { [`--Grid-columns${ownerState.level || ''}`]: value });
   });
   return styles;
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #36335

**Before**:

The nested grid container does not get the `--Grid-columns` value from its parent because it is overridden by its own variable. The fix is similar to how nested spacing works.

https://stackblitz.com/edit/react-6xxqec?file=demo.tsx

<img width="445" alt="image" src="https://user-images.githubusercontent.com/18292247/222627281-37382bff-d863-431b-adb5-0c24108bd814.png">

**After**

https://codesandbox.io/s/material-cra-ts-forked-55ep57?file=/src/App.tsx

<img width="546" alt="image" src="https://user-images.githubusercontent.com/18292247/222629999-61873d78-b188-4834-ad30-675f098b2d5a.png">


---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
