### PR TITLE
[codemod][base] Exclude `Popper` from migration script for `component` prop removal 

### DIFF
--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.js
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.js
@@ -10,9 +10,17 @@ export default function transformer(file, api, options) {
   const transformed = root
     .find(j.ImportDeclaration)
     // Process only Base UI components
-    .filter(({ node }) => node.source.value.startsWith('@mui/base'))
+    .filter(
+      ({ node }) =>
+        // we haven't dropped `component` prop from Base UI Popper
+        node.source.value.startsWith('@mui/base') && !node.source.value.endsWith('Popper'),
+    )
     .forEach((path) => {
       path.node.specifiers.forEach((elementNode) => {
+        if (elementNode.imported?.name === 'Popper') {
+          // we haven't dropped `component` prop from Base UI Popper
+          return;
+        }
         root.findJSXElements(elementNode.local.name).forEach((elementPath) => {
           if (elementPath.node.type !== 'JSXElement') {
             return;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.jsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.jsx
@@ -2,6 +2,8 @@ import MaterialInput from '@mui/material/Input';
 import Input from '@mui/base/Input';
 import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
+import PopperUnstyled from '@mui/base/Popper';
+import { Popper } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -27,3 +29,6 @@ import Badge from '@mui/base/Badge';
 />;
 
 <Input component='a' href='url'></Input>;
+
+<PopperUnstyled component='button' />;
+<Popper component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.jsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.jsx
@@ -4,6 +4,7 @@ import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
 import PopperUnstyled from '@mui/base/Popper';
 import { Popper } from '@mui/base';
+import { Popper as PopperBase } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -32,3 +33,4 @@ import { Popper } from '@mui/base';
 
 <PopperUnstyled component='button' />;
 <Popper component='button' />;
+<PopperBase component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.tsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.tsx
@@ -3,6 +3,8 @@ import MaterialInput from '@mui/material/Input';
 import Input from '@mui/base/Input';
 import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
+import PopperUnstyled from '@mui/base/Popper';
+import { Popper } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -28,3 +30,6 @@ import Badge from '@mui/base/Badge';
 />;
 
 <Input component='a' href='url'></Input>;
+
+<PopperUnstyled component='button' />;
+<Popper component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.tsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/actual.tsx
@@ -5,6 +5,7 @@ import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
 import PopperUnstyled from '@mui/base/Popper';
 import { Popper } from '@mui/base';
+import { Popper as PopperBase } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -33,3 +34,4 @@ import { Popper } from '@mui/base';
 
 <PopperUnstyled component='button' />;
 <Popper component='button' />;
+<PopperBase component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.jsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.jsx
@@ -2,6 +2,8 @@ import MaterialInput from '@mui/material/Input';
 import Input from '@mui/base/Input';
 import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
+import PopperUnstyled from '@mui/base/Popper';
+import { Popper } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -36,3 +38,6 @@ import Badge from '@mui/base/Badge';
 <Input slots={{
   root: 'a'
 }} href='url'></Input>;
+
+<PopperUnstyled component='button' />;
+<Popper component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.jsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.jsx
@@ -4,6 +4,7 @@ import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
 import PopperUnstyled from '@mui/base/Popper';
 import { Popper } from '@mui/base';
+import { Popper as PopperBase } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -41,3 +42,4 @@ import { Popper } from '@mui/base';
 
 <PopperUnstyled component='button' />;
 <Popper component='button' />;
+<PopperBase component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.tsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.tsx
@@ -5,6 +5,7 @@ import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
 import PopperUnstyled from '@mui/base/Popper';
 import { Popper } from '@mui/base';
+import { Popper as PopperBase } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -42,3 +43,4 @@ import { Popper } from '@mui/base';
 
 <PopperUnstyled component='button' />;
 <Popper component='button' />;
+<PopperBase component='button' />;

--- a/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.tsx
+++ b/packages/mui-codemod/src/v5.0.0/base-remove-component-prop.test/expected.tsx
@@ -3,6 +3,8 @@ import MaterialInput from '@mui/material/Input';
 import Input from '@mui/base/Input';
 import Switch from '@mui/base/Switch';
 import Badge from '@mui/base/Badge';
+import PopperUnstyled from '@mui/base/Popper';
+import { Popper } from '@mui/base';
 
 <MaterialInput component={CustomRoot} />;
 
@@ -37,3 +39,6 @@ import Badge from '@mui/base/Badge';
 <Input<'a'> slots={{
   root: 'a'
 }} href='url'></Input>;
+
+<PopperUnstyled component='button' />;
+<Popper component='button' />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Since Base UI Popper supports `component` prop, we should exclude `Popper` from Codemod migration script.