### PR TITLE
Removed default return values from use-slider hook

### DIFF
--- a/docs/pages/base/api/use-slider.json
+++ b/docs/pages/base/api/use-slider.json
@@ -48,12 +48,10 @@
   "returnValue": {
     "active": {
       "type": { "name": "number", "description": "number" },
-      "default": "-1",
       "required": true
     },
     "axis": {
       "type": { "name": "Axis", "description": "Axis" },
-      "default": "horizontal",
       "required": true
     },
     "axisProps": {
@@ -65,7 +63,6 @@
     },
     "dragging": {
       "type": { "name": "boolean", "description": "boolean" },
-      "default": "false",
       "required": true
     },
     "focusedThumbIndex": {
@@ -96,7 +93,6 @@
     "marks": { "type": { "name": "Mark[]", "description": "Mark[]" }, "required": true },
     "open": {
       "type": { "name": "number", "description": "number" },
-      "default": "-1",
       "required": true
     },
     "range": { "type": { "name": "boolean", "description": "boolean" }, "required": true },


### PR DESCRIPTION
This issue: https://github.com/mui/material-ui/issues/37039

Looking forward to your feedback, @michaldudak . If I am on the right way, I will proceed with the other hooks.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
