### PR TITLE
[TablePagination] Drop component prop

### DIFF
--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -106,6 +106,7 @@ Use the `slots` prop to override the root or any other interior slot:
 ```jsx
 <TablePagination slots={{ root: 'div', toolbar: 'nav' }} />
 ```
+
 :::info
 The `slots` prop is available on all non-utility Base components.
 See [Overriding component structure](/base/guides/overriding-component-structure/) for full details.
@@ -117,7 +118,6 @@ The following code snippet applies a CSS class called `my-spacer` to the spacer 
 ```jsx
 <TablePagination slotProps={{ spacer: { className: 'my-spacer' } }} />
 ```
-
 
 ## Customization
 

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -106,7 +106,6 @@ The following props are available on all non-utility Base components.
 See [Usage](/base/getting-started/usage/) for full details.
 :::
 
-
 Use the `slots` prop to override any interior slots in addition to the root:
 
 ```jsx
@@ -127,7 +126,10 @@ The following code snippet applies a CSS class called `my-spacer` to the spacer 
 In TypeScript, you can specify the custom component type used in the `slots.root` as a generic parameter of the unstyled component. This way, you can safely provide the custom root's props directly on the component:
 
 ```tsx
-<TablePagination<typeof CustomComponent> slots={{ root: CustomComponent }} customProp />
+<TablePagination<typeof CustomComponent>
+  slots={{ root: CustomComponent }}
+  customProp
+/>
 ```
 
 The same applies for props specific to custom primitive elements:

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -101,11 +101,15 @@ The Table Pagination component is composed of a root `<td>` that houses up to te
 
 ### Custom structure
 
-Use the `slots.root` prop to override the root slot with a custom element:
+Use the `slots` prop to override the root or any other interior slot:
 
 ```jsx
 <TablePagination slots={{ root: 'div', toolbar: 'nav' }} />
 ```
+:::info
+The `slots` prop is available on all non-utility Base components.
+See [Overriding component structure](/base/guides/overriding-component-structure/) for full details.
+:::
 
 Use the `slotProps` prop to pass custom props to internal slots.
 The following code snippet applies a CSS class called `my-spacer` to the spacer slot:
@@ -114,10 +118,6 @@ The following code snippet applies a CSS class called `my-spacer` to the spacer 
 <TablePagination slotProps={{ spacer: { className: 'my-spacer' } }} />
 ```
 
-:::info
-The `slots` prop is available on all non-utility Base components.
-See [Overriding component structure](/base/guides/overriding-component-structure/) for full details.
-:::
 
 ## Customization
 

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -99,14 +99,9 @@ The Table Pagination component is composed of a root `<td>` that houses up to te
 </td>
 ```
 
-### Slot props
+### Custom structure
 
-:::info
-The following props are available on all non-utility Base components.
-See [Usage](/base/getting-started/usage/) for full details.
-:::
-
-Use the `slots` prop to override any interior slots in addition to the root:
+Use the `slots.root` prop to override the root slot with a custom element:
 
 ```jsx
 <TablePagination slots={{ root: 'div', toolbar: 'nav' }} />
@@ -122,6 +117,7 @@ The following code snippet applies a CSS class called `my-spacer` to the spacer 
 :::info
 The `slots` prop is available on all non-utility Base components.
 See [Overriding component structure](/base/guides/overriding-component-structure/) for full details.
+:::
 
 ## Customization
 

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -22,7 +22,7 @@ It controls two properties of its parent table:
 - number of rows per page
 
 Table Pagination renders its internal elements in a `<td>` tag by default so it can be inserted into a table's `<tr>`.
