### PR TITLE
[Joy][Select] Fix option with null value cannot be marked as selected

### DIFF
--- a/packages/mui-base/src/useList/useList.ts
+++ b/packages/mui-base/src/useList/useList.ts
@@ -349,14 +349,12 @@ function useList<
   const getItemState = React.useCallback(
     (item: ItemValue): ListItemState => {
       const index = items.findIndex((i) => itemComparer(i, item));
-      const selected = (latestSelectedValues.current ?? []).some(
-        (value) => value != null && itemComparer(item, value),
+      const selected = (latestSelectedValues.current ?? []).some((value) =>
+        itemComparer(item, value),
       );
 
       const disabled = isItemDisabled(item, index);
-      const highlighted =
-        latestHighlightedValue.current != null &&
-        itemComparer(item, latestHighlightedValue.current);
+      const highlighted = itemComparer(item, latestHighlightedValue.current as ItemValue);
       const focusable = focusManagement === 'DOM';
 
       return {

--- a/packages/mui-base/src/useSelect/useSelect.ts
+++ b/packages/mui-base/src/useSelect/useSelect.ts
@@ -83,7 +83,7 @@ function useSelect<OptionValue, Multiple extends boolean = false>(
         return valueProp as OptionValue[];
       }
 
-      return valueProp == null ? [] : [valueProp as OptionValue];
+      return [valueProp as OptionValue];
     }
 
     return undefined;

--- a/packages/mui-base/src/useSelect/useSelect.ts
+++ b/packages/mui-base/src/useSelect/useSelect.ts
@@ -73,7 +73,7 @@ function useSelect<OptionValue, Multiple extends boolean = false>(
     if (multiple) {
       defaultValue = defaultValueProp as OptionValue[];
     } else {
-      defaultValue = defaultValueProp == null ? [] : [defaultValueProp as OptionValue];
+      defaultValue = [defaultValueProp as OptionValue];
     }
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes: #37174

I removed null check for value being used on determining wether an option should be selected or highlighted. This way, option with null value can be marked as selected and highlighted.

`value` or `defaultValue` prop with `null` as value was treated as an empty array, which tells the component that nothing is selected. Now, `null` value will be changed to `[null]` (an array with null as element)

Codesandbox:

- [new](https://codesandbox.io/s/frosty-feather-fyi681)
- [old](https://codesandbox.io/s/elated-field-eygwhs?file=/demo.js)
