### PR TITLE
Update usage.md - React import deprecated in transformer

### DIFF
--- a/docs/data/material/getting-started/usage/usage.md
+++ b/docs/data/material/getting-started/usage/usage.md
@@ -7,7 +7,6 @@
 The following code snippet demonstrates a simple app that uses the Material UI [Button](/material-ui/react-button/) component:
 
 ```jsx
-import * as React from 'react';
 import Button from '@mui/material/Button';
 
 export default function MyApp() {


### PR DESCRIPTION
Very minor update but: the need to import `React` has been deprecated since v17. Includes backporting to earlier versions as it happens in the standard JSX transform for a few years now e.g. internally transform if detecting JSX will create the following

```
// Inserted by a compiler (don't import it yourself!)
import {jsx as _jsx} from 'react/jsx-runtime';

function App() {
  return _jsx('h1', { children: 'Hello world' });
}
```

Considering this, it shouldn't be a backwards compatibility concern (especially on v5 doc).

Source: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
Note that it was suggested to fork locally if creating a "large change"/unquote, so hopefully this being a very minor doc update is fine to directly PR quickly.