### PR TITLE
[docs] Ensure classname displayed under Slots section in API docs exists

### DIFF
--- a/docs/pages/base/api/input-unstyled.json
+++ b/docs/pages/base/api/input-unstyled.json
@@ -60,7 +60,7 @@
       "name": "textarea",
       "description": "The component that renders the textarea.",
       "default": "'textarea'",
-      "class": ".MuiInput-textarea"
+      "class": ""
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/input-unstyled.json
+++ b/docs/pages/base/api/input-unstyled.json
@@ -60,7 +60,7 @@
       "name": "textarea",
       "description": "The component that renders the textarea.",
       "default": "'textarea'",
-      "class": ""
+      "class": null
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/slider-unstyled.json
+++ b/docs/pages/base/api/slider-unstyled.json
@@ -102,13 +102,13 @@
     {
       "name": "valueLabel",
       "description": "The component that renders the value label.",
-      "class": ".MuiSlider-valueLabel"
+      "class": ""
     },
     {
       "name": "input",
       "description": "The component that renders the input.",
       "default": "'input'",
-      "class": ".MuiSlider-input"
+      "class": ""
     }
   ],
   "spread": true,

--- a/docs/pages/base/api/slider-unstyled.json
+++ b/docs/pages/base/api/slider-unstyled.json
@@ -102,13 +102,13 @@
     {
       "name": "valueLabel",
       "description": "The component that renders the value label.",
-      "class": ""
+      "class": null
     },
     {
       "name": "input",
       "description": "The component that renders the input.",
       "default": "'input'",
-      "class": ""
+      "class": null
     }
   ],
   "spread": true,

--- a/docs/pages/joy-ui/api/chip.json
+++ b/docs/pages/joy-ui/api/chip.json
@@ -52,7 +52,7 @@
       "name": "action",
       "description": "The component that renders the action.",
       "default": "'button'",
-      "class": ".MuiChip-action"
+      "class": ""
     },
     {
       "name": "startDecorator",

--- a/docs/pages/joy-ui/api/chip.json
+++ b/docs/pages/joy-ui/api/chip.json
@@ -52,7 +52,7 @@
       "name": "action",
       "description": "The component that renders the action.",
       "default": "'button'",
-      "class": ""
+      "class": null
     },
     {
       "name": "startDecorator",

--- a/docs/pages/joy-ui/api/slider.json
+++ b/docs/pages/joy-ui/api/slider.json
@@ -150,7 +150,7 @@
       "name": "input",
       "description": "The component that renders the input.",
       "default": "'input'",
-      "class": ""
+      "class": null
     }
   ],
   "spread": false,

--- a/docs/pages/joy-ui/api/slider.json
+++ b/docs/pages/joy-ui/api/slider.json
@@ -150,7 +150,7 @@
       "name": "input",
       "description": "The component that renders the input.",
       "default": "'input'",
-      "class": ".MuiSlider-input"
+      "class": ""
     }
   ],
   "spread": false,

