### PR TITLE
[Tabs] Fix null reference in ScrollbarSize after unmounting

### DIFF
--- a/packages/mui-material/src/Tabs/ScrollbarSize.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.js
@@ -21,21 +21,22 @@ export default function ScrollbarSize(props) {
   const scrollbarHeight = React.useRef();
   const nodeRef = React.useRef(null);
 
-  const setMeasurements = () => {
-    scrollbarHeight.current = nodeRef.current.offsetHeight - nodeRef.current.clientHeight;
+  const setMeasurements = (element) => {
+    scrollbarHeight.current = element.offsetHeight - element.clientHeight;
   };
 
   React.useEffect(() => {
+    const element = nodeRef.current
     const handleResize = debounce(() => {
       const prevHeight = scrollbarHeight.current;
-      setMeasurements();
+      setMeasurements(element);
 
       if (prevHeight !== scrollbarHeight.current) {
         onChange(scrollbarHeight.current);
       }
     });
 
-    const containerWindow = ownerWindow(nodeRef.current);
+    const containerWindow = ownerWindow(element);
     containerWindow.addEventListener('resize', handleResize);
     return () => {
       handleResize.clear();

--- a/packages/mui-material/src/Tabs/ScrollbarSize.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import debounce from '../utils/debounce';
-import { ownerWindow } from '../utils';
+import { ownerWindow, unstable_useEnhancedEffect as useEnhancedEffect } from '../utils';
 
 const styles = {
   width: 99,
@@ -21,22 +21,21 @@ export default function ScrollbarSize(props) {
   const scrollbarHeight = React.useRef();
   const nodeRef = React.useRef(null);
 
-  const setMeasurements = (element) => {
-    scrollbarHeight.current = element.offsetHeight - element.clientHeight;
+  const setMeasurements = () => {
+    scrollbarHeight.current = nodeRef.current.offsetHeight - nodeRef.current.clientHeight;
   };
 
-  React.useEffect(() => {
-    const element = nodeRef.current;
+  useEnhancedEffect(() => {
     const handleResize = debounce(() => {
       const prevHeight = scrollbarHeight.current;
-      setMeasurements(element);
+      setMeasurements();
 
       if (prevHeight !== scrollbarHeight.current) {
         onChange(scrollbarHeight.current);
       }
     });
 
-    const containerWindow = ownerWindow(element);
+    const containerWindow = ownerWindow(nodeRef.current);
     containerWindow.addEventListener('resize', handleResize);
     return () => {
       handleResize.clear();
@@ -45,7 +44,7 @@ export default function ScrollbarSize(props) {
   }, [onChange]);
 
   React.useEffect(() => {
-    setMeasurements(nodeRef.current);
+    setMeasurements();
     onChange(scrollbarHeight.current);
   }, [onChange]);
 

--- a/packages/mui-material/src/Tabs/ScrollbarSize.js
+++ b/packages/mui-material/src/Tabs/ScrollbarSize.js
@@ -26,7 +26,7 @@ export default function ScrollbarSize(props) {
   };
 
   React.useEffect(() => {
-    const element = nodeRef.current
+    const element = nodeRef.current;
     const handleResize = debounce(() => {
       const prevHeight = scrollbarHeight.current;
       setMeasurements(element);
@@ -45,7 +45,7 @@ export default function ScrollbarSize(props) {
   }, [onChange]);
 
   React.useEffect(() => {
-    setMeasurements();
+    setMeasurements(nodeRef.current);
     onChange(scrollbarHeight.current);
   }, [onChange]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [v] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #26587

As per https://reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing, timeout callback set by `debounce` can be called before effect cleanup, which can leads to calling `setMeasurements` with `nodeRef.current` unset.


