### PR TITLE
[MenuItem][Joy] Add internal id to DOM

### DIFF
--- a/packages/mui-base/src/useMenuItem/useMenuItem.ts
+++ b/packages/mui-base/src/useMenuItem/useMenuItem.ts
@@ -94,6 +94,7 @@ export default function useMenuItem(params: UseMenuItemParameters): UseMenuItemR
       ...resolvedMenuItemProps,
       role: 'menuitem',
       ref: handleRef,
+      id,
     };
   };
 

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -184,6 +184,13 @@ describe('Joy <MenuItem />', () => {
     expect(menuitem).to.have.attribute('aria-disabled', 'true');
   });
 
+  it('should accept external id', () => {
+    render(<MenuItem id='test-id' />);
+    const menuitem = screen.getByRole('menuitem');
+
+    expect(menuitem).to.have.attribute('id', 'test-id');
+  });
+
   it('can be selected', () => {
     render(<MenuItem selected />);
     const menuitem = screen.getByRole('menuitem');

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -185,10 +185,17 @@ describe('Joy <MenuItem />', () => {
   });
 
   it('should accept external id', () => {
-    render(<MenuItem id='test-id' />);
+    render(<MenuItem id="test-id" />);
     const menuitem = screen.getByRole('menuitem');
 
     expect(menuitem).to.have.attribute('id', 'test-id');
+  });
+
+  it('should have id when external id is not passed', () => {
+    render(<MenuItem />);
+    const menuitem = screen.getByRole('menuitem');
+
+    expect(menuitem).to.have.attribute('id');
   });
 
   it('can be selected', () => {

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -184,14 +184,14 @@ describe('Joy <MenuItem />', () => {
     expect(menuitem).to.have.attribute('aria-disabled', 'true');
   });
 
-  it('should accept external id', () => {
+  it('should add external id to DOM and override internal id', () => {
     render(<MenuItem id="test-id" />);
     const menuitem = screen.getByRole('menuitem');
 
     expect(menuitem).to.have.attribute('id', 'test-id');
   });
 
-  it('should have id when external id is not passed', () => {
+  it('should add internal id to DOM when external id is not provided', () => {
     render(<MenuItem />);
     const menuitem = screen.getByRole('menuitem');
 

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -61,6 +61,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     selected = false,
     color: colorProp = selected ? 'primary' : 'neutral',
     orientation = 'horizontal',
+    id,
     variant = 'plain',
     slots = {},
     slotProps = {},
@@ -72,6 +73,7 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
   const { getRootProps, disabled, focusVisible } = useMenuItem({
     disabled: disabledProp,
     rootRef: ref,
+    id,
   });
 
   const ownerState = {
@@ -96,6 +98,9 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     externalForwardedProps,
     className: classes.root,
     ownerState,
+    additionalProps: {
+      id,
+    },
   });
 
   return (

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -98,9 +98,6 @@ const MenuItem = React.forwardRef(function MenuItem(inProps, ref) {
     externalForwardedProps,
     className: classes.root,
     ownerState,
-    additionalProps: {
-      id,
-    },
   });
 
   return (

--- a/packages/mui-joy/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.tsx
@@ -133,6 +133,10 @@ MenuItem.propTypes /* remove-proptypes */ = {
    */
   disabled: PropTypes.bool,
   /**
+   * @ignore
+   */
+  id: PropTypes.string,
+  /**
    * The content direction flow.
    * @default 'horizontal'
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Inspect `first` option of both sandboxes and you can see `id` is added to dom only in `after` sandbox

before: https://codesandbox.io/s/quirky-chaplygin-5skfj3?file=/demo.tsx 
after: https://codesandbox.io/s/nervous-pond-l5cfzp?file=/demo.tsx

## This PR fixes

- adding internal `id` to `MenuItem` DOM when external `id` is not provided
- ovverding internal `id` in `useMenuItem` hook ([code change](https://github.com/mui/material-ui/pull/37361/files#diff-72011721d49bfc0724f198f1feb84c766211fb4b7e947222c8b3e8919ab93d69R76)) when external `id` is provided 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
