### PR TITLE
[docs] Keep slot code order in API docs

### DIFF
--- a/docs/pages/base/api/badge-unstyled.json
+++ b/docs/pages/base/api/badge-unstyled.json
@@ -22,16 +22,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "badge",
-      "description": "The component used to render the badge.",
-      "default": "'span'",
-      "class": ".MuiBadge-badge"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'span'",
       "class": ".MuiBadge-root"
+    },
+    {
+      "name": "badge",
+      "description": "The component used to render the badge.",
+      "default": "'span'",
+      "class": ".MuiBadge-badge"
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/input-unstyled.json
+++ b/docs/pages/base/api/input-unstyled.json
@@ -45,16 +45,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "input",
-      "description": "The component used to render the input.",
-      "default": "'input'",
-      "class": ".MuiInput-input"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiInput-root"
+    },
+    {
+      "name": "input",
+      "description": "The component used to render the input.",
+      "default": "'input'",
+      "class": ".MuiInput-input"
     },
     {
       "name": "textarea",

--- a/docs/pages/base/api/menu-unstyled.json
+++ b/docs/pages/base/api/menu-unstyled.json
@@ -27,16 +27,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "listbox",
-      "description": "The component used to render the listbox.",
-      "default": "'ul'",
-      "class": ".MuiMenu-listbox"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "PopperUnstyled",
       "class": ".MuiMenu-root"
+    },
+    {
+      "name": "listbox",
+      "description": "The component used to render the listbox.",
+      "default": "'ul'",
+      "class": ".MuiMenu-listbox"
     }
   ],
   "spread": false,

