### PR TITLE
[Progress] Add ARIA values to improve accessibility of Progress variants

### DIFF
--- a/docs/data/material/components/progress/CircularDeterminate.js
+++ b/docs/data/material/components/progress/CircularDeterminate.js
@@ -1,19 +1,45 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import CircularProgress from '@mui/material/CircularProgress';
+import { visuallyHidden } from 'packages/mui-utils/src';
+import Button from '@mui/material/Button';
 
 export default function CircularDeterminate() {
   const [progress, setProgress] = React.useState(0);
+  const [running, setRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 10));
-    }, 800);
+    let timer = null;
+
+    if (running) {
+      timer = setInterval(() => {
+        setProgress((oldProgress) => {
+          const nextProgress = oldProgress + 20;
+          if (nextProgress >= 100) {
+            setRunning(false);
+            return 100;
+          }
+          return nextProgress;
+        });
+      }, 1800);
+    }
 
     return () => {
-      clearInterval(timer);
+      if (timer) {
+        clearInterval(timer);
+      }
     };
-  }, []);
+  }, [running]);
+
+  const handleStart = () => {
+    setRunning(true);
+    setProgress(0);
+  };
+
+  const handleStop = () => {
+    setRunning(false);
+    setProgress(0);
+  };
 
   return (
     <Stack spacing={2} direction="row">
@@ -21,7 +47,31 @@ export default function CircularDeterminate() {
       <CircularProgress variant="determinate" value={50} />
       <CircularProgress variant="determinate" value={75} />
       <CircularProgress variant="determinate" value={100} />
-      <CircularProgress variant="determinate" value={progress} />
+      <CircularProgress
+        variant="determinate"
+        value={progress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      />
+      {progress > 0 && (
+        <span style={visuallyHidden} aria-live="polite">
+          {`${progress}% progress`}
+        </span>
+      )}
+
+      <Stack spacing={2} direction="row">
+        {!running && (
+          <Button onClick={handleStart} variant="outlined">
+            Start
+          </Button>
+        )}
+
+        {running && (
+          <Button onClick={handleStop} variant="outlined">
+            Stop
+          </Button>
+        )}
+      </Stack>
     </Stack>
   );
 }

--- a/docs/data/material/components/progress/CircularDeterminate.tsx
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx
@@ -14,7 +14,7 @@ export default function CircularDeterminate() {
     if (running) {
       timer = setInterval(() => {
         setProgress((oldProgress) => {
-          const nextProgress = oldProgress + 25;
+          const nextProgress = oldProgress + 20;
           if (nextProgress >= 100) {
             setRunning(false);
             return 100;
@@ -22,7 +22,7 @@ export default function CircularDeterminate() {
             return nextProgress;
           }
         });
-      }, 2000);
+      }, 1800);
     }
 
     return () => {

--- a/docs/data/material/components/progress/CircularDeterminate.tsx
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx
@@ -18,9 +18,8 @@ export default function CircularDeterminate() {
           if (nextProgress >= 100) {
             setRunning(false);
             return 100;
-          } else {
-            return nextProgress;
           }
+          return nextProgress;
         });
       }, 1800);
     }
