### PR TITLE
[system] container queries support in breakpoints api and sx props

### DIFF
--- a/docs/data/material/customization/breakpoints/breakpoints.md
+++ b/docs/data/material/customization/breakpoints/breakpoints.md
@@ -163,8 +163,9 @@ The `sx` prop may also be used to define styles for specific container props. Mo
 #### Returns
 
 `media / container query`: Either
-* a `media query` string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key (inclusive)
-* or a `container query` string which matches container widths greater than the width given by the breakpoint key (inclusive). The breakpoint width is compared to the next outer container with `container-type: inline-size` defined.
+
+- a `media query` string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key (inclusive)
+- or a `container query` string which matches container widths greater than the width given by the breakpoint key (inclusive). The breakpoint width is compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 
@@ -197,9 +198,9 @@ const styles = (theme) => ({
 #### Returns
 
 `media / container query`: Either
-* a `media query` string ready to be used with most styling solutions, which matches screen widths less than the screen size given by the breakpoint key (exclusive)
-* or a `container query` string which matches container widths less than the width given by the breakpoint key (exclusive). The breakpoint width is compared to the next outer container with `container-type: inline-size` defined.
 
+- a `media query` string ready to be used with most styling solutions, which matches screen widths less than the screen size given by the breakpoint key (exclusive)
+- or a `container query` string which matches container widths less than the width given by the breakpoint key (exclusive). The breakpoint width is compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 
@@ -232,9 +233,9 @@ const styles = (theme) => ({
 #### Returns
 
 `media / container query`: Either
-* a `media query` string ready to be used with most styling solutions, which matches screen widths starting from the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive)
-* or a `container query` string which matches container widths starting from the width given by the breakpoint key (inclusive) and stopping at the width given by the next breakpoint key (exclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
 
+- a `media query` string ready to be used with most styling solutions, which matches screen widths starting from the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive)
+- or a `container query` string which matches container widths starting from the width given by the breakpoint key (inclusive) and stopping at the width given by the next breakpoint key (exclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 
@@ -268,9 +269,9 @@ const styles = (theme) => ({
 #### Returns
 
 `media / container query`: Either
-* a `media query` string ready to be used with most styling solutions, which matches screen widths stopping at the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive)
-* or a `container query` string which matches container widths stopping at the width given by the breakpoint key (exclusive) and starting at the width given by the next breakpoint key (inclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
 
+- a `media query` string ready to be used with most styling solutions, which matches screen widths stopping at the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive)
+- or a `container query` string which matches container widths stopping at the width given by the breakpoint key (exclusive) and starting at the width given by the next breakpoint key (inclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 
@@ -306,8 +307,9 @@ const styles = (theme) => ({
 
 `media query`: A media query string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key in the first argument (inclusive) and less than the screen size given by the breakpoint key in the second argument (exclusive).
 `media / container query`: Either
-* a `media query` string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key in the first argument (inclusive) and less than the screen size given by the breakpoint key in the second argument (exclusive)
-* or a `container query` string which matches container widths greater than the width given by the breakpoint key in the first argument (inclusive) and less than the width given by the breakpoint key in the second argument (exclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
+
+- a `media query` string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key in the first argument (inclusive) and less than the screen size given by the breakpoint key in the second argument (exclusive)
+- or a `container query` string which matches container widths greater than the width given by the breakpoint key in the first argument (inclusive) and less than the width given by the breakpoint key in the second argument (exclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 

--- a/docs/data/material/customization/breakpoints/breakpoints.md
+++ b/docs/data/material/customization/breakpoints/breakpoints.md
@@ -126,19 +126,45 @@ declare module '@mui/material/styles' {
 }
 ```
 
+## Container queries
+
+The breakpoints API also supports generating a container query by providing a `container` param to its functions.
+
+```jsx
+const styles = (theme) => ({
+  root: {
+    padding: theme.spacing(1),
+    [theme.breakpoints.down('md', 'container')]: {
+      backgroundColor: theme.palette.secondary.main,
+    },
+    [theme.breakpoints.up('md', 'container')]: {
+      backgroundColor: theme.palette.primary.main,
+    },
+    [theme.breakpoints.up('lg', 'container')]: {
+      backgroundColor: green[500],
+    },
+  },
+});
+```
+
+The `sx` prop may also be used to define styles for specific container props. More details on the [responsive values](/system/getting-started/usage/#responsive-values) page.
+
 ## API
 
-### `theme.breakpoints.up(key) => media query`
+### `theme.breakpoints.up(key, query) => media / container query`
 
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
 
 #### Arguments
 
 1. `key` (_string_ | _number_): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+2. `query` ('media' | 'container'): Optional param to define whether a `container` query or a `media` query should be built. Defaults to `media`.
 
 #### Returns
 
-`media query`: A media query string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key (inclusive).
+`media / container query`: Either
+* a `media query` string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key (inclusive)
+* or a `container query` string which matches container widths greater than the width given by the breakpoint key (inclusive). The breakpoint width is compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 
@@ -151,21 +177,29 @@ const styles = (theme) => ({
     [theme.breakpoints.up('md')]: {
       backgroundColor: 'red',
     },
+    // container query equivalent
+    [theme.breakpoints.up('md', 'container')]: {
+      backgroundColor: 'red',
+    },
   },
 });
 ```
 
-### `theme.breakpoints.down(key) => media query`
+### `theme.breakpoints.down(key, query) => media / container query`
 
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
 
 #### Arguments
 
 1. `key` (_string_ | _number_): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+2. `query` ('media' | 'container'): Optional param to define whether a `container` query or a `media` query should be built. Defaults to `media`.
 
 #### Returns
 
-`media query`: A media query string ready to be used with most styling solutions, which matches screen widths less than the screen size given by the breakpoint key (exclusive).
+`media / container query`: Either
+* a `media query` string ready to be used with most styling solutions, which matches screen widths less than the screen size given by the breakpoint key (exclusive)
+* or a `container query` string which matches container widths less than the width given by the breakpoint key (exclusive). The breakpoint width is compared to the next outer container with `container-type: inline-size` defined.
+
 
 #### Examples
 
@@ -178,21 +212,29 @@ const styles = (theme) => ({
     [theme.breakpoints.down('md')]: {
       backgroundColor: 'red',
     },
+    // container query equivalent
+    [theme.breakpoints.down('md', 'container')]: {
+      backgroundColor: 'red',
+    },
   },
 });
 ```
 
-### `theme.breakpoints.only(key) => media query`
+### `theme.breakpoints.only(key, query) => media / container query`
 
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
 
 #### Arguments
 
 1. `key` (_string_): A breakpoint key (`xs`, `sm`, etc.).
+2. `query` ('media' | 'container'): Optional param to define whether a `container` query or a `media` query should be built. Defaults to `media`.
 
 #### Returns
 
-`media query`: A media query string ready to be used with most styling solutions, which matches screen widths starting from the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive).
+`media / container query`: Either
+* a `media query` string ready to be used with most styling solutions, which matches screen widths starting from the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive)
+* or a `container query` string which matches container widths starting from the width given by the breakpoint key (inclusive) and stopping at the width given by the next breakpoint key (exclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
+
 
 #### Examples
 
@@ -206,21 +248,29 @@ const styles = (theme) => ({
     [theme.breakpoints.only('md')]: {
       backgroundColor: 'red',
     },
+    // container query equivalent
+    [theme.breakpoints.only('md', 'container')]: {
+      backgroundColor: 'red',
+    },
   },
 });
 ```
 
-### `theme.breakpoints.not(key) => media query`
+### `theme.breakpoints.not(key, query) => media / container query`
 
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
 
 #### Arguments
 
 1. `key` (_string_): A breakpoint key (`xs`, `sm`, etc.).
+2. `query` ('media' | 'container'): Optional param to define whether a `container` query or a `media` query should be built. Defaults to `media`.
 
 #### Returns
 
-`media query`: A media query string ready to be used with most styling solutions, which matches screen widths stopping at the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive).
+`media / container query`: Either
+* a `media query` string ready to be used with most styling solutions, which matches screen widths stopping at the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive)
+* or a `container query` string which matches container widths stopping at the width given by the breakpoint key (exclusive) and starting at the width given by the next breakpoint key (inclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
+
 
 #### Examples
 
@@ -234,11 +284,15 @@ const styles = (theme) => ({
     [theme.breakpoints.not('md')]: {
       backgroundColor: 'red',
     },
+    // container query equivalent
+    [theme.breakpoints.not('md', 'container')]: {
+      backgroundColor: 'red',
+    },
   },
 });
 ```
 
-### `theme.breakpoints.between(start, end) => media query`
+### `theme.breakpoints.between(start, end, query) => media / container query`
 
 <!-- Keep in sync with packages/mui-system/src/createTheme/createBreakpoints.d.ts -->
 
@@ -246,10 +300,14 @@ const styles = (theme) => ({
 
 1. `start` (_string_): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
 2. `end` (_string_): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+3. `query` ('media' | 'container'): Optional param to define whether a `container` query or a `media` query should be built. Defaults to `media`.
 
 #### Returns
 
 `media query`: A media query string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key in the first argument (inclusive) and less than the screen size given by the breakpoint key in the second argument (exclusive).
+`media / container query`: Either
+* a `media query` string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key in the first argument (inclusive) and less than the screen size given by the breakpoint key in the second argument (exclusive)
+* or a `container query` string which matches container widths greater than the width given by the breakpoint key in the first argument (inclusive) and less than the width given by the breakpoint key in the second argument (exclusive). The breakpoint widths are compared to the next outer container with `container-type: inline-size` defined.
 
 #### Examples
 
@@ -260,6 +318,10 @@ const styles = (theme) => ({
     // Match [sm, md)
     //       [600px, 900px)
     [theme.breakpoints.between('sm', 'md')]: {
+      backgroundColor: 'red',
+    },
+    // container query equivalent
+    [theme.breakpoints.between('sm', 'md', 'container')]: {
       backgroundColor: 'red',
     },
   },

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
@@ -41,13 +41,13 @@ export default function ContainerBreakpointsAsObject() {
     <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}>
       <Paper sx={{
         width: '50%',
-        containerType: 'inline-size',
+        containerType: 'inline-size', // <-- this defines the reference container
       }}>
         <ListWithContainerBreakpoints/>
       </Paper>
       <Paper sx={{
         width: '100%',
-        containerType: 'inline-size',
+        containerType: 'inline-size', // <-- this defines the reference container
       }}>
         <ListWithContainerBreakpoints/>
       </Paper>

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
@@ -6,46 +6,47 @@ import {
   List,
   ListItem,
   ListItemAvatar,
-  ListItemButton,
   ListItemText,
   Paper,
 } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const ListWithContainerBreakpoints = () => (
-  <List>
-    {[
-      { name: 'Peter Pan', value: '$100,000' },
-      { name: 'Frida Kahlo', value: '$200,000' },
-    ].map((entry, index) => (
-      <ListItem key={index}>
-        <ListItemAvatar>
-          <Avatar />
-        </ListItemAvatar>
-        <Box
-          sx={{
-            display: 'flex',
-            width: '100%',
-            flexDirection: {
-              cqxs: 'column',
-              cqsm: 'row',
-            },
-          }}
-        >
-          <ListItemText>{entry.name}</ListItemText>
-          <ListItemText
-            sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}
+function ListWithContainerBreakpoints() {
+  return (
+    <List>
+      {[
+        { name: 'Peter Pan', value: '$100,000' },
+        { name: 'Frida Kahlo', value: '$200,000' },
+      ].map((entry, index) => (
+        <ListItem key={index}>
+          <ListItemAvatar>
+            <Avatar />
+          </ListItemAvatar>
+          <Box
+            sx={{
+              display: 'flex',
+              width: '100%',
+              flexDirection: {
+                cqxs: 'column',
+                cqsm: 'row',
+              },
+            }}
           >
-            {entry.value}
-          </ListItemText>
-        </Box>
-        <IconButton>
-          <ChevronRightIcon />
-        </IconButton>
-      </ListItem>
-    ))}
-  </List>
-);
+            <ListItemText>{entry.name}</ListItemText>
+            <ListItemText
+              sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}
+            >
+              {entry.value}
+            </ListItemText>
+          </Box>
+          <IconButton>
+            <ChevronRightIcon />
+          </IconButton>
+        </ListItem>
+      ))}
+    </List>
+  );
+}
 
 export default function ContainerBreakpointsAsObject() {
   return (

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+
+export default function ContainerBreakpointsAsObject() {
+  return (
+    <div>
+      <Box
+        sx={{
+          width: {
+            cqxs: 100, // theme.breakpoints.up('xs', 'container')
+            cqsm: 200, // theme.breakpoints.up('sm', 'container')
+            cqmd: 300, // theme.breakpoints.up('md', 'container')
+            cqlg: 400, // theme.breakpoints.up('lg', 'container')
+            cqxl: 500, // theme.breakpoints.up('xl', 'container')
+          },
+        }}
+      >
+        This box has a responsive width.
+      </Box>
+    </div>
+  );
+}

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
@@ -1,55 +1,72 @@
 import * as React from 'react';
 import {
   Avatar,
-  Box, IconButton,
+  Box,
+  IconButton,
   List,
   ListItem,
   ListItemAvatar,
   ListItemButton,
   ListItemText,
-  Paper
+  Paper,
 } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const ListWithContainerBreakpoints = () => <List>
-  {[{ name: 'Peter Pan', value: '$100,000' },
-    { name: 'Frida Kahlo', value: '$200,000' }].map((entry, index) => (
-    <ListItem key={index}>
-      <ListItemAvatar><Avatar/></ListItemAvatar>
-      <Box sx={{
-        display: 'flex',
-        width: '100%',
-        flexDirection: {
-          cqxs: 'column',
-          cqsm: 'row'
-        }
-      }}>
-        <ListItemText>
-          {entry.name}
-        </ListItemText>
-        <ListItemText sx={{ display: 'flex', justifyContent: {cqsm: 'flex-end' }}}>
-          {entry.value}
-        </ListItemText>
-      </Box>
-      <IconButton><ChevronRightIcon/></IconButton>
-    </ListItem>
-  ))}
-</List>;
+const ListWithContainerBreakpoints = () => (
+  <List>
+    {[
+      { name: 'Peter Pan', value: '$100,000' },
+      { name: 'Frida Kahlo', value: '$200,000' },
+    ].map((entry, index) => (
+      <ListItem key={index}>
+        <ListItemAvatar>
+          <Avatar />
+        </ListItemAvatar>
+        <Box
+          sx={{
+            display: 'flex',
+            width: '100%',
+            flexDirection: {
+              cqxs: 'column',
+              cqsm: 'row',
+            },
+          }}
+        >
+          <ListItemText>{entry.name}</ListItemText>
+          <ListItemText
+            sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}
+          >
+            {entry.value}
+          </ListItemText>
+        </Box>
+        <IconButton>
+          <ChevronRightIcon />
+        </IconButton>
+      </ListItem>
+    ))}
+  </List>
+);
 
 export default function ContainerBreakpointsAsObject() {
   return (
-    <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}>
-      <Paper sx={{
-        width: '50%',
-        containerType: 'inline-size', // <-- this defines the reference container
-      }}>
-        <ListWithContainerBreakpoints/>
+    <Box
+      sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}
+    >
+      <Paper
+        sx={{
+          width: '50%',
+          containerType: 'inline-size', // <-- this defines the reference container
+        }}
+      >
+        <ListWithContainerBreakpoints />
       </Paper>
-      <Paper sx={{
-        width: '100%',
-        containerType: 'inline-size', // <-- this defines the reference container
-      }}>
-        <ListWithContainerBreakpoints/>
+      <Paper
+        sx={{
+          width: '100%',
+          containerType: 'inline-size', // <-- this defines the reference container
+        }}
+      >
+        <ListWithContainerBreakpoints />
       </Paper>
     </Box>
   );

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.js
@@ -1,22 +1,56 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
+import {
+  Avatar,
+  Box, IconButton,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Paper
+} from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+const ListWithContainerBreakpoints = () => <List>
+  {[{ name: 'Peter Pan', value: '$100,000' },
+    { name: 'Frida Kahlo', value: '$200,000' }].map((entry, index) => (
+    <ListItem key={index}>
+      <ListItemAvatar><Avatar/></ListItemAvatar>
+      <Box sx={{
+        display: 'flex',
+        width: '100%',
+        flexDirection: {
+          cqxs: 'column',
+          cqsm: 'row'
+        }
+      }}>
+        <ListItemText>
+          {entry.name}
+        </ListItemText>
+        <ListItemText sx={{ display: 'flex', justifyContent: {cqsm: 'flex-end' }}}>
+          {entry.value}
+        </ListItemText>
+      </Box>
+      <IconButton><ChevronRightIcon/></IconButton>
+    </ListItem>
+  ))}
+</List>;
 
 export default function ContainerBreakpointsAsObject() {
   return (
-    <div>
-      <Box
-        sx={{
-          width: {
-            cqxs: 100, // theme.breakpoints.up('xs', 'container')
-            cqsm: 200, // theme.breakpoints.up('sm', 'container')
-            cqmd: 300, // theme.breakpoints.up('md', 'container')
-            cqlg: 400, // theme.breakpoints.up('lg', 'container')
-            cqxl: 500, // theme.breakpoints.up('xl', 'container')
-          },
-        }}
-      >
-        This box has a responsive width.
-      </Box>
-    </div>
+    <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}>
+      <Paper sx={{
+        width: '50%',
+        containerType: 'inline-size',
+      }}>
+        <ListWithContainerBreakpoints/>
+      </Paper>
+      <Paper sx={{
+        width: '100%',
+        containerType: 'inline-size',
+      }}>
+        <ListWithContainerBreakpoints/>
+      </Paper>
+    </Box>
   );
 }

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
@@ -41,13 +41,13 @@ export default function ContainerBreakpointsAsObject() {
     <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}>
       <Paper sx={{
         width: '50%',
-        containerType: 'inline-size',
+        containerType: 'inline-size', // <-- this defines the reference container
       }}>
         <ListWithContainerBreakpoints/>
       </Paper>
       <Paper sx={{
         width: '100%',
-        containerType: 'inline-size',
+        containerType: 'inline-size', // <-- this defines the reference container
       }}>
         <ListWithContainerBreakpoints/>
       </Paper>

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
@@ -6,46 +6,47 @@ import {
   List,
   ListItem,
   ListItemAvatar,
-  ListItemButton,
   ListItemText,
   Paper,
 } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const ListWithContainerBreakpoints = () => (
-  <List>
-    {[
-      { name: 'Peter Pan', value: '$100,000' },
-      { name: 'Frida Kahlo', value: '$200,000' },
-    ].map((entry, index) => (
-      <ListItem key={index}>
-        <ListItemAvatar>
-          <Avatar />
-        </ListItemAvatar>
-        <Box
-          sx={{
-            display: 'flex',
-            width: '100%',
-            flexDirection: {
-              cqxs: 'column',
-              cqsm: 'row',
-            },
-          }}
-        >
-          <ListItemText>{entry.name}</ListItemText>
-          <ListItemText
-            sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}
+function ListWithContainerBreakpoints() {
+  return (
+    <List>
+      {[
+        { name: 'Peter Pan', value: '$100,000' },
+        { name: 'Frida Kahlo', value: '$200,000' },
+      ].map((entry, index) => (
+        <ListItem key={index}>
+          <ListItemAvatar>
+            <Avatar />
+          </ListItemAvatar>
+          <Box
+            sx={{
+              display: 'flex',
+              width: '100%',
+              flexDirection: {
+                cqxs: 'column',
+                cqsm: 'row',
+              },
+            }}
           >
-            {entry.value}
-          </ListItemText>
-        </Box>
-        <IconButton>
-          <ChevronRightIcon />
-        </IconButton>
-      </ListItem>
-    ))}
-  </List>
-);
+            <ListItemText>{entry.name}</ListItemText>
+            <ListItemText
+              sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}
+            >
+              {entry.value}
+            </ListItemText>
+          </Box>
+          <IconButton>
+            <ChevronRightIcon />
+          </IconButton>
+        </ListItem>
+      ))}
+    </List>
+  );
+}
 
 export default function ContainerBreakpointsAsObject() {
   return (

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+
+export default function ContainerBreakpointsAsObject() {
+  return (
+    <div>
+      <Box
+        sx={{
+          width: {
+            cqxs: 100, // theme.breakpoints.up('xs', 'container')
+            cqsm: 200, // theme.breakpoints.up('sm', 'container')
+            cqmd: 300, // theme.breakpoints.up('md', 'container')
+            cqlg: 400, // theme.breakpoints.up('lg', 'container')
+            cqxl: 500, // theme.breakpoints.up('xl', 'container')
+          },
+        }}
+      >
+        This box has a responsive width.
+      </Box>
+    </div>
+  );
+}

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
@@ -1,22 +1,56 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
+import {
+  Avatar,
+  Box, IconButton,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Paper
+} from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+const ListWithContainerBreakpoints = () => <List>
+  {[{ name: 'Peter Pan', value: '$100,000' },
+    { name: 'Frida Kahlo', value: '$200,000' }].map((entry, index) => (
+    <ListItem key={index}>
+      <ListItemAvatar><Avatar/></ListItemAvatar>
+      <Box sx={{
+        display: 'flex',
+        width: '100%',
+        flexDirection: {
+          cqxs: 'column',
+          cqsm: 'row'
+        }
+      }}>
+        <ListItemText>
+          {entry.name}
+        </ListItemText>
+        <ListItemText sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}>
+          {entry.value}
+        </ListItemText>
+      </Box>
+      <IconButton><ChevronRightIcon/></IconButton>
+    </ListItem>
+  ))}
+</List>;
 
 export default function ContainerBreakpointsAsObject() {
   return (
-    <div>
-      <Box
-        sx={{
-          width: {
-            cqxs: 100, // theme.breakpoints.up('xs', 'container')
-            cqsm: 200, // theme.breakpoints.up('sm', 'container')
-            cqmd: 300, // theme.breakpoints.up('md', 'container')
-            cqlg: 400, // theme.breakpoints.up('lg', 'container')
-            cqxl: 500, // theme.breakpoints.up('xl', 'container')
-          },
-        }}
-      >
-        This box has a responsive width.
-      </Box>
-    </div>
+    <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}>
+      <Paper sx={{
+        width: '50%',
+        containerType: 'inline-size',
+      }}>
+        <ListWithContainerBreakpoints/>
+      </Paper>
+      <Paper sx={{
+        width: '100%',
+        containerType: 'inline-size',
+      }}>
+        <ListWithContainerBreakpoints/>
+      </Paper>
+    </Box>
   );
 }

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx
@@ -1,55 +1,72 @@
 import * as React from 'react';
 import {
   Avatar,
-  Box, IconButton,
+  Box,
+  IconButton,
   List,
   ListItem,
   ListItemAvatar,
   ListItemButton,
   ListItemText,
-  Paper
+  Paper,
 } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const ListWithContainerBreakpoints = () => <List>
-  {[{ name: 'Peter Pan', value: '$100,000' },
-    { name: 'Frida Kahlo', value: '$200,000' }].map((entry, index) => (
-    <ListItem key={index}>
-      <ListItemAvatar><Avatar/></ListItemAvatar>
-      <Box sx={{
-        display: 'flex',
-        width: '100%',
-        flexDirection: {
-          cqxs: 'column',
-          cqsm: 'row'
-        }
-      }}>
-        <ListItemText>
-          {entry.name}
-        </ListItemText>
-        <ListItemText sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}>
-          {entry.value}
-        </ListItemText>
-      </Box>
-      <IconButton><ChevronRightIcon/></IconButton>
-    </ListItem>
-  ))}
-</List>;
+const ListWithContainerBreakpoints = () => (
+  <List>
+    {[
+      { name: 'Peter Pan', value: '$100,000' },
+      { name: 'Frida Kahlo', value: '$200,000' },
+    ].map((entry, index) => (
+      <ListItem key={index}>
+        <ListItemAvatar>
+          <Avatar />
+        </ListItemAvatar>
+        <Box
+          sx={{
+            display: 'flex',
+            width: '100%',
+            flexDirection: {
+              cqxs: 'column',
+              cqsm: 'row',
+            },
+          }}
+        >
+          <ListItemText>{entry.name}</ListItemText>
+          <ListItemText
+            sx={{ display: 'flex', justifyContent: { cqsm: 'flex-end' } }}
+          >
+            {entry.value}
+          </ListItemText>
+        </Box>
+        <IconButton>
+          <ChevronRightIcon />
+        </IconButton>
+      </ListItem>
+    ))}
+  </List>
+);
 
 export default function ContainerBreakpointsAsObject() {
   return (
-    <Box sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}>
-      <Paper sx={{
-        width: '50%',
-        containerType: 'inline-size', // <-- this defines the reference container
-      }}>
-        <ListWithContainerBreakpoints/>
+    <Box
+      sx={{ display: 'flex', gap: '16px', flexDirection: 'column', width: '100%' }}
+    >
+      <Paper
+        sx={{
+          width: '50%',
+          containerType: 'inline-size', // <-- this defines the reference container
+        }}
+      >
+        <ListWithContainerBreakpoints />
       </Paper>
-      <Paper sx={{
-        width: '100%',
-        containerType: 'inline-size', // <-- this defines the reference container
-      }}>
-        <ListWithContainerBreakpoints/>
+      <Paper
+        sx={{
+          width: '100%',
+          containerType: 'inline-size', // <-- this defines the reference container
+        }}
+      >
+        <ListWithContainerBreakpoints />
       </Paper>
     </Box>
   );

--- a/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx.preview
+++ b/docs/data/system/getting-started/usage/ContainerBreakpointsAsObject.tsx.preview
@@ -1,0 +1,16 @@
+<Paper
+  sx={{
+    width: '50%',
+    containerType: 'inline-size', // <-- this defines the reference container
+  }}
+>
+  <ListWithContainerBreakpoints />
+</Paper>
+<Paper
+  sx={{
+    width: '100%',
+    containerType: 'inline-size', // <-- this defines the reference container
+  }}
+>
+  <ListWithContainerBreakpoints />
+</Paper>

--- a/docs/data/system/getting-started/usage/usage.md
+++ b/docs/data/system/getting-started/usage/usage.md
@@ -366,6 +366,52 @@ declare module '@mui/material/styles' {
 }
 ```
 
+#### Container queries
+
+In order to use [`@container` queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries) instead of [`@media` queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries), you can add the prefix `cq` to your sx definitions.
+
+{{"demo": "ContainerBreakpointsAsObject.js"}}
+
+#### Container query breakpoints
+
+In order to use different breakpoints for container queries than the default `xs` to `xl`, you may define them with the same prefix as in the sx props.
+
+```jsx
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  breakpoints: {
+    values: {
+      cqxs: 0,
+      cqsm: 400,
+      cqmd: 800,
+      cqlg: 1000,
+      cqxl: 1400
+    },
+  },
+});
+
+export default function CustomBreakpointsForContainerQueries() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Box
+        sx={{
+          width: {
+            cqxs: 100,
+            cqmd: 300,
+          },
+        }}
+      >
+        This box has a responsive width
+      </Box>
+    </ThemeProvider>
+  );
+}
+```
+If no container query breakpoints are defined, the theme will fall back to the default breakpoints, e.g. `cqxs` → `xs`.
+
 #### Theme getter
 
 If you wish to use the theme for a CSS property that is not supported natively by the system, then you can use a function as the value, in which you can access the theme object.

--- a/docs/data/system/getting-started/usage/usage.md
+++ b/docs/data/system/getting-started/usage/usage.md
@@ -381,7 +381,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
-const theme = createTheme({
+const themeWithCustomBreakpoints = createTheme({
   breakpoints: {
     values: {
       cqxs: 0,

--- a/docs/data/system/getting-started/usage/usage.md
+++ b/docs/data/system/getting-started/usage/usage.md
@@ -388,7 +388,7 @@ const theme = createTheme({
       cqsm: 400,
       cqmd: 800,
       cqlg: 1000,
-      cqxl: 1400
+      cqxl: 1400,
     },
   },
 });
@@ -410,6 +410,7 @@ export default function CustomBreakpointsForContainerQueries() {
   );
 }
 ```
+
 If no container query breakpoints are defined, the theme will fall back to the default breakpoints, e.g. `cqxs` → `xs`.
 
 #### Theme getter

--- a/packages/mui-system/src/breakpoints.js
+++ b/packages/mui-system/src/breakpoints.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import {deepmerge} from '@mui/utils';
+import { deepmerge } from '@mui/utils';
 import merge from './merge';
 
 export const containerQueryPrefix = 'cq';
@@ -38,18 +38,21 @@ export function handleBreakpoints(props, propValue, styleFromPropValue) {
     return Object.keys(propValue).reduce((acc, breakpoint) => {
       // key is breakpoint
       const useContainerQueryWithContainerBreakPoints =
-        breakpoint.indexOf(containerQueryPrefix) === 0
-        && breakpointKeys.includes(breakpoint);
+        breakpoint.indexOf(containerQueryPrefix) === 0 && breakpointKeys.includes(breakpoint);
       const useContainerQueryWithDefaultBreakPoints =
-        breakpoint.indexOf(containerQueryPrefix) === 0
-        && !useContainerQueryWithContainerBreakPoints
-        && breakpointKeys.includes(breakpoint.substring(containerQueryPrefix.length));
-      const useContainerQuery = useContainerQueryWithDefaultBreakPoints || useContainerQueryWithContainerBreakPoints;
+        breakpoint.indexOf(containerQueryPrefix) === 0 &&
+        !useContainerQueryWithContainerBreakPoints &&
+        breakpointKeys.includes(breakpoint.substring(containerQueryPrefix.length));
+      const useContainerQuery =
+        useContainerQueryWithDefaultBreakPoints || useContainerQueryWithContainerBreakPoints;
       const mappedBreakpoint = useContainerQueryWithDefaultBreakPoints
         ? breakpoint.substring(containerQueryPrefix.length).toLowerCase()
         : breakpoint;
       if (breakpointKeys.indexOf(mappedBreakpoint) !== -1) {
-        const mediaKey = themeBreakpoints.up(mappedBreakpoint, useContainerQuery ? 'container' : 'media');
+        const mediaKey = themeBreakpoints.up(
+          mappedBreakpoint,
+          useContainerQuery ? 'container' : 'media',
+        );
         acc[mediaKey] = styleFromPropValue(propValue[breakpoint], mappedBreakpoint);
       } else {
         const cssKey = mappedBreakpoint;
@@ -73,13 +76,19 @@ function breakpoints(styleFunction) {
     const extended = themeBreakpoints.keys.reduce((acc, key) => {
       if (props[key] && key.indexOf(containerQueryPrefix) !== 0) {
         acc = acc || {};
-        acc[themeBreakpoints.up(key)] = styleFunction({theme, ...props[key]});
+        acc[themeBreakpoints.up(key)] = styleFunction({ theme, ...props[key] });
       } else if (props[key] && key.indexOf(containerQueryPrefix) === 0) {
         acc = acc || {};
-        acc[themeBreakpoints.up(key, 'container')] = styleFunction({theme, ...props[`${key}`]});
-      } else if (props[`${containerQueryPrefix}${key}`] || (props[key] && key.indexOf(containerQueryPrefix) === 0)) {
+        acc[themeBreakpoints.up(key, 'container')] = styleFunction({ theme, ...props[`${key}`] });
+      } else if (
+        props[`${containerQueryPrefix}${key}`] ||
+        (props[key] && key.indexOf(containerQueryPrefix) === 0)
+      ) {
         acc = acc || {};
-        acc[themeBreakpoints.up(key, 'container')] = styleFunction({theme, ...props[`${containerQueryPrefix}${key}`]});
+        acc[themeBreakpoints.up(key, 'container')] = styleFunction({
+          theme,
+          ...props[`${containerQueryPrefix}${key}`],
+        });
       }
       return acc;
     }, null);
@@ -90,13 +99,13 @@ function breakpoints(styleFunction) {
   newStyleFunction.propTypes =
     process.env.NODE_ENV !== 'production'
       ? {
-        ...styleFunction.propTypes,
-        xs: PropTypes.object,
-        sm: PropTypes.object,
-        md: PropTypes.object,
-        lg: PropTypes.object,
-        xl: PropTypes.object,
-      }
+          ...styleFunction.propTypes,
+          xs: PropTypes.object,
+          sm: PropTypes.object,
+          md: PropTypes.object,
+          lg: PropTypes.object,
+          xl: PropTypes.object,
+        }
       : {};
 
   newStyleFunction.filterProps = ['xs', 'sm', 'md', 'lg', 'xl', ...styleFunction.filterProps];
@@ -160,10 +169,10 @@ export function computeBreakpointsBase(breakpointValues, themeBreakpoints) {
 }
 
 export function resolveBreakpointValues({
-                                          values: breakpointValues,
-                                          breakpoints: themeBreakpoints,
-                                          base: customBase,
-                                        }) {
+  values: breakpointValues,
+  breakpoints: themeBreakpoints,
+  base: customBase,
+}) {
   const base = customBase || computeBreakpointsBase(breakpointValues, themeBreakpoints);
   const keys = Object.keys(base);
 

--- a/packages/mui-system/src/breakpoints.test.js
+++ b/packages/mui-system/src/breakpoints.test.js
@@ -39,6 +39,25 @@ describe('breakpoints', () => {
     });
   });
 
+  it('should work with container queries', () => {
+    const palette = breakpoints(textColor);
+
+    expect(palette.filterProps.length).to.equal(6);
+    expect(
+      palette({
+        color: 'red',
+        cqsm: {
+          color: 'blue',
+        },
+      }),
+    ).to.deep.equal({
+      color: 'red',
+      '@container (min-width:600px)': {
+        color: 'blue',
+      },
+    });
+  });
+
   describe('function: computeBreakpointsBase', () => {
     describe('mui default breakpoints', () => {
       it('compute base for breakpoint values of array type', () => {
@@ -259,6 +278,32 @@ describe('breakpoints', () => {
       );
       expect(result).to.deep.equal({
         '@media (min-width:0px)': {
+          fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+          fontSize: '0.875rem',
+          letterSpacing: '0.01071em',
+          fontWeight: 400,
+          lineHeight: 1.43,
+        },
+      });
+    });
+
+    it('should remove empty container breakpoints', () => {
+      const result = removeUnusedBreakpoints(
+        ['@container (min-width:0px)', '@container (min-width:600px)', '@container (min-width:960px)'],
+        {
+          '@container (min-width:0px)': {
+            fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+            fontSize: '0.875rem',
+            letterSpacing: '0.01071em',
+            fontWeight: 400,
+            lineHeight: 1.43,
+          },
+          '@container (min-width:600px)': null,
+          '@container (min-width:960px)': {},
+        },
+      );
+      expect(result).to.deep.equal({
+        '@container (min-width:0px)': {
           fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
           fontSize: '0.875rem',
           letterSpacing: '0.01071em',

--- a/packages/mui-system/src/breakpoints.test.js
+++ b/packages/mui-system/src/breakpoints.test.js
@@ -289,7 +289,11 @@ describe('breakpoints', () => {
 
     it('should remove empty container breakpoints', () => {
       const result = removeUnusedBreakpoints(
-        ['@container (min-width:0px)', '@container (min-width:600px)', '@container (min-width:960px)'],
+        [
+          '@container (min-width:0px)',
+          '@container (min-width:600px)',
+          '@container (min-width:960px)',
+        ],
         {
           '@container (min-width:0px)': {
             fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',

--- a/packages/mui-system/src/createTheme/createBreakpoints.d.ts
+++ b/packages/mui-system/src/createTheme/createBreakpoints.d.ts
@@ -6,6 +6,9 @@ export type Breakpoint = OverridableStringUnion<
   'xs' | 'sm' | 'md' | 'lg' | 'xl',
   BreakpointOverrides
 >;
+
+export type QueryType = 'media' | 'container';
+
 export const keys: Breakpoint[];
 
 // Keep in sync with docs/src/pages/customization/breakpoints/breakpoints.md
@@ -30,37 +33,42 @@ export interface Breakpoints {
   values: { [key in Breakpoint]: number };
   /**
    * @param key - A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+   * @param query - By default, `media` queries will be created, one may however choose to create `container` queries instead.
    * @returns A media query string ready to be used with most styling solutions, which matches screen widths greater than the screen size given by the breakpoint key (inclusive).
    * @see [API documentation](https://mui.com/material-ui/customization/breakpoints/#theme-breakpoints-up-key-media-query)
    */
-  up: (key: Breakpoint | number) => string;
+  up: (key: Breakpoint | number, query?: QueryType) => string;
   /**
    * @param key - A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+   * @param query - By default, `media` queries will be created, one may however choose to create `container` queries instead.
    * @returns A media query string ready to be used with most styling solutions, which matches screen widths less than the screen size given by the breakpoint key (exclusive).
    * @see [API documentation](https://mui.com/material-ui/customization/breakpoints/#theme-breakpoints-down-key-media-query)
    */
-  down: (key: Breakpoint | number) => string;
+  down: (key: Breakpoint | number, query?: QueryType) => string;
   /**
    * @param start - A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
    * @param end - A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+   * @param query - By default, `media` queries will be created, one may however choose to create `container` queries instead.
    * @returns A media query string ready to be used with most styling solutions, which matches screen widths greater than
    *          the screen size given by the breakpoint key in the first argument (inclusive) and less than the screen size given by the breakpoint key in the second argument (exclusive).
    * @see [API documentation](https://mui.com/material-ui/customization/breakpoints/#theme-breakpoints-between-start-end-media-query)
    */
-  between: (start: Breakpoint | number, end: Breakpoint | number) => string;
+  between: (start: Breakpoint | number, end: Breakpoint | number, query?: QueryType) => string;
   /**
    * @param key - A breakpoint key (`xs`, `sm`, etc.) or a screen width number in px.
+   * @param query - By default, `media` queries will be created, one may however choose to create `container` queries instead.
    * @returns A media query string ready to be used with most styling solutions, which matches screen widths starting from
    *          the screen size given by the breakpoint key (inclusive) and stopping at the screen size given by the next breakpoint key (exclusive).
    * @see [API documentation](https://mui.com/material-ui/customization/breakpoints/#theme-breakpoints-only-key-media-query)
    */
-  only: (key: Breakpoint) => string;
+  only: (key: Breakpoint, query?: QueryType) => string;
   /**
    * @param key - A breakpoint key (`xs`, `sm`, etc.).
+   * @param query - By default, `media` queries will be created, one may however choose to create `container` queries instead.
    * @returns A media query string ready to be used with most styling solutions, which matches screen widths stopping at
    *          the screen size given by the breakpoint key (exclusive) and starting at the screen size given by the next breakpoint key (inclusive).
    */
-  not: (key: Breakpoint) => string;
+  not: (key: Breakpoint, query?: QueryType) => string;
   /**
    * The unit used for the breakpoint's values.
    * @default 'px'

--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -2,6 +2,8 @@
 // It can't be configured as it's used statically for propTypes.
 export const breakpointKeys = ['xs', 'sm', 'md', 'lg', 'xl'];
 
+const defaultQuery = 'media';
+
 const sortBreakpointsValues = (values) => {
   const breakpointsAsArray = Object.keys(values).map((key) => ({ key, val: values[key] })) || [];
   // Sort in ascending order
@@ -31,21 +33,21 @@ export default function createBreakpoints(breakpoints) {
   const sortedValues = sortBreakpointsValues(values);
   const keys = Object.keys(sortedValues);
 
-  function up(key) {
+  function up(key, query = defaultQuery) {
     const value = typeof values[key] === 'number' ? values[key] : key;
-    return `@media (min-width:${value}${unit})`;
+    return `@${query} (min-width:${value}${unit})`;
   }
 
-  function down(key) {
+  function down(key, query = defaultQuery) {
     const value = typeof values[key] === 'number' ? values[key] : key;
-    return `@media (max-width:${value - step / 100}${unit})`;
+    return `@${query} (max-width:${value - step / 100}${unit})`;
   }
 
-  function between(start, end) {
+  function between(start, end, query = defaultQuery) {
     const endIndex = keys.indexOf(end);
 
     return (
-      `@media (min-width:${
+      `@${query} (min-width:${
         typeof values[start] === 'number' ? values[start] : start
       }${unit}) and ` +
       `(max-width:${
@@ -57,25 +59,25 @@ export default function createBreakpoints(breakpoints) {
     );
   }
 
-  function only(key) {
+  function only(key, query = defaultQuery) {
     if (keys.indexOf(key) + 1 < keys.length) {
-      return between(key, keys[keys.indexOf(key) + 1]);
+      return between(key, keys[keys.indexOf(key) + 1], query);
     }
 
-    return up(key);
+    return up(key, query);
   }
 
-  function not(key) {
+  function not(key, query = defaultQuery) {
     // handle first and last key separately, for better readability
     const keyIndex = keys.indexOf(key);
     if (keyIndex === 0) {
-      return up(keys[1]);
+      return up(keys[1], query);
     }
     if (keyIndex === keys.length - 1) {
-      return down(keys[keyIndex]);
+      return down(keys[keyIndex], query);
     }
 
-    return between(key, keys[keys.indexOf(key) + 1]).replace('@media', '@media not all and');
+    return between(key, keys[keys.indexOf(key) + 1], query).replace(`@${query}`, `@${query} not all and`);
   }
 
   return {

--- a/packages/mui-system/src/createTheme/createBreakpoints.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.js
@@ -77,7 +77,10 @@ export default function createBreakpoints(breakpoints) {
       return down(keys[keyIndex], query);
     }
 
-    return between(key, keys[keys.indexOf(key) + 1], query).replace(`@${query}`, `@${query} not all and`);
+    return between(key, keys[keys.indexOf(key) + 1], query).replace(
+      `@${query}`,
+      `@${query} not all and`,
+    );
   }
 
   return {

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -95,7 +95,9 @@ describe('createBreakpoints', () => {
     });
 
     it('should work for the largest of custom breakpoints with container query', () => {
-      expect(customBreakpoints.down('desktop', 'container')).to.equal('@container (max-width:1279.95px)');
+      expect(customBreakpoints.down('desktop', 'container')).to.equal(
+        '@container (max-width:1279.95px)',
+      );
     });
   });
 
@@ -153,7 +155,9 @@ describe('createBreakpoints', () => {
     });
 
     it('should work with container query', () => {
-      expect(breakpoints.only('md', 'container')).to.equal('@container (min-width:900px) and (max-width:1199.95px)');
+      expect(breakpoints.only('md', 'container')).to.equal(
+        '@container (min-width:900px) and (max-width:1199.95px)',
+      );
     });
 
     it('should work for custom breakpoints with container query', () => {

--- a/packages/mui-system/src/createTheme/createBreakpoints.test.js
+++ b/packages/mui-system/src/createTheme/createBreakpoints.test.js
@@ -47,6 +47,18 @@ describe('createBreakpoints', () => {
     it('should work for custom breakpoints', () => {
       expect(customBreakpoints.up('laptop')).to.equal('@media (min-width:1024px)');
     });
+
+    it('should work for xs with container query', () => {
+      expect(breakpoints.up('xs', 'container')).to.equal('@container (min-width:0px)');
+    });
+
+    it('should work for md with container query', () => {
+      expect(breakpoints.up('md', 'container')).to.equal('@container (min-width:900px)');
+    });
+
+    it('should work for custom breakpoints with container query', () => {
+      expect(customBreakpoints.up('laptop', 'container')).to.equal('@container (min-width:1024px)');
+    });
   });
 
   describe('down', () => {
@@ -77,6 +89,14 @@ describe('createBreakpoints', () => {
     it('should work for the largest of custom breakpoints', () => {
       expect(customBreakpoints.down('desktop')).to.equal('@media (max-width:1279.95px)');
     });
+
+    it('should work with container query', () => {
+      expect(breakpoints.down('sm', 'container')).to.equal('@container (max-width:599.95px)');
+    });
+
+    it('should work for the largest of custom breakpoints with container query', () => {
+      expect(customBreakpoints.down('desktop', 'container')).to.equal('@container (max-width:1279.95px)');
+    });
   });
 
   describe('between', () => {
@@ -103,6 +123,18 @@ describe('createBreakpoints', () => {
         '@media (min-width:640px) and (max-width:1023.95px)',
       );
     });
+
+    it('should work with container query', () => {
+      expect(breakpoints.between('sm', 'md', 'container')).to.equal(
+        '@container (min-width:600px) and (max-width:899.95px)',
+      );
+    });
+
+    it('should work for custom breakpoints with container query', () => {
+      expect(customBreakpoints.between('tablet', 'laptop', 'container')).to.equal(
+        '@container (min-width:640px) and (max-width:1023.95px)',
+      );
+    });
   });
 
   describe('only', () => {
@@ -117,6 +149,16 @@ describe('createBreakpoints', () => {
     it('should work for custom breakpoints', () => {
       expect(customBreakpoints.only('tablet')).to.equal(
         '@media (min-width:640px) and (max-width:1023.95px)',
+      );
+    });
+
+    it('should work with container query', () => {
+      expect(breakpoints.only('md', 'container')).to.equal('@container (min-width:900px) and (max-width:1199.95px)');
+    });
+
+    it('should work for custom breakpoints with container query', () => {
+      expect(customBreakpoints.only('tablet', 'container')).to.equal(
+        '@container (min-width:640px) and (max-width:1023.95px)',
       );
     });
   });
@@ -139,6 +181,18 @@ describe('createBreakpoints', () => {
     it('should work for custom breakpoints', () => {
       expect(customBreakpoints.not('tablet')).to.equal(
         '@media not all and (min-width:640px) and (max-width:1023.95px)',
+      );
+    });
+
+    it('should work with container query', () => {
+      expect(breakpoints.not('md', 'container')).to.equal(
+        '@container not all and (min-width:900px) and (max-width:1199.95px)',
+      );
+    });
+
+    it('should work for custom breakpoints with container query', () => {
+      expect(customBreakpoints.not('tablet', 'container')).to.equal(
+        '@container not all and (min-width:640px) and (max-width:1023.95px)',
       );
     });
   });

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 import createMixins from '@mui/material/styles/createMixins';
 import createTypography from '@mui/material/styles/createTypography';
 import createBreakpoints from '../createTheme/createBreakpoints';
@@ -20,8 +20,8 @@ describe('styleFunctionSx', () => {
     breakpoints: {
       keys: ['xs', 'sm', 'md', 'lg', 'xl'],
       values: breakpointsValues,
-      up: (key) => {
-        return `@media (min-width:${breakpointsValues[key]}px)`;
+      up: (key, query = 'media') => {
+        return `@${query} (min-width:${breakpointsValues[key]}px)`;
       },
     },
     unit: 'px',
@@ -84,18 +84,18 @@ describe('styleFunctionSx', () => {
         '@media print': {
           display: 'block',
         },
-        '@media (min-width:0px)': { border: '1px solid' },
-        '@media (min-width:600px)': { border: '2px solid' },
-        '@media (min-width:960px)': { border: '3px solid' },
-        '@media (min-width:1280px)': { border: '4px solid' },
-        '@media (min-width:1920px)': { border: '5px solid' },
+        '@media (min-width:0px)': {border: '1px solid'},
+        '@media (min-width:600px)': {border: '2px solid'},
+        '@media (min-width:960px)': {border: '3px solid'},
+        '@media (min-width:1280px)': {border: '4px solid'},
+        '@media (min-width:1920px)': {border: '5px solid'},
       });
     });
 
     it('resolves system typography', () => {
       const result = styleFunctionSx({
         theme,
-        sx: { typography: ['body2', 'body1'] },
+        sx: {typography: ['body2', 'body1']},
       });
 
       expect(result).to.deep.equal({
@@ -119,7 +119,7 @@ describe('styleFunctionSx', () => {
     it('allow values to be `null` or `undefined`', () => {
       const result = styleFunctionSx({
         theme,
-        sx: { typography: null, m: 0, p: null, transform: null },
+        sx: {typography: null, m: 0, p: null, transform: null},
       });
       expect(result).to.deep.equal({
         margin: '0px',
@@ -164,26 +164,72 @@ describe('styleFunctionSx', () => {
           borderColor: 'rgb(0, 0, 255)',
           translate: 'transform(20px)',
         },
-        '@media (min-width:960px)': { opacity: 0.3, border: '3px solid' },
-        '@media (min-width:1280px)': { opacity: 0.4 },
-        '@media (min-width:1920px)': { opacity: 0.5 },
+        '@media (min-width:960px)': {opacity: 0.3, border: '3px solid'},
+        '@media (min-width:1280px)': {opacity: 0.4},
+        '@media (min-width:1920px)': {opacity: 0.5},
+      },
+    });
+  });
+
+  it('resolves non system CSS properties with container queries if specified', () => {
+    const result = styleFunctionSx({
+      theme,
+      sx: {
+        background: 'rgb(0, 0, 255)',
+        '&:hover': {
+          backgroundColor: 'primary.main',
+          opacity: {
+            cqxs: 0.1,
+            cqsm: 0.2,
+            cqmd: 0.3,
+            cqlg: 0.4,
+            cqxl: 0.5,
+          },
+          translate: {cqxs: 'transform(10px)', cqsm: 'transform(20px)'},
+          border: {cqxs: 1, cqsm: 2, cqmd: 3},
+          borderColor: (t) => ({
+            cqxs: t.palette.secondary.main, cqsm: t.palette.primary.main,
+          }),
+        },
+      },
+    });
+
+    expect(result).to.deep.equal({
+      background: 'rgb(0, 0, 255)',
+      '&:hover': {
+        backgroundColor: 'rgb(0, 0, 255)',
+        '@container (min-width:0px)': {
+          opacity: 0.1,
+          border: '1px solid',
+          borderColor: 'rgb(0, 255, 0)',
+          translate: 'transform(10px)',
+        },
+        '@container (min-width:600px)': {
+          opacity: 0.2,
+          border: '2px solid',
+          borderColor: 'rgb(0, 0, 255)',
+          translate: 'transform(20px)',
+        },
+        '@container (min-width:960px)': {opacity: 0.3, border: '3px solid'},
+        '@container (min-width:1280px)': {opacity: 0.4},
+        '@container (min-width:1920px)': {opacity: 0.5},
       },
     });
   });
 
   describe('breakpoints', () => {
     const breakpointsExpectedResult = {
-      '@media (min-width:0px)': { border: '1px solid' },
-      '@media (min-width:600px)': { border: '2px solid' },
-      '@media (min-width:960px)': { border: '3px solid' },
-      '@media (min-width:1280px)': { border: '4px solid' },
-      '@media (min-width:1920px)': { border: '5px solid' },
+      '@media (min-width:0px)': {border: '1px solid'},
+      '@media (min-width:600px)': {border: '2px solid'},
+      '@media (min-width:960px)': {border: '3px solid'},
+      '@media (min-width:1280px)': {border: '4px solid'},
+      '@media (min-width:1920px)': {border: '5px solid'},
     };
 
     it('resolves breakpoints array', () => {
       const result = styleFunctionSx({
         theme,
-        sx: { border: [1, 2, 3, 4, 5] },
+        sx: {border: [1, 2, 3, 4, 5]},
       });
 
       expect(result).to.deep.equal(breakpointsExpectedResult);
@@ -206,23 +252,94 @@ describe('styleFunctionSx', () => {
       expect(result).to.deep.equal(breakpointsExpectedResult);
     });
 
+    it('resolves breakpoints object with container query shorthand', () => {
+      const breakpointsExpectedResult = {
+        '@container (min-width:0px)': {border: '1px solid'},
+        '@container (min-width:600px)': {border: '2px solid'},
+        '@container (min-width:960px)': {border: '3px solid'},
+        '@container (min-width:1280px)': {border: '4px solid'},
+        '@container (min-width:1920px)': {border: '5px solid'},
+      };
+      const result = styleFunctionSx({
+        theme,
+        sx: {
+          border: {
+            cqxs: 1,
+            cqsm: 2,
+            cqmd: 3,
+            cqlg: 4,
+            cqxl: 5,
+          },
+        },
+      });
+
+      expect(result).to.deep.equal(breakpointsExpectedResult);
+    });
+
+    it('resolves breakpoints object with container query shorthand with custom container query breakpoints', () => {
+      const customBreakpoints = {
+        xs: 0,
+        sm: 600,
+        md: 960,
+        lg: 1280,
+        xl: 1920,
+        cqxs: 0,
+        cqsm: 400,
+        cqmd: 800,
+        cqlg: 1000,
+        cqxl: 1480,
+      };
+      const customBreakpointsTheme = {
+        ...theme,
+        breakpoints: {
+          ...theme.breakpoints,
+          up: (key, query = 'media') => {
+            return `@${query} (min-width:${customBreakpoints[key]}px)`;
+          },
+          keys: ['xs', 'sm', 'md', 'lg', 'xl', 'cqxs', 'cqsm', 'cqmd', 'cqlg', 'cqxl'],
+          values: customBreakpoints,
+        }
+      };
+      const breakpointsExpectedResult = {
+        '@container (min-width:0px)': {border: '1px solid'},
+        '@container (min-width:400px)': {border: '2px solid'},
+        '@container (min-width:800px)': {border: '3px solid'},
+        '@container (min-width:1000px)': {border: '4px solid'},
+        '@container (min-width:1480px)': {border: '5px solid'},
+      };
+      const result = styleFunctionSx({
+        theme: customBreakpointsTheme,
+        sx: {
+          border: {
+            cqxs: 1,
+            cqsm: 2,
+            cqmd: 3,
+            cqlg: 4,
+            cqxl: 5,
+          },
+        },
+      });
+
+      expect(result).to.deep.equal(breakpointsExpectedResult);
+    });
+
     it('merges multiple breakpoints object', () => {
       const result = styleFunctionSx({
         theme,
-        sx: { m: [1, 2, 3], p: [5, 6, 7] },
+        sx: {m: [1, 2, 3], p: [5, 6, 7]},
       });
 
       expect(result).to.deep.equal({
-        '@media (min-width:0px)': { padding: '50px', margin: '10px' },
-        '@media (min-width:600px)': { padding: '60px', margin: '20px' },
-        '@media (min-width:960px)': { padding: '70px', margin: '30px' },
+        '@media (min-width:0px)': {padding: '50px', margin: '10px'},
+        '@media (min-width:600px)': {padding: '60px', margin: '20px'},
+        '@media (min-width:960px)': {padding: '70px', margin: '30px'},
       });
     });
 
     it('writes breakpoints in correct order', () => {
       const result = styleFunctionSx({
         theme,
-        sx: { m: { md: 1, lg: 2 }, p: { xs: 0, sm: 1, md: 2 } },
+        sx: {m: {md: 1, lg: 2}, p: {xs: 0, sm: 1, md: 2}},
       });
 
       // Test the order
@@ -234,10 +351,10 @@ describe('styleFunctionSx', () => {
       ]);
 
       expect(result).to.deep.equal({
-        '@media (min-width:0px)': { padding: '0px' },
-        '@media (min-width:600px)': { padding: '10px' },
-        '@media (min-width:960px)': { padding: '20px', margin: '10px' },
-        '@media (min-width:1280px)': { margin: '20px' },
+        '@media (min-width:0px)': {padding: '0px'},
+        '@media (min-width:600px)': {padding: '10px'},
+        '@media (min-width:960px)': {padding: '20px', margin: '10px'},
+        '@media (min-width:1280px)': {margin: '20px'},
       });
     });
 
@@ -270,31 +387,31 @@ describe('styleFunctionSx', () => {
       });
 
       // Test the order
-      expect(result).to.deep.equal({ background: 'rgb(0, 0, 255)' });
+      expect(result).to.deep.equal({background: 'rgb(0, 0, 255)'});
     });
 
     it('works on pseudo selectors', () => {
       const result = styleFunctionSx({
         theme,
         sx: {
-          '&:hover': (t) => ({ background: t.palette.primary.main }),
+          '&:hover': (t) => ({background: t.palette.primary.main}),
         },
       });
 
       // Test the order
-      expect(result).to.deep.equal({ '&:hover': { background: 'rgb(0, 0, 255)' } });
+      expect(result).to.deep.equal({'&:hover': {background: 'rgb(0, 0, 255)'}});
     });
 
     it('works on nested selectors', () => {
       const result = styleFunctionSx({
         theme,
         sx: {
-          '& .test-classname': (t) => ({ background: t.palette.primary.main }),
+          '& .test-classname': (t) => ({background: t.palette.primary.main}),
         },
       });
 
       // Test the order
-      expect(result).to.deep.equal({ '& .test-classname': { background: 'rgb(0, 0, 255)' } });
+      expect(result).to.deep.equal({'& .test-classname': {background: 'rgb(0, 0, 255)'}});
     });
   });
 
@@ -328,7 +445,7 @@ describe('styleFunctionSx', () => {
     it('resolves a mix of theme object and system padding', () => {
       const result = styleFunctionSx({
         theme,
-        sx: (userTheme) => ({ p: 1, ...userTheme.typography.body1 }),
+        sx: (userTheme) => ({p: 1, ...userTheme.typography.body1}),
       });
       expect(result).to.deep.equal({
         padding: '10px',
@@ -376,7 +493,7 @@ describe('styleFunctionSx', () => {
       const result = styleFunctionSx({
         theme,
         sx: [
-          { bgcolor: 'primary.main' },
+          {bgcolor: 'primary.main'},
           (t) => ({
             borderRadius: t.spacing(1),
           }),
@@ -384,29 +501,29 @@ describe('styleFunctionSx', () => {
       });
 
       expect(result).to.deep.equal([
-        { backgroundColor: 'rgb(0, 0, 255)' },
-        { borderRadius: '10px' },
+        {backgroundColor: 'rgb(0, 0, 255)'},
+        {borderRadius: '10px'},
       ]);
     });
 
     it('works with media query syntax', () => {
       const result = styleFunctionSx({
         theme,
-        sx: [{ border: [1, 2, 3, 4, 5] }, { m: [1, 2, 3], p: [5, 6, 7] }],
+        sx: [{border: [1, 2, 3, 4, 5]}, {m: [1, 2, 3], p: [5, 6, 7]}],
       });
 
       expect(result).to.deep.equal([
         {
-          '@media (min-width:0px)': { border: '1px solid' },
-          '@media (min-width:600px)': { border: '2px solid' },
-          '@media (min-width:960px)': { border: '3px solid' },
-          '@media (min-width:1280px)': { border: '4px solid' },
-          '@media (min-width:1920px)': { border: '5px solid' },
+          '@media (min-width:0px)': {border: '1px solid'},
+          '@media (min-width:600px)': {border: '2px solid'},
+          '@media (min-width:960px)': {border: '3px solid'},
+          '@media (min-width:1280px)': {border: '4px solid'},
+          '@media (min-width:1920px)': {border: '5px solid'},
         },
         {
-          '@media (min-width:0px)': { padding: '50px', margin: '10px' },
-          '@media (min-width:600px)': { padding: '60px', margin: '20px' },
-          '@media (min-width:960px)': { padding: '70px', margin: '30px' },
+          '@media (min-width:0px)': {padding: '50px', margin: '10px'},
+          '@media (min-width:600px)': {padding: '60px', margin: '20px'},
+          '@media (min-width:960px)': {padding: '70px', margin: '30px'},
         },
       ]);
     });
@@ -423,7 +540,7 @@ describe('styleFunctionSx', () => {
 
   it('resolves inherit typography properties', () => {
     const result = styleFunctionSx({
-      theme: { typography: createTypography({}, {}) },
+      theme: {typography: createTypography({}, {})},
       sx: {
         fontFamily: 'inherit',
         fontWeight: 'inherit',
@@ -444,7 +561,7 @@ describe('styleFunctionSx', () => {
 
   it('resolves theme typography properties', () => {
     const result = styleFunctionSx({
-      theme: { typography: createTypography({}, {}) },
+      theme: {typography: createTypography({}, {})},
       sx: {
         fontFamily: 'default',
         fontWeight: 'fontWeightMedium',

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -1,4 +1,4 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
 import createMixins from '@mui/material/styles/createMixins';
 import createTypography from '@mui/material/styles/createTypography';
 import createBreakpoints from '../createTheme/createBreakpoints';
@@ -84,18 +84,18 @@ describe('styleFunctionSx', () => {
         '@media print': {
           display: 'block',
         },
-        '@media (min-width:0px)': {border: '1px solid'},
-        '@media (min-width:600px)': {border: '2px solid'},
-        '@media (min-width:960px)': {border: '3px solid'},
-        '@media (min-width:1280px)': {border: '4px solid'},
-        '@media (min-width:1920px)': {border: '5px solid'},
+        '@media (min-width:0px)': { border: '1px solid' },
+        '@media (min-width:600px)': { border: '2px solid' },
+        '@media (min-width:960px)': { border: '3px solid' },
+        '@media (min-width:1280px)': { border: '4px solid' },
+        '@media (min-width:1920px)': { border: '5px solid' },
       });
     });
 
     it('resolves system typography', () => {
       const result = styleFunctionSx({
         theme,
-        sx: {typography: ['body2', 'body1']},
+        sx: { typography: ['body2', 'body1'] },
       });
 
       expect(result).to.deep.equal({
@@ -119,7 +119,7 @@ describe('styleFunctionSx', () => {
     it('allow values to be `null` or `undefined`', () => {
       const result = styleFunctionSx({
         theme,
-        sx: {typography: null, m: 0, p: null, transform: null},
+        sx: { typography: null, m: 0, p: null, transform: null },
       });
       expect(result).to.deep.equal({
         margin: '0px',
@@ -164,9 +164,9 @@ describe('styleFunctionSx', () => {
           borderColor: 'rgb(0, 0, 255)',
           translate: 'transform(20px)',
         },
-        '@media (min-width:960px)': {opacity: 0.3, border: '3px solid'},
-        '@media (min-width:1280px)': {opacity: 0.4},
-        '@media (min-width:1920px)': {opacity: 0.5},
+        '@media (min-width:960px)': { opacity: 0.3, border: '3px solid' },
+        '@media (min-width:1280px)': { opacity: 0.4 },
+        '@media (min-width:1920px)': { opacity: 0.5 },
       },
     });
   });
@@ -185,10 +185,11 @@ describe('styleFunctionSx', () => {
             cqlg: 0.4,
             cqxl: 0.5,
           },
-          translate: {cqxs: 'transform(10px)', cqsm: 'transform(20px)'},
-          border: {cqxs: 1, cqsm: 2, cqmd: 3},
+          translate: { cqxs: 'transform(10px)', cqsm: 'transform(20px)' },
+          border: { cqxs: 1, cqsm: 2, cqmd: 3 },
           borderColor: (t) => ({
-            cqxs: t.palette.secondary.main, cqsm: t.palette.primary.main,
+            cqxs: t.palette.secondary.main,
+            cqsm: t.palette.primary.main,
           }),
         },
       },
@@ -210,26 +211,26 @@ describe('styleFunctionSx', () => {
           borderColor: 'rgb(0, 0, 255)',
           translate: 'transform(20px)',
         },
-        '@container (min-width:960px)': {opacity: 0.3, border: '3px solid'},
-        '@container (min-width:1280px)': {opacity: 0.4},
-        '@container (min-width:1920px)': {opacity: 0.5},
+        '@container (min-width:960px)': { opacity: 0.3, border: '3px solid' },
+        '@container (min-width:1280px)': { opacity: 0.4 },
+        '@container (min-width:1920px)': { opacity: 0.5 },
       },
     });
   });
 
   describe('breakpoints', () => {
     const breakpointsExpectedResult = {
-      '@media (min-width:0px)': {border: '1px solid'},
-      '@media (min-width:600px)': {border: '2px solid'},
-      '@media (min-width:960px)': {border: '3px solid'},
-      '@media (min-width:1280px)': {border: '4px solid'},
-      '@media (min-width:1920px)': {border: '5px solid'},
+      '@media (min-width:0px)': { border: '1px solid' },
+      '@media (min-width:600px)': { border: '2px solid' },
+      '@media (min-width:960px)': { border: '3px solid' },
+      '@media (min-width:1280px)': { border: '4px solid' },
+      '@media (min-width:1920px)': { border: '5px solid' },
     };
 
     it('resolves breakpoints array', () => {
       const result = styleFunctionSx({
         theme,
-        sx: {border: [1, 2, 3, 4, 5]},
+        sx: { border: [1, 2, 3, 4, 5] },
       });
 
       expect(result).to.deep.equal(breakpointsExpectedResult);
@@ -254,11 +255,11 @@ describe('styleFunctionSx', () => {
 
     it('resolves breakpoints object with container query shorthand', () => {
       const breakpointsExpectedResult = {
-        '@container (min-width:0px)': {border: '1px solid'},
-        '@container (min-width:600px)': {border: '2px solid'},
-        '@container (min-width:960px)': {border: '3px solid'},
-        '@container (min-width:1280px)': {border: '4px solid'},
-        '@container (min-width:1920px)': {border: '5px solid'},
+        '@container (min-width:0px)': { border: '1px solid' },
+        '@container (min-width:600px)': { border: '2px solid' },
+        '@container (min-width:960px)': { border: '3px solid' },
+        '@container (min-width:1280px)': { border: '4px solid' },
+        '@container (min-width:1920px)': { border: '5px solid' },
       };
       const result = styleFunctionSx({
         theme,
@@ -298,14 +299,14 @@ describe('styleFunctionSx', () => {
           },
           keys: ['xs', 'sm', 'md', 'lg', 'xl', 'cqxs', 'cqsm', 'cqmd', 'cqlg', 'cqxl'],
           values: customBreakpoints,
-        }
+        },
       };
       const breakpointsExpectedResult = {
-        '@container (min-width:0px)': {border: '1px solid'},
-        '@container (min-width:400px)': {border: '2px solid'},
-        '@container (min-width:800px)': {border: '3px solid'},
-        '@container (min-width:1000px)': {border: '4px solid'},
-        '@container (min-width:1480px)': {border: '5px solid'},
+        '@container (min-width:0px)': { border: '1px solid' },
+        '@container (min-width:400px)': { border: '2px solid' },
+        '@container (min-width:800px)': { border: '3px solid' },
+        '@container (min-width:1000px)': { border: '4px solid' },
+        '@container (min-width:1480px)': { border: '5px solid' },
       };
       const result = styleFunctionSx({
         theme: customBreakpointsTheme,
@@ -326,20 +327,20 @@ describe('styleFunctionSx', () => {
     it('merges multiple breakpoints object', () => {
       const result = styleFunctionSx({
         theme,
-        sx: {m: [1, 2, 3], p: [5, 6, 7]},
+        sx: { m: [1, 2, 3], p: [5, 6, 7] },
       });
 
       expect(result).to.deep.equal({
-        '@media (min-width:0px)': {padding: '50px', margin: '10px'},
-        '@media (min-width:600px)': {padding: '60px', margin: '20px'},
-        '@media (min-width:960px)': {padding: '70px', margin: '30px'},
+        '@media (min-width:0px)': { padding: '50px', margin: '10px' },
+        '@media (min-width:600px)': { padding: '60px', margin: '20px' },
+        '@media (min-width:960px)': { padding: '70px', margin: '30px' },
       });
     });
 
     it('writes breakpoints in correct order', () => {
       const result = styleFunctionSx({
         theme,
-        sx: {m: {md: 1, lg: 2}, p: {xs: 0, sm: 1, md: 2}},
+        sx: { m: { md: 1, lg: 2 }, p: { xs: 0, sm: 1, md: 2 } },
       });
 
       // Test the order
@@ -351,10 +352,10 @@ describe('styleFunctionSx', () => {
       ]);
 
       expect(result).to.deep.equal({
-        '@media (min-width:0px)': {padding: '0px'},
-        '@media (min-width:600px)': {padding: '10px'},
-        '@media (min-width:960px)': {padding: '20px', margin: '10px'},
-        '@media (min-width:1280px)': {margin: '20px'},
+        '@media (min-width:0px)': { padding: '0px' },
+        '@media (min-width:600px)': { padding: '10px' },
+        '@media (min-width:960px)': { padding: '20px', margin: '10px' },
+        '@media (min-width:1280px)': { margin: '20px' },
       });
     });
 
@@ -387,31 +388,31 @@ describe('styleFunctionSx', () => {
       });
 
       // Test the order
-      expect(result).to.deep.equal({background: 'rgb(0, 0, 255)'});
+      expect(result).to.deep.equal({ background: 'rgb(0, 0, 255)' });
     });
 
     it('works on pseudo selectors', () => {
       const result = styleFunctionSx({
         theme,
         sx: {
-          '&:hover': (t) => ({background: t.palette.primary.main}),
+          '&:hover': (t) => ({ background: t.palette.primary.main }),
         },
       });
 
       // Test the order
-      expect(result).to.deep.equal({'&:hover': {background: 'rgb(0, 0, 255)'}});
+      expect(result).to.deep.equal({ '&:hover': { background: 'rgb(0, 0, 255)' } });
     });
 
     it('works on nested selectors', () => {
       const result = styleFunctionSx({
         theme,
         sx: {
-          '& .test-classname': (t) => ({background: t.palette.primary.main}),
+          '& .test-classname': (t) => ({ background: t.palette.primary.main }),
         },
       });
 
       // Test the order
-      expect(result).to.deep.equal({'& .test-classname': {background: 'rgb(0, 0, 255)'}});
+      expect(result).to.deep.equal({ '& .test-classname': { background: 'rgb(0, 0, 255)' } });
     });
   });
 
@@ -445,7 +446,7 @@ describe('styleFunctionSx', () => {
     it('resolves a mix of theme object and system padding', () => {
       const result = styleFunctionSx({
         theme,
-        sx: (userTheme) => ({p: 1, ...userTheme.typography.body1}),
+        sx: (userTheme) => ({ p: 1, ...userTheme.typography.body1 }),
       });
       expect(result).to.deep.equal({
         padding: '10px',
@@ -493,7 +494,7 @@ describe('styleFunctionSx', () => {
       const result = styleFunctionSx({
         theme,
         sx: [
-          {bgcolor: 'primary.main'},
+          { bgcolor: 'primary.main' },
           (t) => ({
             borderRadius: t.spacing(1),
           }),
@@ -501,29 +502,29 @@ describe('styleFunctionSx', () => {
       });
 
       expect(result).to.deep.equal([
-        {backgroundColor: 'rgb(0, 0, 255)'},
-        {borderRadius: '10px'},
+        { backgroundColor: 'rgb(0, 0, 255)' },
+        { borderRadius: '10px' },
       ]);
     });
 
     it('works with media query syntax', () => {
       const result = styleFunctionSx({
         theme,
-        sx: [{border: [1, 2, 3, 4, 5]}, {m: [1, 2, 3], p: [5, 6, 7]}],
+        sx: [{ border: [1, 2, 3, 4, 5] }, { m: [1, 2, 3], p: [5, 6, 7] }],
       });
 
       expect(result).to.deep.equal([
         {
-          '@media (min-width:0px)': {border: '1px solid'},
-          '@media (min-width:600px)': {border: '2px solid'},
-          '@media (min-width:960px)': {border: '3px solid'},
-          '@media (min-width:1280px)': {border: '4px solid'},
-          '@media (min-width:1920px)': {border: '5px solid'},
+          '@media (min-width:0px)': { border: '1px solid' },
+          '@media (min-width:600px)': { border: '2px solid' },
+          '@media (min-width:960px)': { border: '3px solid' },
+          '@media (min-width:1280px)': { border: '4px solid' },
+          '@media (min-width:1920px)': { border: '5px solid' },
         },
         {
-          '@media (min-width:0px)': {padding: '50px', margin: '10px'},
-          '@media (min-width:600px)': {padding: '60px', margin: '20px'},
-          '@media (min-width:960px)': {padding: '70px', margin: '30px'},
+          '@media (min-width:0px)': { padding: '50px', margin: '10px' },
+          '@media (min-width:600px)': { padding: '60px', margin: '20px' },
+          '@media (min-width:960px)': { padding: '70px', margin: '30px' },
         },
       ]);
     });
@@ -540,7 +541,7 @@ describe('styleFunctionSx', () => {
 
   it('resolves inherit typography properties', () => {
     const result = styleFunctionSx({
-      theme: {typography: createTypography({}, {})},
+      theme: { typography: createTypography({}, {}) },
       sx: {
         fontFamily: 'inherit',
         fontWeight: 'inherit',
@@ -561,7 +562,7 @@ describe('styleFunctionSx', () => {
 
   it('resolves theme typography properties', () => {
     const result = styleFunctionSx({
-      theme: {typography: createTypography({}, {})},
+      theme: { typography: createTypography({}, {}) },
       sx: {
         fontFamily: 'default',
         fontWeight: 'fontWeightMedium',

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -254,7 +254,7 @@ describe('styleFunctionSx', () => {
     });
 
     it('resolves breakpoints object with container query shorthand', () => {
-      const breakpointsExpectedResult = {
+      const containerBreakpointsExpectedResult = {
         '@container (min-width:0px)': { border: '1px solid' },
         '@container (min-width:600px)': { border: '2px solid' },
         '@container (min-width:960px)': { border: '3px solid' },
@@ -274,7 +274,7 @@ describe('styleFunctionSx', () => {
         },
       });
 
-      expect(result).to.deep.equal(breakpointsExpectedResult);
+      expect(result).to.deep.equal(containerBreakpointsExpectedResult);
     });
 
     it('resolves breakpoints object with container query shorthand with custom container query breakpoints', () => {
@@ -301,7 +301,7 @@ describe('styleFunctionSx', () => {
           values: customBreakpoints,
         },
       };
-      const breakpointsExpectedResult = {
+      const containerBreakpointsExpectedResult = {
         '@container (min-width:0px)': { border: '1px solid' },
         '@container (min-width:400px)': { border: '2px solid' },
         '@container (min-width:800px)': { border: '3px solid' },
@@ -321,7 +321,7 @@ describe('styleFunctionSx', () => {
         },
       });
 
-      expect(result).to.deep.equal(breakpointsExpectedResult);
+      expect(result).to.deep.equal(containerBreakpointsExpectedResult);
     });
 
     it('merges multiple breakpoints object', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
* Added container queries support with newly introduced shorthands in sx props
* Added container queries support in the breakpoints api
* Documented everything to the best of my knowledge in the docs

Feel free to change the `sx` props shorthand that I chose for container queries. I had some discussions with my teammates and we came to the conclusion that a `cq` prefix for **c**ontainer **q**ueries would make most sense. I'm not too opinionated on this though. Happy to discuss this further. :)

In short: This is my suggestion to implement the desired feature #36670. If you decide to go a different path, that's of course up to you, but I'd really appreciate a handy sx support for container queries.


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
