### PR TITLE
[Select] [joy] handle long text content

### DIFF
--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -20,7 +20,7 @@ import { ListOwnerState } from '../List';
 import FormControlContext from '../FormControl/FormControlContext';
 
 function defaultRenderSingleValue<TValue>(selectedOption: SelectOption<TValue> | null) {
-  return <span>{selectedOption?.label}</span> ?? '';
+  return selectedOption?.label ?? '';
 }
 
 function defaultFormValueProvider<TValue>(selectedOption: SelectOption<TValue> | null) {
@@ -198,12 +198,6 @@ const SelectButton = styled('button', {
   fontSize: 'inherit',
   color: 'inherit',
   alignSelf: 'stretch',
-  // handle long text
-  overflow: 'hidden',
-  '& > *': {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
   // make children horizontally aligned
   display: 'flex',
   alignItems: 'center',
@@ -211,6 +205,7 @@ const SelectButton = styled('button', {
   fontFamily: 'inherit',
   cursor: 'pointer',
   whiteSpace: 'nowrap',
+  overflow: 'hidden', // prevent the scrollbar for long text
   ...((ownerState.value === null || ownerState.value === undefined) && {
     opacity: 'var(--Select-placeholderOpacity)',
   }),

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -20,7 +20,7 @@ import { ListOwnerState } from '../List';
 import FormControlContext from '../FormControl/FormControlContext';
 
 function defaultRenderSingleValue<TValue>(selectedOption: SelectOption<TValue> | null) {
-  return selectedOption?.label ?? '';
+  return <span>{selectedOption?.label}</span> ?? '';
 }
 
 function defaultFormValueProvider<TValue>(selectedOption: SelectOption<TValue> | null) {
@@ -198,6 +198,12 @@ const SelectButton = styled('button', {
   fontSize: 'inherit',
   color: 'inherit',
   alignSelf: 'stretch',
+  // handle long text
+  overflow: 'hidden',
+  '& > *': {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
   // make children horizontally aligned
   display: 'flex',
   alignItems: 'center',
@@ -205,7 +211,6 @@ const SelectButton = styled('button', {
   fontFamily: 'inherit',
   cursor: 'pointer',
   whiteSpace: 'nowrap',
-  overflow: 'auto',
   ...((ownerState.value === null || ownerState.value === undefined) && {
     opacity: 'var(--Select-placeholderOpacity)',
   }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #37277

Please advise if this is a good way to deal with this issue.

I can hide the scrollbars by just putting `overflow: "hidden"` but in order to show the ellipsis I had to first put the content inside a span tag and add `width: 0` to it.

This is needed as the button is a flex container due to which I can't directly add `text-overflow: "ellipsis"` to it.
[https://css-tricks.com/flexbox-truncated-text/](https://css-tricks.com/flexbox-truncated-text/)

Visually everything seems to be working fine.

<img width="360" alt="Screenshot 2023-05-16 at 5 26 48 PM" src="https://github.com/mui/material-ui/assets/26057318/5206d52f-ac77-49ef-99fa-49b8b163add2">

<img width="270" alt="Screenshot 2023-05-16 at 5 26 42 PM" src="https://github.com/mui/material-ui/assets/26057318/aab7c2dc-80f5-48ce-a38f-b43a4961ff85">

<img width="320" alt="Screenshot 2023-05-16 at 5 38 43 PM" src="https://github.com/mui/material-ui/assets/26057318/b6a64dd5-d091-4f56-8151-5b371a3afed7">
