### PR TITLE
Revert "Bump rimraf to ^4.1.3"

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -111,7 +111,7 @@
     "react-virtuoso": "^4.1.0",
     "react-window": "^1.8.8",
     "recharts": "2.4.3",
-    "rimraf": "^4.1.3",
+    "rimraf": "^3.0.2",
     "styled-components": "^5.3.6",
     "stylis": "^4.1.3",
     "stylis-plugin-rtl": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "react-router-dom": "^6.8.1",
     "react-test-renderer": "^18.2.0",
     "remark": "^13.0.0",
-    "rimraf": "^4.1.3",
+    "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/packages/typescript-to-proptypes/package.json
+++ b/packages/typescript-to-proptypes/package.json
@@ -30,7 +30,7 @@
     "@types/uuid": "^8.3.4",
     "fast-glob": "^3.2.12",
     "prettier": "^2.8.4",
-    "rimraf": "^4.1.3"
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "@babel/core": "^7.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13738,11 +13738,6 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.1.3.tgz#e8ace19d5f009b4fa6108deeaffe39ef68bba194"
-  integrity sha512-iyzalDLo3l5FZxxaIGUY7xI4Bf90Xt7pCipc1Mr7RsdU7H3538z+M0tlsUDrz0aHeGS9uNqiKHUJyTewwRP91Q==
-
 rimraf@~2.5.2:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"


### PR DESCRIPTION
Reverts mui/material-ui#36350 It breaks the `yarn docs:api` on Windows. 