### PR TITLE
[docs] Fix console error introduced by #36408

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -285,7 +285,7 @@ AppNavDrawerItem.propTypes = {
   comingSoon: PropTypes.bool,
   depth: PropTypes.number.isRequired,
   href: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  icon: PropTypes.string,
+  icon: PropTypes.elementType,
   legacy: PropTypes.bool,
   linkProps: PropTypes.object,
   newFeature: PropTypes.bool,


### PR DESCRIPTION
From https://github.com/mui/material-ui/pull/36408#issuecomment-1519063829

I moved to the solution discouraging the use of the string API since it's not used anymore, and could be removed when other MUI projects stop using it
