### PR TITLE
[docs][Base] Remove usage of `component` prop in docs

### DIFF
--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -127,7 +127,7 @@ The same applies for props specific to custom primitive elements:
 
 A common use case for tabs is to implement client-side navigation that doesn't require an HTTP round-trip to the server.
 
-The Tab component provides the `component` prop to handle this use case—see [the Material UI documentation on routing](/material-ui/guides/routing/#tabs) for more details.
+The Tab component provides the [slots](/base/react-tabs/#custom-structure) prop to handle this use case—see [the Material UI documentation on routing](/material-ui/guides/routing/#tabs) for more details.
 
 ## Accessibility
 

--- a/docs/data/base/getting-started/usage/usage.md
+++ b/docs/data/base/getting-started/usage/usage.md
@@ -39,21 +39,6 @@ The code snippet below shows how to override this by assigning a `<div>` to the 
 <Badge slots={{ root: 'div' }} />
 ```
 
-### component
-
-The `component` prop provides a shortcut to `slots.root`.
-This is useful if you are only overriding the root element of the component.
-
-The code snippet below shows how to override the root element of the Base UI Badge component using the `component` prop:
-
-```jsx
-<Badge component="div" />
-```
-
-:::warning
-If the root slot is customized with both the `component` and `slots` props, then `component` will take precedence.
-:::
-
 ### slotProps
 
 The `slotProps` prop is an object that contains the props for all slots within a component.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

preview: 
- https://deploy-preview-37462--material-ui.netlify.app/base/react-tabs/#third-party-routing-library
- https://deploy-preview-37462--material-ui.netlify.app/base/getting-started/usage/

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
