### PR TITLE
[Joy][Chip] Chip button not showing up in Firefox browser

### DIFF
--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -143,6 +143,7 @@ const ChipAction = styled('button', {
     left: 0,
     bottom: 0,
     right: 0,
+    width: '100%',
     border: 'none',
     cursor: 'pointer',
     padding: 'initial',

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -143,7 +143,7 @@ const ChipAction = styled('button', {
     left: 0,
     bottom: 0,
     right: 0,
-    width: '100%',
+    width: '100%', // To fix Firefox issue (https://github.com/mui/material-ui/issues/36877)
     border: 'none',
     cursor: 'pointer',
     padding: 'initial',


### PR DESCRIPTION
Fixes a bug where the button width style is set to 0 when using the Chip onClick prop in the Firefox browser.
Add a width 100% style to the button to fix the issue.

Fixes https://github.com/mui/material-ui/issues/36877

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
