### PR TITLE
[Joy] Miscellaneous fixes

### DIFF
--- a/docs/data/joy/components/modal/ResponsiveModal.js
+++ b/docs/data/joy/components/modal/ResponsiveModal.js
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import Modal from '@mui/joy/Modal';
+import ModalDialog from '@mui/joy/ModalDialog';
+import Typography from '@mui/joy/Typography';
+
+export default function ResponsiveModal() {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <React.Fragment>
+      <Button variant="outlined" color="neutral" onClick={() => setOpen(true)}>
+        Open modal
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <ModalDialog
+          aria-labelledby="nested-modal-title"
+          aria-describedby="nested-modal-description"
+          sx={(theme) => ({
+            [theme.breakpoints.only('xs')]: {
+              top: 'unset',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              borderRadius: 0,
+              transform: 'none',
+              maxWidth: 'unset',
+            },
+          })}
+        >
+          <Typography id="nested-modal-title" component="h2">
+            Are you absolutely sure?
+          </Typography>
+          <Typography id="nested-modal-description" textColor="text.tertiary">
+            This action cannot be undone. This will permanently delete your account
+            and remove your data from our servers.
+          </Typography>
+          <Box
+            sx={{
+              mt: 1,
+              display: 'flex',
+              gap: 1,
+              flexDirection: { xs: 'column', sm: 'row-reverse' },
+            }}
+          >
+            <Button variant="solid" color="neutral" onClick={() => setOpen(false)}>
+              Continue
+            </Button>
+            <Button
+              variant="outlined"
+              color="neutral"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+          </Box>
+        </ModalDialog>
+      </Modal>
+    </React.Fragment>
+  );
+}

--- a/docs/data/joy/components/modal/ResponsiveModal.tsx
+++ b/docs/data/joy/components/modal/ResponsiveModal.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import Modal from '@mui/joy/Modal';
+import ModalDialog from '@mui/joy/ModalDialog';
+import Typography from '@mui/joy/Typography';
+
+export default function ResponsiveModal() {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <React.Fragment>
+      <Button variant="outlined" color="neutral" onClick={() => setOpen(true)}>
+        Open modal
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <ModalDialog
+          aria-labelledby="nested-modal-title"
+          aria-describedby="nested-modal-description"
+          sx={(theme) => ({
+            [theme.breakpoints.only('xs')]: {
+              top: 'unset',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              borderRadius: 0,
+              transform: 'none',
+              maxWidth: 'unset',
+            },
+          })}
+        >
+          <Typography id="nested-modal-title" component="h2">
+            Are you absolutely sure?
+          </Typography>
+          <Typography id="nested-modal-description" textColor="text.tertiary">
+            This action cannot be undone. This will permanently delete your account
+            and remove your data from our servers.
+          </Typography>
+          <Box
+            sx={{
+              mt: 1,
+              display: 'flex',
+              gap: 1,
+              flexDirection: { xs: 'column', sm: 'row-reverse' },
+            }}
+          >
+            <Button variant="solid" color="neutral" onClick={() => setOpen(false)}>
+              Continue
+            </Button>
+            <Button
+              variant="outlined"
+              color="neutral"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+          </Box>
+        </ModalDialog>
+      </Modal>
+    </React.Fragment>
+  );
+}

--- a/docs/data/joy/components/modal/modal.md
+++ b/docs/data/joy/components/modal/modal.md
@@ -214,6 +214,14 @@ Therefore, in order to display a modal rendered on the server, disable the porta
 
 {{"demo": "ServerModal.js", "defaultCodeOpen": false}}
 
+## Common examples
+
+### Mobile modal
+
+Use `sx` prop with `theme.breakpoints.only('xs')` to customize the styles of the modal dialog to stick at the bottom in mobile viewport.
+
+{{"demo": "ResponsiveModal.js"}}
+
 ## Limitations
 
 ### Focus trap

--- a/docs/data/joy/components/table/TableStickyHeader.js
+++ b/docs/data/joy/components/table/TableStickyHeader.js
@@ -19,16 +19,21 @@ const rows = [
   createData('10', 356, 16.0, 49, 3.9),
 ];
 
+function sum(column) {
+  return rows.reduce((acc, row) => acc + row[column], 0);
+}
+
 export default function TableStickyHeader() {
   return (
     <div>
       <Typography level="body2" textAlign="center" sx={{ mb: 2 }}>
         The table body is scrollable.
       </Typography>
-      <Sheet sx={{ height: 200, overflow: 'auto' }}>
+      <Sheet sx={{ height: 300, overflow: 'auto' }}>
         <Table
           aria-label="table with sticky header"
           stickyHeader
+          stickyFooter
           stripe="odd"
           hoverRow
         >
@@ -52,6 +57,20 @@ export default function TableStickyHeader() {
               </tr>
             ))}
           </tbody>
