### PR TITLE
[Autocomplete][Material] Add missing `focusVisible` class in AutocompleteClasses

### DIFF
--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -108,6 +108,7 @@
       "fullWidth",
       "expanded",
       "focused",
+      "focusVisible",
       "tag",
       "tagSizeSmall",
       "tagSizeMedium",
@@ -128,8 +129,7 @@
       "noOptions",
       "option",
       "groupLabel",
-      "groupUl",
-      "focusVisible"
+      "groupUl"
     ],
     "globalClasses": {
       "expanded": "Mui-expanded",

--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -128,9 +128,14 @@
       "noOptions",
       "option",
       "groupLabel",
-      "groupUl"
+      "groupUl",
+      "focusVisible"
     ],
-    "globalClasses": { "expanded": "Mui-expanded", "focused": "Mui-focused" },
+    "globalClasses": {
+      "expanded": "Mui-expanded",
+      "focused": "Mui-focused",
+      "focusVisible": "Mui-focusVisible"
+    },
     "name": "MuiAutocomplete"
   },
   "spread": true,

--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -81,6 +81,11 @@
       "nodeName": "the root element",
       "conditions": "focused"
     },
+    "focusVisible": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the option elements",
+      "conditions": "they are keyboard focused"
+    },
     "tag": {
       "description": "Styles applied to {{nodeName}}, {{conditions}}.",
       "nodeName": "the tag elements",
@@ -161,11 +166,6 @@
     "groupUl": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group's ul elements"
-    },
-    "focusVisible": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "keyboard focused"
     }
   }
 }

--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -161,6 +161,11 @@
     "groupUl": {
       "description": "Styles applied to {{nodeName}}.",
       "nodeName": "the group's ul elements"
+    },
+    "focusVisible": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "keyboard focused"
     }
   }
 }

--- a/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
@@ -90,6 +90,13 @@ function MyAutocomplete<
   renderInput={(params) => <TextField {...params} value={params.inputProps.value} />}
 />;
 
+// Test for focusVisible class
+<Autocomplete
+  classes={{ focusVisible: 'test' }}
+  options={[{ label: '1' }, { label: '2' }]}
+  renderInput={(params) => <TextField {...params} />}
+/>;
+
 interface Option {
   label: string;
   value: string;

--- a/packages/mui-material/src/Autocomplete/autocompleteClasses.ts
+++ b/packages/mui-material/src/Autocomplete/autocompleteClasses.ts
@@ -10,6 +10,8 @@ export interface AutocompleteClasses {
   expanded: string;
   /** State class applied to the root element if focused. */
   focused: string;
+  /** Styles applied to the option elements if they are keyboard focused. */
+  focusVisible: string;
   /** Styles applied to the tag elements, e.g. the chips. */
   tag: string;
   /** Styles applied to the tag elements, e.g. the chips if `size="small"`. */
@@ -52,8 +54,6 @@ export interface AutocompleteClasses {
   groupLabel: string;
   /** Styles applied to the group's ul elements. */
   groupUl: string;
-  /** Styles applied to the root element if keyboard focused. */
-  focusVisible: string;
 }
 
 export type AutocompleteClassKey = keyof AutocompleteClasses;

--- a/packages/mui-material/src/Autocomplete/autocompleteClasses.ts
+++ b/packages/mui-material/src/Autocomplete/autocompleteClasses.ts
@@ -52,6 +52,8 @@ export interface AutocompleteClasses {
   groupLabel: string;
   /** Styles applied to the group's ul elements. */
   groupUl: string;
+  /** Styles applied to the root element if keyboard focused. */
+  focusVisible: string;
 }
 
 export type AutocompleteClassKey = keyof AutocompleteClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes:  https://github.com/mui/material-ui/issues/37410

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
