### PR TITLE
[docs] Divider middle prop migration

### DIFF
--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -569,7 +569,7 @@ If you have customized the color of the border, you will need to update the CSS 
 
 ### Support "middle" variant with "vertical" orientation
 
-In the v4, the `orientation` prop with "vertical" and the `variant` prop with "middle" was adding a margin-left and margin-right of `16px` in the component.
+In v4, using `orientation="vertical"` and `variant="middle"` was adding a left and right margins of `16px` in the component.
 In the v5, to avoid fixed spacing on the component, this margin was removed.
 
 :::info

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -572,6 +572,25 @@ If you have customized the color of the border, you will need to update the CSS 
 In the v4, the `orientation` prop with "vertical" and the `variant` prop with "middle" added a margin-left and margin-right of `16px`.
 However, in the v5, this margin was decreased to `8px`.
 
+If you want to revert it, you can do in the theme:
+
+```diff
+const theme = createTheme({
+  components: {
+   MuiDivider: {
++     styleOverrides: {
++       root: ({ ownerState, theme }) => ({
++         ...(ownerState.orientation === 'vertical' && ownerState.variant === 'middle' && {
++           marginLeft: theme.spacing(2),
++           marginRight: theme.spacing(2),
++         }),
++       })
++     }
+    },
+  },
+});
+```
+
 ## ExpansionPanel
 
 ### ✅ Rename components

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -567,12 +567,14 @@ If you have customized the color of the border, you will need to update the CSS 
  }
 ```
 
-### Update the margin spacing from vertical alignment on middle position
+### Support "middle" variant with "vertical" orientation
 
-In the v4, the `orientation` prop with "vertical" and the `variant` prop with "middle" added a margin-left and margin-right of `16px`.
-However, in the v5, this margin was decreased to `8px`.
+In the v4, the `orientation` prop with "vertical" and the `variant` prop with "middle" was adding a margin-left and margin-right of `16px` in the component.
+In the v5, to avoid fixed spacing on the component, this margin was removed.
 
-If you want to revert it, you can do in the theme:
+:::info
+If you want to use the previous margin values, this change can be made in your theme with the following code. See the example on [CodeSandbox demo](https://codesandbox.io/s/v5-migration-vertical-alignment-middle-divider-45vepj?file=/src/index.tsx).
+:::
 
 ```diff
  const theme = createTheme({

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -575,7 +575,7 @@ However, in the v5, this margin was decreased to `8px`.
 If you want to revert it, you can do in the theme:
 
 ```diff
-const theme = createTheme({
+ const theme = createTheme({
   components: {
    MuiDivider: {
 +     styleOverrides: {
@@ -588,7 +588,7 @@ const theme = createTheme({
 +     }
     },
   },
-});
+ });
 ```
 
 ## ExpansionPanel

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -2010,7 +2010,3 @@ This leads to differences when applied to union types.
 -import { Omit } from '@mui/types';
 +import { DistributiveOmit } from '@mui/types';
 ```
-
-```
-
-```

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -567,6 +567,11 @@ If you have customized the color of the border, you will need to update the CSS 
  }
 ```
 
+### Update the margin spacing from vertical alignment on middle position
+
+In the v4, the `orientation` prop with "vertical" and the `variant` prop with "middle" added a margin-left and margin-right of `16px`.
+However, in the v5, this margin was decreased to `8px`.
+
 ## ExpansionPanel
 
 ### ✅ Rename components
@@ -1985,4 +1990,8 @@ This leads to differences when applied to union types.
 ```diff
 -import { Omit } from '@mui/types';
 +import { DistributiveOmit } from '@mui/types';
+```
+
+```
+
 ```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- Added a description on Divider migration documentation of the change in margin of the `variant` "middle" in the "vertical" `orientation` of this  #component;
- Added an example of how to override the change to avoid issues;

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