--- a/docs/pages/base/api/modal-unstyled.json
+++ b/docs/pages/base/api/modal-unstyled.json
@@ -35,15 +35,15 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "backdrop",
-      "description": "The component used to render the backdrop.",
-      "class": ".MuiModal-backdrop"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiModal-root"
+    },
+    {
+      "name": "backdrop",
+      "description": "The component used to render the backdrop.",
+      "class": ".MuiModal-backdrop"
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/option-group-unstyled.json
+++ b/docs/pages/base/api/option-group-unstyled.json
@@ -22,6 +22,12 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'li'",
+      "class": ".MuiOptionGroup-root"
+    },
+    {
       "name": "label",
       "description": "The component used to render the label.",
       "default": "'span'",
@@ -32,12 +38,6 @@
       "description": "The component used to render the list.",
       "default": "'ul'",
       "class": ".MuiOptionGroup-list"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'li'",
-      "class": ".MuiOptionGroup-root"
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/select-unstyled.json
+++ b/docs/pages/base/api/select-unstyled.json
@@ -34,6 +34,12 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'button'",
+      "class": ".MuiSelect-root"
+    },
+    {
       "name": "listbox",
       "description": "The component used to render the listbox.",
       "default": "'ul'",
@@ -44,12 +50,6 @@
       "description": "The component used to render the popper.",
       "default": "PopperUnstyled",
       "class": ".MuiSelect-popper"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'button'",
-      "class": ".MuiSelect-root"
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/slider-unstyled.json
+++ b/docs/pages/base/api/slider-unstyled.json
@@ -64,10 +64,28 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "input",
-      "description": "The component used to render the input.",
-      "default": "'input'",
-      "class": ".MuiSlider-input"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'span'",
+      "class": ".MuiSlider-root"
+    },
+    {
+      "name": "track",
+      "description": "The component used to render the track.",
+      "default": "'span'",
+      "class": ".MuiSlider-track"
+    },
+    {
+      "name": "rail",
+      "description": "The component used to render the rail.",
+      "default": "'span'",
+      "class": ".MuiSlider-rail"
+    },
+    {
+      "name": "thumb",
+      "description": "The component used to render the thumb.",
+      "default": "'span'",
+      "class": ".MuiSlider-thumb"
     },
     {
       "name": "mark",
@@ -82,33 +100,15 @@
       "class": ".MuiSlider-markLabel"
     },
     {
-      "name": "rail",
-      "description": "The component used to render the rail.",
-      "default": "'span'",
-      "class": ".MuiSlider-rail"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'span'",
-      "class": ".MuiSlider-root"
-    },
-    {
-      "name": "thumb",
-      "description": "The component used to render the thumb.",
-      "default": "'span'",
-      "class": ".MuiSlider-thumb"
-    },
-    {
-      "name": "track",
-      "description": "The component used to render the track.",
-      "default": "'span'",
-      "class": ".MuiSlider-track"
-    },
-    {
       "name": "valueLabel",
       "description": "The component used to render the value label.",
       "class": ".MuiSlider-valueLabel"
+    },
+    {
+      "name": "input",
+      "description": "The component used to render the input.",
+      "default": "'input'",
+      "class": ".MuiSlider-input"
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/switch-unstyled.json
+++ b/docs/pages/base/api/switch-unstyled.json
@@ -26,16 +26,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "input",
-      "description": "The component used to render the input.",
-      "default": "'input'",
-      "class": ".MuiSwitch-input"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'span'",
       "class": ".MuiSwitch-root"
+    },
+    {
+      "name": "input",
+      "description": "The component used to render the input.",
+      "default": "'input'",
+      "class": ".MuiSwitch-input"
     },
     {
       "name": "thumb",

--- a/docs/pages/base/api/table-pagination-unstyled.json
+++ b/docs/pages/base/api/table-pagination-unstyled.json
@@ -43,28 +43,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "actions",
-      "description": "The component used to render the actions.",
-      "default": "TablePaginationActionsUnstyled",
-      "class": ".MuiTablePagination-actions"
-    },
-    {
-      "name": "displayedRows",
-      "description": "The component used to render the displayed rows.",
-      "default": "'p'",
-      "class": ".MuiTablePagination-displayedRows"
-    },
-    {
-      "name": "menuItem",
-      "description": "The component used to render the menu item.",
-      "default": "'option'",
-      "class": ".MuiTablePagination-menuItem"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'td'",
       "class": ".MuiTablePagination-root"
+    },
+    {
+      "name": "actions",
+      "description": "The component used to render the actions.",
+      "default": "TablePaginationActionsUnstyled",
+      "class": ".MuiTablePagination-actions"
     },
     {
       "name": "select",
@@ -79,16 +67,28 @@
       "class": ".MuiTablePagination-selectLabel"
     },
     {
-      "name": "spacer",
-      "description": "The component used to render the spacer.",
-      "default": "'div'",
-      "class": ".MuiTablePagination-spacer"
+      "name": "menuItem",
+      "description": "The component used to render the menu item.",
+      "default": "'option'",
+      "class": ".MuiTablePagination-menuItem"
+    },
+    {
+      "name": "displayedRows",
+      "description": "The component used to render the displayed rows.",
+      "default": "'p'",
+      "class": ".MuiTablePagination-displayedRows"
     },
     {
       "name": "toolbar",
       "description": "The component used to render the toolbar.",
       "default": "'div'",
       "class": ".MuiTablePagination-toolbar"
+    },
+    {
+      "name": "spacer",
+      "description": "The component used to render the spacer.",
+      "default": "'div'",
+      "class": ".MuiTablePagination-spacer"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/alert.json
+++ b/docs/pages/joy-ui/api/alert.json
@@ -35,12 +35,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiAlert-endDecorator"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
@@ -51,6 +45,12 @@
       "description": "The component used to render the start decorator.",
       "default": "'span'",
       "class": ".MuiAlert-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiAlert-endDecorator"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/aspect-ratio.json
+++ b/docs/pages/joy-ui/api/aspect-ratio.json
@@ -39,16 +39,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "content",
-      "description": "The component used to render the content.",
-      "default": "'div'",
-      "class": ".MuiAspectRatio-content"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiAspectRatio-root"
+    },
+    {
+      "name": "content",
+      "description": "The component used to render the content.",
+      "default": "'div'",
+      "class": ".MuiAspectRatio-content"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/autocomplete.json
+++ b/docs/pages/joy-ui/api/autocomplete.json
@@ -90,16 +90,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "clearIndicator",
-      "description": "The component used to render the clear indicator.",
-      "default": "'button'",
-      "class": ".MuiAutocomplete-clearIndicator"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'div'",
+      "class": ".MuiAutocomplete-root"
     },
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiAutocomplete-endDecorator"
+      "name": "wrapper",
+      "description": "The component used to render the wrapper.",
+      "default": "'div'",
+      "class": ".MuiAutocomplete-wrapper"
     },
     {
       "name": "input",
@@ -108,16 +108,40 @@
       "class": ".MuiAutocomplete-input"
     },
     {
-      "name": "limitTag",
-      "description": "The component used to render the limit tag.",
+      "name": "startDecorator",
+      "description": "The component used to render the start decorator.",
       "default": "'span'",
-      "class": ".MuiAutocomplete-limitTag"
+      "class": ".MuiAutocomplete-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiAutocomplete-endDecorator"
+    },
+    {
+      "name": "clearIndicator",
+      "description": "The component used to render the clear indicator.",
+      "default": "'button'",
+      "class": ".MuiAutocomplete-clearIndicator"
+    },
+    {
+      "name": "popupIndicator",
+      "description": "The component used to render the popup indicator.",
+      "default": "'button'",
+      "class": ".MuiAutocomplete-popupIndicator"
     },
     {
       "name": "listbox",
       "description": "The component used to render the listbox.",
       "default": "'ul'",
       "class": ".MuiAutocomplete-listbox"
+    },
+    {
+      "name": "option",
+      "description": "The component used to render the option.",
+      "default": "'li'",
+      "class": ".MuiAutocomplete-option"
     },
     {
       "name": "loading",
@@ -132,34 +156,10 @@
       "class": ".MuiAutocomplete-noOptions"
     },
     {
-      "name": "option",
-      "description": "The component used to render the option.",
-      "default": "'li'",
-      "class": ".MuiAutocomplete-option"
-    },
-    {
-      "name": "popupIndicator",
-      "description": "The component used to render the popup indicator.",
-      "default": "'button'",
-      "class": ".MuiAutocomplete-popupIndicator"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'div'",
-      "class": ".MuiAutocomplete-root"
-    },
-    {
-      "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
+      "name": "limitTag",
+      "description": "The component used to render the limit tag.",
       "default": "'span'",
-      "class": ".MuiAutocomplete-startDecorator"
-    },
-    {
-      "name": "wrapper",
-      "description": "The component used to render the wrapper.",
-      "default": "'div'",
-      "class": ".MuiAutocomplete-wrapper"
+      "class": ".MuiAutocomplete-limitTag"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/avatar.json
+++ b/docs/pages/joy-ui/api/avatar.json
@@ -36,10 +36,10 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "fallback",
-      "description": "The component used to render the fallback.",
-      "default": "'svg'",
-      "class": ".MuiAvatar-fallback"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'div'",
+      "class": ".MuiAvatar-root"
     },
     {
       "name": "img",
@@ -48,10 +48,10 @@
       "class": ".MuiAvatar-img"
     },
     {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'div'",
-      "class": ".MuiAvatar-root"
+      "name": "fallback",
+      "description": "The component used to render the fallback.",
+      "default": "'svg'",
+      "class": ".MuiAvatar-fallback"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/badge.json
+++ b/docs/pages/joy-ui/api/badge.json
@@ -48,16 +48,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "badge",
-      "description": "The component used to render the badge.",
-      "default": "'div'",
-      "class": ".MuiBadge-badge"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiBadge-root"
+    },
+    {
+      "name": "badge",
+      "description": "The component used to render the badge.",
+      "default": "'div'",
+      "class": ".MuiBadge-badge"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/breadcrumbs.json
+++ b/docs/pages/joy-ui/api/breadcrumbs.json
@@ -20,10 +20,10 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "li",
-      "description": "The component used to render the li.",
-      "default": "'li'",
-      "class": ".MuiBreadcrumbs-li"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'nav'",
+      "class": ".MuiBreadcrumbs-root"
     },
     {
       "name": "ol",
@@ -32,10 +32,10 @@
       "class": ".MuiBreadcrumbs-ol"
     },
     {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'nav'",
-      "class": ".MuiBreadcrumbs-root"
+      "name": "li",
+      "description": "The component used to render the li.",
+      "default": "'li'",
+      "class": ".MuiBreadcrumbs-li"
     },
     {
       "name": "separator",

--- a/docs/pages/joy-ui/api/button.json
+++ b/docs/pages/joy-ui/api/button.json
@@ -51,18 +51,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiButton-endDecorator"
-    },
-    {
-      "name": "loadingIndicatorCenter",
-      "description": "The component used to render the loading indicator center.",
-      "default": "'span'",
-      "class": ".MuiButton-loadingIndicatorCenter"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'button'",
@@ -73,6 +61,18 @@
       "description": "The component used to render the start decorator.",
       "default": "'span'",
       "class": ".MuiButton-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiButton-endDecorator"
+    },
+    {
+      "name": "loadingIndicatorCenter",
+      "description": "The component used to render the loading indicator center.",
+      "default": "'span'",
+      "class": ".MuiButton-loadingIndicatorCenter"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/checkbox.json
+++ b/docs/pages/joy-ui/api/checkbox.json
@@ -50,16 +50,22 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "action",
-      "description": "The component used to render the action.",
+      "name": "root",
+      "description": "The component used to render the root.",
       "default": "'span'",
-      "class": ".MuiCheckbox-action"
+      "class": ".MuiCheckbox-root"
     },
     {
       "name": "checkbox",
       "description": "The component used to render the checkbox.",
       "default": "'span'",
       "class": ".MuiCheckbox-checkbox"
+    },
+    {
+      "name": "action",
+      "description": "The component used to render the action.",
+      "default": "'span'",
+      "class": ".MuiCheckbox-action"
     },
     {
       "name": "input",
@@ -72,12 +78,6 @@
       "description": "The component used to render the label.",
       "default": "'label'",
       "class": ".MuiCheckbox-label"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'span'",
-      "class": ".MuiCheckbox-root"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/chip.json
+++ b/docs/pages/joy-ui/api/chip.json
@@ -37,16 +37,10 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "action",
-      "description": "The component used to render the action.",
-      "default": "'button'",
-      "class": ".MuiChip-action"
-    },
-    {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiChip-endDecorator"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'div'",
+      "class": ".MuiChip-root"
     },
     {
       "name": "label",
@@ -55,16 +49,22 @@
       "class": ".MuiChip-label"
     },
     {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'div'",
-      "class": ".MuiChip-root"
+      "name": "action",
+      "description": "The component used to render the action.",
+      "default": "'button'",
+      "class": ".MuiChip-action"
     },
     {
       "name": "startDecorator",
       "description": "The component used to render the start decorator.",
       "default": "'span'",
       "class": ".MuiChip-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiChip-endDecorator"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/circular-progress.json
+++ b/docs/pages/joy-ui/api/circular-progress.json
@@ -35,12 +35,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "progress",
-      "description": "The component used to render the progress.",
-      "default": "'circle'",
-      "class": ".MuiCircularProgress-progress"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'span'",
@@ -57,6 +51,12 @@
       "description": "The component used to render the track.",
       "default": "'circle'",
       "class": ".MuiCircularProgress-track"
+    },
+    {
+      "name": "progress",
+      "description": "The component used to render the progress.",
+      "default": "'circle'",
+      "class": ".MuiCircularProgress-progress"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/form-label.json
+++ b/docs/pages/joy-ui/api/form-label.json
@@ -14,16 +14,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "asterisk",
-      "description": "The component used to render the asterisk.",
-      "default": "'span'",
-      "class": ".MuiFormLabel-asterisk"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'label'",
       "class": ".MuiFormLabel-root"
+    },
+    {
+      "name": "asterisk",
+      "description": "The component used to render the asterisk.",
+      "default": "'span'",
+      "class": ".MuiFormLabel-asterisk"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/input.json
+++ b/docs/pages/joy-ui/api/input.json
@@ -34,10 +34,10 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiInput-endDecorator"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'div'",
+      "class": ".MuiInput-root"
     },
     {
       "name": "input",
@@ -46,16 +46,16 @@
       "class": ".MuiInput-input"
     },
     {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'div'",
-      "class": ".MuiInput-root"
-    },
-    {
       "name": "startDecorator",
       "description": "The component used to render the start decorator.",
       "default": "'span'",
       "class": ".MuiInput-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiInput-endDecorator"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/link.json
+++ b/docs/pages/joy-ui/api/link.json
@@ -45,12 +45,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiLink-endDecorator"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'a'",
@@ -61,6 +55,12 @@
       "description": "The component used to render the start decorator.",
       "default": "'span'",
       "class": ".MuiLink-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiLink-endDecorator"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/list-item.json
+++ b/docs/pages/joy-ui/api/list-item.json
@@ -31,12 +31,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endAction",
-      "description": "The component used to render the end action.",
-      "default": "'div'",
-      "class": ".MuiListItem-endAction"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'li'",
@@ -47,6 +41,12 @@
       "description": "The component used to render the start action.",
       "default": "'div'",
       "class": ".MuiListItem-startAction"
+    },
+    {
+      "name": "endAction",
+      "description": "The component used to render the end action.",
+      "default": "'div'",
+      "class": ".MuiListItem-endAction"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/modal.json
+++ b/docs/pages/joy-ui/api/modal.json
@@ -23,16 +23,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "backdrop",
-      "description": "The component used to render the backdrop.",
-      "default": "'div'",
-      "class": ".MuiModal-backdrop"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiModal-root"
+    },
+    {
+      "name": "backdrop",
+      "description": "The component used to render the backdrop.",
+      "default": "'div'",
+      "class": ".MuiModal-backdrop"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/radio.json
+++ b/docs/pages/joy-ui/api/radio.json
@@ -46,16 +46,28 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "action",
-      "description": "The component used to render the action.",
+      "name": "root",
+      "description": "The component used to render the root.",
       "default": "'span'",
-      "class": ".MuiRadio-action"
+      "class": ".MuiRadio-root"
+    },
+    {
+      "name": "radio",
+      "description": "The component used to render the radio.",
+      "default": "'span'",
+      "class": ".MuiRadio-radio"
     },
     {
       "name": "icon",
       "description": "The component used to render the icon.",
       "default": "'span'",
       "class": ".MuiRadio-icon"
+    },
+    {
+      "name": "action",
+      "description": "The component used to render the action.",
+      "default": "'span'",
+      "class": ".MuiRadio-action"
     },
     {
       "name": "input",
@@ -68,18 +80,6 @@
       "description": "The component used to render the label.",
       "default": "'label'",
       "class": ".MuiRadio-label"
-    },
-    {
-      "name": "radio",
-      "description": "The component used to render the radio.",
-      "default": "'span'",
-      "class": ".MuiRadio-radio"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'span'",
-      "class": ".MuiRadio-root"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/select.json
+++ b/docs/pages/joy-ui/api/select.json
@@ -53,10 +53,22 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'div'",
+      "class": ".MuiSelect-root"
+    },
+    {
       "name": "button",
       "description": "The component used to render the button.",
       "default": "'button'",
       "class": ".MuiSelect-button"
+    },
+    {
+      "name": "startDecorator",
+      "description": "The component used to render the start decorator.",
+      "default": "'span'",
+      "class": ".MuiSelect-startDecorator"
     },
     {
       "name": "endDecorator",
@@ -75,18 +87,6 @@
       "description": "The component used to render the listbox.",
       "default": "'ul'",
       "class": ".MuiSelect-listbox"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'div'",
-      "class": ".MuiSelect-root"
-    },
-    {
-      "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
-      "default": "'span'",
-      "class": ".MuiSelect-startDecorator"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/slider.json
+++ b/docs/pages/joy-ui/api/slider.json
@@ -105,10 +105,28 @@
   },
   "slots": [
     {
-      "name": "input",
-      "description": "The component used to render the input.",
-      "default": "'input'",
-      "class": ".MuiSlider-input"
+      "name": "root",
+      "description": "The component used to render the root.",
+      "default": "'span'",
+      "class": ".MuiSlider-root"
+    },
+    {
+      "name": "track",
+      "description": "The component used to render the track.",
+      "default": "'span'",
+      "class": ".MuiSlider-track"
+    },
+    {
+      "name": "rail",
+      "description": "The component used to render the rail.",
+      "default": "'span'",
+      "class": ".MuiSlider-rail"
+    },
+    {
+      "name": "thumb",
+      "description": "The component used to render the thumb.",
+      "default": "'span'",
+      "class": ".MuiSlider-thumb"
     },
     {
       "name": "mark",
@@ -123,34 +141,16 @@
       "class": ".MuiSlider-markLabel"
     },
     {
-      "name": "rail",
-      "description": "The component used to render the rail.",
-      "default": "'span'",
-      "class": ".MuiSlider-rail"
-    },
-    {
-      "name": "root",
-      "description": "The component used to render the root.",
-      "default": "'span'",
-      "class": ".MuiSlider-root"
-    },
-    {
-      "name": "thumb",
-      "description": "The component used to render the thumb.",
-      "default": "'span'",
-      "class": ".MuiSlider-thumb"
-    },
-    {
-      "name": "track",
-      "description": "The component used to render the track.",
-      "default": "'span'",
-      "class": ".MuiSlider-track"
-    },
-    {
       "name": "valueLabel",
       "description": "The component used to render the value label.",
       "default": "'span'",
       "class": ".MuiSlider-valueLabel"
+    },
+    {
+      "name": "input",
+      "description": "The component used to render the input.",
+      "default": "'input'",
+      "class": ".MuiSlider-input"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/switch.json
+++ b/docs/pages/joy-ui/api/switch.json
@@ -40,34 +40,10 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "action",
-      "description": "The component used to render the action.",
-      "default": "'div'",
-      "class": ".MuiSwitch-action"
-    },
-    {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiSwitch-endDecorator"
-    },
-    {
-      "name": "input",
-      "description": "The component used to render the input.",
-      "default": "'input'",
-      "class": ".MuiSwitch-input"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiSwitch-root"
-    },
-    {
-      "name": "startDecorator",
-      "description": "The component used to render the start decorator.",
-      "default": "'span'",
-      "class": ".MuiSwitch-startDecorator"
     },
     {
       "name": "thumb",
@@ -76,10 +52,34 @@
       "class": ".MuiSwitch-thumb"
     },
     {
+      "name": "action",
+      "description": "The component used to render the action.",
+      "default": "'div'",
+      "class": ".MuiSwitch-action"
+    },
+    {
+      "name": "input",
+      "description": "The component used to render the input.",
+      "default": "'input'",
+      "class": ".MuiSwitch-input"
+    },
+    {
       "name": "track",
       "description": "The component used to render the track.",
       "default": "'span'",
       "class": ".MuiSwitch-track"
+    },
+    {
+      "name": "startDecorator",
+      "description": "The component used to render the start decorator.",
+      "default": "'span'",
+      "class": ".MuiSwitch-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiSwitch-endDecorator"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/textarea.json
+++ b/docs/pages/joy-ui/api/textarea.json
@@ -34,16 +34,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'div'",
-      "class": ".MuiTextarea-endDecorator"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiTextarea-root"
+    },
+    {
+      "name": "textarea",
+      "description": "The component used to render the textarea.",
+      "default": "'textarea'",
+      "class": ".MuiTextarea-textarea"
     },
     {
       "name": "startDecorator",
@@ -52,10 +52,10 @@
       "class": ".MuiTextarea-startDecorator"
     },
     {
-      "name": "textarea",
-      "description": "The component used to render the textarea.",
-      "default": "'textarea'",
-      "class": ".MuiTextarea-textarea"
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'div'",
+      "class": ".MuiTextarea-endDecorator"
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/tooltip.json
+++ b/docs/pages/joy-ui/api/tooltip.json
@@ -66,16 +66,16 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "arrow",
-      "description": "The component used to render the arrow.",
-      "default": "'span'",
-      "class": ".MuiTooltip-arrow"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'div'",
       "class": ".MuiTooltip-root"
+    },
+    {
+      "name": "arrow",
+      "description": "The component used to render the arrow.",
+      "default": "'span'",
+      "class": ".MuiTooltip-arrow"
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/typography.json
+++ b/docs/pages/joy-ui/api/typography.json
@@ -41,12 +41,6 @@
   "styles": { "classes": [], "globalClasses": {}, "name": null },
   "slots": [
     {
-      "name": "endDecorator",
-      "description": "The component used to render the end decorator.",
-      "default": "'span'",
-      "class": ".MuiTypography-endDecorator"
-    },
-    {
       "name": "root",
       "description": "The component used to render the root.",
       "default": "'a'",
@@ -57,6 +51,12 @@
       "description": "The component used to render the start decorator.",
       "default": "'span'",
       "class": ".MuiTypography-startDecorator"
+    },
+    {
+      "name": "endDecorator",
+      "description": "The component used to render the end decorator.",
+      "default": "'span'",
+      "class": ".MuiTypography-endDecorator"
     }
   ],
   "spread": true,

--- a/docs/translations/api-docs-joy/alert/alert.json
+++ b/docs/translations/api-docs-joy/alert/alert.json
@@ -11,8 +11,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endDecorator": "The component used to render the end decorator.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/aspect-ratio/aspect-ratio.json
+++ b/docs/translations/api-docs-joy/aspect-ratio/aspect-ratio.json
@@ -12,7 +12,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "content": "The component used to render the content.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "content": "The component used to render the content."
   }
 }

