### PR TITLE
[docs] Add stray Joy UI documentation improvements

### DIFF
--- a/docs/data/joy/components/accordion/accordion.md
+++ b/docs/data/joy/components/accordion/accordion.md
@@ -38,7 +38,7 @@ Animation is created by targeting a CSS variable, `--radix-accordion-content-hei
 - [Accordion component documentation](https://www.radix-ui.com/docs/primitives/components/accordion)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-feat-radix-accordion-4n2p04?module=%2Fdemo.tsx&fontsize=14&hidenavigation=1&theme=dark&view=preview"
-     style="width:100%; height:360px; border:0; border-radius: 8px; overflow:hidden;"
+     style="width:100%; height:360px; border:0; border-radius: 12px; overflow:hidden;"
      title="Joy UI feat. Radix UI Accordion"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -54,7 +54,7 @@ Headless UI does not provide an API to create animation so you have to use other
 - [Disclosure component documentation](https://headlessui.com/react/disclosure)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-feat-headless-ui-disclosure-g2mqpr?module=%2Fdemo.tsx&fontsize=14&hidenavigation=1&theme=dark&view=preview"
-     style="width:100%; height:360px; border:0; border-radius: 8px; overflow:hidden;"
+     style="width:100%; height:360px; border:0; border-radius: 12px; overflow:hidden;"
      title="Joy UI feat. Headless UI Disclosure"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"

--- a/docs/data/joy/components/alert/alert.md
+++ b/docs/data/joy/components/alert/alert.md
@@ -10,18 +10,18 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 
 <p class="description">Alerts display brief messages for the user without interrupting their use of the app.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The Alert component can be used to provide important and potentially time-sensitive information in a way that does not interfere with the user's tasks. (Source: [ARIA APG](https://www.w3.org/WAI/ARIA/apg/patterns/alert/).)
+
+{{"demo": "AlertUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
 :::info
 Alerts should not be confused with alert _dialogs_ ([ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)), which _are_ intended to interrupt the user to obtain a response.
 Use the Joy UI [Modal](https://mui.com/joy-ui/react-modal/) if you need the behavior of a dialog.
 :::
-
-{{"demo": "AlertUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/autocomplete/autocomplete.md
+++ b/docs/data/joy/components/autocomplete/autocomplete.md
@@ -10,13 +10,13 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
 
 <p class="description">The autocomplete is a text input enhanced by a panel of suggested options when users start typing.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 `Autocomplete` is an enhanced version of text input that shows suggested options as the users type and also let them select an option from the list.
 
 {{"demo": "Playground.js", "hideToolbar": true}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Usage
 

--- a/docs/data/joy/components/avatar/avatar.md
+++ b/docs/data/joy/components/avatar/avatar.md
@@ -9,13 +9,13 @@ githubLabel: 'component: avatar'
 
 <p class="description">An avatar is a graphical representation of a user's identity.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The Avatar component can be used to display graphical information about a user in places such as menus, tables, and chats.
 
 {{"demo": "AvatarUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/badge/badge.md
+++ b/docs/data/joy/components/badge/badge.md
@@ -10,14 +10,14 @@ unstyled: /base/react-badge/
 
 <p class="description">The Badge component generates a small label that is attached to its child element.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 A badge is a small descriptor for UI elements.
 It typically sits on or near an element and indicates the status of that element by displaying a number, icon, or other short set of characters.
 
 {{"demo": "BadgeUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/breadcrumbs/breadcrumbs.md
+++ b/docs/data/joy/components/breadcrumbs/breadcrumbs.md
@@ -9,14 +9,14 @@ githubLabel: 'component: breadcrumbs'
 
 <p class="description">A breadcrumb trail is a navigational tool that helps users keep track of their location within an app.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The Breadcrumbs component consists of a list of links that show the user the hierarchy of a given page in relation to the app's structure.
 It provides a simple visual aid for better context and ease of navigation between higher- and lower-level pages.
 
 {{"demo": "BreadcrumbsUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -11,14 +11,14 @@ unstyled: /base/react-button/
 
 <p class="description">Buttons let users take actions and make choices with a single tap.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Buttons communicate actions that users can take.
 The Joy UI Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
 
 {{"demo": "ButtonUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -10,6 +10,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 
 <p class="description">Checkboxes give users binary choices when presented with multiple options in a series.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Checkboxes provide users with a graphical representation of a binary choice (yes or no, on or off).
@@ -17,16 +19,14 @@ They are most commonly presented in a series, giving the user multiple choices t
 
 The Joy UI Checkbox component replaces the native HTML `<input type="checkbox">` element, and offers expanded options for styling and accessibility.
 
+{{"demo": "CheckboxUsage.js", "hideToolbar": true, "bg": "gradient"}}
+
 :::success
 When should you use checkboxes rather than switches or radio buttons?
 
 - Use a switch to provide the user with **a single binary choice**—checkboxes are preferable when you need to give the user multiple binary choices.
 - Use radio buttons to give the user **mutually exclusive options**—checkboxes are preferable when you need to let the user select one, some, all, or none from a series of options.
   :::
-
-{{"demo": "CheckboxUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/chip/chip.md
+++ b/docs/data/joy/components/chip/chip.md
@@ -9,17 +9,13 @@ githubLabel: 'component: chip'
 
 <p class="description">Chip generates a compact element that can represent an input, attribute, or action.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Chips are most frequently used in two main use cases: as pills of informative content or as filtering options.
 
 {{"demo": "ChipUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-:::info
-To learn how to add more variants or sizes to the component, check out the [Themed components](/joy-ui/customization/themed-components/) page.
-:::
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/circular-progress/circular-progress.md
+++ b/docs/data/joy/components/circular-progress/circular-progress.md
@@ -9,6 +9,8 @@ githubLabel: 'component: CircularProgress'
 
 <p class="description">The Circular Progress component showcases the duration of a process or an indefinite wait period.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 A circular progress indicator, often referred to as a spinner, is a visual representation of the progress of an operation or task.
@@ -17,8 +19,6 @@ The Circular Progress component defaults to indeterminate, signifying an undefin
 Use [determinate](#determinate) mode to indicate how long a given operation will take.
 
 {{"demo": "CircularProgressUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 :::info
 The component's animations rely primarily on CSS to ensure that it functions even before JavaScript loads.

--- a/docs/data/joy/components/css-baseline/css-baseline.md
+++ b/docs/data/joy/components/css-baseline/css-baseline.md
@@ -57,7 +57,9 @@ export default function MyApp() {
 }
 ```
 
