### PR TITLE
[TextField] fix running click event on disabled

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -439,8 +439,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
     if (inputRef.current && event.currentTarget === event.target) {
       inputRef.current.focus();
     }
-
-    if (onClick) {
+    if (onClick && !fcs.disabled) {
       onClick(event);
     }
   };

--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -111,6 +111,10 @@ export interface BaseTextFieldProps
   name?: string;
   onBlur?: InputBaseProps['onBlur'];
   onFocus?: StandardInputProps['onFocus'];
+    /**
+   * @ignore
+   */
+     onClick?: InputBaseProps['onClick'];
   /**
    * The short hint displayed in the `input` before the user enters a value.
    */

--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -111,10 +111,10 @@ export interface BaseTextFieldProps
   name?: string;
   onBlur?: InputBaseProps['onBlur'];
   onFocus?: StandardInputProps['onFocus'];
-    /**
+  /**
    * @ignore
    */
-     onClick?: InputBaseProps['onClick'];
+  onClick?: InputBaseProps['onClick'];
   /**
    * The short hint displayed in the `input` before the user enters a value.
    */

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -94,6 +94,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     name,
     onBlur,
     onChange,
+    onClick,
     onFocus,
     placeholder,
     required = false,
@@ -168,6 +169,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
       onBlur={onBlur}
       onChange={onChange}
       onFocus={onFocus}
+      onClick={onClick}
       placeholder={placeholder}
       inputProps={inputProps}
       {...InputMore}
@@ -345,6 +347,10 @@ TextField.propTypes /* remove-proptypes */ = {
    * You can pull out the new value by accessing `event.target.value` (string).
    */
   onChange: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onClick: PropTypes.func,
   /**
    * @ignore
    */

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { createRenderer, describeConformance } from 'test/utils';
 import FormControl from '@mui/material/FormControl';
 import { inputBaseClasses } from '@mui/material/InputBase';
@@ -151,6 +152,20 @@ describe('<TextField />', () => {
       );
 
       expect(getByTestId('InputComponent')).not.to.equal(null);
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('should not run click event when disabled', () => {
+      const handleClick = spy();
+      render(<TextField disabled onClick={handleClick} />);
+      expect(handleClick.callCount).to.equal(0);
+    });
+
+    it('should not run click event disabled and onClick prop is set through InputProps', () => {
+      const handleClick = spy();
+      render(<TextField disabled InputProps={{ onClick: handleClick }} />);
+      expect(handleClick.callCount).to.equal(0);
     });
   });
 

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from 'test/utils';
+import { createRenderer, describeConformance, fireEvent } from 'test/utils';
 import FormControl from '@mui/material/FormControl';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import MenuItem from '@mui/material/MenuItem';
@@ -158,13 +158,15 @@ describe('<TextField />', () => {
   describe('prop: disabled', () => {
     it('should not run click event when disabled', () => {
       const handleClick = spy();
-      render(<TextField disabled onClick={handleClick} />);
+      const { getByRole } = render(<TextField disabled onClick={handleClick} />);
+      fireEvent.click(getByRole('textbox'));
       expect(handleClick.callCount).to.equal(0);
     });
 
-    it('should not run click event disabled and onClick prop is set through InputProps', () => {
+    it('should not run click event when disabled and when onClick prop is set through InputProps', () => {
       const handleClick = spy();
-      render(<TextField disabled InputProps={{ onClick: handleClick }} />);
+      const { getByRole } = render(<TextField disabled InputProps={{ onClick: handleClick }} />);
+      fireEvent.click(getByRole('textbox'));
       expect(handleClick.callCount).to.equal(0);
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/36867

before : https://codesandbox.io/s/zen-meadow-lr2flp?file=/demo.tsx
after : https://codesandbox.io/s/beautiful-panka-24o4h2?file=/demo.tsx

Actual issue lies in `TextField` component not in `Autocomplete`. Right now `onClick` event of `TextField` runs even if `TextField` is disabled. This PR fixes it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
