### PR TITLE
Don't mutate highlighted value for MultiSelect

### DIFF
--- a/packages/mui-base/src/useSelect/useSelect.ts
+++ b/packages/mui-base/src/useSelect/useSelect.ts
@@ -209,11 +209,15 @@ function useSelect<TValue, Multiple extends boolean = false>(
         case ActionTypes.blur:
         case ActionTypes.setValue:
         case ActionTypes.optionsChange:
-          return {
-            ...newState,
-            highlightedValue:
-              newState.selectedValues.length > 0 ? newState.selectedValues[0] : null,
-          };
+          if(!multiple) {
+            return {
+              ...newState,
+              highlightedValue:
+                newState.selectedValues.length > 0 ? newState.selectedValues[0] : null,
+            };
+          }
+          
+          break;
 
         default:
           return newState;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As at @mui/base v5.0.0-alpha.122, when `<Select multiple>` is used as a _controlled_ component, the highlighted value will jump (to the first item in the selected value array) whenever an item is selected/unselected. This should fix it.