### PR TITLE
[typescript][base] Fix types of components callbacks parameters

### DIFF
--- a/packages/mui-base/src/Button/Button.spec.tsx
+++ b/packages/mui-base/src/Button/Button.spec.tsx
@@ -35,6 +35,16 @@ const polymorphicComponentTest = () => {
 
       <Button slots={{ root: 'a' }} href="#" />
 
+      <Button
+        ref={(elem) => {
+          expectType<HTMLButtonElement | null, typeof elem>(elem);
+        }}
+        onClick={(e) => {
+          expectType<React.MouseEvent<HTMLButtonElement, MouseEvent>, typeof e>(e);
+        }}
+        type="submit"
+      />
+
       <Button<typeof CustomComponent>
         slots={{ root: CustomComponent }}
         stringProp="test"

--- a/packages/mui-base/src/utils/PolymorphicComponent.ts
+++ b/packages/mui-base/src/utils/PolymorphicComponent.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { OverridableTypeMap } from '@mui/types';
+import { DistributiveOmit, OverridableTypeMap } from '@mui/types';
 
 /**
  * A component whose root component can be controlled explicitly with a generic type parameter.
@@ -21,4 +21,5 @@ export type PolymorphicComponent<TypeMap extends OverridableTypeMap> = {
 export type PolymorphicProps<
   TypeMap extends OverridableTypeMap,
   RootComponent extends React.ElementType,
-> = TypeMap['props'] & Omit<React.ComponentPropsWithRef<RootComponent>, keyof TypeMap['props']>;
+> = TypeMap['props'] &
+  DistributiveOmit<React.ComponentPropsWithRef<RootComponent>, keyof TypeMap['props']>;


### PR DESCRIPTION
Fixes the regression introduced in #36677 and restores proper types of callbacks and ref parameters.

Closes #37157