### PR TITLE
[core] Move esmExternals to the shared next config

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -241,7 +241,4 @@ module.exports = withDocsInfra({
       { source: `/static/x/:rest*`, destination: 'http://0.0.0.0:3001/static/x/:rest*' },
     ];
   },
-  experimental: {
-    esmExternals: false,
-  },
 });

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -60,6 +60,7 @@ function withDocsInfra(nextConfig) {
     },
     experimental: {
       scrollRestoration: true,
+      esmExternals: false,
       ...nextConfig.experimental,
     },
     eslint: {


### PR DESCRIPTION
Moved the `esmExternals` config key to the shared Next.js config, so other applications can use it.
The original reason behind adding the key is #37264
