### PR TITLE
Use Babel assumptions instead of `loose` mode

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -62,12 +62,6 @@ module.exports = function getBabelConfig(api) {
       },
     ],
     'babel-plugin-optimize-clsx',
-    // Need the following 3 proposals for all targets in .browserslistrc.
-    // With our usage the transpiled loose mode is equivalent to spec mode.
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
-    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
-    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
     [
       '@babel/plugin-transform-runtime',
       {
@@ -98,8 +92,15 @@ module.exports = function getBabelConfig(api) {
   }
 
   return {
+    // https://babeljs.io/docs/assumptions
     assumptions: {
       noDocumentAll: true,
+      // With our cose these assumptions are safe, and the
+      // resulting behavior is equivalent to spec mode.
+      setPublicClassFields: true,
+      privateFieldsAsProperties: true,
+      objectRestNoSymbols: true,
+      setSpreadProperties: true,
     },
     presets,
     plugins,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

[assumptions](https://babeljs.io/docs/assumptions):
- allow more fine-grained control of "loose mode"
- are better self-documenting, since the name of the option tells what the option does
- don't require you to explicitly list the plugins you want to modify in your config, so when the plugin will be unnecessary because your targets evolve you will not have to remember to manually disable it