--- a/docs/translations/api-docs-joy/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs-joy/autocomplete/autocomplete.json
@@ -54,17 +54,17 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "clearIndicator": "The component used to render the clear indicator.",
-    "endDecorator": "The component used to render the end decorator.",
+    "root": "The component used to render the root.",
+    "wrapper": "The component used to render the wrapper.",
     "input": "The component used to render the input.",
-    "limitTag": "The component used to render the limit tag.",
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator.",
+    "clearIndicator": "The component used to render the clear indicator.",
+    "popupIndicator": "The component used to render the popup indicator.",
     "listbox": "The component used to render the listbox.",
+    "option": "The component used to render the option.",
     "loading": "The component used to render the loading.",
     "noOptions": "The component used to render the no-options.",
-    "option": "The component used to render the option.",
-    "popupIndicator": "The component used to render the popup indicator.",
-    "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator.",
-    "wrapper": "The component used to render the wrapper."
+    "limitTag": "The component used to render the limit tag."
   }
 }

--- a/docs/translations/api-docs-joy/avatar/avatar.json
+++ b/docs/translations/api-docs-joy/avatar/avatar.json
@@ -12,8 +12,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "fallback": "The component used to render the fallback.",
+    "root": "The component used to render the root.",
     "img": "The component used to render the img.",
