### PR TITLE
docs: add installation guide for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ npm install @mui/material @emotion/react @emotion/styled
 yarn add @mui/material @emotion/react @emotion/styled
 ```
 
+**pnpm:**
+
+```sh
+pnpm add @mui/material @emotion/react @emotion/styled
+```
+
 <details>
   <summary>Older versions</summary>
 
@@ -79,6 +85,12 @@ npm install @mui/base
 yarn add @mui/base
 ```
 
+**pnpm:**
+
+```sh
+pnpm add @mui/base
+```
+
 **Note**: Base UI is still in alpha.
 We are adding new components regularly and you're welcome to contribute!
 
@@ -98,6 +110,12 @@ npm install @mui/system @emotion/react @emotion/styled
 yarn add @mui/system @emotion/react @emotion/styled
 ```
 
+**pnpm:**
+
+```sh
+pnpm add @mui/system @emotion/react @emotion/styled
+```
+
 Or if you want to use `styled-components` as a styling engine:
 
 **npm:**
@@ -110,6 +128,12 @@ npm install @mui/material @mui/styled-engine-sc styled-components
 
 ```sh
 yarn add @mui/material @mui/styled-engine-sc styled-components
+```
+
+**pnpm:**
+
+```sh
+pnpm add @mui/material @mui/styled-engine-sc styled-components
 ```
 
 Visit our [`styled-engine` guide](https://mui.com/material-ui/guides/styled-engine/) for more information about how to configure `styled-components` as the style engine.


### PR DESCRIPTION
This pull request adds documentation for installing the package with PNPM, a fast and disk space-efficient package manager. I think this would be a useful addition for users who prefer PNPM over NPM or yarn. Thank you for considering my contribution.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
