### PR TITLE
[docs][material] Tabs API section cleanup

### DIFF
--- a/docs/data/material/components/tabs/tabs.md
+++ b/docs/data/material/components/tabs/tabs.md
@@ -1,7 +1,7 @@
 ---
 product: material-ui
 title: React Tabs component
-components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel, TabsUnstyled, TabUnstyled, TabPanelUnstyled, TabsListUnstyled
+components: Tabs, Tab, TabScrollButton, TabContext, TabList, TabPanel
 githubLabel: 'component: tabs'
 materialDesign: https://m2.material.io/components/tabs
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -53,23 +53,6 @@ test.describe('Material docs', () => {
       );
     });
 
-    test('should have correct API link to mui-base', async ({ page }) => {
-      await page.goto('/material-ui/react-tabs/');
-
-      await expect(page.locator('a[href="/base/api/tab-panel-unstyled/"]')).toContainText(
-        '<TabPanelUnstyled />',
-      );
-      await expect(page.locator('a[href="/base/api/tab-unstyled/"]')).toContainText(
-        '<TabUnstyled />',
-      );
-      await expect(page.locator('a[href="/base/api/tabs-list-unstyled/"]')).toContainText(
-        '<TabsListUnstyled />',
-      );
-      await expect(page.locator('a[href="/base/api/tabs-unstyled/"]')).toContainText(
-        '<TabsUnstyled />',
-      );
-    });
-
     test('should have correct link for sidebar anchor', async ({ page }) => {
       await page.goto('/material-ui/react-card/');
 


### PR DESCRIPTION
The tabs API already has an Unstyled section in the docs - https://mui.com/material-ui/react-tabs/#unstyled, no need to specify API for all Mateiral UI and Base UI APIs. There will be even more confusion once the name of the components are the same. This is left over from the time when we were documenting the Base UI's demos on the Material UI page. This is currently blocker for https://github.com/mui/material-ui/pull/36873.

I tried to see what it would take in order for the infra to support this one-off in https://github.com/mui/material-ui/pull/36936, but I don't think it's worth it.