### PR TITLE
[website] Fix backlinks to homepage

### DIFF
--- a/docs/data/material/discover-more/related-projects/related-projects.md
+++ b/docs/data/material/discover-more/related-projects/related-projects.md
@@ -42,11 +42,11 @@ Feel free to submit a pull request!
 
 ### One-Time Password
 
-- [mui-otp-input](https://viclafouch.github.io/mui-otp-input): A One-Time Password input designed for use with Material UI.
+- [mui-otp-input](https://viclafouch.github.io/mui-otp-input/): A One-Time Password input designed for use with Material UI.
 
 ### File
 
-- [mui-file-input](https://viclafouch.github.io/mui-file-input): A file input designed for use with Material UI.
+- [mui-file-input](https://viclafouch.github.io/mui-file-input/): A file input designed for use with Material UI.
 
 ### Color picker
 

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -411,6 +411,8 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /zh/base/* /base/:splat 301
 /pt/system/* /system/:splat 301
 /zh/system/* /system/:splat 301
+/pt/ / 301
+/zh/ / 301
 /material-ui/guides/flow/ https://v4.mui.com/guides/flow/ 301
 /:lang/material-ui/guides/flow/ https://v4.mui.com/:lang/guides/flow/ 301
 # 2023


### PR DESCRIPTION
A continuation of #34820. Ahrefs has a nice feature that allows seeing backlinks to mui.com that are now 404: https://app.ahrefs.com/v2-site-explorer/broken-backlinks?anchorRules=&domainNameRules=&followType=all&grouping=one-per-domain&limit=50&mode=prefix&offset=0&refPageTitleRules=&refPageUrlRules=&sort=traffic&sortDirection=desc&surroundingRules=&target=https%3A%2F%2Fmui.com%2F&targetUrlRules=. I couldn't find any other broken links that are really worth fixing, otherther than maybe pt and zh links, e.g. https://reactjsexample.com/pokedex-pokemon-api-with-reactjs/