### PR TITLE
[docs][material] Highlight global state classes in CSS table in API docs

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -3,12 +3,14 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { exactProp } from '@mui/utils';
 import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import PropertiesTable from 'docs/src/modules/components/PropertiesTable';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import AppLayoutDocs from 'docs/src/modules/components/AppLayoutDocs';
 import Ad from 'docs/src/modules/components/Ad';
+import { sxChip } from './AppNavDrawerItem';
 
 function ClassesTable(props) {
   const { componentStyles, classDescriptions } = props;
@@ -30,16 +32,21 @@ function ClassesTable(props) {
             <tr key={className}>
               <td align="left">
                 <span className="prop-name">
-                  {isGlobalStateClass ? <b>{className}</b> : className}
+                  {isGlobalStateClass ? (
+                    <React.Fragment>
+                      {className}
+                      <Chip size="small" label={t('api-docs.state')} sx={sxChip('primary')} />
+                    </React.Fragment>
+                  ) : (
+                    className
+                  )}
                 </span>
               </td>
               <td align="left">
                 <span className="prop-name">
-                  {isGlobalStateClass ? (
-                    <b>.{componentStyles.globalClasses[className]}</b>
-                  ) : (
-                    `.${componentStyles.name}-${className}`
-                  )}
+                  .
+                  {componentStyles.globalClasses[className] ||
+                    `${componentStyles.name}-${className}`}
                 </span>
               </td>
               <td

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -24,29 +24,37 @@ function ClassesTable(props) {
         </tr>
       </thead>
       <tbody>
-        {componentStyles.classes.map((className) => (
-          <tr key={className}>
-            <td align="left">
-              <span className="prop-name">{className}</span>
-            </td>
-            <td align="left">
-              <span className="prop-name">
-                .
-                {componentStyles.globalClasses[className] || `${componentStyles.name}-${className}`}
-              </span>
-            </td>
-            <td
-              align="left"
-              dangerouslySetInnerHTML={{
-                __html:
-                  classDescriptions[className] &&
-                  classDescriptions[className].description
-                    .replace(/{{conditions}}/, classDescriptions[className].conditions)
-                    .replace(/{{nodeName}}/, classDescriptions[className].nodeName),
-              }}
-            />
-          </tr>
-        ))}
+        {componentStyles.classes.map((className) => {
+          const isGlobalStateClass = !!componentStyles.globalClasses[className];
+          return (
+            <tr key={className}>
+              <td align="left">
+                <span className="prop-name">
+                  {isGlobalStateClass ? <b>{className}</b> : className}
+                </span>
+              </td>
+              <td align="left">
+                <span className="prop-name">
+                  {isGlobalStateClass ? (
+                    <b>.{componentStyles.globalClasses[className]}</b>
+                  ) : (
+                    `.${componentStyles.name}-${className}`
+                  )}
+                </span>
+              </td>
+              <td
+                align="left"
+                dangerouslySetInnerHTML={{
+                  __html:
+                    classDescriptions[className] &&
+                    classDescriptions[className].description
+                      .replace(/{{conditions}}/, classDescriptions[className].conditions)
+                      .replace(/{{nodeName}}/, classDescriptions[className].nodeName),
+                }}
+              />
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );
@@ -340,6 +348,7 @@ import { ${pageContent.name} } from '${source}';`}
         {Object.keys(componentStyles.classes).length ? (
           <React.Fragment>
             <Heading hash="css" />
+            <p dangerouslySetInnerHTML={{ __html: t('api-docs.cssDescription') }} />
             <ClassesTable componentStyles={componentStyles} classDescriptions={classDescriptions} />
             <br />
             <p dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -175,7 +175,7 @@ const StyledLi = styled('li', { shouldForwardProp: (prop) => prop !== 'depth' })
   }),
 );
 
-const sxChip = (color) => [
+export const sxChip = (color) => [
   (theme) => ({
     ml: 1.5,
     fontSize: theme.typography.pxToRem(10),

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -5,7 +5,7 @@
     "componentsApi": "Components API",
     "themeDefaultProps": "Theme default props",
     "themeDefaultPropsDescription": "You can use <code>{{muiName}}</code> to change the default props of this component <a href={{defaultPropsLink}}>with the theme</a>.",
-    "cssDescription": "The following class names are useful for styling with CSS (the <a href=\"/material-ui/customization/how-to-customize/#state-classes\">state classes</a> are in <b>bold</b>). <br /> To learn more, visit the <a href=\"/material-ui/customization/theme-components/\">component customization</a> page.",
+    "cssDescription": "The following class names are useful for styling with CSS (the <a href=\"/material-ui/customization/how-to-customize/#state-classes\">state classes</a> are marked). <br /> To learn more, visit the <a href=\"/material-ui/customization/theme-components/\">component customization</a> page.",
     "cssComponent": "As a CSS utility, the {{name}} component also supports all <a href=\"/system/properties/\"><code>system</code></a> properties. You can use them as props directly on the component.",
     "default": "Default",
     "defaultValue": "Default value",
@@ -36,6 +36,7 @@
     "ruleName": "Rule name",
     "slots": "Slots",
     "spreadHint": "Props of the {{spreadHintElement}} component are also available.",
+    "state": "STATE",
     "styleOverrides": "The name <code>{{componentStyles.name}}</code> can be used when providing <a href={{defaultPropsLink}}>default props</a> or <a href={{styleOverridesLink}}>style overrides</a> in the theme.",
     "slotDescription": "To learn how to customize the slot, check out the <a href={{slotGuideLink}}>Overriding component structure</a> guide.",
     "type": "Type"

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -5,7 +5,7 @@
     "componentsApi": "Components API",
     "themeDefaultProps": "Theme default props",
     "themeDefaultPropsDescription": "You can use <code>{{muiName}}</code> to change the default props of this component <a href={{defaultPropsLink}}>with the theme</a>.",
-    "cssDescription": "The following class names are useful for styling with CSS. The global state classes are in <b>bold</b>. To learn more about state classes, check out the <a href=\"/material-ui/customization/how-to-customize/#state-classes\">State classes</a> guide.",
+    "cssDescription": "The following class names are useful for styling with CSS (the <a href=\"/material-ui/customization/how-to-customize/#state-classes\">state classes</a> are in <b>bold</b>). <br /> To learn more, visit the <a href=\"/material-ui/customization/theme-components/\">component customization</a> page.",
     "cssComponent": "As a CSS utility, the {{name}} component also supports all <a href=\"/system/properties/\"><code>system</code></a> properties. You can use them as props directly on the component.",
     "default": "Default",
     "defaultValue": "Default value",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -5,6 +5,7 @@
     "componentsApi": "Components API",
     "themeDefaultProps": "Theme default props",
     "themeDefaultPropsDescription": "You can use <code>{{muiName}}</code> to change the default props of this component <a href={{defaultPropsLink}}>with the theme</a>.",
+    "cssDescription": "The following class names are useful for styling with CSS. The global state classes are in <b>bold</b>. To learn more about state classes, check out the <a href=\"/material-ui/customization/how-to-customize/#state-classes\">State classes</a> guide.",
     "cssComponent": "As a CSS utility, the {{name}} component also supports all <a href=\"/system/properties/\"><code>system</code></a> properties. You can use them as props directly on the component.",
     "default": "Default",
     "defaultValue": "Default value",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- This is a follow-up of the suggestion I made during a discussion in a separate PR: https://github.com/mui/material-ui/pull/36586#discussion_r1145121013
- This PR is to make it clearer to developers the distinction between global state classes and component-level state classes
- **:warning:** If this PR is approved and merged, the same needs to be done for "Classes" table which is in Joy/Base API docs introduced in https://github.com/mui/material-ui/pull/36589

### Changes
- Make global state classes in CSS table in API docs **bold**
- Add a heading below the section name "CSS": `"The following class names are useful for styling with CSS. The global state classes are in **bold**. To learn more about state classes, check out the [State classes](https://mui.com/material-ui/customization/how-to-customize/#state-classes) guide."`

### Preview
- e.g., https://deploy-preview-36633--material-ui.netlify.app/material-ui/api/accordion/#css
<img width="1083" alt="Screenshot 2023-03-24 at 17 05 03" src="https://user-images.githubusercontent.com/32841130/227641009-12abf76b-420b-4b68-9a42-f9a0f6f88119.png">
