### PR TITLE
[AppBar] Fix component type

### DIFF
--- a/packages/mui-material/src/AppBar/AppBar.d.ts
+++ b/packages/mui-material/src/AppBar/AppBar.d.ts
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { DistributiveOmit, OverridableStringUnion } from '@mui/types';
+import { OverridableStringUnion } from '@mui/types';
 import { OverridableComponent, OverrideProps } from '@mui/material/OverridableComponent';
 import { PropTypes, Theme } from '..';
-import { PaperProps } from '../Paper';
 import { AppBarClasses } from './appBarClasses';
+import { ExtendPaperTypeMap } from '../Paper/Paper';
 
 export interface AppBarPropsColorOverrides {}
 
-export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
-  props: P &
-    DistributiveOmit<PaperProps, 'position' | 'color' | 'classes'> & {
+export type AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> = ExtendPaperTypeMap<
+  {
+    props: P & {
       /**
        * Override or extend the styles applied to the component.
        */
@@ -39,8 +39,10 @@ export interface AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> {
        */
       sx?: SxProps<Theme>;
     };
-  defaultComponent: D;
-}
+    defaultComponent: D;
+  },
+  'position' | 'color' | 'classes'
+>;
 
 /**
  *

--- a/packages/mui-material/src/AppBar/AppBar.spec.tsx
+++ b/packages/mui-material/src/AppBar/AppBar.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import AppBar from '@mui/material/AppBar';
+import { expectType } from '@mui/types';
 
 const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> =
   function CustomComponent() {
@@ -12,7 +13,13 @@ function AppBarTest() {
       <AppBar />
       <AppBar elevation={4} />
 
-      <AppBar component="a" href="test" />
+      <AppBar
+        component="a"
+        href="test"
+        onClick={(event) => {
+          expectType<React.MouseEvent<HTMLAnchorElement, MouseEvent>, typeof event>(event);
+        }}
+      />
       <AppBar component={CustomComponent} stringProp="test" numberProp={0} />
       {/* @ts-expect-error missing stringProp and numberProp */}
       <AppBar component={CustomComponent} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

before: https://codesandbox.io/s/gifted-bash-gsto2d?file=/demo.tsx:0-226

after: https://codesandbox.io/s/amazing-cori-xt0uds

# Steps to reproduce

1. go to before sandbox
2. hover on the `event` argument on `onClick` function.
3. notice the type of event is set to `React.MouseEvent<HTMLDivElement, MouseEvent>` where type of `event` should be `React.MouseEvent<HTMLAnchorElement, MouseEvent>` as `component='a'` is set to `AppBar`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
