### PR TITLE
[docs] Fix anchor link in customization

### DIFF
--- a/docs/data/material/customization/how-to-customize/how-to-customize.md
+++ b/docs/data/material/customization/how-to-customize/how-to-customize.md
@@ -25,7 +25,7 @@ It can be used with all Material UI components.
 
 {{"demo": "SxProp.js" }}
 
-#### Overriding nested component styles
+### Overriding nested component styles
 
 To customize a specific part of a component, you can use the class name provided by Material UI inside the `sx` prop. As an example, let's say you want to change the `Slider` component's thumb from a circle to a square.
 


### PR DESCRIPTION
This header was changed in #31997, but it doesn't seem to need to be a h3. h2 seems enough and retains the anchor link.

e.g. of a broken anchor link: https://marmelab.com/react-admin/BooleanField.html#sx-css-api 

<img width="242" alt="Screenshot 2023-04-24 at 22 59 53" src="https://user-images.githubusercontent.com/3165635/234115755-d72be988-aadd-4cae-ab9f-c5505e0c139a.png">

Noticed in https://github.com/marmelab/react-admin/pull/8857