### PR TITLE
[Select][joy] Fix popup does not close

### DIFF
--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -618,6 +618,12 @@ describe('Joy <Select />', () => {
     });
 
     expect(getByRole('combobox', { hidden: true })).to.have.attribute('aria-expanded', 'true');
+
+    // click again should close
+    act(() => {
+      getByTestId('test-element').click();
+    });
+    expect(getByRole('combobox', { hidden: true })).to.have.attribute('aria-expanded', 'false');
   });
 
   it('should not show dropdown if stop propagation is handled', () => {

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -470,13 +470,9 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
     externalForwardedProps,
     getSlotProps: (handlers) => ({
       onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => {
-        if (
-          !listboxOpen &&
-          !buttonRef.current?.contains(event.target as Node) &&
-          !event.isPropagationStopped()
-        ) {
-          // show the popup if user click outside of the button element.
-          // the close action is already handled by blur event.
+        if (!buttonRef.current?.contains(event.target as Node) && !event.isPropagationStopped()) {
+          // SelectActionTypes.buttonClick action will toggle the listbox
+          // see selectReducer for the implementation
           dispatch({ type: SelectActionTypes.buttonClick, event });
         }
         handlers.onMouseDown?.(event);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Due to https://github.com/mui/material-ui/pull/37244, the focus is on the button instead of the list box.

## Fix

Remove the check of the open state. It is not necessary anymore because the `dispatch({ type: SelectActionTypes.buttonClick, event })` will toggle the state.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
