### PR TITLE
[core] Do not let Renovate handle `examples` packages updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,11 @@
       "enabled": false
     },
     {
+      "groupName": "examples",
+      "matchPaths": ["examples/**/package.json"],
+      "enabled": false
+    },
+    {
       "groupName": "Playwright",
       "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -86,16 +86,6 @@
       "enabled": false
     },
     {
-      "groupName": "examples",
-      "matchPaths": ["examples/**/package.json"],
-      "minor": {
-        "enabled": false
-      },
-      "patch": {
-        "enabled": false
-      }
-    },
-    {
       "groupName": "Playwright",
       "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"]
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I noticed renovate opening dependency updates PR for the `examples` packages to a major version. We eventually close them because we don't want the legacy example `material-next-ts-v4-v5-migration`, which uses `@mui/styles` for styling to use the latest versions of Next.js and React (See [multiple closed PRs for examples (major)](https://github.com/mui/material-ui/pulls?page=1&q=is%3Apr+Bump+examples+%28major%29+is%3Aclosed)). All examples packages are pinned to the `latest` versions except `material-next-ts-v4-v5-migration`.

I propose to altogether remove the config from renovate. Those who are not aware of it could unknowingly merge them.