-    "root": "The component used to render the root."
+    "fallback": "The component used to render the fallback."
   }
 }

--- a/docs/translations/api-docs-joy/badge/badge.json
+++ b/docs/translations/api-docs-joy/badge/badge.json
@@ -15,7 +15,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "badge": "The component used to render the badge.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "badge": "The component used to render the badge."
   }
 }

--- a/docs/translations/api-docs-joy/breadcrumbs/breadcrumbs.json
+++ b/docs/translations/api-docs-joy/breadcrumbs/breadcrumbs.json
@@ -8,9 +8,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "li": "The component used to render the li.",
-    "ol": "The component used to render the ol.",
     "root": "The component used to render the root.",
+    "ol": "The component used to render the ol.",
+    "li": "The component used to render the li.",
     "separator": "The component used to render the separator."
   }
 }

--- a/docs/translations/api-docs-joy/button/button.json
+++ b/docs/translations/api-docs-joy/button/button.json
@@ -16,9 +16,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endDecorator": "The component used to render the end decorator.",
-    "loadingIndicatorCenter": "The component used to render the loading indicator center.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator.",
+    "loadingIndicatorCenter": "The component used to render the loading indicator center."
   }
 }

--- a/docs/translations/api-docs-joy/checkbox/checkbox.json
+++ b/docs/translations/api-docs-joy/checkbox/checkbox.json
@@ -24,10 +24,10 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "action": "The component used to render the action.",
+    "root": "The component used to render the root.",
     "checkbox": "The component used to render the checkbox.",
