### PR TITLE
[Docs] Paper Hover effect animation guide

### DIFF
--- a/docs/data/material/components/paper/HoverEffect.js
+++ b/docs/data/material/components/paper/HoverEffect.js
@@ -10,6 +10,7 @@ export default function SimplePaper() {
         display: 'flex',
         flexWrap: 'wrap',
         textAlign: 'center',
+        cursor: 'pointer',
         '& > :not(style)': {
           m: 1,
           p: 2,

--- a/docs/data/material/components/paper/HoverEffect.js
+++ b/docs/data/material/components/paper/HoverEffect.js
@@ -23,7 +23,7 @@ export default function SimplePaper() {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {isHovered ? 'Hovering' : 'Hover over me'}
+        {isHovered ? 'Hovering' : 'Hover me'}
       </Paper>
     </Box>
   );

--- a/docs/data/material/components/paper/HoverEffect.js
+++ b/docs/data/material/components/paper/HoverEffect.js
@@ -10,7 +10,6 @@ export default function SimplePaper() {
         display: 'flex',
         flexWrap: 'wrap',
         textAlign: 'center',
-        cursor: 'pointer',
         '& > :not(style)': {
           m: 1,
           p: 2,

--- a/docs/data/material/components/paper/HoverEffect.js
+++ b/docs/data/material/components/paper/HoverEffect.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+
+export default function SimplePaper() {
+  const [isHovered, setIsHovered] = React.useState(false);
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        textAlign: 'center',
+        '& > :not(style)': {
+          m: 1,
+          p: 2,
+          width: 128,
+          height: 128,
+        },
+      }}
+    >
+      <Paper
+        elevation={isHovered ? 12 : 2}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        {isHovered ? 'Hovering' : 'Not hovering'}
+      </Paper>
+    </Box>
+  );
+}

--- a/docs/data/material/components/paper/HoverEffect.js
+++ b/docs/data/material/components/paper/HoverEffect.js
@@ -23,7 +23,7 @@ export default function SimplePaper() {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {isHovered ? 'Hovering' : 'Not hovering'}
+        {isHovered ? 'Hovering' : 'Hover over me'}
       </Paper>
     </Box>
   );

--- a/docs/data/material/components/paper/paper.md
+++ b/docs/data/material/components/paper/paper.md
@@ -36,10 +36,14 @@ To ignore the shading and set the background color that is not affected by eleva
 
 ## Hover Animations
 
-We can Elevate the Paper on mouse Hover by having a simple onHover state and our Elevation Prop
+If you want to add a hover effect to a Paper component, you can use the `onMouseEnter` and `onMouseLeave` props to toggle the component's elevation. This can create a simple but effective animation that elevates the Paper when the user hovers over it.
+
+To achieve this, you can create a state called `isHovered` and set it to `false` by default. Then, in the `onMouseEnter` event, you can set `isHovered` to true, and in the `onMouseLeave` event, you can set it back to `false`.
+
+Here's an example of how you can implement this in a HoverEffect component:
 
 {{"demo": "HoverEffect.js", "bg": "true"}}
 
-Here we are creating a state called `isHovered` and setting it to false by default and `onMouseEnter` we are setting
-it as true and `onMouseLeave` we are again setting it to false to revert it back to the default state, we can pass
-`onMouseEnter` and `onMouseLeave` directly to the Paper Component
+In this example, the elevation prop is set to 2 by default and 12 when the `isHovered` state is `true`. This will make the Paper component appear elevated when the user hovers over it.
+
+You can customize the elevation values to achieve the desired effect. Additionally, you can add other CSS styles to the Paper component to further enhance the hover animation.

--- a/docs/data/material/components/paper/paper.md
+++ b/docs/data/material/components/paper/paper.md
@@ -33,3 +33,13 @@ The elevation can be used to establish a hierarchy between other content. In pra
 The change of shade in dark mode is done by applying a semi-transparent gradient to the `background-image` property.
 This can lead to confusion when overriding the styles of `Paper`, as setting just the `background-color` property will not affect the elevation-related shading.
 To ignore the shading and set the background color that is not affected by elevation in dark mode, override the `background` property (or both `background-color` and `background-image`).
+
+## Hover Animations
+
+We can Elevate the Paper on mouse Hover by having a simple onHover state and our Elevation Prop
+
+{{"demo": "HoverEffect.js", "bg": "true"}}
+
+Here we are creating a state called `isHovered` and setting it to false by default and `onMouseEnter` we are setting
+it as true and `onMouseLeave` we are again setting it to false to revert it back to the default state, we can pass
+`onMouseEnter` and `onMouseLeave` directly to the Paper Component


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Description:

This pull request adds a simple hover effect to the Paper component in a new HoverEffect component. When the user hovers over the Paper, it elevates slightly, creating a subtle but effective animation.

Changes Made:

Added a new HoverEffect component that implements the hover effect.
Created a state called isHovered to track the hover state.
Implemented the onMouseEnter and onMouseLeave events to toggle the isHovered state and update the Paper's elevation prop.
Added a demo in the HoverEffect.js file to showcase the hover effect.

Added Explanations an implementation on Paper Docs

Screenshots:

https://user-images.githubusercontent.com/41958072/233986973-917e7e9e-5c80-4a7c-b066-dc2b7c56a657.mov



