### PR TITLE
[docs-infra] Throw on incorrect internal links

### DIFF
--- a/docs/data/joy/guides/using-icon-libraries/using-icon-libraries.md
+++ b/docs/data/joy/guides/using-icon-libraries/using-icon-libraries.md
@@ -191,9 +191,9 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 ### Iconify
 
 - [Browse icons](https://icon-sets.iconify.design/)
-- [Installation—React](https://docs.iconify.design/icon-components/react/)
-- [Installation—Web component](https://docs.iconify.design/iconify-icon/)
-- [Figma plugin](https://docs.iconify.design/design/figma/)
+- [Installation—React](https://iconify.design/docs/icon-components/react/)
+- [Installation—Web component](https://iconify.design/docs/iconify-icon/)
+- [Figma plugin](https://iconify.design/docs/design/figma/)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-iconify-r8fjrm?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
      style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"

--- a/docs/data/material/customization/theming/theming.md
+++ b/docs/data/material/customization/theming/theming.md
@@ -45,7 +45,7 @@ const theme = createTheme({
 ```
 
 :::warning
-⚠️ `vars` is a private field for [CSS theme variables](material-ui/experimental-api/css-theme-variables/overview/). It will throw an error if you try to pass a value to it:
+`vars` is a private field for [CSS theme variables](/material-ui/experimental-api/css-theme-variables/overview/). It will throw an error if you try to pass a value to it:
 
 ```jsx
 createTheme({

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -258,9 +258,9 @@ export default function ApiPage(props) {
     : '/material-ui/customization/theme-components/#theme-style-overrides';
   let slotGuideLink = '';
   if (isJoyComponent) {
-    slotGuideLink = '/joy-ui/guides/overriding-component-structure';
+    slotGuideLink = '/joy-ui/guides/overriding-component-structure/';
   } else if (isBaseComponent) {
-    slotGuideLink = '/base/guides/overriding-component-structure';
+    slotGuideLink = '/base/guides/overriding-component-structure/';
   }
 
   const {

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -164,9 +164,9 @@ export default function ComponentsApiContent(props) {
       : '/material-ui/customization/theme-components/#theme-style-overrides';
     let slotGuideLink = '';
     if (isJoyComponent) {
-      slotGuideLink = '/joy-ui/guides/overriding-component-structure';
+      slotGuideLink = '/joy-ui/guides/overriding-component-structure/';
     } else if (isBaseComponent) {
-      slotGuideLink = '/base/guides/overriding-component-structure';
+      slotGuideLink = '/base/guides/overriding-component-structure/';
     }
 
     const source = filename

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -38,14 +38,21 @@ function escape(html, encode) {
 }
 
 function checkUrlHealth(href, linkText, context) {
-  // Skip links that are externals to MUI
-  if (!(href[0] === '/' || href.startsWith('https://mui.com/'))) {
+  const url = new URL(href, 'https://mui.com/');
+
+  // External links to MUI, ignore
+  if (url.host !== 'mui.com') {
     return;
   }
 
-  const url = new URL(href, 'https://mui.com/');
-
-  if (url.host === 'mui.com' && url.pathname[url.pathname.length - 1] !== '/') {
+  /**
+   * Break for links like:
+   * /material-ui/customization/theming
+   *
+   * It needs to be:
+   * /material-ui/customization/theming/
+   */
+  if (url.pathname[url.pathname.length - 1] !== '/') {
     throw new Error(
       [
         'Missing trailing slash. The following link:',
@@ -55,6 +62,26 @@ function checkUrlHealth(href, linkText, context) {
         '',
       ].join('\n'),
     );
+  }
+
+  // Relative links
+  if (href[0] !== '#' && !(href.startsWith('https://') || href.startsWith('http://'))) {
+    /**
+     * Break for links like:
+     * material-ui/customization/theming/
+     *
+     * It needs to be:
+     * /material-ui/customization/theming/
+     */
+    if (href[0] !== '/') {
+      throw new Error(
+        [
+          'Missing leading slash. The following link:',
+          `[${linkText}](${href}) in ${context.location} is missing a leading slash, please add it.`,
+          '',
+        ].join('\n'),
+      );
+    }
   }
 }
 

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -441,5 +441,23 @@ authors:
         });
       }).to.throw(/\[foo]\(\/foo\) in \/docs\/test\/index\.md is missing a trailing slash/);
     });
+
+    it('should report missing leading splashes', () => {
+      const markdown = `
+# Localization
+
+<p class="description">Foo</p>
+
+[bar](/bar/)
+[foo](foo/)
+`;
+
+      expect(() => {
+        prepareMarkdown({
+          ...defaultParams,
+          translations: [{ filename: 'index.md', markdown, userLanguage: 'en' }],
+        });
+      }).to.throw(/\[foo]\(foo\/\) in \/docs\/test\/index\.md is missing a leading slash/);
+    });
   });
 });


### PR DESCRIPTION
Quick fixes. I have found them looking with Jan into how we can improve Algolia's experience on the docs, especially around the no search results. Its crawler reports issues (301, 404, etc.)

<img width="1164" alt="Screenshot 2023-05-18 at 18 22 33" src="https://github.com/mui/material-ui/assets/3165635/415b61f4-4816-4ee2-8073-b199a0c79208">

https://crawler.algolia.com/admin/crawlers/739c29c8-99ea-4945-bd27-17a1df391902/monitoring/summary

---

Docs-infra change: I have added a new logic to break the CI if the link is wrong, this shouldn't go to production.

<img width="704" alt="Screenshot 2023-05-19 at 15 37 22" src="https://github.com/mui/material-ui/assets/3165635/8b634b18-ea74-40a1-a550-f497f02cd158">
