### PR TITLE
[Joy] Fix `--List-decorator*` vars

### DIFF
--- a/docs/data/joy/components/list/DecoratedList.js
+++ b/docs/data/joy/components/list/DecoratedList.js
@@ -18,7 +18,7 @@ export default function DecoratedList() {
       </Typography>
       <List
         aria-labelledby="decorated-list-demo"
-        sx={{ '--List-decoratorSize': '32px' }}
+        sx={{ '--ListItemDecorator-size': '32px' }}
       >
         <ListItem>
           <ListItemDecorator>🧅</ListItemDecorator> 1 red onion

--- a/docs/data/joy/components/list/DecoratedList.tsx
+++ b/docs/data/joy/components/list/DecoratedList.tsx
@@ -18,7 +18,7 @@ export default function DecoratedList() {
       </Typography>
       <List
         aria-labelledby="decorated-list-demo"
-        sx={{ '--List-decoratorSize': '32px' }}
+        sx={{ '--ListItemDecorator-size': '32px' }}
       >
         <ListItem>
           <ListItemDecorator>🧅</ListItemDecorator> 1 red onion

--- a/docs/data/joy/components/list/DividedList.js
+++ b/docs/data/joy/components/list/DividedList.js
@@ -29,7 +29,7 @@ export default function DividedList() {
               minWidth: 240,
               borderRadius: 'sm',
               boxShadow: 'sm',
-              '--List-decoratorSize': '48px',
+              '--ListItemDecorator-size': '48px',
               '--ListItem-paddingLeft': '1.5rem',
               '--ListItem-paddingRight': '1rem',
             }}

--- a/docs/data/joy/components/list/DividedList.tsx
+++ b/docs/data/joy/components/list/DividedList.tsx
@@ -30,7 +30,7 @@ export default function DividedList() {
                 minWidth: 240,
                 borderRadius: 'sm',
                 boxShadow: 'sm',
-                '--List-decoratorSize': '48px',
+                '--ListItemDecorator-size': '48px',
                 '--ListItem-paddingLeft': '1.5rem',
                 '--ListItem-paddingRight': '1rem',
               }}

