### PR TITLE
[docs] Adjust the Material Icons page design and formatting

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -412,6 +412,9 @@ const Paper = styled(MuiPaper)(({ theme }) => ({
   alignItems: 'center',
   marginBottom: theme.spacing(2),
   width: '100%',
+  borderRadius: '12px',
+  border: '1px solid',
+  borderColor: theme.palette.divider,
 }));
 
 function formatNumber(value) {

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -399,9 +399,10 @@ DialogDetails.propTypes = {
   selectedIcon: PropTypes.object,
 };
 
-const Form = styled('form')(({ theme }) => ({
-  margin: theme.spacing(2, 0),
-}));
+const Form = styled('form')({
+  position: 'sticky',
+  top: 80,
+});
 
 const Paper = styled(MuiPaper)(({ theme }) => ({
   position: 'sticky',
@@ -538,9 +539,12 @@ export default function SearchIcons() {
   );
 
   return (
-    <Grid container sx={{ minHeight: 500 }}>
+    <Grid container sx={{ minHeight: 500, my: 2 }}>
       <Grid item xs={12} sm={3}>
         <Form>
+          <Typography fontWeight={500} sx={{ mb: 1 }}>
+            Filter the style
+          </Typography>
           <RadioGroup>
             {['Filled', 'Outlined', 'Rounded', 'Two tone', 'Sharp'].map(
               (currentTheme) => {
@@ -549,6 +553,7 @@ export default function SearchIcons() {
                     key={currentTheme}
                     control={
                       <Radio
+                        size="small"
                         checked={theme === currentTheme}
                         onChange={() => setTheme(currentTheme)}
                         value={currentTheme}

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -10,20 +10,23 @@ githubLabel: 'package: icons'
 
 <p class="description">2,100+ ready-to-use React Material Icons from the official website.</p>
 
-The following npm package,
-[@mui/icons-material](https://www.npmjs.com/package/@mui/icons-material),
-includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to [`SvgIcon`](/material-ui/api/svg-icon/) components.
+{{"component": "modules/components/ComponentLinkHeader.js"}}
+<br/>
 
-:::info
-The `@mui/icons-material` package depends on `@mui/material`, which requires Emotion packages.
-If you don't use Material UI in your project yet, install the icons package with:
-`npm install @mui/icons-material @mui/material @emotion/styled @emotion/react`.
+[@mui/icons-material](https://www.npmjs.com/package/@mui/icons-material)
+includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to [`SvgIcon`](/material-ui/api/svg-icon/) components.
+It depends on `@mui/material`, which requires Emotion packages.
+Use the following command to install it:
+
+```sh
+npm install @mui/icons-material @mui/material @emotion/styled @emotion/react
+```
 
 See the [Installation](/material-ui/getting-started/installation/) page for additional docs about how to make sure everything is set up correctly.
-:::
 
-{{"component": "modules/components/ComponentLinkHeader.js"}}
+<hr/>
+
+Browse through all the icons and find the one you need!
+The search below support synonyms－for example, try searching for "hamburger" or "logout".
 
 {{"demo": "SearchIcons.js", "hideToolbar": true, "bg": true}}
-
-ℹ️ The search supports synonyms. Try searching for "hamburger" or "logout".

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -27,6 +27,6 @@ See the [Installation](/material-ui/getting-started/installation/) page for addi
 <hr/>
 
 Browse through the icons below to find the one you need.
-The search below support synonyms－for example, try searching for "hamburger" or "logout".
+The search field supports synonyms—for example, try searching for "hamburger" or "logout."
 
 {{"demo": "SearchIcons.js", "hideToolbar": true, "bg": true}}

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -26,7 +26,7 @@ See the [Installation](/material-ui/getting-started/installation/) page for addi
 
 <hr/>
 
-Browse through all the icons and find the one you need!
+Browse through the icons below to find the one you need.
 The search below support synonyms－for example, try searching for "hamburger" or "logout".
 
 {{"demo": "SearchIcons.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -342,7 +342,7 @@ const Root = styled('div')(
     },
     '& hr': {
       height: 1,
-      margin: theme.spacing(6, 0),
+      margin: theme.spacing(5, 0),
       border: 0,
       flexShrink: 0,
       backgroundColor: `var(--muidocs-palette-divider, ${lightTheme.palette.divider})`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR does some copy/design/formatting adjustments to the Material Icons documentation page. I thought that the content on the current version was too tight, and the callout could be removed for less visual noise. Took advantage of the opportunity to do some light design tweaking as well ⎯ nothing big.

**👉 https://deploy-preview-36937--material-ui.netlify.app/material-ui/material-icons/**

| Before | After |
|--------|--------|
| <img width="1658" alt="Screen Shot 2023-04-19 at 10 24 22" src="https://user-images.githubusercontent.com/67129314/233089454-fc852f02-9bbd-4868-9ac0-e60bfd182c5f.png"> | <img width="1658" alt="Screen Shot 2023-04-19 at 10 24 19" src="https://user-images.githubusercontent.com/67129314/233089438-84b0fc6d-5d6d-4175-978f-0f413d41ec78.png"> | 



