### PR TITLE
[Dialog] Fixed issue with screen reader not narrating role of dialog once the dialog is displayed

### DIFF
--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -269,7 +269,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
             as={PaperComponent}
             elevation={24}
             role="dialog"
-            // aria-modal="true"
+            aria-modal="true"
             aria-describedby={ariaDescribedby}
             aria-labelledby={ariaLabelledby}
             {...PaperProps}

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -269,7 +269,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
             as={PaperComponent}
             elevation={24}
             role="dialog"
-            aria-modal="true"
+            // aria-modal="true"
             aria-describedby={ariaDescribedby}
             aria-labelledby={ariaLabelledby}
             {...PaperProps}

--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -269,6 +269,7 @@ const Dialog = React.forwardRef(function Dialog(inProps, ref) {
             as={PaperComponent}
             elevation={24}
             role="dialog"
+            aria-modal="true"
             aria-describedby={ariaDescribedby}
             aria-labelledby={ariaLabelledby}
             {...PaperProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- This PR fixes the issues in #36471 by setting the aria-attribute role to dialog for each of the components within the dialog. Now when the screen reader reads each dialog the state of the dialog being opened before reading the actual context is working correctly.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
