### PR TITLE
[docs] Tabs API add slots section

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -57,7 +57,7 @@ ClassesTable.propTypes = {
   componentStyles: PropTypes.object.isRequired,
 };
 
-function SlotsTable(props) {
+export function SlotsTable(props) {
   const { componentSlots, slotDescriptions } = props;
   const t = useTranslate();
 

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -6,7 +6,7 @@ import { exactProp } from '@mui/utils';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import { SlotsTable } from 'docs/src/modules/components/ApiPage';
 import Divider from 'docs/src/modules/components/ApiDivider';
-import PropsTable from 'docs/src/modules/components/PropretiesTable';
+import PropertiesTable from 'docs/src/modules/components/PropretiesTable';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 
@@ -61,8 +61,8 @@ function getTranslatedHeader(t, header, text) {
   const translations = {
     demos: t('api-docs.demos'),
     import: t('api-docs.import'),
-    'component-name': t('api-docs.componentName'),
     props: t('api-docs.props'),
+    'theme-default-props': t('api-docs.themeDefaultProps'),
     inheritance: t('api-docs.inheritance'),
     slots: t('api-docs.slots'),
     css: 'CSS',
@@ -102,6 +102,7 @@ export default function ComponentsApiContent(props) {
   const numberOfComponents = components.length;
 
   return components.map((key, idx) => {
+    const pageContent = pageContents[key];
     const {
       cssComponent,
       filename,
@@ -112,7 +113,7 @@ export default function ComponentsApiContent(props) {
       spread,
       styles: componentStyles,
       slots: componentSlots,
-    } = pageContents[key];
+    } = pageContent;
 
     const { classDescriptions, propDescriptions, slotDescriptions } =
       descriptions[key][userLanguage];
@@ -169,38 +170,21 @@ export default function ComponentsApiContent(props) {
           <Heading text="import" hash={`${componentNameKebabCase}-import`} level="h3" />
           <HighlightedCode
             code={`
-import ${componentName} from '${source}/${componentName}';
+import ${pageContent.name} from '${source}/${pageContent.name}';
 // ${t('or')}
-import { ${componentName} } from '${source}';`}
+import { ${pageContent.name} } from '${source}';`}
             language="jsx"
           />
           <span dangerouslySetInnerHTML={{ __html: t('api-docs.importDifference') }} />
-          {componentStyles.name && (
-            <React.Fragment>
-              <Heading
-                text="component-name"
-                hash={`${componentNameKebabCase}-component-name`}
-                level="h3"
-              />
-              <span
-                dangerouslySetInnerHTML={{
-                  __html: t('api-docs.styleOverrides').replace(
-                    /{{componentStyles\.name}}/,
-                    componentStyles.name,
-                  ),
-                }}
-              />
-            </React.Fragment>
-          )}
           <Heading text="props" hash={`${componentNameKebabCase}-props`} level="h3" />
           <p dangerouslySetInnerHTML={{ __html: spreadHint }} />
-          <PropsTable properties={componentProps} propertiesDescriptions={propDescriptions} />
+          <PropertiesTable properties={componentProps} propertiesDescriptions={propDescriptions} />
           <br />
           {cssComponent && (
             <React.Fragment>
               <span
                 dangerouslySetInnerHTML={{
-                  __html: t('api-docs.cssComponent').replace(/{{name}}/, componentName),
+                  __html: t('api-docs.cssComponent').replace(/{{name}}/, pageContent.name),
                 }}
               />
               <br />
@@ -221,25 +205,34 @@ import { ${componentName} } from '${source}';`}
                     .replace(/{{component}}/, inheritance.component)
                     .replace(/{{pathname}}/, inheritance.pathname)
                     .replace(/{{suffix}}/, inheritanceSuffix)
-                    .replace(/{{componentName}}/, componentName),
+                    .replace(/{{name}}/, pageContent.name),
                 }}
               />
             </React.Fragment>
           )}
-          {componentSlots?.length ? (
+          {pageContent.themeDefaultProps && (
             <React.Fragment>
-              <Heading text="slots" hash={`${componentNameKebabCase}-slots`} level="h3" />
-              {slotGuideLink && (
-                <p
-                  dangerouslySetInnerHTML={{
-                    __html: t('api-docs.slotDescription').replace(
-                      /{{slotGuideLink}}/,
-                      slotGuideLink,
-                    ),
-                  }}
-                />
-              )}
-              <SlotsTable componentSlots={componentSlots} slotDescriptions={slotDescriptions} />
+              <Heading
+                text="theme-default-props"
+                hash={`${componentName}-theme-default-props`}
+                level="h4"
+              />
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: t('api-docs.themeDefaultPropsDescription')
+                    .replace(/{{muiName}}/, pageContent.muiName)
+                    .replace(/{{defaultPropsLink}}/, defaultPropsLink),
+                }}
+              />
+            </React.Fragment>
+          )}
+          {Object.keys(componentStyles.classes).length ? (
+            <React.Fragment>
+              <Heading text="css" hash={`${componentName}-css`} level="h3" />
+              <ClassesTable
+                componentStyles={componentStyles}
+                classDescriptions={classDescriptions}
+              />
               <br />
               <p dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />
               <span
@@ -252,17 +245,19 @@ import { ${componentName} } from '${source}';`}
               />
             </React.Fragment>
           ) : null}
-          {Object.keys(componentStyles.classes).length ? (
+          {componentSlots?.length ? (
             <React.Fragment>
-              <Heading text="css" hash={`${componentNameKebabCase}-css`} level="h3" />
-              <ClassesTable
-                componentStyles={componentStyles}
-                classDescriptions={classDescriptions}
-              />
+              <Heading text="slots" hash={`${componentNameKebabCase}-slots`} level="h3" />
+              <SlotsTable componentSlots={componentSlots} slotDescriptions={slotDescriptions} />
               <br />
-              <span dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />
+              <p dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />
               <span
-                dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStylesStyledComponent') }}
+                dangerouslySetInnerHTML={{
+                  __html: t('api-docs.overrideStylesStyledComponent').replace(
+                    /{{styleOverridesLink}}/,
+                    styleOverridesLink,
+                  ),
+                }}
               />
             </React.Fragment>
           ) : null}

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -248,6 +248,13 @@ import { ${pageContent.name} } from '${source}';`}
           {componentSlots?.length ? (
             <React.Fragment>
               <Heading text="slots" hash={`${componentNameKebabCase}-slots`} level="h3" />
+              {slotGuideLink && (
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink),
+                  }}
+                />
+              )}
               <SlotsTable componentSlots={componentSlots} slotDescriptions={slotDescriptions} />
               <br />
               <p dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -251,7 +251,10 @@ import { ${pageContent.name} } from '${source}';`}
               {slotGuideLink && (
                 <p
                   dangerouslySetInnerHTML={{
-                    __html: t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink),
+                    __html: t('api-docs.slotDescription').replace(
+                      /{{slotGuideLink}}/,
+                      slotGuideLink,
+                    ),
                   }}
                 />
               )}

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import kebabCase from 'lodash/kebabCase';
 import { exactProp } from '@mui/utils';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
+import { SlotsTable } from 'docs/src/modules/components/ApiPage';
 import Divider from 'docs/src/modules/components/ApiDivider';
 import PropsTable from 'docs/src/modules/components/PropretiesTable';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
@@ -63,6 +64,7 @@ function getTranslatedHeader(t, header, text) {
     'component-name': t('api-docs.componentName'),
     props: t('api-docs.props'),
     inheritance: t('api-docs.inheritance'),
+    slots: t('api-docs.slots'),
     css: 'CSS',
   };
 
@@ -109,9 +111,26 @@ export default function ComponentsApiContent(props) {
       props: componentProps,
       spread,
       styles: componentStyles,
+      slots: componentSlots,
     } = pageContents[key];
 
-    const { classDescriptions, propDescriptions } = descriptions[key][userLanguage];
+    const { classDescriptions, propDescriptions, slotDescriptions } =
+      descriptions[key][userLanguage];
+
+    const isJoyComponent = filename.includes('mui-joy');
+    const isBaseComponent = filename.includes('mui-base');
+    const defaultPropsLink = isJoyComponent
+      ? '/joy-ui/customization/themed-components/#theme-default-props'
+      : '/material-ui/customization/theme-components/#theme-default-props';
+    const styleOverridesLink = isJoyComponent
+      ? '/joy-ui/customization/themed-components/#theme-style-overrides'
+      : '/material-ui/customization/theme-components/#theme-style-overrides';
+    let slotGuideLink = '';
+    if (isJoyComponent) {
+      slotGuideLink = '/joy-ui/customization/themed-components/#component-identifier';
+    } else if (isBaseComponent) {
+      slotGuideLink = '/base/getting-started/customization/#overriding-subcomponent-slots';
+    }
 
     const source = filename
       .replace(/\/packages\/mui(-(.+?))?\/src/, (match, dash, pkg) => `@mui/${pkg}`)
@@ -207,6 +226,32 @@ import { ${componentName} } from '${source}';`}
               />
             </React.Fragment>
           )}
