### PR TITLE
[Tooltip][Joy] Interactive doesn't work

### DIFF
--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -70,8 +70,8 @@ const TooltipRoot = styled('div', {
     lineHeight: theme.vars.lineHeight.sm,
     wordWrap: 'break-word',
     position: 'relative',
-    ...(!ownerState.disableInteractive && {
-      pointerEvents: 'auto',
+    ...(ownerState.disableInteractive && {
+      pointerEvents: 'none',
     }),
     ...variantStyle,
     ...(!variantStyle.backgroundColor && {

--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -80,6 +80,7 @@ const TooltipRoot = styled('div', {
     '&::before': {
       // acts as a invisible connector between the element and the tooltip
       // so that the cursor can move to the tooltip without losing focus.
+      content: '""',
       display: 'block',
       position: 'absolute',
       width: ownerState.placement?.match(/(top|bottom)/)
@@ -621,7 +622,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     externalForwardedProps,
     ownerState,
   });
-
 
   const result = (
     <SlotRoot

--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -84,7 +84,7 @@ const TooltipRoot = styled('div', {
     '&::before': {
       // acts as a invisible connector between the element and the tooltip
       // so that the cursor can move to the tooltip without losing focus.
-      content: '""',
+      content: '"a"',
       display: 'block',
       position: 'absolute',
       width: ownerState.placement?.match(/(top|bottom)/)
@@ -331,6 +331,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   });
 
   const handleEnter = (event: React.MouseEvent<HTMLElement>) => {
+    console.log("enter")
     if (ignoreNonTouchEvents.current && event.type !== 'touchstart') {
       return;
     }
@@ -356,7 +357,9 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     }
   };
 
+  // TODO -> find out where function is called from
   const handleLeave = (event: React.MouseEvent<HTMLElement>) => {
+    console.log("leave")
     clearTimeout(enterTimer.current);
     clearTimeout(leaveTimer.current);
     leaveTimer.current = setTimeout(() => {
@@ -626,6 +629,8 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     externalForwardedProps,
     ownerState,
   });
+
+  // console.log(rootProps)
 
   const result = (
     <SlotRoot

--- a/packages/mui-joy/src/Tooltip/Tooltip.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.tsx
@@ -63,7 +63,6 @@ const TooltipRoot = styled('div', {
       fontSize: theme.vars.fontSize.md,
     }),
     zIndex: theme.vars.zIndex.tooltip,
-    pointerEvents: 'none',
     borderRadius: theme.vars.radius.xs,
     boxShadow: theme.shadow.sm,
     fontFamily: theme.vars.fontFamily.body,
@@ -74,9 +73,6 @@ const TooltipRoot = styled('div', {
     ...(!ownerState.disableInteractive && {
       pointerEvents: 'auto',
     }),
-    ...(!ownerState.open && {
-      pointerEvents: 'none',
-    }),
     ...variantStyle,
     ...(!variantStyle.backgroundColor && {
       backgroundColor: theme.vars.palette.background.surface,
@@ -84,7 +80,6 @@ const TooltipRoot = styled('div', {
     '&::before': {
       // acts as a invisible connector between the element and the tooltip
       // so that the cursor can move to the tooltip without losing focus.
-      content: '"a"',
       display: 'block',
       position: 'absolute',
       width: ownerState.placement?.match(/(top|bottom)/)
@@ -331,7 +326,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   });
 
   const handleEnter = (event: React.MouseEvent<HTMLElement>) => {
-    console.log("enter")
     if (ignoreNonTouchEvents.current && event.type !== 'touchstart') {
       return;
     }
@@ -357,9 +351,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     }
   };
 
-  // TODO -> find out where function is called from
   const handleLeave = (event: React.MouseEvent<HTMLElement>) => {
-    console.log("leave")
     clearTimeout(enterTimer.current);
     clearTimeout(leaveTimer.current);
     leaveTimer.current = setTimeout(() => {
@@ -630,7 +622,6 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
     ownerState,
   });
 
-  // console.log(rootProps)
 
   const result = (
     <SlotRoot


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes: https://github.com/mui/material-ui/issues/37132

Took me way too long, hopefully this is it.
The culprit is `pointer-events: none;`, so I delete the 2 locations where this is set. In Material UI's implementation, the tooltip is 2 layers of `div`, so adding `pointer-events: none;` to the child `div` is okay. `mouseenter` event will still be called by the parent `div` when mouse comes to the tooltip. In Joy UI, however, the tooltip is only a div. Adding `pointer-events: none;` here causes `mouseenter` event to not be called when the mouse enter the tooltip.

Example:
- [old](https://mui.com/joy-ui/react-tooltip/#variants:~:text=/%3E%3B%0A%7D-,Variants,-The%20tooltip%20component)
- [new](https://codesandbox.io/s/mui-material-ui-forked-zmmgvb)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