@@ -48,13 +47,18 @@ export default function CircularDeterminate() {
       <CircularProgress variant="determinate" value={50} />
       <CircularProgress variant="determinate" value={75} />
       <CircularProgress variant="determinate" value={100} />
-        <CircularProgress
-          variant="determinate"
-          value={progress}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        />
-      {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+      <CircularProgress
+        variant="determinate"
+        value={progress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      />
+      {progress > 0 && (
+        <span
+          style={visuallyHidden}
+          aria-live="polite"
+        >{`${progress}% progress`}</span>
+      )}
 
       <Stack spacing={2} direction="row">
         {!running && (

--- a/docs/data/material/components/progress/CircularDeterminate.tsx
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx
@@ -6,17 +6,17 @@ import Button from '@mui/material/Button';
 
 export default function CircularDeterminate() {
   const [progress, setProgress] = React.useState(0);
-  const [isRunning, setIsRunning] = React.useState(false);
+  const [running, setRunning] = React.useState(false);
 
   React.useEffect(() => {
     let timer: NodeJS.Timeout | null = null;
 
-    if (isRunning) {
+    if (running) {
       timer = setInterval(() => {
-        setProgress((prevProgress) => {
-          const nextProgress = prevProgress + 25;
+        setProgress((oldProgress) => {
+          const nextProgress = oldProgress + 25;
           if (nextProgress >= 100) {
-            setIsRunning(false);
+            setRunning(false);
             return 100;
           } else {
             return nextProgress;
@@ -30,17 +30,15 @@ export default function CircularDeterminate() {
         clearInterval(timer);
       }
     };
-  }, [isRunning]);
-
-  const progressDescription = `${progress}% progress`;
+  }, [running]);
 
   const handleStart = () => {
-    setIsRunning(true);
+    setRunning(true);
     setProgress(0);
   };
 
   const handleStop = () => {
-    setIsRunning(false);
+    setRunning(false);
     setProgress(0);
   };
 
@@ -50,24 +48,21 @@ export default function CircularDeterminate() {
       <CircularProgress variant="determinate" value={50} />
       <CircularProgress variant="determinate" value={75} />
       <CircularProgress variant="determinate" value={100} />
-      <div aria-describedby="progress-description" aria-live="polite">
         <CircularProgress
           variant="determinate"
           value={progress}
           aria-valuemin={0}
           aria-valuemax={100}
         />
-        <div id="progress-description" style={visuallyHidden}>
-          {progressDescription}
-        </div>
-      </div>
+      {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+
       <Stack spacing={2} direction="row">
-        {!isRunning && (
+        {!running && (
           <Button onClick={handleStart} variant="outlined">
             Start
           </Button>
         )}
-        {isRunning && (
+        {running && (
           <Button onClick={handleStop} variant="outlined">
             Stop
           </Button>

--- a/docs/data/material/components/progress/CircularDeterminate.tsx
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx
@@ -4,16 +4,29 @@ import CircularProgress from '@mui/material/CircularProgress';
 
 export default function CircularDeterminate() {
   const [progress, setProgress] = React.useState(0);
-
+  const srOnlyStyle: React.CSSProperties = {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    whiteSpace: 'nowrap',
+    border: '0'
+  };
+  
   React.useEffect(() => {
     const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 10));
-    }, 800);
+      setProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 25));
+    }, 2500);
 
     return () => {
       clearInterval(timer);
     };
   }, []);
+
+  const progressDescription = `${progress}% progress`;
 
   return (
     <Stack spacing={2} direction="row">
@@ -21,7 +34,19 @@ export default function CircularDeterminate() {
       <CircularProgress variant="determinate" value={50} />
       <CircularProgress variant="determinate" value={75} />
       <CircularProgress variant="determinate" value={100} />
-      <CircularProgress variant="determinate" value={progress} />
+      <div aria-describedby='progress-description' aria-live="polite" >
+        <CircularProgress 
+        variant="determinate" 
+        value={progress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuetext={progressDescription}
+        />
+        <div id="progress-description" style={srOnlyStyle}>
+          {progressDescription}
+        </div>
+      </div>
+
     </Stack>
   );
 }

--- a/docs/data/material/components/progress/CircularDeterminate.tsx
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx
@@ -2,21 +2,47 @@ import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import CircularProgress from '@mui/material/CircularProgress';
 import { visuallyHidden } from 'packages/mui-utils/src';
+import Button from '@mui/material/Button';
 
 export default function CircularDeterminate() {
   const [progress, setProgress] = React.useState(0);
-  
+  const [isRunning, setIsRunning] = React.useState(false);
+
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 25));
-    }, 2500);
+    let timer: NodeJS.Timeout | null = null;
+
+    if (isRunning) {
+      timer = setInterval(() => {
+        setProgress((prevProgress) => {
+          const nextProgress = prevProgress + 25;
+          if (nextProgress >= 100) {
+            setIsRunning(false);
+            return 100;
+          } else {
+            return nextProgress;
+          }
+        });
+      }, 2000);
+    }
 
     return () => {
-      clearInterval(timer);
+      if (timer) {
+        clearInterval(timer);
+      }
     };
-  }, []);
+  }, [isRunning]);
 
   const progressDescription = `${progress}% progress`;
+
+  const handleStart = () => {
+    setIsRunning(true);
+    setProgress(0);
+  };
+
+  const handleStop = () => {
+    setIsRunning(false);
+    setProgress(0);
+  };
 
   return (
     <Stack spacing={2} direction="row">
@@ -24,18 +50,29 @@ export default function CircularDeterminate() {
       <CircularProgress variant="determinate" value={50} />
       <CircularProgress variant="determinate" value={75} />
       <CircularProgress variant="determinate" value={100} />
-      <div aria-describedby='progress-description' aria-live="polite" >
-        <CircularProgress 
-        variant="determinate" 
-        value={progress}
-        aria-valuemin={0}
-        aria-valuemax={100}
+      <div aria-describedby="progress-description" aria-live="polite">
+        <CircularProgress
+          variant="determinate"
+          value={progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
         />
         <div id="progress-description" style={visuallyHidden}>
           {progressDescription}
         </div>
       </div>
-
+      <Stack spacing={2} direction="row">
+        {!isRunning && (
+          <Button onClick={handleStart} variant="outlined">
+            Start
+          </Button>
+        )}
+        {isRunning && (
+          <Button onClick={handleStop} variant="outlined">
+            Stop
+          </Button>
+        )}
+      </Stack>
     </Stack>
   );
 }

--- a/docs/data/material/components/progress/CircularDeterminate.tsx
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx
@@ -1,20 +1,10 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import CircularProgress from '@mui/material/CircularProgress';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function CircularDeterminate() {
   const [progress, setProgress] = React.useState(0);
-  const srOnlyStyle: React.CSSProperties = {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: '0',
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0,0,0,0)',
-    whiteSpace: 'nowrap',
-    border: '0'
-  };
   
   React.useEffect(() => {
     const timer = setInterval(() => {
@@ -40,9 +30,8 @@ export default function CircularDeterminate() {
         value={progress}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuetext={progressDescription}
         />
-        <div id="progress-description" style={srOnlyStyle}>
+        <div id="progress-description" style={visuallyHidden}>
           {progressDescription}
         </div>
       </div>

--- a/docs/data/material/components/progress/CircularDeterminate.tsx.preview
+++ b/docs/data/material/components/progress/CircularDeterminate.tsx.preview
@@ -1,5 +1,0 @@
-<CircularProgress variant="determinate" value={25} />
-<CircularProgress variant="determinate" value={50} />
-<CircularProgress variant="determinate" value={75} />
-<CircularProgress variant="determinate" value={100} />
-<CircularProgress variant="determinate" value={progress} />

--- a/docs/data/material/components/progress/CircularIntegration.js
+++ b/docs/data/material/components/progress/CircularIntegration.js
@@ -34,7 +34,7 @@ export default function CircularIntegration() {
       timer.current = window.setTimeout(() => {
         setSuccess(true);
         setLoading(false);
-      }, 2000);
+      }, 1800);
     }
   };
 
@@ -42,10 +42,13 @@ export default function CircularIntegration() {
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <Box sx={{ m: 1, position: 'relative' }}>
         <Fab
-          aria-label="save"
           color="primary"
           sx={buttonSx}
           onClick={handleButtonClick}
+          aria-busy={loading ? 'true' : 'false'}
+          aria-live={success ? 'polite' : undefined}
+          aria-atomic={success ? 'true' : undefined}
+          aria-label={success ? 'Progress complete' : 'save'}
         >
           {success ? <CheckIcon /> : <SaveIcon />}
         </Fab>
@@ -59,6 +62,9 @@ export default function CircularIntegration() {
               left: -6,
               zIndex: 1,
             }}
+            role="status"
+            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-live="assertive"
           />
         )}
       </Box>
@@ -68,6 +74,10 @@ export default function CircularIntegration() {
           sx={buttonSx}
           disabled={loading}
           onClick={handleButtonClick}
+          aria-busy={loading ? 'true' : 'false'}
+          aria-live={success ? 'polite' : undefined}
+          aria-atomic={success ? 'true' : undefined}
+          aria-label={success ? 'Progress complete' : 'Accept terms'}
         >
           Accept terms
         </Button>
@@ -82,6 +92,9 @@ export default function CircularIntegration() {
               marginTop: '-12px',
               marginLeft: '-12px',
             }}
+            role="status"
+            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-live="assertive"
           />
         )}
       </Box>

--- a/docs/data/material/components/progress/CircularIntegration.tsx
+++ b/docs/data/material/components/progress/CircularIntegration.tsx
@@ -34,7 +34,7 @@ export default function CircularIntegration() {
       timer.current = window.setTimeout(() => {
         setSuccess(true);
         setLoading(false);
-      }, 2000);
+      }, 1800);
     }
   };
 

--- a/docs/data/material/components/progress/CircularIntegration.tsx
+++ b/docs/data/material/components/progress/CircularIntegration.tsx
@@ -42,10 +42,13 @@ export default function CircularIntegration() {
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <Box sx={{ m: 1, position: 'relative' }}>
         <Fab
-          aria-label="save"
           color="primary"
           sx={buttonSx}
           onClick={handleButtonClick}
+          aria-busy={loading ? 'true' : 'false'}
+          aria-live={success ? 'polite' : undefined}
+          aria-atomic={success ? 'true' : undefined}
+          aria-label={success ? 'Progress complete' : 'save'}
         >
           {success ? <CheckIcon /> : <SaveIcon />}
         </Fab>
@@ -59,6 +62,9 @@ export default function CircularIntegration() {
               left: -6,
               zIndex: 1,
             }}
+            role="status"
+            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-live="assertive"
           />
         )}
       </Box>
@@ -68,6 +74,10 @@ export default function CircularIntegration() {
           sx={buttonSx}
           disabled={loading}
           onClick={handleButtonClick}
+          aria-busy={loading ? 'true' : 'false'}
+          aria-live={success ? 'polite' : undefined}
+          aria-atomic={success ? 'true' : undefined}
+          aria-label={success ? 'Progress complete' : 'Accept terms'}
         >
           Accept terms
         </Button>
@@ -82,6 +92,9 @@ export default function CircularIntegration() {
               marginTop: '-12px',
               marginLeft: '-12px',
             }}
+            role="status"
+            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-live="assertive"
           />
         )}
       </Box>

