### PR TITLE
[Utils] fix downstream bundlers remove React 17 useId compatibility

### DIFF
--- a/packages/mui-utils/src/useId.ts
+++ b/packages/mui-utils/src/useId.ts
@@ -17,8 +17,8 @@ function useGlobalId(idOverride?: string): string | undefined {
   return id;
 }
 
-// eslint-disable-next-line no-useless-concat -- Workaround for https://github.com/webpack/webpack/issues/14814
-const maybeReactUseId: undefined | (() => string) = (React as any)['useId' + ''];
+// downstream bundlers may remove unnecessary concatenation, but won't remove toString call -- Workaround for https://github.com/webpack/webpack/issues/14814
+const maybeReactUseId: undefined | (() => string) = (React as any)['useId'.toString()];
 /**
  *
  * @example <div id={useId()} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Summary

Fixes #37182. Based on [this commit from floating-ui](https://github.com/hawkstein/floating-ui/commit/961ec59dc03af9ffc2ea14b9f8b0108d3db609f1). I've confirmed that this will resolve the issue by manually tweaking the `useId` code in a local install of `@mui/utils` and running it through the same bundle process that's stripping the string concatenation.

### Bundle output before tweak to confirm fix, using string concatenation in utils source

Note that `+""` has been stripped from `React3["useId"+""]` on line 15. This is what's causing the downstream build issue.

```javascript
// ../../common/temp/node_modules/.pnpm/@mui+utils@5.11.13_react@17.0.2/node_modules/@mui/utils/esm/useId.js
import * as React3 from "react";
var globalId = 0;
function useGlobalId(idOverride) {
  const [defaultId, setDefaultId] = React3.useState(idOverride);
  const id = idOverride || defaultId;
  React3.useEffect(() => {
    if (defaultId == null) {
      globalId += 1;
      setDefaultId(`mui-${globalId}`);
    }
  }, [defaultId]);
  return id;
}
var maybeReactUseId = React3["useId"];
function useId2(idOverride) {
  if (maybeReactUseId !== void 0) {
    const reactId = maybeReactUseId();
    return idOverride != null ? idOverride : reactId;
  }
  return useGlobalId(idOverride);
}
```

### Bundle output after tweak to confirm fix, using `.toString()` in utils source

Note that the call to `toString` has been preserved on line 15.

```javascript
// ../../common/temp/node_modules/.pnpm/@mui+utils@5.11.13_react@17.0.2/node_modules/@mui/utils/esm/useId.js
import * as React3 from "react";
var globalId = 0;
function useGlobalId(idOverride) {
  const [defaultId, setDefaultId] = React3.useState(idOverride);
  const id = idOverride || defaultId;
  React3.useEffect(() => {
    if (defaultId == null) {
      globalId += 1;
      setDefaultId(`mui-${globalId}`);
    }
  }, [defaultId]);
  return id;
}
var maybeReactUseId = React3["useId".toString()];
function useId(idOverride) {
  if (maybeReactUseId !== void 0) {
    const reactId = maybeReactUseId();
    return idOverride != null ? idOverride : reactId;
  }
  return useGlobalId(idOverride);
}
```