### PR TITLE
[docs] Info markdown not rendering in Contributing Guide README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,10 +321,10 @@ Copy this file and move it to the project directory you want to test in, then ru
 $test-project> npm i ./path-to-file/mui-material-x.x.x.tar.gz
 ```
 
-:::info
-If you have already installed this package, your changes will not be reflected when you reinstall it.
-As a quick fix, you can temporarily bump the version number in your `package.json` before running `yarn build`.
-:::
+> **Note**
+> 
+> If you have already installed this package, your changes will not be reflected when you reinstall it.
+> As a quick fix, you can temporarily bump the version number in your `package.json` before running `yarn build`.
 
 ## Translations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,7 +322,7 @@ $test-project> npm i ./path-to-file/mui-material-x.x.x.tar.gz
 ```
 
 > **Note**
-> 
+>
 > If you have already installed this package, your changes will not be reflected when you reinstall it.
 > As a quick fix, you can temporarily bump the version number in your `package.json` before running `yarn build`.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #36435

### Changes

**Before**
- [Link](https://github.com/mui/material-ui/blob/master/CONTRIBUTING.md#how-can-i-use-a-change-that-wasnt-released-yet)
<img width="1043" alt="Screenshot 2023-03-10 at 10 11 51" src="https://user-images.githubusercontent.com/32841130/224289269-fa27ec98-4887-4436-ac1e-247b05fb99d7.png">

**After**
- [Link](https://github.com/hbjORbj/material-ui/blob/docs/contributing-readme/CONTRIBUTING.md#how-can-i-use-a-change-that-wasnt-released-yet)
<img width="1051" alt="Screenshot 2023-03-10 at 10 11 32" src="https://user-images.githubusercontent.com/32841130/224289317-055bd0a3-2043-4c17-9f47-48bb1934ea48.png">