+:::warning
 ⚠️ Make sure you import `ScopedCssBaseline` first to avoid box-sizing conflicts as in the above example.
+:::
 
 ## Approach
 

--- a/docs/data/joy/components/divider/divider.md
+++ b/docs/data/joy/components/divider/divider.md
@@ -9,13 +9,13 @@ githubLabel: 'component: divider'
 
 <p class="description">A divider is a thin line that groups content in lists and layouts.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Dividers separate content into clear groups.
 
 {{"demo": "DividerUsage.js", "hideToolbar": "true", "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 
@@ -33,19 +33,18 @@ export default function MyApp() {
 
 Use the `Divider` to wrap elements that will be added to it.
 
+{{"demo": "DividerText.js"}}
+
 :::warning
 When using the `Divider` component for visual decoration, such as in a heading, explicitly specify `role="presentation"` on it to make sure screen readers can announce its content:
 
 ```js
 <Divider component="div" role="presentation">
   {/* any elements nested inside the role="presentation" preserve their semantics. */}
-  <Typography variant="h2">My Heading</Typography>
 </Divider>
 ```
 
 :::
-
-{{"demo": "DividerText.js"}}
 
 ### Vertical divider
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -9,13 +9,13 @@ unstyled: /base/react-input/
 
 <p class="description">The Input component facilitates the entry of text data from the user.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The Input component enhances the functionality of the native HTML `<input>` tag by providing expanded customization options and accessibility features.
 
 {{"demo": "InputUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/linear-progress/linear-progress.md
+++ b/docs/data/joy/components/linear-progress/linear-progress.md
@@ -9,6 +9,8 @@ githubLabel: 'component: LinearProgress'
 
 <p class="description">Linear Progress indicators, commonly known as loaders, express an unspecified wait time or display the length of a process.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Progress indicators inform users about the status of ongoing processes, such as loading an app, submitting a form, or saving updates.
@@ -19,8 +21,6 @@ To actually have it represent how long an operation will take, use the [determin
 The animations of the components rely on CSS as much as possible to work even before the JavaScript is loaded.
 
 {{"demo": "LinearProgressUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/link/link.md
+++ b/docs/data/joy/components/link/link.md
@@ -10,14 +10,14 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/link/
 
 <p class="description">The <code>Link</code> component allows you to customize anchor tags with theme colors and typography styles.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The `Link` component represents the HTML `<a>` element.
 It accepts the same props as the [`Typography`](/joy-ui/react-typography/) component, as well as the system props.
 
 {{"demo": "LinkUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/modal/modal.md
+++ b/docs/data/joy/components/modal/modal.md
@@ -10,6 +10,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 <p class="description">The modal component provides a solid foundation for creating dialogs, popovers, lightboxes, or whatever else.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Joy UI provides three modal-related components:
@@ -27,8 +29,6 @@ Joy UI provides three modal-related components:
 - 🔐 Disables page scrolling while open.
 - ⌨️ Manages focus correctly between the modal and its parent app.
 - ♿️ Adds the appropriate ARIA roles automatically.
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 :::info
 The term "modal" is sometimes used interchangeably with "dialog," but this is incorrect.

--- a/docs/data/joy/components/radio-button/radio-button.md
+++ b/docs/data/joy/components/radio-button/radio-button.md
@@ -1,6 +1,6 @@
 ---
 product: joy-ui
-title: React Radio Group component
+title: React Radio Button component
 components: Radio, RadioGroup
 githubLabel: 'component: radio'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/radio/
@@ -10,12 +10,16 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/radio/
 
 <p class="description">Radio buttons enable the user to select one option from a set.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Radio buttons let users make a mutually exclusive choice (e.g., this or that).
 Only one selection is allowed from the available set of options.
 
 Radio buttons should have the most commonly used option selected by default.
+
+{{"demo": "RadioUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
 :::success
 When should you use radio buttons rather than checkboxes, switches, or selects?
@@ -25,14 +29,6 @@ When should you use radio buttons rather than checkboxes, switches, or selects?
 - Consider using a select if it's not important for the user to be able to see all options.
 - If available options can be collapsed, consider using a Select component to conserve space.
   :::
-
-{{"demo": "RadioUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-:::info
-To learn how to add more variants or sizes to the component, check out the [Themed components](/joy-ui/customization/themed-components/) page.
-:::
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/select/select.md
+++ b/docs/data/joy/components/select/select.md
@@ -11,17 +11,13 @@ unstyled: /base/react-select/
 
 <p class="description">Select components are used for collecting user provided information from a list of options.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The `Select` component is used to trigger a popup that displays a list of `Option` components.
 
 {{"demo": "SelectUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-:::info
-To learn how to add more variants or sizes to the component, check out the [Themed components](/joy-ui/customization/themed-components/) page.
-:::
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/sheet/sheet.md
+++ b/docs/data/joy/components/sheet/sheet.md
@@ -8,14 +8,14 @@ components: Sheet
 
 <p class="description">Sheet is a generic container that supports Joy UI's global variants.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The `Sheet` container is a generic container.
 It's a sibling to the [`Box`](/system/react-box/) component, and equivalent to Material UI's [`Paper`](/material-ui/react-paper/), with the difference being that it supports Joy UI's global variants out of the box.
 
 {{"demo": "SheetUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/slider/slider.md
+++ b/docs/data/joy/components/slider/slider.md
@@ -10,17 +10,13 @@ unstyled: /base/react-slider/
 
 <p class="description">Slider generates a background element that can be used for various purposes.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Sliders are ideal for interface controls that benefit from a visual representation of adjustable content, such as volume or brightness settings, or for applying image filters such as gradients or saturation.
 
 {{"demo": "SliderUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-:::info
-To learn how to add more variants or sizes to the component, check out [Themed components](/joy-ui/customization/themed-components/).
-:::
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/stack/stack.md
+++ b/docs/data/joy/components/stack/stack.md
@@ -9,6 +9,8 @@ githubLabel: 'component: Stack'
 
 <p class="description">Stack is a container component for arranging elements vertically or horizontally.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The Stack component manages the layout of its immediate children along the vertical or horizontal axis, with optional spacing and dividers between each child.
@@ -16,8 +18,6 @@ The Stack component manages the layout of its immediate children along the verti
 :::info
 Stack is ideal for one-dimensional layouts, while Grid is preferable when you need both vertical _and_ horizontal arrangement.
 :::
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 

--- a/docs/data/joy/components/switch/switch.md
+++ b/docs/data/joy/components/switch/switch.md
@@ -10,6 +10,8 @@ unstyled: /base/react-switch/
 
 <p class="description">Switches toggle the state of a single setting on or off.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Switches are very commonly used for adjusting settings on mobile.
@@ -17,12 +19,6 @@ The option that the switch controls, as well as the state it's in,
 should be made clear from the corresponding inline label.
 
 {{"demo": "SwitchUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-:::info
-To learn how to add more sizes to the component, check out [Themed components—Extend sizes](/joy-ui/customization/themed-components/#extend-sizes).
-:::
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/table/table.md
+++ b/docs/data/joy/components/table/table.md
@@ -10,13 +10,13 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/table/
 
 <p class="description">Tables display sets of data organized in rows and columns.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 The Joy UI Table component lets you use plain HTML structure to assemble a table in JSX.
 
 {{"demo": "TableUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Basics
 
@@ -233,12 +233,9 @@ There are two workarounds:
 ### Text ellipsis
 
 To truncate the text, set `noWrap` to true.
+The header cells always truncate the text to keep the header's height predictable.
 
 {{"demo": "TableTextEllipsis.js"}}
-
-:::info
-The header cells always truncate the text to keep the header's height predictable.
-:::
 
 ## CSS variable playground
 

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -11,6 +11,8 @@ unstyled: /base/react-tabs/
 
 <p class="description">Tabs make it easy to explore and switch between different views.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Joy UI provides four tabs-related components:
@@ -21,8 +23,6 @@ Joy UI provides four tabs-related components:
 - `TabPanel`: A pane that displays on the screen when its value matches with the selected tab.
 
 {{"demo": "TabsUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 
@@ -121,7 +121,7 @@ You can use those to customize the component on both the `sx` prop and the theme
 
 ## Common examples
 
-### Underline tabs
+### Underlined tabs
 
 {{"demo": "TabsUnderlineExample.js"}}
 
@@ -129,7 +129,7 @@ You can use those to customize the component on both the `sx` prop and the theme
 
 {{"demo": "TabsPricingExample.js"}}
 
-### Page tabs with chips
+### With counter chips
 
 {{"demo": "TabsPageExample.js"}}
 

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -10,13 +10,13 @@ unstyled: /base/react-textarea-autosize/
 
 <p class="description">Textarea component gives you a textarea HTML element that automatically adjusts its height to match the length of the content within.</p>
 
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+
 ## Introduction
 
 Joy UI's textarea component is built on top of the Base UI [`TextareaAutoSize`](/base/react-textarea-autosize/) component.
 
 {{"demo": "TextareaUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/components/tooltip/tooltip.md
+++ b/docs/data/joy/components/tooltip/tooltip.md
@@ -8,13 +8,13 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 
 # Tooltip
 
-<p class="description">A tooltip .</p>
+<p class="description">Tooltips display informative text when users hover over, focus on, or tap an element.</p>
+
+{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Introduction
 
 {{"demo": "TooltipUsage.js", "hideToolbar": true, "bg": "gradient"}}
-
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
 
 ## Component
 

--- a/docs/data/joy/customization/theme-colors/PaletteThemeViewer.js
+++ b/docs/data/joy/customization/theme-colors/PaletteThemeViewer.js
@@ -39,7 +39,7 @@ const collator = new Intl.Collator(undefined, {
 const Table = styled('table')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.vars.palette.divider,
-  borderRadius: theme.vars.radius.xs,
+  borderRadius: theme.vars.radius.md,
   borderCollapse: 'separate',
   borderSpacing: 0,
   display: 'block',

--- a/docs/data/joy/customization/theme-colors/PaletteThemeViewer.tsx
+++ b/docs/data/joy/customization/theme-colors/PaletteThemeViewer.tsx
@@ -39,7 +39,7 @@ const collator = new Intl.Collator(undefined, {
 const Table = styled('table')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.vars.palette.divider,
-  borderRadius: theme.vars.radius.xs,
+  borderRadius: theme.vars.radius.md,
   borderCollapse: 'separate',
   borderSpacing: 0,
   display: 'block',

--- a/docs/data/joy/customization/theme-colors/theme-colors.md
+++ b/docs/data/joy/customization/theme-colors/theme-colors.md
@@ -1,6 +1,6 @@
 # Theme colors
 
-<p class="description">Learn about the theme's default colors and how to customize them.</p>
+<p class="description">Learn about the default theme's color palette and how to customize it.</p>
 
 ## Default tokens
 

--- a/docs/data/joy/customization/theme-shadow/ShadowThemeViewer.js
+++ b/docs/data/joy/customization/theme-shadow/ShadowThemeViewer.js
@@ -13,7 +13,7 @@ import Check from '@mui/icons-material/CheckCircle';
 const Table = styled('table')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.vars.palette.divider,
-  borderRadius: theme.vars.radius.xs,
+  borderRadius: theme.vars.radius.md,
   borderCollapse: 'separate',
   borderSpacing: 0,
   width: '100%',

--- a/docs/data/joy/customization/theme-shadow/ShadowThemeViewer.tsx
+++ b/docs/data/joy/customization/theme-shadow/ShadowThemeViewer.tsx
@@ -13,7 +13,7 @@ import Check from '@mui/icons-material/CheckCircle';
 const Table = styled('table')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.vars.palette.divider,
-  borderRadius: theme.vars.radius.xs,
+  borderRadius: theme.vars.radius.md,
   borderCollapse: 'separate',
   borderSpacing: 0,
   width: '100%',

--- a/docs/data/joy/customization/theme-shadow/theme-shadow.md
+++ b/docs/data/joy/customization/theme-shadow/theme-shadow.md
@@ -123,7 +123,7 @@ The `shadowChannel` value must be rgb channels, e.g. `187 187 187`.
 
 To customize a shadow color or shadow ring on a specific instance, use the raw value from the `theme.shadow.*`.
 
-:::error  
+:::error
 **Don't** use shadows from `theme.vars` or the shorthand syntax `{ shadow: '{key}' }` because the value points to the global CSS variable which does not work with the custom `shadowChannel` and `shadowRing` on the instance.
 :::
 

--- a/docs/data/joy/customization/theme-shadow/theme-shadow.md
+++ b/docs/data/joy/customization/theme-shadow/theme-shadow.md
@@ -1,11 +1,10 @@
 # Theme shadow
 
-<p class="description">Learn about the theme's default shadow and how to customize it.</p>
+<p class="description">Learn about the default theme's shadow scale and how to customize it.</p>
 
 ## Default tokens
 
 Joy UI uses a T-shirt scale (sm, md, lg, etc.) for defining shadows used by components such as [Card](/joy-ui/react-card/), [Menu](/joy-ui/react-menu/), and more.
-
 These tokens are grouped inside the `theme.shadow` node:
 
 {{"demo": "ShadowThemeViewer.js", "bg": "inline"}}
@@ -124,7 +123,7 @@ The `shadowChannel` value must be rgb channels, e.g. `187 187 187`.
 
 To customize a shadow color or shadow ring on a specific instance, use the raw value from the `theme.shadow.*`.
 
-:::warning
+:::error  
 **Don't** use shadows from `theme.vars` or the shorthand syntax `{ shadow: '{key}' }` because the value points to the global CSS variable which does not work with the custom `shadowChannel` and `shadowRing` on the instance.
 :::
 

--- a/docs/data/joy/customization/theme-typography/TypographyThemeViewer.js
+++ b/docs/data/joy/customization/theme-typography/TypographyThemeViewer.js
@@ -9,11 +9,12 @@ const defaultTheme = extendTheme();
 const Table = styled('table')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.vars.palette.divider,
-  borderRadius: theme.vars.radius.xs,
+  borderRadius: theme.vars.radius.md,
   borderCollapse: 'separate',
   borderSpacing: 0,
   display: 'block',
   width: 'max-content',
+  overflow: 'auto',
   th: {
     textAlign: 'left',
     padding: 12,

--- a/docs/data/joy/customization/theme-typography/TypographyThemeViewer.tsx
+++ b/docs/data/joy/customization/theme-typography/TypographyThemeViewer.tsx
@@ -9,11 +9,12 @@ const defaultTheme = extendTheme();
 const Table = styled('table')(({ theme }) => ({
   border: '1px solid',
   borderColor: theme.vars.palette.divider,
-  borderRadius: theme.vars.radius.xs,
+  borderRadius: theme.vars.radius.md,
   borderCollapse: 'separate',
   borderSpacing: 0,
   display: 'block',
   width: 'max-content',
+  overflow: 'auto',
   th: {
     textAlign: 'left',
     padding: 12,

--- a/docs/data/joy/customization/theme-typography/theme-typography.md
+++ b/docs/data/joy/customization/theme-typography/theme-typography.md
@@ -1,6 +1,6 @@
 # Theme typography
 
-<p class="description">Learn about the typography system and how to customize it.</p>
+<p class="description">Learn about the default theme's typography system and how to customize it.</p>
 
 Joy UI includes a typography system within the theme to help you create consistent text across your application. You can customize the default system or start from scratch depending on your needs.
 
@@ -124,20 +124,21 @@ There are several ways that you can use the theme typography in your application
 ## Common examples
 
 Here is a collection of well-known typography systems that you can use with Joy UI.
+Feel free to [submit a PR](https://github.com/mui/material-ui/compare) to add your favorite if it's not here. ❤️
 
-### Fluent (Microsoft)
+### Microsoft's Fluent
 
 - Design resource: [Figma](https://www.figma.com/community/file/836828295772957889)
 - Font: [Segoe UI](https://learn.microsoft.com/en-us/typography/font-list/segoe-ui)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-fluent-typography-system-j86fct?module=%2Fdemo.tsx&fontsize=14&hidenavigation=1&theme=dark&view=preview"
-     style="width:100%; height:360px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:360px; border:0; border-radius: 12px; overflow:hidden;"
      title="Joy UI - Fluent Typography System"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-### Human Interface Guidelines (Apple)
+### Apple's Human Interface Guidelines
 
 - Design resource: [Sketch library](https://developer.apple.com/design/resources/)
 - Font: [San Francisco (SF)](https://developer.apple.com/fonts/)
@@ -149,18 +150,14 @@ Here is a collection of well-known typography systems that you can use with Joy 
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-### Material Design 3 (Google)
+### Google's Material Design 3
 
 - Design resource: [Figma](https://www.figma.com/community/file/1035203688168086460)
 - Font: [Roboto](https://fonts.google.com/specimen/Roboto)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-material-3-typography-system-lx044f?module=%2Fdemo.tsx&fontsize=14&hidenavigation=1&theme=dark&view=preview"
-     style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:500px; border:0; border-radius: 12px; overflow:hidden;"
      title="Joy UI - Joy UI - Material 3 Typography System"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
-
-:::info
-Feel free to [submit a PR](https://github.com/mui/material-ui/compare) to add your favorite typography system. ❤️
-:::

--- a/docs/data/joy/customization/themed-components/themed-components.md
+++ b/docs/data/joy/customization/themed-components/themed-components.md
@@ -144,10 +144,6 @@ Once these values are defined as above, you can make use of them directly on ins
 <Button color="tertiary">Tertiary color</Button>
 ```
 
-:::info
-To learn how to extend size properties, check out the [Extend sizes](#extend-sizes) section in this document.
-:::
-
 #### TypeScript
 
 Module augmentation is required to pass the values to the `color` prop of the component.
@@ -211,10 +207,8 @@ Once these values are defined as above, you can make use of them directly on ins
 <Button size="xl">Extra large</Button>
 ```
 
-:::info
 The properties used for extending sizes should only relate to the density or the dimensions of the component.
 To learn how to extend variant properties, check out the [Extend variants](#extend-variants) section in this document.
-:::
 
 #### TypeScript
 

--- a/docs/data/joy/customization/using-css-variables/using-css-variables.md
+++ b/docs/data/joy/customization/using-css-variables/using-css-variables.md
@@ -9,32 +9,38 @@ It also creates an object that refers to the generated CSS variables under `them
 
 The `theme.vars` is available in all styling APIs that Joy UI offers:
 
-- `styled` function
-  ```js
-  const Div = styled('div')(({ theme }) => ({
-    // The result is 'var(--joy-palette-primary-500)'
-    color: theme.vars.palette.primary[500],
-  }));
-  ```
-- `sx` prop
-  ```jsx
-  // The result is 'var(--joy-shadow-sm)'
-  <Chip sx={(theme) => ({ boxShadow: theme.vars.shadow.sm })} />
-  ```
-- style overrides (themed components)
-  ```jsx
-  extendTheme({
-    components: {
-      JoyButton: {
-        root: ({ theme }) => ({
-          // The result is 'var(--joy-fontFamily-display)'
-          fontFamily: theme.vars.fontFamily.display,
-        }),
-      },
+1. The `styled` function
+
+```js
+const Div = styled('div')(({ theme }) => ({
+  // The result is 'var(--joy-palette-primary-500)'
+  color: theme.vars.palette.primary[500],
+}));
+```
+
+2. The `sx` prop
+
+```jsx
+// The result is 'var(--joy-shadow-sm)'
+<Chip sx={(theme) => ({ boxShadow: theme.vars.shadow.sm })} />
+```
+
+3. Style overrides (themed components)
+
+```jsx
+extendTheme({
+  components: {
+    JoyButton: {
+      root: ({ theme }) => ({
+        // The result is 'var(--joy-fontFamily-display)'
+        fontFamily: theme.vars.fontFamily.display,
+      }),
     },
-  });
-  ```
-- `useTheme` hook
+  },
+});
+```
+
+4. The `useTheme` hook.
 
 ### Alpha channel colors
 

--- a/docs/data/joy/customization/using-css-variables/using-css-variables.md
+++ b/docs/data/joy/customization/using-css-variables/using-css-variables.md
@@ -4,7 +4,7 @@
 
 ## Theme object
 
-The `CssVarsProvider` reads the theme input (or the default theme) and create the CSS variables according to the theme structure.
+The `CssVarsProvider` reads the theme input (or the default theme) and creates the CSS variables according to the theme structure.
 It also creates an object that refers to the generated CSS variables under `theme.vars` so that you can use them from the JavaScript theme object.
 
 The `theme.vars` is available in all styling APIs that Joy UI offers:
@@ -66,8 +66,8 @@ const Div = styled('div')(({ theme }) => ({
 The format of the channel tokens uses a space as a separator, e.g. `61 131 246`, which means you have to use `/` to combine the channel token with an opacity value.
 
 ```js
-`rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`, ✅ correct format
-`rgba(${theme.vars.palette.primary.mainChannel}, 0.12)`, 🚫 will not work
+`rgba(${theme.vars.palette.primary.mainChannel} / 0.12)`, ✅ correct
+`rgba(${theme.vars.palette.primary.mainChannel}, 0.12)`, 🚫 incorrect
 ```
 
 :::
@@ -79,7 +79,7 @@ For example, you can create the `inset` shadow from the theme like this:
 
 ```js
 const Div = styled('div')(({ theme }) => ({
-  // Note that it is using `theme.shadow` not `theme.vars.shadow`
+  // Note that it's using `theme.shadow`, not `theme.vars.shadow`
   boxShadow: theme.shadow.sm.replace(/,/g, ', inset'),
 }));
 ```

--- a/docs/data/joy/guides/using-icon-libraries/using-icon-libraries.md
+++ b/docs/data/joy/guides/using-icon-libraries/using-icon-libraries.md
@@ -134,7 +134,7 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 - [Installation](https://react-icons.github.io/react-icons/)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-react-icons-n6jljq?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
-     style="width:100%; height:250px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"
      title="joy-ui-react-icons"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -146,7 +146,7 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 - [Installation](https://ionic.io/ionicons/usage)
 
 <iframe src="https://codesandbox.io/embed/inspiring-visvesvaraya-etcc3x?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
-     style="width:100%; height:250px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"
      title="inspiring-visvesvaraya-etcc3x"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -158,7 +158,7 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 - [Installation](https://github.com/tailwindlabs/heroicons#react)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-heroicons-wv2ev1?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
-     style="width:100%; height:250px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"
      title="joy-ui-heroicons"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -170,7 +170,7 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 - [Installation](https://icons.getbootstrap.com/#install)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-bootstrap-icons-x8g0cm?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
-     style="width:100%; height:250px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"
      title="joy-ui-bootstrap"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
@@ -182,7 +182,7 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 - [Installation](https://fontawesome.com/docs/web/use-with/react/)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-fontawesome-kjbnqj?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
-     style="width:100%; height:250px; border:0; border-radius: 4px; overflow:hidden;"
+     style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"
      title="joy-ui-fontawesome"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -9,8 +9,8 @@ There are two main use cases for using them together:
 1. Your existing project already uses Material UI but you're willing to explore the new components and style Joy UI offers.
 2. You've started your project with Joy UI but you find a key component you need is missing.
 
-:::success
-Once Joy UI reaches component parity with Material UI, we recommend that you _choose one or the other_. Not only do they have a different design language (and therefore a different theme structure) but they would increase your bundle size as well as potentially create unnecessary complexities.
+:::info
+Once Joy UI reaches component parity with Material UI, we recommend that you **_choose one or the other_**. Not only do they have a different design language (and therefore a different theme structure) but they would increase your bundle size as well as potentially create unnecessary complexities.
 :::
 
 Additionally, keep these in mind when using them together:
@@ -99,29 +99,29 @@ If you want to change the `defaultMode`, you have to specify the prop to both of
 
 ## Caveat
 
-- Both libraries have the same class name prefix:
+Both libraries have the same class name prefix:
 
-  ```js
-  import MaterialTypography, {
-    typographyClasses as muiTypographyClasses,
-  } from '@mui/material/Typography';
-  import JoyTypography, {
-    typographyClasses as joyTyographyClasses,
-  } from '@mui/joy/Typography';
-  import Stack from '@mui/material/Stack';
+```js
+import MaterialTypography, {
+  typographyClasses as muiTypographyClasses,
+} from '@mui/material/Typography';
+import JoyTypography, {
+  typographyClasses as joyTyographyClasses,
+} from '@mui/joy/Typography';
+import Stack from '@mui/material/Stack';
 
-  <Stack
-    sx={{
-      // similar to `& .${joyTyographyClasses.root}`
-      [`& .${muiTypographyClasses.root}`]: {
-        color: 'red',
-      },
-    }}
-  >
-    {/* Both components are red. */}
-    <MaterialTypography>Red</MaterialTypography>
-    <JoyTypography>Red</JoyTypography>
-  </Stack>;
-  ```
+<Stack
+  sx={{
+    // similar to `& .${joyTyographyClasses.root}`
+    [`& .${muiTypographyClasses.root}`]: {
+      color: 'red',
+    },
+  }}
+>
+  {/* Both components are red. */}
+  <MaterialTypography>Red</MaterialTypography>
+  <JoyTypography>Red</JoyTypography>
+</Stack>;
+```
 
-- Joy UI and Material UI components have different name for [theming the components](/joy-ui/customization/themed-components/#component-identifier). For example, Joy UI's Button uses `JoyButton` whereas Material UI's Button uses `MuiButton`.
+Joy UI and Material UI components have different name for [theming the components](/joy-ui/customization/themed-components/#component-identifier). For example, Joy UI's Button uses `JoyButton` whereas Material UI's Button uses `MuiButton`.

--- a/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
+++ b/docs/data/joy/guides/using-joy-ui-and-material-ui/using-joy-ui-and-material-ui.md
@@ -124,4 +124,4 @@ import Stack from '@mui/material/Stack';
 </Stack>;
 ```
 
-Joy UI and Material UI components have different name for [theming the components](/joy-ui/customization/themed-components/#component-identifier). For example, Joy UI's Button uses `JoyButton` whereas Material UI's Button uses `MuiButton`.
+Joy UI and Material UI components have a different name for [theming the components](/joy-ui/customization/themed-components/#component-identifier). For example, Joy UI's Button uses `JoyButton` whereas Material UI's Button uses `MuiButton`.

--- a/docs/data/joy/main-features/dark-mode-optimization/dark-mode-optimization.md
+++ b/docs/data/joy/main-features/dark-mode-optimization/dark-mode-optimization.md
@@ -16,7 +16,7 @@ Indeed, this light-mode "flash" will occur _every_ time you load up the app in t
 
 This can cause eye fatigue in a low-light setting, not to mention a frustrating interruption of the user experience—especially for those who interact with the app when it's in between modes.
 
-The animated screen capture below illustrates this problem as it would appear on [mui.com](https://mui.com/) without a fix:
+The gif below illustrates this problem as it would appear on [mui.com](https://mui.com/) without a fix:
 
 <img src="https://media.giphy.com/media/9hvxemkpotSiQGzLo8/giphy.gif" style="margin-bottom: 24px; width: 240px;" alt="The dark-mode flashing problem at mui.com." width="480" height="294" />
 

--- a/docs/data/joy/pages.ts
+++ b/docs/data/joy/pages.ts
@@ -35,7 +35,7 @@ const pages = [
           { pathname: '/joy-ui/react-button' },
           { pathname: '/joy-ui/react-checkbox' },
           { pathname: '/joy-ui/react-input' },
-          { pathname: '/joy-ui/react-radio-button', title: 'Radio Group' },
+          { pathname: '/joy-ui/react-radio-button' },
           { pathname: '/joy-ui/react-select' },
           { pathname: '/joy-ui/react-slider' },
           { pathname: '/joy-ui/react-switch' },

--- a/docs/data/joy/pages.ts
+++ b/docs/data/joy/pages.ts
@@ -35,7 +35,7 @@ const pages = [
           { pathname: '/joy-ui/react-button' },
           { pathname: '/joy-ui/react-checkbox' },
           { pathname: '/joy-ui/react-input' },
-          { pathname: '/joy-ui/react-radio-button' },
+          { pathname: '/joy-ui/react-radio-button', title: 'Radio Button' },
           { pathname: '/joy-ui/react-select' },
           { pathname: '/joy-ui/react-slider' },
           { pathname: '/joy-ui/react-switch' },

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -443,7 +443,7 @@
     "/joy-ui/react-button": "Button",
     "/joy-ui/react-checkbox": "Checkbox",
     "/joy-ui/react-input": "Input",
-    "/joy-ui/react-radio-button": "Radio Group",
+    "/joy-ui/react-radio-button": "Radio Button",
     "/joy-ui/react-select": "Select",
     "/joy-ui/react-slider": "Slider",
     "/joy-ui/react-switch": "Switch",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR tweaks almost every currently available Joy UI page. They're all simple changes, though, and mostly on the Markdown files. Generally, I'm just going for tiny style fixes, light copywriting updates, and overall formatting refinement. Some of the trends I've identified that got me thinking and interested in opening this PR:

1. I think we use way too many callouts, there's a lot of them on some pages. 
2. There are a few cases where we introduce sections⎯with a callout⎯that are just a couple of lines away.
3. Some components had the "learn how to extend the variants" callout but others didn't. I removed some of them, for now. It's valuable information we should probably append consistently in the "Variants" section.
4. Placement of the extra info chips below the introduction demo. I moved them all to be above it so that, once we introduce tabs in the Joy docs as well, it's a smoother transition.