### PR TITLE
[docs] Improve Multiselect demo styling

### DIFF
--- a/docs/data/base/components/select/UnstyledSelectMultiple.js
+++ b/docs/data/base/components/select/UnstyledSelectMultiple.js
@@ -146,14 +146,16 @@ const StyledOption = styled(Option)(
   }
 
   @supports selector(:has(*)) {
-    &.${optionClasses.selected} + .${optionClasses.selected} {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-    }
+    &.${optionClasses.selected} {
+      & + .${optionClasses.selected} {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+      }
 
-    &:where(.${optionClasses.selected}):has(+ .${optionClasses.selected}) {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      &:has(+ .${optionClasses.selected}) {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
     }
   }
 

--- a/docs/data/base/components/select/UnstyledSelectMultiple.js
+++ b/docs/data/base/components/select/UnstyledSelectMultiple.js
@@ -129,6 +129,7 @@ const StyledOption = styled(Option)(
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  transition: border-radius 300ms ease;
 
   &:last-of-type {
     border-bottom: none;
@@ -142,6 +143,18 @@ const StyledOption = styled(Option)(
   &.${optionClasses.highlighted} {
     background-color: ${theme.palette.mode === 'dark' ? grey[800] : grey[100]};
     color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  }
+
+  @supports selector(:has(*)) {
+    &.${optionClasses.selected} + .${optionClasses.selected} {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    &:where(.${optionClasses.selected}):has(+ .${optionClasses.selected}) {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 
   &.${optionClasses.highlighted}.${optionClasses.selected} {

--- a/docs/data/base/components/select/UnstyledSelectMultiple.tsx
+++ b/docs/data/base/components/select/UnstyledSelectMultiple.tsx
@@ -118,6 +118,7 @@ const StyledOption = styled(Option)(
   padding: 8px;
   border-radius: 8px;
   cursor: default;
+  transition: border-radius 300ms ease;
 
   &:last-of-type {
     border-bottom: none;
@@ -131,6 +132,18 @@ const StyledOption = styled(Option)(
   &.${optionClasses.highlighted} {
     background-color: ${theme.palette.mode === 'dark' ? grey[800] : grey[100]};
     color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  }
+
+  @supports selector(:has(*)) {
+    &.${optionClasses.selected} + .${optionClasses.selected} {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    &:where(.${optionClasses.selected}):has(+ .${optionClasses.selected}) {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 
   &.${optionClasses.highlighted}.${optionClasses.selected} {

--- a/docs/data/base/components/select/UnstyledSelectMultiple.tsx
+++ b/docs/data/base/components/select/UnstyledSelectMultiple.tsx
@@ -135,14 +135,16 @@ const StyledOption = styled(Option)(
   }
 
   @supports selector(:has(*)) {
-    &.${optionClasses.selected} + .${optionClasses.selected} {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-    }
+    &.${optionClasses.selected} {
+      & + .${optionClasses.selected} {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+      }
 
-    &:where(.${optionClasses.selected}):has(+ .${optionClasses.selected}) {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+      &:has(+ .${optionClasses.selected}) {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
     }
   }
 

--- a/docs/src/createEmotionCache.ts
+++ b/docs/src/createEmotionCache.ts
@@ -8,8 +8,8 @@ function globalSelector(element: Element) {
   switch (element.type) {
     case RULESET:
       element.props = (element.props as string[]).map((value: any) => {
-        if (value.match(/(:where|:has)\(/)) {
-          value = value.replace(/\.[^:]+(:where|:has)/, '$1');
+        if (value.match(/(:where|:is)\(/)) {
+          value = value.replace(/\.[^:]+(:where|:is)/, '$1');
           return value;
         }
         return value;


### PR DESCRIPTION
Improved the look of multiple selected options in Base UI's Select demos.

Before: 
<img width="332" alt="Screenshot 2023-05-01 at 05 18 11" src="https://user-images.githubusercontent.com/4696105/235450751-53a7ed3b-5adc-4d72-8b5f-5412fc7a6556.png">

After:
<img width="336" alt="Screenshot 2023-05-01 at 05 17 59" src="https://user-images.githubusercontent.com/4696105/235450780-70633170-99f4-47b4-a1b8-9ce412ca3ad7.png">

This relies on the `:has` CSS selector and won't currently work on Firefox (it'll look like before).

~~Interestingly, I couldn't make it work by writing `&.${optionClasses.selected}:has(+ .${optionClasses.selected})`, as for some reason, Emotion was transforming this into `&:has(+ .MuiSelected)`. I wasn't able to isolate this issue, though.~~

I discussed the issue with @siriwatknp, who proposed a fix in createEmotionCache that I included in the PR.