+    "action": "The component used to render the action.",
     "input": "The component used to render the input.",
-    "label": "The component used to render the label.",
-    "root": "The component used to render the root."
+    "label": "The component used to render the label."
   }
 }

--- a/docs/translations/api-docs-joy/chip/chip.json
+++ b/docs/translations/api-docs-joy/chip/chip.json
@@ -13,10 +13,10 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "action": "The component used to render the action.",
-    "endDecorator": "The component used to render the end decorator.",
-    "label": "The component used to render the label.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "label": "The component used to render the label.",
+    "action": "The component used to render the action.",
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/circular-progress/circular-progress.json
+++ b/docs/translations/api-docs-joy/circular-progress/circular-progress.json
@@ -11,9 +11,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "progress": "The component used to render the progress.",
     "root": "The component used to render the root.",
     "svg": "The component used to render the svg.",
-    "track": "The component used to render the track."
+    "track": "The component used to render the track.",
+    "progress": "The component used to render the progress."
   }
 }

--- a/docs/translations/api-docs-joy/form-label/form-label.json
+++ b/docs/translations/api-docs-joy/form-label/form-label.json
@@ -8,7 +8,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "asterisk": "The component used to render the asterisk.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "asterisk": "The component used to render the asterisk."
   }
 }

--- a/docs/translations/api-docs-joy/input/input.json
+++ b/docs/translations/api-docs-joy/input/input.json
@@ -13,9 +13,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endDecorator": "The component used to render the end decorator.",
-    "input": "The component used to render the input.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "input": "The component used to render the input.",
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/link/link.json
+++ b/docs/translations/api-docs-joy/link/link.json
@@ -15,8 +15,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endDecorator": "The component used to render the end decorator.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/list-item/list-item.json
+++ b/docs/translations/api-docs-joy/list-item/list-item.json
@@ -13,8 +13,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endAction": "The component used to render the end action.",
     "root": "The component used to render the root.",
