### PR TITLE
[website] Make the Core page refer to Material UI

### DIFF
--- a/docs/pages/core.tsx
+++ b/docs/pages/core.tsx
@@ -15,8 +15,8 @@ export default function Core() {
   return (
     <BrandingCssVarsProvider>
       <Head
-        title="MUI Core: Ready to use components, free forever"
-        description="Get a growing list of React components, ready-to-use, free forever and with accessibility always in mind."
+        title="Material UI: An open-source React component library that implements Google's Material Design"
+        description="A comprehensive collection of prebuilt components that are ready for use in production right out of the box."
         card="/static/social-previews/core-preview.jpg"
       />
       <AppHeaderBanner />

--- a/docs/src/components/productCore/CoreComponents.tsx
+++ b/docs/src/components/productCore/CoreComponents.tsx
@@ -153,7 +153,7 @@ export default function CoreComponents() {
                   <GradientText>40+</GradientText> building block components
                 </Typography>
               }
-              description="We've built the foundational components for your design system, enabling you to launch that cool product you've been thinking about even faster. We got your back!"
+              description="We're meticulous about our implementation of Material Design, ensuring that every Material UI component meets the highest standards of form and function."
             />
           </Box>
           <Group desktopColumns={2} sx={{ mt: 4, pb: { xs: 0, md: 2 } }}>

--- a/docs/src/components/productCore/CoreHero.tsx
+++ b/docs/src/components/productCore/CoreHero.tsx
@@ -225,20 +225,28 @@ export default function Hero() {
               justifyContent: { xs: 'center', md: 'flex-start' },
               '& > *': { mr: 1 },
               ...theme.applyDarkStyles({
-                color: 'primary.400',
+                color: 'primary.300',
               }),
             })}
           >
-            <IconImage width={28} height={28} name="product-core" /> MUI Core
+            <IconImage width={28} height={28} name="product-core" /> MUI Core{' '}
+            <Typography component="span" variant="inherit" sx={{ color: 'text.primary' }}>
+              &nbsp;&nbsp;
+              <Typography component="span" variant="inherit" sx={{ color: 'divider' }}>
+                /
+              </Typography>
+              &nbsp;&nbsp;Material UI
+            </Typography>
           </Typography>
           <Typography variant="h1" sx={{ my: 2, maxWidth: 500 }}>
-            Ready to use components, <br />
-            <GradientText>free forever</GradientText>
+            Ready to use <br />
+            <GradientText>Material Design</GradientText>
+            <br />
+            components
           </Typography>
           <Typography color="text.secondary" sx={{ mb: 3, maxWidth: 500 }}>
-            Get a growing list of React components, ready-to-use, free forever, and with
-            accessibility always in mind. We&apos;ve built the foundational UI blocks for your
-            design system so you don&apos;t have to.
+            Material UI is beautiful by design and features a suite of customization options that
+            make it easy to implement your own custom design system on top of our components.
           </Typography>
           <GetStartedButtons />
         </Box>

--- a/docs/src/components/productCore/CoreHero.tsx
+++ b/docs/src/components/productCore/CoreHero.tsx
@@ -32,7 +32,7 @@ import CheckCircleRounded from '@mui/icons-material/CheckCircleRounded';
 import CakeRounded from '@mui/icons-material/CakeRounded';
 import CelebrationRounded from '@mui/icons-material/CelebrationRounded';
 import AttractionsRounded from '@mui/icons-material/AttractionsRounded';
-import ShoppingCartRounded from '@mui/icons-material/ShoppingCartRounded';
+import DownloadIcon from '@mui/icons-material/Download';
 import LocalFireDepartment from '@mui/icons-material/LocalFireDepartment';
 import AcUnitRounded from '@mui/icons-material/AcUnitRounded';
 import FavoriteBorderRounded from '@mui/icons-material/FavoriteBorderRounded';
