### PR TITLE
[Menu][joy] Classname listbox is missing

### DIFF
--- a/packages/mui-joy/src/Menu/Menu.tsx
+++ b/packages/mui-joy/src/Menu/Menu.tsx
@@ -24,6 +24,7 @@ const useUtilityClasses = (ownerState: MenuOwnerState) => {
       color && `color${capitalize(color)}`,
       size && `size${capitalize(size)}`,
     ],
+    listbox: ['listbox'],
   };
 
   return composeClasses(slots, getMenuUtilityClass, {});

--- a/packages/mui-joy/src/Menu/menuClasses.ts
+++ b/packages/mui-joy/src/Menu/menuClasses.ts
@@ -3,6 +3,8 @@ import { generateUtilityClass, generateUtilityClasses } from '../className';
 export interface MenuClasses {
   /** Classname applied to the root element. */
   root: string;
+  /** Classname applied to the listbox element. */
+  listbox: string;
   /** Classname applied to the root element when the menu open. */
   expanded: string;
   /** Classname applied to the root element if `color="primary"`. */
@@ -43,6 +45,7 @@ export function getMenuUtilityClass(slot: string): string {
 
 const menuClasses: MenuClasses = generateUtilityClasses('MuiMenu', [
   'root',
+  'listbox',
   'expanded',
   'colorPrimary',
   'colorNeutral',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Problem

`menuClasses` exported from Joy `Menu` doesn't include `listbox`.

### How did I find the problem?

https://github.com/mui/material-ui/blob/d1662e4d83ed525af30c42a568dc05ac06968488/docs/data/joy/components/menu/MenuIconSideNavExample.js#L101