### PR TITLE
Use fullWidth prop from Autocomplete to render input

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -570,7 +570,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
         {renderInput({
           id,
           disabled,
-          fullWidth: true,
+          fullWidth,
           size: size === 'small' ? 'small' : undefined,
           InputLabelProps: getInputLabelProps(),
           InputProps: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Currently Autocomplete's `renderInput` force input to be `fullWidth`. This PR changes it to respect the `fullWidth` prop of `AutoComplete`. If `Autocomplete` is `fullWidth`, then the input is. If `Autocomplete` is NOT `fullWidth`, then the input is NOT.

Fix #36841 