@@ -112,6 +112,7 @@ function BadgeVisibilityDemo() {
       variant="outlined"
       elevation={0}
       sx={{
+        width: '100%',
         color: 'action.active',
         p: 2,
         display: 'flex',
@@ -124,7 +125,7 @@ function BadgeVisibilityDemo() {
     >
       <div>
         <Badge color="primary" badgeContent={count}>
-          <ShoppingCartRounded fontSize="small" />
+          <DownloadIcon fontSize="small" />
         </Badge>
         <ButtonGroup>
           <Button
@@ -265,10 +266,10 @@ export default function Hero() {
                 <StepLabel>Search for React UI libraries</StepLabel>
               </Step>
               <Step>
-                <StepLabel>Spot MUI</StepLabel>
+                <StepLabel>Spot Material UI</StepLabel>
               </Step>
               <Step>
-                <StepLabel>Choose MUI</StepLabel>
+                <StepLabel>Choose Material UI</StepLabel>
               </Step>
             </Stepper>
           </Paper>
@@ -299,8 +300,8 @@ export default function Hero() {
                   </AccordionSummary>
                   <AccordionDetails>
                     <Typography variant="body2">
-                      MUI components work in isolation. They are self-supporting, and will only
-                      inject the styles they need to display.
+                      Material UI components work in isolation. They are self-supporting, and will
+                      only inject the styles they need to display.
                     </Typography>
                   </AccordionDetails>
                 </Accordion>
@@ -314,8 +315,8 @@ export default function Hero() {
                   </AccordionSummary>
                   <AccordionDetails>
                     <Typography variant="body2">
-                      MUI usage experience can be improved with a handful of important globals that
-                      you&apos;ll need to be aware of.
+                      Material UI usage experience can be improved with a handful of important
+                      globals that you&apos;ll need to be aware of.
                     </Typography>
                   </AccordionDetails>
                 </Accordion>
@@ -384,12 +385,12 @@ export default function Hero() {
               </Paper>
             </Stack>
             <Stack spacing={4} sx={{ ml: 4, '& > .MuiPaper-root': { maxWidth: 'none' } }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Button variant="contained" startIcon={<ShoppingCartRounded fontSize="small" />}>
-                  Add to Cart
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2 }}>
+                <Button variant="contained" startIcon={<DownloadIcon fontSize="small" />} fullWidth>
+                  Install library
                 </Button>
-                <Button variant="outlined" startIcon={<ShoppingCartRounded fontSize="small" />}>
-                  Add to Cart
+                <Button variant="outlined" startIcon={<DownloadIcon fontSize="small" />} fullWidth>
+                  Install library
                 </Button>
               </Box>
               <Paper elevation={0} variant="outlined" sx={{ p: 2 }}>
@@ -403,13 +404,25 @@ export default function Hero() {
                 </Typography>
                 <SlideDemo />
               </Paper>
-              <TextField id="core-hero-input" defaultValue="Ultraviolet" label="Basement" />
-              <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
+              <TextField
+                id="core-hero-input"
+                defaultValue="Material UI"
+                label="Component library"
+              />
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                }}
+              >
                 <BadgeVisibilityDemo />
                 <Paper
                   variant="outlined"
                   elevation={0}
                   sx={{
+                    width: '100%',
                     py: 2,
                     px: 2,
                     display: 'flex',

--- a/docs/src/components/productCore/CoreTheming.tsx
+++ b/docs/src/components/productCore/CoreTheming.tsx
@@ -95,7 +95,7 @@ export default function CoreTheming() {
                   Build <GradientText>your design system</GradientText> just as you want it to be
                 </Typography>
               }
-              description="Use the advanced theming feature to easily tailor the components to your needs. You can also quickly start with Material Design."
+              description="Start quickly with Material Design or use the advanced theming feature to easily tailor the components to your needs."
             />
           </Box>
           <Group sx={{ mt: 4, pb: { xs: 0, md: 2 } }}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The current Core page is confusing as it mainly refers to Material UI, which is not a synonym for MUI Core. As we get closer to "officially" introducing (as in stable) Base UI as part of the Core product group offering, that confusion is even more highlighted. To alleviate it, and to also better sit on the same level as the to-be-launched Base UI page (https://github.com/mui/material-ui/pull/36622), this PR changes the wording of this page to refer to Material UI directly. In the meantime, we'll be missing a Core-focused page, but it is even to be discussed if we really need it.

By the time this and the Base page PR are merged, we'll have marketing pages for two Core products.

**https://deploy-preview-37452--material-ui.netlify.app/core/**

### Tasks
- [x] First pass at adjusting the copywriting.
- [ ] Copywriting review.
- [ ] Adjust page URL & routing.
- [ ] Verify SEO-related implications to make sure we're not damaging anything there.