### PR TITLE
[styled-engine][styled-engine-sc] Add support for tagged template styles with tags

### DIFF
--- a/packages/mui-styled-engine-sc/src/index.js
+++ b/packages/mui-styled-engine-sc/src/index.js
@@ -36,6 +36,10 @@ export default function styled(tag, options) {
   return stylesFactory;
 }
 
+Object.keys(scStyled).forEach((tag) => {
+  styled[tag] = scStyled[tag];
+});
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const internal_processStyles = (tag, processor) => {
   // Styled-components attaches an instance to `componentStyle`.

--- a/packages/mui-styled-engine-sc/src/styled.test.js
+++ b/packages/mui-styled-engine-sc/src/styled.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import scStyled from 'styled-components';
 import { createRenderer } from 'test/utils';
 import styled from '@mui/styled-engine-sc';
 
@@ -37,6 +38,10 @@ describe('styled', () => {
 
   it("should not allow styled-components's APIs: .attrs", () => {
     expect(typeof styled('span').attrs).to.equal('undefined');
+  });
+
+  it('has primitive', () => {
+    expect(styled.div).to.equal(scStyled.div);
   });
 
   // The babel-plugin-styled-components depends on the withConfig option to be defined

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as CSS from 'csstype';
-import { StyledComponent, StyledOptions, StyledTags } from '@emotion/styled';
+import { StyledComponent, StyledOptions, StyledTags as EmotionStyledTags } from '@emotion/styled';
 import { PropsOf } from '@emotion/react';
 
 export * from '@emotion/styled';
@@ -106,7 +106,7 @@ export interface CreateStyledComponent<
   SpecificComponentProps extends {} = {},
   JSXProps extends {} = {},
   T extends object = {},
-> extends StyledTags {
+> {
   (
     ...styles: Array<Interpolation<ComponentProps & SpecificComponentProps & { theme: T }>>
   ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;
@@ -136,11 +136,21 @@ export interface CreateStyledComponent<
   ): StyledComponent<ComponentProps & AdditionalProps, SpecificComponentProps, JSXProps>;
 }
 
+export type StyledTags<Theme> = {
+  [Tag in keyof JSX.IntrinsicElements]: CreateStyledComponent<
+    {
+      theme?: Theme;
+      as?: React.ElementType;
+    },
+    JSX.IntrinsicElements[Tag]
+  >;
+};
+
 export interface CreateMUIStyled<
   MUIStyledCommonProps extends {},
   MuiStyledOptions,
   Theme extends object,
-> {
+> extends StyledTags<Theme> {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
     ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -1,5 +1,5 @@
 import * as CSS from 'csstype';
-import { StyledComponent, StyledOptions } from '@emotion/styled';
+import { StyledComponent, StyledOptions, StyledTags } from '@emotion/styled';
 import { PropsOf } from '@emotion/react';
 
 export * from '@emotion/styled';
@@ -106,7 +106,7 @@ export interface CreateStyledComponent<
   SpecificComponentProps extends {} = {},
   JSXProps extends {} = {},
   T extends object = {},
-> {
+> extends StyledTags {
   (
     ...styles: Array<Interpolation<ComponentProps & SpecificComponentProps & { theme: T }>>
   ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>;

--- a/packages/mui-styled-engine/src/index.js
+++ b/packages/mui-styled-engine/src/index.js
@@ -26,6 +26,10 @@ export default function styled(tag, options) {
   return stylesFactory;
 }
 
+Object.keys(emStyled).forEach((tag) => {
+  styled[tag] = emStyled[tag];
+});
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const internal_processStyles = (tag, processor) => {
   // Emotion attaches all the styles as `__emotion_styles`.

--- a/packages/mui-styled-engine/src/styled.test.js
+++ b/packages/mui-styled-engine/src/styled.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import emStyled from '@emotion/styled';
 import styled from './index';
 
 describe('styled', () => {
@@ -10,5 +11,9 @@ describe('styled', () => {
     expect(() => {
       styled('span')(undefined, { color: 'red' });
     }).toErrorDev('MUI: the styled("span")(...args) API requires all its args to be defined');
+  });
+
+  it('has primitive', () => {
+    expect(styled.div).to.equal(emStyled.div);
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR implements the changes that @mnajdova shared in [this comment](https://github.com/mui/material-ui/issues/28574#issuecomment-938568571). It should fix #28574.

This should provide the ability to use HTML tags as accessors on `styled` for both styled engines when writing tagged template string styles:

```tsx
import { styled } from "@mui/material";

export const Example = styled.aside`
  color: red;
`;
```


### Background

Both Styled Components and Emotion Styled docs use HTML tag accessors with tagged template strings as the default usage pattern. 

#### Styled Components Homepage

<img width="681" alt="Screenshot 2023-03-03 at 3 49 56 PM" src="https://user-images.githubusercontent.com/7614039/222856385-9a1cb277-188d-426d-ad47-a65dda6c9479.png">

https://styled-components.com

#### Emotion Styled Components Docs

<img width="876" alt="Screenshot 2023-03-03 at 3 48 56 PM" src="https://user-images.githubusercontent.com/7614039/222856332-ed13d99c-cfd2-4b27-bdd9-c81731d8a22b.png">


https://emotion.sh/docs/styled#styling-elements-and-components