--- a/docs/data/material/components/progress/CircularWithValueLabel.js
+++ b/docs/data/material/components/progress/CircularWithValueLabel.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 function CircularProgressWithLabel(props) {
   return (
@@ -38,16 +41,56 @@ CircularProgressWithLabel.propTypes = {
 };
 
 export default function CircularStatic() {
-  const [progress, setProgress] = React.useState(10);
+  const [progress, setProgress] = React.useState(0);
+  const [isRunning, setIsRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 10));
-    }, 800);
+    let timerId = null;
+    if (isRunning) {
+      timerId = setInterval(() => {
+        handleProgress();
+      }, 1800);
+    }
     return () => {
-      clearInterval(timer);
+      if (timerId) {
+        clearInterval(timerId);
+      }
     };
-  }, []);
+  }, [isRunning]);
 
-  return <CircularProgressWithLabel value={progress} />;
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setIsRunning(false);
+        return 0;
+      }
+      const nextProgress = oldProgress + 20;
+      return nextProgress;
+    });
+  };
+
+  const handleClick = () => {
+    if (progress === 100) {
+      setProgress(0);
+    }
+    setIsRunning(!isRunning);
+  };
+
+  return (
+    <Stack spacing={2} direction="row">
+      <CircularProgressWithLabel value={progress} />
+      <Button
+        onClick={handleClick}
+        variant="outlined"
+        disabled={isRunning && progress !== 100}
+      >
+        {isRunning && progress !== 100 ? 'Stop' : 'Start'}
+      </Button>
+      {progress > 0 && (
+        <span style={visuallyHidden} aria-live="polite">
+          {`${progress}% progress`}
+        </span>
+      )}
+    </Stack>
+  );
 }

--- a/docs/data/material/components/progress/CircularWithValueLabel.tsx
+++ b/docs/data/material/components/progress/CircularWithValueLabel.tsx
@@ -26,11 +26,7 @@ function CircularProgressWithLabel(
           justifyContent: 'center',
         }}
       >
-        <Typography
-          variant="caption"
-          component="div"
-          color="text.secondary"
-        >
+        <Typography variant="caption" component="div" color="text.secondary">
           {`${Math.round(props.value)}%`}
         </Typography>
       </Box>
