### PR TITLE
[core] Include scoped JSX namespace when resolving props

### DIFF
--- a/packages/api-docs-builder/utils/getPropsFromComponentSymbol.ts
+++ b/packages/api-docs-builder/utils/getPropsFromComponentSymbol.ts
@@ -15,7 +15,10 @@ function isTypeJSXElementLike(type: ts.Type, project: TypeScriptProject): boolea
   }
   if (type.symbol) {
     const name = project.checker.getFullyQualifiedName(type.symbol);
-    return name === 'global.JSX.Element' || name === 'React.ReactElement';
+    return (
+      // Remove once global JSX namespace is no longer used by React
+      name === 'global.JSX.Element' || name === 'React.JSX.Element' || name === 'React.ReactElement'
+    );
   }
 
   return false;


### PR DESCRIPTION
Related to https://github.com/mui/material-ui/pull/37190
Updating the condition was forgotten when generating API docs on MUI-X.

Blocks https://github.com/mui/mui-x/pull/8900


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