-    "startAction": "The component used to render the start action."
+    "startAction": "The component used to render the start action.",
+    "endAction": "The component used to render the end action."
   }
 }

--- a/docs/translations/api-docs-joy/modal/modal.json
+++ b/docs/translations/api-docs-joy/modal/modal.json
@@ -17,7 +17,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "backdrop": "The component used to render the backdrop.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "backdrop": "The component used to render the backdrop."
   }
 }

--- a/docs/translations/api-docs-joy/radio/radio.json
+++ b/docs/translations/api-docs-joy/radio/radio.json
@@ -22,11 +22,11 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "action": "The component used to render the action.",
-    "icon": "The component used to render the icon.",
-    "input": "The component used to render the input.",
-    "label": "The component used to render the label.",
+    "root": "The component used to render the root.",
     "radio": "The component used to render the radio.",
-    "root": "The component used to render the root."
+    "icon": "The component used to render the icon.",
+    "action": "The component used to render the action.",
+    "input": "The component used to render the input.",
+    "label": "The component used to render the label."
   }
 }

--- a/docs/translations/api-docs-joy/select/select.json
+++ b/docs/translations/api-docs-joy/select/select.json
@@ -27,11 +27,11 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
+    "root": "The component used to render the root.",
     "button": "The component used to render the button.",