@@ -47,7 +43,6 @@ export default function CircularStatic() {
     if (isRunning) {
       timerId = setInterval(() => {
         handleProgress();
-
       }, 1800);
     }
     return () => {
@@ -76,15 +71,21 @@ export default function CircularStatic() {
   };
 
   return (
-    <>
     <Stack spacing={2} direction="row">
       <CircularProgressWithLabel value={progress} />
-      <Button onClick={handleClick} variant="outlined" disabled={isRunning && progress !== 100}>
+      <Button
+        onClick={handleClick}
+        variant="outlined"
+        disabled={isRunning && progress !== 100}
+      >
         {isRunning && progress !== 100 ? 'Stop' : 'Start'}
       </Button>
-      {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+      {progress > 0 && (
+        <span
+          style={visuallyHidden}
+          aria-live="polite"
+        >{`${progress}% progress`}</span>
+      )}
     </Stack>
-      
-    </>
   );
 }

--- a/docs/data/material/components/progress/CircularWithValueLabel.tsx
+++ b/docs/data/material/components/progress/CircularWithValueLabel.tsx
@@ -71,7 +71,7 @@ export default function CircularStatic() {
     <Stack spacing={2} direction="row">
       <CircularProgressWithLabel value={progress} />
       <Button onClick={handleClick} variant="outlined" disabled={isRunning && progress !== 100}>
-        {isRunning && progress !== 100 ? 'Running' : 'Start'}
+        {isRunning && progress !== 100 ? 'Stop' : 'Start'}
       </Button>
     </Stack>
       

--- a/docs/data/material/components/progress/CircularWithValueLabel.tsx
+++ b/docs/data/material/components/progress/CircularWithValueLabel.tsx
@@ -30,7 +30,6 @@ function CircularProgressWithLabel(
           variant="caption"
           component="div"
           color="text.secondary"
-          aria-live="polite"
         >
           {`${Math.round(props.value)}%`}
         </Typography>
@@ -49,7 +48,7 @@ export default function CircularStatic() {
       timerId = setInterval(() => {
         handleProgress();
 
-      }, 1000);
+      }, 1800);
     }
     return () => {
       if (timerId) {

--- a/docs/data/material/components/progress/CircularWithValueLabel.tsx
+++ b/docs/data/material/components/progress/CircularWithValueLabel.tsx
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
-
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 function CircularProgressWithLabel(
   props: CircularProgressProps & { value: number },
@@ -47,10 +47,9 @@ export default function CircularStatic() {
     let timerId: NodeJS.Timeout | null = null;
     if (isRunning) {
       timerId = setInterval(() => {
-        setProgress((prevProgress) =>
-          prevProgress >= 100 ? 100 : prevProgress + 10
-        );
-      }, 800);
+        handleProgress();
+
+      }, 1000);
     }
     return () => {
       if (timerId) {
@@ -58,6 +57,17 @@ export default function CircularStatic() {
       }
     };
   }, [isRunning]);
+
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setIsRunning(false);
+        return 0;
+      }
+      const nextProgress = oldProgress + 20;
+      return nextProgress;
+    });
+  };
 
   const handleClick = () => {
     if (progress === 100) {
@@ -73,6 +83,7 @@ export default function CircularStatic() {
       <Button onClick={handleClick} variant="outlined" disabled={isRunning && progress !== 100}>
         {isRunning && progress !== 100 ? 'Stop' : 'Start'}
       </Button>
+      {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
     </Stack>
       
     </>

--- a/docs/data/material/components/progress/CircularWithValueLabel.tsx
+++ b/docs/data/material/components/progress/CircularWithValueLabel.tsx
@@ -4,6 +4,9 @@ import CircularProgress, {
 } from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+
 
 function CircularProgressWithLabel(
   props: CircularProgressProps & { value: number },
@@ -27,23 +30,51 @@ function CircularProgressWithLabel(
           variant="caption"
           component="div"
           color="text.secondary"
-        >{`${Math.round(props.value)}%`}</Typography>
+          aria-live="polite"
+        >
+          {`${Math.round(props.value)}%`}
+        </Typography>
       </Box>
     </Box>
   );
 }
 
 export default function CircularStatic() {
-  const [progress, setProgress] = React.useState(10);
+  const [progress, setProgress] = React.useState(0);
+  const [isRunning, setIsRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 0 : prevProgress + 10));
-    }, 800);
+    let timerId: NodeJS.Timeout | null = null;
+    if (isRunning) {
+      timerId = setInterval(() => {
+        setProgress((prevProgress) =>
+          prevProgress >= 100 ? 100 : prevProgress + 10
+        );
+      }, 800);
+    }
     return () => {
-      clearInterval(timer);
+      if (timerId) {
+        clearInterval(timerId);
+      }
     };
-  }, []);
+  }, [isRunning]);
 
-  return <CircularProgressWithLabel value={progress} />;
+  const handleClick = () => {
+    if (progress === 100) {
+      setProgress(0);
+    }
+    setIsRunning(!isRunning);
+  };
+
+  return (
+    <>
+    <Stack spacing={2} direction="row">
+      <CircularProgressWithLabel value={progress} />
+      <Button onClick={handleClick} variant="outlined" disabled={isRunning && progress !== 100}>
+        {isRunning && progress !== 100 ? 'Running' : 'Start'}
+      </Button>
+    </Stack>
+      
+    </>
+  );
 }

--- a/docs/data/material/components/progress/CircularWithValueLabel.tsx.preview
+++ b/docs/data/material/components/progress/CircularWithValueLabel.tsx.preview
@@ -1,1 +1,14 @@
 <CircularProgressWithLabel value={progress} />
+<Button
+  onClick={handleClick}
+  variant="outlined"
+  disabled={isRunning && progress !== 100}
+>
+  {isRunning && progress !== 100 ? 'Stop' : 'Start'}
+</Button>
+{progress > 0 && (
+  <span
+    style={visuallyHidden}
+    aria-live="polite"
+  >{`${progress}% progress`}</span>
+)}

--- a/docs/data/material/components/progress/DelayingAppearance.js
+++ b/docs/data/material/components/progress/DelayingAppearance.js
@@ -4,6 +4,7 @@ import Fade from '@mui/material/Fade';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function DelayingAppearance() {
   const [loading, setLoading] = React.useState(false);
@@ -34,7 +35,7 @@ export default function DelayingAppearance() {
     setQuery('progress');
     timerRef.current = window.setTimeout(() => {
       setQuery('success');
-    }, 2000);
+    }, 2500);
   };
 
   return (
@@ -47,7 +48,11 @@ export default function DelayingAppearance() {
           }}
           unmountOnExit
         >
-          <CircularProgress />
+          <CircularProgress
+            role="status"
+            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-live="assertive"
+          />
         </Fade>
       </Box>
       <Button onClick={handleClickLoading} sx={{ m: 2 }}>
@@ -71,6 +76,11 @@ export default function DelayingAppearance() {
       <Button onClick={handleClickQuery} sx={{ m: 2 }}>
         {query !== 'idle' ? 'Reset' : 'Simulate a load'}
       </Button>
+      {query !== 'idle' && (
+        <span style={visuallyHidden} aria-live="polite">
+          {query === 'success' ? 'Progress complete' : 'Progress loading'}
+        </span>
+      )}
     </Box>
   );
 }

--- a/docs/data/material/components/progress/DelayingAppearance.js
+++ b/docs/data/material/components/progress/DelayingAppearance.js
@@ -50,7 +50,7 @@ export default function DelayingAppearance() {
         >
           <CircularProgress
             role="status"
-            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-label={loading ? 'Progress loading' : 'Progress stopped'}
             aria-live="assertive"
           />
         </Fade>

--- a/docs/data/material/components/progress/DelayingAppearance.tsx
+++ b/docs/data/material/components/progress/DelayingAppearance.tsx
@@ -48,11 +48,11 @@ export default function DelayingAppearance() {
           }}
           unmountOnExit
         >
-          <CircularProgress 
-          
-          role="status"
-          aria-label={loading ? 'Progress loading' : 'Progress complete'}
-          aria-live="assertive"/>
+          <CircularProgress
+            role="status"
+            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-live="assertive"
+          />
         </Fade>
       </Box>
       <Button onClick={handleClickLoading} sx={{ m: 2 }}>
