### PR TITLE
[website] make Toolpad alpha labels consistent

### DIFF
--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -369,7 +369,7 @@ export default function HeaderNavBar() {
                         href={ROUTES.productToolpad}
                         icon={<IconImage name="product-toolpad" />}
                         name="MUI Toolpad"
-                        chip={<Chip label="Alpha" size="small" color="grey" />}
+                        chip={<Chip label="Alpha" size="small" color="primary" variant="outlined" />}
                         description="Low-code admin builder."
                         onKeyDown={handleKeyDown}
                       />

--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -369,7 +369,9 @@ export default function HeaderNavBar() {
                         href={ROUTES.productToolpad}
                         icon={<IconImage name="product-toolpad" />}
                         name="MUI Toolpad"
-                        chip={<Chip label="Alpha" size="small" color="primary" variant="outlined" />}
+                        chip={
+                          <Chip label="Alpha" size="small" color="primary" variant="outlined" />
+                        }
                         description="Low-code admin builder."
                         onKeyDown={handleKeyDown}
                       />

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -224,7 +224,7 @@ export default function HeaderNavDropdown() {
                           >
                             {item.name}
                             {item.chip ? (
-                              <Chip size="small" label={item.chip} color="grey" />
+                              <Chip size="small" label={item.chip} color="primary" variant="outlined" />
                             ) : null}
                           </Box>
                           <Typography variant="body2" color="text.secondary">
@@ -270,7 +270,7 @@ export default function HeaderNavDropdown() {
                           >
                             {item.name}
                             {item.chip ? (
-                              <Chip size="small" label={item.chip} color="grey" />
+                              <Chip size="small" label={item.chip} color="primary" variant="outlined" />
                             ) : null}
                           </Box>
                           <Typography variant="body2" color="text.secondary">

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -224,7 +224,12 @@ export default function HeaderNavDropdown() {
                           >
                             {item.name}
                             {item.chip ? (
-                              <Chip size="small" label={item.chip} color="primary" variant="outlined" />
+                              <Chip
+                                size="small"
+                                label={item.chip}
+                                color="primary"
+                                variant="outlined"
+                              />
                             ) : null}
                           </Box>
                           <Typography variant="body2" color="text.secondary">
@@ -270,7 +275,12 @@ export default function HeaderNavDropdown() {
                           >
                             {item.name}
                             {item.chip ? (
-                              <Chip size="small" label={item.chip} color="primary" variant="outlined" />
+                              <Chip
+                                size="small"
+                                label={item.chip}
+                                color="primary"
+                                variant="outlined"
+                              />
                             ) : null}
                           </Box>
                           <Typography variant="body2" color="text.secondary">

--- a/docs/src/modules/components/MuiProductSelector.tsx
+++ b/docs/src/modules/components/MuiProductSelector.tsx
@@ -198,7 +198,7 @@ export default function MuiProductSelector() {
             icon={<IconImage name="product-toolpad" />}
             name="MUI Toolpad"
             description="Low-code admin builder."
-            chip={<Chip size="small" label="Alpha" color="grey" />}
+            chip={<Chip size="small" label="Alpha" color="primary" variant="outlined" />}
           />
         </Link>
       </li>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Updating the Toolpad alpha labels in the submenus to be consistent with the [new Toolpad landing page stylistic changes](https://github.com/mui/mui-toolpad/pull/1786#pullrequestreview-1402061970). 