### PR TITLE
Export `shouldSkipGeneratingVar` from Material UI

### DIFF
--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -121,7 +121,7 @@ export interface Theme extends ThemeScales, RuntimeColorSystem {
    *  then, keys = ['foo', 'bar']
    *        value = 'var(--test)'
    */
-  shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
+  shouldSkipGeneratingVar: (keys: string[], value: string | number) => boolean;
   unstable_sxConfig: SxConfig;
   unstable_sx: (props: SxProps) => CSSObject;
 }

--- a/packages/mui-material-next/src/styles/Theme.types.ts
+++ b/packages/mui-material-next/src/styles/Theme.types.ts
@@ -1,4 +1,4 @@
-import { SxProps as SystemSxProps, SxConfig, CSSObject } from '@mui/system';
+import { SxProps as SystemSxProps } from '@mui/system';
 import {
   CssVarsTheme as MD2Theme,
   SupportedColorScheme,
@@ -263,16 +263,6 @@ export interface Theme extends Omit<MD2Theme, 'vars'> {
     css: Record<string, string | number>;
     vars: Theme['vars'];
   };
-  /**
-   * A function to determine if the key, value should be attached as CSS Variable
-   * `keys` is an array that represents the object path keys.
-   *  Ex, if the theme is { foo: { bar: 'var(--test)' } }
-   *  then, keys = ['foo', 'bar']
-   *        value = 'var(--test)'
-   */
-  shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
-  unstable_sxConfig: SxConfig;
-  unstable_sx: (props: SystemSxProps<Theme>) => CSSObject;
 }
 
 export type SxProps = SystemSxProps<Theme>;

--- a/packages/mui-material-next/src/styles/extendTheme.ts
+++ b/packages/mui-material-next/src/styles/extendTheme.ts
@@ -28,6 +28,7 @@ import md3State from './state';
 import { elevationLight, elevationDark } from './elevation';
 import createMotions from './motion';
 import md3shape from './shape';
