### PR TITLE
[docs] Change "coming soon" chip color

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -293,7 +293,7 @@ export default function AppNavDrawerItem(props) {
         {plan === 'premium' && <span className="plan-premium" title="Premium plan" />}
         {legacy && <Chip label="Legacy" sx={sxChip('warning')} />}
         {newFeature && <Chip label="New" sx={sxChip('success')} />}
-        {comingSoon && <Chip label="Coming soon" sx={sxChip('primary')} />}
+        {comingSoon && <Chip label="Coming soon" sx={sxChip('grey')} />}
         {expandable && !subheader && <ItemButtonIcon className="ItemButtonIcon" open={open} />}
       </Item>
       {expandable ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Following @oliviertassinari's suggestion on https://github.com/mui/material-ui/pull/36279?notification_referrer_id=NT_kwDOBABP4rM1NjU4NjExNzIyOjY3MTI5MzE0#issuecomment-1498315520: this PR changes the "coming soon" chip color from blue to gray, so it grabs less attention from the reader.

| Before | After |
|--------|--------|
| <img width="200" alt="Screen Shot 2023-04-05 at 21 16 47" src="https://user-images.githubusercontent.com/67129314/230241653-b14379c3-af50-4d96-a987-e36abf14c86c.png"> | <img width="200" alt="Screen Shot 2023-04-05 at 21 16 38" src="https://user-images.githubusercontent.com/67129314/230241650-3d0e46ec-6dd4-4ad9-9063-2e2f08e1699d.png"> | 
