### PR TITLE
[utils] createChainedFunction() types should allow for null or undefined

### DIFF
--- a/packages/mui-utils/src/createChainedFunction.ts
+++ b/packages/mui-utils/src/createChainedFunction.ts
@@ -5,11 +5,11 @@
  * otherwise will pass back existing functions or null.
  */
 export default function createChainedFunction<Args extends any[], This>(
-  ...funcs: Array<(this: This, ...args: Args) => any>
+  ...funcs: Array<(this: This, ...args: Args) => any | null | undefined>
 ): (this: This, ...args: Args) => void {
   return funcs.reduce(
     (acc, func) => {
-      if (func == null) {
+      if (func === null || func === undefined) {
         return acc;
       }
 


### PR DESCRIPTION
...as is allowed by the implementation.  This is a convenience method and neither null nor undefined values should diminish it's convenience.

I bumped into this when transitioning from v4-v5.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