+          <tfoot>
+            <tr>
+              <th scope="row">Totals</th>
+              <td>{sum('calories').toFixed(2)}</td>
+              <td>{sum('fat').toFixed(2)}</td>
+              <td>{sum('carbs').toFixed(2)}</td>
+              <td>{sum('protein').toFixed(2)}</td>
+            </tr>
+            <tr>
+              <td colSpan={5} style={{ textAlign: 'center' }}>
+                {sum('calories') + sum('fat') + sum('carbs') + sum('protein')} Kcal
+              </td>
+            </tr>
+          </tfoot>
         </Table>
       </Sheet>
     </div>

--- a/docs/data/joy/components/table/TableStickyHeader.tsx
+++ b/docs/data/joy/components/table/TableStickyHeader.tsx
@@ -24,6 +24,9 @@ const rows = [
   createData('9', 305, 3.7, 67, 4.3),
   createData('10', 356, 16.0, 49, 3.9),
 ];
+function sum(column: 'calories' | 'fat' | 'carbs' | 'protein') {
+  return rows.reduce((acc, row) => acc + row[column], 0);
+}
 
 export default function TableStickyHeader() {
   return (
@@ -31,10 +34,11 @@ export default function TableStickyHeader() {
       <Typography level="body2" textAlign="center" sx={{ mb: 2 }}>
         The table body is scrollable.
       </Typography>
-      <Sheet sx={{ height: 200, overflow: 'auto' }}>
+      <Sheet sx={{ height: 300, overflow: 'auto' }}>
         <Table
           aria-label="table with sticky header"
           stickyHeader
+          stickyFooter
           stripe="odd"
           hoverRow
         >
@@ -58,6 +62,20 @@ export default function TableStickyHeader() {
               </tr>
             ))}
           </tbody>
+          <tfoot>
+            <tr>
+              <th scope="row">Totals</th>
+              <td>{sum('calories').toFixed(2)}</td>
+              <td>{sum('fat').toFixed(2)}</td>
+              <td>{sum('carbs').toFixed(2)}</td>
+              <td>{sum('protein').toFixed(2)}</td>
+            </tr>
+            <tr>
+              <td colSpan={5} style={{ textAlign: 'center' }}>
+                {sum('calories') + sum('fat') + sum('carbs') + sum('protein')} Kcal
+              </td>
+            </tr>
+          </tfoot>
         </Table>
       </Sheet>
     </div>

--- a/docs/data/joy/components/table/TableUsage.js
+++ b/docs/data/joy/components/table/TableUsage.js
@@ -39,11 +39,19 @@ export default function ButtonUsage() {
           defaultValue: false,
         },
         {
+          propName: 'stickyFooter',
+          knob: 'switch',
+          defaultValue: false,
+        },
+        {
           propName: 'stripe',
           knob: 'radio',
           options: ['odd', 'even'],
         },
       ]}
