### PR TITLE
[Joy] Add `invertedColors` to Menu and Alert

### DIFF
--- a/docs/data/joy/components/alert/AlertInvertedColors.js
+++ b/docs/data/joy/components/alert/AlertInvertedColors.js
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import Alert from '@mui/joy/Alert';
+import AspectRatio from '@mui/joy/AspectRatio';
+import IconButton from '@mui/joy/IconButton';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import CircularProgress from '@mui/joy/CircularProgress';
+import LinearProgress from '@mui/joy/LinearProgress';
+import Stack from '@mui/joy/Stack';
+import Typography from '@mui/joy/Typography';
+import Check from '@mui/icons-material/Check';
+import Close from '@mui/icons-material/Close';
+import Warning from '@mui/icons-material/Warning';
+
+export default function AlertBasic() {
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 400 }}>
+      <Alert
+        size="lg"
+        color="success"
+        variant="solid"
+        invertedColors
+        startDecorator={
+          <AspectRatio
+            variant="solid"
+            ratio="1"
+            sx={{
+              minWidth: 40,
+              borderRadius: '50%',
+              boxShadow: '0 2px 12px 0 rgb(0 0 0/0.2)',
+            }}
+          >
+            <div>
+              <Check fontSize="xl2" />
+            </div>
+          </AspectRatio>
+        }
+        endDecorator={
+          <IconButton
+            variant="plain"
+            sx={{
+              '--IconButton-size': '32px',
+              transform: 'translate(0.5rem, -0.5rem)',
+            }}
+          >
+            <Close />
+          </IconButton>
+        }
+        sx={{ alignItems: 'flex-start', overflow: 'hidden' }}
+      >
+        <Box>
+          <Typography level="body1" fontWeight="lg">
+            Success
+          </Typography>
+          <Typography level="body3">
+            Success is walking from failure to failure with no loss of enthusiam.
+          </Typography>
+        </Box>
+        <LinearProgress
+          variant="soft"
+          value={40}
+          sx={(theme) => ({
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            color: `rgb(${theme.vars.palette.success.lightChannel} / 0.72)`,
+            '--LinearProgress-radius': '0px',
+          })}
+        />
+      </Alert>
+
+      <Alert
+        variant="soft"
+        color="danger"
+        invertedColors
+        startDecorator={
+          <CircularProgress size="lg">
+            <Warning />
+          </CircularProgress>
+        }
+        sx={{ alignItems: 'flex-start', '--Alert-gap': '1rem' }}
+      >
+        <Box sx={{ flex: 1 }}>
+          <Typography sx={{ mt: 1 }}>
+            Network loss, please recheck your connection.
+          </Typography>
+          <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+            <Button variant="outlined" size="sm">
+              Open network setting
+            </Button>
+            <Button variant="soft" size="sm">
+              Okay
+            </Button>
+          </Box>
+        </Box>
+      </Alert>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/alert/AlertInvertedColors.tsx
+++ b/docs/data/joy/components/alert/AlertInvertedColors.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import Alert from '@mui/joy/Alert';
+import AspectRatio from '@mui/joy/AspectRatio';
+import IconButton from '@mui/joy/IconButton';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import CircularProgress from '@mui/joy/CircularProgress';
+import LinearProgress from '@mui/joy/LinearProgress';
+import Stack from '@mui/joy/Stack';
+import Typography from '@mui/joy/Typography';
+import Check from '@mui/icons-material/Check';
+import Close from '@mui/icons-material/Close';
+import Warning from '@mui/icons-material/Warning';
+
+export default function AlertBasic() {
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 400 }}>
+      <Alert
+        size="lg"
+        color="success"
+        variant="solid"
+        invertedColors
+        startDecorator={
+          <AspectRatio
+            variant="solid"
+            ratio="1"
+            sx={{
+              minWidth: 40,
+              borderRadius: '50%',
+              boxShadow: '0 2px 12px 0 rgb(0 0 0/0.2)',
+            }}
+          >
+            <div>
+              <Check fontSize="xl2" />
+            </div>
+          </AspectRatio>
+        }
+        endDecorator={
+          <IconButton
+            variant="plain"
+            sx={{
+              '--IconButton-size': '32px',
+              transform: 'translate(0.5rem, -0.5rem)',
+            }}
+          >
+            <Close />
+          </IconButton>
+        }
+        sx={{ alignItems: 'flex-start', overflow: 'hidden' }}
+      >
+        <Box>
+          <Typography level="body1" fontWeight="lg">
+            Success
+          </Typography>
+          <Typography level="body3">
+            Success is walking from failure to failure with no loss of enthusiam.
+          </Typography>
+        </Box>
+        <LinearProgress
+          variant="soft"
+          value={40}
+          sx={(theme) => ({
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            color: `rgb(${theme.vars.palette.success.lightChannel} / 0.72)`,
+            '--LinearProgress-radius': '0px',
+          })}
+        />
+      </Alert>
+
+      <Alert
+        variant="soft"
+        color="danger"
+        invertedColors
+        startDecorator={
+          <CircularProgress size="lg">
+            <Warning />
+          </CircularProgress>
+        }
+        sx={{ alignItems: 'flex-start', '--Alert-gap': '1rem' }}
+      >
+        <Box sx={{ flex: 1 }}>
+          <Typography sx={{ mt: 1 }}>
+            Network loss, please recheck your connection.
+          </Typography>
+          <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+            <Button variant="outlined" size="sm">
+              Open network setting
+            </Button>
+            <Button variant="soft" size="sm">
+              Okay
+            </Button>
+          </Box>
+        </Box>
+      </Alert>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/alert/alert.md
+++ b/docs/data/joy/components/alert/alert.md
@@ -69,6 +69,12 @@ Use the `startDecorator` and `endDecorator` props to append actions and icons to
 
 {{"demo": "AlertWithDecorators.js"}}
 
