### PR TITLE
[FocusTrap] Prevent restoring focus while opening a dialog/modal

### DIFF
--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -193,7 +193,7 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
 
     return () => {
       // restoreLastFocus()
-      if (!disableRestoreFocus) {
+      if (!disableRestoreFocus && open) {
         // In IE11 it is possible for document.activeElement to be null resulting
         // in nodeToRestore.current being null.
         // Not all elements in IE11 have a focus method.


### PR DESCRIPTION
In strict mode with the dev react build, FocusTrap is mounted twice. The unmount between the two mounts triggers restoring focus. My initial idea for the fix was before I understood exactly what was happening. My initial commit didn't help.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
