### PR TITLE
[docs] Sync <Stack> between projects

### DIFF
--- a/docs/data/joy/components/grid/AutoGrid.js
+++ b/docs/data/joy/components/grid/AutoGrid.js
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function AutoGrid() {

--- a/docs/data/joy/components/grid/AutoGrid.tsx
+++ b/docs/data/joy/components/grid/AutoGrid.tsx
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function AutoGrid() {

--- a/docs/data/joy/components/grid/BasicGrid.js
+++ b/docs/data/joy/components/grid/BasicGrid.js
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function BasicGrid() {

--- a/docs/data/joy/components/grid/BasicGrid.tsx
+++ b/docs/data/joy/components/grid/BasicGrid.tsx
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function BasicGrid() {

--- a/docs/data/joy/components/grid/CSSGrid.js
+++ b/docs/data/joy/components/grid/CSSGrid.js
@@ -4,10 +4,13 @@ import Box from '@mui/joy/Box';
 import Sheet from '@mui/joy/Sheet';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function CSSGrid() {

--- a/docs/data/joy/components/grid/CSSGrid.tsx
+++ b/docs/data/joy/components/grid/CSSGrid.tsx
@@ -4,10 +4,13 @@ import Box from '@mui/joy/Box';
 import Sheet from '@mui/joy/Sheet';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function CSSGrid() {

--- a/docs/data/joy/components/grid/ColumnsGrid.js
+++ b/docs/data/joy/components/grid/ColumnsGrid.js
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function ColumnsGrid() {

--- a/docs/data/joy/components/grid/ColumnsGrid.tsx
+++ b/docs/data/joy/components/grid/ColumnsGrid.tsx
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function ColumnsGrid() {

--- a/docs/data/joy/components/grid/FullWidthGrid.js
+++ b/docs/data/joy/components/grid/FullWidthGrid.js
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function FullWidthGrid() {

--- a/docs/data/joy/components/grid/FullWidthGrid.tsx
+++ b/docs/data/joy/components/grid/FullWidthGrid.tsx
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function FullWidthGrid() {

--- a/docs/data/joy/components/grid/ResponsiveGrid.js
+++ b/docs/data/joy/components/grid/ResponsiveGrid.js
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function ResponsiveGrid() {

--- a/docs/data/joy/components/grid/ResponsiveGrid.tsx
+++ b/docs/data/joy/components/grid/ResponsiveGrid.tsx
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function ResponsiveGrid() {

--- a/docs/data/joy/components/grid/RowAndColumnSpacing.js
+++ b/docs/data/joy/components/grid/RowAndColumnSpacing.js
@@ -4,10 +4,13 @@ import Grid from '@mui/joy/Grid';
 import Sheet from '@mui/joy/Sheet';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function RowAndColumnSpacing() {

--- a/docs/data/joy/components/grid/RowAndColumnSpacing.tsx
+++ b/docs/data/joy/components/grid/RowAndColumnSpacing.tsx
@@ -4,10 +4,13 @@ import Grid from '@mui/joy/Grid';
 import Sheet from '@mui/joy/Sheet';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function RowAndColumnSpacing() {

--- a/docs/data/joy/components/grid/VariableWidthGrid.js
+++ b/docs/data/joy/components/grid/VariableWidthGrid.js
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function VariableWidthGrid() {

--- a/docs/data/joy/components/grid/VariableWidthGrid.tsx
+++ b/docs/data/joy/components/grid/VariableWidthGrid.tsx
@@ -4,10 +4,13 @@ import Sheet from '@mui/joy/Sheet';
 import Grid from '@mui/joy/Grid';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function VariableWidthGrid() {

--- a/docs/data/joy/components/stack/BasicStack.js
+++ b/docs/data/joy/components/stack/BasicStack.js
@@ -1,21 +1,27 @@
 import * as React from 'react';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
+import Box from '@mui/joy/Box';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function BasicStack() {
   return (
-    <Stack spacing={2} sx={{ width: '100%' }}>
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <Box sx={{ width: '100%' }}>
+      <Stack spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/joy/components/stack/BasicStack.tsx
+++ b/docs/data/joy/components/stack/BasicStack.tsx
@@ -1,21 +1,27 @@
 import * as React from 'react';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
+import Box from '@mui/joy/Box';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function BasicStack() {
   return (
-    <Stack spacing={2} sx={{ width: '100%' }}>
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <Box sx={{ width: '100%' }}>
+      <Stack spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/joy/components/stack/BasicStack.tsx.preview
+++ b/docs/data/joy/components/stack/BasicStack.tsx.preview
@@ -1,3 +1,5 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Item 3</Item>
+<Stack spacing={2}>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/joy/components/stack/DirectionStack.js
+++ b/docs/data/joy/components/stack/DirectionStack.js
@@ -4,23 +4,23 @@ import Stack from '@mui/joy/Stack';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function DirectionStack() {
   return (
-    <Stack
-      direction="row"
-      spacing={2}
-      justifyContent="center"
-      sx={{ width: '100%' }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <div>
+      <Stack direction="row" spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
   );
 }

--- a/docs/data/joy/components/stack/DirectionStack.tsx
+++ b/docs/data/joy/components/stack/DirectionStack.tsx
@@ -4,23 +4,23 @@ import Stack from '@mui/joy/Stack';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function DirectionStack() {
   return (
-    <Stack
-      direction="row"
-      spacing={2}
-      justifyContent="center"
-      sx={{ width: '100%' }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <div>
+      <Stack direction="row" spacing={2}>
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
   );
 }

--- a/docs/data/joy/components/stack/DirectionStack.tsx.preview
+++ b/docs/data/joy/components/stack/DirectionStack.tsx.preview
@@ -1,3 +1,5 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Item 3</Item>
+<Stack direction="row" spacing={2}>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/joy/components/stack/DividerStack.js
+++ b/docs/data/joy/components/stack/DividerStack.js
@@ -2,27 +2,32 @@ import * as React from 'react';
 import Divider from '@mui/joy/Divider';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
+import Box from '@mui/joy/Box';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function DividerStack() {
   return (
-    <Stack
-      direction="row"
-      divider={<Divider orientation="vertical" />}
-      spacing={2}
-      justifyContent="center"
-      sx={{ width: '100%' }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <Box sx={{ width: '100%' }}>
+      <Stack
+        direction="row"
+        divider={<Divider orientation="vertical" />}
+        spacing={2}
+        justifyContent="center"
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/joy/components/stack/DividerStack.tsx
+++ b/docs/data/joy/components/stack/DividerStack.tsx
@@ -2,27 +2,32 @@ import * as React from 'react';
 import Divider from '@mui/joy/Divider';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
+import Box from '@mui/joy/Box';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function DividerStack() {
   return (
-    <Stack
-      direction="row"
-      divider={<Divider orientation="vertical" />}
-      spacing={2}
-      justifyContent="center"
-      sx={{ width: '100%' }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <Box sx={{ width: '100%' }}>
+      <Stack
+        direction="row"
+        divider={<Divider orientation="vertical" />}
+        spacing={2}
+        justifyContent="center"
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/joy/components/stack/DividerStack.tsx.preview
+++ b/docs/data/joy/components/stack/DividerStack.tsx.preview
@@ -1,3 +1,10 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Item 3</Item>
+<Stack
+  direction="row"
+  divider={<Divider orientation="vertical" />}
+  spacing={2}
+  justifyContent="center"
+>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/joy/components/stack/FlexboxGapStack.js
+++ b/docs/data/joy/components/stack/FlexboxGapStack.js
@@ -1,27 +1,28 @@
 import * as React from 'react';
-import { styled } from '@mui/joy/styles';
+import Box from '@mui/joy/Box';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
+import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
+  flexGrow: 1,
 }));
 
 export default function FlexboxGapStack() {
   return (
-    <Stack
-      spacing={{ xs: 1, sm: 2 }}
-      direction="row"
-      useFlexGap
-      flexWrap="wrap"
-      sx={{ width: 200, '& > *': { flexGrow: 1 } }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Long content</Item>
-    </Stack>
+    <Box sx={{ width: 200 }}>
+      <Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Long content</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/joy/components/stack/FlexboxGapStack.tsx
+++ b/docs/data/joy/components/stack/FlexboxGapStack.tsx
@@ -1,27 +1,28 @@
 import * as React from 'react';
-import { styled } from '@mui/joy/styles';
+import Box from '@mui/joy/Box';
 import Sheet from '@mui/joy/Sheet';
 import Stack from '@mui/joy/Stack';
+import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
+  flexGrow: 1,
 }));
 
 export default function FlexboxGapStack() {
   return (
-    <Stack
-      spacing={{ xs: 1, sm: 2 }}
-      direction="row"
-      useFlexGap
-      flexWrap="wrap"
-      sx={{ width: 200, '& > *': { flexGrow: 1 } }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Long content</Item>
-    </Stack>
+    <Box sx={{ width: 200 }}>
+      <Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Long content</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/joy/components/stack/FlexboxGapStack.tsx.preview
+++ b/docs/data/joy/components/stack/FlexboxGapStack.tsx.preview
@@ -1,3 +1,5 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Long content</Item>
+<Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Long content</Item>
+</Stack>

--- a/docs/data/joy/components/stack/InteractiveStack.js
+++ b/docs/data/joy/components/stack/InteractiveStack.js
@@ -8,6 +8,17 @@ import Sheet from '@mui/joy/Sheet';
 import RadioGroup from '@mui/joy/RadioGroup';
 import Radio from '@mui/joy/Radio';
 import Stack from '@mui/joy/Stack';
+import { styled } from '@mui/joy/styles';
+
+const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
+}));
 
 export default function InteractiveStack() {
   const [direction, setDirection] = React.useState('row');
@@ -34,20 +45,19 @@ export default function InteractiveStack() {
         sx={{ height: 300, pt: 2, pb: 2 }}
       >
         {[0, 1, 2].map((value) => (
-          <Sheet
+          <Item
             key={value}
             sx={{
               p: 2,
               pt: value + 1,
               pb: value + 1,
-              typography: 'body2',
             }}
           >
             {`Item ${value + 1}`}
-          </Sheet>
+          </Item>
         ))}
       </Stack>
-      <Sheet sx={{ p: 2 }}>
+      <Sheet sx={{ p: 2, backgroundColor: 'background.level1' }}>
         <Grid container spacing={3}>
           <Grid xs={12}>
             <FormControl>

--- a/docs/data/joy/components/stack/InteractiveStack.tsx
+++ b/docs/data/joy/components/stack/InteractiveStack.tsx
@@ -8,6 +8,17 @@ import Sheet from '@mui/joy/Sheet';
 import RadioGroup from '@mui/joy/RadioGroup';
 import Radio from '@mui/joy/Radio';
 import Stack, { StackProps } from '@mui/joy/Stack';
+import { styled } from '@mui/joy/styles';
+
+const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
+}));
 
 export default function InteractiveStack() {
   const [direction, setDirection] = React.useState<StackProps['direction']>('row');
@@ -34,20 +45,19 @@ export default function InteractiveStack() {
         sx={{ height: 300, pt: 2, pb: 2 }}
       >
         {[0, 1, 2].map((value) => (
-          <Sheet
+          <Item
             key={value}
             sx={{
               p: 2,
               pt: value + 1,
               pb: value + 1,
-              typography: 'body2',
             }}
           >
             {`Item ${value + 1}`}
-          </Sheet>
+          </Item>
         ))}
       </Stack>
-      <Sheet sx={{ p: 2 }}>
+      <Sheet sx={{ p: 2, backgroundColor: 'background.level1' }}>
         <Grid container spacing={3}>
           <Grid xs={12}>
             <FormControl>

--- a/docs/data/joy/components/stack/ResponsiveStack.js
+++ b/docs/data/joy/components/stack/ResponsiveStack.js
@@ -4,23 +4,26 @@ import Stack from '@mui/joy/Stack';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function ResponsiveStack() {
   return (
-    <Stack
-      direction={{ xs: 'column', sm: 'row' }}
-      spacing={{ xs: 1, sm: 2, md: 4 }}
-      justifyContent="center"
-      sx={{ width: '100%' }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <div>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={{ xs: 1, sm: 2, md: 4 }}
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
   );
 }

--- a/docs/data/joy/components/stack/ResponsiveStack.tsx
+++ b/docs/data/joy/components/stack/ResponsiveStack.tsx
@@ -4,23 +4,26 @@ import Stack from '@mui/joy/Stack';
 import { styled } from '@mui/joy/styles';
 
 const Item = styled(Sheet)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark' ? theme.palette.background.level1 : '#fff',
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
 }));
 
 export default function ResponsiveStack() {
   return (
-    <Stack
-      direction={{ xs: 'column', sm: 'row' }}
-      spacing={{ xs: 1, sm: 2, md: 4 }}
-      justifyContent="center"
-      sx={{ width: '100%' }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Item 3</Item>
-    </Stack>
+    <div>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={{ xs: 1, sm: 2, md: 4 }}
+      >
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Item 3</Item>
+      </Stack>
+    </div>
   );
 }

--- a/docs/data/joy/components/stack/ResponsiveStack.tsx.preview
+++ b/docs/data/joy/components/stack/ResponsiveStack.tsx.preview
@@ -1,3 +1,8 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Item 3</Item>
+<Stack
+  direction={{ xs: 'column', sm: 'row' }}
+  spacing={{ xs: 1, sm: 2, md: 4 }}
+>
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Item 3</Item>
+</Stack>

--- a/docs/data/joy/components/stack/ZeroWidthStack.js
+++ b/docs/data/joy/components/stack/ZeroWidthStack.js
@@ -10,8 +10,9 @@ const Item = styled(Sheet)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
-  maxWidth: '400px',
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
+  maxWidth: 400,
 }));
 
 const message = `Truncation should be conditionally applicable on this long line of text

--- a/docs/data/joy/components/stack/ZeroWidthStack.tsx
+++ b/docs/data/joy/components/stack/ZeroWidthStack.tsx
@@ -10,8 +10,9 @@ const Item = styled(Sheet)(({ theme }) => ({
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: 'center',
-  color: theme.vars.palette.text.tertiary,
-  maxWidth: '400px',
+  borderRadius: 4,
+  color: theme.vars.palette.text.secondary,
+  maxWidth: 400,
 }));
 
 const message = `Truncation should be conditionally applicable on this long line of text

--- a/docs/data/joy/components/stack/stack.md
+++ b/docs/data/joy/components/stack/stack.md
@@ -1,7 +1,8 @@
 ---
 product: joy-ui
 title: React Stack component
-githubLabel: 'component: stack'
+components: Stack
+githubLabel: 'component: Stack'
 ---
 
 # Stack
@@ -32,41 +33,33 @@ The spacing value can be any number, including decimals, or a string.
 
 {{"demo": "BasicStack.js", "bg": true}}
 
-## Customization
+### Stack vs. Grid
 
-### Direction
+`Stack` is concerned with one-dimensional layouts, while [Grid](/joy-ui/react-grid/) handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
+
+## Direction
 
 By default, Stack arranges items vertically in a column.
 Use the `direction` prop to position items horizontally in a row:
 
 {{"demo": "DirectionStack.js", "bg": true}}
 
-### Dividers
+## Dividers
 
 Use the `divider` prop to insert an element between each child.
 This works particularly well with the [Divider](/joy-ui/react-divider/) component, as shown below:
 
 {{"demo": "DividerStack.js", "bg": true}}
 
-### Responsive values
+## Responsive values
 
 You can switch the `direction` or `spacing` values based on the active breakpoint.
 
 {{"demo": "ResponsiveStack.js", "bg": true}}
 
-### System props
-
-As a CSS utility component, Stack supports all [MUI System properties](/system/properties/).
-You can use them as props directly on the component.
-For instance, a margin-top:
-
-```jsx
-<Stack mt={2}>
-```
-
 ## Flexbox gap
 
-To use [flexbox `gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for the spacing implementation, set `useFlexGap` prop to true.
+To use [flexbox `gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for the spacing implementation, set the `useFlexGap` prop to true.
 
 It removes the [known limitations](#limitations) of the default implementation that uses CSS nested selector. However, CSS flexbox gap is not fully supported in some browsers.
 
@@ -104,6 +97,16 @@ function App() {
 Below is an interactive demo that lets you explore the visual results of the different settings:
 
 {{"demo": "InteractiveStack.js", "hideToolbar": true, "bg": true}}
+
+## System props
+
+As a CSS utility component, Stack supports all [MUI System properties](/system/properties/).
+You can use them as props directly on the component.
+For instance, a margin-top:
+
+```jsx
+<Stack mt={2}>
+```
 
 ## Limitations
 

--- a/docs/data/material/components/stack/FlexboxGapStack.js
+++ b/docs/data/material/components/stack/FlexboxGapStack.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 
 const Item = styled(Paper)(({ theme }) => ({
@@ -9,20 +10,17 @@ const Item = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(1),
   textAlign: 'center',
   color: theme.palette.text.secondary,
+  flexGrow: 1,
 }));
 
 export default function FlexboxGapStack() {
   return (
-    <Stack
-      spacing={{ xs: 1, sm: 2 }}
-      direction="row"
-      useFlexGap
-      flexWrap="wrap"
-      sx={{ width: 200, '& > *': { flexGrow: 1 } }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Long content</Item>
-    </Stack>
+    <Box sx={{ width: 200 }}>
+      <Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Long content</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/material/components/stack/FlexboxGapStack.tsx
+++ b/docs/data/material/components/stack/FlexboxGapStack.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 
 const Item = styled(Paper)(({ theme }) => ({
@@ -9,20 +10,17 @@ const Item = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(1),
   textAlign: 'center',
   color: theme.palette.text.secondary,
+  flexGrow: 1,
 }));
 
 export default function FlexboxGapStack() {
   return (
-    <Stack
-      spacing={{ xs: 1, sm: 2 }}
-      direction="row"
-      useFlexGap
-      flexWrap="wrap"
-      sx={{ width: 200, '& > *': { flexGrow: 1 } }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Long content</Item>
-    </Stack>
+    <Box sx={{ width: 200 }}>
+      <Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Long content</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/material/components/stack/FlexboxGapStack.tsx.preview
+++ b/docs/data/material/components/stack/FlexboxGapStack.tsx.preview
@@ -1,3 +1,5 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Long content</Item>
+<Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Long content</Item>
+</Stack>

--- a/docs/data/material/components/stack/ZeroWidthStack.js
+++ b/docs/data/material/components/stack/ZeroWidthStack.js
@@ -12,6 +12,7 @@ const Item = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(1),
   textAlign: 'center',
   color: theme.palette.text.secondary,
+  maxWidth: 400,
 }));
 
 const message = `Truncation should be conditionally applicable on this long line of text

--- a/docs/data/material/components/stack/ZeroWidthStack.tsx
+++ b/docs/data/material/components/stack/ZeroWidthStack.tsx
@@ -12,6 +12,7 @@ const Item = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(1),
   textAlign: 'center',
   color: theme.palette.text.secondary,
+  maxWidth: 400,
 }));
 
 const message = `Truncation should be conditionally applicable on this long line of text

--- a/docs/data/material/components/stack/stack.md
+++ b/docs/data/material/components/stack/stack.md
@@ -7,30 +7,47 @@ githubLabel: 'component: Stack'
 
 # Stack
 
-<p class="description">The Stack component manages layout of immediate children along the vertical or horizontal axis with optional spacing and/or dividers between each child.</p>
+<p class="description">Stack is a container component for arranging elements vertically or horizontally.</p>
+
+## Introduction
+
+The Stack component manages the layout of its immediate children along the vertical or horizontal axis, with optional spacing and dividers between each child.
+
+:::info
+Stack is ideal for one-dimensional layouts, while Grid is preferable when you need both vertical _and_ hortizontal arrangement.
+:::
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
-## Usage
+## Basics
 
-`Stack` is concerned with one-dimensional layouts, while [Grid](/material-ui/react-grid/) handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
+```jsx
+import Stack from '@mui/joy/Stack';
+```
+
+The Stack component acts as a generic container, wrapping around the elements to be arranged.
+
+Use the `spacing` prop to control the space between children.
+The spacing value can be any number, including decimals, or a string.
+(The prop is converted into a CSS property using the [`theme.spacing()`](/material-ui/customization/spacing/) helper.)
 
 {{"demo": "BasicStack.js", "bg": true}}
 
-To control space between children, use the `spacing` prop.
-The spacing value can be any number, including decimals and any string.
-The prop is converted into a CSS property using the [`theme.spacing()`](/material-ui/customization/spacing/) helper.
+### Stack vs. Grid
+
+`Stack` is concerned with one-dimensional layouts, while [Grid](/material-ui/react-grid/) handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
 
 ## Direction
 
-By default, `Stack` arranges items vertically in a `column`.
-However, the `direction` prop can be used to position items horizontally in a `row` as well.
+By default, Stack arranges items vertically in a column.
+Use the `direction` prop to position items horizontally in a row:
 
 {{"demo": "DirectionStack.js", "bg": true}}
 
 ## Dividers
 
-Use the `divider` prop to insert an element between each child. This works particularly well with the [Divider](/material-ui/react-divider/) component.
+Use the `divider` prop to insert an element between each child.
+This works particularly well with the [Divider](/material-ui/react-divider/) component, as shown below:
 
 {{"demo": "DividerStack.js", "bg": true}}
 
@@ -40,24 +57,9 @@ You can switch the `direction` or `spacing` values based on the active breakpoin
 
 {{"demo": "ResponsiveStack.js", "bg": true}}
 
-## Interactive
-
-Below is an interactive demo that lets you explore the visual results of the different settings:
-
-{{"demo": "InteractiveStack.js", "hideToolbar": true, "bg": true}}
-
-## System props
-
-As a CSS utility component, the `Stack` supports all [`system`](/system/properties/) properties. You can use them as props directly on the component.
-For instance, a margin-top:
-
-```jsx
-<Stack mt={2}>
-```
-
 ## Flexbox gap
 
-To use [flexbox `gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for the spacing implementation, set `useFlexGap` prop to true.
+To use [flexbox `gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for the spacing implementation, set the `useFlexGap` prop to true.
 
 It removes the [known limitations](#limitations) of the default implementation that uses CSS nested selector. However, CSS flexbox gap is not fully supported in some browsers.
 
@@ -88,6 +90,21 @@ function App() {
     </ThemeProvider>
   );
 }
+```
+
+## Interactive demo
+
+Below is an interactive demo that lets you explore the visual results of the different settings:
+
+{{"demo": "InteractiveStack.js", "hideToolbar": true, "bg": true}}
+
+## System props
+
+As a CSS utility component, the `Stack` supports all [`system`](/system/properties/) properties. You can use them as props directly on the component.
+For instance, a margin-top:
+
+```jsx
+<Stack mt={2}>
 ```
 
 ## Limitations
@@ -129,3 +146,13 @@ In order for the item to stay within the container you need to set `min-width: 0
 ```
 
 {{"demo": "ZeroWidthStack.js", "bg": true}}
+
+## Anatomy
+
+The Stack component is composed of a single root `<div>` element:
+
+```html
+<div class="MuiStack-root">
+  <!-- Stack contents -->
+</div>
+```

--- a/docs/data/system/components/grid/AutoGridNoWrap.js
+++ b/docs/data/system/components/grid/AutoGridNoWrap.js
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography';
 const Item = styled('div')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.palette.mode === 'dark' ? '#444d58' : '#ced7e0',
-  borderRadius: '4px',
+  borderRadius: 4,
 }));
 
 const message = `Truncation should be conditionally applicable on this long line of text

--- a/docs/data/system/components/grid/AutoGridNoWrap.tsx
+++ b/docs/data/system/components/grid/AutoGridNoWrap.tsx
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography';
 const Item = styled('div')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.palette.mode === 'dark' ? '#444d58' : '#ced7e0',
-  borderRadius: '4px',
+  borderRadius: 4,
 }));
 
 const message = `Truncation should be conditionally applicable on this long line of text

--- a/docs/data/system/components/stack/BasicStack.js
+++ b/docs/data/system/components/stack/BasicStack.js
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Box, Stack } from '@mui/system';
+import Box from '@mui/system/Box';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function BasicStack() {

--- a/docs/data/system/components/stack/BasicStack.tsx
+++ b/docs/data/system/components/stack/BasicStack.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Box, Stack } from '@mui/system';
+import Box from '@mui/system/Box';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function BasicStack() {

--- a/docs/data/system/components/stack/DirectionStack.js
+++ b/docs/data/system/components/stack/DirectionStack.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Stack } from '@mui/system';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function DirectionStack() {

--- a/docs/data/system/components/stack/DirectionStack.tsx
+++ b/docs/data/system/components/stack/DirectionStack.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Stack } from '@mui/system';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function DirectionStack() {

--- a/docs/data/system/components/stack/DividerStack.js
+++ b/docs/data/system/components/stack/DividerStack.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import Divider from '@mui/material/Divider';
-import { styled, Stack } from '@mui/system';
+import Box from '@mui/system/Box';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function DividerStack() {
@@ -14,7 +15,15 @@ export default function DividerStack() {
     <div>
       <Stack
         direction="row"
-        divider={<Divider orientation="vertical" flexItem />}
+        divider={
+          <Box
+            component="hr"
+            sx={{
+              border: (theme) =>
+                `1px solid ${theme.palette.mode === 'dark' ? '#262B32' : '#fff'}`,
+            }}
+          />
+        }
         spacing={2}
       >
         <Item>Item 1</Item>

--- a/docs/data/system/components/stack/DividerStack.tsx
+++ b/docs/data/system/components/stack/DividerStack.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import Divider from '@mui/material/Divider';
-import { styled, Stack } from '@mui/system';
+import Box from '@mui/system/Box';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function DividerStack() {
@@ -14,7 +15,15 @@ export default function DividerStack() {
     <div>
       <Stack
         direction="row"
-        divider={<Divider orientation="vertical" flexItem />}
+        divider={
+          <Box
+            component="hr"
+            sx={{
+              border: (theme) =>
+                `1px solid ${theme.palette.mode === 'dark' ? '#262B32' : '#fff'}`,
+            }}
+          />
+        }
         spacing={2}
       >
         <Item>Item 1</Item>

--- a/docs/data/system/components/stack/DividerStack.tsx.preview
+++ b/docs/data/system/components/stack/DividerStack.tsx.preview
@@ -1,9 +1,0 @@
-<Stack
-  direction="row"
-  divider={<Divider orientation="vertical" flexItem />}
-  spacing={2}
->
-  <Item>Item 1</Item>
-  <Item>Item 2</Item>
-  <Item>Item 3</Item>
-</Stack>

--- a/docs/data/system/components/stack/FlexboxGapStack.js
+++ b/docs/data/system/components/stack/FlexboxGapStack.js
@@ -1,25 +1,24 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Stack } from '@mui/system';
+import Stack from '@mui/system/Stack';
+import Box from '@mui/system/Box';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
+  flexGrow: 1,
 }));
 
 export default function FlexboxGapStack() {
   return (
-    <Stack
-      spacing={{ xs: 1, sm: 2 }}
-      direction="row"
-      useFlexGap
-      flexWrap="wrap"
-      sx={{ width: 200, '& > *': { flexGrow: 1 } }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Long content</Item>
-    </Stack>
+    <Box sx={{ width: 200 }}>
+      <Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Long content</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/system/components/stack/FlexboxGapStack.tsx
+++ b/docs/data/system/components/stack/FlexboxGapStack.tsx
@@ -1,25 +1,24 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Stack } from '@mui/system';
+import Stack from '@mui/system/Stack';
+import Box from '@mui/system/Box';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
+  flexGrow: 1,
 }));
 
 export default function FlexboxGapStack() {
   return (
-    <Stack
-      spacing={{ xs: 1, sm: 2 }}
-      direction="row"
-      useFlexGap
-      flexWrap="wrap"
-      sx={{ width: 200, '& > *': { flexGrow: 1 } }}
-    >
-      <Item>Item 1</Item>
-      <Item>Item 2</Item>
-      <Item>Long content</Item>
-    </Stack>
+    <Box sx={{ width: 200 }}>
+      <Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+        <Item>Item 1</Item>
+        <Item>Item 2</Item>
+        <Item>Long content</Item>
+      </Stack>
+    </Box>
   );
 }

--- a/docs/data/system/components/stack/FlexboxGapStack.tsx.preview
+++ b/docs/data/system/components/stack/FlexboxGapStack.tsx.preview
@@ -1,3 +1,5 @@
-<Item>Item 1</Item>
-<Item>Item 2</Item>
-<Item>Long content</Item>
+<Stack spacing={{ xs: 1, sm: 2 }} direction="row" useFlexGap flexWrap="wrap">
+  <Item>Item 1</Item>
+  <Item>Item 2</Item>
+  <Item>Long content</Item>
+</Stack>

--- a/docs/data/system/components/stack/InteractiveStack.js
+++ b/docs/data/system/components/stack/InteractiveStack.js
@@ -6,7 +6,16 @@ import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import Paper from '@mui/material/Paper';
 import RadioGroup from '@mui/material/RadioGroup';
 import Radio from '@mui/material/Radio';
-import { Stack, Unstable_Grid as Grid } from '@mui/system';
+import Grid from '@mui/system/Unstable_Grid';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
+
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  borderRadius: 4,
+}));
 
 export default function InteractiveStack() {
   const [direction, setDirection] = React.useState('row');
@@ -33,20 +42,16 @@ export default function InteractiveStack() {
         sx={{ height: 240 }}
       >
         {[0, 1, 2].map((value) => (
-          <Paper
+          <Item
             key={value}
             sx={{
               p: 2,
               pt: value + 1,
               pb: value + 1,
-              color: 'text.secondary',
-              typography: 'body2',
-              backgroundColor: (theme) =>
-                theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
             }}
           >
             {`Item ${value + 1}`}
-          </Paper>
+          </Item>
         ))}
       </Stack>
       <Paper sx={{ p: 2 }}>

--- a/docs/data/system/components/stack/InteractiveStack.tsx
+++ b/docs/data/system/components/stack/InteractiveStack.tsx
@@ -6,7 +6,16 @@ import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import Paper from '@mui/material/Paper';
 import RadioGroup from '@mui/material/RadioGroup';
 import Radio from '@mui/material/Radio';
-import { Stack, Unstable_Grid as Grid, StackProps } from '@mui/system';
+import Grid from '@mui/system/Unstable_Grid';
+import Stack, { StackProps } from '@mui/system/Stack';
+import { styled } from '@mui/system';
+
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  borderRadius: 4,
+}));
 
 export default function InteractiveStack() {
   const [direction, setDirection] = React.useState<StackProps['direction']>('row');
@@ -33,20 +42,16 @@ export default function InteractiveStack() {
         sx={{ height: 240 }}
       >
         {[0, 1, 2].map((value) => (
-          <Paper
+          <Item
             key={value}
             sx={{
               p: 2,
               pt: value + 1,
               pb: value + 1,
-              color: 'text.secondary',
-              typography: 'body2',
-              backgroundColor: (theme) =>
-                theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
             }}
           >
             {`Item ${value + 1}`}
-          </Paper>
+          </Item>
         ))}
       </Stack>
       <Paper sx={{ p: 2 }}>

--- a/docs/data/system/components/stack/ResponsiveStack.js
+++ b/docs/data/system/components/stack/ResponsiveStack.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Stack } from '@mui/system';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function ResponsiveStack() {

--- a/docs/data/system/components/stack/ResponsiveStack.tsx
+++ b/docs/data/system/components/stack/ResponsiveStack.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
-import { styled, Stack } from '@mui/system';
+import Stack from '@mui/system/Stack';
+import { styled } from '@mui/system';
 
-const Item = styled(Paper)(({ theme }) => ({
-  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+const Item = styled('div')(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#262B32' : '#fff',
   padding: theme.spacing(1),
   textAlign: 'center',
+  borderRadius: 4,
 }));
 
 export default function ResponsiveStack() {

--- a/docs/data/system/components/stack/stack.md
+++ b/docs/data/system/components/stack/stack.md
@@ -7,30 +7,46 @@ githubLabel: 'component: Stack'
 
 # Stack
 
-<p class="description">The Stack component manages layout of immediate children along the vertical or horizontal axis with optional spacing and/or dividers between each child.</p>
+<p class="description">Stack is a container component for arranging elements vertically or horizontally.</p>
+
+## Introduction
+
+The Stack component manages the layout of its immediate children along the vertical or horizontal axis, with optional spacing and dividers between each child.
+
+:::info
+Stack is ideal for one-dimensional layouts, while Grid is preferable when you need both vertical _and_ hortizontal arrangement.
+:::
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
-## Usage
+## Basics
 
-`Stack` is concerned with one-dimensional layouts, while [Grid](/system/react-grid/) handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
+```jsx
+import Stack from '@mui/joy/Stack';
+```
+
+The Stack component acts as a generic container, wrapping around the elements to be arranged.
+
+Use the `spacing` prop to control the space between children.
+The spacing value can be any number, including decimals, or a string.
+(The prop is converted into a CSS property using the [`theme.spacing()`](/material-ui/customization/spacing/) helper.)
 
 {{"demo": "BasicStack.js", "bg": true}}
 
-To control space between children, use the `spacing` prop.
-The spacing value can be any number, including decimals and any string.
-The prop is converted into a CSS property using the [`theme.spacing()`](/material-ui/customization/spacing/) helper.
+### Stack vs. Grid
+
+`Stack` is concerned with one-dimensional layouts, while [Grid](/system/react-grid/) handles two-dimensional layouts. The default direction is `column` which stacks children vertically.
 
 ## Direction
 
-By default, `Stack` arranges items vertically in a `column`.
-However, the `direction` prop can be used to position items horizontally in a `row` as well.
+By default, Stack arranges items vertically in a column.
+Use the `direction` prop to position items horizontally in a row:
 
 {{"demo": "DirectionStack.js", "bg": true}}
 
 ## Dividers
 
-Use the `divider` prop to insert an element between each child. This works particularly well with the [Divider](/material-ui/react-divider/) component.
+Use the `divider` prop to insert an element between each child, as shown below:
 
 {{"demo": "DividerStack.js", "bg": true}}
 
@@ -40,7 +56,17 @@ You can switch the `direction` or `spacing` values based on the active breakpoin
 
 {{"demo": "ResponsiveStack.js", "bg": true}}
 
-## Interactive
+## Flexbox gap
+
+To use [flexbox `gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for the spacing implementation, set the `useFlexGap` prop to true.
+
+It removes the [known limitations](#limitations) of the default implementation that uses CSS nested selector. However, CSS flexbox gap is not fully supported in some browsers.
+
+We recommend checking the [support percentage](https://caniuse.com/?search=flex%20gap) before using it.
+
+{{"demo": "FlexboxGapStack.js", "bg": true}}
+
+## Interactive demo
 
 Below is an interactive demo that lets you explore the visual results of the different settings:
 
@@ -55,8 +81,50 @@ For instance, a margin-top:
 <Stack mt={2}>
 ```
 
-## Flexbox gap
+## Limitations
 
-To use [flexbox `gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) for the spacing implementation, set `useFlexGap` prop to true.
+### Margin on the children
 
-{{"demo": "FlexboxGapStack.js", "bg": true}}
+Customizing the margin on the children is not supported by default.
+
+For instance, the top-margin on the `button` component below will be ignored.
+
+```jsx
+<Stack>
+  <button style={{ marginTop: '30px' }}>...</button>
+</Stack>
+```
+
+:::success
+To overcome this limitation, set [`useFlexGap`](#flexbox-gap) prop to true to switch to CSS flexbox gap implementation.
+
+You can learn more about this limitation by visiting this [RFC](https://github.com/mui/material-ui/issues/33754).
+:::
+
+### white-space: nowrap
+
+The initial setting on flex items is `min-width: auto`.
+This causes a positioning conflict when children use `white-space: nowrap;`.
+You can reproduce the issue with:
+
+```jsx
+<Stack direction="row">
+  <span style={{ whiteSpace: 'nowrap' }}>
+```
+
+In order for the item to stay within the container you need to set `min-width: 0`.
+
+```jsx
+<Stack direction="row" sx={{ minWidth: 0 }}>
+  <span style={{ whiteSpace: 'nowrap' }}>
+```
+
+## Anatomy
+
+The Stack component is composed of a single root `<div>` element:
+
+```html
+<div class="MuiStack-root">
+  <!-- Stack contents -->
+</div>
+```

--- a/docs/pages/system/api/stack.json
+++ b/docs/pages/system/api/stack.json
@@ -31,6 +31,6 @@
   "forwardsRefTo": "HTMLDivElement",
   "filename": "/packages/mui-system/src/Stack/Stack.tsx",
   "inheritance": null,
-  "demos": "<ul><li><a href=\"/material-ui/react-stack/\">Stack (Material UI)</a></li>\n<li><a href=\"/system/react-stack/\">Stack (MUI System)</a></li></ul>",
+  "demos": "<ul><li><a href=\"/joy/react-stack/\">Stack (Joy UI)</a></li>\n<li><a href=\"/material-ui/react-stack/\">Stack (Material UI)</a></li>\n<li><a href=\"/system/react-stack/\">Stack (MUI System)</a></li></ul>",
   "cssComponent": true
 }

--- a/docs/translations/api-docs-joy/stack/stack.json
+++ b/docs/translations/api-docs-joy/stack/stack.json
@@ -7,7 +7,7 @@
     "divider": "Add an element between each child.",
     "spacing": "Defines the space between immediate children.",
     "sx": "The system prop, which allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details.",
-    "useFlexGap": "If <code>true</code>, the CSS flexbox <code>gap</code> is used instead of applying <code>margin</code> to children.<br>While CSS <code>gap</code> removes the <a href=\"https://mui.com/joy-ui/react-stack#limitations\">known limitations</a>, it is not fully supported in some browsers. We recommend checking <a href=\"https://caniuse.com/?search=flex%20gap\">https://caniuse.com/?search=flex%20gap</a> before using this flag.<br>To enable this flag globally, follow the <a href=\"https://mui.com/joy-ui/customization/themed-components/#default-props\">theme&#39;s default props</a> configuration."
+    "useFlexGap": "If <code>true</code>, the CSS flexbox <code>gap</code> is used instead of applying <code>margin</code> to children.<br>While CSS <code>gap</code> removes the <a href=\"https://mui.com/joy-ui/react-stack/#limitations\">known limitations</a>, it is not fully supported in some browsers. We recommend checking <a href=\"https://caniuse.com/?search=flex%20gap\">https://caniuse.com/?search=flex%20gap</a> before using this flag.<br>To enable this flag globally, follow the <a href=\"https://mui.com/joy-ui/customization/themed-components/#default-props\">theme&#39;s default props</a> configuration."
   },
   "classDescriptions": {}
 }

--- a/docs/translations/api-docs-joy/stack/stack.json
+++ b/docs/translations/api-docs-joy/stack/stack.json
@@ -1,0 +1,13 @@
+{
+  "componentDescription": "",
+  "propDescriptions": {
+    "children": "The content of the component.",
+    "component": "The component used for the root node. Either a string to use a HTML element or a component.",
+    "direction": "Defines the <code>flex-direction</code> style property. It is applied for all screen sizes.",
+    "divider": "Add an element between each child.",
+    "spacing": "Defines the space between immediate children.",
+    "sx": "The system prop, which allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details.",
+    "useFlexGap": "If <code>true</code>, the CSS flexbox <code>gap</code> is used instead of applying <code>margin</code> to children.<br>While CSS <code>gap</code> removes the <a href=\"https://mui.com/joy-ui/react-stack#limitations\">known limitations</a>, it is not fully supported in some browsers. We recommend checking <a href=\"https://caniuse.com/?search=flex%20gap\">https://caniuse.com/?search=flex%20gap</a> before using this flag.<br>To enable this flag globally, follow the <a href=\"https://mui.com/joy-ui/customization/themed-components/#default-props\">theme&#39;s default props</a> configuration."
+  },
+  "classDescriptions": {}
+}

--- a/docs/translations/api-docs/stack/stack.json
+++ b/docs/translations/api-docs/stack/stack.json
@@ -7,7 +7,7 @@
     "divider": "Add an element between each child.",
     "spacing": "Defines the space between immediate children.",
     "sx": "The system prop, which allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details.",
-    "useFlexGap": "If <code>true</code>, the CSS flexbox <code>gap</code> is used instead of applying <code>margin</code> to children.<br>While CSS <code>gap</code> removes the <a href=\"https://mui.com/joy-ui/react-stack#limitations\">known limitations</a>, it is not fully supported in some browsers. We recommend checking <a href=\"https://caniuse.com/?search=flex%20gap\">https://caniuse.com/?search=flex%20gap</a> before using this flag.<br>To enable this flag globally, follow the theme&#39;s default props configuration."
+    "useFlexGap": "If <code>true</code>, the CSS flexbox <code>gap</code> is used instead of applying <code>margin</code> to children.<br>While CSS <code>gap</code> removes the <a href=\"https://mui.com/joy-ui/react-stack/#limitations\">known limitations</a>, it is not fully supported in some browsers. We recommend checking <a href=\"https://caniuse.com/?search=flex%20gap\">https://caniuse.com/?search=flex%20gap</a> before using this flag.<br>To enable this flag globally, follow the theme&#39;s default props configuration."
   },
   "classDescriptions": {}
 }

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -582,11 +582,15 @@ export default async function generateComponentApi(
               }
 
               definitions.forEach((definition) => {
-                if (definition.value?.callee) {
-                  const definitionName = definition.value.callee.name;
+                // definition.value.expression is defined when the source is in TypeScript.
+                const expression = definition.value.expression
+                  ? definition.get('expression')
+                  : definition;
+                if (expression.value?.callee) {
+                  const definitionName = expression.value.callee.name;
 
                   if (definitionName === `create${name}`) {
-                    node = definition;
+                    node = expression;
                   }
                 }
               });

--- a/packages/mui-joy/src/Stack/Stack.tsx
+++ b/packages/mui-joy/src/Stack/Stack.tsx
@@ -73,7 +73,7 @@ Stack.propTypes /* remove-proptypes */ = {
   /**
    * If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.
    *
-   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack#limitations),
+   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack/#limitations),
    * it is not fully supported in some browsers. We recommend checking https://caniuse.com/?search=flex%20gap before using this flag.
    *
    * To enable this flag globally, follow the [theme's default props](https://mui.com/joy-ui/customization/themed-components/#default-props) configuration.

--- a/packages/mui-joy/src/Stack/StackProps.ts
+++ b/packages/mui-joy/src/Stack/StackProps.ts
@@ -29,7 +29,7 @@ export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
     /**
      * If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.
      *
-     * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack#limitations),
+     * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack/#limitations),
      * it is not fully supported in some browsers. We recommend checking https://caniuse.com/?search=flex%20gap before using this flag.
      *
      * To enable this flag globally, follow the [theme's default props](https://mui.com/joy-ui/customization/themed-components/#default-props) configuration.

--- a/packages/mui-material/src/Stack/Stack.d.ts
+++ b/packages/mui-material/src/Stack/Stack.d.ts
@@ -28,7 +28,7 @@ export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
       /**
        * If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.
        *
-       * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack#limitations),
+       * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack/#limitations),
        * it is not fully supported in some browsers. We recommend checking https://caniuse.com/?search=flex%20gap before using this flag.
        *
        * To enable this flag globally, follow the [theme's default props](https://mui.com/material-ui/customization/theme-components/#default-props) configuration.

--- a/packages/mui-material/src/Stack/Stack.js
+++ b/packages/mui-material/src/Stack/Stack.js
@@ -61,7 +61,7 @@ Stack.propTypes /* remove-proptypes */ = {
   /**
    * If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.
    *
-   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack#limitations),
+   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack/#limitations),
    * it is not fully supported in some browsers. We recommend checking https://caniuse.com/?search=flex%20gap before using this flag.
    *
    * To enable this flag globally, follow the [theme's default props](https://mui.com/material-ui/customization/theme-components/#default-props) configuration.

--- a/packages/mui-system/src/Stack/Stack.tsx
+++ b/packages/mui-system/src/Stack/Stack.tsx
@@ -4,6 +4,7 @@ import createStack from './createStack';
  *
  * Demos:
  *
+ * - [Stack (Joy UI)](https://mui.com/joy/react-stack/)
  * - [Stack (Material UI)](https://mui.com/material-ui/react-stack/)
  * - [Stack (MUI System)](https://mui.com/system/react-stack/)
  *

--- a/packages/mui-system/src/Stack/Stack.tsx
+++ b/packages/mui-system/src/Stack/Stack.tsx
@@ -63,7 +63,7 @@ Stack.propTypes /* remove-proptypes */ = {
   /**
    * If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.
    *
-   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack#limitations),
+   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack/#limitations),
    * it is not fully supported in some browsers. We recommend checking https://caniuse.com/?search=flex%20gap before using this flag.
    *
    * To enable this flag globally, follow the theme's default props configuration.

--- a/packages/mui-system/src/Stack/StackProps.ts
+++ b/packages/mui-system/src/Stack/StackProps.ts
@@ -27,7 +27,7 @@ export interface StackBaseProps {
   /**
    * If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.
    *
-   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack#limitations),
+   * While CSS `gap` removes the [known limitations](https://mui.com/joy-ui/react-stack/#limitations),
    * it is not fully supported in some browsers. We recommend checking https://caniuse.com/?search=flex%20gap before using this flag.
    *
    * To enable this flag globally, follow the theme's default props configuration.


### PR DESCRIPTION
I went into a rabbit hole from https://twitter.com/olivtassinari/status/1643701742821949443.

The issues:

1. the Stack docs is inconsistent between Joy UI, Material UI, System. I almost feel like having System for the detailed content would be enough. When we improve the markdown, please let's fix all the pages.
2. on Joy UI, fix the mission Stack in the live preview: https://mui.com/joy-ui/react-stack/

<img width="605" alt="Screenshot 2023-04-05 at 23 47 05" src="https://user-images.githubusercontent.com/3165635/230219308-fd0508a2-53da-4635-a480-992d334fb364.png">

3. on System, remove all dependencies on Material UI https://mui.com/system/react-stack/

<img width="450" alt="Screenshot 2023-04-05 at 23 47 42" src="https://user-images.githubusercontent.com/3165635/230219401-ae12f83a-9979-4fa3-aba5-e7bb7791c940.png">

4. Improve the dark mode for Joy UI https://mui.com/joy-ui/react-stack/#flexbox-gap

<img width="451" alt="Screenshot 2023-04-05 at 23 48 42" src="https://user-images.githubusercontent.com/3165635/230219568-720acd1c-b959-46c7-a62c-77fb3f060458.png">

5. Fix 404, we link the API page for the Stack in the IntelliSense but it's broken: https://mui.com/joy-ui/api/stack/

<img width="470" alt="Screenshot 2023-04-05 at 23 50 46" src="https://user-images.githubusercontent.com/3165635/230219932-70158fd0-5540-45d5-8745-dfe529deea15.png">

6. Fix 301, https://mui.com/joy-ui/react-stack redirects