### PR TITLE
[docs][base] Run removal of `component` prop codemod

### DIFF
--- a/docs/data/base/components/button/UnstyledButtonCustom.js
+++ b/docs/data/base/components/button/UnstyledButtonCustom.js
@@ -22,7 +22,15 @@ ButtonRoot.propTypes = {
 };
 
 const SvgButton = React.forwardRef(function SvgButton(props, ref) {
-  return <ButtonUnstyled {...props} component={CustomButtonRoot} ref={ref} />;
+  return (
+    <ButtonUnstyled
+      {...props}
+      slots={{
+        root: CustomButtonRoot,
+      }}
+      ref={ref}
+    />
+  );
 });
 
 export default function UnstyledButtonCustom() {

--- a/docs/data/base/components/button/UnstyledButtonCustom.tsx
+++ b/docs/data/base/components/button/UnstyledButtonCustom.tsx
@@ -26,7 +26,15 @@ const SvgButton = React.forwardRef(function SvgButton(
   props: ButtonUnstyledProps,
   ref: React.ForwardedRef<any>,
 ) {
-  return <ButtonUnstyled {...props} component={CustomButtonRoot} ref={ref} />;
+  return (
+    <ButtonUnstyled<typeof CustomButtonRoot>
+      {...props}
+      slots={{
+        root: CustomButtonRoot,
+      }}
+      ref={ref}
+    />
+  );
 });
 
 export default function UnstyledButtonCustom() {

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction.js
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction.js
@@ -87,10 +87,34 @@ export default function UnstyledSwitches() {
 
   return (
     <div>
-      <SwitchUnstyled component={Root} {...label} defaultChecked />
-      <SwitchUnstyled component={Root} {...label} />
-      <SwitchUnstyled component={Root} {...label} defaultChecked disabled />
-      <SwitchUnstyled component={Root} {...label} disabled />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+      />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+      />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+        disabled
+      />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        disabled
+      />
     </div>
   );
 }

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction.tsx
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction.tsx
@@ -87,10 +87,34 @@ export default function UnstyledSwitches() {
 
   return (
     <div>
-      <SwitchUnstyled component={Root} {...label} defaultChecked />
-      <SwitchUnstyled component={Root} {...label} />
-      <SwitchUnstyled component={Root} {...label} defaultChecked disabled />
-      <SwitchUnstyled component={Root} {...label} disabled />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+      />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+      />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+        disabled
+      />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        disabled
+      />
     </div>
   );
 }

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction.tsx.preview
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction.tsx.preview
@@ -1,4 +1,0 @@
-<SwitchUnstyled component={Root} {...label} defaultChecked />
-<SwitchUnstyled component={Root} {...label} />
-<SwitchUnstyled component={Root} {...label} defaultChecked disabled />
-<SwitchUnstyled component={Root} {...label} disabled />

--- a/docs/data/base/components/switch/UnstyledSwitches.js
+++ b/docs/data/base/components/switch/UnstyledSwitches.js
@@ -87,10 +87,34 @@ export default function UnstyledSwitches() {
 
   return (
     <div>
-      <SwitchUnstyled component={Root} {...label} defaultChecked />
-      <SwitchUnstyled component={Root} {...label} />
-      <SwitchUnstyled component={Root} {...label} defaultChecked disabled />
-      <SwitchUnstyled component={Root} {...label} disabled />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+      />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+      />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+        disabled
+      />
+      <SwitchUnstyled
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        disabled
+      />
     </div>
   );
 }

--- a/docs/data/base/components/switch/UnstyledSwitches.tsx
+++ b/docs/data/base/components/switch/UnstyledSwitches.tsx
@@ -87,10 +87,34 @@ export default function UnstyledSwitches() {
 
   return (
     <div>
-      <SwitchUnstyled component={Root} {...label} defaultChecked />
-      <SwitchUnstyled component={Root} {...label} />
-      <SwitchUnstyled component={Root} {...label} defaultChecked disabled />
-      <SwitchUnstyled component={Root} {...label} disabled />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+      />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+      />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        defaultChecked
+        disabled
+      />
+      <SwitchUnstyled<typeof Root>
+        slots={{
+          root: Root,
+        }}
+        {...label}
+        disabled
+      />
     </div>
   );
 }

--- a/docs/data/base/components/switch/UnstyledSwitches.tsx.preview
+++ b/docs/data/base/components/switch/UnstyledSwitches.tsx.preview
@@ -1,4 +1,0 @@
-<SwitchUnstyled component={Root} {...label} defaultChecked />
-<SwitchUnstyled component={Root} {...label} />
-<SwitchUnstyled component={Root} {...label} defaultChecked disabled />
-<SwitchUnstyled component={Root} {...label} disabled />

--- a/docs/data/base/guides/overriding-component-structure/OverridingRootSlot.js
+++ b/docs/data/base/guides/overriding-component-structure/OverridingRootSlot.js
@@ -2,5 +2,13 @@ import * as React from 'react';
 import ButtonUnstyled from '@mui/base/ButtonUnstyled';
 
 export default function DivButton() {
-  return <ButtonUnstyled component="div">Button</ButtonUnstyled>;
+  return (
+    <ButtonUnstyled
+      slots={{
+        root: 'div',
+      }}
+    >
+      Button
+    </ButtonUnstyled>
+  );
 }

--- a/docs/data/base/guides/overriding-component-structure/OverridingRootSlot.tsx
+++ b/docs/data/base/guides/overriding-component-structure/OverridingRootSlot.tsx
@@ -2,5 +2,13 @@ import * as React from 'react';
 import ButtonUnstyled from '@mui/base/ButtonUnstyled';
 
 export default function DivButton() {
-  return <ButtonUnstyled component="div">Button</ButtonUnstyled>;
+  return (
+    <ButtonUnstyled<'div'>
+      slots={{
+        root: 'div',
+      }}
+    >
+      Button
+    </ButtonUnstyled>
+  );
 }

--- a/docs/data/base/guides/overriding-component-structure/OverridingRootSlot.tsx.preview
+++ b/docs/data/base/guides/overriding-component-structure/OverridingRootSlot.tsx.preview
@@ -1,1 +1,7 @@
-<ButtonUnstyled component="div">Button</ButtonUnstyled>
+<ButtonUnstyled<'div'>
+  slots={{
+    root: 'div',
+  }}
+>
+  Button
+</ButtonUnstyled>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR has run the up-to-date codemod (https://github.com/mui/material-ui/pull/36952) in docs folder.

The failing tests can pass only after we merge https://github.com/mui/material-ui/pull/36974