### PR TITLE
[docs] Fix Material Design templates

### DIFF
--- a/docs/data/material/getting-started/templates/album/Album.js
+++ b/docs/data/material/getting-started/templates/album/Album.js
@@ -31,11 +31,12 @@ function Copyright() {
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function Album() {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <AppBar position="relative">
         <Toolbar>
@@ -89,13 +90,12 @@ export default function Album() {
                   sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
                 >
                   <CardMedia
-                    component="img"
+                    component="div"
                     sx={{
                       // 16:9
                       pt: '56.25%',
                     }}
-                    image="https://source.unsplash.com/random"
-                    alt="random"
+                    image="https://source.unsplash.com/random?wallpapers"
                   />
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Typography gutterBottom variant="h5" component="h2">

--- a/docs/data/material/getting-started/templates/album/Album.js
+++ b/docs/data/material/getting-started/templates/album/Album.js
@@ -31,7 +31,7 @@ function Copyright() {
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Album() {

--- a/docs/data/material/getting-started/templates/album/Album.tsx
+++ b/docs/data/material/getting-started/templates/album/Album.tsx
@@ -31,11 +31,12 @@ function Copyright() {
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function Album() {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <AppBar position="relative">
         <Toolbar>
@@ -89,13 +90,12 @@ export default function Album() {
                   sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
                 >
                   <CardMedia
-                    component="img"
+                    component="div"
                     sx={{
                       // 16:9
                       pt: '56.25%',
                     }}
-                    image="https://source.unsplash.com/random"
-                    alt="random"
+                    image="https://source.unsplash.com/random?wallpapers"
                   />
                   <CardContent sx={{ flexGrow: 1 }}>
                     <Typography gutterBottom variant="h5" component="h2">

--- a/docs/data/material/getting-started/templates/album/Album.tsx
+++ b/docs/data/material/getting-started/templates/album/Album.tsx
@@ -31,7 +31,7 @@ function Copyright() {
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Album() {

--- a/docs/data/material/getting-started/templates/blog/Blog.js
+++ b/docs/data/material/getting-started/templates/blog/Blog.js
@@ -83,7 +83,7 @@ const sidebar = {
   ],
 };
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Blog() {

--- a/docs/data/material/getting-started/templates/blog/Blog.js
+++ b/docs/data/material/getting-started/templates/blog/Blog.js
@@ -33,7 +33,7 @@ const mainFeaturedPost = {
   title: 'Title of a longer featured blog post',
   description:
     "Multiple lines of text that form the lede, informing new readers quickly and efficiently about what's most interesting in this post's contents.",
-  image: 'https://source.unsplash.com/random/?blog/',
+  image: 'https://source.unsplash.com/random?wallpapers',
   imageText: 'main image description',
   linkText: 'Continue reading…',
 };
@@ -44,7 +44,7 @@ const featuredPosts = [
     date: 'Nov 12',
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
-    image: 'https://source.unsplash.com/random/?blog/',
+    image: 'https://source.unsplash.com/random?wallpapers',
     imageLabel: 'Image Text',
   },
   {
@@ -52,7 +52,7 @@ const featuredPosts = [
     date: 'Nov 11',
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
-    image: 'https://source.unsplash.com/random/?blog/',
+    image: 'https://source.unsplash.com/random?wallpapers',
     imageLabel: 'Image Text',
   },
 ];
@@ -83,11 +83,12 @@ const sidebar = {
   ],
 };
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function Blog() {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <Container maxWidth="lg">
         <Header title="Blog" sections={sections} />

--- a/docs/data/material/getting-started/templates/blog/Blog.tsx
+++ b/docs/data/material/getting-started/templates/blog/Blog.tsx
@@ -83,7 +83,7 @@ const sidebar = {
   ],
 };
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Blog() {

--- a/docs/data/material/getting-started/templates/blog/Blog.tsx
+++ b/docs/data/material/getting-started/templates/blog/Blog.tsx
@@ -33,7 +33,7 @@ const mainFeaturedPost = {
   title: 'Title of a longer featured blog post',
   description:
     "Multiple lines of text that form the lede, informing new readers quickly and efficiently about what's most interesting in this post's contents.",
-  image: 'https://source.unsplash.com/random/?blog/',
+  image: 'https://source.unsplash.com/random?wallpapers',
   imageText: 'main image description',
   linkText: 'Continue reading…',
 };
@@ -44,7 +44,7 @@ const featuredPosts = [
     date: 'Nov 12',
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
-    image: 'https://source.unsplash.com/random/?blog/',
+    image: 'https://source.unsplash.com/random?wallpapers',
     imageLabel: 'Image Text',
   },
   {
@@ -52,7 +52,7 @@ const featuredPosts = [
     date: 'Nov 11',
     description:
       'This is a wider card with supporting text below as a natural lead-in to additional content.',
-    image: 'https://source.unsplash.com/random/?blog/',
+    image: 'https://source.unsplash.com/random?wallpapers',
     imageLabel: 'Image Text',
   },
 ];
@@ -83,11 +83,12 @@ const sidebar = {
   ],
 };
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function Blog() {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <Container maxWidth="lg">
         <Header title="Blog" sections={sections} />

--- a/docs/data/material/getting-started/templates/blog/MainFeaturedPost.js
+++ b/docs/data/material/getting-started/templates/blog/MainFeaturedPost.js
@@ -9,8 +9,6 @@ import Box from '@mui/material/Box';
 function MainFeaturedPost(props) {
   const { post } = props;
 
-  console.log('post.image', post.image);
-
   return (
     <Paper
       sx={{

--- a/docs/data/material/getting-started/templates/blog/MainFeaturedPost.js
+++ b/docs/data/material/getting-started/templates/blog/MainFeaturedPost.js
@@ -9,6 +9,8 @@ import Box from '@mui/material/Box';
 function MainFeaturedPost(props) {
   const { post } = props;
 
+  console.log('post.image', post.image);
+
   return (
     <Paper
       sx={{

--- a/docs/data/material/getting-started/templates/blog/MainFeaturedPost.tsx
+++ b/docs/data/material/getting-started/templates/blog/MainFeaturedPost.tsx
@@ -18,8 +18,6 @@ interface MainFeaturedPostProps {
 export default function MainFeaturedPost(props: MainFeaturedPostProps) {
   const { post } = props;
 
-  console.log('post.image', post.image);
-
   return (
     <Paper
       sx={{

--- a/docs/data/material/getting-started/templates/blog/MainFeaturedPost.tsx
+++ b/docs/data/material/getting-started/templates/blog/MainFeaturedPost.tsx
@@ -18,6 +18,8 @@ interface MainFeaturedPostProps {
 export default function MainFeaturedPost(props: MainFeaturedPostProps) {
   const { post } = props;
 
+  console.log('post.image', post.image);
+
   return (
     <Paper
       sx={{

--- a/docs/data/material/getting-started/templates/checkout/Checkout.js
+++ b/docs/data/material/getting-started/templates/checkout/Checkout.js
@@ -44,7 +44,8 @@ function getStepContent(step) {
   }
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function Checkout() {
   const [activeStep, setActiveStep] = React.useState(0);
@@ -58,7 +59,7 @@ export default function Checkout() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <AppBar
         position="absolute"

--- a/docs/data/material/getting-started/templates/checkout/Checkout.js
+++ b/docs/data/material/getting-started/templates/checkout/Checkout.js
@@ -44,7 +44,7 @@ function getStepContent(step) {
   }
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Checkout() {

--- a/docs/data/material/getting-started/templates/checkout/Checkout.tsx
+++ b/docs/data/material/getting-started/templates/checkout/Checkout.tsx
@@ -44,7 +44,8 @@ function getStepContent(step: number) {
   }
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function Checkout() {
   const [activeStep, setActiveStep] = React.useState(0);
@@ -58,7 +59,7 @@ export default function Checkout() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <CssBaseline />
       <AppBar
         position="absolute"

--- a/docs/data/material/getting-started/templates/checkout/Checkout.tsx
+++ b/docs/data/material/getting-started/templates/checkout/Checkout.tsx
@@ -44,7 +44,7 @@ function getStepContent(step: number) {
   }
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Checkout() {

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.js
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.js
@@ -81,16 +81,17 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
   }),
 );
 
-const mdTheme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
-function DashboardContent() {
+export default function Dashboard() {
   const [open, setOpen] = React.useState(true);
   const toggleDrawer = () => {
     setOpen(!open);
   };
 
   return (
-    <ThemeProvider theme={mdTheme}>
+    <ThemeProvider theme={defaultTheme}>
       <Box sx={{ display: 'flex' }}>
         <CssBaseline />
         <AppBar position="absolute" open={open}>
@@ -201,8 +202,4 @@ function DashboardContent() {
       </Box>
     </ThemeProvider>
   );
-}
-
-export default function Dashboard() {
-  return <DashboardContent />;
 }

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.js
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.js
@@ -81,7 +81,7 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
   }),
 );
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Dashboard() {

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
@@ -85,7 +85,7 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
   }),
 );
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Dashboard() {

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx
@@ -85,16 +85,17 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
   }),
 );
 
-const mdTheme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
-function DashboardContent() {
+export default function Dashboard() {
   const [open, setOpen] = React.useState(true);
   const toggleDrawer = () => {
     setOpen(!open);
   };
 
   return (
-    <ThemeProvider theme={mdTheme}>
+    <ThemeProvider theme={defaultTheme}>
       <Box sx={{ display: 'flex' }}>
         <CssBaseline />
         <AppBar position="absolute" open={open}>
@@ -205,8 +206,4 @@ function DashboardContent() {
       </Box>
     </ThemeProvider>
   );
-}
-
-export default function Dashboard() {
-  return <DashboardContent />;
 }

--- a/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx.preview
+++ b/docs/data/material/getting-started/templates/dashboard/Dashboard.tsx.preview
@@ -1,1 +1,0 @@
-<DashboardContent />

--- a/docs/data/material/getting-started/templates/pricing/Pricing.js
+++ b/docs/data/material/getting-started/templates/pricing/Pricing.js
@@ -94,7 +94,7 @@ const footers = [
   },
 ];
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Pricing() {

--- a/docs/data/material/getting-started/templates/pricing/Pricing.js
+++ b/docs/data/material/getting-started/templates/pricing/Pricing.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -93,9 +94,12 @@ const footers = [
   },
 ];
 
-function PricingContent() {
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
+
+export default function Pricing() {
   return (
-    <React.Fragment>
+    <ThemeProvider theme={defaultTheme}>
       <GlobalStyles styles={{ ul: { margin: 0, padding: 0, listStyle: 'none' } }} />
       <CssBaseline />
       <AppBar
@@ -254,10 +258,6 @@ function PricingContent() {
         <Copyright sx={{ mt: 5 }} />
       </Container>
       {/* End footer */}
-    </React.Fragment>
+    </ThemeProvider>
   );
-}
-
-export default function Pricing() {
-  return <PricingContent />;
 }

--- a/docs/data/material/getting-started/templates/pricing/Pricing.tsx
+++ b/docs/data/material/getting-started/templates/pricing/Pricing.tsx
@@ -93,7 +93,7 @@ const footers = [
   },
 ];
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function Pricing() {

--- a/docs/data/material/getting-started/templates/pricing/Pricing.tsx
+++ b/docs/data/material/getting-started/templates/pricing/Pricing.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -92,9 +93,12 @@ const footers = [
   },
 ];
 
-function PricingContent() {
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
+
+export default function Pricing() {
   return (
-    <React.Fragment>
+    <ThemeProvider theme={defaultTheme}>
       <GlobalStyles styles={{ ul: { margin: 0, padding: 0, listStyle: 'none' } }} />
       <CssBaseline />
       <AppBar
@@ -256,10 +260,6 @@ function PricingContent() {
         <Copyright sx={{ mt: 5 }} />
       </Container>
       {/* End footer */}
-    </React.Fragment>
+    </ThemeProvider>
   );
-}
-
-export default function Pricing() {
-  return <PricingContent />;
 }

--- a/docs/data/material/getting-started/templates/pricing/Pricing.tsx.preview
+++ b/docs/data/material/getting-started/templates/pricing/Pricing.tsx.preview
@@ -1,1 +1,0 @@
-<PricingContent />

--- a/docs/data/material/getting-started/templates/sign-in-side/SignInSide.js
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInSide.js
@@ -26,7 +26,7 @@ function Copyright(props) {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 
 const defaultTheme = createTheme();
 

--- a/docs/data/material/getting-started/templates/sign-in-side/SignInSide.js
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInSide.js
@@ -26,7 +26,9 @@ function Copyright(props) {
   );
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+
+const defaultTheme = createTheme();
 
 export default function SignInSide() {
   const handleSubmit = (event) => {
@@ -39,7 +41,7 @@ export default function SignInSide() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <Grid container component="main" sx={{ height: '100vh' }}>
         <CssBaseline />
         <Grid
@@ -48,7 +50,7 @@ export default function SignInSide() {
           sm={4}
           md={7}
           sx={{
-            backgroundImage: 'url(https://source.unsplash.com/random)',
+            backgroundImage: 'url(https://source.unsplash.com/random?wallpapers)',
             backgroundRepeat: 'no-repeat',
             backgroundColor: (t) =>
               t.palette.mode === 'light' ? t.palette.grey[50] : t.palette.grey[900],

--- a/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx
@@ -26,7 +26,7 @@ function Copyright(props: any) {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function SignInSide() {

--- a/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx
+++ b/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx
@@ -26,7 +26,8 @@ function Copyright(props: any) {
   );
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function SignInSide() {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -39,7 +40,7 @@ export default function SignInSide() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <Grid container component="main" sx={{ height: '100vh' }}>
         <CssBaseline />
         <Grid
@@ -48,7 +49,7 @@ export default function SignInSide() {
           sm={4}
           md={7}
           sx={{
-            backgroundImage: 'url(https://source.unsplash.com/random)',
+            backgroundImage: 'url(https://source.unsplash.com/random?wallpapers)',
             backgroundRepeat: 'no-repeat',
             backgroundColor: (t) =>
               t.palette.mode === 'light' ? t.palette.grey[50] : t.palette.grey[900],

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.js
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.js
@@ -26,7 +26,7 @@ function Copyright(props) {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 
 const defaultTheme = createTheme();
 

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.js
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.js
@@ -26,7 +26,9 @@ function Copyright(props) {
   );
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+
+const defaultTheme = createTheme();
 
 export default function SignIn() {
   const handleSubmit = (event) => {
@@ -39,7 +41,7 @@ export default function SignIn() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <Box

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
@@ -26,7 +26,8 @@ function Copyright(props: any) {
   );
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function SignIn() {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -39,7 +40,7 @@ export default function SignIn() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <Box

--- a/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
+++ b/docs/data/material/getting-started/templates/sign-in/SignIn.tsx
@@ -26,7 +26,7 @@ function Copyright(props: any) {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function SignIn() {

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.js
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.js
@@ -26,7 +26,7 @@ function Copyright(props) {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 
 const defaultTheme = createTheme();
 

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.js
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.js
@@ -26,7 +26,9 @@ function Copyright(props) {
   );
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+
+const defaultTheme = createTheme();
 
 export default function SignUp() {
   const handleSubmit = (event) => {
@@ -39,7 +41,7 @@ export default function SignUp() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <Box

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
@@ -26,7 +26,8 @@ function Copyright(props: any) {
   );
 }
 
-const theme = createTheme();
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
 
 export default function SignUp() {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -39,7 +40,7 @@ export default function SignUp() {
   };
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={defaultTheme}>
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <Box

--- a/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
+++ b/docs/data/material/getting-started/templates/sign-up/SignUp.tsx
@@ -26,7 +26,7 @@ function Copyright(props: any) {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function SignUp() {

--- a/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.js
+++ b/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.js
@@ -19,7 +19,7 @@ function Copyright() {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function StickyFooter() {

--- a/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.js
+++ b/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
@@ -18,45 +19,50 @@ function Copyright() {
   );
 }
 
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
+
 export default function StickyFooter() {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-      }}
-    >
-      <CssBaseline />
-      <Container component="main" sx={{ mt: 8, mb: 2 }} maxWidth="sm">
-        <Typography variant="h2" component="h1" gutterBottom>
-          Sticky footer
-        </Typography>
-        <Typography variant="h5" component="h2" gutterBottom>
-          {'Pin a footer to the bottom of the viewport.'}
-          {'The footer will move as the main element of the page grows.'}
-        </Typography>
-        <Typography variant="body1">Sticky footer placeholder.</Typography>
-      </Container>
+    <ThemeProvider theme={defaultTheme}>
       <Box
-        component="footer"
         sx={{
-          py: 3,
-          px: 2,
-          mt: 'auto',
-          backgroundColor: (theme) =>
-            theme.palette.mode === 'light'
-              ? theme.palette.grey[200]
-              : theme.palette.grey[800],
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh',
         }}
       >
-        <Container maxWidth="sm">
-          <Typography variant="body1">
-            My sticky footer can be found here.
+        <CssBaseline />
+        <Container component="main" sx={{ mt: 8, mb: 2 }} maxWidth="sm">
+          <Typography variant="h2" component="h1" gutterBottom>
+            Sticky footer
           </Typography>
-          <Copyright />
+          <Typography variant="h5" component="h2" gutterBottom>
+            {'Pin a footer to the bottom of the viewport.'}
+            {'The footer will move as the main element of the page grows.'}
+          </Typography>
+          <Typography variant="body1">Sticky footer placeholder.</Typography>
         </Container>
+        <Box
+          component="footer"
+          sx={{
+            py: 3,
+            px: 2,
+            mt: 'auto',
+            backgroundColor: (theme) =>
+              theme.palette.mode === 'light'
+                ? theme.palette.grey[200]
+                : theme.palette.grey[800],
+          }}
+        >
+          <Container maxWidth="sm">
+            <Typography variant="body1">
+              My sticky footer can be found here.
+            </Typography>
+            <Copyright />
+          </Container>
+        </Box>
       </Box>
-    </Box>
+    </ThemeProvider>
   );
 }

--- a/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.tsx
+++ b/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.tsx
@@ -19,7 +19,7 @@ function Copyright() {
   );
 }
 
-// TODO remove this demo shouldn't need to reset the theme.
+// TODO remove, this demo shouldn't need to reset the theme.
 const defaultTheme = createTheme();
 
 export default function StickyFooter() {

--- a/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.tsx
+++ b/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
@@ -18,45 +19,50 @@ function Copyright() {
   );
 }
 
+// TODO remove this demo shouldn't need to reset the theme.
+const defaultTheme = createTheme();
+
 export default function StickyFooter() {
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-      }}
-    >
-      <CssBaseline />
-      <Container component="main" sx={{ mt: 8, mb: 2 }} maxWidth="sm">
-        <Typography variant="h2" component="h1" gutterBottom>
-          Sticky footer
-        </Typography>
-        <Typography variant="h5" component="h2" gutterBottom>
-          {'Pin a footer to the bottom of the viewport.'}
-          {'The footer will move as the main element of the page grows.'}
-        </Typography>
-        <Typography variant="body1">Sticky footer placeholder.</Typography>
-      </Container>
+    <ThemeProvider theme={defaultTheme}>
       <Box
-        component="footer"
         sx={{
-          py: 3,
-          px: 2,
-          mt: 'auto',
-          backgroundColor: (theme) =>
-            theme.palette.mode === 'light'
-              ? theme.palette.grey[200]
-              : theme.palette.grey[800],
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh',
         }}
       >
-        <Container maxWidth="sm">
-          <Typography variant="body1">
-            My sticky footer can be found here.
+        <CssBaseline />
+        <Container component="main" sx={{ mt: 8, mb: 2 }} maxWidth="sm">
+          <Typography variant="h2" component="h1" gutterBottom>
+            Sticky footer
           </Typography>
-          <Copyright />
+          <Typography variant="h5" component="h2" gutterBottom>
+            {'Pin a footer to the bottom of the viewport.'}
+            {'The footer will move as the main element of the page grows.'}
+          </Typography>
+          <Typography variant="body1">Sticky footer placeholder.</Typography>
         </Container>
+        <Box
+          component="footer"
+          sx={{
+            py: 3,
+            px: 2,
+            mt: 'auto',
+            backgroundColor: (theme) =>
+              theme.palette.mode === 'light'
+                ? theme.palette.grey[200]
+                : theme.palette.grey[800],
+          }}
+        >
+          <Container maxWidth="sm">
+            <Typography variant="body1">
+              My sticky footer can be found here.
+            </Typography>
+            <Copyright />
+          </Container>
+        </Box>
       </Box>
-    </Box>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
🙈 

1. Open https://mui.com/material-ui/getting-started/templates/sign-in-side/ broken image like in #36991.

<img width="802" alt="Screenshot 2023-05-06 at 21 46 50" src="https://user-images.githubusercontent.com/3165635/236643822-881c886a-7f21-4f4d-b9f9-6c79105b9bfc.png">

2. Open https://mui.com/material-ui/getting-started/templates/album/ broken cards

<img width="314" alt="Screenshot 2023-05-06 at 21 46 36" src="https://user-images.githubusercontent.com/3165635/236643828-576e635e-6f27-4ac4-8b44-6e84d6482773.png">

3. Open https://mui.com/material-ui/getting-started/templates/pricing/ wrong theme

<img width="615" alt="Screenshot 2023-05-06 at 21 46 30" src="https://user-images.githubusercontent.com/3165635/236643830-e016b120-fc09-4413-be18-07fe8859c171.png">

But these templates still have room to receive a lot more love.