### PR TITLE
[Grid] Missing slot

### DIFF
--- a/packages/mui-joy/src/Grid/Grid.tsx
+++ b/packages/mui-joy/src/Grid/Grid.tsx
@@ -7,6 +7,7 @@ import { GridTypeMap } from './GridProps';
 const Grid = createGrid({
   createStyledComponent: styled('div', {
     name: 'JoyGrid',
+    slot: 'Root',
     overridesResolver: (props, styles) => styles.root,
   }),
   useThemeProps: (inProps) => useThemeProps({ props: inProps, name: 'JoyGrid' }),

--- a/packages/mui-material/src/Unstable_Grid2/Grid2.tsx
+++ b/packages/mui-material/src/Unstable_Grid2/Grid2.tsx
@@ -7,6 +7,7 @@ import { Grid2TypeMap } from './Grid2Props';
 const Grid2 = createGrid2({
   createStyledComponent: styled('div', {
     name: 'MuiGrid2',
+    slot: 'Root',
     overridesResolver: (props, styles) => styles.root,
   }),
   componentName: 'MuiGrid2',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #36651

This bug is hidden because styled-component v5 uses `isPropValid` (same as emotion) so `sx` and `ownerState` never leak to DOM.

However, styled-component [v6 removes this automatic props filtering](https://github.com/styled-components/styled-components/releases/tag/v6.0.0-beta.14) so the `slot` is required to explicitly pass the `shouldForwardProp` to styled-component.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
