### PR TITLE
[docs] Introduce markdown permalink to source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5406,7 +5406,7 @@ _Sep 1, 2021_
 A big thanks to the 18 contributors who made this release possible. Here are some highlights ✨:
 
 - 🎉 Renamed packages to `@mui/*` as part of rebranding the company, following the strategy of expanding the library scope beyond Material Design. For more details about it, check the [GitHub discussion](https://github.com/mui/material-ui/discussions/27803).
-- 🛠 Added `mui-replace` codemod for migrating `@material-ui/*` to new packages `@mui/*`. Check out this [codemod detail](https://github.com/mui/material-ui/blob/next/packages/mui-codemod/README.md#mui-replace) or head to [migration guide](https://mui.com/material-ui/migration/migration-v4/#preset-safe)
+- 🛠 Added `mui-replace` codemod for migrating `@material-ui/*` to new packages `@mui/*`. Check out this [codemod detail](https://github.com/mui/material-ui/blob/v5.0.0/packages/mui-codemod/README.md#mui-replace) or head to [migration guide](https://mui.com/material-ui/migration/migration-v4/#preset-safe)
 - 🧪 Added new `<Mansory>` component to the lab, [check it out](https://mui.com/components/masonry/). It has been crafted by our first intern, @hbjORbj 👏!
 
 ### `@mui/material@5.0.0-rc.0`
@@ -5438,7 +5438,7 @@ A big thanks to the 18 contributors who made this release possible. Here are som
 
   > **Note**: `@mui/base` (previously `@material-ui/unstyled`) is not the same as `@material-ui/core`.
 
-  We encourage you to use the [codemod](https://github.com/mui/material-ui/blob/next/packages/mui-codemod/README.md#mui-replace) for smooth migration.
+  We encourage you to use the [codemod](https://github.com/mui/material-ui/blob/v5.0.0/packages/mui-codemod/README.md#mui-replace) for smooth migration.
 
 #### Changes
 
@@ -6573,7 +6573,7 @@ A big thanks to the 14 contributors who made this release possible. Here are som
 
 - 👩‍🎤 We have completed the migration to emotion of all the components (`@material-ui/core` and `@material-ui/lab`) @siriwatknp, @mnajdova.
 - 📦 Save [10 kB gzipped](https://bundlephobia.com/package/@material-ui/core@5.0.0-alpha.34) by removing the dependency on `@material-ui/styles` (JSS) from the core and the lab (#26377, #26382, #26376) @mnajdova.
-- ⚒️ Add many new [codemods](https://github.com/mui/material-ui/blob/HEAD/packages/mui-codemod/README.md) to automate the migration from v4 to v5 (#24867) @mbrookes.
+- ⚒️ Add many new [codemods](https://github.com/mui/material-ui/blob/v5.0.0/packages/mui-codemod/README.md) to automate the migration from v4 to v5 (#24867) @mbrookes.
 - And many more 🐛 bug fixes and 📚 improvements.
 
 ### `@material-ui/core@5.0.0-alpha.35`
@@ -8841,7 +8841,7 @@ A big thanks to the 17 contributors who made this release possible. Here are som
 
 - [Box] Remove deprecated props (#23716) @mnajdova
   All props are now available under the `sx` prop. A deprecation will be landing in v4.
-  Thanks to @mbrookes developers can automate the migration with a [codemod](https://github.com/mui/material-ui/blob/next/packages/mui-codemod/README.md#box-sx-prop).
+  Thanks to @mbrookes developers can automate the migration with a [codemod](https://github.com/mui/material-ui/blob/v5.0.0/packages/mui-codemod/README.md#box-sx-prop).
 
   ```diff
   -<Box p={2} bgcolor="primary.main">

--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -11757,7 +11757,7 @@ We are releasing sooner than we use to for this **special day** :christmas_tree:
 That wouldn't have been possible without this awesome community.
 **Thank you!**
 
-But this's just the beginning, some [exciting stuff](https://github.com/mui/material-ui/blob/next/ROADMAP.md) is coming in 2017 :sparkles:.
+But this's just the beginning, some [exciting stuff](https://github.com/mui/material-ui/blob/v0.16.6/ROADMAP.md) is coming in 2017 :sparkles:.
 You can preview a **very early** version of the `next` branch following [this link](https://material-ui-next.com).
 
 ### Component Fixes / Enhancements

--- a/docs/data/joy/customization/themed-components/themed-components.md
+++ b/docs/data/joy/customization/themed-components/themed-components.md
@@ -15,7 +15,7 @@ To customize a specific component in the theme, specify the component identifier
 - Use `styleOverrides` to apply styles to each component slots.
   - Every Joy UI component contains the `root` slot.
 
-Visit the [`components.d.ts`](https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/components.d.ts) file to see all component identifiers.
+Visit the [`components.d.ts`](https://github.com/mui/material-ui/blob/-/packages/mui-joy/src/styles/components.d.ts) file to see all component identifiers.
 
 ```js
 import { CssVarsProvider, extendTheme } from '@mui/joy/styles';

--- a/docs/data/material/customization/default-theme/default-theme.md
+++ b/docs/data/material/customization/default-theme/default-theme.md
@@ -19,5 +19,5 @@ Please note that **the documentation site is using a custom theme**.
 
 <!-- #default-branch-switch -->
 
-If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/createTheme.js),
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createTheme.js`](https://github.com/mui/material-ui/blob/-/packages/mui-material/src/styles/createTheme.js),
 and the related imports which `createTheme` uses.

--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -15,7 +15,7 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 
 <!-- #default-branch-switch -->
 
-An extensive list can be found in our [.browserlistrc](https://github.com/mui/material-ui/blob/master/.browserslistrc#L12-L27) (check the `stable` entry).
+An extensive list can be found in our [.browserlistrc](https://github.com/mui/material-ui/blob/-/.browserslistrc#L12-L27) (check the `stable` entry).
 
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that MUI supports it.
 [WRS regularly updates the rendering engine it uses](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -89,7 +89,7 @@ export default function PlainCssPriority() {
 }
 ```
 
-**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look on the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/master/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
+**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look on the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/-/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
 
 ### Deeper elements
 
@@ -242,7 +242,7 @@ export default function GlobalCssPriority() {
 }
 ```
 
-**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look on the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/master/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
+**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look on the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/-/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
 
 ### Deeper elements
 
@@ -499,7 +499,7 @@ export default function CssModulesPriority() {
 }
 ```
 
-**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look on the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/master/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
+**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look on the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/-/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
 
 ### Deeper elements
 
@@ -687,7 +687,7 @@ export default function PlainCssPriority() {
 }
 ```
 
-**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look at the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/master/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
+**Note:** If you are using styled-components and have `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`. If you are curious to see how it can be done, you can take a look at the [`StyledEngineProvider`](https://github.com/mui/material-ui/blob/-/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) implementation in the `@mui/styled-engine-sc` package.
 
 5. Change the target container for `Portal`-related elements so that they are injected under the main app wrapper that was used in step 3 for setting up the `important` option in the Tailwind config.
 

--- a/docs/data/material/guides/routing/routing.md
+++ b/docs/data/material/guides/routing/routing.md
@@ -101,7 +101,7 @@ const LinkBehavior = React.forwardRef((props, ref) => (
 
 The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-next-ts) provides an adapter for the use of [Next.js's Link component](https://nextjs.org/docs/api-reference/next/link) with Material UI.
 
-- The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/blob/HEAD/examples/material-next-ts/src/Link.tsx) component.
+- The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/blob/-/examples/material-next-ts/src/Link.tsx) component.
   This component is unstyled and only responsible for handling the navigation.
   The prop `href` was renamed `to` to avoid a naming conflict.
   This is similar to react-router's Link component.

--- a/docs/data/material/migration/migration-v3/migration-v3.md
+++ b/docs/data/material/migration/migration-v3/migration-v3.md
@@ -7,7 +7,7 @@ Looking for the v3 docs? You can [find the latest version here](https://mui.com/
 :::info
 This document is a work in progress.
 Have you upgraded your site and run into something that's not covered here?
-[Add your changes on GitHub](https://github.com/mui/material-ui/blob/master/docs/data/material/migration/migration-v3/migration-v3.md).
+[Add your changes on GitHub](https://github.com/mui/material-ui/blob/HEAD/docs/data/material/migration/migration-v3/migration-v3.md).
 :::
 
 ## Introduction

--- a/docs/data/material/migration/migration-v4/migration-v4.md
+++ b/docs/data/material/migration/migration-v4/migration-v4.md
@@ -64,7 +64,7 @@ The default bundle supports the following minimum versions:
 - Edge 91 (up from 14)
 - Firefox 78 (up from 52)
 - Safari 14 (macOS) and 12.5 (iOS) (up from 10)
-- and more (see [.browserslistrc (`stable` entry)](https://github.com/mui/material-ui/blob/HEAD/.browserslistrc#L11))
+- and more (see [.browserslistrc (`stable` entry)](https://github.com/mui/material-ui/blob/v5.0.0/.browserslistrc#L11))
 
 Material UI no longer supports IE 11.
 If you need to support IE 11, check out our [legacy bundle](/material-ui/guides/minimizing-bundle-size/#legacy-bundle).

--- a/docs/data/material/migration/migration-v4/v5-style-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-style-changes.md
@@ -211,7 +211,7 @@ To correct the injection order, add the `prepend` option to `createCache`, as sh
 :::warning
 If you are using styled-components and have a `StyleSheetManager` with a custom `target`, make sure that the target is the first element in the HTML `<head>`.
 
-To see how it can be done, take a look at the [`StyledEngineProvider` implementation](https://github.com/mui/material-ui/blob/master/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) in the `@mui/styled-engine-sc` package.
+To see how it can be done, take a look at the [`StyledEngineProvider` implementation](https://github.com/mui/material-ui/blob/-/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.js) in the `@mui/styled-engine-sc` package.
 :::
 
 ## Theme structure

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -99,6 +99,10 @@ module.exports = withDocsInfra({
                     options: {
                       ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
                       languagesInProgress: LANGUAGES_IN_PROGRESS,
+                      env: {
+                        SOURCE_CODE_REPO: options.config.env.SOURCE_CODE_REPO,
+                        LIB_VERSION: options.config.env.LIB_VERSION,
+                      },
                     },
                   },
                 ],

--- a/docs/pages/blog/material-ui-v4-is-out.md
+++ b/docs/pages/blog/material-ui-v4-is-out.md
@@ -21,7 +21,7 @@ Material UI v4 has finally arrived. We are so excited about this release, as it 
 - [High-level goals for v4](#high-level-goals-for-v4)
 - [What's new?](#whats-new)
 - [What's next?](#whats-next)
-- [Premium themes store](#premium-themes-store)
+- [Premium themes store](#premium-themes-store-✨)
 
 ## High-level goals for v4
 

--- a/docs/scripts/reportBrokenLinks.js
+++ b/docs/scripts/reportBrokenLinks.js
@@ -71,7 +71,12 @@ function getLinksAndAnchors(fileName) {
     headingHashes,
     toc,
     userLanguage,
-    ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
+    options: {
+      ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
+      env: {
+        SOURCE_CODE_REPO: '',
+      },
+    },
   });
 
   const data = fse.readFileSync(fileName, { encoding: 'utf8' });

--- a/docs/src/modules/utils/mapApiPageTranslations.js
+++ b/docs/src/modules/utils/mapApiPageTranslations.js
@@ -30,7 +30,12 @@ export default function mapApiPageTranslations(req) {
         toc: componentDescriptionToc,
         userLanguage,
         location: filenames,
-        ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
+        options: {
+          ignoreLanguagePages: LANGUAGES_IGNORE_PAGES,
+          env: {
+            SOURCE_CODE_REPO: '',
+          },
+        },
       });
       translation.componentDescription = render(translation.componentDescription);
       translation.componentDescriptionToc = componentDescriptionToc;

--- a/packages/markdown/loader.js
+++ b/packages/markdown/loader.js
@@ -78,7 +78,7 @@ packages.forEach((pkg) => {
  */
 module.exports = async function demoLoader() {
   const englishFilepath = this.resourcePath;
-  const config = this.getOptions();
+  const options = this.getOptions();
 
   const englishFilename = path.basename(englishFilepath, '.md');
 
@@ -98,7 +98,7 @@ module.exports = async function demoLoader() {
         if (
           filename.startsWith(englishFilename) &&
           matchNotEnglishMarkdown !== null &&
-          config.languagesInProgress.indexOf(matchNotEnglishMarkdown[1]) !== -1
+          options.languagesInProgress.indexOf(matchNotEnglishMarkdown[1]) !== -1
         ) {
           return {
             filename,
@@ -129,7 +129,7 @@ module.exports = async function demoLoader() {
     pageFilename,
     translations,
     componentPackageMapping,
-    ignoreLanguagePages: config.ignoreLanguagePages,
+    options,
   });
 
   const demos = {};

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -187,10 +187,10 @@ const noSEOadvantage = [
  * @param {Record<string, string>} context.headingHashes - WILL BE MUTATED
  * @param {TableOfContentsEntry[]} context.toc - WILL BE MUTATED
  * @param {string} context.userLanguage
- * @param {function(string):boolean} context.ignoreLanguagePages
+ * @param {object} context.options
  */
 function createRender(context) {
-  const { headingHashes, toc, userLanguage, ignoreLanguagePages } = context;
+  const { headingHashes, toc, userLanguage, options } = context;
   const headingHashesFallbackTranslated = {};
   let headingIndex = -1;
 
@@ -280,8 +280,19 @@ function createRender(context) {
 
       checkUrlHealth(href, linkText, context);
 
-      if (userLanguage !== 'en' && href.indexOf('/') === 0 && !ignoreLanguagePages(href)) {
+      if (userLanguage !== 'en' && href.indexOf('/') === 0 && !options.ignoreLanguagePages(href)) {
         finalHref = `/${userLanguage}${href}`;
+      }
+
+      // This logic turns link like:
+      // https://github.com/mui/material-ui/blob/-/packages/mui-joy/src/styles/components.d.ts
+      // into a permalink:
+      // https://github.com/mui/material-ui/blob/v5.11.15/packages/mui-joy/src/styles/components.d.ts
+      if (finalHref.startsWith(`${options.env.SOURCE_CODE_REPO}/blob/-/`)) {
+        finalHref = finalHref.replace(
+          `${options.env.SOURCE_CODE_REPO}/blob/-/`,
+          `${options.env.SOURCE_CODE_REPO}/blob/v${options.env.LIB_VERSION}/`,
+        );
       }
 
       return `<a href="${finalHref}"${more}>${linkText}</a>`;
@@ -385,10 +396,10 @@ function resolveComponentApiUrl(product, componentPkg, component) {
  * @param {object} config
  * @param {Array<{ markdown: string, filename: string, userLanguage: string }>} config.translations - Mapping of locale to its markdown
  * @param {string} config.pageFilename - posix filename relative to nextjs pages directory
- * @param {function(string):boolean} config.ignoreLanguagePages
+ * @param {object} config.options - provided to the webpack loader
  */
 function prepareMarkdown(config) {
-  const { pageFilename, translations, componentPackageMapping = {}, ignoreLanguagePages } = config;
+  const { pageFilename, translations, componentPackageMapping = {}, options } = config;
 
   const demos = {};
   /**
@@ -471,7 +482,7 @@ ${headers.hooks
         toc,
         userLanguage,
         location,
-        ignoreLanguagePages,
+        options,
       });
 
       const rendered = contents.map((content) => {

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -8,6 +8,13 @@ import {
 } from './parseMarkdown';
 
 describe('parseMarkdown', () => {
+  const defaultParams = {
+    pageFilename: '/test',
+    options: {
+      env: {},
+    },
+  };
+
   describe('getTitle', () => {
     it('remove backticks', () => {
       expect(
@@ -171,7 +178,7 @@ authors:
           en: { toc },
         },
       } = prepareMarkdown({
-        pageFilename: '/test',
+        ...defaultParams,
         translations: [{ filename: 'index.md', markdown, userLanguage: 'en' }],
       });
 
@@ -205,7 +212,7 @@ authors:
           en: { toc },
         },
       } = prepareMarkdown({
-        pageFilename: '/test',
+        ...defaultParams,
         translations: [{ filename: 'index.md', markdown, userLanguage: 'en' }],
       });
 
@@ -429,7 +436,7 @@ authors:
 
       expect(() => {
         prepareMarkdown({
-          pageFilename: '/test',
+          ...defaultParams,
           translations: [{ filename: 'index.md', markdown, userLanguage: 'en' }],
         });
       }).to.throw(/\[foo]\(\/foo\) in \/docs\/test\/index\.md is missing a trailing slash/);

--- a/packages/mui-joy/src/TextField/TextField.tsx
+++ b/packages/mui-joy/src/TextField/TextField.tsx
@@ -3,6 +3,11 @@
  */
 export default (function DeletedTextField() {
   throw new Error(
-    'MUI: `TextField` component has been removed in favor of Input composition.\n\nTo migrate, run `npx @mui/codemod v5.0.0/joy-text-field-to-input <path>`.\nFor the codemod detail, visit https://github.com/mui/material-ui/blob/master/packages/mui-codemod/README.md#joy-text-field-to-input\n\nTo learn more why it has been removed, visit the RFC https://github.com/mui/material-ui/issues/34176',
+    [
+      'MUI: `TextField` component has been removed in favor of Input composition.',
+      '',
+      'To migrate, run `npx @mui/codemod v5.0.0/joy-text-field-to-input <path>`.',
+      'For the codemod detail, visit https://github.com/mui/material-ui/blob/master/packages/mui-codemod/README.md#joy-text-field-to-input\n\nTo learn more why it has been removed, visit the RFC https://github.com/mui/material-ui/issues/34176',
+    ].join('\n'),
   );
 });


### PR DESCRIPTION
The objective is so that the links in the docs continue to work after the code on GitHub is changed. The developers will continue to browse the docs of older versions for a long time. We found the opportunity in https://github.com/mui/mui-x/pull/8383#issuecomment-1485983855.

Before: https://mui.com/joy-ui/customization/themed-components/ links to
`https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/components.d.ts`

After: https://deploy-preview-36729--material-ui.netlify.app/joy-ui/customization/themed-components/ links to
`https://github.com/mui/material-ui/blob/v5.11.15/packages/mui-joy/src/styles/components.d.ts`