### PR TITLE
[docs] Show default value for `filterOptions` prop in Autocomplete's API docs

### DIFF
--- a/docs/pages/base/api/use-autocomplete.json
+++ b/docs/pages/base/api/use-autocomplete.json
@@ -54,7 +54,8 @@
       "type": {
         "name": "(options: T[], state: FilterOptionsState&lt;T&gt;) =&gt; T[]",
         "description": "(options: T[], state: FilterOptionsState&lt;T&gt;) =&gt; T[]"
-      }
+      },
+      "default": "createFilterOptions()"
     },
     "filterSelectedOptions": {
       "type": { "name": "boolean", "description": "boolean" },

--- a/docs/pages/joy-ui/api/autocomplete.json
+++ b/docs/pages/joy-ui/api/autocomplete.json
@@ -23,7 +23,7 @@
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "endDecorator": { "type": { "name": "node" } },
     "error": { "type": { "name": "bool" }, "default": "false" },
-    "filterOptions": { "type": { "name": "func" } },
+    "filterOptions": { "type": { "name": "func" }, "default": "createFilterOptions()" },
     "forcePopupIcon": {
       "type": { "name": "union", "description": "'auto'<br>&#124;&nbsp;bool" },
       "default": "'auto'"

--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -36,7 +36,7 @@
     "disabledItemsFocusable": { "type": { "name": "bool" }, "default": "false" },
     "disableListWrap": { "type": { "name": "bool" }, "default": "false" },
     "disablePortal": { "type": { "name": "bool" }, "default": "false" },
-    "filterOptions": { "type": { "name": "func" } },
+    "filterOptions": { "type": { "name": "func" }, "default": "createFilterOptions()" },
     "filterSelectedOptions": { "type": { "name": "bool" }, "default": "false" },
     "forcePopupIcon": {
       "type": { "name": "union", "description": "'auto'<br>&#124;&nbsp;bool" },

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
@@ -132,6 +132,7 @@ export interface UseAutocompleteProps<
   /**
    * A function that determines the filtered options to be rendered on search.
    *
+   * @default createFilterOptions()
    * @param {T[]} options The options to render.
    * @param {object} state The state of the component.
    * @returns {T[]}

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -842,6 +842,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * A function that determines the filtered options to be rendered on search.
    *
+   * @default createFilterOptions()
    * @param {T[]} options The options to render.
    * @param {object} state The state of the component.
    * @returns {T[]}

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -829,6 +829,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * A function that determines the filtered options to be rendered on search.
    *
+   * @default createFilterOptions()
    * @param {T[]} options The options to render.
    * @param {object} state The state of the component.
    * @returns {T[]}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #36780

Material UI - https://deploy-preview-37230--material-ui.netlify.app/material-ui/api/autocomplete/
Joy UI - https://deploy-preview-37230--material-ui.netlify.app/joy-ui/api/autocomplete/
