### PR TITLE
[Material][Autocomplete] Fix missing focusVisible from AutocompleteClasses.

### DIFF
--- a/packages/mui-material/src/Autocomplete/autocompleteClasses.ts
+++ b/packages/mui-material/src/Autocomplete/autocompleteClasses.ts
@@ -52,7 +52,7 @@ export interface AutocompleteClasses {
   groupLabel: string;
   /** Styles applied to the group's ul elements. */
   groupUl: string;
-  /** Styles applied to the root element if keyboard focused. */ 
+  /** Styles applied to the root element if keyboard focused. */
   focusVisible: string;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #37410.