-You can use the `component` or `slots.root` prop to render a different root element—for example, if you need to place the pagination controls outside of the table.
+You can use the `slots.root` prop to render a different root element—for example, if you need to place the pagination controls outside of the table.
 See the [Slot props section](#slot-props) for details.
 
 {{"demo": "UnstyledPaginationIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
@@ -106,21 +106,12 @@ The following props are available on all non-utility Base components.
 See [Usage](/base/getting-started/usage/) for full details.
 :::
 
-Use the `component` prop to override the root slot with a custom element:
-
-```jsx
-<TablePagination component="div" />
-```
 
 Use the `slots` prop to override any interior slots in addition to the root:
 
 ```jsx
 <TablePagination slots={{ root: 'div', toolbar: 'nav' }} />
 ```
-
-:::warning
-If the root element is customized with both the `component` and `slots` props, then `component` will take precedence.
-:::
 
 Use the `slotProps` prop to pass custom props to internal slots.
 The following code snippet applies a CSS class called `my-spacer` to the spacer slot:
@@ -130,6 +121,20 @@ The following code snippet applies a CSS class called `my-spacer` to the spacer 
 ```
 
 ## Customization
+
+### Usage with TypeScript
+
+In TypeScript, you can specify the custom component type used in the `slots.root` as a generic parameter of the unstyled component. This way, you can safely provide the custom root's props directly on the component:
+
+```tsx
+<TablePagination<typeof CustomComponent> slots={{ root: CustomComponent }} customProp />
+```
+
+The same applies for props specific to custom primitive elements:
+
+```tsx
+<TablePagination<'button'> slots={{ root: 'button' }} onClick={() => {}} />
+```
 
 ### Custom pagination options
 

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -119,6 +119,10 @@ The following code snippet applies a CSS class called `my-spacer` to the spacer 
 <TablePagination slotProps={{ spacer: { className: 'my-spacer' } }} />
 ```
 
+:::info
+The `slots` prop is available on all non-utility Base components.
+See [Overriding component structure](/base/guides/overriding-component-structure/) for full details.
+
 ## Customization
 
 ### Usage with TypeScript

--- a/docs/pages/base/api/table-pagination.json
+++ b/docs/pages/base/api/table-pagination.json
@@ -26,7 +26,7 @@
     "slotProps": {
       "type": {
         "name": "shape",
-        "description": "{ actions?: func<br>&#124;&nbsp;{ count?: number, direction?: 'ltr'<br>&#124;&nbsp;'rtl', getItemAriaLabel?: func, onPageChange?: func, page?: number, rowsPerPage?: number, showFirstButton?: bool, showLastButton?: bool, slotProps?: { backButton?: func<br>&#124;&nbsp;object, firstButton?: func<br>&#124;&nbsp;object, lastButton?: func<br>&#124;&nbsp;object, nextButton?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object }, slots?: { backButton?: elementType, backPageIcon?: elementType, firstButton?: elementType, firstPageIcon?: elementType, lastButton?: elementType, lastPageIcon?: elementType, nextButton?: elementType, nextPageIcon?: elementType, root?: elementType } }, displayedRows?: func<br>&#124;&nbsp;object, menuItem?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object, select?: func<br>&#124;&nbsp;object, selectLabel?: func<br>&#124;&nbsp;object, spacer?: func<br>&#124;&nbsp;object, toolbar?: func<br>&#124;&nbsp;object }"
+        "description": "{ actions?: func<br>&#124;&nbsp;object, displayedRows?: func<br>&#124;&nbsp;object, menuItem?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object, select?: func<br>&#124;&nbsp;object, selectLabel?: func<br>&#124;&nbsp;object, spacer?: func<br>&#124;&nbsp;object, toolbar?: func<br>&#124;&nbsp;object }"
       },
       "default": "{}"
     },

--- a/docs/pages/base/api/table-pagination.json
+++ b/docs/pages/base/api/table-pagination.json
@@ -4,7 +4,6 @@
     "onPageChange": { "type": { "name": "func" }, "required": true },
     "page": { "type": { "name": "custom", "description": "integer" }, "required": true },
     "rowsPerPage": { "type": { "name": "custom", "description": "integer" }, "required": true },
-    "component": { "type": { "name": "elementType" } },
     "getItemAriaLabel": {
       "type": { "name": "func" },
       "default": "function defaultGetAriaLabel(type: ItemAriaLabelType) {\n  return `Go to ${type} page`;\n}"
@@ -27,7 +26,7 @@
     "slotProps": {
       "type": {
         "name": "shape",
-        "description": "{ actions?: func<br>&#124;&nbsp;object, displayedRows?: func<br>&#124;&nbsp;object, menuItem?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object, select?: func<br>&#124;&nbsp;object, selectLabel?: func<br>&#124;&nbsp;object, spacer?: func<br>&#124;&nbsp;object, toolbar?: func<br>&#124;&nbsp;object }"
+        "description": "{ actions?: func<br>&#124;&nbsp;{ count?: number, direction?: 'ltr'<br>&#124;&nbsp;'rtl', getItemAriaLabel?: func, onPageChange?: func, page?: number, rowsPerPage?: number, showFirstButton?: bool, showLastButton?: bool, slotProps?: { backButton?: func<br>&#124;&nbsp;object, firstButton?: func<br>&#124;&nbsp;object, lastButton?: func<br>&#124;&nbsp;object, nextButton?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object }, slots?: { backButton?: elementType, backPageIcon?: elementType, firstButton?: elementType, firstPageIcon?: elementType, lastButton?: elementType, lastPageIcon?: elementType, nextButton?: elementType, nextPageIcon?: elementType, root?: elementType } }, displayedRows?: func<br>&#124;&nbsp;object, menuItem?: func<br>&#124;&nbsp;object, root?: func<br>&#124;&nbsp;object, select?: func<br>&#124;&nbsp;object, selectLabel?: func<br>&#124;&nbsp;object, spacer?: func<br>&#124;&nbsp;object, toolbar?: func<br>&#124;&nbsp;object }"
       },
       "default": "{}"
     },

--- a/docs/translations/api-docs-base/table-pagination/table-pagination.json
+++ b/docs/translations/api-docs-base/table-pagination/table-pagination.json
@@ -1,7 +1,6 @@
 {
   "componentDescription": "A pagination for tables.",
   "propDescriptions": {
-    "component": "The component used for the root node. Either a string to use a HTML element or a component.",
     "count": "The total number of rows.<br>To enable server side pagination for an unknown number of items, provide -1.",
     "getItemAriaLabel": "Accepts a function which returns a string value that provides a user-friendly name for the current page. This is important for screen reader users.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.<br><br><strong>Signature:</strong><br><code>function(type: string) =&gt; string</code><br><em>type:</em> The link or button type to format (&#39;first&#39; | &#39;last&#39; | &#39;next&#39; | &#39;previous&#39;).",
     "labelDisplayedRows": "Customize the displayed rows label. Invoked with a <code>{ from, to, count, page }</code> object.<br>For localization purposes, you can use the provided <a href=\"/material-ui/guides/localization/\">translations</a>.",

--- a/packages/mui-base/src/TablePagination/TablePagination.spec.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import TablePagination from '@mui/base/TablePagination';
+import { expectType } from '@mui/types';
 import {
   TablePaginationActionsSlotProps,
   TablePaginationDisplayedRowsSlotProps,
@@ -75,3 +76,59 @@ const styledTablePagination = (
     }}
   />
 );
+
+const polymorphicComponentTest = () => {
+  const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> =
+    function CustomComponent() {
+      return <div />;
+    };
+
+  const requiredProps = {
+    count: 10,
+    getItemAriaLabel: () => '',
+    onPageChange: () => {},
+    page: 0,
+    rowsPerPage: 10,
+    showFirstButton: true,
+    showLastButton: true,
+  };
+
+  return (
+    <div>
+      {/* @ts-expect-error */}
+      <TablePagination {...requiredProps} invalidProp={0} />
+
+      <TablePagination<'a'> {...requiredProps} slots={{ root: 'a' }} href="#" />
+
+      <TablePagination<typeof CustomComponent>
+        {...requiredProps}
+        slots={{ root: CustomComponent }}
+        stringProp="test"
+        numberProp={0}
+      />
+      {/* @ts-expect-error */}
+      <TablePagination<typeof CustomComponent>
+        {...requiredProps}
+        slots={{ root: CustomComponent }}
+      />
+
+      <TablePagination<'button'>
+        {...requiredProps}
+        slots={{ root: 'button' }}
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => e.currentTarget.checkValidity()}
+      />
+
+      <TablePagination<'button'>
+        {...requiredProps}
+        slots={{ root: 'button' }}
+        ref={(elem) => {
+          expectType<HTMLButtonElement | null, typeof elem>(elem);
+        }}
+        onMouseDown={(e) => {
+          expectType<React.MouseEvent<HTMLButtonElement, MouseEvent>, typeof e>(e);
+          e.currentTarget.checkValidity();
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/mui-base/src/TablePagination/TablePagination.test.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.test.tsx
@@ -62,6 +62,7 @@ describe('<TablePagination />', () => {
           testWithElement: 'th',
         },
       },
+      skip: ['componentProp'],
     }),
   );
 

--- a/packages/mui-base/src/TablePagination/TablePagination.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.tsx
@@ -84,7 +84,7 @@ const TablePagination = React.forwardRef(function TablePagination<
 
   let colSpan;
   const Root = slots.root ?? 'td';
-  if (!Root || Root === 'td' || !isHostComponent(Root)) {
+  if (Root === 'td' || !isHostComponent(Root)) {
     colSpan = colSpanProp || 1000; // col-span over everything
   }
 

--- a/packages/mui-base/src/TablePagination/TablePagination.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { unstable_useId as useId, chainPropTypes, integerPropType } from '@mui/utils';
-import { OverridableComponent } from '@mui/types';
-import { useSlotProps, WithOptionalOwnerState } from '../utils';
+import { PolymorphicComponent, useSlotProps, WithOptionalOwnerState } from '../utils';
 import composeClasses from '../composeClasses';
 import isHostComponent from '../utils/isHostComponent';
 import TablePaginationActions from './TablePaginationActions';
@@ -63,7 +62,6 @@ const TablePagination = React.forwardRef(function TablePagination<
   RootComponentType extends React.ElementType,
 >(props: TablePaginationProps<RootComponentType>, forwardedRef: React.ForwardedRef<Element>) {
   const {
-    component,
     colSpan: colSpanProp,
     count,
     getItemAriaLabel = defaultGetAriaLabel,
@@ -85,7 +83,8 @@ const TablePagination = React.forwardRef(function TablePagination<
   const classes = useUtilityClasses();
 
   let colSpan;
-  if (!component || component === 'td' || !isHostComponent(component)) {
+  const Root = slots.root ?? 'td';
+  if (!Root || Root === 'td' || !isHostComponent(Root)) {
     colSpan = colSpanProp || 1000; // col-span over everything
   }
 
@@ -99,7 +98,6 @@ const TablePagination = React.forwardRef(function TablePagination<
   const selectId = useId(selectIdProp);
   const labelId = useId(labelIdProp);
 
-  const Root = component ?? slots.root ?? 'td';
   const rootProps: WithOptionalOwnerState<TablePaginationRootSlotProps> = useSlotProps({
     elementType: Root,
     externalSlotProps: slotProps.root,
@@ -237,7 +235,7 @@ const TablePagination = React.forwardRef(function TablePagination<
       </Toolbar>
     </Root>
   );
-}) as OverridableComponent<TablePaginationTypeMap>;
+}) as PolymorphicComponent<TablePaginationTypeMap>;
 
 TablePagination.propTypes /* remove-proptypes */ = {
   // ----------------------------- Warning --------------------------------
@@ -247,16 +245,7 @@ TablePagination.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
-  children: PropTypes.node,
-  /**
-   * @ignore
-   */
   colSpan: PropTypes.number,
-  /**
-   * The component used for the root node.
-   * Either a string to use a HTML element or a component.
-   */
-  component: PropTypes.elementType,
   /**
    * The total number of rows.
    *
@@ -358,7 +347,37 @@ TablePagination.propTypes /* remove-proptypes */ = {
    * @default {}
    */
   slotProps: PropTypes.shape({
-    actions: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    actions: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({
+        count: PropTypes.number,
+        direction: PropTypes.oneOf(['ltr', 'rtl']),
+        getItemAriaLabel: PropTypes.func,
+        onPageChange: PropTypes.func,
+        page: PropTypes.number,
+        rowsPerPage: PropTypes.number,
+        showFirstButton: PropTypes.bool,
+        showLastButton: PropTypes.bool,
+        slotProps: PropTypes.shape({
+          backButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+          firstButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+          lastButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+          nextButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+          root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+        }),
+        slots: PropTypes.shape({
+          backButton: PropTypes.elementType,
+          backPageIcon: PropTypes.elementType,
+          firstButton: PropTypes.elementType,
+          firstPageIcon: PropTypes.elementType,
+          lastButton: PropTypes.elementType,
+          lastPageIcon: PropTypes.elementType,
+          nextButton: PropTypes.elementType,
+          nextPageIcon: PropTypes.elementType,
+          root: PropTypes.elementType,
+        }),
+      }),
+    ]),
     displayedRows: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     menuItem: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/packages/mui-base/src/TablePagination/TablePagination.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.tsx
@@ -346,11 +346,8 @@ TablePagination.propTypes /* remove-proptypes */ = {
    * The props used for each slot inside the TablePagination.
    * @default {}
    */
-  slotProps: PropTypes.shape({
-    actions: /* @typescript-to-proptypes-ignore */ PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.object,
-    ]),
+  slotProps: PropTypes /* @typescript-to-proptypes-ignore */.shape({
+    actions: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     displayedRows: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     menuItem: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/packages/mui-base/src/TablePagination/TablePagination.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.tsx
@@ -347,36 +347,9 @@ TablePagination.propTypes /* remove-proptypes */ = {
    * @default {}
    */
   slotProps: PropTypes.shape({
-    actions: PropTypes.oneOfType([
+    actions: /* @typescript-to-proptypes-ignore */ PropTypes.oneOfType([
       PropTypes.func,
-      PropTypes.shape({
-        count: PropTypes.number,
-        direction: PropTypes.oneOf(['ltr', 'rtl']),
-        getItemAriaLabel: PropTypes.func,
-        onPageChange: PropTypes.func,
-        page: PropTypes.number,
-        rowsPerPage: PropTypes.number,
-        showFirstButton: PropTypes.bool,
-        showLastButton: PropTypes.bool,
-        slotProps: PropTypes.shape({
-          backButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-          firstButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-          lastButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-          nextButton: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-          root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-        }),
-        slots: PropTypes.shape({
-          backButton: PropTypes.elementType,
-          backPageIcon: PropTypes.elementType,
-          firstButton: PropTypes.elementType,
-          firstPageIcon: PropTypes.elementType,
-          lastButton: PropTypes.elementType,
-          lastPageIcon: PropTypes.elementType,
-          nextButton: PropTypes.elementType,
-          nextPageIcon: PropTypes.elementType,
-          root: PropTypes.elementType,
-        }),
-      }),
+      PropTypes.object,
     ]),
     displayedRows: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     menuItem: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/packages/mui-base/src/TablePagination/TablePagination.types.ts
+++ b/packages/mui-base/src/TablePagination/TablePagination.types.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { OverrideProps } from '@mui/types';
-import { SlotComponentProps } from '../utils';
+import { PolymorphicProps, SlotComponentProps } from '../utils';
 import TablePaginationActions from './TablePaginationActions';
 import { ItemAriaLabelType } from './common.types';
 
@@ -205,9 +204,7 @@ export interface TablePaginationTypeMap<
 
 export type TablePaginationProps<
   RootComponentType extends React.ElementType = TablePaginationTypeMap['defaultComponent'],
-> = OverrideProps<TablePaginationTypeMap<{}, RootComponentType>, RootComponentType> & {
-  component?: RootComponentType;
-};
+> = PolymorphicProps<TablePaginationTypeMap<{}, RootComponentType>, RootComponentType>;
 
 export type TablePaginationOwnerState = TablePaginationOwnProps;
 

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.spec.tsx
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.spec.tsx
@@ -56,26 +56,29 @@ const polymorphicComponentTest = () => {
       {/* @ts-expect-error */}
       <TablePaginationActions {...requiredProps} invalidProp={0} />
 
-      <TablePaginationActions {...requiredProps} component="a" href="#" />
+      <TablePaginationActions<'a'> {...requiredProps} slots={{ root: 'a' }} href="#" />
 
-      <TablePaginationActions
+      <TablePaginationActions<typeof CustomComponent>
         {...requiredProps}
-        component={CustomComponent}
+        slots={{ root: CustomComponent }}
         stringProp="test"
         numberProp={0}
       />
       {/* @ts-expect-error */}
-      <TablePaginationActions {...requiredProps} component={CustomComponent} />
+      <TablePaginationActions<typeof CustomComponent>
+        {...requiredProps}
+        slots={{ root: CustomComponent }}
+      />
 
       <TablePaginationActions
         {...requiredProps}
-        component="button"
+        slots={{ root: 'button' }}
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => e.currentTarget.checkValidity()}
       />
 
       <TablePaginationActions<'button'>
         {...requiredProps}
-        component="button"
+        slots={{ root: 'button' }}
         ref={(elem) => {
           expectType<HTMLButtonElement | null, typeof elem>(elem);
         }}

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.tsx
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { OverridableComponent } from '@mui/types';
-import { useSlotProps, WithOptionalOwnerState } from '../utils';
+import { PolymorphicComponent, useSlotProps, WithOptionalOwnerState } from '../utils';
 import {
   TablePaginationActionsButtonSlotProps,
   TablePaginationActionsProps,
@@ -36,7 +35,6 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions<
   forwardedRef: React.ForwardedRef<Element>,
 ) {
   const {
-    component,
     count,
     getItemAriaLabel = defaultGetAriaLabel,
     onPageChange,
@@ -70,7 +68,7 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions<
     onPageChange(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1));
   };
 
-  const Root = slots.root ?? component ?? 'div';
+  const Root = slots.root ?? 'div';
   const rootProps: WithOptionalOwnerState<TablePaginationActionsRootSlotProps> = useSlotProps({
     elementType: Root,
     externalSlotProps: slotProps.root,
@@ -160,6 +158,6 @@ const TablePaginationActions = React.forwardRef(function TablePaginationActions<
       )}
     </Root>
   );
-}) as OverridableComponent<TablePaginationActionsTypeMap>;
+}) as PolymorphicComponent<TablePaginationActionsTypeMap>;
 
 export default TablePaginationActions;

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.types.ts
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.types.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { OverrideProps } from '@mui/types';
-import { SlotComponentProps } from '../utils';
+import { PolymorphicProps, SlotComponentProps } from '../utils';
 
 export interface TablePaginationActionsRootSlotPropsOverrides {}
 export interface TablePaginationActionsFirstButtonSlotPropsOverrides {}
@@ -118,9 +117,7 @@ export interface TablePaginationActionsSlots {
 
 export type TablePaginationActionsProps<
   RootComponentType extends React.ElementType = TablePaginationActionsTypeMap['defaultComponent'],
-> = OverrideProps<TablePaginationActionsTypeMap<{}, RootComponentType>, RootComponentType> & {
-  component?: RootComponentType;
-};
+> = PolymorphicProps<TablePaginationActionsTypeMap<{}, RootComponentType>, RootComponentType>
 
 export interface TablePaginationActionsTypeMap<
   AdditionalProps = {},

--- a/packages/mui-base/src/TablePagination/TablePaginationActions.types.ts
+++ b/packages/mui-base/src/TablePagination/TablePaginationActions.types.ts
@@ -117,7 +117,7 @@ export interface TablePaginationActionsSlots {
 
 export type TablePaginationActionsProps<
   RootComponentType extends React.ElementType = TablePaginationActionsTypeMap['defaultComponent'],
-> = PolymorphicProps<TablePaginationActionsTypeMap<{}, RootComponentType>, RootComponentType>
+> = PolymorphicProps<TablePaginationActionsTypeMap<{}, RootComponentType>, RootComponentType>;
 
 export interface TablePaginationActionsTypeMap<
   AdditionalProps = {},


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

part of https://github.com/mui/material-ui/issues/36679


# BREAKING CHANGE

It will be covered by codemod, see https://github.com/mui/material-ui/pull/36831

For Base UI components,  the `component` prop value should be moved to `slots.root`: 

```diff
 <TablePagination
-  component="span"
+  slots={{ root: "span" }}
 />
```

If using TypeScript, you should add the custom component type as a generic on the `TablePagination` component.

```diff
-<TablePagination
+<TablePagination<typeof CustomComponent>
   slots={{ root: CustomComponent }}
   customProp="foo"
 />
```


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
