### PR TITLE
[docs] Fix Material UI's API linking to Base UI

### DIFF
--- a/packages/markdown/loader.js
+++ b/packages/markdown/loader.js
@@ -38,6 +38,7 @@ const packages = [
   {
     product: 'material-ui',
     paths: [
+      path.join(__dirname, '../../packages/mui-base/src'),
       path.join(__dirname, '../../packages/mui-lab/src'),
       path.join(__dirname, '../../packages/mui-material/src'),
     ],

--- a/packages/markdown/loader.js
+++ b/packages/markdown/loader.js
@@ -40,7 +40,6 @@ const packages = [
     paths: [
       path.join(__dirname, '../../packages/mui-lab/src'),
       path.join(__dirname, '../../packages/mui-material/src'),
-      path.join(__dirname, '../../packages/mui-base/src'),
     ],
   },
   {

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -370,6 +370,10 @@ function createRender(context) {
   return render;
 }
 
+const BaseUIReexportedComponents = [
+  'ClickAwayListener',
+];
+
 /**
  * @param {string} product
  * @example 'material'
@@ -386,7 +390,7 @@ function resolveComponentApiUrl(product, componentPkg, component) {
   if (product === 'date-pickers') {
     return `/x/api/date-pickers/${kebabCase(component)}/`;
   }
-  if (componentPkg === 'mui-base') {
+  if (componentPkg === 'mui-base' || BaseUIReexportedComponents.indexOf(component) >= 0) {
     return `/base/api/${kebabCase(component)}/`;
   }
   return `/${product}/api/${kebabCase(component)}/`;

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -370,9 +370,7 @@ function createRender(context) {
   return render;
 }
 
-const BaseUIReexportedComponents = [
-  'ClickAwayListener',
-];
+const BaseUIReexportedComponents = ['ClickAwayListener'];
 
 /**
  * @param {string} product

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -121,7 +121,7 @@ test.describe('Material docs', () => {
       const textContent = await firstAnchor.textContent();
 
       await expect(textContent).toEqual('<Button />');
-      await expect(firstAnchor).toHaveAttribute('href', '/base/api/react-clickaway-listener/');
+      await expect(firstAnchor).toHaveAttribute('href', '/base/api/click-away-listener/');
     });
   });
 

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -98,7 +98,9 @@ test.describe('Material docs', () => {
       await expect(anchor).toHaveText('Material Icons');
     });
 
-    test('should have correct API links when name of components conflicts with Base UI', async ({ page }) => {
+    test('should have correct API links when name of components conflicts with Base UI', async ({
+      page,
+    }) => {
       await page.goto('/material-ui/react-button/');
 
       const anchors = page.locator('div > h2#api ~ ul a');
@@ -107,10 +109,19 @@ test.describe('Material docs', () => {
       const textContent = await firstAnchor.textContent();
 
       await expect(textContent).toEqual('<Button />');
-      await expect(firstAnchor).toHaveAttribute(
-        'href',
-        '/material-ui/api/button/',
-      );
+      await expect(firstAnchor).toHaveAttribute('href', '/material-ui/api/button/');
+    });
+
+    test('should have correct API links when linking Base UI components', async ({ page }) => {
+      await page.goto('/material-ui/react-clickaway-listener/');
+
+      const anchors = page.locator('div > h2#api ~ ul a');
+
+      const firstAnchor = anchors.first();
+      const textContent = await firstAnchor.textContent();
+
+      await expect(textContent).toEqual('<Button />');
+      await expect(firstAnchor).toHaveAttribute('href', '/base/api/react-clickaway-listener/');
     });
   });
 

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -113,7 +113,7 @@ test.describe('Material docs', () => {
     });
 
     test('should have correct API links when linking Base UI components', async ({ page }) => {
-      await page.goto('/material-ui/react-clickaway-listener/');
+      await page.goto('/material-ui/react-click-away-listener/');
 
       const anchors = page.locator('div > h2#api ~ ul a');
 

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -120,7 +120,7 @@ test.describe('Material docs', () => {
       const firstAnchor = anchors.first();
       const textContent = await firstAnchor.textContent();
 
-      await expect(textContent).toEqual('<Button />');
+      await expect(textContent).toEqual('<ClickAwayListener />');
       await expect(firstAnchor).toHaveAttribute('href', '/base/api/click-away-listener/');
     });
   });

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -97,6 +97,21 @@ test.describe('Material docs', () => {
       await expect(anchor).toHaveAttribute('href', '/material-ui/material-icons/');
       await expect(anchor).toHaveText('Material Icons');
     });
+
+    test('should have correct API links when name of components conflicts with Base UI', async ({ page }) => {
+      await page.goto('/material-ui/react-button/');
+
+      const anchors = page.locator('div > h2#api ~ ul a');
+
+      const firstAnchor = anchors.first();
+      const textContent = await firstAnchor.textContent();
+
+      await expect(textContent).toEqual('<Button />');
+      await expect(firstAnchor).toHaveAttribute(
+        'href',
+        '/material-ui/api/button/',
+      );
+    });
   });
 
   test.describe('API page', () => {


### PR DESCRIPTION
The API links on the Material UI's documentation that conflicts with Base UI's components name, have the wrong links, for e.g.: https://mui.com/material-ui/react-button/#api (the Button link is pointing to the wrong API).

The problem comes from the fact that initially we were planning to use the Base UI's components inside Material UI, so we thought that we would like to document the Base UI components on the Material UI's pages. However, this is no longer the case, as we decided to use the headless hooks. We can basically drop this assumption now.

The problem arise after removing the `unstyled` suffix from the Base UI's components, so the names of the components conflicted.

Here is a link for verifying the fix: https://deploy-preview-37121--material-ui.netlify.app/material-ui/react-button/#api