### PR TITLE
[docs] Add pages for coming soon components

### DIFF
--- a/docs/data/joy/components/drawer/drawer.md
+++ b/docs/data/joy/components/drawer/drawer.md
@@ -1,0 +1,20 @@
+---
+product: joy-ui
+title: React Drawer component
+githubLabel: 'component: drawer'
+---
+
+# Drawer
+
+<p class="description">Navigation drawers provide quick access to other destinations in your app without removing the user out of context.</p>
+
+:::info
+💡 The Joy UI Drawer component is still in development.
+If you're in need of it, please upvote [**this issue**](https://github.com/mui/material-ui/issues/36292) to help us prioritize the next batch of new components.
+:::
+
+## Integration with headless UI libraries
+
+In the meantime, you can still adopt Joy UI today for building a drawer!
+
+This document shows how to construct it with existing Joy UI components combined with popular headless UI libraries.

--- a/docs/data/joy/components/skeleton/skeleton.md
+++ b/docs/data/joy/components/skeleton/skeleton.md
@@ -1,0 +1,20 @@
+---
+product: joy-ui
+title: React Skeleton component
+githubLabel: 'component: skeleton'
+---
+
+# Skeleton
+
+<p class="description">Skeletons are preview placeholders for components that haven't loaded yet, reducing load-time frustration.</p>
+
+:::info
+💡 The Joy UI Skeleton component is still in development.
+If you're in need of it, please upvote [**this issue**](https://github.com/mui/material-ui/issues/36105) to help us prioritize the next batch of new components.
+:::
+
+## Integration with headless UI libraries
+
+In the meantime, you can still adopt Joy UI today for building a skeleton!
+
+This document shows how to construct it with existing Joy UI components combined with popular headless UI libraries.

--- a/docs/data/joy/pages.ts
+++ b/docs/data/joy/pages.ts
@@ -67,6 +67,7 @@ const pages = [
           { pathname: '/joy-ui/react-circular-progress', title: 'Circular Progress' },
           { pathname: '/joy-ui/react-linear-progress', title: 'Linear Progress' },
           { pathname: '/joy-ui/react-modal' },
+          { pathname: '/joy-ui/react-skeleton', comingSoon: true },
           { pathname: '/joy-ui/react-snackbar', comingSoon: true },
         ],
       },
@@ -84,6 +85,7 @@ const pages = [
         subheader: 'navigation',
         children: [
           { pathname: '/joy-ui/react-breadcrumbs' },
+          { pathname: '/joy-ui/react-drawer', comingSoon: true },
           { pathname: '/joy-ui/react-link' },
           { pathname: '/joy-ui/react-menu' },
           { pathname: '/joy-ui/react-tabs' },

--- a/docs/pages/joy-ui/react-drawer.js
+++ b/docs/pages/joy-ui/react-drawer.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/joy/components/drawer/drawer.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/pages/joy-ui/react-skeleton.js
+++ b/docs/pages/joy-ui/react-skeleton.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/joy/components/skeleton/skeleton.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds pages for both the Drawer and Skeleton components, which are still marked at `comingSoon`. These pages help build awareness for the open issues, allowing us to have a tighter grasp of prioritization!

- [ ] Add "integration with headless UI libraries" for both of them, if relevant.