### PR TITLE
[docs] Add info about passing ref to input element

### DIFF
--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -87,7 +87,7 @@ With inputs, decorators are typically located at the top and/or bottom of the in
 ### Inner HTML input
 
 If you need to pass props to the inner HTML `<input>`, use `slotProps={{ input: { ...props } }}`.
-These props may include HTML attributes such as `min`, `max`, and `autocomplete`.
+These props may include HTML attributes such as `ref`, `min`, `max`, and `autocomplete`.
 
 {{"demo": "InputSlotProps.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a small change so you can now Ctrl+F to find how to pass `ref` to `<input/>` element. I think this is enough, but maybe it would be better if it would be it's own paragraph. Something like
> To get the `ref` of the `<input/>` element, you can use the `slotProps` prop
and a code example