### PR TITLE
[typescript] Add the missing explicit component return types

### DIFF
--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
@@ -268,7 +268,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
       />
     </React.Fragment>
   );
-});
+}) as React.ForwardRefExoticComponent<TextareaAutosizeProps & React.RefAttributes<Element>>;
 
 TextareaAutosize.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------

--- a/packages/mui-material-next/src/Button/TouchRipple.tsx
+++ b/packages/mui-material-next/src/Button/TouchRipple.tsx
@@ -275,7 +275,7 @@ const TouchRipple = React.forwardRef<TouchRippleActions, TouchRippleProps>(funct
       </TransitionGroup>
     </TouchRippleRoot>
   );
-});
+}) as React.ForwardRefExoticComponent<TouchRippleProps & React.RefAttributes<TouchRippleActions>>;
 
 TouchRipple.propTypes = {
   /**


### PR DESCRIPTION
Adds the explicit return type for TextareaAutosize and material-next's TouchRipple, similarly to #36013. These two were inadvertently omitted from the mentioned PR.

Fixes #36571.