### PR TITLE
Update Button.d.ts to include the `download` attribute

### DIFF
--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -51,6 +51,10 @@ export type ButtonTypeMap<
      */
     disableFocusRipple?: boolean;
     /**
+     * To be used with the `href` attribute. Set the `download` attribute of the `a` element.
+     */
+    download?: string;
+    /**
      * Element placed after the children.
      */
     endIcon?: React.ReactNode;


### PR DESCRIPTION
When we are setting the `href` attribute on the button, it is turned into an `a` element. `download` is a valid attribute for a `a` element, that is often used on buttons.