### PR TITLE
[Popover] fix content changing during transition

### DIFF
--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -284,7 +284,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
   const cachedChildren = React.useRef(children);
 
   React.useEffect(() => {
-    if(open) {
+    if (open) {
       cachedChildren.current = children;
     }
   }, [children, open]);

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -280,6 +280,15 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
 
   const [isPositioned, setIsPositioned] = React.useState(open);
 
+  // we cache the children to avoid changes of the content during closing animation
+  const cachedChildren = React.useRef(children);
+
+  React.useEffect(() => {
+    if(open) {
+      cachedChildren.current = children;
+    }
+  }, [children, open]);
+
   const setPositioningStyles = React.useCallback(() => {
     const element = paperRef.current;
 
@@ -385,7 +394,7 @@ const Popover = React.forwardRef(function Popover(inProps, ref) {
           {...(isPositioned ? undefined : { style: { ...PaperProps.style, opacity: 0 } })}
           ownerState={ownerState}
         >
-          {children}
+          {cachedChildren.current}
         </PopoverPaper>
       </TransitionComponent>
     </PopoverRoot>

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -112,7 +112,7 @@ describe('<Popover />', () => {
       );
 
       setProps({ open: false });
-      setProps({ children: <div data-testid="second-children"/> });
+      setProps({ children: <div data-testid="second-children" /> });
 
       expect(screen.getByTestId('children')).toBeVisible();
 
@@ -121,7 +121,7 @@ describe('<Popover />', () => {
       setProps({ open: true });
 
       expect(screen.queryByTestId('second-children')).toBeVisible();
-    })
+    });
 
     describe('getOffsetTop', () => {
       it('should return vertical when vertical is a number', () => {

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -104,6 +104,25 @@ describe('<Popover />', () => {
       expect(screen.queryByTestId('children')).to.equal(null);
     });
 
+    it('should not change the rendered children during closing transition', () => {
+      const { setProps } = render(
+        <Popover open anchorEl={document.createElement('div')} transitionDuration={1974}>
+          <div data-testid="children" />
+        </Popover>,
+      );
+
+      setProps({ open: false });
+      setProps({ children: <div data-testid="second-children"/> });
+
+      expect(screen.getByTestId('children')).toBeVisible();
+
+      clock.tick(1974);
+
+      setProps({ open: true });
+
+      expect(screen.queryByTestId('second-children')).toBeVisible();
+    })
+
     describe('getOffsetTop', () => {
       it('should return vertical when vertical is a number', () => {
         const vertical = 1;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Here I have solved the bug reported in the following issue: https://github.com/mui/material-ui/issues/36660
I have created a cached version of the child in order to not allow the content to mutate during the transition. 
Actually, I don't know how edge this case may be, BTW I don't see any too big restriction in the behavior of the component by applying these changes. Do you think the storing of children may have huge performance impacts?
