### PR TITLE
[TextField] Fix typescript error when using inputAdornedStart, inputAdornedEnd classes with default variant and standard variant

### DIFF
--- a/docs/pages/material-ui/api/input.json
+++ b/docs/pages/material-ui/api/input.json
@@ -71,6 +71,8 @@
       "input",
       "inputSizeSmall",
       "inputMultiline",
+      "inputAdornedStart",
+      "inputAdornedEnd",
       "inputTypeSearch"
     ],
     "globalClasses": { "focused": "Mui-focused", "disabled": "Mui-disabled", "error": "Mui-error" },

--- a/docs/translations/api-docs/input/input.json
+++ b/docs/translations/api-docs/input/input.json
@@ -92,6 +92,16 @@
       "nodeName": "the input element",
       "conditions": "<code>multiline={true}</code>"
     },
+    "inputAdornedStart": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the input element",
+      "conditions": "<code>startAdornment</code> is provided"
+    },
+    "inputAdornedEnd": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the input element",
+      "conditions": "<code>endAdornment</code> is provided"
+    },
     "inputTypeSearch": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the input element",

--- a/packages/mui-material/src/Input/inputClasses.ts
+++ b/packages/mui-material/src/Input/inputClasses.ts
@@ -29,6 +29,10 @@ export interface InputClasses {
   inputSizeSmall: string;
   /** Styles applied to the input element if `multiline={true}`. */
   inputMultiline: string;
+  /** Styles applied to the input element if `startAdornment` is provided. */
+  inputAdornedStart: string;
+  /** Styles applied to the input element if `endAdornment` is provided. */
+  inputAdornedEnd: string;
   /** Styles applied to the input element if `type="search"`. */
   inputTypeSearch: string;
 }

--- a/packages/mui-material/src/TextField/TextField.spec.tsx
+++ b/packages/mui-material/src/TextField/TextField.spec.tsx
@@ -17,6 +17,12 @@ import { expectType } from '@mui/types';
   const filledInputTypeSearch = (
     <TextField variant="filled" InputProps={{ classes: { inputTypeSearch: 'search-input' } }} />
   );
+  const StandardInputAdornedStart = (
+    <TextField variant="standard" InputProps={{ classes: { inputAdornedStart: 'search-input' } }} />
+  );
+  const DefaultInputAdornedStart = (
+    <TextField InputProps={{ classes: { inputAdornedStart: 'search-input' } }} />
+  );
   const standardOutlinedClassname = (
     <TextField
       variant="standard"

--- a/packages/mui-material/src/TextField/TextField.spec.tsx
+++ b/packages/mui-material/src/TextField/TextField.spec.tsx
@@ -17,11 +17,20 @@ import { expectType } from '@mui/types';
   const filledInputTypeSearch = (
     <TextField variant="filled" InputProps={{ classes: { inputTypeSearch: 'search-input' } }} />
   );
-  const StandardInputAdornedStart = (
-    <TextField variant="standard" InputProps={{ classes: { inputAdornedStart: 'search-input' } }} />
+  const StandardInputAdorned = (
+    <TextField
+      variant="standard"
+      InputProps={{
+        classes: { inputAdornedStart: 'search-input', inputAdornedEnd: 'search-input' },
+      }}
+    />
   );
-  const DefaultInputAdornedStart = (
-    <TextField InputProps={{ classes: { inputAdornedStart: 'search-input' } }} />
+  const DefaultInputAdorned = (
+    <TextField
+      InputProps={{
+        classes: { inputAdornedStart: 'search-input', inputAdornedEnd: 'search-input' },
+      }}
+    />
   );
   const standardOutlinedClassname = (
     <TextField

--- a/packages/mui-material/test/typescript/hoc-interop.spec.tsx
+++ b/packages/mui-material/test/typescript/hoc-interop.spec.tsx
@@ -21,23 +21,17 @@ const filledProps = {
 
 // baseline behavior
 <TextField variant="filled" {...filledProps} />;
-// @ts-expect-error
-<TextField {...filledProps} />; // desired to throw
 
 // styled
 {
   const StyledTextField = styled(TextField)``;
   <StyledTextField variant="filled" {...filledProps} />; // desired to pass
-  // @ts-expect-error
-  <StyledTextField {...filledProps} />; // undesired, should throw
 }
 
 // @emotion/styled
 {
   const StyledTextField = emotionStyled(TextField)``;
   <StyledTextField variant="filled" {...filledProps} />;
-  // @ts-expect-error
-  <StyledTextField {...filledProps} />; // desired to throw
 }
 
 // https://github.com/mui/material-ui/issues/14586


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/36862

before: https://codesandbox.io/s/infallible-haibt-ytenql?file=/styles.css:0-38
after: https://codesandbox.io/s/goofy-leavitt-428poo?file=/demo.tsx

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
