### PR TITLE
[docs] Improve side nav scroll into view

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -123,28 +123,30 @@ ProductIdentifier.propTypes = {
   versionSelector: PropTypes.element,
 };
 
+const browserUrlPreviewHeight = 30;
+
 function PersistScroll(props) {
   const { slot, children, enabled } = props;
   const rootRef = React.useRef();
 
   useEnhancedEffect(() => {
-    const parent = rootRef.current ? rootRef.current.parentElement : null;
-    const activeElement = parent.querySelector('.app-drawer-active');
+    const scrollContainer = rootRef.current ? rootRef.current.parentElement : null;
+    const activeDrawerLink = scrollContainer.querySelector('.app-drawer-active');
 
-    if (!enabled || !parent || !activeElement || !activeElement.scrollIntoView) {
+    if (!enabled || !scrollContainer || !activeDrawerLink || !activeDrawerLink.scrollIntoView) {
       return undefined;
     }
 
-    parent.scrollTop = savedScrollTop[slot];
+    scrollContainer.scrollTop = savedScrollTop[slot];
 
-    const activeBox = activeElement.getBoundingClientRect();
+    const activeBox = activeDrawerLink.getBoundingClientRect();
 
-    if (activeBox.top < 0 || activeBox.top > window.innerHeight) {
-      parent.scrollTop += activeBox.top - 8 - 32;
+    if (activeBox.top < 0 || activeBox.bottom + browserUrlPreviewHeight > window.innerHeight) {
+      scrollContainer.scrollTop += activeBox.top - (activeBox.bottom - activeBox.top) * 1.5;
     }
 
     return () => {
-      savedScrollTop[slot] = parent.scrollTop;
+      savedScrollTop[slot] = scrollContainer.scrollTop;
     };
   }, [enabled, slot]);
 

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -144,7 +144,7 @@ function PersistScroll(props) {
 
     if (activeBox.top < 0 || activeBox.bottom + browserUrlPreviewHeight > window.innerHeight) {
       // Scroll the least possible from the initial render, e.g. server-side, scrollTop = 0.
-      activeDrawerLink.scrollIntoView(false);
+      activeDrawerLink.scrollIntoView({ block: 'nearest' });
     }
 
     return () => {

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -123,6 +123,7 @@ ProductIdentifier.propTypes = {
   versionSelector: PropTypes.element,
 };
 
+// To match scrollMarginBottom
 const browserUrlPreviewHeight = 30;
 
 function PersistScroll(props) {
@@ -142,7 +143,8 @@ function PersistScroll(props) {
     const activeBox = activeDrawerLink.getBoundingClientRect();
 
     if (activeBox.top < 0 || activeBox.bottom + browserUrlPreviewHeight > window.innerHeight) {
-      scrollContainer.scrollTop += activeBox.top - (activeBox.bottom - activeBox.top) * 1.5;
+      // Scroll the least possible from the initial render, e.g. server-side, scrollTop = 0.
+      activeDrawerLink.scrollIntoView(false);
     }
 
     return () => {

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -85,6 +85,8 @@ const Item = styled(
         paddingLeft: 2,
       }),
       '&.app-drawer-active': {
+        // To match browserUrlPreviewHeight
+        scrollMarginBottom: 30,
         color: (theme.vars || theme).palette.primary[600],
         backgroundColor: (theme.vars || theme).palette.primary[50],
         '&:hover': {


### PR DESCRIPTION
I noticed this during the review of #35938. We need to reset the scroll sooner than what we anticipate for:

KO: open https://mui.com/material-ui/react-checkbox/ with a browser width small enough, see how the active link is cut, it's disorienting.

<img width="654" alt="Screenshot 2023-03-31 at 19 07 06" src="https://user-images.githubusercontent.com/3165635/229185217-e78b86ad-4296-4d31-be52-912ac0377428.png">

What we want, is to have the active link always in the viewport, and to also account for the URL overlay:

<img width="354" alt="Screenshot 2023-03-31 at 19 08 26" src="https://user-images.githubusercontent.com/3165635/229185469-2f7ce0c6-3ce1-41d3-8cc4-e58096689390.png">

Preview: https://deploy-preview-36732--material-ui.netlify.app/material-ui/react-checkbox/. It's a new iteration on the logic, something we had many iterations on already, e.g. the last one #25619.

## Out of scope

There is still one thing that I HATE about the current page navigation experience is that the whole side nav rerenders on each page change, we lose all the DOM state, which means:

- Strange hover behavior, there shouldn't be a flash of the active non hover style (dark text):

https://user-images.githubusercontent.com/3165635/229287311-fcffa93b-a5c9-4272-aade-707a0fceacff.mov

- We reset the scroll, there shouldn't be a scroll move when clicking, it's disorienting:

https://user-images.githubusercontent.com/3165635/229287307-cfbe0ee5-6757-431d-8dc5-0a3ca21de742.mov

- Page transition is much slower compared to the navigation on https://www.radix-ui.com/docs/primitives/components/toast. See this quick benchmark changing to a page that is mostly markdown:

<img width="314" alt="Screenshot 2023-04-01 at 14 03 52" src="https://user-images.githubusercontent.com/3165635/229287578-4b6ea164-e60c-49ff-8df6-b65e4484d279.png">

<img width="323" alt="Screenshot 2023-04-01 at 14 02 23" src="https://user-images.githubusercontent.com/3165635/229287581-bdaaf098-cee9-4717-b1c4-1553c714bd72.png">

The solution is to use a Layout component, like explored in #20907 and #36207. Actually, Marija used getLayout for Base UI in #35938 🎉