+### Inverted colors
+
+The Alert component supports Joy UI's [color inversion](/joy-ui/main-features/color-inversion/) by using `invertedColors` prop.
+
+{{"demo": "AlertInvertedColors.js"}}
+
 ## Common examples
 
 ### Various states

--- a/docs/data/joy/components/menu/AppsMenu.js
+++ b/docs/data/joy/components/menu/AppsMenu.js
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import Avatar from '@mui/joy/Avatar';
+import Box from '@mui/joy/Box';
+import ListItemDecorator from '@mui/joy/ListItemDecorator';
+import IconButton from '@mui/joy/IconButton';
+import Menu from '@mui/joy/Menu';
+import MenuItem from '@mui/joy/MenuItem';
+import Apps from '@mui/icons-material/Apps';
+
+export default function AppsMenu() {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  return (
+    <Box>
+      <IconButton
+        id="apps-menu-demo"
+        aria-label="Applications"
+        aria-controls={open ? 'apps-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        variant="plain"
+        color="neutral"
+        onClick={handleClick}
+        sx={{ borderRadius: 40 }}
+      >
+        <Apps />
+      </IconButton>
+      <Menu
+        id="apps-menu"
+        variant="solid"
+        invertedColors
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="apps-menu-demo"
+        sx={{
+          '--List-padding': '0.5rem',
+          '--ListItemDecorator-size': '3rem',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 100px)',
+          gridAutoRows: '100px',
+          gap: 1,
+        }}
+      >
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>S</Avatar>
+          </ListItemDecorator>
+          Search
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>M</Avatar>
+          </ListItemDecorator>
+          Maps
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>M</Avatar>
+          </ListItemDecorator>
+          Mail
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>D</Avatar>
+          </ListItemDecorator>
+          Drive
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>C</Avatar>
+          </ListItemDecorator>
+          Calendar
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/menu/AppsMenu.tsx
+++ b/docs/data/joy/components/menu/AppsMenu.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import Avatar from '@mui/joy/Avatar';
+import Box from '@mui/joy/Box';
+import ListItemDecorator from '@mui/joy/ListItemDecorator';
+import IconButton from '@mui/joy/IconButton';
+import Menu from '@mui/joy/Menu';
+import MenuItem from '@mui/joy/MenuItem';
+import Apps from '@mui/icons-material/Apps';
+
+export default function AppsMenu() {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  return (
+    <Box>
+      <IconButton
+        id="apps-menu-demo"
+        aria-label="Applications"
+        aria-controls={open ? 'apps-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        variant="plain"
+        color="neutral"
+        onClick={handleClick}
+        sx={{ borderRadius: 40 }}
+      >
+        <Apps />
+      </IconButton>
+      <Menu
+        id="apps-menu"
+        variant="solid"
+        invertedColors
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="apps-menu-demo"
+        sx={{
+          '--List-padding': '0.5rem',
+          '--ListItemDecorator-size': '3rem',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 100px)',
+          gridAutoRows: '100px',
+          gap: 1,
+        }}
+      >
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>S</Avatar>
+          </ListItemDecorator>
+          Search
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>M</Avatar>
+          </ListItemDecorator>
+          Maps
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>M</Avatar>
+          </ListItemDecorator>
+          Mail
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>D</Avatar>
+          </ListItemDecorator>
+          Drive
+        </MenuItem>
+        <MenuItem orientation="vertical" onClick={handleClose}>
+          <ListItemDecorator>
+            <Avatar>C</Avatar>
+          </ListItemDecorator>
+          Calendar
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+}

--- a/docs/data/joy/components/menu/MenuUsage.js
+++ b/docs/data/joy/components/menu/MenuUsage.js
@@ -53,6 +53,14 @@ export default function MenuUsage() {
           defaultValue: 'md',
         },
         {
+          propName: 'open',
+          knob: 'controlled',
+        },
+        {
+          propName: 'invertedColors',
+          knob: 'switch',
+        },
+        {
           propName: 'children',
           defaultValue: '<MenuItem>...</MenuItem>',
         },
@@ -77,6 +85,10 @@ export default function MenuUsage() {
             id="menu-usage-demo"
             anchorEl={anchorEl}
             open={open}
+            {...(typeof props.open === 'boolean' && {
+              open: props.open,
+              anchorEl: buttonRef.current,
+            })}
             onClose={handleClose}
             slotProps={{
               listbox: {

--- a/docs/data/joy/components/menu/menu.md
+++ b/docs/data/joy/components/menu/menu.md
@@ -98,6 +98,12 @@ You can also access this option by using [command menu and search for it](https:
 
 ## Common examples
 
+### Apps menu
+
+This example replicates a menu that contain links to other applications.
+
+{{"demo": "AppsMenu.js"}}
+
 ### Menu bar
 
 This example replicates the application menu bar on macOS.

--- a/docs/pages/joy-ui/api/alert.json
+++ b/docs/pages/joy-ui/api/alert.json
@@ -9,6 +9,7 @@
     },
     "component": { "type": { "name": "elementType" } },
     "endDecorator": { "type": { "name": "node" } },
+    "invertedColors": { "type": { "name": "bool" }, "default": "false" },
     "role": { "type": { "name": "string" }, "default": "'alert'" },
     "size": {
       "type": {

--- a/docs/pages/joy-ui/api/menu-item.json
+++ b/docs/pages/joy-ui/api/menu-item.json
@@ -8,6 +8,10 @@
       },
       "default": "selected ? 'primary' : 'neutral'"
     },
+    "orientation": {
+      "type": { "name": "enum", "description": "'horizontal'<br>&#124;&nbsp;'vertical'" },
+      "default": "'horizontal'"
+    },
     "selected": { "type": { "name": "bool" }, "default": "false" },
     "slotProps": {
       "type": { "name": "shape", "description": "{ root?: func<br>&#124;&nbsp;object }" },

--- a/docs/pages/joy-ui/api/menu.json
+++ b/docs/pages/joy-ui/api/menu.json
@@ -11,6 +11,7 @@
     },
     "component": { "type": { "name": "elementType" } },
     "disablePortal": { "type": { "name": "bool" }, "default": "false" },
+    "invertedColors": { "type": { "name": "bool" }, "default": "false" },
     "keepMounted": { "type": { "name": "bool" }, "default": "false" },
     "modifiers": {
       "type": {

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -69,7 +69,8 @@ function createCode(
             typeof prop[1] === 'number' ? `{${prop[1]}}` : `"${prop[1]}"`
           }`;
         }
-      } else {
+      }
+      if (prop[0] === 'children') {
         children = prop[1] as string;
       }
     });

--- a/docs/translations/api-docs-joy/alert/alert.json
+++ b/docs/translations/api-docs-joy/alert/alert.json
@@ -4,6 +4,7 @@
     "color": "The color of the component. It supports those theme colors that make sense for this component. To learn how to add your own colors, check out <a href=\"/joy-ui/customization/themed-components/#extend-colors\">Themed components—Extend colors</a>.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "endDecorator": "Element placed after the children.",
+    "invertedColors": "If <code>true</code>, the children with an implicit color prop invert their colors to match the component&#39;s variant and color.",
     "role": "The ARIA role attribute of the element.",
     "size": "The size of the component. To learn how to add custom sizes to the component, check out <a href=\"/joy-ui/customization/themed-components/#extend-sizes\">Themed components—Extend sizes</a>.",
     "slotProps": "The props used for each slot inside.",

--- a/docs/translations/api-docs-joy/menu-item/menu-item.json
+++ b/docs/translations/api-docs-joy/menu-item/menu-item.json
@@ -3,6 +3,7 @@
   "propDescriptions": {
     "children": "The content of the component.",
     "color": "The color of the component. It supports those theme colors that make sense for this component. To learn how to add your own colors, check out <a href=\"/joy-ui/customization/themed-components/#extend-colors\">Themed components—Extend colors</a>.",
+    "orientation": "The content direction flow.",
     "selected": "If <code>true</code>, the component is selected.",
     "slotProps": "The props used for each slot inside.",
     "slots": "The components used for each slot inside. See <a href=\"#slots\">Slots API</a> below for more details.",

--- a/docs/translations/api-docs-joy/menu/menu.json
+++ b/docs/translations/api-docs-joy/menu/menu.json
@@ -6,6 +6,7 @@
     "color": "The color of the component. It supports those theme colors that make sense for this component. To learn how to add your own colors, check out <a href=\"/joy-ui/customization/themed-components/#extend-colors\">Themed components—Extend colors</a>.",
     "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "disablePortal": "The <code>children</code> will be under the DOM hierarchy of the parent component.",
+    "invertedColors": "If <code>true</code>, the children with an implicit color prop invert their colors to match the component&#39;s variant and color.",
     "keepMounted": "Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Popper.",
     "modifiers": "Popper.js is based on a &quot;plugin-like&quot; architecture, most of its features are fully encapsulated &quot;modifiers&quot;.<br>A modifier is a function that is called each time Popper.js needs to compute the position of the popper. For this reason, modifiers should be very performant to avoid bottlenecks. To learn how to create a modifier, <a href=\"https://popper.js.org/docs/v2/modifiers/\">read the modifiers documentation</a>.",
     "onClose": "Triggered when focus leaves the menu and the menu should close.",

--- a/packages/mui-joy/src/Alert/Alert.tsx
+++ b/packages/mui-joy/src/Alert/Alert.tsx
@@ -222,6 +222,11 @@ Alert.propTypes /* remove-proptypes */ = {
    */
   endDecorator: PropTypes.node,
   /**
+   * If `true`, the children with an implicit color prop invert their colors to match the component's variant and color.
+   * @default false
+   */
+  invertedColors: PropTypes.bool,
+  /**
    * The ARIA role attribute of the element.
    * @default 'alert'
    */

--- a/packages/mui-joy/src/Alert/Alert.tsx
+++ b/packages/mui-joy/src/Alert/Alert.tsx
@@ -175,20 +175,24 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
   });
 
   const result = (
-    <SlotRoot {...rootProps}>
+    <React.Fragment>
       {startDecorator && (
         <SlotStartDecorator {...startDecoratorProps}>{startDecorator}</SlotStartDecorator>
       )}
-
       {children}
       {endDecorator && <SlotEndDecorator {...endDecoratorProps}>{endDecorator}</SlotEndDecorator>}
-    </SlotRoot>
+    </React.Fragment>
   );
 
-  if (invertedColors) {
-    return <ColorInversionProvider variant={variant}>{result}</ColorInversionProvider>;
-  }
-  return result;
+  return (
+    <SlotRoot {...rootProps}>
+      {invertedColors ? (
+        <ColorInversionProvider variant={variant}>{result}</ColorInversionProvider>
+      ) : (
+        result
+      )}
+    </SlotRoot>
+  );
 }) as OverridableComponent<AlertTypeMap>;
 
 Alert.propTypes /* remove-proptypes */ = {

--- a/packages/mui-joy/src/Alert/Alert.tsx
+++ b/packages/mui-joy/src/Alert/Alert.tsx
@@ -6,7 +6,7 @@ import { OverridableComponent } from '@mui/types';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
-import { useColorInversion } from '../styles/ColorInversion';
+import { ColorInversionProvider, useColorInversion } from '../styles/ColorInversion';
 import useSlot from '../utils/useSlot';
 import { getAlertUtilityClass } from './alertClasses';
 import { AlertProps, AlertOwnerState, AlertTypeMap } from './AlertProps';
@@ -32,46 +32,52 @@ const AlertRoot = styled('div', {
   name: 'JoyAlert',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: AlertOwnerState }>(({ theme, ownerState }) => ({
-  '--Alert-radius': theme.vars.radius.sm,
-  '--Alert-decoratorChildRadius':
-    'max((var(--Alert-radius) - var(--variant-borderWidth, 0px)) - var(--Alert-padding), min(var(--Alert-padding) + var(--variant-borderWidth, 0px), var(--Alert-radius) / 2))',
-  '--Button-minHeight': 'var(--Alert-decoratorChildHeight)',
-  '--IconButton-size': 'var(--Alert-decoratorChildHeight)',
-  '--Button-radius': 'var(--Alert-decoratorChildRadius)',
-  '--IconButton-radius': 'var(--Alert-decoratorChildRadius)',
-  ...(ownerState.size === 'sm' && {
-    '--Alert-padding': '0.5rem',
-    '--Alert-gap': '0.375rem',
-    '--Alert-decoratorChildHeight': '1.5rem',
-    '--Icon-fontSize': '1.125rem',
-    fontSize: theme.vars.fontSize.sm,
-  }),
-  ...(ownerState.size === 'md' && {
-    '--Alert-padding': '0.75rem',
-    '--Alert-gap': '0.5rem',
-    '--Alert-decoratorChildHeight': '2rem',
-    '--Icon-fontSize': '1.25rem',
-    fontSize: theme.vars.fontSize.sm,
-    fontWeight: theme.vars.fontWeight.md,
-  }),
-  ...(ownerState.size === 'lg' && {
-    '--Alert-padding': '1rem',
-    '--Alert-gap': '0.75rem',
-    '--Alert-decoratorChildHeight': '2.375rem',
-    '--Icon-fontSize': '1.5rem',
-    fontSize: theme.vars.fontSize.md,
-    fontWeight: theme.vars.fontWeight.md,
-  }),
-  fontFamily: theme.vars.fontFamily.body,
-  lineHeight: theme.vars.lineHeight.md,
-  backgroundColor: 'transparent',
-  display: 'flex',
-  alignItems: 'center',
-  padding: `var(--Alert-padding)`,
-  borderRadius: 'var(--Alert-radius)',
-  ...theme.variants[ownerState.variant!]?.[ownerState.color!],
-}));
+})<{ ownerState: AlertOwnerState }>(({ theme, ownerState }) => [
+  {
+    '--Alert-radius': theme.vars.radius.sm,
+    '--Alert-decoratorChildRadius':
+      'max((var(--Alert-radius) - var(--variant-borderWidth, 0px)) - var(--Alert-padding), min(var(--Alert-padding) + var(--variant-borderWidth, 0px), var(--Alert-radius) / 2))',
+    '--Button-minHeight': 'var(--Alert-decoratorChildHeight)',
+    '--IconButton-size': 'var(--Alert-decoratorChildHeight)',
+    '--Button-radius': 'var(--Alert-decoratorChildRadius)',
+    '--IconButton-radius': 'var(--Alert-decoratorChildRadius)',
+    ...(ownerState.size === 'sm' && {
+      '--Alert-padding': '0.5rem',
+      '--Alert-gap': '0.375rem',
+      '--Alert-decoratorChildHeight': '1.5rem',
+      '--Icon-fontSize': '1.125rem',
+      fontSize: theme.vars.fontSize.sm,
+    }),
+    ...(ownerState.size === 'md' && {
+      '--Alert-padding': '0.75rem',
+      '--Alert-gap': '0.5rem',
+      '--Alert-decoratorChildHeight': '2rem',
+      '--Icon-fontSize': '1.25rem',
+      fontSize: theme.vars.fontSize.sm,
+      fontWeight: theme.vars.fontWeight.md,
+    }),
+    ...(ownerState.size === 'lg' && {
+      '--Alert-padding': '1rem',
+      '--Alert-gap': '0.75rem',
+      '--Alert-decoratorChildHeight': '2.375rem',
+      '--Icon-fontSize': '1.5rem',
+      fontSize: theme.vars.fontSize.md,
+      fontWeight: theme.vars.fontWeight.md,
+    }),
+    fontFamily: theme.vars.fontFamily.body,
+    lineHeight: theme.vars.lineHeight.md,
+    backgroundColor: 'transparent',
+    display: 'flex',
+    position: 'relative',
+    alignItems: 'center',
+    padding: `var(--Alert-padding)`,
+    borderRadius: 'var(--Alert-radius)',
+    ...theme.variants[ownerState.variant!]?.[ownerState.color!],
+  },
+  ownerState.color !== 'context' &&
+    ownerState.invertedColors &&
+    theme.colorInversion[ownerState.variant!]?.[ownerState.color!],
+]);
 
 const AlertStartDecorator = styled('span', {
   name: 'JoyAlert',
@@ -119,6 +125,7 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
     children,
     className,
     color: colorProp = 'primary',
+    invertedColors = false,
     role = 'alert',
     variant = 'soft',
     size = 'md',
@@ -167,7 +174,7 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
     ownerState,
   });
 
-  return (
+  const result = (
     <SlotRoot {...rootProps}>
       {startDecorator && (
         <SlotStartDecorator {...startDecoratorProps}>{startDecorator}</SlotStartDecorator>
@@ -177,6 +184,11 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
       {endDecorator && <SlotEndDecorator {...endDecoratorProps}>{endDecorator}</SlotEndDecorator>}
     </SlotRoot>
   );
+
+  if (invertedColors) {
+    return <ColorInversionProvider variant={variant}>{result}</ColorInversionProvider>;
+  }
+  return result;
 }) as OverridableComponent<AlertTypeMap>;
 
 Alert.propTypes /* remove-proptypes */ = {

--- a/packages/mui-joy/src/Alert/Alert.tsx
+++ b/packages/mui-joy/src/Alert/Alert.tsx
@@ -179,6 +179,7 @@ const Alert = React.forwardRef(function Alert(inProps, ref) {
       {startDecorator && (
         <SlotStartDecorator {...startDecoratorProps}>{startDecorator}</SlotStartDecorator>
       )}
+
       {children}
       {endDecorator && <SlotEndDecorator {...endDecoratorProps}>{endDecorator}</SlotEndDecorator>}
     </React.Fragment>

--- a/packages/mui-joy/src/Alert/AlertProps.ts
+++ b/packages/mui-joy/src/Alert/AlertProps.ts
@@ -49,6 +49,11 @@ export interface AlertTypeMap<P = {}, D extends React.ElementType = 'div'> {
        */
       endDecorator?: React.ReactNode;
       /**
+       * If `true`, the children with an implicit color prop invert their colors to match the component's variant and color.
+       * @default false
+       */
+      invertedColors?: boolean;
+      /**
        * The ARIA role attribute of the element.
        * @default 'alert'
        */

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.tsx
@@ -53,8 +53,13 @@ export const StyledListItemButton = styled('div')<{ ownerState: ListItemButtonOw
       boxSizing: 'border-box',
       position: 'relative',
       display: 'flex',
-      flexDirection: ownerState.orientation === 'vertical' ? 'column' : 'row',
+      flexDirection: 'row',
       alignItems: 'center',
+      alignSelf: 'stretch', // always stretch itself to fill the parent (List|ListItem)
+      ...(ownerState.orientation === 'vertical' && {
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }),
       textAlign: 'initial',
       textDecoration: 'initial', // reset native anchor tag
       backgroundColor: 'initial', // reset button background

--- a/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
+++ b/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.tsx
@@ -24,14 +24,15 @@ const ListItemDecoratorRoot = styled('span', {
 })<{ ownerState: ListItemDecoratorOwnerState }>(({ ownerState }) => ({
   boxSizing: 'border-box',
   display: 'inline-flex',
-  alignItems: 'center',
   color: `var(--ListItemDecorator-color)`,
   ...(ownerState.parentOrientation === 'horizontal'
     ? {
         minInlineSize: 'var(--ListItemDecorator-size)',
+        alignItems: 'center',
       }
     : {
         minBlockSize: 'var(--ListItemDecorator-size)',
+        justifyContent: 'center',
       }),
 }));
 /**

--- a/packages/mui-joy/src/Menu/Menu.tsx
+++ b/packages/mui-joy/src/Menu/Menu.tsx
@@ -244,6 +244,11 @@ Menu.propTypes /* remove-proptypes */ = {
    */
   id: PropTypes.string,
   /**
+   * If `true`, the children with an implicit color prop invert their colors to match the component's variant and color.
+   * @default false
+   */
+  invertedColors: PropTypes.bool,
+  /**
    * Always keep the children in the DOM.
    * This prop can be useful in SEO situation or
    * when you want to maximize the responsiveness of the Popper.

--- a/packages/mui-joy/src/Menu/Menu.tsx
+++ b/packages/mui-joy/src/Menu/Menu.tsx
@@ -170,7 +170,19 @@ const Menu = React.forwardRef(function Menu(inProps, ref: React.ForwardedRef<HTM
     className: classes.root,
   });
 
-  const result = (
+  let result = (
+    <MenuProvider value={contextValue}>
+      <GroupListContext.Provider value="menu">
+        <ListProvider nested>{children}</ListProvider>
+      </GroupListContext.Provider>
+    </MenuProvider>
+  );
+
+  if (invertedColors) {
+    result = <ColorInversionProvider variant={variant}>{result}</ColorInversionProvider>;
+  }
+
+  result = (
     <MenuRoot
       {...rootProps}
       {...(!props.slots?.root && {
@@ -180,17 +192,9 @@ const Menu = React.forwardRef(function Menu(inProps, ref: React.ForwardedRef<HTM
         },
       })}
     >
-      <MenuProvider value={contextValue}>
-        <GroupListContext.Provider value="menu">
-          <ListProvider nested>{children}</ListProvider>
-        </GroupListContext.Provider>
-      </MenuProvider>
+      {result}
     </MenuRoot>
   );
-
-  if (invertedColors) {
-    return <ColorInversionProvider variant={variant}>{result}</ColorInversionProvider>;
-  }
 
   return disablePortal ? (
     result

--- a/packages/mui-joy/src/Menu/MenuProps.ts
+++ b/packages/mui-joy/src/Menu/MenuProps.ts
@@ -41,6 +41,11 @@ export interface MenuTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      */
     color?: OverridableStringUnion<ColorPaletteProp, MenuPropsColorOverrides>;
     /**
+     * If `true`, the children with an implicit color prop invert their colors to match the component's variant and color.
+     * @default false
+     */
+    invertedColors?: boolean;
+    /**
      * Triggered when focus leaves the menu and the menu should close.
      */
     onClose?: () => void;

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -9,6 +9,7 @@ import { useColorInversion } from '../styles/ColorInversion';
 import { getMenuItemUtilityClass } from './menuItemClasses';
 import { MenuItemOwnerState, ExtendMenuItem, MenuItemTypeMap } from './MenuItemProps';
 import RowListContext from '../List/RowListContext';
+import ListItemButtonOrientationContext from '../ListItemButton/ListItemButtonOrientationContext';
 import useSlot from '../utils/useSlot';
 
 const useUtilityClasses = (ownerState: MenuItemOwnerState) => {
@@ -59,6 +60,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     component = 'li',
     selected = false,
     color: colorProp = selected ? 'primary' : 'neutral',
+    orientation = 'horizontal',
     variant = 'plain',
     slots = {},
     slotProps = {},
@@ -78,6 +80,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     color,
     disabled,
     focusVisible,
+    orientation,
     selected,
     row,
     variant,
@@ -95,7 +98,11 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     ownerState,
   });
 
-  return <SlotRoot {...rootProps}>{children}</SlotRoot>;
+  return (
+    <ListItemButtonOrientationContext.Provider value={orientation}>
+      <SlotRoot {...rootProps}>{children}</SlotRoot>
+    </ListItemButtonOrientationContext.Provider>
+  );
 }) as ExtendMenuItem<MenuItemTypeMap>;
 
 MenuItem.propTypes /* remove-proptypes */ = {

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -131,6 +131,11 @@ MenuItem.propTypes /* remove-proptypes */ = {
    */
   disabled: PropTypes.bool,
   /**
+   * The content direction flow.
+   * @default 'horizontal'
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
    * If `true`, the component is selected.
    * @default false
    */

--- a/packages/mui-joy/src/styles/ColorInversion.tsx
+++ b/packages/mui-joy/src/styles/ColorInversion.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useTheme as useSystemTheme } from '@mui/system';
+import { useTheme } from './ThemeProvider';
 import defaultTheme from './defaultTheme';
 import { ColorPaletteProp, VariantProp } from './types';
 
@@ -35,7 +35,7 @@ interface ColorInversionProviderProps {
 }
 
 export function ColorInversionProvider({ children, variant }: ColorInversionProviderProps) {
-  const theme = useSystemTheme(defaultTheme);
+  const theme = useTheme();
   return (
     <ColorInversion.Provider
       value={

--- a/packages/mui-joy/src/styles/variantUtils.ts
+++ b/packages/mui-joy/src/styles/variantUtils.ts
@@ -282,8 +282,8 @@ export const createSoftInversion = (
           [prefixVar('--palette-divider')]: `rgba(${getCssVar(
             `palette-${color}-mainChannel`,
           )} / 0.32)`,
-          '--variant-plainColor': `rgba(${getCssVar(`palette-${color}-mainChannel`)} / 1)`,
-          '--variant-plainHoverColor': getCssVar(`palette-${color}-600`),
+          '--variant-plainColor': `rgba(${getCssVar(`palette-${color}-darkChannel`)} / 0.8)`,
+          '--variant-plainHoverColor': `rgba(${getCssVar(`palette-${color}-darkChannel`)} / 1)`,
           '--variant-plainHoverBg': `rgba(${getCssVar(`palette-${color}-mainChannel`)} / 0.12)`,
           '--variant-plainActiveBg': `rgba(${getCssVar(`palette-${color}-mainChannel`)} / 0.24)`,
           '--variant-plainDisabledColor': `rgba(${getCssVar(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

There are real-world examples of the Menu and Alert that use color inversion.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/18292247/233906968-5e3d53ce-9984-48f9-a4a0-9b4621cbb400.png">

<img width="812" alt="image" src="https://user-images.githubusercontent.com/18292247/233907215-5003fc27-16df-4ba9-84d1-37fe584806d3.png">


closes #36876

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