+      getCodeBlock={(code) => `<Sheet>
+  ${code}
+</Sheet>`}
       renderDemo={(props) => (
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           <Typography
@@ -54,51 +62,59 @@ export default function ButtonUsage() {
           >
             The table is scrollable.
           </Typography>
-          <Sheet
-            variant="outlined"
-            sx={{
-              height: 200,
-              overflow: 'auto',
-              p: 2,
-              borderRadius: 'sm',
-            }}
-          >
-            <Table {...props}>
-              <thead>
-                <tr>
-                  <th style={{ width: 64 }}>ID</th>
-                  <th>Job Title</th>
-                  <th>Name</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>1</td>
-                  <td>Doctor</td>
-                  <td>Chris Johnson</td>
-                </tr>
-                <tr>
-                  <td>2</td>
-                  <td>Electrician</td>
-                  <td>Joseph Morris</td>
-                </tr>
-                <tr>
-                  <td>3</td>
-                  <td>Operator</td>
-                  <td>Aiden Moreno</td>
-                </tr>
-                <tr>
-                  <td>4</td>
-                  <td>Baker</td>
-                  <td>Mike Simmons</td>
-                </tr>
-                <tr>
-                  <td>5</td>
-                  <td>Clerk</td>
-                  <td>Enoch Addison</td>
-                </tr>
-              </tbody>
-            </Table>
+          <Sheet variant="outlined" sx={{ p: 2, borderRadius: 'sm' }}>
+            <Sheet
+              sx={{
+                height: 200,
+                overflow: 'auto',
+                borderRadius: 0,
+              }}
+            >
+              <Table {...props}>
+                <thead>
+                  <tr>
+                    <th style={{ width: 64 }}>ID</th>
+                    <th>Job Title</th>
+                    <th>Name</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>1</td>
+                    <td>Doctor</td>
+                    <td>Chris Johnson</td>
+                  </tr>
+                  <tr>
+                    <td>2</td>
+                    <td>Electrician</td>
+                    <td>Joseph Morris</td>
+                  </tr>
+                  <tr>
+                    <td>3</td>
+                    <td>Operator</td>
+                    <td>Aiden Moreno</td>
+                  </tr>
+                  <tr>
+                    <td>4</td>
+                    <td>Baker</td>
+                    <td>Mike Simmons</td>
+                  </tr>
+                  <tr>
+                    <td>5</td>
+                    <td>Clerk</td>
+                    <td>Enoch Addison</td>
+                  </tr>
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td>Total</td>
+                    <td colSpan={2} style={{ textAlign: 'center' }}>
+                      4 people
+                    </td>
+                  </tr>
+                </tfoot>
+              </Table>
+            </Sheet>
           </Sheet>
         </Box>
       )}

--- a/docs/data/joy/components/table/table.md
+++ b/docs/data/joy/components/table/table.md
@@ -161,12 +161,14 @@ declare module '@mui/joy/Table' {
 }
 ```
 
-### Sticky header
+### Sticky header and footer
 
-Set the `stickyHeader` prop to true to make the header follow the user as they scroll down the page.
+Set the `stickyHeader` to true to always stick the header at the top as users scroll the table.
+
+Set the `stickyFooter` to true to always stick the footer at the bottom of the table.
 
 :::success
-For `stickyHeader` to work correctly, the Table must be a child of a fixed-height element with overflow `auto` (or `scroll`).
+For `stickyHeader` and `stickyFooter` to work correctly, the Table must be a child of a fixed-height element with overflow `auto` (or `scroll`).
 We recommend wrapping your Table with [Sheet](/joy-ui/react-sheet/) for this purpose.
 See [usage with Sheet](#usage-with-sheet) to learn more.
 :::

--- a/docs/pages/joy-ui/api/table.json
+++ b/docs/pages/joy-ui/api/table.json
@@ -33,6 +33,7 @@
       "type": { "name": "shape", "description": "{ root?: elementType }" },
       "default": "{}"
     },
+    "stickyFooter": { "type": { "name": "bool" }, "default": "false" },
     "stickyHeader": { "type": { "name": "bool" }, "default": "false" },
     "stripe": {
       "type": {
@@ -85,6 +86,7 @@
       "sizeLg",
       "sizeMd",
       "sizeSm",
+      "stickyFooter",
       "stickyHeader",
       "variantOutlined",
       "variantPlain",

--- a/docs/translations/api-docs-joy/table/table.json
+++ b/docs/translations/api-docs-joy/table/table.json
@@ -10,7 +10,8 @@
     "size": "The size of the component. It accepts theme values between &#39;sm&#39; and &#39;lg&#39;. To learn how to add custom sizes to the component, check out <a href=\"/joy-ui/customization/themed-components/#extend-sizes\">Themed components—Extend sizes</a>.",
     "slotProps": "The props used for each slot inside.",
     "slots": "The components used for each slot inside. See <a href=\"#slots\">Slots API</a> below for more details.",
-    "stickyHeader": "Set the header sticky.<br>⚠️ It doesn&#39;t work with IE11.",
+    "stickyFooter": "If <code>true</code>, the footer always appear at the bottom of the overflow table.<br>⚠️ It doesn&#39;t work with IE11.",
+    "stickyHeader": "If <code>true</code>, the header always appear at the top of the overflow table.<br>⚠️ It doesn&#39;t work with IE11.",
     "stripe": "The odd or even row of the table body will have subtle background color.",
     "sx": "The system prop that allows defining system overrides as well as additional CSS styles. See the <a href=\"/system/getting-started/the-sx-prop/\">`sx` page</a> for more details.",
     "variant": "The <a href=\"https://mui.com/joy-ui/main-features/global-variants/\">global variant</a> to use. To learn how to add your own variants, check out <a href=\"/joy-ui/customization/themed-components/#extend-variants\">Themed components—Extend variants</a>."
@@ -91,6 +92,11 @@
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>stickyHeader</code> is true"
+    },
+    "stickyFooter": {
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>stickyFooter</code> is true"
     },
     "noWrap": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",

--- a/packages/mui-joy/src/AspectRatio/AspectRatio.tsx
+++ b/packages/mui-joy/src/AspectRatio/AspectRatio.tsx
@@ -57,6 +57,7 @@ const AspectRatioContent = styled('div', {
     height: 0,
     paddingBottom: 'calc(var(--AspectRatio-paddingBottom) - 2 * var(--variant-borderWidth, 0px))',
     overflow: 'hidden',
+    transition: 'inherit', // makes it easy to add transition to the content
     // use data-attribute instead of :first-child to support zero config SSR (emotion)
     // use nested selector for integrating with nextjs image `fill` layout (spans are inserted on top of the img)
     '& [data-first-child]': {

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -91,7 +91,8 @@ const ModalDialogRoot = styled(SheetRoot, {
     top: '50%',
     left: '50%',
     transform: 'translate(-50%, -50%)',
-    maxWidth: 'calc(100vw - 2 * var(--ModalDialog-padding))',
+    maxWidth:
+      'min(calc(100vw - 2 * var(--ModalDialog-padding)), var(--ModalDialog-maxWidth, 100vw))',
     maxHeight: 'calc(100% - 2 * var(--ModalDialog-padding))',
   }),
   [`& [id="${ownerState['aria-labelledby']}"]`]: {

--- a/packages/mui-joy/src/Table/Table.test.tsx
+++ b/packages/mui-joy/src/Table/Table.test.tsx
@@ -126,4 +126,10 @@ describe('<Table />', () => {
 
     expect(getByRole('table')).to.have.class(classes.stickyHeader);
   });
+
+  it('adds `stickyFooter` class', () => {
+    const { getByRole } = render(<Table stickyFooter />);
+
+    expect(getByRole('table')).to.have.class(classes.stickyFooter);
+  });
 });

--- a/packages/mui-joy/src/Table/Table.tsx
+++ b/packages/mui-joy/src/Table/Table.tsx
@@ -423,6 +423,12 @@ Table.propTypes /* remove-proptypes */ = {
   /**
    * Set the header sticky.
    *
+   * @default false
+   */
+  stickyFooter: PropTypes.bool,
+  /**
+   * Set the header sticky.
+   *
    * ⚠️ It doesn't work with IE11.
    * @default false
    */

--- a/packages/mui-joy/src/Table/Table.tsx
+++ b/packages/mui-joy/src/Table/Table.tsx
@@ -13,11 +13,13 @@ import { TypographyInheritContext } from '../Typography/Typography';
 import useSlot from '../utils/useSlot';
 
 const useUtilityClasses = (ownerState: TableOwnerState) => {
-  const { size, variant, color, borderAxis, stickyHeader, noWrap, hoverRow } = ownerState;
+  const { size, variant, color, borderAxis, stickyHeader, stickyFooter, noWrap, hoverRow } =
+    ownerState;
   const slots = {
     root: [
       'root',
       stickyHeader && 'stickyHeader',
+      stickyFooter && 'stickyFooter',
       noWrap && 'noWrap',
       hoverRow && 'hoverRow',
       borderAxis && `borderAxis${capitalize(borderAxis)}`,
@@ -97,6 +99,9 @@ const tableSelector = {
   getFooterCell() {
     return '& tfoot th, & tfoot td';
   },
+  getFooterFirstRowCell() {
+    return `& tfoot tr:not(:last-of-type) th, & tfoot tr:not(:last-of-type) td`;
+  },
 };
 
 const TableRoot = styled('table', {
@@ -132,6 +137,7 @@ const TableRoot = styled('table', {
       width: '100%',
       borderSpacing: '0px',
       borderCollapse: 'separate',
+      borderRadius: 'var(--TableCell-cornerRadius, var(--unstable_actionRadius))',
       color: theme.vars.palette.text.primary,
       ...theme.variants[ownerState.variant!]?.[ownerState.color!],
       '& caption': {
@@ -250,16 +256,28 @@ const TableRoot = styled('table', {
     },
     ownerState.stickyHeader && {
       // The column header
-      [tableSelector.getHeadCell()]: {
+      [tableSelector.getHeaderCell()]: {
         position: 'sticky',
         top: 0,
-      },
-      [tableSelector.getHeaderCell()]: {
         zIndex: theme.vars.zIndex.table,
       },
       [tableSelector.getHeaderCellOfRow(2)]: {
         // support upto 2 rows for the sticky header
         top: 'var(--unstable_TableCell-height)',
+      },
+    },
+    ownerState.stickyFooter && {
+      // The column header
+      [tableSelector.getFooterCell()]: {
+        position: 'sticky',
+        bottom: 0,
+        zIndex: theme.vars.zIndex.table,
+        color: theme.vars.palette.text.secondary,
+        fontWeight: theme.vars.fontWeight.lg,
+      },
+      [tableSelector.getFooterFirstRowCell()]: {
+        // support upto 2 rows for the sticky footer
+        bottom: 'var(--unstable_TableCell-height)',
       },
     },
   ];
@@ -292,6 +310,7 @@ const Table = React.forwardRef(function Table(inProps, ref) {
     color: colorProp = 'neutral',
     stripe,
     stickyHeader = false,
+    stickyFooter = false,
     slots = {},
     slotProps = {},
     ...other
@@ -310,6 +329,7 @@ const Table = React.forwardRef(function Table(inProps, ref) {
     variant,
     stripe,
     stickyHeader,
+    stickyFooter,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-joy/src/Table/Table.tsx
+++ b/packages/mui-joy/src/Table/Table.tsx
@@ -421,13 +421,14 @@ Table.propTypes /* remove-proptypes */ = {
     root: PropTypes.elementType,
   }),
   /**
-   * Set the header sticky.
+   * If `true`, the footer always appear at the bottom of the overflow table.
    *
+   * ⚠️ It doesn't work with IE11.
    * @default false
    */
   stickyFooter: PropTypes.bool,
   /**
-   * Set the header sticky.
+   * If `true`, the header always appear at the top of the overflow table.
    *
    * ⚠️ It doesn't work with IE11.
    * @default false

--- a/packages/mui-joy/src/Table/TableProps.ts
+++ b/packages/mui-joy/src/Table/TableProps.ts
@@ -71,6 +71,12 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
      */
     stickyHeader?: boolean;
     /**
+     * Set the header sticky.
+     *
+     * @default false
+     */
+    stickyFooter?: boolean;
+    /**
      * The odd or even row of the table body will have subtle background color.
      */
     stripe?: 'odd' | 'even' | (string & Record<never, never>);

--- a/packages/mui-joy/src/Table/TableProps.ts
+++ b/packages/mui-joy/src/Table/TableProps.ts
@@ -64,15 +64,16 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', TablePropsSizeOverrides>;
     /**
-     * Set the header sticky.
+     * If `true`, the header always appear at the top of the overflow table.
      *
      * ⚠️ It doesn't work with IE11.
      * @default false
      */
     stickyHeader?: boolean;
     /**
-     * Set the header sticky.
+     * If `true`, the footer always appear at the bottom of the overflow table.
      *
+     * ⚠️ It doesn't work with IE11.
      * @default false
      */
     stickyFooter?: boolean;

--- a/packages/mui-joy/src/Table/tableClasses.ts
+++ b/packages/mui-joy/src/Table/tableClasses.ts
@@ -58,10 +58,10 @@ export interface TableClasses {
 export type TableClassKey = keyof TableClasses;
 
 export function getTableUtilityClass(slot: string): string {
-  return generateUtilityClass('JoyTable', slot);
+  return generateUtilityClass('MuiTable', slot);
 }
 
-const tableClasses: TableClasses = generateUtilityClasses('JoyTable', [
+const tableClasses: TableClasses = generateUtilityClasses('MuiTable', [
   'root',
   'colorPrimary',
   'colorNeutral',

--- a/packages/mui-joy/src/Table/tableClasses.ts
+++ b/packages/mui-joy/src/Table/tableClasses.ts
@@ -33,6 +33,8 @@ export interface TableClasses {
   sizeLg: string;
   /** Class name applied to the root element if `stickyHeader` is true. */
   stickyHeader: string;
+  /** Class name applied to the root element if `stickyFooter` is true. */
+  stickyFooter: string;
   /** Class name applied to the root element if `noWrap` is true. */
   noWrap: string;
   /** Class name applied to the root element if `hoverRow` is true. */
@@ -76,6 +78,7 @@ const tableClasses: TableClasses = generateUtilityClasses('JoyTable', [
   'sizeMd',
   'sizeLg',
   'stickyHeader',
+  'stickyFooter',
   'noWrap',
   'hoverRow',
   'borderAxisNone',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- AspectRatio: add `transition: inherit` to the content slot to make customization at the root slot easier.
- Table: add `stickyFooter` prop and fix className prefix.
- Modal: add `--ModalDialog-maxWidth` and responsive modal example.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
