### PR TITLE
Upgrading @types/react-is in @mui/utils

### DIFF
--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@babel/runtime": "^7.21.0",
     "@types/prop-types": "^15.7.5",
-    "@types/react-is": "^16.7.1 || ^17.0.0",
+    "@types/react-is": "^17.0.0 || ^18.0.0",
     "prop-types": "^15.8.1",
     "react-is": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3599,7 +3599,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-is@^16.7.1 || ^17.0.0", "@types/react-is@^17.0.3":
+"@types/react-is@^17.0.0 || ^18.0.0", "@types/react-is@^17.0.3":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
   integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==


### PR DESCRIPTION
Aligns with used versions of `react` and `react-is`

I hope this resolves https://github.com/mui/material-ui/issues/37068 for me and those affected by that bug, but I wasn't able to successfully test these changes locally.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
