### PR TITLE
[core] Return valid id on first render of `useId` hook

### DIFF
--- a/packages/mui-utils/src/useId.test.js
+++ b/packages/mui-utils/src/useId.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, screen } from 'test/utils';
-import useId from './useId';
+import useId, { useGlobalId } from './useId';
 
 describe('useId', () => {
   const { render, renderToString } = createRenderer();
@@ -93,5 +93,19 @@ describe('useId', () => {
     renderToString(<TestComponent />);
 
     expect(screen.getByTestId('target').id).not.to.equal('');
+  });
+
+  describe('useGlobalId', () => {
+    it('should generate an initial ID and increment on each render', () => {
+      const ids = [];
+      function TestComponent() {
+        const id = useGlobalId();
+        ids.push(id);
+        return id;
+      }
+
+      render(<TestComponent />);
+      expect(ids).to.deep.equal(['mui-1', 'mui-2']);
+    });
   });
 });

--- a/packages/mui-utils/src/useId.test.js
+++ b/packages/mui-utils/src/useId.test.js
@@ -96,7 +96,7 @@ describe('useId', () => {
   });
 
   describe('useGlobalId', () => {
-    it('should generate an initial ID and increment on each render', () => {
+    it('should generate an ID on first render and increment on each render', () => {
       const ids = [];
       function TestComponent() {
         const id = useGlobalId();

--- a/packages/mui-utils/src/useId.ts
+++ b/packages/mui-utils/src/useId.ts
@@ -2,7 +2,14 @@ import * as React from 'react';
 
 let globalId = 0;
 function useGlobalId(idOverride?: string): string | undefined {
-  const [defaultId, setDefaultId] = React.useState(idOverride);
+  const [defaultId, setDefaultId] = React.useState(
+    idOverride == null
+      ? () => {
+          globalId += 1;
+          return `mui-${globalId}`;
+        }
+      : idOverride,
+  );
   const id = idOverride || defaultId;
   React.useEffect(() => {
     if (defaultId == null) {

--- a/packages/mui-utils/src/useId.ts
+++ b/packages/mui-utils/src/useId.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 let globalId = 0;
-function useGlobalId(idOverride?: string): string | undefined {
+export function useGlobalId(idOverride?: string): string | undefined {
   const [defaultId, setDefaultId] = React.useState(
     idOverride == null
       ? () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/37251

before: https://codesandbox.io/s/falling-hooks-4tbj3g?file=/package.json
after:  https://codesandbox.io/s/lively-water-ldw1t6?file=/demo.tsx

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
