### PR TITLE
[docs] Remove `shouldSkipGeneratingVar` usage

### DIFF
--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -27,12 +27,8 @@ import { deepmerge } from '@mui/utils';
 import {
   Experimental_CssVarsProvider as CssVarsProvider,
   experimental_extendTheme as extendMuiTheme,
-  shouldSkipGeneratingVar as muiShouldSkipGeneratingVar,
 } from '@mui/material/styles';
-import {
-  extendTheme as extendJoyTheme,
-  shouldSkipGeneratingVar as joyShouldSkipGeneratingVar,
-} from '@mui/joy/styles';
+import { extendTheme as extendJoyTheme } from '@mui/joy/styles';
 
 const { unstable_sxConfig: joySxConfig, ...joyTheme } = extendTheme({
   // This is required to point to `var(--mui-*)` because we are using
@@ -102,8 +98,6 @@ const mergedTheme = ({
     ...muiTheme.zIndex
   }
 } as unknown) as ReturnType<typeof extendMuiTheme>;
-mergedTheme.shouldSkipGeneratingVar = (keys) =>
-  joyShouldSkipGeneratingVar(keys) || muiShouldSkipGeneratingVar(keys);
 mergedTheme.generateCssVars = (colorScheme) => ({
   css: {
     ...joyTheme.generateCssVars(colorScheme).css,
@@ -142,13 +136,11 @@ This setup uses the `CssVarsProvider` component from Joy UI and configures the M
 import { deepmerge } from '@mui/utils';
 import {
   experimental_extendTheme as extendMuiTheme,
-  shouldSkipGeneratingVar as muiShouldSkipGeneratingVar,
 } from '@mui/material/styles';
 import colors from '@mui/joy/colors';
 import {
   extendTheme as extendJoyTheme,
   CssVarsProvider,
-  shouldSkipGeneratingVar as joyShouldSkipGeneratingVar,
 } from '@mui/joy/styles';
 
 const { unstable_sxConfig: muiSxConfig, ...muiTheme } = extendMuiTheme({
@@ -229,9 +221,6 @@ const mergedTheme = ({
   }
 } as unknown) as ReturnType<typeof extendJoyTheme>;
 
-mergedTheme.shouldSkipGeneratingVar = (...params) =>
-  joyShouldSkipGeneratingVar(params[0]) ||
-  muiShouldSkipGeneratingVar(params[0]);
 mergedTheme.generateCssVars = (colorScheme) => ({
   css: {
     ...muiTheme.generateCssVars(colorScheme).css,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Since https://github.com/mui/material-ui/pull/35739, `shouldSkipGeneratingVar` has been moved to `extendTheme`. For using Joy and Material UI, there is no need to merge those functions. 

Remove them in the guide to make it a bit simpler.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
