### PR TITLE
[Base] Add JSDoc comments for classes of Base components

### DIFF
--- a/packages/mui-base/src/FormControlUnstyled/formControlUnstyledClasses.ts
+++ b/packages/mui-base/src/FormControlUnstyled/formControlUnstyledClasses.ts
@@ -4,15 +4,15 @@ import generateUtilityClasses from '../generateUtilityClasses';
 export interface FormControlUnstyledClasses {
   /** Class applied to the root element. */
   root: string;
-  /** Class applied to the root element if `disabled={true}`. */
+  /** State class applied to the root element if `disabled={true}`. */
   disabled: string;
-  /** Class applied to the root element if `error={true}`. */
+  /** State class applied to the root element if `error={true}`. */
   error: string;
-  /** Class applied to the root element if the inner input has value. */
+  /** State class applied to the root element if the inner input has value. */
   filled: string;
-  /** Class applied to the root element if the inner input is focused. */
+  /** State class applied to the root element if the inner input is focused. */
   focused: string;
-  /** Class applied to the root element if `required={true}`. */
+  /** State class applied to the root element if `required={true}`. */
   required: string;
 }
 

--- a/packages/mui-base/src/InputUnstyled/inputUnstyledClasses.ts
+++ b/packages/mui-base/src/InputUnstyled/inputUnstyledClasses.ts
@@ -10,9 +10,9 @@ export interface InputUnstyledClasses {
   adornedStart: string;
   /** Class name applied to the root element if `endAdornment` is provided. */
   adornedEnd: string;
-  /** Class name applied to the root element if the component is focused. */
+  /** State class applied to the root element if the component is focused. */
   focused: string;
-  /** Class name applied to the root element if `disabled={true}`. */
+  /** State class applied to the root element if `disabled={true}`. */
   disabled: string;
   /** State class applied to the root element if `error={true}`. */
   error: string;

--- a/packages/mui-base/src/MenuItemUnstyled/menuItemUnstyledClasses.ts
+++ b/packages/mui-base/src/MenuItemUnstyled/menuItemUnstyledClasses.ts
@@ -2,8 +2,11 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface MenuItemUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `button` element if `disabled={true}`. */
   disabled: string;
+  /** State class applied to the root `button` element if `focusVisible={true}`. */
   focusVisible: string;
 }
 

--- a/packages/mui-base/src/MenuUnstyled/menuUnstyledClasses.ts
+++ b/packages/mui-base/src/MenuUnstyled/menuUnstyledClasses.ts
@@ -6,7 +6,7 @@ export interface MenuUnstyledClasses {
   root: string;
   /** Class name applied to the listbox element. */
   listbox: string;
-  /** State class applied to the root element and the listbox element if `open={true}`. */
+  /** State class applied to the root `PopperUnstyled` element and the listbox `ul` element if `open={true}`. */
   expanded: string;
 }
 

--- a/packages/mui-base/src/MenuUnstyled/menuUnstyledClasses.ts
+++ b/packages/mui-base/src/MenuUnstyled/menuUnstyledClasses.ts
@@ -2,8 +2,11 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface MenuUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** Class name applied to the listbox element. */
   listbox: string;
+  /** State class applied to the root element and the listbox element if `open={true}`. */
   expanded: string;
 }
 

--- a/packages/mui-base/src/OptionGroupUnstyled/optionGroupUnstyledClasses.ts
+++ b/packages/mui-base/src/OptionGroupUnstyled/optionGroupUnstyledClasses.ts
@@ -2,8 +2,13 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface OptionGroupUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `li` element if `disabled={true}`. */
+  disabled: string;
+  /** Class name applied to the label element. */
   label: string;
+  /** Class name applied to the list element. */
   list: string;
 }
 
@@ -15,7 +20,7 @@ export function getOptionGroupUnstyledUtilityClass(slot: string): string {
 
 const optionGroupUnstyledClasses: OptionGroupUnstyledClasses = generateUtilityClasses(
   'MuiOptionGroup',
-  ['root', 'label', 'list'],
+  ['root', 'disabled', 'label', 'list'],
 );
 
 export default optionGroupUnstyledClasses;

--- a/packages/mui-base/src/OptionUnstyled/optionUnstyledClasses.tsx
+++ b/packages/mui-base/src/OptionUnstyled/optionUnstyledClasses.tsx
@@ -2,9 +2,13 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface OptionUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `li` element if `disabled={true}`. */
   disabled: string;
+  /** State class applied to the root `li` element if `selected={true}`. */
   selected: string;
+  /** State class applied to the root `li` element if `highlighted={true}`. */
   highlighted: string;
 }
 

--- a/packages/mui-base/src/PopperUnstyled/popperUnstyledClasses.ts
+++ b/packages/mui-base/src/PopperUnstyled/popperUnstyledClasses.ts
@@ -2,6 +2,7 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface PopperUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
 }
 

