### PR TITLE
[core] Remove wrong code from yarn.lock

### DIFF
--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.21.0",
-    "@mui/base": "5.0.0-alpha.119",
+    "@mui/base": "5.0.0-alpha.120",
     "@mui/core-downloads-tracker": "^5.11.12",
     "@mui/system": "^5.11.12",
     "@mui/types": "^7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,20 +1849,6 @@
     react-test-renderer "^18.0.0"
     semver "^5.7.0"
 
-"@mui/base@5.0.0-alpha.119":
-  version "5.0.0-alpha.119"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.119.tgz#923e148ceb84898fdd28da069b7c42635053c128"
-  integrity sha512-XA5zhlYfXi67u613eIF0xRmktkatx6ERy3h+PwrMN5IcWFbgiL1guz8VpdXON+GWb8+G7B8t5oqTFIaCqaSAeA==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
-    "@emotion/is-prop-valid" "^1.2.0"
-    "@mui/types" "^7.2.3"
-    "@mui/utils" "^5.11.11"
-    "@popperjs/core" "^2.11.6"
-    clsx "^1.2.1"
-    prop-types "^15.8.1"
-    react-is "^18.2.0"
-
 "@mui/x-data-grid-generator@6.0.0-alpha.14":
   version "6.0.0-alpha.14"
   resolved "https://registry.yarnpkg.com/@mui/x-data-grid-generator/-/x-data-grid-generator-6.0.0-alpha.14.tgz#b1df18c118688d2ada5a9d0c2fe7a535c352d2d2"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In the latest release (v5.11.12) (#36443), I made a mistake of adding a code snippet to `yarn.lock` to pass a CI test failure. This occurred because I didn't bump the version of `@mui/base` from alpha 119 to alpha 120 in the `package.json` of `@mui/material`. (The version of MUI Base itself was bumped and in other packages as well except for the `@mui/material`).

> **Note**
> 
> This PR doesn't need to be merged as this can be resolved as part of the v5.11.13 release on upcoming Monday. Opened this PR as a reference point just in case.