--- a/docs/data/joy/components/list/EllipsisList.js
+++ b/docs/data/joy/components/list/EllipsisList.js
@@ -22,7 +22,7 @@ export default function EllipsisList() {
       </Typography>
       <List
         aria-labelledby="ellipsis-list-demo"
-        sx={{ '--List-decoratorSize': '56px' }}
+        sx={{ '--ListItemDecorator-size': '56px' }}
       >
         <ListItem>
           <ListItemDecorator sx={{ alignSelf: 'flex-start' }}>

--- a/docs/data/joy/components/list/EllipsisList.tsx
+++ b/docs/data/joy/components/list/EllipsisList.tsx
@@ -22,7 +22,7 @@ export default function EllipsisList() {
       </Typography>
       <List
         aria-labelledby="ellipsis-list-demo"
-        sx={{ '--List-decoratorSize': '56px' }}
+        sx={{ '--ListItemDecorator-size': '56px' }}
       >
         <ListItem>
           <ListItemDecorator sx={{ alignSelf: 'flex-start' }}>

--- a/docs/data/joy/components/list/ExampleGmailList.js
+++ b/docs/data/joy/components/list/ExampleGmailList.js
@@ -24,8 +24,8 @@ export default function ExampleGmailList() {
         sx={{
           // ...applyRadiusOnEdges({ target: 'deepest' | 'nested' }),
           '--ListItem-paddingLeft': '0px',
-          '--List-decoratorSize': '64px',
-          '--List-decoratorColor': (theme) => theme.vars.palette.text.secondary,
+          '--ListItemDecorator-size': '64px',
+          '--ListItemDecorator-color': (theme) => theme.vars.palette.text.secondary,
           '--ListItem-minHeight': '32px',
           '--List-nestedInsetStart': '13px',
           [`& .${listItemDecoratorClasses.root}`]: {

--- a/docs/data/joy/components/list/ExampleGmailList.tsx
+++ b/docs/data/joy/components/list/ExampleGmailList.tsx
@@ -24,8 +24,8 @@ export default function ExampleGmailList() {
         sx={{
           // ...applyRadiusOnEdges({ target: 'deepest' | 'nested' }),
           '--ListItem-paddingLeft': '0px',
-          '--List-decoratorSize': '64px',
-          '--List-decoratorColor': (theme) => theme.vars.palette.text.secondary,
+          '--ListItemDecorator-size': '64px',
+          '--ListItemDecorator-color': (theme) => theme.vars.palette.text.secondary,
           '--ListItem-minHeight': '32px',
           '--List-nestedInsetStart': '13px',
           [`& .${listItemDecoratorClasses.root}`]: {

--- a/docs/data/joy/components/list/ExampleIOSList.js
+++ b/docs/data/joy/components/list/ExampleIOSList.js
@@ -59,7 +59,7 @@ export default function ExampleIOSList() {
         })}
       >
         <ListItem nested>
-          <List aria-label="Personal info" sx={{ '--List-decoratorSize': '72px' }}>
+          <List aria-label="Personal info" sx={{ '--ListItemDecorator-size': '72px' }}>
             <ListItem>
               <ListItemDecorator>
                 <Avatar size="lg" sx={{ '--Avatar-size': '60px' }}>

--- a/docs/data/joy/components/list/ExampleIOSList.js
+++ b/docs/data/joy/components/list/ExampleIOSList.js
@@ -59,7 +59,10 @@ export default function ExampleIOSList() {
         })}
       >
         <ListItem nested>
-          <List aria-label="Personal info" sx={{ '--ListItemDecorator-size': '72px' }}>
+          <List
+            aria-label="Personal info"
+            sx={{ '--ListItemDecorator-size': '72px' }}
+          >
             <ListItem>
               <ListItemDecorator>
                 <Avatar size="lg" sx={{ '--Avatar-size': '60px' }}>

--- a/docs/data/joy/components/list/ExampleIOSList.tsx
+++ b/docs/data/joy/components/list/ExampleIOSList.tsx
@@ -59,7 +59,7 @@ export default function ExampleIOSList() {
         })}
       >
         <ListItem nested>
-          <List aria-label="Personal info" sx={{ '--List-decoratorSize': '72px' }}>
+          <List aria-label="Personal info" sx={{ '--ListItemDecorator-size': '72px' }}>
             <ListItem>
               <ListItemDecorator>
                 <Avatar size="lg" sx={{ '--Avatar-size': '60px' }}>

--- a/docs/data/joy/components/list/ExampleIOSList.tsx
+++ b/docs/data/joy/components/list/ExampleIOSList.tsx
@@ -59,7 +59,10 @@ export default function ExampleIOSList() {
         })}
       >
         <ListItem nested>
-          <List aria-label="Personal info" sx={{ '--ListItemDecorator-size': '72px' }}>
+          <List
+            aria-label="Personal info"
+            sx={{ '--ListItemDecorator-size': '72px' }}
+          >
             <ListItem>
               <ListItemDecorator>
                 <Avatar size="lg" sx={{ '--Avatar-size': '60px' }}>

--- a/docs/data/joy/components/list/ExampleNavigationMenu.js
+++ b/docs/data/joy/components/list/ExampleNavigationMenu.js
@@ -154,7 +154,7 @@ const AboutMenu = React.forwardRef(({ focusNext, focusPrevious, ...props }, ref)
               '--List-radius': '8px',
               '--List-padding': '4px',
               '--ListDivider-gap': '4px',
-              '--List-decoratorSize': '32px',
+              '--ListItemDecorator-size': '32px',
             }}
           >
             <ListItem role="none">

--- a/docs/data/joy/components/list/ExampleNavigationMenu.tsx
+++ b/docs/data/joy/components/list/ExampleNavigationMenu.tsx
@@ -177,7 +177,7 @@ const AboutMenu = React.forwardRef(
                 '--List-radius': '8px',
                 '--List-padding': '4px',
                 '--ListDivider-gap': '4px',
-                '--List-decoratorSize': '32px',
+                '--ListItemDecorator-size': '32px',
               }}
             >
               <ListItem role="none">

