### PR TITLE
[TextField] Remove usage of dangerouslySetInnerHTML (#30776)

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -380,8 +380,8 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       >
         {/* So the vertical align positioning algorithm kicks in. */}
         {isEmpty(display) ? (
-          // eslint-disable-next-line react/no-danger
-          <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
+          // notranslate needed while Google Translate will not fix zero-width space issue
+          <span className="notranslate">&#8203;</span>
         ) : (
           display
         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- [ ] This back ports the fix removing dangerouslySetInnerHTML from the code base to 4.x version
- [ ] This fix is critical to be able to protect products using this library with Trusted types
