### PR TITLE
[examples] Remove `@babel/plugin-proposal-class-properties` from Material-Express-SSR example

### DIFF
--- a/examples/material-express-ssr/.babelrc
+++ b/examples/material-express-ssr/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
 }

--- a/examples/material-express-ssr/package.json
+++ b/examples/material-express-ssr/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@babel/core": "latest",
     "@babel/node": "latest",
-    "@babel/plugin-proposal-class-properties": "latest",
     "@babel/preset-env": "latest",
     "@babel/preset-react": "latest",
     "@emotion/cache": "latest",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Similar to #36795. It is included by default in `@bable/preset-env`.