@@ -76,7 +76,11 @@ export default function DelayingAppearance() {
       <Button onClick={handleClickQuery} sx={{ m: 2 }}>
         {query !== 'idle' ? 'Reset' : 'Simulate a load'}
       </Button>
-      {query !== 'idle' && <span style={visuallyHidden} aria-live="polite">{query === 'success' ? 'Progress complete' : 'Progress loading'}</span>}
+      {query !== 'idle' && (
+        <span style={visuallyHidden} aria-live="polite">
+          {query === 'success' ? 'Progress complete' : 'Progress loading'}
+        </span>
+      )}
     </Box>
   );
 }

--- a/docs/data/material/components/progress/DelayingAppearance.tsx
+++ b/docs/data/material/components/progress/DelayingAppearance.tsx
@@ -4,11 +4,14 @@ import Fade from '@mui/material/Fade';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function DelayingAppearance() {
   const [loading, setLoading] = React.useState(false);
   const [query, setQuery] = React.useState('idle');
   const timerRef = React.useRef<number>();
+  const [clicked, setClicked] = React.useState(false);
+
 
   React.useEffect(
     () => () => {
@@ -19,6 +22,7 @@ export default function DelayingAppearance() {
 
   const handleClickLoading = () => {
     setLoading((prevLoading) => !prevLoading);
+    setClicked((prevClicked) => !prevClicked);
   };
 
   const handleClickQuery = () => {
@@ -34,7 +38,7 @@ export default function DelayingAppearance() {
     setQuery('progress');
     timerRef.current = window.setTimeout(() => {
       setQuery('success');
-    }, 2000);
+    }, 2500);
   };
 
   return (
@@ -47,12 +51,17 @@ export default function DelayingAppearance() {
           }}
           unmountOnExit
         >
-          <CircularProgress />
+          <CircularProgress 
+          
+          role="status"
+          aria-label={loading ? 'Progress loading' : 'Progress complete'}
+          aria-live="assertive"/>
         </Fade>
       </Box>
       <Button onClick={handleClickLoading} sx={{ m: 2 }}>
         {loading ? 'Stop loading' : 'Loading'}
       </Button>
+      {/* { clicked && <span style={visuallyHidden} aria-live="polite">{loading ? 'Progress loading' : 'Progress stopped'}</span>} */}
       <Box sx={{ height: 40 }}>
         {query === 'success' ? (
           <Typography>Success!</Typography>
@@ -71,6 +80,7 @@ export default function DelayingAppearance() {
       <Button onClick={handleClickQuery} sx={{ m: 2 }}>
         {query !== 'idle' ? 'Reset' : 'Simulate a load'}
       </Button>
+      {query !== 'idle' && <span style={visuallyHidden} aria-live="polite">{query === 'success' ? 'Progress complete' : 'Progress loading'}</span>}
     </Box>
   );
 }

--- a/docs/data/material/components/progress/DelayingAppearance.tsx
+++ b/docs/data/material/components/progress/DelayingAppearance.tsx
@@ -50,7 +50,7 @@ export default function DelayingAppearance() {
         >
           <CircularProgress
             role="status"
-            aria-label={loading ? 'Progress loading' : 'Progress complete'}
+            aria-label={loading ? 'Progress loading' : 'Progress stopped'}
             aria-live="assertive"
           />
         </Fade>

--- a/docs/data/material/components/progress/DelayingAppearance.tsx
+++ b/docs/data/material/components/progress/DelayingAppearance.tsx
@@ -10,8 +10,6 @@ export default function DelayingAppearance() {
   const [loading, setLoading] = React.useState(false);
   const [query, setQuery] = React.useState('idle');
   const timerRef = React.useRef<number>();
-  const [clicked, setClicked] = React.useState(false);
-
 
   React.useEffect(
     () => () => {
@@ -22,7 +20,6 @@ export default function DelayingAppearance() {
 
   const handleClickLoading = () => {
     setLoading((prevLoading) => !prevLoading);
-    setClicked((prevClicked) => !prevClicked);
   };
 
   const handleClickQuery = () => {
@@ -61,7 +58,6 @@ export default function DelayingAppearance() {
       <Button onClick={handleClickLoading} sx={{ m: 2 }}>
         {loading ? 'Stop loading' : 'Loading'}
       </Button>
-      {/* { clicked && <span style={visuallyHidden} aria-live="polite">{loading ? 'Progress loading' : 'Progress stopped'}</span>} */}
       <Box sx={{ height: 40 }}>
         {query === 'success' ? (
           <Typography>Success!</Typography>

--- a/docs/data/material/components/progress/LinearBuffer.js
+++ b/docs/data/material/components/progress/LinearBuffer.js
@@ -1,39 +1,59 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function LinearBuffer() {
   const [progress, setProgress] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
+  const [running, setRunning] = React.useState(false);
 
-  const progressRef = React.useRef(() => {});
   React.useEffect(() => {
-    progressRef.current = () => {
-      if (progress > 100) {
-        setProgress(0);
-        setBuffer(10);
-      } else {
-        const diff = Math.random() * 10;
+    const handleProgress = () => {
+      setProgress((oldProgress) => {
+        if (oldProgress === 100) {
+          setRunning(false);
+          return 0;
+        }
         const diff2 = Math.random() * 10;
-        setProgress(progress + diff);
-        setBuffer(progress + diff + diff2);
-      }
+        setBuffer(progress + 20 + diff2);
+        const nextProgress = oldProgress + 20;
+        return nextProgress;
+      });
     };
-  });
-
-  React.useEffect(() => {
-    const timer = setInterval(() => {
-      progressRef.current();
-    }, 500);
+    let timer;
+    if (running) {
+      timer = setInterval(() => {
+        handleProgress();
+      }, 1800);
+    }
 
     return () => {
-      clearInterval(timer);
+      if (timer) {
+        clearInterval(timer);
+      }
     };
-  }, []);
+  }, [running, progress]);
+
+  const handleButtonClick = () => {
+    setRunning(!running);
+  };
 
   return (
-    <Box sx={{ width: '100%' }}>
-      <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
-    </Box>
+    <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
+      <Button variant="outlined" onClick={handleButtonClick}>
+        {running ? 'Stop' : 'Start'}
+      </Button>
+      <Box sx={{ width: '100%' }}>
+        <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
+      </Box>
+      {progress > 0 && (
+        <span style={visuallyHidden} aria-live="polite">
+          {`${progress}% progress`}
+        </span>
+      )}
+    </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearBuffer.tsx
+++ b/docs/data/material/components/progress/LinearBuffer.tsx
@@ -10,13 +10,12 @@ export default function LinearBuffer() {
   const [buffer, setBuffer] = React.useState(10);
   const [running, setRunning] = React.useState(false);
 
-  const progressRef = React.useRef(() => {});
   React.useEffect(() => {
     let timer: NodeJS.Timeout | undefined;
     if (running) {
       timer = setInterval(() => {
         handleProgress();
-      }, 2000);
+      }, 1800);
     }
 
     return () => {
@@ -33,8 +32,8 @@ export default function LinearBuffer() {
         return 0;
       }
       const diff2 = Math.random() * 10;
-      setBuffer(progress + 25 + diff2);
-      const nextProgress = oldProgress + 25;
+      setBuffer(progress + 20 + diff2);
+      const nextProgress = oldProgress + 20;
       return nextProgress;
     });
   };

--- a/docs/data/material/components/progress/LinearBuffer.tsx
+++ b/docs/data/material/components/progress/LinearBuffer.tsx
@@ -1,39 +1,55 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function LinearBuffer() {
   const [progress, setProgress] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
+  const [running, setRunning] = React.useState(false);
 
   const progressRef = React.useRef(() => {});
   React.useEffect(() => {
-    progressRef.current = () => {
-      if (progress > 100) {
-        setProgress(0);
-        setBuffer(10);
-      } else {
-        const diff = Math.random() * 10;
-        const diff2 = Math.random() * 10;
-        setProgress(progress + diff);
-        setBuffer(progress + diff + diff2);
-      }
-    };
-  });
-
-  React.useEffect(() => {
-    const timer = setInterval(() => {
-      progressRef.current();
-    }, 500);
+    let timer: NodeJS.Timeout | undefined;
+    if (running) {
+      timer = setInterval(() => {
+        handleProgress();
+      }, 2000);
+    }
 
     return () => {
-      clearInterval(timer);
+      if (timer) {
+        clearInterval(timer);
+      }
     };
-  }, []);
+  }, [running]);
+
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setRunning(false);
+        return 0;
+      }
+      const diff2 = Math.random() * 10;
+      setBuffer(progress + 25 + diff2);
+      const nextProgress = oldProgress + 25;
+      return nextProgress;
+    });
+  };
+
+  const handleButtonClick = () => {
+    setRunning(!running);
+  };
 
   return (
-    <Box sx={{ width: '100%' }}>
-      <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
-    </Box>
+    <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
+      <Button variant="outlined" onClick={handleButtonClick}>{running ? 'Stop' : 'Start'}</Button>
+        <Box sx={{ width: '100%' }}>
+          <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
+        </Box>
+        {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+    </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearBuffer.tsx
+++ b/docs/data/material/components/progress/LinearBuffer.tsx
@@ -11,6 +11,18 @@ export default function LinearBuffer() {
   const [running, setRunning] = React.useState(false);
 
   React.useEffect(() => {
+    const handleProgress = () => {
+      setProgress((oldProgress) => {
+        if (oldProgress === 100) {
+          setRunning(false);
+          return 0;
+        }
+        const diff2 = Math.random() * 10;
+        setBuffer(progress + 20 + diff2);
+        const nextProgress = oldProgress + 20;
+        return nextProgress;
+      });
+    };
     let timer: NodeJS.Timeout | undefined;
     if (running) {
       timer = setInterval(() => {
@@ -23,20 +35,7 @@ export default function LinearBuffer() {
         clearInterval(timer);
       }
     };
-  }, [running]);
-
-  const handleProgress = () => {
-    setProgress((oldProgress) => {
-      if (oldProgress === 100) {
-        setRunning(false);
-        return 0;
-      }
-      const diff2 = Math.random() * 10;
-      setBuffer(progress + 20 + diff2);
-      const nextProgress = oldProgress + 20;
-      return nextProgress;
-    });
-  };
+  }, [running, progress]);
 
   const handleButtonClick = () => {
     setRunning(!running);
@@ -44,11 +43,18 @@ export default function LinearBuffer() {
 
   return (
     <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
-      <Button variant="outlined" onClick={handleButtonClick}>{running ? 'Stop' : 'Start'}</Button>
-        <Box sx={{ width: '100%' }}>
-          <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
-        </Box>
-        {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+      <Button variant="outlined" onClick={handleButtonClick}>
+        {running ? 'Stop' : 'Start'}
+      </Button>
+      <Box sx={{ width: '100%' }}>
+        <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
+      </Box>
+      {progress > 0 && (
+        <span
+          style={visuallyHidden}
+          aria-live="polite"
+        >{`${progress}% progress`}</span>
+      )}
     </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearBuffer.tsx.preview
+++ b/docs/data/material/components/progress/LinearBuffer.tsx.preview
@@ -1,1 +1,12 @@
-<LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
+<Button variant="outlined" onClick={handleButtonClick}>
+  {running ? 'Stop' : 'Start'}
+</Button>
+<Box sx={{ width: '100%' }}>
+  <LinearProgress variant="buffer" value={progress} valueBuffer={buffer} />
+</Box>
+{progress > 0 && (
+  <span
+    style={visuallyHidden}
+    aria-live="polite"
+  >{`${progress}% progress`}</span>
+)}

--- a/docs/data/material/components/progress/LinearDeterminate.js
+++ b/docs/data/material/components/progress/LinearDeterminate.js
@@ -1,29 +1,57 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function LinearDeterminate() {
   const [progress, setProgress] = React.useState(0);
+  const [running, setRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((oldProgress) => {
-        if (oldProgress === 100) {
-          return 0;
-        }
-        const diff = Math.random() * 10;
-        return Math.min(oldProgress + diff, 100);
-      });
-    }, 500);
+    let timer;
+    if (running) {
+      timer = setInterval(() => {
+        handleProgress();
+      }, 1800);
+    }
 
     return () => {
-      clearInterval(timer);
+      if (timer) {
+        clearInterval(timer);
+      }
     };
-  }, []);
+  }, [running]);
+
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setRunning(false);
+        return 0;
+      }
+      const nextProgress = oldProgress + 20;
+      return nextProgress;
+    });
+  };
+
+  const handleButtonClick = () => {
+    setRunning(!running);
+  };
 
   return (
-    <Box sx={{ width: '100%' }}>
-      <LinearProgress variant="determinate" value={progress} />
-    </Box>
+    <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
+      <Button variant="outlined" onClick={handleButtonClick}>
+        {running ? 'Stop' : 'Start'}
+      </Button>
+      <Box sx={{ width: '100%' }}>
+        <LinearProgress variant="determinate" value={progress} />
+      </Box>
+      {progress > 0 && (
+        <span style={visuallyHidden} aria-live="polite">
+          {`${progress}% progress`}
+        </span>
+      )}
+    </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearDeterminate.tsx
+++ b/docs/data/material/components/progress/LinearDeterminate.tsx
@@ -1,29 +1,51 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import LinearProgress from '@mui/material/LinearProgress';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 export default function LinearDeterminate() {
   const [progress, setProgress] = React.useState(0);
+  const [running, setRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((oldProgress) => {
-        if (oldProgress === 100) {
-          return 0;
-        }
-        const diff = Math.random() * 10;
-        return Math.min(oldProgress + diff, 100);
-      });
-    }, 500);
+    let timer: NodeJS.Timeout | undefined;
+    if (running) {
+      timer = setInterval(() => {
+        handleProgress();
+      }, 2000);
+    }
 
     return () => {
-      clearInterval(timer);
+      if (timer) {
+        clearInterval(timer);
+      }
     };
-  }, []);
+  }, [running]);
+
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setRunning(false);
+        return 0;
+      }
+      const nextProgress = oldProgress + 25;
+      return nextProgress;
+    });
+  };
+
+  const handleButtonClick = () => {
+    setRunning(!running);
+  };
 
   return (
-    <Box sx={{ width: '100%' }}>
-      <LinearProgress variant="determinate" value={progress} />
-    </Box>
+    <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
+      <Button variant="outlined" onClick={handleButtonClick}>{running ? 'Stop' : 'Start'}</Button>
+        <Box sx={{ width: '100%' }}>
+          <LinearProgress variant="determinate" value={progress} />
+        </Box>
+        {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+    </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearDeterminate.tsx
+++ b/docs/data/material/components/progress/LinearDeterminate.tsx
@@ -14,7 +14,7 @@ export default function LinearDeterminate() {
     if (running) {
       timer = setInterval(() => {
         handleProgress();
-      }, 2000);
+      }, 1800);
     }
 
     return () => {
@@ -30,7 +30,7 @@ export default function LinearDeterminate() {
         setRunning(false);
         return 0;
       }
-      const nextProgress = oldProgress + 25;
+      const nextProgress = oldProgress + 20;
       return nextProgress;
     });
   };

