### PR TITLE
[Input][joy] Simplify focus with `:focus-within` and add examples

### DIFF
--- a/docs/data/joy/components/input/FloatingLabelInput.js
+++ b/docs/data/joy/components/input/FloatingLabelInput.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function BasicInput() {
+  return <Input placeholder="Type in here…" />;
+}

--- a/docs/data/joy/components/input/FloatingLabelInput.js
+++ b/docs/data/joy/components/input/FloatingLabelInput.js
@@ -25,12 +25,23 @@ const StyledInput = styled('input')({
   '&:focus::placeholder': {
     opacity: 1,
   },
-  '&:focus ~ label, &:not(:placeholder-shown) ~ label': {
+  '&:focus ~ label, &:not(:placeholder-shown) ~ label, &:-webkit-autofill ~ label': {
     top: '0.5rem',
     fontSize: '0.75rem',
   },
   '&:focus ~ label': {
     color: 'var(--Input-focusedHighlight)',
+  },
+  '&:-webkit-autofill': {
+    alignSelf: 'stretch', // to fill the height of the root slot
+  },
+  '&:-webkit-autofill:not(* + &)': {
+    marginInlineStart: 'calc(-1 * var(--Input-paddingInline))',
+    paddingInlineStart: 'var(--Input-paddingInline)',
+    borderTopLeftRadius:
+      'calc(var(--Input-radius) - var(--variant-borderWidth, 0px))',
+    borderBottomLeftRadius:
+      'calc(var(--Input-radius) - var(--variant-borderWidth, 0px))',
   },
 });
 
@@ -59,10 +70,10 @@ export default function FloatingLabelInput() {
       placeholder="Type in here…"
       endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
       slots={{ input: InnerInput }}
-      slotProps={{ input: { placeholder: 'A placeholder' } }}
+      slotProps={{ input: { placeholder: 'A placeholder', type: 'password' } }}
       sx={{
         '--Input-minHeight': '56px',
-        borderRadius: '6px',
+        '--Input-radius': '6px',
       }}
     />
   );

--- a/docs/data/joy/components/input/FloatingLabelInput.js
+++ b/docs/data/joy/components/input/FloatingLabelInput.js
@@ -1,6 +1,69 @@
 import * as React from 'react';
+import { styled } from '@mui/joy/styles';
 import Input from '@mui/joy/Input';
+import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 
-export default function BasicInput() {
-  return <Input placeholder="Type in here…" />;
+const StyledInput = styled('input')(({ theme }) => ({
+  border: 'none', // remove the native input width
+  minWidth: 0, // remove the native input width
+  outline: 0, // remove the native input outline
+  padding: 0, // remove the native input padding
+  paddingTop: '1em',
+  flex: 1,
+  color: 'inherit',
+  backgroundColor: 'transparent',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  fontStyle: 'inherit',
+  fontWeight: 'inherit',
+  lineHeight: 'inherit',
+  textOverflow: 'ellipsis',
+  '&::placeholder': {
+    opacity: 0,
+    transition: '0.1s ease-out',
+  },
+  '&:focus::placeholder': {
+    opacity: 1,
+  },
+  '&:focus + label, &:not(:placeholder-shown) + label': {
+    top: '0.5rem',
+    fontSize: '0.75rem',
+  },
+  '&:focus + label': {
+    color: 'var(--Input-focusedHighlight)',
+  },
+}));
+
+const StyledLabel = styled('label')(({ theme }) => ({
+  position: 'absolute',
+  lineHeight: 1,
+  top: 'calc((var(--Input-minHeight) - 1em) / 2)',
+  color: theme.vars.palette.text.tertiary,
+  fontWeight: theme.vars.fontWeight.md,
+  transition: 'all 150ms cubic-bezier(0.4, 0, 0.2, 1)',
+}));
+
+const InnerInput = React.forwardRef(function InnerInput(props, ref) {
+  const id = React.useId();
+  return (
+    <React.Fragment>
+      <StyledInput ref={ref} id={id} {...props} />
+      <StyledLabel htmlFor={id}>Label</StyledLabel>
+    </React.Fragment>
+  );
+});
+
+export default function FloatingLabelInput() {
+  return (
+    <Input
+      placeholder="Type in here…"
+      endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
+      slots={{ input: InnerInput }}
+      slotProps={{ input: { placeholder: 'A placeholder' } }}
+      sx={{
+        '--Input-minHeight': '56px',
+        borderRadius: '6px',
+      }}
+    />
+  );
 }

--- a/docs/data/joy/components/input/FloatingLabelInput.js
+++ b/docs/data/joy/components/input/FloatingLabelInput.js
@@ -3,7 +3,7 @@ import { styled } from '@mui/joy/styles';
 import Input from '@mui/joy/Input';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 
-const StyledInput = styled('input')(({ theme }) => ({
+const StyledInput = styled('input')({
   border: 'none', // remove the native input width
   minWidth: 0, // remove the native input width
   outline: 0, // remove the native input outline
@@ -25,14 +25,14 @@ const StyledInput = styled('input')(({ theme }) => ({
   '&:focus::placeholder': {
     opacity: 1,
   },
-  '&:focus + label, &:not(:placeholder-shown) + label': {
+  '&:focus ~ label, &:not(:placeholder-shown) ~ label': {
     top: '0.5rem',
     fontSize: '0.75rem',
   },
-  '&:focus + label': {
+  '&:focus ~ label': {
     color: 'var(--Input-focusedHighlight)',
   },
-}));
+});
 
 const StyledLabel = styled('label')(({ theme }) => ({
   position: 'absolute',
@@ -47,7 +47,7 @@ const InnerInput = React.forwardRef(function InnerInput(props, ref) {
   const id = React.useId();
   return (
     <React.Fragment>
-      <StyledInput ref={ref} id={id} {...props} />
+      <StyledInput {...props} ref={ref} id={id} />
       <StyledLabel htmlFor={id}>Label</StyledLabel>
     </React.Fragment>
   );

--- a/docs/data/joy/components/input/FloatingLabelInput.js
+++ b/docs/data/joy/components/input/FloatingLabelInput.js
@@ -4,7 +4,7 @@ import Input from '@mui/joy/Input';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 
 const StyledInput = styled('input')({
-  border: 'none', // remove the native input width
+  border: 'none', // remove the native input border
   minWidth: 0, // remove the native input width
   outline: 0, // remove the native input outline
   padding: 0, // remove the native input padding
@@ -67,7 +67,6 @@ const InnerInput = React.forwardRef(function InnerInput(props, ref) {
 export default function FloatingLabelInput() {
   return (
     <Input
-      placeholder="Type in here…"
       endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
       slots={{ input: InnerInput }}
       slotProps={{ input: { placeholder: 'A placeholder', type: 'password' } }}

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx
@@ -25,12 +25,23 @@ const StyledInput = styled('input')({
   '&:focus::placeholder': {
     opacity: 1,
   },
-  '&:focus ~ label, &:not(:placeholder-shown) ~ label': {
+  '&:focus ~ label, &:not(:placeholder-shown) ~ label, &:-webkit-autofill ~ label': {
     top: '0.5rem',
     fontSize: '0.75rem',
   },
   '&:focus ~ label': {
     color: 'var(--Input-focusedHighlight)',
+  },
+  '&:-webkit-autofill': {
+    alignSelf: 'stretch', // to fill the height of the root slot
+  },
+  '&:-webkit-autofill:not(* + &)': {
+    marginInlineStart: 'calc(-1 * var(--Input-paddingInline))',
+    paddingInlineStart: 'var(--Input-paddingInline)',
+    borderTopLeftRadius:
+      'calc(var(--Input-radius) - var(--variant-borderWidth, 0px))',
+    borderBottomLeftRadius:
+      'calc(var(--Input-radius) - var(--variant-borderWidth, 0px))',
   },
 });
 
@@ -62,10 +73,10 @@ export default function FloatingLabelInput() {
       placeholder="Type in here…"
       endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
       slots={{ input: InnerInput }}
-      slotProps={{ input: { placeholder: 'A placeholder' } }}
+      slotProps={{ input: { placeholder: 'A placeholder', type: 'password' } }}
       sx={{
         '--Input-minHeight': '56px',
-        borderRadius: '6px',
+        '--Input-radius': '6px',
       }}
     />
   );

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { styled } from '@mui/joy/styles';
+import Input from '@mui/joy/Input';
+
+const StyledInput = styled('input')({
+  border: 'none', // remove the native input width
+  minWidth: 0, // remove the native input width
+  outline: 0, // remove the native input outline
+  padding: 0, // remove the native input padding
+  flex: 1,
+  color: 'inherit',
+  backgroundColor: 'transparent',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  fontStyle: 'inherit',
+  fontWeight: 'inherit',
+  lineHeight: 'inherit',
+  textOverflow: 'ellipsis',
+  '&::placeholder': {
+    opacity: 0,
+  },
+});
+
+const StyledLabel = styled('label')({
+  position: 'absolute',
+});
+
+const InnerInput = React.forwardRef<
+  HTMLInputElement,
+  JSX.IntrinsicElements['input']
+>(function InnerInput(props, ref) {
+  const id = React.useId();
+  return (
+    <React.Fragment>
+      <StyledInput ref={ref} id={id} {...props} />
+      <StyledLabel htmlFor={id}>Label</StyledLabel>
+    </React.Fragment>
+  );
+});
+
+export default function FloatingLabelInput() {
+  return (
+    <Input
+      placeholder="Type in here…"
+      slots={{ input: InnerInput }}
+      slotProps={{ input: { placeholder: 'A placeholder' } }}
+      sx={{ '--Input-minHeight': '56px' }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/joy/styles';
 import Input from '@mui/joy/Input';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 
-const StyledInput = styled('input')(({ theme }) => ({
+const StyledInput = styled('input')({
   border: 'none', // remove the native input width
   minWidth: 0, // remove the native input width
   outline: 0, // remove the native input outline
@@ -25,14 +25,14 @@ const StyledInput = styled('input')(({ theme }) => ({
   '&:focus::placeholder': {
     opacity: 1,
   },
-  '&:focus + label, &:not(:placeholder-shown) + label': {
+  '&:focus ~ label, &:not(:placeholder-shown) ~ label': {
     top: '0.5rem',
     fontSize: '0.75rem',
   },
-  '&:focus + label': {
+  '&:focus ~ label': {
     color: 'var(--Input-focusedHighlight)',
   },
-}));
+});
 
 const StyledLabel = styled('label')(({ theme }) => ({
   position: 'absolute',
@@ -50,7 +50,7 @@ const InnerInput = React.forwardRef<
   const id = React.useId();
   return (
     <React.Fragment>
-      <StyledInput ref={ref} id={id} {...props} />
+      <StyledInput {...props} ref={ref} id={id} />
       <StyledLabel htmlFor={id}>Label</StyledLabel>
     </React.Fragment>
   );

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { styled } from '@mui/joy/styles';
 import Input from '@mui/joy/Input';
+import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 
-const StyledInput = styled('input')({
+const StyledInput = styled('input')(({ theme }) => ({
   border: 'none', // remove the native input width
   minWidth: 0, // remove the native input width
   outline: 0, // remove the native input outline
   padding: 0, // remove the native input padding
+  paddingTop: '1em',
   flex: 1,
   color: 'inherit',
   backgroundColor: 'transparent',
@@ -18,12 +20,28 @@ const StyledInput = styled('input')({
   textOverflow: 'ellipsis',
   '&::placeholder': {
     opacity: 0,
+    transition: '0.1s ease-out',
   },
-});
+  '&:focus::placeholder': {
+    opacity: 1,
+  },
+  '&:focus + label, &:not(:placeholder-shown) + label': {
+    top: '0.5rem',
+    fontSize: '0.75rem',
+  },
+  '&:focus + label': {
+    color: 'var(--Input-focusedHighlight)',
+  },
+}));
 
-const StyledLabel = styled('label')({
+const StyledLabel = styled('label')(({ theme }) => ({
   position: 'absolute',
-});
+  lineHeight: 1,
+  top: 'calc((var(--Input-minHeight) - 1em) / 2)',
+  color: theme.vars.palette.text.tertiary,
+  fontWeight: theme.vars.fontWeight.md,
+  transition: 'all 150ms cubic-bezier(0.4, 0, 0.2, 1)',
+}));
 
 const InnerInput = React.forwardRef<
   HTMLInputElement,
@@ -42,9 +60,13 @@ export default function FloatingLabelInput() {
   return (
     <Input
       placeholder="Type in here…"
+      endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
       slots={{ input: InnerInput }}
       slotProps={{ input: { placeholder: 'A placeholder' } }}
-      sx={{ '--Input-minHeight': '56px' }}
+      sx={{
+        '--Input-minHeight': '56px',
+        borderRadius: '6px',
+      }}
     />
   );
 }

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx
@@ -4,7 +4,7 @@ import Input from '@mui/joy/Input';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 
 const StyledInput = styled('input')({
-  border: 'none', // remove the native input width
+  border: 'none', // remove the native input border
   minWidth: 0, // remove the native input width
   outline: 0, // remove the native input outline
   padding: 0, // remove the native input padding
@@ -70,7 +70,6 @@ const InnerInput = React.forwardRef<
 export default function FloatingLabelInput() {
   return (
     <Input
-      placeholder="Type in here…"
       endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
       slots={{ input: InnerInput }}
       slotProps={{ input: { placeholder: 'A placeholder', type: 'password' } }}

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx.preview
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx.preview
@@ -1,0 +1,10 @@
+<Input
+  placeholder="Type in here…"
+  endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
+  slots={{ input: InnerInput }}
+  slotProps={{ input: { placeholder: 'A placeholder' } }}
+  sx={{
+    '--Input-minHeight': '56px',
+    borderRadius: '6px',
+  }}
+/>

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx.preview
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx.preview
@@ -2,9 +2,9 @@
   placeholder="Type in here…"
   endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
   slots={{ input: InnerInput }}
-  slotProps={{ input: { placeholder: 'A placeholder' } }}
+  slotProps={{ input: { placeholder: 'A placeholder', type: 'password' } }}
   sx={{
     '--Input-minHeight': '56px',
-    borderRadius: '6px',
+    '--Input-radius': '6px',
   }}
 />

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx.preview
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx.preview
@@ -1,5 +1,4 @@
 <Input
-  placeholder="Type in here…"
   endDecorator={<CheckCircleOutlined sx={{ color: 'text.tertiary' }} />}
   slots={{ input: InnerInput }}
   slotProps={{ input: { placeholder: 'A placeholder', type: 'password' } }}

--- a/docs/data/joy/components/input/FocusOutlineInput.js
+++ b/docs/data/joy/components/input/FocusOutlineInput.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function FocusOutlineInput() {
+  return (
+    <Input
+      placeholder="Type in here…"
+      sx={{
+        '&::before': {
+          display: 'none',
+        },
+        '&:focus-within': {
+          outline: '2px solid var(--Input-focusedHighlight)',
+          outlineOffset: '2px',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/FocusOutlineInput.tsx
+++ b/docs/data/joy/components/input/FocusOutlineInput.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function FocusOutlineInput() {
+  return (
+    <Input
+      placeholder="Type in here…"
+      sx={{
+        '&::before': {
+          display: 'none',
+        },
+        '&:focus-within': {
+          outline: '2px solid var(--Input-focusedHighlight)',
+          outlineOffset: '2px',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/FocusOutlineInput.tsx.preview
+++ b/docs/data/joy/components/input/FocusOutlineInput.tsx.preview
@@ -1,0 +1,12 @@
+<Input
+  placeholder="Type in here…"
+  sx={{
+    '&::before': {
+      display: 'none',
+    },
+    '&:focus-within': {
+      outline: '2px solid var(--Input-focusedHighlight)',
+      outlineOffset: '2px',
+    },
+  }}
+/>

--- a/docs/data/joy/components/input/FocusedRingInput.js
+++ b/docs/data/joy/components/input/FocusedRingInput.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function FocusedRingInput() {
+  return (
+    <Input
+      placeholder="Bootstrap"
+      sx={{
+        '--Input-focusedInset': 'var(--any, )',
+        '--Input-focusedThickness': '0.25rem',
+        '--Input-focusedHighlight': 'rgba(13,110,253,.25)',
+        '&::before': {
+          transition: 'box-shadow .15s ease-in-out',
+        },
+        '&:focus-within': {
+          borderColor: '#86b7fe',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/FocusedRingInput.tsx
+++ b/docs/data/joy/components/input/FocusedRingInput.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function FocusedRingInput() {
+  return (
+    <Input
+      placeholder="Bootstrap"
+      sx={{
+        '--Input-focusedInset': 'var(--any, )',
+        '--Input-focusedThickness': '0.25rem',
+        '--Input-focusedHighlight': 'rgba(13,110,253,.25)',
+        '&::before': {
+          transition: 'box-shadow .15s ease-in-out',
+        },
+        '&:focus-within': {
+          borderColor: '#86b7fe',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/FocusedRingInput.tsx.preview
+++ b/docs/data/joy/components/input/FocusedRingInput.tsx.preview
@@ -1,0 +1,14 @@
+<Input
+  placeholder="Bootstrap"
+  sx={{
+    '--Input-focusedInset': 'var(--any, )',
+    '--Input-focusedThickness': '0.25rem',
+    '--Input-focusedHighlight': 'rgba(13,110,253,.25)',
+    '&::before': {
+      transition: 'box-shadow .15s ease-in-out',
+    },
+    '&:focus-within': {
+      borderColor: '#86b7fe',
+    },
+  }}
+/>

--- a/docs/data/joy/components/input/PasswordMeterInput.js
+++ b/docs/data/joy/components/input/PasswordMeterInput.js
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import Stack from '@mui/joy/Stack';
+import Input from '@mui/joy/Input';
+import LinearProgress from '@mui/joy/LinearProgress';
+import Typography from '@mui/joy/Typography';
+import Key from '@mui/icons-material/Key';
+
+export default function PasswordMeterInput() {
+  const [value, setValue] = React.useState('');
+  const minLength = 12;
+  return (
+    <Stack
+      spacing={0.5}
+      sx={{
+        '--hue': Math.min(value.length * 10, 120),
+      }}
+    >
+      <Input
+        type="password"
+        placeholder="Type in here…"
+        startDecorator={<Key />}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+      />
+      <LinearProgress
+        determinate
+        size="sm"
+        value={Math.min((value.length * 100) / minLength, 100)}
+        sx={{
+          bgcolor: 'background.level3',
+          color: 'hsl(var(--hue) 80% 40%)',
+        }}
+      />
+      <Typography
+        level="body3"
+        sx={{ alignSelf: 'flex-end', color: 'hsl(var(--hue) 80% 30%)' }}
+      >
+        {value.length < 3 && 'Very weak'}
+        {value.length >= 3 && value.length < 6 && 'Weak'}
+        {value.length >= 6 && value.length < 10 && 'Strong'}
+        {value.length >= 10 && 'Very strong'}
+      </Typography>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/input/PasswordMeterInput.tsx
+++ b/docs/data/joy/components/input/PasswordMeterInput.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import Stack from '@mui/joy/Stack';
+import Input from '@mui/joy/Input';
+import LinearProgress from '@mui/joy/LinearProgress';
+import Typography from '@mui/joy/Typography';
+import Key from '@mui/icons-material/Key';
+
+export default function PasswordMeterInput() {
+  const [value, setValue] = React.useState('');
+  const minLength = 12;
+  return (
+    <Stack
+      spacing={0.5}
+      sx={{
+        '--hue': Math.min(value.length * 10, 120),
+      }}
+    >
+      <Input
+        type="password"
+        placeholder="Type in here…"
+        startDecorator={<Key />}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+      />
+      <LinearProgress
+        determinate
+        size="sm"
+        value={Math.min((value.length * 100) / minLength, 100)}
+        sx={{
+          bgcolor: 'background.level3',
+          color: 'hsl(var(--hue) 80% 40%)',
+        }}
+      />
+      <Typography
+        level="body3"
+        sx={{ alignSelf: 'flex-end', color: 'hsl(var(--hue) 80% 30%)' }}
+      >
+        {value.length < 3 && 'Very weak'}
+        {value.length >= 3 && value.length < 6 && 'Weak'}
+        {value.length >= 6 && value.length < 10 && 'Strong'}
+        {value.length >= 10 && 'Very strong'}
+      </Typography>
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/input/TriggerFocusInput.js
+++ b/docs/data/joy/components/input/TriggerFocusInput.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function TriggerFocusInput() {
+  return (
+    <Input
+      placeholder="Looks like I'm focused but no"
+      sx={{ '--Input-focused': 1, width: 256 }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/TriggerFocusInput.tsx
+++ b/docs/data/joy/components/input/TriggerFocusInput.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function TriggerFocusInput() {
+  return (
+    <Input
+      placeholder="Looks like I'm focused but no"
+      sx={{ '--Input-focused': 1, width: 256 }}
+    />
+  );
+}

--- a/docs/data/joy/components/input/TriggerFocusInput.tsx.preview
+++ b/docs/data/joy/components/input/TriggerFocusInput.tsx.preview
@@ -1,0 +1,4 @@
+<Input
+  placeholder="Looks like I'm focused but no"
+  sx={{ '--Input-focused': 1, width: 256 }}
+/>

--- a/docs/data/joy/components/input/UnderlineInput.js
+++ b/docs/data/joy/components/input/UnderlineInput.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+
+export default function BasicInput() {
+  return <Input placeholder="Type in here…" />;
+}

--- a/docs/data/joy/components/input/UnderlineInput.js
+++ b/docs/data/joy/components/input/UnderlineInput.js
@@ -29,9 +29,9 @@ export default function UnderlineInput() {
         placeholder="Type in here…"
         variant="soft"
         sx={{
+          '--Input-radius': '0px',
           borderBottom: '2px solid',
           borderColor: 'neutral.outlinedBorder',
-          borderRadius: 0,
           '&:hover': {
             borderColor: 'neutral.outlinedHoverBorder',
           },

--- a/docs/data/joy/components/input/UnderlineInput.js
+++ b/docs/data/joy/components/input/UnderlineInput.js
@@ -1,6 +1,55 @@
 import * as React from 'react';
 import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
 
-export default function BasicInput() {
-  return <Input placeholder="Type in here…" />;
+export default function UnderlineInput() {
+  return (
+    <Stack spacing={2}>
+      <Input
+        placeholder="Type in here…"
+        sx={{
+          '&::before': {
+            border: '1.5px solid var(--Input-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: '2.5px',
+            right: '2.5px',
+            bottom: 0,
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+            borderBottomLeftRadius: '64px 20px',
+            borderBottomRightRadius: '64px 20px',
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+      <Input
+        placeholder="Type in here…"
+        variant="soft"
+        sx={{
+          borderBottom: '2px solid',
+          borderColor: 'neutral.outlinedBorder',
+          borderRadius: 0,
+          '&:hover': {
+            borderColor: 'neutral.outlinedHoverBorder',
+          },
+          '&::before': {
+            border: '1px solid var(--Input-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: 0,
+            right: 0,
+            bottom: '-2px',
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+    </Stack>
+  );
 }

--- a/docs/data/joy/components/input/UnderlineInput.tsx
+++ b/docs/data/joy/components/input/UnderlineInput.tsx
@@ -29,9 +29,9 @@ export default function UnderlineInput() {
         placeholder="Type in here…"
         variant="soft"
         sx={{
+          '--Input-radius': '0px',
           borderBottom: '2px solid',
           borderColor: 'neutral.outlinedBorder',
-          borderRadius: 0,
           '&:hover': {
             borderColor: 'neutral.outlinedHoverBorder',
           },

--- a/docs/data/joy/components/input/UnderlineInput.tsx
+++ b/docs/data/joy/components/input/UnderlineInput.tsx
@@ -11,8 +11,8 @@ export default function UnderlineInput() {
           '&::before': {
             border: '1.5px solid var(--Input-focusedHighlight)',
             transform: 'scaleX(0)',
-            left: '2px',
-            right: '2px',
+            left: '2.5px',
+            right: '2.5px',
             bottom: 0,
             top: 'unset',
             transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
@@ -27,9 +27,9 @@ export default function UnderlineInput() {
       />
       <Input
         placeholder="Type in here…"
-        variant="plain"
+        variant="soft"
         sx={{
-          borderBottom: '1px solid',
+          borderBottom: '2px solid',
           borderColor: 'neutral.outlinedBorder',
           borderRadius: 0,
           '&:hover': {
@@ -40,7 +40,7 @@ export default function UnderlineInput() {
             transform: 'scaleX(0)',
             left: 0,
             right: 0,
-            bottom: '-1px',
+            bottom: '-2px',
             top: 'unset',
             transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
             borderRadius: 0,

--- a/docs/data/joy/components/input/UnderlineInput.tsx
+++ b/docs/data/joy/components/input/UnderlineInput.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
+
+export default function UnderlineInput() {
+  return (
+    <Stack spacing={2}>
+      <Input
+        placeholder="Type in here…"
+        sx={{
+          '&::before': {
+            border: '1.5px solid var(--Input-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: '2px',
+            right: '2px',
+            bottom: 0,
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+            borderBottomLeftRadius: '64px 20px',
+            borderBottomRightRadius: '64px 20px',
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+      <Input
+        placeholder="Type in here…"
+        variant="plain"
+        sx={{
+          borderBottom: '1px solid',
+          borderColor: 'neutral.outlinedBorder',
+          borderRadius: 0,
+          '&:hover': {
+            borderColor: 'neutral.outlinedHoverBorder',
+          },
+          '&::before': {
+            border: '1px solid var(--Input-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: 0,
+            right: 0,
+            bottom: '-1px',
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -81,6 +81,23 @@ To get full control of the focused ring, customize the `box-shadow` of the `::be
 
 :::
 
+#### Debugging the focus ring
+
+To display the Input's focus ring by simulating user's focus, inspect the Input element and toggle the [pseudostate panel](https://developer.chrome.com/docs/devtools/css/#pseudostates).
+
+- If you inspect the Input's root element, with `.MuiInput-root` class, you have to toggle on the `:focus-within` state.
+- If you inspect the `<input>` element, you have to toggle on the `:focus` state.
+
+### Triggering the focus ring
+
+To trigger the focus ring programmatically, set the CSS variable `--Input-focused: 1`.
+
+{{"demo": "TriggerFocusInput.js"}}
+
+:::info
+💡 The focus ring still appear on focus even though you set `--Input-focused: 0`.
+:::
+
 ### Validation
 
 Use the `error` prop to toggle the error state:
@@ -93,6 +110,8 @@ Using the `color` prop with `danger` as the value gives you the same result:
 ```js
 <Input color="danger" />
 ```
+
+:::
 
 ### Decorators
 
@@ -112,7 +131,7 @@ These props may include HTML attributes such as `ref`, `min`, `max`, and `autoco
 
 ### Focus outline
 
-This example shows how to replace the default focus ring appearance with CSS outline.
+This example shows how to replace the default focus ring (using `::before`) with CSS `outline`.
 
 {{"demo": "FocusOutlineInput.js"}}
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -62,6 +62,25 @@ You can add standard form attributes such as `required` and `disabled` to the In
 
 {{"demo": "InputFormProps.js"}}
 
+### Focused ring
+
+Provide these CSS variables to `sx` prop to control the focused ring appearance:
+
+- `--Input-focusedInset`: the focused ring's **position**, either inside(`inset`) or outside(`var(--any, )`) of the Input.
+- `--Input-focusedThickness`: the **size** of the focused ring.
+- `--Input-focusedHighlight`: the **color** of the focused ring.
+
+{{"demo": "FocusedRingInput.js"}}
+
+:::success
+To get full control of the focused ring, customize the `box-shadow` of the `::before` pseudo element directly
+
+```js
+<Input sx={{ '&:focus-within(::before)': { boxShadow: '...your custom value' } }} />
+```
+
+:::
+
 ### Validation
 
 Use the `error` prop to toggle the error state:
@@ -74,8 +93,6 @@ Using the `color` prop with `danger` as the value gives you the same result:
 ```js
 <Input color="danger" />
 ```
-
-:::
 
 ### Decorators
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -110,7 +110,15 @@ These props may include HTML attributes such as `ref`, `min`, `max`, and `autoco
 
 ## Common examples
 
+### Focus outline
+
+This example shows how to replace the default focus ring appearance with CSS outline.
+
+{{"demo": "FocusOutlineInput.js"}}
+
 ### Floating label
+
+To create a floating label input, a custom component (combination of `<input>` and `<label>`) is required to replace the default input slot.
 
 {{"demo": "FloatingLabelInput.js"}}
 
@@ -121,6 +129,10 @@ These props may include HTML attributes such as `ref`, `min`, `max`, and `autoco
 ### Newsletter Subscription
 
 {{"demo": "InputSubscription.js"}}
+
+### Password meter
+
+{{"demo": "PasswordMeterInput.js"}}
 
 ## CSS variable playground
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -110,6 +110,14 @@ These props may include HTML attributes such as `ref`, `min`, `max`, and `autoco
 
 ## Common examples
 
+### Floating label
+
+{{"demo": "FloatingLabelInput.js"}}
+
+### Underline input
+
+{{"demo": "UnderlineInput.js"}}
+
 ### Newsletter Subscription
 
 {{"demo": "InputSubscription.js"}}

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -76,7 +76,7 @@ Provide these CSS variables to `sx` prop to control the focused ring appearance:
 To get full control of the focused ring, customize the `box-shadow` of the `::before` pseudo element directly
 
 ```js
-<Input sx={{ '&:focus-within(::before)': { boxShadow: '...your custom value' } }} />
+<Input sx={{ '&:focus-within::before': { boxShadow: '...your custom value' } }} />
 ```
 
 :::
@@ -86,7 +86,7 @@ To get full control of the focused ring, customize the `box-shadow` of the `::be
 To display the Input's focus ring by simulating user's focus, inspect the Input element and toggle the [pseudostate panel](https://developer.chrome.com/docs/devtools/css/#pseudostates).
 
 - If you inspect the Input's root element, with `.MuiInput-root` class, you have to toggle on the `:focus-within` state.
-- If you inspect the `<input>` element, you have to toggle on the `:focus` state.
+- If you inspect the `<input>` element, you can toggle with either `:focus` or `:focus-within` states.
 
 ### Triggering the focus ring
 

--- a/docs/data/joy/components/textarea/FloatingLabelTextarea.js
+++ b/docs/data/joy/components/textarea/FloatingLabelTextarea.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { styled } from '@mui/joy/styles';
+import Textarea from '@mui/joy/Textarea';
+
+const StyledTextarea = styled(TextareaAutosize)({
+  resize: 'none',
+  border: 'none', // remove the native textarea width
+  minWidth: 0, // remove the native textarea width
+  outline: 0, // remove the native textarea outline
+  padding: 0, // remove the native textarea padding
+  paddingBlockStart: '1em',
+  paddingInlineEnd: `var(--Textarea-paddingInline)`,
+  flex: 'auto',
+  alignSelf: 'stretch',
+  color: 'inherit',
+  backgroundColor: 'transparent',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  fontStyle: 'inherit',
+  fontWeight: 'inherit',
+  lineHeight: 'inherit',
+  '&::placeholder': {
+    opacity: 0,
+    transition: '0.1s ease-out',
+  },
+  '&:focus::placeholder': {
+    opacity: 1,
+  },
+  // specific to TextareaAutosize, cannot use '&:focus ~ label'
+  '&:focus + textarea + label, &:not(:placeholder-shown) + textarea + label': {
+    top: '0.5rem',
+    fontSize: '0.75rem',
+  },
+  '&:focus + textarea + label': {
+    color: 'var(--Textarea-focusedHighlight)',
+  },
+});
+
+const StyledLabel = styled('label')(({ theme }) => ({
+  position: 'absolute',
+  lineHeight: 1,
+  top: 'calc((var(--Textarea-minHeight) - 1em) / 2)',
+  color: theme.vars.palette.text.tertiary,
+  fontWeight: theme.vars.fontWeight.md,
+  transition: 'all 150ms cubic-bezier(0.4, 0, 0.2, 1)',
+}));
+
+const InnerTextarea = React.forwardRef(function InnerTextarea(props, ref) {
+  const id = React.useId();
+  return (
+    <React.Fragment>
+      <StyledTextarea minRows={2} {...props} ref={ref} id={id} />
+      <StyledLabel htmlFor={id}>Label</StyledLabel>
+    </React.Fragment>
+  );
+});
+
+export default function FloatingLabelTextarea() {
+  return (
+    <Textarea
+      slots={{ textarea: InnerTextarea }}
+      slotProps={{ textarea: { placeholder: 'A placeholder' } }}
+      sx={{ borderRadius: '6px' }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/FloatingLabelTextarea.js
+++ b/docs/data/joy/components/textarea/FloatingLabelTextarea.js
@@ -5,7 +5,7 @@ import Textarea from '@mui/joy/Textarea';
 
 const StyledTextarea = styled(TextareaAutosize)({
   resize: 'none',
-  border: 'none', // remove the native textarea width
+  border: 'none', // remove the native textarea border
   minWidth: 0, // remove the native textarea width
   outline: 0, // remove the native textarea outline
   padding: 0, // remove the native textarea padding

--- a/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx
+++ b/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { styled } from '@mui/joy/styles';
+import Textarea from '@mui/joy/Textarea';
+
+const StyledTextarea = styled(TextareaAutosize)({
+  resize: 'none',
+  border: 'none', // remove the native textarea width
+  minWidth: 0, // remove the native textarea width
+  outline: 0, // remove the native textarea outline
+  padding: 0, // remove the native textarea padding
+  paddingBlockStart: '1em',
+  paddingInlineEnd: `var(--Textarea-paddingInline)`,
+  flex: 'auto',
+  alignSelf: 'stretch',
+  color: 'inherit',
+  backgroundColor: 'transparent',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  fontStyle: 'inherit',
+  fontWeight: 'inherit',
+  lineHeight: 'inherit',
+  '&::placeholder': {
+    opacity: 0,
+    transition: '0.1s ease-out',
+  },
+  '&:focus::placeholder': {
+    opacity: 1,
+  },
+  // specific to TextareaAutosize, cannot use '&:focus ~ label'
+  '&:focus + textarea + label, &:not(:placeholder-shown) + textarea + label': {
+    top: '0.5rem',
+    fontSize: '0.75rem',
+  },
+  '&:focus + textarea + label': {
+    color: 'var(--Textarea-focusedHighlight)',
+  },
+});
+
+const StyledLabel = styled('label')(({ theme }) => ({
+  position: 'absolute',
+  lineHeight: 1,
+  top: 'calc((var(--Textarea-minHeight) - 1em) / 2)',
+  color: theme.vars.palette.text.tertiary,
+  fontWeight: theme.vars.fontWeight.md,
+  transition: 'all 150ms cubic-bezier(0.4, 0, 0.2, 1)',
+}));
+
+const InnerTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  JSX.IntrinsicElements['textarea']
+>(function InnerTextarea(props, ref) {
+  const id = React.useId();
+  return (
+    <React.Fragment>
+      <StyledTextarea minRows={2} {...props} ref={ref} id={id} />
+      <StyledLabel htmlFor={id}>Label</StyledLabel>
+    </React.Fragment>
+  );
+});
+
+export default function FloatingLabelTextarea() {
+  return (
+    <Textarea
+      slots={{ textarea: InnerTextarea }}
+      slotProps={{ textarea: { placeholder: 'A placeholder' } }}
+      sx={{ borderRadius: '6px' }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx
+++ b/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx
@@ -5,7 +5,7 @@ import Textarea from '@mui/joy/Textarea';
 
 const StyledTextarea = styled(TextareaAutosize)({
   resize: 'none',
-  border: 'none', // remove the native textarea width
+  border: 'none', // remove the native textarea border
   minWidth: 0, // remove the native textarea width
   outline: 0, // remove the native textarea outline
   padding: 0, // remove the native textarea padding

--- a/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx.preview
+++ b/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx.preview
@@ -1,0 +1,5 @@
+<Textarea
+  slots={{ textarea: InnerTextarea }}
+  slotProps={{ textarea: { placeholder: 'A placeholder' } }}
+  sx={{ borderRadius: '6px' }}
+/>

--- a/docs/data/joy/components/textarea/FocusOutlineTextarea.js
+++ b/docs/data/joy/components/textarea/FocusOutlineTextarea.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+
+export default function FocusOutlineTextarea() {
+  return (
+    <Textarea
+      placeholder="Type in here…"
+      minRows={2}
+      sx={{
+        '&::before': {
+          display: 'none',
+        },
+        '&:focus-within': {
+          outline: '2px solid var(--Textarea-focusedHighlight)',
+          outlineOffset: '2px',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/FocusOutlineTextarea.tsx
+++ b/docs/data/joy/components/textarea/FocusOutlineTextarea.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+
+export default function FocusOutlineTextarea() {
+  return (
+    <Textarea
+      placeholder="Type in here…"
+      minRows={2}
+      sx={{
+        '&::before': {
+          display: 'none',
+        },
+        '&:focus-within': {
+          outline: '2px solid var(--Textarea-focusedHighlight)',
+          outlineOffset: '2px',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/FocusOutlineTextarea.tsx.preview
+++ b/docs/data/joy/components/textarea/FocusOutlineTextarea.tsx.preview
@@ -1,0 +1,13 @@
+<Textarea
+  placeholder="Type in here…"
+  minRows={2}
+  sx={{
+    '&::before': {
+      display: 'none',
+    },
+    '&:focus-within': {
+      outline: '2px solid var(--Textarea-focusedHighlight)',
+      outlineOffset: '2px',
+    },
+  }}
+/>

--- a/docs/data/joy/components/textarea/FocusedRingTextarea.js
+++ b/docs/data/joy/components/textarea/FocusedRingTextarea.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+
+export default function FocusedRingTextarea() {
+  return (
+    <Textarea
+      placeholder="Bootstrap"
+      minRows={2}
+      sx={{
+        '--Textarea-focusedInset': 'var(--any, )',
+        '--Textarea-focusedThickness': '0.25rem',
+        '--Textarea-focusedHighlight': 'rgba(13,110,253,.25)',
+        '&::before': {
+          transition: 'box-shadow .15s ease-in-out',
+        },
+        '&:focus-within': {
+          borderColor: '#86b7fe',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/FocusedRingTextarea.tsx
+++ b/docs/data/joy/components/textarea/FocusedRingTextarea.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+
+export default function FocusedRingTextarea() {
+  return (
+    <Textarea
+      placeholder="Bootstrap"
+      minRows={2}
+      sx={{
+        '--Textarea-focusedInset': 'var(--any, )',
+        '--Textarea-focusedThickness': '0.25rem',
+        '--Textarea-focusedHighlight': 'rgba(13,110,253,.25)',
+        '&::before': {
+          transition: 'box-shadow .15s ease-in-out',
+        },
+        '&:focus-within': {
+          borderColor: '#86b7fe',
+        },
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/FocusedRingTextarea.tsx.preview
+++ b/docs/data/joy/components/textarea/FocusedRingTextarea.tsx.preview
@@ -1,0 +1,15 @@
+<Textarea
+  placeholder="Bootstrap"
+  minRows={2}
+  sx={{
+    '--Textarea-focusedInset': 'var(--any, )',
+    '--Textarea-focusedThickness': '0.25rem',
+    '--Textarea-focusedHighlight': 'rgba(13,110,253,.25)',
+    '&::before': {
+      transition: 'box-shadow .15s ease-in-out',
+    },
+    '&:focus-within': {
+      borderColor: '#86b7fe',
+    },
+  }}
+/>

--- a/docs/data/joy/components/textarea/TriggerFocusTextarea.js
+++ b/docs/data/joy/components/textarea/TriggerFocusTextarea.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+
+export default function TriggerFocusTextarea() {
+  return (
+    <Textarea
+      placeholder="Looks like I'm focused but no"
+      sx={{
+        '--Textarea-focused': 1,
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/TriggerFocusTextarea.tsx
+++ b/docs/data/joy/components/textarea/TriggerFocusTextarea.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+
+export default function TriggerFocusTextarea() {
+  return (
+    <Textarea
+      placeholder="Looks like I'm focused but no"
+      sx={{
+        '--Textarea-focused': 1,
+      }}
+    />
+  );
+}

--- a/docs/data/joy/components/textarea/TriggerFocusTextarea.tsx.preview
+++ b/docs/data/joy/components/textarea/TriggerFocusTextarea.tsx.preview
@@ -1,0 +1,6 @@
+<Textarea
+  placeholder="Looks like I'm focused but no"
+  sx={{
+    '--Textarea-focused': 1,
+  }}
+/>

--- a/docs/data/joy/components/textarea/UnderlineTextarea.js
+++ b/docs/data/joy/components/textarea/UnderlineTextarea.js
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+import Stack from '@mui/joy/Stack';
+
+export default function UnderlineTextarea() {
+  return (
+    <Stack spacing={2}>
+      <Textarea
+        minRows={2}
+        placeholder="Type in here…"
+        sx={{
+          '&::before': {
+            border: '1.5px solid var(--Textarea-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: '2.5px',
+            right: '2.5px',
+            bottom: 0,
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+            borderBottomLeftRadius: '64px 20px',
+            borderBottomRightRadius: '64px 20px',
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+      <Textarea
+        minRows={2}
+        placeholder="Type in here…"
+        variant="soft"
+        sx={{
+          borderBottom: '2px solid',
+          borderColor: 'neutral.outlinedBorder',
+          borderRadius: 0,
+          '&:hover': {
+            borderColor: 'neutral.outlinedHoverBorder',
+          },
+          '&::before': {
+            border: '1px solid var(--Textarea-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: 0,
+            right: 0,
+            bottom: '-2px',
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/textarea/UnderlineTextarea.tsx
+++ b/docs/data/joy/components/textarea/UnderlineTextarea.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import Textarea from '@mui/joy/Textarea';
+import Stack from '@mui/joy/Stack';
+
+export default function UnderlineTextarea() {
+  return (
+    <Stack spacing={2}>
+      <Textarea
+        minRows={2}
+        placeholder="Type in here…"
+        sx={{
+          '&::before': {
+            border: '1.5px solid var(--Textarea-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: '2.5px',
+            right: '2.5px',
+            bottom: 0,
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+            borderBottomLeftRadius: '64px 20px',
+            borderBottomRightRadius: '64px 20px',
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+      <Textarea
+        minRows={2}
+        placeholder="Type in here…"
+        variant="soft"
+        sx={{
+          borderBottom: '2px solid',
+          borderColor: 'neutral.outlinedBorder',
+          borderRadius: 0,
+          '&:hover': {
+            borderColor: 'neutral.outlinedHoverBorder',
+          },
+          '&::before': {
+            border: '1px solid var(--Textarea-focusedHighlight)',
+            transform: 'scaleX(0)',
+            left: 0,
+            right: 0,
+            bottom: '-2px',
+            top: 'unset',
+            transition: 'transform .15s cubic-bezier(0.1,0.9,0.2,1)',
+            borderRadius: 0,
+          },
+          '&:focus-within::before': {
+            transform: 'scaleX(1)',
+          },
+        }}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -54,6 +54,27 @@ Standard form attributes are supported e.g. `required`, `disabled`, etc.
 
 {{"demo": "TextareaFormProps.js"}}
 
+### Focused ring
+
+Provide these CSS variables to `sx` prop to control the focused ring appearance:
+
+- `--Textarea-focusedInset`: the focused ring's **position**, either inside(`inset`) or outside(`var(--any, )`) of the Textarea.
+- `--Textarea-focusedThickness`: the **size** of the focused ring.
+- `--Textarea-focusedHighlight`: the **color** of the focused ring.
+
+{{"demo": "FocusedRingTextarea.js"}}
+
+:::success
+To get full control of the focused ring, customize the `box-shadow` of the `::before` pseudo element directly
+
+```js
+<Textarea
+  sx={{ '&:focus-within(::before)': { boxShadow: '...your custom value' } }}
+/>
+```
+
+:::
+
 ### Validation
 
 To toggle the error state, use the `error` prop.

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -75,6 +75,23 @@ To get full control of the focused ring, customize the `box-shadow` of the `::be
 
 :::
 
+#### Debugging the focus ring
+
+To display the Textarea's focus ring by simulating user's focus, inspect the Textarea element and toggle the [pseudostate panel](https://developer.chrome.com/docs/devtools/css/#pseudostates).
+
+- If you inspect the Textarea's root element, with `.MuiTextarea-root` class, you have to toggle on the `:focus-within` state.
+- If you inspect the `<input>` element, you have to toggle on the `:focus` state.
+
+### Triggering the focus ring
+
+To trigger the focus ring programmatically, set the CSS variable `--Textarea-focused: 1`.
+
+{{"demo": "TriggerFocusTextarea.js"}}
+
+:::info
+💡 The focus ring still appear on focus even though you set `--Textarea-focused: 0`.
+:::
+
 ### Validation
 
 To toggle the error state, use the `error` prop.

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -123,6 +123,22 @@ Alternatively, you can do it manually by targeting the textarea slot:
 
 ## Common examples
 
+### Focus outline
+
+This example shows how to replace the default focus ring appearance with CSS outline.
+
+{{"demo": "FocusOutlineTextarea.js"}}
+
+### Floating label
+
+To create a floating label textarea, a custom component (combination of `<textarea>` and `<label>`) is required to replace the default textarea slot.
+
+{{"demo": "FloatingLabelTextarea.js"}}
+
+### Underline input
+
+{{"demo": "UnderlineTextarea.js"}}
+
 ### Comment box
 
 {{"demo": "ExampleTextareaComment.js"}}

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -68,9 +68,7 @@ Provide these CSS variables to `sx` prop to control the focused ring appearance:
 To get full control of the focused ring, customize the `box-shadow` of the `::before` pseudo element directly
 
 ```js
-<Textarea
-  sx={{ '&:focus-within::before': { boxShadow: '...your custom value' } }}
-/>
+<Textarea sx={{ '&:focus-within::before': { boxShadow: '...your custom value' } }} />
 ```
 
 :::

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -69,7 +69,7 @@ To get full control of the focused ring, customize the `box-shadow` of the `::be
 
 ```js
 <Textarea
-  sx={{ '&:focus-within(::before)': { boxShadow: '...your custom value' } }}
+  sx={{ '&:focus-within::before': { boxShadow: '...your custom value' } }}
 />
 ```
 

--- a/docs/pages/joy-ui/api/autocomplete.json
+++ b/docs/pages/joy-ui/api/autocomplete.json
@@ -124,13 +124,13 @@
     {
       "name": "startDecorator",
       "description": "The component that renders the start decorator.",
-      "default": "'span'",
+      "default": "'div'",
       "class": ".MuiAutocomplete-startDecorator"
     },
     {
       "name": "endDecorator",
       "description": "The component that renders the end decorator.",
-      "default": "'span'",
+      "default": "'div'",
       "class": ".MuiAutocomplete-endDecorator"
     },
     {
@@ -172,7 +172,7 @@
     {
       "name": "limitTag",
       "description": "The component that renders the limit tag.",
-      "default": "'span'",
+      "default": "'div'",
       "class": ".MuiAutocomplete-limitTag"
     }
   ],

--- a/docs/pages/joy-ui/api/input.json
+++ b/docs/pages/joy-ui/api/input.json
@@ -48,13 +48,13 @@
     {
       "name": "startDecorator",
       "description": "The component that renders the start decorator.",
-      "default": "'span'",
+      "default": "'div'",
       "class": ".MuiInput-startDecorator"
     },
     {
       "name": "endDecorator",
       "description": "The component that renders the end decorator.",
-      "default": "'span'",
+      "default": "'div'",
       "class": ".MuiInput-endDecorator"
     }
   ],

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -200,6 +200,7 @@ const AutocompleteClearIndicator = styled(StyledIconButton as unknown as 'button
   slot: 'ClearIndicator',
   overridesResolver: (props, styles) => styles.clearIndicator,
 })<{ ownerState: OwnerState }>(({ ownerState }) => ({
+  alignSelf: 'center',
   ...(!ownerState.hasPopupIcon && {
     marginInlineEnd: 'calc(var(--Input-decoratorChildOffset) * -1)',
   }),
@@ -212,6 +213,7 @@ const AutocompletePopupIndicator = styled(StyledIconButton as unknown as 'button
   slot: 'PopupIndicator',
   overridesResolver: (props, styles) => styles.popupIndicator,
 })<{ ownerState: OwnerState }>(({ ownerState }) => ({
+  alignSelf: 'center',
   marginInlineStart: 'calc(var(--_Input-paddingBlock) / 2)',
   marginInlineEnd: 'calc(var(--Input-decoratorChildOffset) * -1)',
   ...(ownerState.popupOpen && {

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -176,13 +176,13 @@ const AutocompleteInput = styled(StyledInputHtml as unknown as 'input', {
   }),
 }));
 
-const AutocompleteStartDecorator = styled(StyledInputStartDecorator as unknown as 'span', {
+const AutocompleteStartDecorator = styled(StyledInputStartDecorator as unknown as 'div', {
   name: 'JoyAutocomplete',
   slot: 'StartDecorator',
   overridesResolver: (props, styles) => styles.startDecorator,
 })<{ ownerState: OwnerState }>({});
 
-const AutocompleteEndDecorator = styled(StyledInputEndDecorator as unknown as 'span', {
+const AutocompleteEndDecorator = styled(StyledInputEndDecorator as unknown as 'div', {
   name: 'JoyAutocomplete',
   slot: 'EndDecorator',
   overridesResolver: (props, styles) => styles.endDecorator,
@@ -249,7 +249,7 @@ const AutocompleteNoOptions = styled(ListItem, {
   color: (theme.vars || theme).palette.text.secondary,
 }));
 
-const AutocompleteLimitTag = styled('span', {
+const AutocompleteLimitTag = styled('div', {
   name: 'JoyAutocomplete',
   slot: 'NoOptions',
   overridesResolver: (props, styles) => styles.noOptions,

--- a/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts
+++ b/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts
@@ -44,12 +44,12 @@ export interface AutocompleteSlots {
   input?: React.ElementType;
   /**
    * The component that renders the start decorator.
-   * @default 'span'
+   * @default 'div'
    */
   startDecorator?: React.ElementType;
   /**
    * The component that renders the end decorator.
-   * @default 'span'
+   * @default 'div'
    */
   endDecorator?: React.ElementType;
   /**
@@ -84,7 +84,7 @@ export interface AutocompleteSlots {
   noOptions?: React.ElementType;
   /**
    * The component that renders the limit tag.
-   * @default 'span'
+   * @default 'div'
    */
   limitTag?: React.ElementType;
 }

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -39,6 +39,7 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
         '--Input-gap': '0.5rem',
         '--Input-placeholderColor': 'inherit',
         '--Input-placeholderOpacity': 0.5,
+        '--Input-focused': '0',
         '--Input-focusedThickness': theme.vars.focus.thickness,
         ...(ownerState.color === 'context'
           ? {
@@ -89,7 +90,6 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
         cursor: 'text',
         position: 'relative',
         display: 'flex',
-        alignItems: 'center',
         paddingInline: `var(--Input-paddingInline)`,
         borderRadius: 'var(--Input-radius)',
         fontFamily: theme.vars.fontFamily.body,
@@ -110,6 +110,7 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
           zIndex: 1,
           borderRadius: 'inherit',
           margin: 'calc(var(--variant-borderWidth, 0px) * -1)', // for outlined variant
+          boxShadow: `var(--Input-focusedInset, inset) 0 0 0 calc(var(--Input-focused) * var(--Input-focusedThickness)) var(--Input-focusedHighlight)`,
         },
       },
       {
@@ -122,9 +123,7 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
         },
         [`&.${inputClasses.disabled}`]:
           theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-        '&:focus-within::before': {
-          boxShadow: `var(--Input-focusedInset, inset) 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
-        },
+        '&:focus-within::before': { '--Input-focused': '1' },
       },
     ];
   },
@@ -182,7 +181,7 @@ export const StyledInputHtml = styled('input')<{ ownerState: InputOwnerState }>(
   }),
 );
 
-export const StyledInputStartDecorator = styled('span')<{ ownerState: InputOwnerState }>(
+export const StyledInputStartDecorator = styled('div')<{ ownerState: InputOwnerState }>(
   ({ theme, ownerState }) => ({
     '--Button-margin': '0 0 0 calc(var(--Input-decoratorChildOffset) * -1)',
     '--IconButton-margin': '0 0 0 calc(var(--Input-decoratorChildOffset) * -1)',
@@ -203,7 +202,7 @@ export const StyledInputStartDecorator = styled('span')<{ ownerState: InputOwner
   }),
 );
 
-export const StyledInputEndDecorator = styled('span')<{ ownerState: InputOwnerState }>(
+export const StyledInputEndDecorator = styled('div')<{ ownerState: InputOwnerState }>(
   ({ theme, ownerState }) => ({
     '--Button-margin': '0 calc(var(--Input-decoratorChildOffset) * -1) 0 0',
     '--IconButton-margin': '0 calc(var(--Input-decoratorChildOffset) * -1) 0 0',

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -116,16 +116,14 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
         // variant styles
         ...variantStyle,
         backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
-        [`&:hover:not(.${inputClasses.focused})`]: {
+        '&:hover:not(:focus-within)': {
           ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
           backgroundColor: null, // it is not common to change background on hover for Input
         },
         [`&.${inputClasses.disabled}`]:
           theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-        [`&.${inputClasses.focused}`]: {
-          '&:before': {
-            boxShadow: `inset 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
-          },
+        '&:focus-within::before': {
+          boxShadow: `inset 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
         },
       },
     ];

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -116,7 +116,7 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
         // variant styles
         ...variantStyle,
         backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
-        '&:hover:not(:focus-within)': {
+        '&:hover': {
           ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
           backgroundColor: null, // it is not common to change background on hover for Input
         },

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -123,7 +123,7 @@ export const StyledInputRoot = styled('div')<{ ownerState: InputOwnerState }>(
         [`&.${inputClasses.disabled}`]:
           theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
         '&:focus-within::before': {
-          boxShadow: `inset 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
+          boxShadow: `var(--Input-focusedInset, inset) 0 0 0 var(--Input-focusedThickness) var(--Input-focusedHighlight)`,
         },
       },
     ];

--- a/packages/mui-joy/src/Input/InputProps.ts
+++ b/packages/mui-joy/src/Input/InputProps.ts
@@ -18,12 +18,12 @@ export interface InputSlots {
   input?: React.ElementType;
   /**
    * The component that renders the start decorator.
-   * @default 'span'
+   * @default 'div'
    */
   startDecorator?: React.ElementType;
   /**
    * The component that renders the end decorator.
-   * @default 'span'
+   * @default 'div'
    */
   endDecorator?: React.ElementType;
 }

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -128,7 +128,7 @@ const TextareaRoot = styled('div', {
       [`&.${textareaClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
       '&:focus-within::before': {
-        boxShadow: `inset 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
+        boxShadow: `var(--Textarea-focusedInset, inset) 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
       },
     },
   ];

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -120,9 +120,9 @@ const TextareaRoot = styled('div', {
       // variant styles
       ...variantStyle,
       backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
-      '&:hover:not(:focus-within)': {
+      '&:hover': {
         ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
-        backgroundColor: null, // it is not common to change background on hover for Input
+        backgroundColor: null, // it is not common to change background on hover for Textarea
         cursor: 'text',
       },
       [`&.${textareaClasses.disabled}`]:

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -120,17 +120,15 @@ const TextareaRoot = styled('div', {
       // variant styles
       ...variantStyle,
       backgroundColor: variantStyle?.backgroundColor ?? theme.vars.palette.background.surface,
-      [`&:hover:not(.${textareaClasses.focused})`]: {
+      '&:hover:not(:focus-within)': {
         ...theme.variants[`${ownerState.variant!}Hover`]?.[ownerState.color!],
         backgroundColor: null, // it is not common to change background on hover for Input
         cursor: 'text',
       },
       [`&.${textareaClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-      [`&.${textareaClasses.focused}`]: {
-        '&:before': {
-          boxShadow: `inset 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
-        },
+      '&:focus-within::before': {
+        boxShadow: `inset 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
       },
     },
   ];

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -42,6 +42,7 @@ const TextareaRoot = styled('div', {
       '--Textarea-gap': '0.5rem',
       '--Textarea-placeholderColor': 'inherit',
       '--Textarea-placeholderOpacity': 0.5,
+      '--Textarea-focused': '0',
       '--Textarea-focusedThickness': theme.vars.focus.thickness,
       ...(ownerState.color === 'context'
         ? {
@@ -114,6 +115,7 @@ const TextareaRoot = styled('div', {
         zIndex: 1,
         borderRadius: 'inherit',
         margin: 'calc(var(--variant-borderWidth, 0px) * -1)', // for outlined variant
+        boxShadow: `var(--Textarea-focusedInset, inset) 0 0 0 calc(var(--Textarea-focused) * var(--Textarea-focusedThickness)) var(--Textarea-focusedHighlight)`,
       },
     },
     {
@@ -127,9 +129,7 @@ const TextareaRoot = styled('div', {
       },
       [`&.${textareaClasses.disabled}`]:
         theme.variants[`${ownerState.variant!}Disabled`]?.[ownerState.color!],
-      '&:focus-within::before': {
-        boxShadow: `var(--Textarea-focusedInset, inset) 0 0 0 var(--Textarea-focusedThickness) var(--Textarea-focusedHighlight)`,
-      },
+      '&:focus-within::before': { '--Textarea-focused': '1' },
     },
   ];
 });
@@ -154,10 +154,6 @@ const TextareaInput = styled(TextareaAutosize, {
   fontStyle: 'inherit',
   fontWeight: 'inherit',
   lineHeight: 'inherit',
-  '&:-webkit-autofill': {
-    WebkitBackgroundClip: 'text', // remove autofill background
-    WebkitTextFillColor: 'currentColor',
-  },
   '&::-webkit-input-placeholder': {
     color: 'var(--Textarea-placeholderColor)',
     opacity: 'var(--Textarea-placeholderOpacity)',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #37247

<img width="365" alt="image" src="https://github.com/mui/material-ui/assets/18292247/0b501766-c0cd-4848-b03d-4aa95675972b">


## Docs

- Add focus ring explanation to [Input](https://deploy-preview-37385--material-ui.netlify.app/joy-ui/react-input/#focused-ring) and [Textarea](https://deploy-preview-37385--material-ui.netlify.app/joy-ui/react-textarea/#focused-ring) pages
- Add common examples to [Input](https://deploy-preview-37385--material-ui.netlify.app/joy-ui/react-input/#common-examples) and [Textarea](https://deploy-preview-37385--material-ui.netlify.app/joy-ui/react-textarea/#common-examples) to demonstrate customization

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