+    "startDecorator": "The component used to render the start decorator.",
     "endDecorator": "The component used to render the end decorator.",
     "indicator": "The component used to render the indicator.",
-    "listbox": "The component used to render the listbox.",
-    "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "listbox": "The component used to render the listbox."
   }
 }

--- a/docs/translations/api-docs-joy/slider/slider.json
+++ b/docs/translations/api-docs-joy/slider/slider.json
@@ -103,13 +103,13 @@
     }
   },
   "slotDescriptions": {
-    "input": "The component used to render the input.",
+    "root": "The component used to render the root.",
+    "track": "The component used to render the track.",
+    "rail": "The component used to render the rail.",
+    "thumb": "The component used to render the thumb.",
     "mark": "The component used to render the mark.",
     "markLabel": "The component used to render the mark label.",
-    "rail": "The component used to render the rail.",
-    "root": "The component used to render the root.",
-    "thumb": "The component used to render the thumb.",
-    "track": "The component used to render the track.",
-    "valueLabel": "The component used to render the value label."
+    "valueLabel": "The component used to render the value label.",
+    "input": "The component used to render the input."
   }
 }

--- a/docs/translations/api-docs-joy/switch/switch.json
+++ b/docs/translations/api-docs-joy/switch/switch.json
@@ -16,12 +16,12 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "action": "The component used to render the action.",
-    "endDecorator": "The component used to render the end decorator.",
-    "input": "The component used to render the input.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator.",
     "thumb": "The component used to render the thumb.",
-    "track": "The component used to render the track."
+    "action": "The component used to render the action.",
+    "input": "The component used to render the input.",
+    "track": "The component used to render the track.",
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/textarea/textarea.json
+++ b/docs/translations/api-docs-joy/textarea/textarea.json
@@ -13,9 +13,9 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endDecorator": "The component used to render the end decorator.",
     "root": "The component used to render the root.",
+    "textarea": "The component used to render the textarea.",
     "startDecorator": "The component used to render the start decorator.",
-    "textarea": "The component used to render the textarea."
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs-joy/tooltip/tooltip.json
+++ b/docs/translations/api-docs-joy/tooltip/tooltip.json
@@ -31,7 +31,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "arrow": "The component used to render the arrow.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "arrow": "The component used to render the arrow."
   }
 }

--- a/docs/translations/api-docs-joy/typography/typography.json
+++ b/docs/translations/api-docs-joy/typography/typography.json
@@ -16,8 +16,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "endDecorator": "The component used to render the end decorator.",
     "root": "The component used to render the root.",
-    "startDecorator": "The component used to render the start decorator."
+    "startDecorator": "The component used to render the start decorator.",
+    "endDecorator": "The component used to render the end decorator."
   }
 }

--- a/docs/translations/api-docs/badge-unstyled/badge-unstyled.json
+++ b/docs/translations/api-docs/badge-unstyled/badge-unstyled.json
@@ -12,7 +12,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "badge": "The component used to render the badge.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "badge": "The component used to render the badge."
   }
 }

