### PR TITLE
[docs][joy] Error in the exemplary Codesandbox of using Material UI and Joy UI together

### DIFF
--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -24,10 +24,10 @@ For this case, the Material UI theme should override the Joy UI's.
 
 ```js
 import { deepmerge } from '@mui/utils';
+import { unstable_createCssVarsTheme as createCssVarsTheme } from '@mui/system';
 import {
   Experimental_CssVarsProvider as CssVarsProvider,
   experimental_extendTheme as extendMuiTheme,
-  shouldSkipGeneratingVar as muiShouldSkipGeneratingVar,
 } from '@mui/material/styles';
 import {
   extendTheme as extendJoyTheme,
@@ -81,6 +81,7 @@ const { unstable_sxConfig: joySxConfig, ...joyTheme } = extendTheme({
     lg: `var(--mui-shadowRing), ${muiTheme.shadows[8]}`,
     xl: `var(--mui-shadowRing), ${muiTheme.shadows[12]}`,
   },
+  shouldSkipGeneratingVar: (keys) => joyShouldSkipGeneratingVar(keys),
 });
 
 // Note: you can't put `joyTheme` inside Material UI's `extendMuiTheme(joyTheme)`
@@ -102,10 +103,7 @@ mergedTheme.unstable_sxConfig = {
 export default function App() {
   return (
     <CssVarsProvider
-      theme={mergedTheme}
-      shouldSkipGeneratingVar={(keys) =>
-        muiShouldSkipGeneratingVar(keys) || joyShouldSkipGeneratingVar(keys)
-      }
+      theme={createCssVarsTheme(mergedTheme)}
     >
       ...Material UI and Joy UI components
     </CssVarsProvider>
@@ -117,7 +115,7 @@ export default function App() {
 
 Visit the following CodeSandbox to preview this use case setup.
 
-[![Edit Joy UI in a Material UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/material-ui-feat-joy-ui-vvvv59?file=/demo.tsx)
+[![Edit Joy UI in a Material UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/material-ui-feat-joy-ui-1jkvm9?file=/demo.tsx)
 
 ## Case B: Material UI in a Joy UI project
 
@@ -125,9 +123,9 @@ This setup uses the `CssVarsProvider` component from Joy UI and configures the M
 
 ```js
 import { deepmerge } from '@mui/utils';
+import { unstable_createCssVarsTheme as createCssVarsTheme } from '@mui/system';
 import {
   experimental_extendTheme as extendMuiTheme,
-  shouldSkipGeneratingVar as muiShouldSkipGeneratingVar,
 } from '@mui/material/styles';
 import colors from '@mui/joy/colors';
 import {
@@ -202,7 +200,9 @@ const { unstable_sxConfig: muiSxConfig, ...muiTheme } = extendMuiTheme({
   },
 });
 
-const { unstable_sxConfig: joySxConfig, ...joyTheme} = extendJoyTheme();
+const { unstable_sxConfig: joySxConfig, ...joyTheme } = extendJoyTheme({
+  shouldSkipGeneratingVar: (keys) => joyShouldSkipGeneratingVar(keys)
+});
 
 // You can use your own `deepmerge` function.
 // joyTheme will deeply merge to muiTheme.
@@ -218,10 +218,7 @@ mergedTheme.unstable_sxConfig = {
 export default function App() {
   return (
     <CssVarsProvider
-      theme={mergedTheme}
-      shouldSkipGeneratingVar={(keys) =>
-        muiShouldSkipGeneratingVar(keys) || joyShouldSkipGeneratingVar(keys)
-      }
+      theme={createCssVarsTheme(mergedTheme)}
     >
       ...Material UI and Joy UI components
     </CssVarsProvider>
@@ -233,7 +230,7 @@ export default function App() {
 
 Visit the following CodeSandbox to preview this use case setup.
 
-[![Edit Material UI in a Joy UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/joy-ui-feat-material-ui-k86j2j?file=/demo.tsx)
+[![Edit Material UI in a Joy UI project](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/joy-ui-feat-material-ui-zhcprk?file=/demo.tsx)
 
 ## TypeScript setup
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #36451

### Problem
- The Codesandboxes in https://mui.com/joy-ui/guides/using-joy-ui-and-material-ui-together/ broke after we released the changes introduced in #35739 

### Codesandboxes
- Before: (1) https://codesandbox.io/s/material-ui-feat-joy-ui-vvvv59?file=/demo.tsx and (2) https://codesandbox.io/s/joy-ui-feat-material-ui-k86j2j?file=/demo.tsx
- After: (1) https://codesandbox.io/s/material-ui-feat-joy-ui-1jkvm9?file=/demo.tsx and (2) https://codesandbox.io/s/joy-ui-feat-material-ui-zhcprk?file=/demo.tsx

### Preview
- https://deploy-preview-36462--material-ui.netlify.app/joy-ui/guides/using-joy-ui-and-material-ui-together/