### PR TITLE
[ThemeProvider] Fix theme proptypes

### DIFF
--- a/packages/mui-material/src/styles/ThemeProvider.js
+++ b/packages/mui-material/src/styles/ThemeProvider.js
@@ -15,5 +15,12 @@ export default function ThemeProvider({ theme: themeInput, ...props }) {
 }
 
 ThemeProvider.propTypes = {
-  theme: PropTypes.object,
+  /**
+   * Your component tree.
+   */
+  children: PropTypes.node,
+  /**
+   * A theme object. You can provide a function to extend the outer theme.
+   */
+  theme: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
 };

--- a/packages/mui-material/src/styles/ThemeProvider.test.tsx
+++ b/packages/mui-material/src/styles/ThemeProvider.test.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { expect } from 'chai';
+import { createRenderer } from 'test/utils';
+
+describe('ThemeProvider', () => {
+  const { render } = createRenderer();
+  it('When theme is a function, it should not show warning', () => {
+    expect(() =>
+      render(
+        <ThemeProvider theme={{}}>
+          <ThemeProvider theme={() => ({})} />
+        </ThemeProvider>,
+      ),
+    ).not.toWarnDev();
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

regression from #36664

The `theme` prop can be a function but it is not listed in the prop-types, so there is a warning in the docs.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
