### PR TITLE
[Autocomplete] Fix autocomplete left padding

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -131,7 +131,9 @@ const AutocompleteRoot = styled('div', {
     },
   },
   [`& .${outlinedInputClasses.root}`]: {
-    padding: 9,
+    paddingTop: 9,
+    paddingBottom: 9,
+    paddingLeft: 12,
     [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
       paddingRight: 26 + 4 + 9,
     },
@@ -139,7 +141,7 @@ const AutocompleteRoot = styled('div', {
       paddingRight: 52 + 4 + 9,
     },
     [`& .${autocompleteClasses.input}`]: {
-      padding: '7.5px 4px 7.5px 6px',
+      padding: '7.5px 4px 7.5px 2px',
     },
     [`& .${autocompleteClasses.endAdornment}`]: {
       right: 9,
@@ -150,9 +152,9 @@ const AutocompleteRoot = styled('div', {
     // one of the popup or clear icon as the specificity is equal so the latter one wins
     paddingTop: 6,
     paddingBottom: 6,
-    paddingLeft: 6,
+    paddingLeft: 9,
     [`& .${autocompleteClasses.input}`]: {
-      padding: '2.5px 4px 2.5px 6px',
+      padding: '7.5px 4px 7.5px 5px',
     },
   },
   [`& .${filledInputClasses.root}`]: {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -131,9 +131,7 @@ const AutocompleteRoot = styled('div', {
     },
   },
   [`& .${outlinedInputClasses.root}`]: {
-    paddingTop: 9,
-    paddingBottom: 9,
-    paddingLeft: 12,
+    padding: 9,
     [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
       paddingRight: 26 + 4 + 9,
     },
@@ -141,7 +139,7 @@ const AutocompleteRoot = styled('div', {
       paddingRight: 52 + 4 + 9,
     },
     [`& .${autocompleteClasses.input}`]: {
-      padding: '7.5px 4px 7.5px 2px',
+      padding: '7.5px 4px 7.5px 5px',
     },
     [`& .${autocompleteClasses.endAdornment}`]: {
       right: 9,
@@ -152,9 +150,9 @@ const AutocompleteRoot = styled('div', {
     // one of the popup or clear icon as the specificity is equal so the latter one wins
     paddingTop: 6,
     paddingBottom: 6,
-    paddingLeft: 9,
+    paddingLeft: 6,
     [`& .${autocompleteClasses.input}`]: {
-      padding: '7.5px 4px 7.5px 5px',
+      padding: '2.5px 4px 2.5px 8px',
     },
   },
   [`& .${filledInputClasses.root}`]: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/36630

I adjusted the padding between the root element of `Autocomplete` and the `<input>` itself so it aligns with similar components

### Before:
<img width="504" alt="Screenshot 2023-03-29 at 7 36 45 PM" src="https://user-images.githubusercontent.com/4997971/228523727-9b585e1c-7479-41af-932f-cdf2cd985519.png">

### After:
<img width="674" alt="Screenshot 2023-03-29 at 7 32 09 PM" src="https://user-images.githubusercontent.com/4997971/228522810-09a1b03c-da4d-47e5-be51-05c9138e1f0b.png">

Sandbox preview: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-36649-cuhcqo?file=/src/App.tsx