### PR TITLE
[docs] Improve ordering of slots in Slots section in API pages

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -60,6 +60,18 @@ ClassesTable.propTypes = {
 function SlotsTable(props) {
   const { componentSlots, slotDescriptions } = props;
   const t = useTranslate();
+  const componentSlotsWithRootAtFront = componentSlots.reduce((acc, curr) => {
+    if (curr.name === 'root') {
+      acc.unshift(curr);
+    } else {
+      acc.push(curr);
+    }
+    return acc;
+  }, []);
+  const componentSlotsSorted = [
+    componentSlotsWithRootAtFront[0],
+    ...componentSlotsWithRootAtFront.slice(1).sort((a, b) => a.name - b.name),
+  ];
 
   return (
     <table>
@@ -72,7 +84,7 @@ function SlotsTable(props) {
         </tr>
       </thead>
       <tbody>
-        {componentSlots.map(({ class: className, name, default: defaultValue }) => {
+        {componentSlotsSorted.map(({ class: className, name, default: defaultValue }) => {
           return (
             <tr key={name}>
               <td align="left" width="15%">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Follow-up** on https://github.com/mui/material-ui/pull/36328#issuecomment-1464980498

**This PR makes changes to the "**Slots**" section in API pages**
- places `root` slot at the top of the list in the "**Slots**" section
- sorts other slots except `root` slot in alphabetical order

**Before:**
- [base](https://deploy-preview-36330--material-ui.netlify.app/base/api/badge-unstyled/#slots)
- [joy](https://deploy-preview-36328--material-ui.netlify.app/joy-ui/api/alert/#slots)

**After:**
- [base](https://deploy-preview-36519--material-ui.netlify.app/base/api/badge-unstyled/#slots)
- [joy](https://deploy-preview-36519--material-ui.netlify.app/joy-ui/api/alert/#slots)