### PR TITLE
[Joy] Ensure new CSS variable naming is everywhere

### DIFF
--- a/docs/data/joy/components/list/list.md
+++ b/docs/data/joy/components/list/list.md
@@ -62,7 +62,7 @@ To learn how to add more sizes to the component, check out [Themed components—
 
 Use the `ListItemDecorator` component to add supporting icons or elements to the list item.
 
-It comes with a minimum set width that you can adjust via the `--List-decorator-size` CSS variable within the `List` component.
+It comes with a minimum set width that you can adjust via the `--List-decoratorSize` CSS variable within the `List` component.
 
 {{"demo": "DecoratedList.js"}}
 
@@ -102,7 +102,7 @@ It works by default on both light and dark modes.
 Use the `nested` prop, within the `ListItem` component, to create a nested list.
 Note that layout and spacing of the nested list remain intact, as if it isn't nested.
 
-The nested list inherits the list `size` and a few other CSS variables, such as `--List-radius` and `--List-item-radius` from the root `List` component to adjust the design consistently.
+The nested list inherits the list `size` and a few other CSS variables, such as `--List-radius` and `--ListItem-radius` from the root `List` component to adjust the design consistently.
 
 {{"demo": "NestedList.js"}}
 

--- a/docs/data/joy/components/list/list.md
+++ b/docs/data/joy/components/list/list.md
@@ -62,7 +62,7 @@ To learn how to add more sizes to the component, check out [Themed components—
 
 Use the `ListItemDecorator` component to add supporting icons or elements to the list item.
 
-It comes with a minimum set width that you can adjust via the `--List-decoratorSize` CSS variable within the `List` component.
+It comes with a minimum set width that you can adjust via the `--ListItemDecorator-size` CSS variable within the `List` component.
 
 {{"demo": "DecoratedList.js"}}
 

--- a/docs/data/joy/components/radio/radio.md
+++ b/docs/data/joy/components/radio/radio.md
@@ -91,7 +91,7 @@ You can also use it directly in the `RadioGroup` component as it will automatica
 {{"demo": "OverlayRadio.js"}}
 
 :::info
-Use the CSS variable `--Radio-action-radius` to control the border radius of the clickable area.
+Use the CSS variable `--Radio-actionRadius` to control the border radius of the clickable area.
 :::
 
 ### Icon

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.js
@@ -77,7 +77,10 @@ export default function transformer(file) {
       .replace(
         /--([a-zA-Z]+)([-_])([a-zA-Z]+)-([a-zA-Z]+)/gm,
         (matched, capture1, capture2, capture3, capture4) => {
-          if (!JoyComponents.includes(capture1) && !['internal', 'unstable'].includes(capture1)) {
+          if (
+            !JoyComponents.includes(capture1) &&
+            !['internal', 'unstable', 'private'].includes(capture1)
+          ) {
             return matched;
           }
           // turn `--List-item-...` and `--List-divider-...` to `--ListItem-...` and `--ListDivider-...`
@@ -89,5 +92,7 @@ export default function transformer(file) {
       )
       // from `--internal-...` to `--unstable_...`
       .replace(/--internal-/gm, '--unstable_')
+      // from `--private_...` to `--unstable_...`
+      .replace(/--private_/gm, '--unstable_')
   );
 }

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/actual.js
@@ -9,5 +9,6 @@
   <Autocomplete sx={{ '--Autocomplete-wrapperGap': '10px' }} />
   <Switch sx={{ '--Switch-trackWidth': '40px' }} />
   <Item sx={{ py: 'var(--internal-action-radius)' }} />
+  <Item sx={{ py: 'var(--private_action-radius)' }} />
   <Item sx={{ py: 'var(--unstable_action-radius)' }} />
 </div>;

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/expected.js
@@ -10,4 +10,5 @@
   <Switch sx={{ '--Switch-trackWidth': '40px' }} />
   <Item sx={{ py: 'var(--unstable_actionRadius)' }} />
   <Item sx={{ py: 'var(--unstable_actionRadius)' }} />
+  <Item sx={{ py: 'var(--unstable_actionRadius)' }} />
 </div>;

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -75,10 +75,10 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
       // only apply size variables if instanceSize is provided so that the variables can be pass down to children by default.
       ...applySizeVars(ownerState.instanceSize),
       '--ListItem-paddingRight': 'var(--ListItem-paddingX)',
-      '--ListItem-paddingLeft': 'var(--NestedList-item-paddingLeft)',
+      '--ListItem-paddingLeft': 'var(--NestedListItem-paddingLeft)',
       // reset ListItem, ListItemButton negative margin (caused by NestedListItem)
-      '--List-itemButtonMarginBlock': '0px',
-      '--List-itemButtonMarginInline': '0px',
+      '--ListItemButton-marginBlock': '0px',
+      '--ListItemButton-marginInline': '0px',
       '--ListItem-marginBlock': '0px',
       '--ListItem-marginInline': '0px',
       padding: 0,

--- a/packages/mui-joy/src/List/ListProvider.tsx
+++ b/packages/mui-joy/src/List/ListProvider.tsx
@@ -18,10 +18,10 @@ import NestedListContext from './NestedListContext';
 export const scopedVariables = {
   '--NestedList-marginRight': '0px',
   '--NestedList-marginLeft': '0px',
-  '--NestedList-item-paddingLeft': 'var(--ListItem-paddingX)',
+  '--NestedListItem-paddingLeft': 'var(--ListItem-paddingX)',
   // reset ListItem, ListItemButton negative margin (caused by NestedListItem)
-  '--List-itemButtonMarginBlock': '0px',
-  '--List-itemButtonMarginInline': '0px',
+  '--ListItemButton-marginBlock': '0px',
+  '--ListItemButton-marginInline': '0px',
   '--ListItem-marginBlock': '0px',
   '--ListItem-marginInline': '0px',
 };

--- a/packages/mui-joy/src/ListItem/ListItem.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.tsx
@@ -44,8 +44,8 @@ const ListItemRoot = styled('li', {
 })<{ ownerState: ListItemOwnerState }>(({ theme, ownerState }) => [
   !ownerState.nested && {
     // add negative margin to ListItemButton equal to this ListItem padding
-    '--List-itemButtonMarginInline': `calc(-1 * var(--ListItem-paddingLeft)) calc(-1 * var(--ListItem-paddingRight))`,
-    '--List-itemButtonMarginBlock': 'calc(-1 * var(--ListItem-paddingY))',
+    '--ListItemButton-marginInline': `calc(-1 * var(--ListItem-paddingLeft)) calc(-1 * var(--ListItem-paddingRight))`,
+    '--ListItemButton-marginBlock': 'calc(-1 * var(--ListItem-paddingY))',
     alignItems: 'center',
     marginInline: 'var(--ListItem-marginInline)',
   },
@@ -53,10 +53,10 @@ const ListItemRoot = styled('li', {
     // add negative margin to NestedList equal to this ListItem padding
     '--NestedList-marginRight': 'calc(-1 * var(--ListItem-paddingRight))',
     '--NestedList-marginLeft': 'calc(-1 * var(--ListItem-paddingLeft))',
-    '--NestedList-item-paddingLeft': `calc(var(--ListItem-paddingLeft) + var(--List-nestedInsetStart))`,
+    '--NestedListItem-paddingLeft': `calc(var(--ListItem-paddingLeft) + var(--List-nestedInsetStart))`,
     // add negative margin to ListItem, ListItemButton to make them start from the edge.
-    '--List-itemButtonMarginBlock': '0px',
-    '--List-itemButtonMarginInline':
+    '--ListItemButton-marginBlock': '0px',
+    '--ListItemButton-marginInline':
       'calc(-1 * var(--ListItem-paddingLeft)) calc(-1 * var(--ListItem-paddingRight))',
     '--ListItem-marginInline':
       'calc(-1 * var(--ListItem-paddingLeft)) calc(-1 * var(--ListItem-paddingRight))',

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -59,8 +59,8 @@ export const StyledListItemButton = styled('div')<{ ownerState: ListItemButtonOw
       backgroundColor: 'initial', // reset button background
       cursor: 'pointer',
       // In some cases, ListItemButton is a child of ListItem so the margin needs to be controlled by the ListItem. The value is negative to account for the ListItem's padding
-      marginInline: 'var(--List-itemButtonMarginInline)',
-      marginBlock: 'var(--List-itemButtonMarginBlock)',
+      marginInline: 'var(--ListItemButton-marginInline)',
+      marginBlock: 'var(--ListItemButton-marginBlock)',
       ...(ownerState['data-first-child'] === undefined && {
         marginInlineStart: ownerState.row ? 'var(--List-gap)' : undefined,
         marginBlockStart: ownerState.row ? undefined : 'var(--List-gap)',

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -96,17 +96,17 @@ const ModalDialogRoot = styled(SheetRoot, {
     '--Typography-margin': 'calc(-1 * var(--ModalDialog-titleOffset)) 0 var(--ModalDialog-gap) 0',
     '--Typography-fontSize': '1.125em',
     [`& + [id="${ownerState['aria-describedby']}"]`]: {
-      '--private_ModalDialog-descriptionOffset': 'calc(-1 * var(--ModalDialog-descriptionOffset))',
+      '--unstable_ModalDialog-descriptionOffset': 'calc(-1 * var(--ModalDialog-descriptionOffset))',
     },
   },
   [`& [id="${ownerState['aria-describedby']}"]`]: {
     '--Typography-fontSize': '1em',
     '--Typography-margin':
-      'var(--private_ModalDialog-descriptionOffset, var(--ModalDialog-gap)) 0 0 0',
+      'var(--unstable_ModalDialog-descriptionOffset, var(--ModalDialog-gap)) 0 0 0',
     '&:not(:last-child)': {
       // create spacing between description and the next element.
       '--Typography-margin':
-        'var(--private_ModalDialog-descriptionOffset, var(--ModalDialog-gap)) 0 var(--ModalDialog-gap) 0',
+        'var(--unstable_ModalDialog-descriptionOffset, var(--ModalDialog-gap)) 0 var(--ModalDialog-gap) 0',
     },
   },
 }));

--- a/packages/mui-joy/src/Slider/Slider.spec.tsx
+++ b/packages/mui-joy/src/Slider/Slider.spec.tsx
@@ -26,10 +26,10 @@ import Slider, { SliderOwnerState } from '@mui/joy/Slider';
 
 <Slider
   sx={{
-    '--joy-Slider-track-radius': '8px',
-    '--joy-Slider-track-width': '48px',
-    '--joy-Slider-track-height': '24px',
-    '--joy-Slider-thumb-size': '16px',
+    '--joy-Slider-trackRadius': '8px',
+    '--joy-Slider-trackWidth': '48px',
+    '--joy-Slider-trackHeight': '24px',
+    '--joy-Slider-thumbSize': '16px',
   }}
 />;
 

--- a/packages/mui-joy/src/Switch/Switch.spec.tsx
+++ b/packages/mui-joy/src/Switch/Switch.spec.tsx
@@ -38,10 +38,10 @@ import { expectType } from '@mui/types';
 
 <Switch
   sx={{
-    '--joy-Switch-track-radius': '8px',
-    '--joy-Switch-track-width': '48px',
-    '--joy-Switch-track-height': '24px',
-    '--joy-Switch-thumb-size': '16px',
+    '--joy-Switch-trackRadius': '8px',
+    '--joy-Switch-trackWidth': '48px',
+    '--joy-Switch-trackHeight': '24px',
+    '--joy-Switch-thumbSize': '16px',
   }}
 />;
 

--- a/packages/mui-joy/src/Table/Table.tsx
+++ b/packages/mui-joy/src/Table/Table.tsx
@@ -115,19 +115,19 @@ const TableRoot = styled('table', {
       '--TableCell-borderColor': variantStyle?.borderColor ?? theme.vars.palette.divider,
       '--TableCell-headBackground': `var(--Sheet-background, ${theme.vars.palette.background.surface})`,
       ...(ownerState.size === 'sm' && {
-        '--private_TableCell-height': 'var(--TableCell-height, 32px)',
+        '--unstable_TableCell-height': 'var(--TableCell-height, 32px)',
         '--TableCell-paddingX': '0.25rem',
         '--TableCell-paddingY': '0.25rem',
         fontSize: theme.vars.fontSize.xs,
       }),
       ...(ownerState.size === 'md' && {
-        '--private_TableCell-height': 'var(--TableCell-height, 40px)',
+        '--unstable_TableCell-height': 'var(--TableCell-height, 40px)',
         '--TableCell-paddingX': '0.5rem',
         '--TableCell-paddingY': '0.375rem',
         fontSize: theme.vars.fontSize.sm,
       }),
       ...(ownerState.size === 'lg' && {
-        '--private_TableCell-height': 'var(--TableCell-height, 48px)',
+        '--unstable_TableCell-height': 'var(--TableCell-height, 48px)',
         '--TableCell-paddingX': '0.75rem',
         '--TableCell-paddingY': '0.5rem',
         fontSize: theme.vars.fontSize.md,
@@ -144,7 +144,7 @@ const TableRoot = styled('table', {
       },
       [tableSelector.getDataCell()]: {
         padding: 'var(--TableCell-paddingY) var(--TableCell-paddingX)',
-        height: 'var(--private_TableCell-height)',
+        height: 'var(--unstable_TableCell-height)',
         borderColor: 'var(--TableCell-borderColor)', // must come after border bottom
         backgroundColor: 'var(--TableCell-dataBackground)', // use `background-color` in case the Sheet has gradient background
         ...(ownerState.noWrap && {
@@ -157,7 +157,7 @@ const TableRoot = styled('table', {
         textAlign: 'left',
         padding: 'var(--TableCell-paddingY) var(--TableCell-paddingX)',
         backgroundColor: 'var(--TableCell-headBackground)', // use `background-color` in case the Sheet has gradient background
-        height: 'var(--private_TableCell-height)',
+        height: 'var(--unstable_TableCell-height)',
         fontWeight: theme.vars.fontWeight.lg,
         borderColor: 'var(--TableCell-borderColor)',
         color: theme.vars.palette.text.secondary,
@@ -263,7 +263,7 @@ const TableRoot = styled('table', {
       },
       [tableSelector.getHeaderCellOfRow(2)]: {
         // support upto 2 rows for the sticky header
-        top: 'var(--private_TableCell-height)',
+        top: 'var(--unstable_TableCell-height)',
       },
     },
   ];

--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -131,7 +131,7 @@ const TooltipArrow = styled('span', {
 })<{ ownerState: TooltipOwnerState }>(({ theme, ownerState }) => {
   const variantStyle = theme.variants[ownerState.variant!]?.[ownerState.color!];
   return {
-    '--unstable_TooltipArrow-rotation': 0,
+    '--unstable_Tooltip-arrowRotation': 0,
     width: 'var(--Tooltip-arrowSize)',
     height: 'var(--Tooltip-arrowSize)',
     boxSizing: 'border-box',
@@ -150,21 +150,21 @@ const TooltipArrow = styled('span', {
       borderRadius: `0px 2px 0px 0px`,
       boxShadow: `var(--variant-borderWidth, 0px) calc(-1 * var(--variant-borderWidth, 0px)) 0px 0px ${variantStyle.borderColor}`,
       transformOrigin: 'center center',
-      transform: 'rotate(calc(-45deg + 90deg * var(--unstable_TooltipArrow-rotation)))',
+      transform: 'rotate(calc(-45deg + 90deg * var(--unstable_Tooltip-arrowRotation)))',
     },
     '[data-popper-placement*="bottom"] &': {
       top: 'calc(0.5px + var(--Tooltip-arrowSize) * -1 / 2)', // 0.5px is for perfect overlap with the Tooltip
     },
     '[data-popper-placement*="top"] &': {
-      '--unstable_TooltipArrow-rotation': 2,
+      '--unstable_Tooltip-arrowRotation': 2,
       bottom: 'calc(0.5px + var(--Tooltip-arrowSize) * -1 / 2)',
     },
     '[data-popper-placement*="left"] &': {
-      '--unstable_TooltipArrow-rotation': 1,
+      '--unstable_Tooltip-arrowRotation': 1,
       right: 'calc(0.5px + var(--Tooltip-arrowSize) * -1 / 2)',
     },
     '[data-popper-placement*="right"] &': {
-      '--unstable_TooltipArrow-rotation': 3,
+      '--unstable_Tooltip-arrowRotation': 3,
       left: 'calc(0.5px + var(--Tooltip-arrowSize) * -1 / 2)',
     },
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow-up on #36282 

**This PR fixes**
- Replace `--private_...` with `--unstable_...`
- `--List-itemButtonMargin...` to `--ListItemButton-margin....`
- `--TooltipArrow-...` to `--Tooltip-arrow...`

**This PR adds**
- improvements to `rename-css-variables` Codemod script and its tests
