### PR TITLE
[docs] Fix crash access to localStorage in Firefox 

### DIFF
--- a/docs/src/layouts/AppHeader.tsx
+++ b/docs/src/layouts/AppHeader.tsx
@@ -62,7 +62,11 @@ export default function AppHeader(props: AppHeaderProps) {
     const paletteMode = checked ? 'dark' : 'light';
     setMode(paletteMode);
 
-    localStorage.setItem('mui-mode', paletteMode); // syncing with homepage, can be removed once all pages are migrated to CSS variables
+    try {
+      localStorage.setItem('mui-mode', paletteMode); // syncing with homepage, can be removed once all pages are migrated to CSS variables
+    } catch (error) {
+      // do nothing
+    }
     changeTheme({ paletteMode });
   };
 

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -65,10 +65,18 @@ function AppSettingsDrawer(props) {
     setMode(paletteMode);
 
     if (paletteMode === 'system') {
-      localStorage.setItem('mui-mode', 'system'); // syncing with homepage, can be removed once all pages are migrated to CSS variables
+      try {
+        localStorage.setItem('mui-mode', 'system'); // syncing with homepage, can be removed once all pages are migrated to CSS variables
+      } catch (error) {
+        // thrown when cookies are disabled.
+      }
       changeTheme({ paletteMode: preferredMode });
     } else {
-      localStorage.setItem('mui-mode', paletteMode); // syncing with homepage, can be removed once all pages are migrated to CSS variables
+      try {
+        localStorage.setItem('mui-mode', paletteMode); // syncing with homepage, can be removed once all pages are migrated to CSS variables
+      } catch (error) {
+        // thrown when cookies are disabled.
+      }
       changeTheme({ paletteMode });
     }
   };

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -168,7 +168,13 @@ export function ThemeProvider(props) {
 
   useEnhancedEffect(() => {
     const nextPaletteColors = JSON.parse(getCookie('paletteColors') || 'null');
-    let nextPaletteMode = localStorage.getItem('mui-mode') || preferredMode; // syncing with homepage, can be removed once all pages are migrated to CSS variables
+    let nextPaletteMode = preferredMode; // syncing with homepage, can be removed once all pages are migrated to CSS variables
+    try {
+      nextPaletteMode = localStorage.getItem('mui-mode') ?? preferredMode;
+    } catch (error) {
+      // mainly thrown when cookies are disabled.
+    }
+
     if (nextPaletteMode === 'system') {
       nextPaletteMode = preferredMode;
     }


### PR DESCRIPTION
This avoids the page crashing when accessed in Firefox with cookies disabled

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #37514 