### PR TITLE
[docs] Add multiline Chip example

### DIFF
--- a/docs/data/material/components/chips/MultilineChips.js
+++ b/docs/data/material/components/chips/MultilineChips.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+
+const longText = 'This is a chip that has multiple lines';
+
+const chipStyles = { height: 'auto' };
+
+const labelStyles = {
+  whiteSpace: 'normal',
+  display: 'block',
+};
+
+export default function MultilineChips() {
+  return (
+    <Box width={100}>
+      <Chip sx={chipStyles} label={<span style={labelStyles}>{longText}</span>} />
+    </Box>
+  );
+}

--- a/docs/data/material/components/chips/MultilineChips.js
+++ b/docs/data/material/components/chips/MultilineChips.js
@@ -2,19 +2,19 @@ import * as React from 'react';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
 
-const longText = 'This is a chip that has multiple lines';
-
-const chipStyles = { height: 'auto' };
-
-const labelStyles = {
-  whiteSpace: 'normal',
-  display: 'block',
-};
-
 export default function MultilineChips() {
   return (
     <Box width={100}>
-      <Chip sx={chipStyles} label={<span style={labelStyles}>{longText}</span>} />
+      <Chip
+        sx={{
+          height: 'auto',
+          '& .MuiChip-label': {
+            display: 'block',
+            whiteSpace: 'normal',
+          },
+        }}
+        label="This is a chip that has multiple lines."
+      />
     </Box>
   );
 }

--- a/docs/data/material/components/chips/MultilineChips.tsx
+++ b/docs/data/material/components/chips/MultilineChips.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
+
+const longText = 'This is a chip that has multiple lines';
+
+const chipStyles = { height: 'auto' };
+
+const labelStyles = {
+  whiteSpace: 'normal',
+  display: 'block',
+};
+
+export default function MultilineChips() {
+  return (
+    <Box width={100}>
+      <Chip sx={chipStyles} label={<span style={labelStyles}>{longText}</span>} />
+    </Box>
+  );
+}

--- a/docs/data/material/components/chips/MultilineChips.tsx
+++ b/docs/data/material/components/chips/MultilineChips.tsx
@@ -2,19 +2,19 @@ import * as React from 'react';
 import Chip from '@mui/material/Chip';
 import Box from '@mui/material/Box';
 
-const longText = 'This is a chip that has multiple lines';
-
-const chipStyles = { height: 'auto' };
-
-const labelStyles = {
-  whiteSpace: 'normal',
-  display: 'block',
-};
-
 export default function MultilineChips() {
   return (
     <Box width={100}>
-      <Chip sx={chipStyles} label={<span style={labelStyles}>{longText}</span>} />
+      <Chip
+        sx={{
+          height: 'auto',
+          '& .MuiChip-label': {
+            display: 'block',
+            whiteSpace: 'normal',
+          },
+        }}
+        label="This is a chip that has multiple lines."
+      />
     </Box>
   );
 }

--- a/docs/data/material/components/chips/MultilineChips.tsx.preview
+++ b/docs/data/material/components/chips/MultilineChips.tsx.preview
@@ -1,0 +1,10 @@
+<Chip
+  sx={{
+    height: 'auto',
+    '& .MuiChip-label': {
+      display: 'block',
+      whiteSpace: 'normal',
+    },
+  }}
+  label="This is a chip that has multiple lines."
+/>

--- a/docs/data/material/components/chips/chips.md
+++ b/docs/data/material/components/chips/chips.md
@@ -77,6 +77,12 @@ You can use the `size` prop to define a small Chip.
 
 {{"demo": "SizesChips.js"}}
 
+## Multiline chip
+
+By default, `Chip` just displays labels in single line. To use multiline chips you can add `height: 'auto'` to the Chip component and `whiteSpace: 'normal'` to the `label` styles.
+
+{{"demo": "MultilineChips.js"}}
+
 ## Chip array
 
 An example of rendering multiple chips from an array of values.

--- a/docs/data/material/components/chips/chips.md
+++ b/docs/data/material/components/chips/chips.md
@@ -80,7 +80,7 @@ You can use the `size` prop to define a small Chip.
 ## Multiline chip
 
 By default, Chips displays labels only in a single line.
-To have them support multiline content, add `height:auto` to the Chip component, and `whiteSpace: normal` to the `label` styles.
+To have them support multiline content, use the `sx` prop to add `height:auto` to the Chip component, and `whiteSpace: normal` to the `label` styles.
 
 {{"demo": "MultilineChips.js"}}
 

--- a/docs/data/material/components/chips/chips.md
+++ b/docs/data/material/components/chips/chips.md
@@ -79,7 +79,8 @@ You can use the `size` prop to define a small Chip.
 
 ## Multiline chip
 
-By default, `Chip` just displays labels in single line. To use multiline chips you can add `height: 'auto'` to the Chip component and `whiteSpace: 'normal'` to the `label` styles.
+By default, Chips displays labels only in a single line.
+To have them support multiline content, add `height:auto` to the Chip component, and `whiteSpace: normal` to the `label` styles.
 
 {{"demo": "MultilineChips.js"}}
 

--- a/docs/data/material/components/chips/chips.md
+++ b/docs/data/material/components/chips/chips.md
@@ -91,7 +91,7 @@ Deleting a chip removes it from the array. Note that since no
 `onClick` prop is defined, the `Chip` can be focused, but does not
 gain depth while clicked or touched.
 
-{{"demo": "ChipsArray.js", "bg": true}}
+{{"demo": "ChipsArray.js"}}
 
 ## Chip playground
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This adds a basic example on the docs regarding multilined chips. 

It's a known issue regarding `Autocomplete`  (#15185) and generic `Chip` (#14864). 

https://stackoverflow.com/questions/61385380/material-ui-autocomplete-chip-multiline.

Alternative solutions are:
- `Chip` component should export `labelProps`, like `labelProps`.
- Multiline chips should be the default behaviour. 
