### PR TITLE
[Menu][base] MenuItem as a link does not work 

### DIFF
--- a/packages/mui-base/src/useList/useListItem.ts
+++ b/packages/mui-base/src/useList/useListItem.ts
@@ -70,7 +70,7 @@ export default function useListItem<ItemValue>(
         return;
       }
 
-      if (event.target.tagName.toLowerCase() !== 'a') {
+      if ((event.target as HTMLElement).tagName.toLowerCase() !== 'a') {
         event.preventDefault();
       }
 

--- a/packages/mui-base/src/useList/useListItem.ts
+++ b/packages/mui-base/src/useList/useListItem.ts
@@ -70,7 +70,7 @@ export default function useListItem<ItemValue>(
         return;
       }
 
-      if (!(event.target instanceof HTMLAnchorElement)) {
+      if (event.target.tagName.toLowerCase() !== 'a') {
         event.preventDefault();
       }
 

--- a/packages/mui-base/src/useList/useListItem.ts
+++ b/packages/mui-base/src/useList/useListItem.ts
@@ -70,7 +70,9 @@ export default function useListItem<ItemValue>(
         return;
       }
 
-      event.preventDefault();
+      if (!(event.target instanceof HTMLAnchorElement)) {
+        event.preventDefault();
+      }
 
       dispatch({
         type: ListActionTypes.itemClick,

--- a/packages/mui-base/src/useList/useListItem.ts
+++ b/packages/mui-base/src/useList/useListItem.ts
@@ -70,10 +70,6 @@ export default function useListItem<ItemValue>(
         return;
       }
 
-      if ((event.target as HTMLElement).tagName.toLowerCase() !== 'a') {
-        event.preventDefault();
-      }
-
       dispatch({
         type: ListActionTypes.itemClick,
         item,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

fixes: https://github.com/mui/material-ui/issues/36979

This PR adds additional check inside callback fn for a root element of a list item. It check if `event.target` is instance of `HTMLAnchorElement`. If it is from an `a` tag, then the default event shouldn't be prevented.

codesandboxes:

- [old](https://codesandbox.io/s/still-platform-rh966j?file=/demo.tsx)
- [new](https://codesandbox.io/s/affectionate-nightingale-ui752q?file=/demo.tsx)
