### PR TITLE
[core] Add VSCode extensions recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iml
 .vscode/*
 !.vscode/launch.json
+!.vscode/extensions.json
 *.log
 *.tsbuildinfo
 /.eslintcache

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "yoavbls.pretty-ts-errors"
+  ]
+}


### PR DESCRIPTION
Added the VSCode [recommended workspace extensions](https://code.visualstudio.com/docs/editor/extension-marketplace#_recommended-extensions). 

The following are included:
- Editorconfig
- ESLint
- Markdownlint
- Prettier
- Pretty TypeScript Errors
