### PR TITLE
[docs] Fix Chakra UI theme scoping typo

### DIFF
--- a/docs/data/material/guides/styled-engine/styled-engine.md
+++ b/docs/data/material/guides/styled-engine/styled-engine.md
@@ -180,7 +180,7 @@ function App() {
 Render Material UI's theme provider below Chakra UI's provider and assign the material theme to the `THEME_ID` property.
 
 ```js
-import { ChakraProvider, chakraExtendTheme } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme as chakraExtendTheme } from '@chakra-ui/react';
 import {
   ThemeProvider as MaterialThemeProvider,
   createTheme as muiCreateTheme,


### PR DESCRIPTION
Just fixing a small typo discovered when trying to repro https://github.com/mui/material-ui/issues/36910

Proof that it works: https://codesandbox.io/s/chakra-material-forked-qsbpog?file=/src/App.tsx

Closes #36910