### PR TITLE
[useMenu] fixes a bug that highlighted value was forcefully set on almost every action

### DIFF
--- a/packages/mui-base/src/useMenu/useMenu.ts
+++ b/packages/mui-base/src/useMenu/useMenu.ts
@@ -31,7 +31,7 @@ function stateReducer(
   const newState = defaultListboxReducer(state, action);
 
   if (
-    action.type !== ActionTypes.setHighlight &&
+    action.type === ActionTypes.setHighlight &&
     newState.highlightedValue === null &&
     action.props.options.length > 0
   ) {


### PR DESCRIPTION
The highlighted value should be set only when the action is `setHightlight` and no value was selected after applying the default reducer, not vice versa on every other action

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
