### PR TITLE
[FormControl] Fix `filled` when value is set through `inputProps`

### DIFF
--- a/packages/mui-material/src/FormControl/FormControl.js
+++ b/packages/mui-material/src/FormControl/FormControl.js
@@ -143,7 +143,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
           return;
         }
 
-        if (isFilled(child.props, true)) {
+        if (isFilled(child.props, true) || isFilled(child.props.inputProps, true)) {
           initialFilled = true;
         }
       });

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -142,6 +142,17 @@ describe('<FormControl />', () => {
       expect(readContext.args[0][0]).to.have.property('filled', true);
     });
 
+    it('should be filled when a value is set through inputProps', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <Input inputProps={{ value: 'bar' }} />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('filled', true);
+    });
+
     it('should be filled when a defaultValue is set', () => {
       const readContext = spy();
       render(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/36744

before: https://www.loom.com/share/dd51510906a945849760449e4f6a0ba7

after: https://www.loom.com/share/441a51c2c10c4a60bcfe9315a99b2829

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