+import defaultShouldSkipGeneratingVar from './shouldSkipGeneratingVar';
 
 const defaultLightOverlays: Overlays = [...Array(25)].map(() => undefined) as Overlays;
 const defaultDarkOverlays: Overlays = [...Array(25)].map((_, index) => {
@@ -37,11 +38,6 @@ const defaultDarkOverlays: Overlays = [...Array(25)].map((_, index) => {
   const overlay = getOverlayAlpha(index);
   return `linear-gradient(rgba(255 255 255 / ${overlay}), rgba(255 255 255 / ${overlay}))`;
 }) as Overlays;
-
-export const defaultShouldSkipGeneratingVar = (keys: string[]) =>
-  !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
-  !!keys[0].match(/sxConfig$/) || // ends with sxConfig
-  (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/));
 
 function assignNode(obj: any, keys: string[]) {
   keys.forEach((k) => {

--- a/packages/mui-material-next/src/styles/index.ts
+++ b/packages/mui-material-next/src/styles/index.ts
@@ -3,4 +3,5 @@ export * from './extendTheme';
 export { default as extendTheme } from './extendTheme';
 export { default as styled } from './styled';
 export { default as defaultTheme } from './defaultTheme';
+export { default as shouldSkipGeneratingVar } from './shouldSkipGeneratingVar';
 export * from './CssVarsProvider';

--- a/packages/mui-material-next/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material-next/src/styles/shouldSkipGeneratingVar.ts
@@ -1,6 +1,6 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
   return (
-    !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
+    !!keys[0].match(/(cssVarPrefix|typography|mixins|breakpoints|direction|transitions)/) ||
     !!keys[0].match(/sxConfig$/) || // ends with sxConfig
     (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))
   );

--- a/packages/mui-material-next/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material-next/src/styles/shouldSkipGeneratingVar.ts
@@ -1,0 +1,7 @@
+export default function shouldSkipGeneratingVar(keys: string[]) {
+  return (
+    !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
+    !!keys[0].match(/sxConfig$/) || // ends with sxConfig
+    (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))
+  );
+}

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -421,7 +421,7 @@ export interface CssVarsTheme extends ColorSystem {
    *  then, keys = ['foo', 'bar']
    *        value = 'var(--test)'
    */
-  shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
+  shouldSkipGeneratingVar: (keys: string[], value: string | number) => boolean;
   unstable_sxConfig: SxConfig;
   unstable_sx: (props: SxProps<CssVarsTheme>) => CSSObject;
 }

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -400,7 +400,7 @@ export interface CssVarsTheme extends ColorSystem {
   vars: ThemeVars;
   getCssVar: (field: ThemeCssVar, ...vars: ThemeCssVar[]) => string;
   getColorSchemeSelector: (colorScheme: SupportedColorScheme) => string;
-  generateCssVars: (colorScheme?: string) => {
+  generateCssVars: (colorScheme?: SupportedColorScheme) => {
     css: Record<string, string | number>;
     vars: ThemeVars;
   };

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -400,6 +400,10 @@ export interface CssVarsTheme extends ColorSystem {
   vars: ThemeVars;
   getCssVar: (field: ThemeCssVar, ...vars: ThemeCssVar[]) => string;
   getColorSchemeSelector: (colorScheme: SupportedColorScheme) => string;
+  generateCssVars: (colorScheme?: string) => {
+    css: Record<string, string | number>;
+    vars: ThemeVars;
+  };
 
   // Default theme tokens
   spacing: Theme['spacing'];

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -10,6 +10,7 @@ import {
   unstable_styleFunctionSx as styleFunctionSx,
   unstable_prepareCssVars as prepareCssVars,
 } from '@mui/system';
+import defaultShouldSkipGeneratingVar from './shouldSkipGeneratingVar';
 import createThemeWithoutVars from './createTheme';
 import getOverlayAlpha from './getOverlayAlpha';
 
@@ -58,11 +59,6 @@ const silent = (fn) => {
 };
 
 export const createGetCssVar = (cssVarPrefix = 'mui') => systemCreateGetCssVar(cssVarPrefix);
-
-export const defaultShouldSkipGeneratingVar = (keys) =>
-  !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
-  !!keys[0].match(/sxConfig$/) || // ends with sxConfig
-  (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/));
 
 export default function extendTheme(options = {}, ...args) {
   const {

--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -133,6 +133,7 @@ export type {
   ColorSystemOptions,
 } from './experimental_extendTheme';
 export { default as getOverlayAlpha } from './getOverlayAlpha';
+export { default as shouldSkipGeneratingVar } from './shouldSkipGeneratingVar';
 
 // Private methods for creating parts of the theme
 export { default as private_createTypography } from './createTypography';

--- a/packages/mui-material/src/styles/index.js
+++ b/packages/mui-material/src/styles/index.js
@@ -45,6 +45,7 @@ export { default as withTheme } from './withTheme';
 export * from './CssVarsProvider';
 export { default as experimental_extendTheme } from './experimental_extendTheme';
 export { default as getOverlayAlpha } from './getOverlayAlpha';
+export { default as shouldSkipGeneratingVar } from './shouldSkipGeneratingVar';
 
 // Private methods for creating parts of the theme
 export { default as private_createTypography } from './createTypography';

--- a/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
@@ -1,6 +1,6 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
   return (
-    !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
+    !!keys[0].match(/(cssVarPrefix|typography|mixins|breakpoints|direction|transitions)/) ||
     !!keys[0].match(/sxConfig$/) || // ends with sxConfig
     (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))
   );

--- a/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
@@ -1,0 +1,7 @@
+export default function shouldSkipGeneratingVar(keys: string[]) {
+  return (
+    !!keys[0].match(/(typography|mixins|breakpoints|direction|transitions)/) ||
+    !!keys[0].match(/sxConfig$/) || // ends with sxConfig
+    (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))
+  );
+}

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -84,48 +84,6 @@ export interface CreateCssVarsProviderResult<ColorScheme extends string> {
     >,
   ) => React.ReactElement;
   useColorScheme: () => ColorSchemeContextValue<ColorScheme>;
-  generateCssThemeVars: (options?: {
-    /**
-     * Design system default color scheme.
-     * - provides string if the design system has one default color scheme (either light or dark)
-     * - provides object if the design system has default light & dark color schemes
-     */
-    defaultColorScheme?: ColorScheme | { light: ColorScheme; dark: ColorScheme };
-    /**
-     * @default 'light'
-     */
-    defaultMode?: 'light' | 'dark';
-    /**
-     * The selector for attaching CSS variables that are **outside** of `theme.colorSchemes.*`.
-     * @default ':root'
-     */
-    rootSelector: string;
-    /**
-     * The selector for attaching CSS variables that are **outside** of `theme.colorSchemes.*`.
-     * @default (key) => `[data-color-scheme="${key}"]`
-     */
-    colorSchemeSelector: (key: ColorScheme) => string;
-    /**
-     * A function to determine if the key, value should be attached as CSS Variable
-     * `keys` is an array that represents the object path keys.
-     *  Ex, if the theme is { foo: { bar: 'var(--test)' } }
-     *  then, keys = ['foo', 'bar']
-     *        value = 'var(--test)'
-     */
-    shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
-    /**
-     * Controlled mode. If not provided, it will try to read the value from the upper CssVarsProvider.
-     */
-    mode?: Mode;
-    /**
-     * Controlled color scheme. If not provided, it will try to read the value from the upper CssVarsProvider.
-     */
-    colorScheme?: ColorScheme;
-    theme?: {
-      cssVarPrefix?: string;
-      colorSchemes: Record<ColorScheme, Record<string, any>>;
-    };
-  }) => Record<string, any>;
   getInitColorSchemeScript: typeof getInitColorSchemeScript;
 }
 

--- a/packages/mui-system/src/cssVars/createCssVarsTheme.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsTheme.ts
@@ -5,7 +5,7 @@ interface Theme extends DefaultCssVarsTheme {
   shouldSkipGeneratingVar?: (objectPathKeys: Array<string>, value: string | number) => boolean;
 }
 
-function createCssVarsTheme<T extends Theme, ThemeVars>(theme: T) {
+function createCssVarsTheme<T extends Theme, ThemeVars extends Record<string, any>>(theme: T) {
   const { cssVarPrefix, shouldSkipGeneratingVar, ...otherTheme } = theme;
 
   return {

--- a/packages/mui-system/src/cssVars/cssVarsParser.ts
+++ b/packages/mui-system/src/cssVars/cssVarsParser.ts
@@ -120,7 +120,7 @@ const getCssValue = (keys: string[], value: string | number) => {
  * console.log(vars) // { fontSize: 'var(--foo-fontSize)', lineHeight: 'var(--foo-lineHeight)', palette: { primary: { 500: 'var(--foo-palette-primary-500)' } } }
  */
 export default function cssVarsParser<T extends Record<string, any>>(
-  theme: T,
+  theme: Record<string, any>,
   options?: {
     prefix?: string;
     shouldSkipGeneratingVar?: (objectPathKeys: Array<string>, value: string | number) => boolean;
@@ -128,7 +128,7 @@ export default function cssVarsParser<T extends Record<string, any>>(
 ) {
   const { prefix, shouldSkipGeneratingVar } = options || {};
   const css = {} as Record<string, string | number>;
-  const vars = {} as NestedRecord<string>;
+  const vars = {} as T;
   const varsWithDefaults = {};
 
   walkObjectDeep(

--- a/packages/mui-system/src/cssVars/prepareCssVars.ts
+++ b/packages/mui-system/src/cssVars/prepareCssVars.ts
@@ -5,7 +5,7 @@ export interface DefaultCssVarsTheme {
   colorSchemes: Record<string, any>;
 }
 
-function prepareCssVars<T extends DefaultCssVarsTheme, ThemeVars>(
+function prepareCssVars<T extends DefaultCssVarsTheme, ThemeVars extends Record<string, any>>(
   theme: T,
   parserConfig?: {
     prefix?: string;
@@ -18,19 +18,20 @@ function prepareCssVars<T extends DefaultCssVarsTheme, ThemeVars>(
     vars: rootVars,
     css: rootCss,
     varsWithDefaults: rootVarsWithDefaults,
-  } = cssVarsParser(otherTheme, parserConfig);
+  } = cssVarsParser<ThemeVars>(otherTheme, parserConfig);
   let themeVars = rootVarsWithDefaults as unknown as ThemeVars;
 
-  const colorSchemesMap: Record<string, any> = {};
+  const colorSchemesMap: Record<string, { css: Record<string, string | number>; vars: ThemeVars }> =
+    {};
   const { light, ...otherColorSchemes } = colorSchemes;
   Object.entries(otherColorSchemes || {}).forEach(([key, scheme]) => {
-    const { vars, css, varsWithDefaults } = cssVarsParser(scheme, parserConfig);
+    const { vars, css, varsWithDefaults } = cssVarsParser<ThemeVars>(scheme, parserConfig);
     themeVars = deepmerge(themeVars, varsWithDefaults);
     colorSchemesMap[key] = { css, vars };
   });
   if (light) {
     // light color scheme vars should be merged last to set as default
-    const { css, vars, varsWithDefaults } = cssVarsParser(light, parserConfig);
+    const { css, vars, varsWithDefaults } = cssVarsParser<ThemeVars>(light, parserConfig);
     themeVars = deepmerge(themeVars, varsWithDefaults);
     colorSchemesMap.light = { css, vars };
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Regression from #35739, `shouldSkipGeneratingVar` is not exported from `@mui/material/styles`.

**Before**: https://codesandbox.io/s/material-ui-feat-joy-ui-vvvv59?file=/demo.tsx
**After**: https://codesandbox.io/s/material-cra-ts-forked-xkczu2?file=/src/App.tsx

There are other minor fixes that I think can be batched with this fix.

- Extract `shouldSkipGeneratingVar` into a separate file for consistency between Material UI and Joy UI
- `generateCssVars` type is missing
- Some types in material-ui-next are redundant

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
