### PR TITLE
Revert "Bump rollup to ^3.21.8 (#35619)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "react-test-renderer": "^18.2.0",
     "remark": "^13.0.0",
     "rimraf": "^3.0.2",
-    "rollup": "^3.21.8",
+    "rollup": "^2.79.1",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-globals": "^1.4.0",

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -32,7 +32,7 @@
     "build:modern": "node ../../scripts/build.mjs modern",
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
-    "build:umd": "cross-env BABEL_ENV=stable rollup -c scripts/rollup.config.mjs",
+    "build:umd": "cross-env BABEL_ENV=stable rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copyFiles.mjs",
     "build:types": "node ../../scripts/buildTypes.mjs",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",

--- a/packages/mui-material/scripts/rollup.config.js
+++ b/packages/mui-material/scripts/rollup.config.js
@@ -2,7 +2,6 @@ import { promises as fs, existsSync } from 'fs';
 import path from 'path';
 import zlib from 'zlib';
 import { promisify } from 'util';
-import * as url from 'url';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
@@ -11,7 +10,6 @@ import nodeGlobals from 'rollup-plugin-node-globals';
 import { terser } from 'rollup-plugin-terser';
 
 const gzip = promisify(zlib.gzip);
-const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @param {{snapshotPath: string}} options
@@ -79,7 +77,7 @@ function sizeSnapshot(options) {
 function resolveNestedImport(packageFolder, importee) {
   const folder = importee.split('/')[2];
   const resolvedFilename = path.resolve(
-    currentDirectory,
+    __dirname,
     `../../../packages/${packageFolder}/src/${folder}/index`,
   );
 
@@ -126,7 +124,7 @@ const babelOptions = {
   // We are using @babel/plugin-transform-runtime
   runtimeHelpers: true,
   extensions: ['.js', '.ts', '.tsx'],
-  configFile: path.resolve(currentDirectory, '../../../babel.config.js'),
+  configFile: path.resolve(__dirname, '../../../babel.config.js'),
 };
 const commonjsOptions = {
   ignoreGlobal: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14543,10 +14543,10 @@ rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.8.1:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^3.21.8:
-  version "3.21.8"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.21.8.tgz#fc768008fe2c953f18210370fd70fe1ffff59e2c"
-  integrity sha512-SSFV2T2fWtQ/vvBip85u2Nr0GNKireabH9d7nXswBg+XSH+jbVDSYptRAEbCEsquhs503rpPA9POYAp0/Jhasw==
+rollup@^2.79.1:
+  version "2.79.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.1.tgz#bedee8faef7c9f93a2647ac0108748f497f081c7"
+  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
This reverts commit ea7201aa8f2cc6295d9c51b866b595757ad992c4.

It causes an error when running `yarn release:build` (Error: EPIPE).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