--- a/docs/data/material/components/progress/LinearDeterminate.tsx
+++ b/docs/data/material/components/progress/LinearDeterminate.tsx
@@ -41,11 +41,18 @@ export default function LinearDeterminate() {
 
   return (
     <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
-      <Button variant="outlined" onClick={handleButtonClick}>{running ? 'Stop' : 'Start'}</Button>
-        <Box sx={{ width: '100%' }}>
-          <LinearProgress variant="determinate" value={progress} />
-        </Box>
-        {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+      <Button variant="outlined" onClick={handleButtonClick}>
+        {running ? 'Stop' : 'Start'}
+      </Button>
+      <Box sx={{ width: '100%' }}>
+        <LinearProgress variant="determinate" value={progress} />
+      </Box>
+      {progress > 0 && (
+        <span
+          style={visuallyHidden}
+          aria-live="polite"
+        >{`${progress}% progress`}</span>
+      )}
     </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearDeterminate.tsx.preview
+++ b/docs/data/material/components/progress/LinearDeterminate.tsx.preview
@@ -1,1 +1,12 @@
-<LinearProgress variant="determinate" value={progress} />
+<Button variant="outlined" onClick={handleButtonClick}>
+  {running ? 'Stop' : 'Start'}
+</Button>
+<Box sx={{ width: '100%' }}>
+  <LinearProgress variant="determinate" value={progress} />
+</Box>
+{progress > 0 && (
+  <span
+    style={visuallyHidden}
+    aria-live="polite"
+  >{`${progress}% progress`}</span>
+)}

--- a/docs/data/material/components/progress/LinearWithValueLabel.js
+++ b/docs/data/material/components/progress/LinearWithValueLabel.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import LinearProgress from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 function LinearProgressWithLabel(props) {
   return (
@@ -11,9 +14,9 @@ function LinearProgressWithLabel(props) {
         <LinearProgress variant="determinate" {...props} />
       </Box>
       <Box sx={{ minWidth: 35 }}>
-        <Typography variant="body2" color="text.secondary">{`${Math.round(
-          props.value,
-        )}%`}</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {`${Math.round(props.value)}%`}
+        </Typography>
       </Box>
     </Box>
   );
@@ -28,20 +31,54 @@ LinearProgressWithLabel.propTypes = {
 };
 
 export default function LinearWithValueLabel() {
-  const [progress, setProgress] = React.useState(10);
+  const [progress, setProgress] = React.useState(0);
+  const [isRunning, setIsRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 10 : prevProgress + 10));
-    }, 800);
+    let timerId = null;
+    if (isRunning) {
+      timerId = setInterval(() => {
+        handleProgress();
+      }, 1800);
+    }
     return () => {
-      clearInterval(timer);
+      if (timerId) {
+        clearInterval(timerId);
+      }
     };
-  }, []);
+  }, [isRunning]);
+
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setIsRunning(false);
+        return 0;
+      }
+      const nextProgress = oldProgress + 20;
+      return nextProgress;
+    });
+  };
+
+  const handleClick = () => {
+    if (progress === 100) {
+      setProgress(0);
+    }
+    setIsRunning(!isRunning);
+  };
 
   return (
-    <Box sx={{ width: '100%' }}>
-      <LinearProgressWithLabel value={progress} />
-    </Box>
+    <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
+      <Button variant="outlined" onClick={handleClick}>
+        {isRunning && progress !== 100 ? 'Stop' : 'Start'}
+      </Button>
+      <Box sx={{ width: '100%' }}>
+        <LinearProgressWithLabel value={progress} />
+      </Box>
+      {progress > 0 && (
+        <span style={visuallyHidden} aria-live="polite">
+          {`${progress}% progress`}
+        </span>
+      )}
+    </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearWithValueLabel.tsx
+++ b/docs/data/material/components/progress/LinearWithValueLabel.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import LinearProgress, { LinearProgressProps } from '@mui/material/LinearProgress';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { visuallyHidden } from 'packages/mui-utils/src';
 
 function LinearProgressWithLabel(props: LinearProgressProps & { value: number }) {
   return (
@@ -10,29 +13,61 @@ function LinearProgressWithLabel(props: LinearProgressProps & { value: number })
         <LinearProgress variant="determinate" {...props} />
       </Box>
       <Box sx={{ minWidth: 35 }}>
-        <Typography variant="body2" color="text.secondary">{`${Math.round(
-          props.value,
-        )}%`}</Typography>
+        <Typography 
+        variant="body2" 
+        color="text.secondary">
+          {`${Math.round(props.value,)}%`}
+        </Typography>
       </Box>
     </Box>
   );
 }
 
 export default function LinearWithValueLabel() {
-  const [progress, setProgress] = React.useState(10);
+  const [progress, setProgress] = React.useState(0);
+  const [isRunning, setIsRunning] = React.useState(false);
 
   React.useEffect(() => {
-    const timer = setInterval(() => {
-      setProgress((prevProgress) => (prevProgress >= 100 ? 10 : prevProgress + 10));
-    }, 800);
+    let timerId: NodeJS.Timeout | null = null;
+    if (isRunning) {
+      timerId = setInterval(() => {
+        handleProgress();
+      }, 1000);
+    }
     return () => {
-      clearInterval(timer);
+      if (timerId) {
+        clearInterval(timerId);
+      }
     };
-  }, []);
+  }, [isRunning]);
+
+  const handleProgress = () => {
+    setProgress((oldProgress) => {
+      if (oldProgress === 100) {
+        setIsRunning(false);
+        return 0;
+      }
+      const nextProgress = oldProgress + 20;
+      return nextProgress;
+    });
+  };
+
+
+  const handleClick = () => {
+    if (progress === 100) {
+    setProgress(0);
+  }
+  setIsRunning(!isRunning);
+  };
 
   return (
-    <Box sx={{ width: '100%' }}>
-      <LinearProgressWithLabel value={progress} />
-    </Box>
+
+    <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
+      <Button variant="outlined" onClick={handleClick}>{isRunning && progress !== 100 ? 'Stop' : 'Start'}</Button>
+        <Box sx={{ width: '100%' }}>
+        <LinearProgressWithLabel value={progress} />
+        </Box>
+        {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+    </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearWithValueLabel.tsx
+++ b/docs/data/material/components/progress/LinearWithValueLabel.tsx
@@ -32,7 +32,7 @@ export default function LinearWithValueLabel() {
     if (isRunning) {
       timerId = setInterval(() => {
         handleProgress();
-      }, 1000);
+      }, 1800);
     }
     return () => {
       if (timerId) {

--- a/docs/data/material/components/progress/LinearWithValueLabel.tsx
+++ b/docs/data/material/components/progress/LinearWithValueLabel.tsx
@@ -13,10 +13,8 @@ function LinearProgressWithLabel(props: LinearProgressProps & { value: number })
         <LinearProgress variant="determinate" {...props} />
       </Box>
       <Box sx={{ minWidth: 35 }}>
-        <Typography 
-        variant="body2" 
-        color="text.secondary">
-          {`${Math.round(props.value,)}%`}
+        <Typography variant="body2" color="text.secondary">
+          {`${Math.round(props.value)}%`}
         </Typography>
       </Box>
     </Box>
@@ -52,22 +50,27 @@ export default function LinearWithValueLabel() {
     });
   };
 
-
   const handleClick = () => {
     if (progress === 100) {
-    setProgress(0);
-  }
-  setIsRunning(!isRunning);
+      setProgress(0);
+    }
+    setIsRunning(!isRunning);
   };
 
   return (
-
     <Stack sx={{ width: '100%', alignItems: 'center' }} spacing={2} direction="row">
-      <Button variant="outlined" onClick={handleClick}>{isRunning && progress !== 100 ? 'Stop' : 'Start'}</Button>
-        <Box sx={{ width: '100%' }}>
+      <Button variant="outlined" onClick={handleClick}>
+        {isRunning && progress !== 100 ? 'Stop' : 'Start'}
+      </Button>
+      <Box sx={{ width: '100%' }}>
         <LinearProgressWithLabel value={progress} />
-        </Box>
-        {progress > 0 && <span style={visuallyHidden} aria-live="polite">{`${progress}% progress`}</span>}
+      </Box>
+      {progress > 0 && (
+        <span
+          style={visuallyHidden}
+          aria-live="polite"
+        >{`${progress}% progress`}</span>
+      )}
     </Stack>
   );
 }

--- a/docs/data/material/components/progress/LinearWithValueLabel.tsx.preview
+++ b/docs/data/material/components/progress/LinearWithValueLabel.tsx.preview
@@ -1,1 +1,12 @@
-<LinearProgressWithLabel value={progress} />
+<Button variant="outlined" onClick={handleClick}>
+  {isRunning && progress !== 100 ? 'Stop' : 'Start'}
+</Button>
+<Box sx={{ width: '100%' }}>
+  <LinearProgressWithLabel value={progress} />
+</Box>
+{progress > 0 && (
+  <span
+    style={visuallyHidden}
+    aria-live="polite"
+  >{`${progress}% progress`}</span>
+)}


### PR DESCRIPTION
### Description
This PR resolves https://github.com/mui/material-ui/issues/31376 by adding the proper ARIA values to the different Progress component variants in order to communicate progress state changes via screenreader. 
- When components that dynamically change progress values are interacted with using assistive technology, they will announce changes in progress.

### Motivation for this change:
- Progress indicator components do not consistently communicate role or state to assistive technology. 
- Level A WCAG failure of 4.1.2: Name, Role, Value.

- [x] I have followed the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).