--- a/packages/mui-base/src/SelectUnstyled/selectUnstyledClasses.ts
+++ b/packages/mui-base/src/SelectUnstyled/selectUnstyledClasses.ts
@@ -2,13 +2,19 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface SelectUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
-  button: string;
+  /** Class name applied to the listbox element. */
   listbox: string;
+  /** Class name applied to the popper element. */
   popper: string;
+  /** State class applied to the root `button` element if `active={true}`. */
   active: string;
+  /** State class applied to the root `button` element if `expanded={true}`. */
   expanded: string;
+  /** State class applied to the root `button` element and the listbox 'ul' element if `disabled={true}`. */
   disabled: string;
+  /** State class applied to the root `button` element if `focusVisible={true}`. */
   focusVisible: string;
 }
 

--- a/packages/mui-base/src/SwitchUnstyled/switchUnstyledClasses.ts
+++ b/packages/mui-base/src/SwitchUnstyled/switchUnstyledClasses.ts
@@ -10,11 +10,11 @@ export interface SwitchUnstyledClasses {
   track: string;
   /** Class applied to the thumb element */
   thumb: string;
-  /** Class applied to the root element if the switch is checked */
+  /** State class applied to the root element if the switch is checked */
   checked: string;
-  /** Class applied to the root element if the switch is disabled */
+  /** State class applied to the root element if the switch is disabled */
   disabled: string;
-  /** Class applied to the root element if the switch has visible focus */
+  /** State class applied to the root element if the switch has visible focus */
   focusVisible: string;
   /** Class applied to the root element if the switch is read-only */
   readOnly: string;

--- a/packages/mui-base/src/TabPanelUnstyled/tabPanelUnstyledClasses.ts
+++ b/packages/mui-base/src/TabPanelUnstyled/tabPanelUnstyledClasses.ts
@@ -2,7 +2,9 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface TabPanelUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `div` element if `hidden={true}`. */
   hidden: string;
 }
 

--- a/packages/mui-base/src/TabUnstyled/tabUnstyledClasses.ts
+++ b/packages/mui-base/src/TabUnstyled/tabUnstyledClasses.ts
@@ -2,8 +2,11 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface TabUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `button` element if `selected={true}`. */
   selected: string;
+  /** State class applied to the root `button` element if `disabled={true}`. */
   disabled: string;
 }
 

--- a/packages/mui-base/src/TabsListUnstyled/tabsListUnstyledClasses.ts
+++ b/packages/mui-base/src/TabsListUnstyled/tabsListUnstyledClasses.ts
@@ -2,8 +2,11 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface TabsListUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `div` element if `orientation='horizontal'`. */
   horizontal: string;
+  /** State class applied to the root `div` element if `orientation='vertical'`. */
   vertical: string;
 }
 

--- a/packages/mui-base/src/TabsListUnstyled/tabsListUnstyledClasses.ts
+++ b/packages/mui-base/src/TabsListUnstyled/tabsListUnstyledClasses.ts
@@ -4,9 +4,9 @@ import generateUtilityClasses from '../generateUtilityClasses';
 export interface TabsListUnstyledClasses {
   /** Class name applied to the root element. */
   root: string;
-  /** State class applied to the root `div` element if `orientation='horizontal'`. */
+  /** Class name applied to the root element if `orientation='horizontal'`. */
   horizontal: string;
-  /** State class applied to the root `div` element if `orientation='vertical'`. */
+  /** Class name applied to the root element if `orientation='vertical'`. */
   vertical: string;
 }
 

--- a/packages/mui-base/src/TabsUnstyled/tabsUnstyledClasses.ts
+++ b/packages/mui-base/src/TabsUnstyled/tabsUnstyledClasses.ts
@@ -4,9 +4,9 @@ import generateUtilityClasses from '../generateUtilityClasses';
 export interface TabsUnstyledClasses {
   /** Class name applied to the root element. */
   root: string;
-  /** State class applied to the root `div` element if `orientation='horizontal'`. */
+  /** Class name applied to the root element if `orientation='horizontal'`. */
   horizontal: string;
-  /** State class applied to the root `div` element if `orientation='vertical'`. */
+  /** Class name applied to the root element if `orientation='vertical'`. */
   vertical: string;
 }
 

--- a/packages/mui-base/src/TabsUnstyled/tabsUnstyledClasses.ts
+++ b/packages/mui-base/src/TabsUnstyled/tabsUnstyledClasses.ts
@@ -2,8 +2,11 @@ import generateUtilityClass from '../generateUtilityClass';
 import generateUtilityClasses from '../generateUtilityClasses';
 
 export interface TabsUnstyledClasses {
+  /** Class name applied to the root element. */
   root: string;
+  /** State class applied to the root `div` element if `orientation='horizontal'`. */
   horizontal: string;
+  /** State class applied to the root `div` element if `orientation='vertical'`. */
   vertical: string;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In #36539, I added JSDoc comments for classes of `ButtonUnstyled`. This PR is to do the same for those of other Base components to maintain consistency throughout the codebase.