### PR TITLE
[docs] Add usage of createCssVarsProvider

### DIFF
--- a/docs/data/system/experimental-api/css-theme-variables/CreateCssVarsProvider.js
+++ b/docs/data/system/experimental-api/css-theme-variables/CreateCssVarsProvider.js
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import {
+  unstable_createCssVarsProvider as createCssVarsProvider,
+  unstable_prepareCssVars as prepareCssVars,
+  styled,
+} from '@mui/system';
+
+const lightColorScheme = {
+  palette: {
+    mode: 'light',
+    primary: {
+      default: '#3990FF',
+      dark: '#02367D',
+    },
+    text: {
+      default: '#111111',
+    },
+    // ... other colors
+  },
+};
+
+const darkColorScheme = {
+  palette: {
+    mode: 'dark',
+    primary: {
+      default: '#265D97',
+      dark: '#132F4C',
+      main: '#5090D3',
+    },
+    text: {
+      default: '#ffffff',
+    },
+    // ... other colors
+  },
+};
+
+function extendTheme({ cssVarPrefix = 'system-demo' } = {}) {
+  const { vars: themeVars, generateCssVars } = prepareCssVars(
+    {
+      colorSchemes: {
+        light: lightColorScheme,
+        dark: darkColorScheme,
+      },
+    },
+    {
+      prefix: cssVarPrefix,
+    },
+  );
+
+  const theme = {
+    colorSchemes: {
+      light: lightColorScheme,
+      dark: darkColorScheme,
+    },
+    // ... any other objects independent of color-scheme,
+    // like fontSizes, spacing etc
+    vars: themeVars,
+    generateCssVars,
+    palette: {
+      ...lightColorScheme.palette,
+      colorScheme: 'light',
+    },
+  };
+
+  return theme;
+}
+
+const myCustomDefaultTheme = extendTheme();
+
+const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
+  theme: myCustomDefaultTheme,
+  modeStorageKey: 'system-demo-mode',
+  attribute: 'data-system-demo-color-scheme',
+  defaultColorScheme: {
+    light: 'light',
+    dark: 'dark',
+  },
+});
+
+const Button = styled('button')(({ theme }) => ({
+  backgroundColor: theme.vars.palette.primary.default,
+  border: `1px solid ${theme.vars.palette.primary.dark}`,
+  color: theme.vars.palette.text.default,
+  padding: 10,
+  borderRadius: 5,
+  fontWeight: 'bold',
+}));
+
+const WrapperDiv = styled('div')(({ theme }) => ({
+  width: '100%',
+  minHeight: 100,
+  padding: 20,
+  color: theme.vars.palette.text.default,
+  backgroundColor: theme.palette.mode === 'dark' ? '#111' : '#fff',
+}));
+
+function App() {
+  // changes specific to this demo.
+  const [shouldRender, setShouldRender] = React.useState(false);
+  const { setMode, mode } = useColorScheme();
+  const toggleMode = () => {
+    setMode(mode === 'dark' ? 'light' : 'dark');
+  };
+
+  // to avoid hydration error in demo. unrelated to the actual implementation
+  React.useEffect(() => {
+    setShouldRender(true);
+  }, []);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <WrapperDiv className="App">
+      <div className="card">
+        <h2>Current mode: {mode}</h2>
+        <Button type="button" onClick={toggleMode}>
+          Toggle Mode
+        </Button>
+      </div>
+    </WrapperDiv>
+  );
+}
+
+export default function Demo() {
+  return (
+    <CssVarsProvider>
+      <App />
+    </CssVarsProvider>
+  );
+}

