### PR TITLE
[core] Check dependency cycles inside packages directory only

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
 
     // Not sure why it doesn't work
     'import/named': 'off',
+    'import/no-cycle': 'off',
     // Missing yarn workspace support
     'import/no-extraneous-dependencies': 'off',
     // The code is already coupled to webpack. Prefer explicit coupling.
@@ -413,6 +414,7 @@ module.exports = {
             ],
           },
         ],
+        'import/no-cycle': ['error', { ignoreExternal: true }],
       },
     },
     {


### PR DESCRIPTION
Improve linting time by checking for cyclic dependencies in production code only.

Results from my local machine:

Before:
```
Rule                                 |  Time (ms) | Relative
:------------------------------------|-----------:|--------:
import/no-cycle                      | 227269.294 |    81.7%
import/extensions                    |  10279.738 |     3.7%
import/no-unresolved                 |   4367.926 |     1.6%
@typescript-eslint/naming-convention |   3440.758 |     1.2%
import/order                         |   2216.073 |     0.8%
import/no-duplicates                 |   1916.750 |     0.7%
import/no-named-as-default           |   1767.365 |     0.6%
import/no-import-module-exports      |   1427.037 |     0.5%
@typescript-eslint/no-redeclare      |   1282.992 |     0.5%
react/default-props-match-prop-types |   1185.290 |     0.4%
Done in 309.20s.
```

After:
```
Rule                                 | Time (ms) | Relative
:------------------------------------|----------:|--------:
import/no-cycle                      | 47719.902 |    46.9%
import/extensions                    |  8183.325 |     8.0%
import/no-named-as-default           |  7344.888 |     7.2%
@typescript-eslint/naming-convention |  3636.665 |     3.6%
import/no-unresolved                 |  3424.987 |     3.4%
import/order                         |  2215.172 |     2.2%
import/no-duplicates                 |  1665.064 |     1.6%
import/no-import-module-exports      |  1553.346 |     1.5%
@typescript-eslint/no-redeclare      |  1536.921 |     1.5%
react/default-props-match-prop-types |  1194.546 |     1.2%
Done in 135.13s.
```