### PR TITLE
[docs] Hide the default API column if it's empty

### DIFF
--- a/docs/src/modules/components/PropertiesTable.js
+++ b/docs/src/modules/components/PropertiesTable.js
@@ -45,7 +45,7 @@ export default function PropertiesTable(props) {
   const t = useTranslate();
 
   const showDefaultPropColumn = Object.entries(properties).some(
-    ([_, propData]) => propData.default != null,
+    ([, propData]) => propData.default != null,
   );
 
   return (

--- a/docs/src/modules/components/PropertiesTable.js
+++ b/docs/src/modules/components/PropertiesTable.js
@@ -44,6 +44,10 @@ export default function PropertiesTable(props) {
   const { properties, propertiesDescriptions, showOptionalAbbr = false } = props;
   const t = useTranslate();
 
+  const showDefaultPropColumn = Object.entries(properties).some(
+    ([_, propData]) => propData.default != null,
+  );
+
   return (
     <Wrapper>
       <Table>
@@ -51,7 +55,7 @@ export default function PropertiesTable(props) {
           <tr>
             <th align="left">{t('api-docs.name')}</th>
             <th align="left">{t('api-docs.type')}</th>
-            <th align="left">{t('api-docs.default')}</th>
+            {showDefaultPropColumn && <th align="left">{t('api-docs.default')}</th>}
             <th align="left">{t('api-docs.description')}</th>
           </tr>
         </thead>
@@ -85,9 +89,11 @@ export default function PropertiesTable(props) {
                   <td align="left">
                     <span className="prop-type" dangerouslySetInnerHTML={{ __html: typeName }} />
                   </td>
-                  <td align="left">
-                    {propDefault && <span className="prop-default">{propDefault}</span>}
-                  </td>
+                  {showDefaultPropColumn && (
+                    <td align="left">
+                      {propDefault && <span className="prop-default">{propDefault}</span>}
+                    </td>
+                  )}
                   <td align="left">
                     {propData.deprecated && (
                       <Alert severity="warning" sx={{ mb: 1, py: 0 }}>


### PR DESCRIPTION
Resolves https://github.com/mui/material-ui/pull/35938#issuecomment-1486563297, it hides the default column in the API properties table if none of the properties have default value.

Previously:

![image](https://user-images.githubusercontent.com/4512430/229088901-68a5ae78-dd68-43f6-90bf-b77e83419f84.png)


Now:

![image](https://user-images.githubusercontent.com/4512430/229088955-2485766e-a3e9-488e-93e5-416797ff8e24.png)
