### PR TITLE
[base] Add `useMenu` onClose event callback

### DIFF
--- a/docs/pages/base/api/use-menu.json
+++ b/docs/pages/base/api/use-menu.json
@@ -4,7 +4,12 @@
     "listboxRef": {
       "type": { "name": "React.Ref&lt;any&gt;", "description": "React.Ref&lt;any&gt;" }
     },
-    "onClose": { "type": { "name": "() =&gt; void", "description": "() =&gt; void" } },
+    "onClose": {
+      "type": {
+        "name": "(event: React.KeyboardEvent | React.FocusEvent) =&gt; void",
+        "description": "(event: React.KeyboardEvent | React.FocusEvent) =&gt; void"
+      }
+    },
     "open": { "type": { "name": "boolean", "description": "boolean" } }
   },
   "returnValue": {

--- a/docs/translations/api-docs/use-menu/use-menu.json
+++ b/docs/translations/api-docs/use-menu/use-menu.json
@@ -1,6 +1,11 @@
 {
   "hookDescription": "",
-  "parametersDescriptions": {},
+  "parametersDescriptions": {
+    "listboxId": "Id of the listbox element within the Menu.",
+    "listboxRef": "Ref of the listbox DOM element within the Menu.",
+    "onClose": "Callback fired when the component requests to be closed.\nTypically <code>onClose</code> is used to set state in the parent component,\nwhich is used to control the <code>Menu</code> <code>open</code> prop.",
+    "open": "If <code>true</code>, the component is shown."
+  },
   "returnValueDescriptions": {
     "contextValue": "The value for the menu context.",
     "getListboxProps": "Resolver for the listbox component's props.",

--- a/packages/mui-base/src/useMenu/useMenu.ts
+++ b/packages/mui-base/src/useMenu/useMenu.ts
@@ -1,16 +1,16 @@
-import * as React from 'react';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
-import useListbox, {
-  defaultListboxReducer,
-  ListboxState,
-  ActionTypes,
-  ListboxReducerAction,
-} from '../useListbox';
-import { UseMenuListboxSlotProps, UseMenuParameters, UseMenuReturnValue } from './useMenu.types';
-import { EventHandlers } from '../utils';
-import useMenuChangeNotifiers from '../MenuUnstyled/useMenuChangeNotifiers';
-import type { MenuUnstyledContextType } from '../MenuUnstyled';
+import * as React from 'react';
 import { MenuItemMetadata, MenuItemState } from '../MenuItemUnstyled/MenuItemUnstyled.types';
+import type { MenuUnstyledContextType } from '../MenuUnstyled';
+import useMenuChangeNotifiers from '../MenuUnstyled/useMenuChangeNotifiers';
+import useListbox, {
+  ActionTypes,
+  defaultListboxReducer,
+  ListboxReducerAction,
+  ListboxState,
+} from '../useListbox';
+import { EventHandlers } from '../utils';
+import { UseMenuListboxSlotProps, UseMenuParameters, UseMenuReturnValue } from './useMenu.types';
 
 function stateReducer(
   state: ListboxState<string>,
@@ -122,7 +122,7 @@ export default function useMenu(parameters: UseMenuParameters = {}): UseMenuRetu
     }
 
     if (e.key === 'Escape' && open) {
-      onClose?.();
+      onClose?.(e);
     }
   };
 
@@ -130,7 +130,7 @@ export default function useMenu(parameters: UseMenuParameters = {}): UseMenuRetu
     otherHandlers.onBlur?.(e);
 
     if (!listboxRef.current?.contains(e.relatedTarget)) {
-      onClose?.();
+      onClose?.(e);
     }
   };
 

--- a/packages/mui-base/src/useMenu/useMenu.types.ts
+++ b/packages/mui-base/src/useMenu/useMenu.types.ts
@@ -5,9 +5,28 @@ import { UseListboxRootSlotProps } from '../useListbox';
 import { EventHandlers } from '../utils/types';
 
 export interface UseMenuParameters {
+  /**
+   * If `true`, the component is shown.
+   */
   open?: boolean;
-  onClose?: () => void;
+
+  /**
+   * Callback fired when the component requests to be closed.
+   * Typically `onClose` is used to set state in the parent component,
+   * which is used to control the `Menu` `open` prop.
+   *
+   * @param {React.KeyboardEvent | React.FocusEvent} event The event source of the callback.
+   */
+  onClose?: (event: React.KeyboardEvent | React.FocusEvent) => void;
+
+  /**
+   * Id of the listbox element within the Menu.
+   */
   listboxId?: string;
+
+  /**
+   * Ref of the listbox DOM element within the Menu.
+   */
   listboxRef?: React.Ref<any>;
 }
 


### PR DESCRIPTION
- added the event that triggered the `onClose` callback within every instance of `onClose` within the useMenu hook
- revised the useMenu Typescript types to reflect the update
- revised the documentation files to reflect the update
- added descriptive comments to the UseMenuParameters interface following patterns set forth in similar files


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