--- a/docs/data/joy/components/list/HorizontalDividedList.js
+++ b/docs/data/joy/components/list/HorizontalDividedList.js
@@ -16,7 +16,7 @@ export default function HorizontalDividedList() {
         boxShadow: 'sm',
         flexGrow: 0,
         mx: 'auto',
-        '--List-decoratorSize': '48px',
+        '--ListItemDecorator-size': '48px',
         '--ListItem-paddingY': '1rem',
       }}
     >

--- a/docs/data/joy/components/list/HorizontalDividedList.tsx
+++ b/docs/data/joy/components/list/HorizontalDividedList.tsx
@@ -16,7 +16,7 @@ export default function HorizontalDividedList() {
         boxShadow: 'sm',
         flexGrow: 0,
         mx: 'auto',
-        '--List-decoratorSize': '48px',
+        '--ListItemDecorator-size': '48px',
         '--ListItem-paddingY': '1rem',
       }}
     >

--- a/docs/data/joy/components/list/ListVariables.js
+++ b/docs/data/joy/components/list/ListVariables.js
@@ -25,7 +25,7 @@ export default function ListVariables() {
         { var: '--ListItem-minHeight', defaultValue: '40px' },
         { var: '--ListItem-paddingY', defaultValue: '6px' },
         { var: '--ListItem-paddingX', defaultValue: '12px' },
-        { var: '--List-decoratorSize', defaultValue: '40px' },
+        { var: '--ListItemDecorator-size', defaultValue: '40px' },
         { var: '--ListDivider-gap', defaultValue: '6px' },
       ]}
       renderDemo={(sx) => (

--- a/docs/data/joy/components/menu/GroupMenu.js
+++ b/docs/data/joy/components/menu/GroupMenu.js
@@ -41,7 +41,7 @@ export default function BasicMenu() {
         open={open}
         onClose={handleClose}
         aria-labelledby="group-demo-button"
-        sx={{ minWidth: 160, '--List-decorator-size': '24px' }}
+        sx={{ minWidth: 160, '--ListItemDecorator-size': '24px' }}
       >
         <MenuItem
           onClick={() => {

--- a/docs/data/joy/components/menu/GroupMenu.tsx
+++ b/docs/data/joy/components/menu/GroupMenu.tsx
@@ -41,7 +41,7 @@ export default function BasicMenu() {
         open={open}
         onClose={handleClose}
         aria-labelledby="group-demo-button"
-        sx={{ minWidth: 160, '--List-decorator-size': '24px' }}
+        sx={{ minWidth: 160, '--ListItemDecorator-size': '24px' }}
       >
         <MenuItem
           onClick={() => {

--- a/docs/data/joy/components/radio-button/RadioPositionEnd.js
+++ b/docs/data/joy/components/radio-button/RadioPositionEnd.js
@@ -17,7 +17,7 @@ export default function RadioPositionEnd() {
           '--List-gap': '0.5rem',
           '--ListItem-paddingY': '1rem',
           '--ListItem-radius': '8px',
-          '--List-decoratorSize': '32px',
+          '--ListItemDecorator-size': '32px',
         }}
       >
         {['Individual', 'Team', 'Enterprise'].map((item, index) => (

--- a/docs/data/joy/components/radio-button/RadioPositionEnd.tsx
+++ b/docs/data/joy/components/radio-button/RadioPositionEnd.tsx
@@ -17,7 +17,7 @@ export default function RadioPositionEnd() {
           '--List-gap': '0.5rem',
           '--ListItem-paddingY': '1rem',
           '--ListItem-radius': '8px',
-          '--List-decoratorSize': '32px',
+          '--ListItemDecorator-size': '32px',
         }}
       >
         {['Individual', 'Team', 'Enterprise'].map((item, index) => (

--- a/docs/data/joy/components/select/SelectCustomOption.js
+++ b/docs/data/joy/components/select/SelectCustomOption.js
@@ -12,12 +12,12 @@ export default function SelectCustomOption() {
       slotProps={{
         listbox: {
           sx: {
-            '--List-decoratorSize': '44px',
+            '--ListItemDecorator-size': '44px',
           },
         },
       }}
       sx={{
-        '--List-decoratorSize': '44px',
+        '--ListItemDecorator-size': '44px',
         minWidth: 240,
       }}
     >

--- a/docs/data/joy/components/select/SelectCustomOption.tsx
+++ b/docs/data/joy/components/select/SelectCustomOption.tsx
@@ -12,12 +12,12 @@ export default function SelectCustomOption() {
       slotProps={{
         listbox: {
           sx: {
-            '--List-decoratorSize': '44px',
+            '--ListItemDecorator-size': '44px',
           },
         },
       }}
       sx={{
-        '--List-decoratorSize': '44px',
+        '--ListItemDecorator-size': '44px',
         minWidth: 240,
       }}
     >

--- a/docs/data/joy/components/select/SelectCustomValueAppearance.js
+++ b/docs/data/joy/components/select/SelectCustomValueAppearance.js
@@ -25,7 +25,7 @@ export default function SelectCustomValueAppearance() {
       slotProps={{
         listbox: {
           sx: {
-            '--List-decoratorSize': '48px',
+            '--ListItemDecorator-size': '48px',
           },
         },
       }}

--- a/docs/data/joy/components/select/SelectCustomValueAppearance.tsx
+++ b/docs/data/joy/components/select/SelectCustomValueAppearance.tsx
@@ -24,7 +24,7 @@ export default function SelectCustomValueAppearance() {
       slotProps={{
         listbox: {
           sx: {
-            '--List-decoratorSize': '48px',
+            '--ListItemDecorator-size': '48px',
           },
         },
       }}

--- a/docs/data/joy/components/select/SelectGroupedOptions.js
+++ b/docs/data/joy/components/select/SelectGroupedOptions.js
@@ -42,7 +42,7 @@ export default function SelectGroupedOptions() {
           {index !== 0 && <ListDivider role="none" />}
           <List
             aria-labelledby={`select-group-${name}`}
-            sx={{ '--List-decoratorSize': '28px' }}
+            sx={{ '--ListItemDecorator-size': '28px' }}
           >
             <ListItem id={`select-group-${name}`} sticky>
               <Typography level="body3" textTransform="uppercase" letterSpacing="md">

--- a/docs/data/joy/components/select/SelectGroupedOptions.tsx
+++ b/docs/data/joy/components/select/SelectGroupedOptions.tsx
@@ -42,7 +42,7 @@ export default function SelectGroupedOptions() {
           {index !== 0 && <ListDivider role="none" />}
           <List
             aria-labelledby={`select-group-${name}`}
-            sx={{ '--List-decoratorSize': '28px' }}
+            sx={{ '--ListItemDecorator-size': '28px' }}
           >
             <ListItem id={`select-group-${name}`} sticky>
               <Typography level="body3" textTransform="uppercase" letterSpacing="md">

--- a/docs/data/joy/components/tabs/TabsBottomNavExample.js
+++ b/docs/data/joy/components/tabs/TabsBottomNavExample.js
@@ -48,7 +48,7 @@ export default function TabsBottomNavExample() {
           },
         })}
       >
-        <TabList variant="plain" sx={{ '--List-decoratorSize': '28px' }}>
+        <TabList variant="plain" sx={{ '--ListItemDecorator-size': '28px' }}>
           <Tab
             orientation="vertical"
             {...(index === 0 && { variant: 'soft', color: colors[0] })}

--- a/docs/data/joy/components/tabs/TabsBottomNavExample.tsx
+++ b/docs/data/joy/components/tabs/TabsBottomNavExample.tsx
@@ -48,7 +48,7 @@ export default function TabsBottomNavExample() {
           },
         })}
       >
-        <TabList variant="plain" sx={{ '--List-decoratorSize': '28px' }}>
+        <TabList variant="plain" sx={{ '--ListItemDecorator-size': '28px' }}>
           <Tab
             orientation="vertical"
             {...(index === 0 && { variant: 'soft', color: colors[0] })}

--- a/docs/data/joy/components/textarea/ExampleTextareaComment.js
+++ b/docs/data/joy/components/textarea/ExampleTextareaComment.js
@@ -48,7 +48,7 @@ export default function TextareaValidator() {
               onClose={() => setAnchorEl(null)}
               size="sm"
               placement="bottom-start"
-              sx={{ '--List-decoratorSize': '24px' }}
+              sx={{ '--ListItemDecorator-size': '24px' }}
             >
               {['200', 'normal', 'bold'].map((weight) => (
                 <MenuItem

--- a/docs/data/joy/components/textarea/ExampleTextareaComment.tsx
+++ b/docs/data/joy/components/textarea/ExampleTextareaComment.tsx
@@ -48,7 +48,7 @@ export default function TextareaValidator() {
               onClose={() => setAnchorEl(null)}
               size="sm"
               placement="bottom-start"
-              sx={{ '--List-decoratorSize': '24px' }}
+              sx={{ '--ListItemDecorator-size': '24px' }}
             >
               {['200', 'normal', 'bold'].map((weight) => (
                 <MenuItem

--- a/docs/data/joy/getting-started/templates/email/components/Navigation.tsx
+++ b/docs/data/joy/getting-started/templates/email/components/Navigation.tsx
@@ -95,7 +95,7 @@ export default function EmailNav() {
           aria-labelledby="nav-list-tags"
           size="sm"
           sx={{
-            '--List-decoratorSize': '32px',
+            '--ListItemDecorator-size': '32px',
             '& .JoyListItemButton-root': { p: '8px' },
           }}
         >

--- a/docs/data/joy/getting-started/templates/files/components/Navigation.tsx
+++ b/docs/data/joy/getting-started/templates/files/components/Navigation.tsx
@@ -77,7 +77,7 @@ export default function Navigation() {
           aria-labelledby="nav-list-tags"
           size="sm"
           sx={{
-            '--List-decoratorSize': '32px',
+            '--ListItemDecorator-size': '32px',
           }}
         >
           <ListItem>

--- a/docs/data/joy/getting-started/templates/team/App.tsx
+++ b/docs/data/joy/getting-started/templates/team/App.tsx
@@ -470,7 +470,7 @@ export default function TeamExample() {
                   </Box>
                 </Box>
                 <Divider component="div" sx={{ my: 2 }} />
-                <List sx={{ '--List-decoratorSize': '48px' }}>
+                <List sx={{ '--ListItemDecorator-size': '48px' }}>
                   <ListItem sx={{ alignItems: 'flex-start' }}>
                     <ListItemDecorator
                       sx={{

--- a/docs/data/joy/main-features/automatic-adjustment/ListThemes.js
+++ b/docs/data/joy/main-features/automatic-adjustment/ListThemes.js
@@ -17,7 +17,7 @@ export default function ButtonThemes() {
   const rootPresets = {
     dense: {
       '--ListItem-minHeight': '27px',
-      '--List-decoratorSize': '28px',
+      '--ListItemDecorator-size': '28px',
       '--ListItem-radius': '5px',
       '--List-gap': '5px',
       '--List-padding': '10px',
@@ -26,14 +26,14 @@ export default function ButtonThemes() {
       '--ListItem-paddingY': '0px',
       '--ListItem-fontSize': '14px',
       '--List-nestedInsetStart': '28px',
-      '--List-decoratorColor': 'var(--joy-palette-primary-plainColor)',
+      '--ListItemDecorator-color': 'var(--joy-palette-primary-plainColor)',
     },
     cozy: {
       '--List-radius': '20px',
       '--ListItem-minHeight': '48px',
       '--List-padding': '8px',
       '--List-gap': '8px',
-      '--List-nestedInsetStart': 'var(--List-decoratorSize)',
+      '--List-nestedInsetStart': 'var(--ListItemDecorator-size)',
     },
   };
   const nestedPresets = {

--- a/docs/data/joy/main-features/color-inversion/ColorInversionFooter.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionFooter.js
@@ -135,7 +135,7 @@ export default function ColorInversionFooter() {
           </ListItem>
           <ListItem nested sx={{ width: { xs: '50%', md: 180 } }}>
             <ListSubheader>Product</ListSubheader>
-            <List sx={{ '--List-decoratorSize': '32px' }}>
+            <List sx={{ '--ListItemDecorator-size': '32px' }}>
               <ListItem>
                 <ListItemButton>
                   <ListItemDecorator>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionFooter.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionFooter.tsx
@@ -134,7 +134,7 @@ export default function ColorInversionFooter() {
           </ListItem>
           <ListItem nested sx={{ width: { xs: '50%', md: 180 } }}>
             <ListSubheader>Product</ListSubheader>
-            <List sx={{ '--List-decoratorSize': '32px' }}>
+            <List sx={{ '--ListItemDecorator-size': '32px' }}>
               <ListItem>
                 <ListItemButton>
                   <ListItemDecorator>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
@@ -80,7 +80,7 @@ export default function ColorInversionHeader() {
           disablePortal
           size="sm"
           sx={{
-            '--List-decoratorSize': '24px',
+            '--ListItemDecorator-size': '24px',
             '--ListItem-minHeight': '40px',
             '--ListDivider-gap': '4px',
             minWidth: 200,

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -79,7 +79,7 @@ export default function ColorInversionHeader() {
           disablePortal
           size="sm"
           sx={{
-            '--List-decoratorSize': '24px',
+            '--ListItemDecorator-size': '24px',
             '--ListItem-minHeight': '40px',
             '--ListDivider-gap': '4px',
             minWidth: 200,

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -506,7 +506,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                     slotProps={{
                       listbox: {
                         sx: {
-                          '--List-decoratorSize': '24px',
+                          '--ListItemDecorator-size': '24px',
                         },
                       },
                     }}

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.js
@@ -58,6 +58,7 @@ const JoyComponents = [
   'Switch',
   'Tab',
   'Table',
+  'TableCell',
   'TabList',
   'TabPanel',
   'Tabs',
@@ -87,7 +88,14 @@ export default function transformer(file) {
           if (capture1 === 'List' && ['divider', 'item'].includes(capture3)) {
             return `--${capture1}${capitalize(capture3)}-${capture4}`;
           }
-          return `--${capture1}${capture2}${capture3}${capitalize(capture4)}`;
+          // turn `--List-decorator-...` to `--ListItemDecorator-...`
+          if (capture1 === 'List' && ['decorator'].includes(capture3)) {
+            return `--${capture1}Item${capitalize(capture3)}-${capture4}`;
+          }
+          if (!JoyComponents.includes(capture3)) {
+            return `--${capture1}${capture2}${capture3}${capitalize(capture4)}`;
+          }
+          return matched;
         },
       )
       // from `--internal-...` to `--unstable_...`

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.js
@@ -98,6 +98,8 @@ export default function transformer(file) {
           return matched;
         },
       )
+      .replace(/--List-decoratorSize/gm, '--ListItemDecorator-size')
+      .replace(/--List-decoratorColor/gm, '--ListItemDecorator-color')
       // from `--internal-...` to `--unstable_...`
       .replace(/--internal-/gm, '--unstable_')
       // from `--private_...` to `--unstable_...`

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test.js
@@ -15,7 +15,7 @@ describe('@mui/codemod', () => {
         const actual = transform(
           {
             source: read('./rename-css-variables.test/actual.js'),
-            path: require.resolve('./joy-rename-components-to-slots.test/actual.js'),
+            path: require.resolve('./rename-css-variables.test/actual.js'),
           },
           { jscodeshift },
           {},

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/actual.js
@@ -1,11 +1,12 @@
 <div>
-  <List sx={{ py: 'var(--ListDivider-gap)' }} />
+  <List sx={{ py: 'var(--ListDivider-gap)', '--List-decorator-size': '24px' }} />
   <ListItem sx={{ '--ListItem-minHeight': '20px' }} />
   <Input
     sx={{
       '--Input-decoratorChildHeight': '10px',
     }}
   />
+  <ModalDialog sx={{ '--unstable_ModalDialog-descriptionOffset': '12px' }} />
   <Autocomplete sx={{ '--Autocomplete-wrapperGap': '10px' }} />
   <Switch sx={{ '--Switch-trackWidth': '40px' }} />
   <Item sx={{ py: 'var(--internal-action-radius)' }} />

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/actual.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/actual.js
@@ -1,5 +1,6 @@
 <div>
   <List sx={{ py: 'var(--ListDivider-gap)', '--List-decorator-size': '24px' }} />
+  <List sx={{ '--List-decoratorSize': '24px' }} />
   <ListItem sx={{ '--ListItem-minHeight': '20px' }} />
   <Input
     sx={{

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/expected.js
@@ -1,5 +1,6 @@
 <div>
   <List sx={{ py: 'var(--ListDivider-gap)', '--ListItemDecorator-size': '24px' }} />
+  <List sx={{ '--ListItemDecorator-size': '24px' }} />
   <ListItem sx={{ '--ListItem-minHeight': '20px' }} />
   <Input
     sx={{

--- a/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/expected.js
+++ b/packages/mui-codemod/src/v5.0.0/rename-css-variables.test/expected.js
@@ -1,11 +1,12 @@
 <div>
-  <List sx={{ py: 'var(--ListDivider-gap)' }} />
+  <List sx={{ py: 'var(--ListDivider-gap)', '--ListItemDecorator-size': '24px' }} />
   <ListItem sx={{ '--ListItem-minHeight': '20px' }} />
   <Input
     sx={{
       '--Input-decoratorChildHeight': '10px',
     }}
   />
+  <ModalDialog sx={{ '--unstable_ModalDialog-descriptionOffset': '12px' }} />
   <Autocomplete sx={{ '--Autocomplete-wrapperGap': '10px' }} />
   <Switch sx={{ '--Switch-trackWidth': '40px' }} />
   <Item sx={{ py: 'var(--unstable_actionRadius)' }} />

--- a/packages/mui-joy/src/List/List.tsx
+++ b/packages/mui-joy/src/List/List.tsx
@@ -41,7 +41,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
         '--ListItem-paddingY': '0.25rem',
         '--ListItem-paddingX': '0.5rem',
         '--ListItem-fontSize': theme.vars.fontSize.sm,
-        '--List-decoratorSize': ownerState.orientation === 'horizontal' ? '1.5rem' : '2rem',
+        '--ListItemDecorator-size': ownerState.orientation === 'horizontal' ? '1.5rem' : '2rem',
         '--Icon-fontSize': '1.125rem',
       };
     }
@@ -52,7 +52,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
         '--ListItem-paddingY': '0.375rem',
         '--ListItem-paddingX': '0.75rem',
         '--ListItem-fontSize': theme.vars.fontSize.md,
-        '--List-decoratorSize': ownerState.orientation === 'horizontal' ? '1.75rem' : '2.5rem',
+        '--ListItemDecorator-size': ownerState.orientation === 'horizontal' ? '1.75rem' : '2.5rem',
         '--Icon-fontSize': '1.25rem',
       };
     }
@@ -63,7 +63,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
         '--ListItem-paddingY': '0.5rem',
         '--ListItem-paddingX': '1rem',
         '--ListItem-fontSize': theme.vars.fontSize.md,
-        '--List-decoratorSize': ownerState.orientation === 'horizontal' ? '2.25rem' : '3rem',
+        '--ListItemDecorator-size': ownerState.orientation === 'horizontal' ? '2.25rem' : '3rem',
         '--Icon-fontSize': '1.5rem',
       };
     }
@@ -90,7 +90,7 @@ export const StyledList = styled('ul')<{ ownerState: ListOwnerState }>(({ theme,
     !ownerState.nesting && {
       ...applySizeVars(ownerState.size),
       '--List-gap': '0px',
-      '--List-decoratorColor': theme.vars.palette.text.tertiary,
+      '--ListItemDecorator-color': theme.vars.palette.text.tertiary,
       '--List-nestedInsetStart': '0px',
       '--ListItem-paddingLeft': 'var(--ListItem-paddingX)',
       '--ListItem-paddingRight': 'var(--ListItem-paddingX)',

--- a/packages/mui-joy/src/ListDivider/ListDivider.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.tsx
@@ -59,7 +59,7 @@ const ListDividerRoot = styled(DividerRoot as unknown as 'li', {
       marginInlineStart: 'var(--ListItem-paddingLeft)',
     }),
     ...(ownerState.inset === 'startContent' && {
-      marginInlineStart: 'calc(var(--ListItem-paddingLeft) + var(--List-decoratorSize))',
+      marginInlineStart: 'calc(var(--ListItem-paddingLeft) + var(--ListItemDecorator-size))',
     }),
   }),
 }));

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -42,10 +42,10 @@ export const StyledListItemButton = styled('div')<{ ownerState: ListItemButtonOw
   ({ theme, ownerState }) => [
     {
       ...(ownerState.selected && {
-        '--List-decoratorColor': 'initial',
+        '--ListItemDecorator-color': 'initial',
       }),
       ...(ownerState.disabled && {
-        '--List-decoratorColor':
+        '--ListItemDecorator-color':
           theme.variants?.[`${ownerState.variant!}Disabled`]?.[ownerState.color!]?.color,
       }),
       WebkitTapHighlightColor: 'transparent',

--- a/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
+++ b/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
@@ -24,13 +24,13 @@ const ListItemDecoratorRoot = styled('span', {
   boxSizing: 'border-box',
   display: 'inline-flex',
   alignItems: 'center',
-  color: `var(--List-decoratorColor)`,
+  color: `var(--ListItemDecorator-color)`,
   ...(ownerState.parentOrientation === 'horizontal'
     ? {
-        minInlineSize: 'var(--List-decoratorSize)',
+        minInlineSize: 'var(--ListItemDecorator-size)',
       }
     : {
-        minBlockSize: 'var(--List-decoratorSize)',
+        minBlockSize: 'var(--ListItemDecorator-size)',
       }),
 }));
 /**

--- a/test/regressions/fixtures/SelectJoy/GroupedOptionSelect.js
+++ b/test/regressions/fixtures/SelectJoy/GroupedOptionSelect.js
@@ -41,7 +41,10 @@ export default function SelectGroupedOptions() {
         {Object.entries(group).map(([name, animals], index) => (
           <React.Fragment key={name}>
             {index !== 0 && <ListDivider role="none" />}
-            <List aria-labelledby={`select-group-${name}`} sx={{ '--ListItemDecorator-size': '28px' }}>
+            <List
+              aria-labelledby={`select-group-${name}`}
+              sx={{ '--ListItemDecorator-size': '28px' }}
+            >
               <ListItem id={`select-group-${name}`} sticky>
                 <Typography level="body3" textTransform="uppercase" letterSpacing="md">
                   {name} ({animals.length})

--- a/test/regressions/fixtures/SelectJoy/GroupedOptionSelect.js
+++ b/test/regressions/fixtures/SelectJoy/GroupedOptionSelect.js
@@ -41,7 +41,7 @@ export default function SelectGroupedOptions() {
         {Object.entries(group).map(([name, animals], index) => (
           <React.Fragment key={name}>
             {index !== 0 && <ListDivider role="none" />}
-            <List aria-labelledby={`select-group-${name}`} sx={{ '--List-decoratorSize': '28px' }}>
+            <List aria-labelledby={`select-group-${name}`} sx={{ '--ListItemDecorator-size': '28px' }}>
               <ListItem id={`select-group-${name}`} sticky>
                 <Typography level="body3" textTransform="uppercase" letterSpacing="md">
                   {name} ({animals.length})


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The transformation in https://github.com/mui/material-ui/pull/36282/files#diff-3e64c06413e58efa8d337c4e2e53db6a4fe714613064bc302b702a6ff9bbea79 is wrong.

According to the decision in #35474, it should be:

**Before**: `--List-decorator-size`
**After**: `--ListItemDecorator-size`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