--- a/docs/translations/api-docs/input-unstyled/input-unstyled.json
+++ b/docs/translations/api-docs/input-unstyled/input-unstyled.json
@@ -26,8 +26,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "input": "The component used to render the input.",
     "root": "The component used to render the root.",
+    "input": "The component used to render the input.",
     "textarea": "The component used to render the textarea."
   }
 }

--- a/docs/translations/api-docs/menu-unstyled/menu-unstyled.json
+++ b/docs/translations/api-docs/menu-unstyled/menu-unstyled.json
@@ -12,7 +12,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "listbox": "The component used to render the listbox.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "listbox": "The component used to render the listbox."
   }
 }

--- a/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
+++ b/docs/translations/api-docs/modal-unstyled/modal-unstyled.json
@@ -21,7 +21,7 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "backdrop": "The component used to render the backdrop.",
-    "root": "The component used to render the root."
+    "root": "The component used to render the root.",
+    "backdrop": "The component used to render the backdrop."
   }
 }

--- a/docs/translations/api-docs/option-group-unstyled/option-group-unstyled.json
+++ b/docs/translations/api-docs/option-group-unstyled/option-group-unstyled.json
@@ -9,8 +9,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
+    "root": "The component used to render the root.",
     "label": "The component used to render the label.",
-    "list": "The component used to render the list.",
-    "root": "The component used to render the root."
+    "list": "The component used to render the list."
   }
 }

--- a/docs/translations/api-docs/select-unstyled/select-unstyled.json
+++ b/docs/translations/api-docs/select-unstyled/select-unstyled.json
@@ -21,8 +21,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
+    "root": "The component used to render the root.",
     "listbox": "The component used to render the listbox.",
-    "popper": "The component used to render the popper.",
-    "root": "The component used to render the root."
+    "popper": "The component used to render the popper."
   }
 }

--- a/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
+++ b/docs/translations/api-docs/slider-unstyled/slider-unstyled.json
@@ -29,13 +29,13 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "input": "The component used to render the input.",
+    "root": "The component used to render the root.",
+    "track": "The component used to render the track.",
+    "rail": "The component used to render the rail.",
+    "thumb": "The component used to render the thumb.",
     "mark": "The component used to render the mark.",
     "markLabel": "The component used to render the mark label.",
-    "rail": "The component used to render the rail.",
-    "root": "The component used to render the root.",
-    "thumb": "The component used to render the thumb.",
-    "track": "The component used to render the track.",
-    "valueLabel": "The component used to render the value label."
+    "valueLabel": "The component used to render the value label.",
+    "input": "The component used to render the input."
   }
 }

--- a/docs/translations/api-docs/switch-unstyled/switch-unstyled.json
+++ b/docs/translations/api-docs/switch-unstyled/switch-unstyled.json
@@ -13,8 +13,8 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "input": "The component used to render the input.",
     "root": "The component used to render the root.",
+    "input": "The component used to render the input.",
     "thumb": "The component used to render the thumb.",
     "track": "The component used to render the track."
   }

--- a/docs/translations/api-docs/table-pagination-unstyled/table-pagination-unstyled.json
+++ b/docs/translations/api-docs/table-pagination-unstyled/table-pagination-unstyled.json
@@ -18,13 +18,13 @@
   },
   "classDescriptions": {},
   "slotDescriptions": {
-    "actions": "The component used to render the actions.",
-    "displayedRows": "The component used to render the displayed rows.",
-    "menuItem": "The component used to render the menu item.",
     "root": "The component used to render the root.",
+    "actions": "The component used to render the actions.",
     "select": "The component used to render the select.",
     "selectLabel": "The component used to render the select label.",
-    "spacer": "The component used to render the spacer.",
-    "toolbar": "The component used to render the toolbar."
+    "menuItem": "The component used to render the menu item.",
+    "displayedRows": "The component used to render the displayed rows.",
+    "toolbar": "The component used to render the toolbar.",
+    "spacer": "The component used to render the spacer."
   }
 }

--- a/packages/api-docs-builder/utils/parseSlots.ts
+++ b/packages/api-docs-builder/utils/parseSlots.ts
@@ -47,7 +47,7 @@ export default function parseSlots({
       };
     });
 
-    result = Object.values(slots).sort((a, b) => a.name.localeCompare(b.name));
+    result = Object.values(slots);
   } catch (e) {
     console.error(`No declaration for ${interfaceName}`);
   }


### PR DESCRIPTION
A follow-up on https://github.com/mui/material-ui/pull/36490#issuecomment-1465308374, this seems to make more sense to communicate the DOM order:

**Before**
https://mui.com/base/api/slider-unstyled/#slots

**After**
https://deploy-preview-36499--material-ui.netlify.app/base/api/slider-unstyled/#slots

Ok, for https://mui.com/x/api/data-grid/data-grid/#slots, it doesn't make sense, but they can still sort ASC the properties in the code.

Edit, it seems that it was also requested in https://github.com/mui/material-ui/pull/36328#issuecomment-1464980498.