### PR TITLE
[FormControl][base] Do not use optional fields in useFormControlContext's return value

### DIFF
--- a/docs/pages/base/api/use-form-control-context.json
+++ b/docs/pages/base/api/use-form-control-context.json
@@ -1,26 +1,27 @@
 {
   "parameters": {},
   "returnValue": {
+    "disabled": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
+    "error": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "filled": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "focused": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "onBlur": {
       "type": { "name": "() =&gt; void", "description": "() =&gt; void" },
       "required": true
     },
-    "onFocus": {
-      "type": { "name": "() =&gt; void", "description": "() =&gt; void" },
-      "required": true
-    },
-    "disabled": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
-    "error": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
     "onChange": {
       "type": {
         "name": "React.ChangeEventHandler&lt;NativeFormControlElement&gt;",
         "description": "React.ChangeEventHandler&lt;NativeFormControlElement&gt;"
-      }
+      },
+      "required": true
     },
-    "required": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
-    "value": { "type": { "name": "unknown", "description": "unknown" } }
+    "onFocus": {
+      "type": { "name": "() =&gt; void", "description": "() =&gt; void" },
+      "required": true
+    },
+    "required": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
+    "value": { "type": { "name": "unknown", "description": "unknown" }, "required": true }
   },
   "name": "useFormControlContext",
   "filename": "/packages/mui-base/src/FormControl/useFormControlContext.ts",

--- a/packages/mui-base/src/FormControl/FormControl.types.ts
+++ b/packages/mui-base/src/FormControl/FormControl.types.ts
@@ -86,28 +86,44 @@ export type FormControlOwnerState = Simplify<
     }
 >;
 
-type ContextFromPropsKey = 'disabled' | 'error' | 'onChange' | 'required' | 'value';
-
-export type FormControlState = Simplify<
-  Pick<FormControlProps, ContextFromPropsKey> & {
-    /**
-     * If `true`, the form element has some value.
-     */
-    filled: boolean;
-    /**
-     * If `true`, the form element is focused and not disabled.
-     */
-    focused: boolean;
-    /**
-     * Callback fired when the form element has lost focus.
-     */
-    onBlur: () => void;
-    /**
-     * Callback fired when the form element receives focus.
-     */
-    onFocus: () => void;
-  }
->;
+export type FormControlState = {
+  /**
+   * If `true`, the label, input and helper text should be displayed in a disabled state.
+   */
+  disabled: boolean;
+  /**
+   * If `true`, the label is displayed in an error state.
+   */
+  error: boolean;
+  /**
+   * If `true`, the form element has some value.
+   */
+  filled: boolean;
+  /**
+   * If `true`, the form element is focused and not disabled.
+   */
+  focused: boolean;
+  /**
+   * Callback fired when the form element has lost focus.
+   */
+  onBlur: () => void;
+  /**
+   * Callback fired when the form element's value is modified.
+   */
+  onChange: React.ChangeEventHandler<NativeFormControlElement>;
+  /**
+   * Callback fired when the form element receives focus.
+   */
+  onFocus: () => void;
+  /**
+   * If `true`, the label will indicate that the `input` is required.
+   */
+  required: boolean;
+  /**
+   * The value of the form element.
+   */
+  value: unknown;
+};
 
 export type FormControlRootSlotProps = {
   children: React.ReactNode | ((state: FormControlState) => React.ReactNode);


### PR DESCRIPTION
The docs of the useFormControlContext's return value stated that some fields are optional:

<img width="670" alt="image" src="https://user-images.githubusercontent.com/4696105/234593577-b2351e65-c986-4f49-acb2-96cc3249e064.png">

This (nor default values) doesn't make much sense in a return value, so I made all the values present.