+          {componentSlots?.length ? (
+            <React.Fragment>
+              <Heading text="slots" hash={`${componentNameKebabCase}-slots`} level="h3" />
+              {slotGuideLink && (
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: t('api-docs.slotDescription').replace(
+                      /{{slotGuideLink}}/,
+                      slotGuideLink,
+                    ),
+                  }}
+                />
+              )}
+              <SlotsTable componentSlots={componentSlots} slotDescriptions={slotDescriptions} />
+              <br />
+              <p dangerouslySetInnerHTML={{ __html: t('api-docs.overrideStyles') }} />
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: t('api-docs.overrideStylesStyledComponent').replace(
+                    /{{styleOverridesLink}}/,
+                    styleOverridesLink,
+                  ),
+                }}
+              />
+            </React.Fragment>
+          ) : null}
           {Object.keys(componentStyles.classes).length ? (
             <React.Fragment>
               <Heading text="css" hash={`${componentNameKebabCase}-css`} level="h3" />

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -105,24 +105,18 @@ export default function MarkdownDocsV2(props) {
   const componentsApiToc = [];
 
   Object.keys(componentsApiPageContents).forEach((key) => {
-    const { componentDescriptionToc = [] } = componentsApiDescriptions[key][userLanguage];
-
-    const { name: componentName } = componentsApiPageContents[key];
+    const { componentDescriptionToc = [], s } = componentsApiDescriptions[key][userLanguage];
+    const { name: componentName, styles, inheritance, slots } = componentsApiPageContents[key];
 
     const componentNameKebabCase = kebabCase(componentName);
 
     const componentApiToc = [
       createComponentTocEntry(componentNameKebabCase, 'import'),
       ...componentDescriptionToc,
-      componentsApiPageContents[key].styles.name &&
-        createComponentTocEntry(componentNameKebabCase, 'component-name'),
-      createComponentTocEntry(
-        componentNameKebabCase,
-        'props',
-        componentsApiPageContents[key].inheritance,
-      ),
-      componentsApiPageContents[key].styles.classes.length > 0 &&
-        createComponentTocEntry(componentNameKebabCase, 'css'),
+      styles.name && createComponentTocEntry(componentNameKebabCase, 'component-name'),
+      createComponentTocEntry(componentNameKebabCase, 'props', inheritance),
+      styles.classes.length > 0 && createComponentTocEntry(componentNameKebabCase, 'css'),
+      slots?.length > 0 && createComponentTocEntry(componentNameKebabCase, 'slots'),
     ].filter(Boolean);
 
     componentsApiToc.push({

--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -90,13 +90,20 @@ export default function MarkdownDocsV2(props) {
     });
   });
 
-  function createComponentTocEntry(componentName, sectionName, hasInheritance = false) {
+  function createComponentTocEntry(
+    componentName,
+    sectionName,
+    options = { inheritance: false, themeDefaultProps: false },
+  ) {
     return {
       text: getComponentTranslatedHeader(t, sectionName),
       hash: `${componentName}-${sectionName}`,
       children: [
-        ...(hasInheritance
+        ...(options.inheritance
           ? [{ text: t('api-docs.inheritance'), hash: 'inheritance', children: [] }]
+          : []),
+        ...(options.themeDefaultProps
+          ? [{ text: t('api-docs.themeDefaultProps'), hash: 'theme-default-props', children: [] }]
           : []),
       ],
     };
@@ -105,16 +112,21 @@ export default function MarkdownDocsV2(props) {
   const componentsApiToc = [];
 
   Object.keys(componentsApiPageContents).forEach((key) => {
-    const { componentDescriptionToc = [], s } = componentsApiDescriptions[key][userLanguage];
-    const { name: componentName, styles, inheritance, slots } = componentsApiPageContents[key];
-
+    const { componentDescriptionToc = [] } = componentsApiDescriptions[key][userLanguage];
+    const {
+      name: componentName,
+      styles,
+      inheritance,
+      slots,
+      themeDefaultProps,
+    } = componentsApiPageContents[key];
     const componentNameKebabCase = kebabCase(componentName);
 
     const componentApiToc = [
       createComponentTocEntry(componentNameKebabCase, 'import'),
       ...componentDescriptionToc,
       styles.name && createComponentTocEntry(componentNameKebabCase, 'component-name'),
-      createComponentTocEntry(componentNameKebabCase, 'props', inheritance),
+      createComponentTocEntry(componentNameKebabCase, 'props', { inheritance, themeDefaultProps }),
       styles.classes.length > 0 && createComponentTocEntry(componentNameKebabCase, 'css'),
       slots?.length > 0 && createComponentTocEntry(componentNameKebabCase, 'slots'),
     ].filter(Boolean);


### PR DESCRIPTION
Backports changes from https://github.com/mui/material-ui/pull/36104 (and the follow-up improvements on it).

The slots information was missing in the new components API pages in Base UI:

- previously: https://master--material-ui.netlify.app/base/react-button/components-api/
- now: https://deploy-preview-36769--material-ui.netlify.app/base/react-button/components-api/