### PR TITLE
[Dialog] fixed broken dialog when using maxWidth="xs" and custom breakpoint unit

### DIFF
--- a/packages/mui-material/src/Dialog/Dialog.js
+++ b/packages/mui-material/src/Dialog/Dialog.js
@@ -125,7 +125,7 @@ const DialogPaper = styled(Paper, {
     maxWidth:
       theme.breakpoints.unit === 'px'
         ? Math.max(theme.breakpoints.values.xs, 444)
-        : `${theme.breakpoints.values.xs}${theme.breakpoints.unit}`,
+        : `max(${theme.breakpoints.values.xs}${theme.breakpoints.unit}, 444px)`,
     [`&.${dialogClasses.paperScrollBody}`]: {
       [theme.breakpoints.down(Math.max(theme.breakpoints.values.xs, 444) + 32 * 2)]: {
         maxWidth: 'calc(100% - 64px)',


### PR DESCRIPTION
Resolves https://github.com/mui/material-ui/issues/37241

Here's a demo of the fix: https://codesandbox.io/s/https-github-com-mui-material-ui-issues-37241-r5334g

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