--- a/packages/api-docs-builder/utils/parseSlots.ts
+++ b/packages/api-docs-builder/utils/parseSlots.ts
@@ -20,14 +20,23 @@ export default function parseSlots({
 }): Slot[] {
   // Generate the params
   let result: Slot[] = [];
-  const interfaceName = `${componentName}Slots`;
-
+  const slotsInterface = `${componentName}Slots`;
   try {
-    const exportedSymbol = project.exports[interfaceName];
+    const exportedSymbol = project.exports[slotsInterface];
     const type = project.checker.getDeclaredTypeOfSymbol(exportedSymbol);
     const typeDeclaration = type?.symbol?.declarations?.[0];
     if (!typeDeclaration || !ts.isInterfaceDeclaration(typeDeclaration)) {
       return [];
+    }
+
+    // Obtain an array of classes for the given component
+    const classesInterface = `${componentName}Classes`;
+    const classesType = project.checker.getDeclaredTypeOfSymbol(project.exports[classesInterface]);
+    const classesTypeDeclaration = classesType?.symbol?.declarations?.[0];
+    let classNames: string[] = [];
+    if (classesTypeDeclaration && ts.isInterfaceDeclaration(classesTypeDeclaration)) {
+      const classesProperties = classesType.getProperties();
+      classNames = classesProperties.map((symbol) => symbol.name);
     }
 
     const slots: Record<string, Slot> = {};
@@ -38,18 +47,18 @@ export default function parseSlots({
       if (tags.ignore) {
         return;
       }
-
-      slots[propertySymbol.name] = {
-        name: propertySymbol.name,
+      const slotName = propertySymbol.name;
+      slots[slotName] = {
+        name: slotName,
         description: getSymbolDescription(propertySymbol, project),
         default: tags.default?.text?.[0].text,
-        class: `.${muiName}-${propertySymbol.name}`,
+        class: classNames.includes(slotName) ? `.${muiName}-${slotName}` : '',
       };
     });
 
     result = Object.values(slots);
   } catch (e) {
-    console.error(`No declaration for ${interfaceName}`);
+    console.error(`No declaration for ${slotsInterface}`);
   }
 
   return result;

--- a/packages/api-docs-builder/utils/parseSlots.ts
+++ b/packages/api-docs-builder/utils/parseSlots.ts
@@ -3,7 +3,7 @@ import { getSymbolDescription, getSymbolJSDocTags } from '../buildApiUtils';
 import { TypeScriptProject } from './createTypeScriptProject';
 
 export interface Slot {
-  class: string;
+  class: string | null;
   name: string;
   description: string;
   default?: string;
@@ -52,7 +52,7 @@ export default function parseSlots({
         name: slotName,
         description: getSymbolDescription(propertySymbol, project),
         default: tags.default?.text?.[0].text,
-        class: classNames.includes(slotName) ? `.${muiName}-${slotName}` : '',
+        class: classNames.includes(slotName) ? `.${muiName}-${slotName}` : null,
       };
     });
 

--- a/packages/mui-base/src/ButtonUnstyled/buttonUnstyledClasses.ts
+++ b/packages/mui-base/src/ButtonUnstyled/buttonUnstyledClasses.ts
@@ -2,9 +2,13 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface ButtonUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `button` element if `active={true}`. */
   active: string;
+  /** State class applied to the root `button` element if `disabled={true}`. */
   disabled: string;
+  /** State class applied to the root `button` element if `focusVisible={true}`. */
   focusVisible: string;
 }
 

--- a/packages/mui-base/src/ButtonUnstyled/index.ts
+++ b/packages/mui-base/src/ButtonUnstyled/index.ts
@@ -1,6 +1,4 @@
 export { default } from './ButtonUnstyled';
-export {
-  default as buttonUnstyledClasses,
-} from './buttonUnstyledClasses';
+export { default as buttonUnstyledClasses } from './buttonUnstyledClasses';
 export * from './buttonUnstyledClasses';
 export * from './ButtonUnstyled.types';

--- a/packages/mui-base/src/ButtonUnstyled/index.ts
+++ b/packages/mui-base/src/ButtonUnstyled/index.ts
@@ -1,6 +1,6 @@
 export { default } from './ButtonUnstyled';
 export {
   default as buttonUnstyledClasses,
-  getButtonUnstyledUtilityClass,
 } from './buttonUnstyledClasses';
+export * from './buttonUnstyledClasses';
 export * from './ButtonUnstyled.types';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Follow-up** on (5) of https://github.com/mui/material-ui/pull/36490#issuecomment-1465308374

- Classnames displayed in "Slots" section in API docs are wrong for some components' docs. For example, the className for the input slot and the valueLabel slot are wrong in https://deploy-preview-36499--material-ui.netlify.app/base/api/slider-unstyled/#slots. These classnames don't exist for `SliderUnstyled`.
- I improved `parseSlots` function so that only existing classnames are displayed.

**Before**
https://master--material-ui.netlify.app/base/api/slider-unstyled/#slots

**After**
https://deploy-preview-36539--material-ui.netlify.app/base/api/slider-unstyled/#slots