### PR TITLE
[test] `e2e-website` related minor fixes

### DIFF
--- a/test/e2e-website/README.md
+++ b/test/e2e-website/README.md
@@ -3,7 +3,7 @@
 ## Running locally
 
 1. Run `yarn docs:dev` to start docs in development server.
-2. Run `yarn test:e2e-website` in a separate terminal to run the test suites (`*.spec.ts`) inside `test/e2e-website` folder.
+2. Run `yarn test:e2e-website:dev` in a separate terminal to run the test suites (`*.spec.ts`) inside `test/e2e-website` folder.
 
 > use --headed to run tests in headed browsers, check out [Playwright CLI](https://playwright.dev/docs/intro#command-line) for more options
 

--- a/test/e2e-website/material-docs.spec.ts
+++ b/test/e2e-website/material-docs.spec.ts
@@ -1,6 +1,5 @@
 import { test as base, expect, Page } from '@playwright/test';
 import kebabCase from 'lodash/kebabCase';
-import FEATURE_TOGGLE from 'docs/src/featureToggle';
 import { TestFixture } from './playwright.config';
 
 const test = base.extend<TestFixture>({});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- Remove the unnecessary import `FEATURE_TOGGLE`
- Fix e2e-website README. It should be `test:e2e-website:dev`

Noticed while adding tests in #37175.