### PR TITLE
[Breadcrumbs] [Joy] Convert Breadcrumbs test to typescript

### DIFF
--- a/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.test.tsx
@@ -30,11 +30,14 @@ describe('<Breadcrumbs />', () => {
 
       expect(getByRole('navigation')).to.have.class(classes.sizeMd);
     });
-    ['sm', 'md', 'lg'].forEach((size) => {
+    const sizes = ['sm', 'md', 'lg'] as const;
+    sizes.forEach((size) => {
       it(`should render ${size}`, () => {
         const { getByRole } = render(<Breadcrumbs size={size} />);
 
-        expect(getByRole('navigation')).to.have.class(classes[`size${capitalize(size)}`]);
+        expect(getByRole('navigation')).to.have.class(
+          classes[`size${capitalize(size)}` as keyof typeof classes],
+        );
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #37078

Converts the Breadcrumbs.test.js file to Breadcrumbs.test.tsx
All tests are running fine and no eslint errors are found after the conversion.

I checked the negative case and it is failing in case of typo.