### PR TITLE
perf: avoid calling `clearTimeout()`

### DIFF
--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -136,7 +136,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
   const ignoringMouseDown = React.useRef(false);
   // We use a timer in order to only show the ripples for touch "click" like events.
   // We don't want to display the ripple for touch scroll events.
-  const startTimer = React.useRef(null);
+  const startTimer = React.useRef(0);
 
   // This is the hook called once the previous timeout is ready.
   const startTimerCommit = React.useRef(null);
@@ -144,7 +144,9 @@ const TouchRipple = React.forwardRef(function TouchRipple(inProps, ref) {
 
   React.useEffect(() => {
     return () => {
-      clearTimeout(startTimer.current);
+      if (startTimer.current) {
+        clearTimeout(startTimer.current);
+      }
     };
   }, []);
 


### PR DESCRIPTION
I've been profiling the X DataGrid as part of https://github.com/mui/mui-x/pull/9037, I've noticed that the `clearTimeout()` calls coming from `TouchRipple.js` are consistently taking about 5% of the CPU time for each of our scroll events on blink-based browsers.

I'm guessing `clearTimeout` crosses the boundary into C++ code, which isn't great for performance. This PR avoids calling the function if no timeout has been started.

I'm guessing the same performance hit applies to all `clearTimeout()` calls in the codebase, I'm not sure if you'd like to find a more general solution. Let me know if you prefer the change to be applied to all `clearTimeout` calls.

![image](https://github.com/mui/material-ui/assets/1423607/48b8f313-d256-4240-87d6-ab4ff993261d)