--- a/docs/data/system/experimental-api/css-theme-variables/CreateCssVarsProvider.tsx
+++ b/docs/data/system/experimental-api/css-theme-variables/CreateCssVarsProvider.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import {
+  unstable_createCssVarsProvider as createCssVarsProvider,
+  unstable_prepareCssVars as prepareCssVars,
+  styled,
+} from '@mui/system';
+
+type Theme = {
+  colorSchemes: {
+    light: typeof lightColorScheme;
+    dark: typeof lightColorScheme;
+  };
+  palette: {
+    colorScheme: 'light' | 'dark';
+  } & (typeof lightColorScheme)['palette'];
+  vars: ReturnType<typeof prepareCssVars>['vars'];
+  generateCssVars: ReturnType<typeof prepareCssVars>['generateCssVars'];
+};
+
+const lightColorScheme = {
+  palette: {
+    mode: 'light',
+    primary: {
+      default: '#3990FF',
+      dark: '#02367D',
+    },
+    text: {
+      default: '#111111',
+    },
+    // ... other colors
+  },
+};
+
+const darkColorScheme = {
+  palette: {
+    mode: 'dark',
+    primary: {
+      default: '#265D97',
+      dark: '#132F4C',
+      main: '#5090D3',
+    },
+    text: {
+      default: '#ffffff',
+    },
+    // ... other colors
+  },
+};
+
+function extendTheme({ cssVarPrefix = 'system-demo' } = {}) {
+  const { vars: themeVars, generateCssVars } = prepareCssVars(
+    {
+      colorSchemes: {
+        light: lightColorScheme,
+        dark: darkColorScheme,
+      },
+    },
+    {
+      prefix: cssVarPrefix,
+    },
+  );
+  const theme: Theme = {
+    colorSchemes: {
+      light: lightColorScheme,
+      dark: darkColorScheme,
+    },
+    // ... any other objects independent of color-scheme,
+    // like fontSizes, spacing etc
+    vars: themeVars,
+    generateCssVars,
+    palette: {
+      ...lightColorScheme.palette,
+      colorScheme: 'light',
+    },
+  };
+
+  return theme;
+}
+
+const myCustomDefaultTheme = extendTheme();
+
+const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
+  theme: myCustomDefaultTheme,
+  modeStorageKey: 'system-demo-mode',
+  attribute: 'data-system-demo-color-scheme',
+  defaultColorScheme: {
+    light: 'light',
+    dark: 'dark',
+  },
+});
+
+const Button = styled('button')<{ theme?: Theme }>(({ theme }) => ({
+  backgroundColor: theme.vars.palette.primary.default,
+  border: `1px solid ${theme.vars.palette.primary.dark}`,
+  color: theme.vars.palette.text.default,
+  padding: 10,
+  borderRadius: 5,
+  fontWeight: 'bold',
+}));
+
+const WrapperDiv = styled('div')<{ theme?: Theme }>(({ theme }) => ({
+  width: '100%',
+  minHeight: 100,
+  padding: 20,
+  color: theme.vars.palette.text.default,
+  backgroundColor: theme.palette.mode === 'dark' ? '#111' : '#fff',
+}));
+
+function App() {
+  // changes specific to this demo.
+  const [shouldRender, setShouldRender] = React.useState(false);
+  const { setMode, mode } = useColorScheme();
+  const toggleMode = () => {
+    setMode(mode === 'dark' ? 'light' : 'dark');
+  };
+
+  // to avoid hydration error in demo. unrelated to the actual implementation
+  React.useEffect(() => {
+    setShouldRender(true);
+  }, []);
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <WrapperDiv className="App">
+      <div className="card">
+        <h2>Current mode: {mode}</h2>
+        <Button type="button" onClick={toggleMode}>
+          Toggle Mode
+        </Button>
+      </div>
+    </WrapperDiv>
+  );
+}
+
+export default function Demo() {
+  return (
+    <CssVarsProvider>
+      <App />
+    </CssVarsProvider>
+  );
+}

--- a/docs/data/system/experimental-api/css-theme-variables/CreateCssVarsProvider.tsx.preview
+++ b/docs/data/system/experimental-api/css-theme-variables/CreateCssVarsProvider.tsx.preview
@@ -1,0 +1,3 @@
+<CssVarsProvider>
+  <App />
+</CssVarsProvider>

