### PR TITLE
[WIP][docs] Update components header to include product

### DIFF
--- a/docs/data/material/components/tabs/tabs.md
+++ b/docs/data/material/components/tabs/tabs.md
@@ -1,7 +1,7 @@
 ---
 product: material-ui
 title: React Tabs component
-components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
+components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, base:TabsUnstyled, base:TabUnstyled, base:TabPanelUnstyled, base:TabsListUnstyled
 githubLabel: 'component: tabs'
 materialDesign: https://m2.material.io/components/tabs
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -301,8 +301,6 @@ const getApiPath = (
     apiPath = `${cleanedDemosPathname}${
       name.startsWith('use') ? 'hooks-api' : 'components-api'
     }/#${kebabCase(name)}`;
-  } else {
-    console.log(`Warning: No demos found for ${name}`);
   }
 
   return apiPath;

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -318,7 +318,10 @@ export function getBaseComponentInfo(filename: string): ComponentInfo {
   // resolve demos, so that we can getch the API url
   const allMarkdowns = findPagesMarkdown()
     .filter((markdown) => {
-      return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
+      if (migratedBaseComponents.some((component) => filename.includes(component))) {
+        return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
+      }
+      return true;
     })
     .map((markdown) => {
       const markdownContent = fs.readFileSync(markdown.filename, 'utf8');
@@ -370,7 +373,10 @@ export function getBaseHookInfo(filename: string): HookInfo {
 
   const allMarkdowns = findPagesMarkdown()
     .filter((markdown) => {
-      return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
+      if (migratedBaseComponents.some((component) => filename.includes(component))) {
+        return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
+      }
+      return true;
     })
     .map((markdown) => {
       const markdownContent = fs.readFileSync(markdown.filename, 'utf8');

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -290,7 +290,7 @@ const getApiPath = (
   let demo = demos && demos.length > 0 ? demos[0] : null;
   let idx = 0;
 
-  while(demo && demo.demoPathname.indexOf('/base/') < 0) {
+  while (demo && demo.demoPathname.indexOf('/base/') < 0 && idx < demos.length) {
     idx += 1;
     demo = demos[idx];
   }
@@ -302,7 +302,7 @@ const getApiPath = (
       name.startsWith('use') ? 'hooks-api' : 'components-api'
     }/#${kebabCase(name)}`;
   } else {
-    console.log(`Warning: No demos found for ${name}`)
+    console.log(`Warning: No demos found for ${name}`);
   }
 
   return apiPath;

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -287,12 +287,22 @@ const getApiPath = (
 ) => {
   let apiPath = null;
 
-  if (demos && demos.length > 0) {
+  let demo = demos && demos.length > 0 ? demos[0] : null;
+  let idx = 0;
+
+  while(demo && demo.demoPathname.indexOf('/base/') < 0) {
+    idx += 1;
+    demo = demos[idx];
+  }
+
+  if (demo) {
     // remove the hash from the demoPathname, for e.g. "#hooks"
     const cleanedDemosPathname = demos[0].demoPathname.split('#')[0];
     apiPath = `${cleanedDemosPathname}${
       name.startsWith('use') ? 'hooks-api' : 'components-api'
     }/#${kebabCase(name)}`;
+  } else {
+    console.log(`Warning: No demos found for ${name}`)
   }
 
   return apiPath;
@@ -308,10 +318,7 @@ export function getBaseComponentInfo(filename: string): ComponentInfo {
   // resolve demos, so that we can getch the API url
   const allMarkdowns = findPagesMarkdown()
     .filter((markdown) => {
-      if (migratedBaseComponents.some((component) => filename.includes(component))) {
-        return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
-      }
-      return true;
+      return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
     })
     .map((markdown) => {
       const markdownContent = fs.readFileSync(markdown.filename, 'utf8');
@@ -363,10 +370,7 @@ export function getBaseHookInfo(filename: string): HookInfo {
 
   const allMarkdowns = findPagesMarkdown()
     .filter((markdown) => {
-      if (migratedBaseComponents.some((component) => filename.includes(component))) {
-        return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
-      }
-      return true;
+      return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
     })
     .map((markdown) => {
       const markdownContent = fs.readFileSync(markdown.filename, 'utf8');

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -13,5 +13,8 @@
     "lodash": "^4.17.21",
     "marked": "^4.3.0",
     "prismjs": "^1.29.0"
+  },
+  "browser": { 
+    "fs": false
   }
 }

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -493,10 +493,7 @@ function resolveApiUrl(product, packageName, importName) {
     // Once the docs for all products support tabs, this will need to be generalized for all products
     const allMarkdowns = findPagesMarkdown()
       .filter((markdown) => {
-        if (migratedBaseComponents.some((component) => filename.includes(component))) {
-          return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
-        }
-        return true;
+        return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
       })
       .map((markdown) => {
         const markdownContent = fs.readFileSync(markdown.filename, 'utf8');
@@ -599,7 +596,8 @@ ${headers.components
   .join('\n')}
 ${headers.hooks
   .map((hookInput) => {
-    let hook, product;
+    let hook;
+    let product;
 
     if (hookInput.indexOf(':') >= 0) {
       [product, hook] = hookInput.split(':');

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -449,30 +449,6 @@ const getBaseApiPath = (demos, name) => {
   return apiPath;
 };
 
-const migratedBaseComponents = [
-  'BadgeUnstyled',
-  'ButtonUnstyled',
-  'ClickAwayListener',
-  'FocusTrap',
-  'InputUnstyled',
-  'MenuItemUnstyled',
-  'MenuUnstyled',
-  'ModalUnstyled',
-  'NoSsr',
-  'OptionGroupUnstyled',
-  'OptionUnstyled',
-  'PopperUnstyled',
-  'Portal',
-  'SelectUnstyled',
-  'SliderUnstyled',
-  'SwitchUnstyled',
-  'TablePaginationUnstyled',
-  'TabPanelUnstyled',
-  'TabsListUnstyled',
-  'TabsUnstyled',
-  'TabUnstyled',
-];
-
 /**
  * @param {string} product
  * @example 'material'

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -410,37 +410,33 @@ function findPagesMarkdown(
   return pagesMarkdown;
 }
 
-
+// returns information about all pages containing demos for the component or hook specified in the importName prop
 function findBaseDemos(importName, pagesMarkdown) {
   return pagesMarkdown
     .filter((page) => page.components.includes(importName))
     .map((page) => ({
       demoPageTitle: getTitle(page.markdownContent),
-      demoPathname: page.pathname.match(/material\//)
-        ? replaceComponentLinks(`${page.pathname.replace(/^\/material/, '')}/`)
-        : `${page.pathname.replace('/components/', '/react-')}/`,
+      demoPathname: `${page.pathname.replace('/components/', '/react-')}/`,
     }));
 }
 
 /**
  * @param {string} product
  * @example 'material'
- * @param {string} componentPkg
+ * @param {string} package
  * @example 'mui-base'
  * @param {string} importName (hook or component)
  * @example 'ButtonUnstyled'
  * @returns {string}
  */
-function resolveApiUrl(product, componentPkg, importName) {
+function resolveApiUrl(product, package, importName) {
   if (!product) {
     return `/api/${kebabCase(importName)}/`;
   }
   if (product === 'date-pickers') {
     return `/x/api/date-pickers/${kebabCase(importName)}/`;
   }
-  if (componentPkg === 'mui-base' || product === 'base') {
-    // TODO: Duplicated from buildApiUrl
-
+  if (package === 'mui-base' || product === 'base') {
     const allMarkdowns = findPagesMarkdown()
       .filter((markdown) => {
         return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -372,6 +372,8 @@ function createRender(context) {
   return render;
 }
 
+// Taken from buildApiUtils and sligthly adjusted.
+// Returns all markdown pages specified in the docs/data directory.
 function findPagesMarkdown(
   directory = path.resolve(__dirname, '../../docs/data'),
   pagesMarkdown = [],
@@ -410,6 +412,7 @@ function findPagesMarkdown(
   return pagesMarkdown;
 }
 
+// Taken from buildApiUtils and sligthly adjusted.
 // Returns information about all pages containing demos
 // for the component or hook specified in the importName prop
 function findBaseDemos(importName, pagesMarkdown) {
@@ -421,6 +424,7 @@ function findBaseDemos(importName, pagesMarkdown) {
     }));
 }
 
+// Taken from buildApiUtils and sligthly adjusted.
 // Navigates trough the demos for the base components and creates
 // the API link for the specified name (component or hook)
 const getBaseApiPath = (demos, name) => {
@@ -445,6 +449,30 @@ const getBaseApiPath = (demos, name) => {
   return apiPath;
 };
 
+const migratedBaseComponents = [
+  'BadgeUnstyled',
+  'ButtonUnstyled',
+  'ClickAwayListener',
+  'FocusTrap',
+  'InputUnstyled',
+  'MenuItemUnstyled',
+  'MenuUnstyled',
+  'ModalUnstyled',
+  'NoSsr',
+  'OptionGroupUnstyled',
+  'OptionUnstyled',
+  'PopperUnstyled',
+  'Portal',
+  'SelectUnstyled',
+  'SliderUnstyled',
+  'SwitchUnstyled',
+  'TablePaginationUnstyled',
+  'TabPanelUnstyled',
+  'TabsListUnstyled',
+  'TabsUnstyled',
+  'TabUnstyled',
+];
+
 /**
  * @param {string} product
  * @example 'material'
@@ -465,7 +493,10 @@ function resolveApiUrl(product, packageName, importName) {
     // Once the docs for all products support tabs, this will need to be generalized for all products
     const allMarkdowns = findPagesMarkdown()
       .filter((markdown) => {
-        return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
+        if (migratedBaseComponents.some((component) => filename.includes(component))) {
+          return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
+        }
+        return true;
       })
       .map((markdown) => {
         const markdownContent = fs.readFileSync(markdown.filename, 'utf8');

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -562,7 +562,7 @@ ${headers.components
 
     product = product ?? headers.product;
 
-    const componentPkgMap = componentPackageMapping[product ?? product];
+    const componentPkgMap = componentPackageMapping[product];
     const componentPkg = componentPkgMap ? componentPkgMap[component] : null;
     return `- [\`<${component} />\`](${resolveApiUrl(product, componentPkg, component)})`;
   })
@@ -578,7 +578,7 @@ ${headers.hooks
     }
 
     product = product ?? headers.product;
-    const hookPkgMap = componentPackageMapping[headers.product];
+    const hookPkgMap = componentPackageMapping[product];
     const hookPkg = hookPkgMap ? hookPkgMap[hook] : null;
     return `- [\`${hook}\`](${resolveApiUrl(headers.product, hookPkg, hook)})`;
   })


### PR DESCRIPTION
**IMPORTANT NOTE:** This is a temporary fix, until the documentation for all products support the tabs API.

------

As we are removing the `Unstyled` suffix in the Base UI's components, we need to add support for namespace in the `components` header in the markdown files, as otherwise we will have conflicts in the components, for e.g. Tabs from @mui/material and Tabs from @mui/base.

This is needed in scenarios where Material UI components show the API of a Base UI's components in some of the components pages. I've also updated the generation of the links that point to Base UI's component to follow the new structure. To make this work, I needed to copy some utils from `@mui-internal/api-docs-builder` (I couldn't import the utils directly from here in the @mui/markdown as it is a commonjs module, while the  api-docs-utils is an ES module).
