### PR TITLE
[NativeSelect] Incorrect overriding of `type: undefined`

### DIFF
--- a/packages/mui-material/src/NativeSelect/NativeSelect.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.js
@@ -59,9 +59,9 @@ const NativeSelect = React.forwardRef(function NativeSelect(inProps, ref) {
           classes: otherClasses,
           IconComponent,
           variant: fcs.variant,
-          type: undefined, // We render a select. We can ignore the type provided by the `Input`.
           ...inputProps,
           ...(input ? input.props.inputProps : {}),
+          type: undefined, // We render a select. We can ignore the type provided by the `Input`.
         },
         ref,
         ...other,

--- a/packages/mui-material/src/NativeSelect/NativeSelect.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.test.js
@@ -107,7 +107,6 @@ describe('<NativeSelect />', () => {
   it('should not add `type` attribute to <select/> element', () => {
     const { getByRole } = render(
       <NativeSelect inputProps={{ type: 'number' }}>
-        <option value="">empty</option>
         <option value={10}>Ten</option>
         <option value={20}>Twenty</option>
         <option value={30}>Thirty</option>

--- a/packages/mui-material/src/NativeSelect/NativeSelect.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.test.js
@@ -103,4 +103,17 @@ describe('<NativeSelect />', () => {
     expect(getByTestId('root')).to.have.class('foo');
     expect(getByTestId('root')).to.have.class('bar');
   });
+
+  it('should not add `type` attribute to <select/> element', () => {
+    const { getByRole } = render(
+      <NativeSelect inputProps={{ type: 'number' }}>
+        <option value="">empty</option>
+        <option value={10}>Ten</option>
+        <option value={20}>Twenty</option>
+        <option value={30}>Thirty</option>
+      </NativeSelect>,
+    );
+
+    expect(getByRole('combobox')).to.not.have.attribute('type');
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

`type: undefined` is set to `input` [component here ](https://github.com/mui/material-ui/blob/9f5ae34c2454b600347417bf3d6037d1390df9d0/packages/mui-material/src/NativeSelect/NativeSelect.js#L62). But `type` coming from [inputProps](https://github.com/mui/material-ui/blob/9f5ae34c2454b600347417bf3d6037d1390df9d0/packages/mui-material/src/NativeSelect/NativeSelect.js#L63) is overriding `type: undefined`. This PR fixes the issue



- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