--- a/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
+++ b/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
@@ -1,0 +1,229 @@
+# CSS theme variables
+
+<p class="description">An overview of adopting CSS theme variables in Material UI or Joy UI.</p>
+
+[CSS variables](https://www.w3.org/TR/css-variables-1/) are a modern cross-browser feature that let you declare variables in CSS and reuse them in other properties.
+
+:::info
+If this is your first time encountering CSS variables, you should check out [the MDN Web Docs on CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) before continuing here.
+:::
+
+## Introduction
+
+CSS theme variable support is a new feature in MUI System added in [`v5.0.5`](https://github.com/mui/material-ui/releases/tag/v5.0.5) as an experimental export. It tells the underlying Material UI, Joy UI or even custom UI library components to use the generated CSS theme variables instead of raw values. This provides significant improvements in developer experience related to theming and customization.
+With these variables, you can inject a theme into your app's stylesheet _at build time_ to apply the user's selected settings before the whole app is rendered.
+You can checkout the [advantages](https://mui.com/material-ui/experimental-api/css-theme-variables/overview/#advantages) and [trade-offs](https://mui.com/material-ui/experimental-api/css-theme-variables/overview/#trade-offs) of using CSS theme variables before using them.
+
+### Advantages
+
+- It lets you prevent [dark-mode SSR flickering](https://github.com/mui/material-ui/issues/27651).
+- You can create unlimited color schemes beyond `light` and `dark`.
+- It offers a better debugging experience not only for developers but also designers on your team.
+- The color scheme of your website is automatically synced between browser tabs.
+- It simplifies integration with third-party tools because CSS theme variables are available globally.
+- It reduces the need for a nested theme when you want to apply dark styles to a specific part of your application.
+
+## Trade-offs
+
+For server-side applications, there are some trade-offs to consider:
+
+|                                                      | Compare to the default method | Reason                                                                                                       |
+| :--------------------------------------------------- | :---------------------------- | :----------------------------------------------------------------------------------------------------------- |
+| HTML size                                            | Bigger                        | CSS variables are generated for both light and dark mode at build time.                                      |
+| [First Contentful Paint (FCP)](https://web.dev/fcp/) | Larger                        | Since the HTML size is generally bigger, the time to download the HTML before showing the content is longer. |
+| [Time to Interactive (TTI)](https://web.dev/tti/)    | Smaller (for dark mode)       | Stylesheets are not regenerated between light and dark mode, so it takes less time for JavaScript to run.    |
+
+:::warning
+The comparison described in the table above may not be applicable to large and complex applications since there are so many factors that can impact performance metrics.
+:::
+
+## Usage
+
+The CSS variables API usage is exposed as a higher order function called `unstable_createCssVarsProvider` which can be called to create a theme provider and other utitlities to share the theme config throughout your app. This is a very low-level function and has a lot of moving parts. If you are already using [Material UI](https://mui.com/material-ui/experimental-api/css-theme-variables/overview/) or [Joy UI](https://mui.com/joy-ui/customization/using-css-variables/), they already expose their own `CssVarsProvider` component that you can use directly without needing to configure your theme. Now that's out of the way, we can continue with how this util can be used.
+
+We'll first define a minimal theme palette for light and dark modes.
+
+```js
+// extendTheme.js
+import {
+  unstable_createGetCssVar as systemCreateGetCssVar,
+  unstable_prepareCssVars as prepareCssVars,
+} from '@mui/system';
+
+const lightColorScheme = {
+  palette: {
+    mode: 'light',
+    primary: {
+      default: '#3990FF',
+      dark: '#02367D',
+    },
+    text: {
+      default: '#111111',
+    },
+    // ... other colors
+  },
+};
+
+const darkColorScheme = {
+  palette: {
+    mode: 'dark',
+    primary: {
+      default: '#265D97',
+      dark: '#132F4C',
+      main: '#5090D3',
+    },
+    text: {
+      default: '#ffffff',
+    },
+    // ... other colors
+  },
+};
+
+const createGetCssVar = (cssVarPrefix = 'my-app') =>
+  systemCreateGetCssVar(cssVarPrefix);
+
+function extendTheme({ cssVarPrefix = 'my-app' } = {}) {
+  const getCssVar = createGetCssVar(cssVarPrefix);
+  const theme = {
+    colorSchemes: {
+      light: lightColorScheme,
+      dark: darkColorScheme,
+    },
+    // ... any other objects independent of color-scheme,
+    // like fontSizes, spacing tokens, etc
+  };
+
+  const { vars: themeVars, generateCssVars } = prepareCssVars(
+    { colorSchemes: theme.colorSchemes },
+    {
+      prefix: cssVarPrefix,
+    },
+  );
+  theme.vars = themeVars;
+  theme.generateCssVars = generateCssVars;
+  theme.palette = {
+    ...theme.colorSchemes.light.palette,
+    colorScheme: 'light',
+  };
+
+  return theme;
+}
+
+const myCustomDefaultTheme = extendTheme();
+
+export default myCustomDefaultTheme;
+```
+
+Here, the returned `theme` object needs to follow a certain structure to be used correctly by the final `CssVarsProvider`. It should have a `colorSchemes` key with the light and dark (and any other) palette. `prepareCssVars` import from `@mui/system` is used to create css variable names which can then be easily accessed using the returned `vars`. This is also added to the `theme` object. Finally, `myCustomDefaultTheme` theme object is created that can now be passed to the `createCssVarsProvider` to get a `CssVarsProvider`.
+
+```js
+// CssVarsProvider.js
+import { unstable_createCssVarsProvider as createCssVarsProvider } from '@mui/system';
+
+const { CssVarsProvider, useColorScheme } = createCssVarsProvider({
+  defaultColorScheme: {
+    light: 'light',
+    dark: 'dark',
+  },
+  theme: myCustomDefaultTheme,
+});
+
+export { CssVarsProvider, useColorScheme };
+```
+
+Now wrap your top level app component with this `CssVarsProvider` component and then you can access the passed theme value to any of the components rendered inside the provider.
+
+Example of a component using the css variable -
+
+```js
+// Button.js
+import { styled } from '@mui/system';
+
+const Button = styled('button')(({ theme }) => ({
+  backgroundColor: theme.vars.palette.primary.default,
+  border: `1px solid ${theme.vars.palette.primary.dark}`,
+  color: theme.vars.palette.text.default,
+}));
+
+export default Button;
+```
+
+The hook, `useColorScheme` can be used to get the current `mode` (light or dark) and can also update the mode like:
+
+```js
+// App.js
+function App() {
+  const { setMode, mode } = useColorScheme();
+  const toggleMode = () => {
+    setMode(mode === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <div>
+      <h1>Current Mode: {mode}</h1>
+      <Button onClick={toggleMode}>Toggle Mode</Button>
+    </div>
+  );
+}
+
+// main.js
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { CssVarsProvider } from './CssVarsProvider';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <CssVarsProvider>
+    <App />
+  </CssVarsProvider>,
+);
+```
+
+Now, the Button's `backgroundColor`, `borderColor` and text `color` values will correctly use the colors based on the selected `mode`.
+
+### Demo
+
+{{"demo": "CreateCssVarsProvider.js"}}
+
+For framework or language specific setup, see [this](https://mui.com/material-ui/experimental-api/css-theme-variables/usage/#server-side-rendering)
+
+See the complete usage of `createVssVarsProvider` in [Material UI](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/CssVarsProvider.tsx) and [Joy UI](https://github.com/mui/material-ui/blob/master/packages/mui-joy/src/styles/CssVarsProvider.tsx).
+
+## API
+
+### `createCssVarsProvider` options
+
+- `attribute?`: DOM attribute for applying color scheme (`data-color-scheme` by default)
+- `modeStorageKey?`: localStorage key used to store application `mode` (`mode` by default)
+- `colorSchemeStorageKey?`: localStorage key used to store `colorScheme`
+- `defaultColorScheme`: Design system default color scheme (string or object depending on if the design system has 1 or more themes, can be `light` or `dark`)
+- `defaultMode?`: Design system default mode (`light` by default)
+- `disableTransitionOnChange?`: Disable CSS transitions when switching between modes or color schemes (`false` by default)
+- `themeId?`: The design system's unique id for getting the corresponded theme when there are multiple design systems.
+- `theme`: Design system default theme. It's structure, besides the minimium requirements by `createCssVarsProvider`, is upto the design system to implement.
+- `resolveTheme(theme: Theme) => Theme`: A function to be called after the CSS variables are attached. The result of this function will be the final theme pass to `ThemeProvider`.
+
+`createCssVarsProvider` returns 3 items.
+
+### `<CssVarsProvider>` props
+
+- `defaultMode?: 'light' | 'dark' | 'system'` - Application's default mode (`light` by default)
+- `disableTransitionOnChange : boolean` - Disable CSS transitions when switching between modes
+- `enableColorScheme: boolean` - Indicate to the browser which color scheme is used (light or dark) for rendering built-in UI
+- `prefix: string` - CSS variable prefix
+- `theme: ThemeInput` - the theme provided to React's context
+- `modeStorageKey?: string` - localStorage key used to store application `mode`
+- `attribute?: string` - DOM attribute for applying color scheme
+
+### `useColorScheme: () => ColorSchemeContextValue`
+
+- `mode: string` - The user's selected mode
+- `setMode: mode => {…}` - Function for setting the `mode`. The `mode` is saved to internal state and local storage; if `mode` is null, it will be reset to the default mode
+
+### `getInitColorSchemeScript: (options) => React.ReactElement`
+
+**options**
+
+- `defaultMode?: 'light' | 'dark' | 'system'`: - Application's default mode before React renders the tree (`light` by default)
+- `modeStorageKey?: string`: - localStorage key used to store application `mode`
+- `attribute?: string` - DOM attribute for applying color scheme

--- a/docs/data/system/pages.ts
+++ b/docs/data/system/pages.ts
@@ -58,6 +58,10 @@ const pages = [
         pathname: '/system/experimental-api/configure-the-sx-prop',
         title: 'Configure the sx prop',
       },
+      {
+        pathname: '/system/experimental-api/css-theme-variables',
+        title: 'CSS Theme Variables',
+      },
     ],
   },
   {

--- a/docs/pages/system/experimental-api/css-theme-variables.js
+++ b/docs/pages/system/experimental-api/css-theme-variables.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import * as pageProps from 'docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md?@mui/markdown';
+
+export default function Page() {
+  return <MarkdownDocs {...pageProps} />;
+}

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -213,6 +213,7 @@
     "/system/react-stack": "Stack",
     "/system/experimental-api": "Experimental APIs",
     "/system/experimental-api/configure-the-sx-prop": "Configure the sx prop",
+    "/system/experimental-api/css-theme-variables": "CSS Theme Variables",
     "/system/styles": "Styles",
     "/system/styles/basics": "Basics",
     "/system/styles/advanced": "Advanced",

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -58,7 +58,7 @@ export interface CssVarsThemeOptions extends Partial2Level<ThemeScalesOptions> {
    * // { ..., typography: { body1: { fontSize: 'var(--foo-bar-fontSize-md)' } }, ... }
    *
    * @example <caption>Provides empty string ('') to remove the prefix</caption>
-   * extendTheme({ cssVarPrefix: 'foo-bar' })
+   * extendTheme({ cssVarPrefix: '' })
    * // { ..., typography: { body1: { fontSize: 'var(--fontSize-md)' } }, ... }
    */
   cssVarPrefix?: string;

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -18,6 +18,12 @@ export const DISABLE_CSS_TRANSITION =
 export default function createCssVarsProvider(options) {
   const {
     themeId,
+    /**
+     * This `theme` object needs to follow a certain structure to
+     * be used correctly by the finel `CssVarsProvider`. It should have a
+     * `colorSchemes` key with the light and dark (and any other) palette.
+     * It should also ideally have a vars object created using `prepareCssVars`.
+     */
     theme: defaultTheme = {},
     attribute: defaultAttribute = DEFAULT_ATTRIBUTE,
     modeStorageKey: defaultModeStorageKey = DEFAULT_MODE_STORAGE_KEY,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Added a minimal code example to showcase how `createCssVarsProvider` is used.