### PR TITLE
[Stack] Fix CSS selector

### DIFF
--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -29,35 +29,29 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       '@media (min-width:0px)': {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '8px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginLeft: '16px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         flexDirection: 'row',
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginLeft: '32px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       display: 'flex',
@@ -76,24 +70,20 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '16px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginLeft: '16px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         flexDirection: 'row',
       },
@@ -113,23 +103,19 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '16px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '32px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       display: 'flex',
@@ -148,33 +134,27 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '16px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '0px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '32px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       display: 'flex',
@@ -192,13 +172,11 @@ describe('<Stack />', () => {
         theme,
       }),
     ).to.deep.equal({
-<<<<<<< HEAD
       '& > :not(style) ~ :not(style)': {
-=======
-      '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-        margin: 0,
         marginLeft: '24px',
+      },
+      '& > :not(style):not(style)': {
+        margin: 0,
       },
       display: 'flex',
       flexDirection: 'row',
@@ -216,24 +194,20 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       '@media (min-width:0px)': {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '8px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '16px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
       },
       display: 'flex',
@@ -252,13 +226,11 @@ describe('<Stack />', () => {
           theme,
         }),
       ).to.deep.equal({
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginBottom: '8px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         display: 'flex',
         flexDirection: 'column-reverse',
@@ -276,34 +248,28 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         '@media (min-width:0px)': {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '8px',
           },
           flexDirection: 'column',
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginLeft: '16px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginLeft: '24px',
           },
         },
@@ -340,43 +306,35 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '0px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginLeft: '16px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginLeft: '32px',
           },
         },
@@ -394,54 +352,44 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '0px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginLeft: '0px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginLeft: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '16px',
           },
           flexDirection: 'column',
         },
         [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '32px',
           },
         },
@@ -463,32 +411,26 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         '@media (min-width:0px)': {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '8px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '24px',
           },
         },
@@ -519,13 +461,11 @@ describe('<Stack />', () => {
           theme: customTheme,
         }),
       ).to.deep.equal({
-<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
-=======
-        '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
-          margin: 0,
           marginTop: '32px',
+        },
+        '& > :not(style):not(style)': {
+          margin: 0,
         },
         display: 'flex',
         flexDirection: 'column',
@@ -555,12 +495,10 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${customTheme.breakpoints.values.small}px)`]: {
-<<<<<<< HEAD
-          '& > :not(style) ~ :not(style)': {
-=======
           '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
+          },
+          '& > :not(style) ~ :not(style)': {
             marginTop: '32px',
           },
         },

--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -29,21 +29,33 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       '@media (min-width:0px)': {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '8px',
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginLeft: '16px',
         },
         flexDirection: 'row',
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginLeft: '32px',
         },
@@ -64,14 +76,22 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '16px',
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginLeft: '16px',
         },
@@ -93,13 +113,21 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '16px',
         },
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '32px',
         },
@@ -120,19 +148,31 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '16px',
         },
       },
       [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '0px',
         },
       },
       [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '32px',
         },
@@ -152,7 +192,11 @@ describe('<Stack />', () => {
         theme,
       }),
     ).to.deep.equal({
+<<<<<<< HEAD
       '& > :not(style) ~ :not(style)': {
+=======
+      '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
         margin: 0,
         marginLeft: '24px',
       },
@@ -172,14 +216,22 @@ describe('<Stack />', () => {
       }),
     ).to.deep.equal({
       '@media (min-width:0px)': {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '8px',
         },
         flexDirection: 'column',
       },
       [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '16px',
         },
@@ -200,7 +252,11 @@ describe('<Stack />', () => {
           theme,
         }),
       ).to.deep.equal({
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginBottom: '8px',
         },
@@ -220,21 +276,33 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         '@media (min-width:0px)': {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '8px',
           },
           flexDirection: 'column',
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginLeft: '16px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginLeft: '24px',
           },
@@ -272,26 +340,42 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '0px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginLeft: '16px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginLeft: '32px',
           },
@@ -310,33 +394,53 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${theme.breakpoints.values.xs}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '0px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginLeft: '0px',
           },
           flexDirection: 'row',
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginLeft: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.lg}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '16px',
           },
           flexDirection: 'column',
         },
         [`@media (min-width:${theme.breakpoints.values.xl}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '32px',
           },
@@ -359,19 +463,31 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         '@media (min-width:0px)': {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '8px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.sm}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '16px',
           },
         },
         [`@media (min-width:${theme.breakpoints.values.md}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '24px',
           },
@@ -403,7 +519,11 @@ describe('<Stack />', () => {
           theme: customTheme,
         }),
       ).to.deep.equal({
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           marginTop: '32px',
         },
@@ -435,7 +555,11 @@ describe('<Stack />', () => {
         }),
       ).to.deep.equal({
         [`@media (min-width:${customTheme.breakpoints.values.small}px)`]: {
+<<<<<<< HEAD
           '& > :not(style) ~ :not(style)': {
+=======
+          '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
             margin: 0,
             marginTop: '32px',
           },

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -135,7 +135,11 @@ export const style = ({ ownerState, theme }: StyleFunctionProps) => {
         return { gap: getValue(transformer, propValue) };
       }
       return {
+<<<<<<< HEAD
         '& > :not(style) ~ :not(style)': {
+=======
+        '& > :not(style):not(style)': {
+>>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
           [`margin${getSideFromDirection(
             breakpoint ? directionValues[breakpoint] : ownerState.direction,
@@ -198,7 +202,7 @@ export default function createStack(
     };
 
     const classes = useUtilityClasses();
-
+    // console.log(children);
     return (
       <StackRoot
         as={component}

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -135,12 +135,12 @@ export const style = ({ ownerState, theme }: StyleFunctionProps) => {
         return { gap: getValue(transformer, propValue) };
       }
       return {
-<<<<<<< HEAD
-        '& > :not(style) ~ :not(style)': {
-=======
+        // The useFlexGap={false} implement relies on each child to give up control of the margin.
+        // We need to reset the margin to avoid double spacing.
         '& > :not(style):not(style)': {
->>>>>>> 0a02719a60 ([Stack] Fix css selector)
           margin: 0,
+        },
+        '& > :not(style) ~ :not(style)': {
           [`margin${getSideFromDirection(
             breakpoint ? directionValues[breakpoint] : ownerState.direction,
           )}`]: getValue(transformer, propValue),
@@ -202,7 +202,7 @@ export default function createStack(
     };
 
     const classes = useUtilityClasses();
-    // console.log(children);
+
     return (
       <StackRoot
         as={component}


### PR DESCRIPTION
closes: https://github.com/mui/material-ui/issues/37381 by forcing the `margin: 0` reset on all the children of the Stack component. Before this change, the reset is done on almost all the children but not the first child.

https://deploy-preview-37525--material-ui.netlify.app/system/react-stack/

before: https://codesandbox.io/s/sad-aj-45wiii?file=/src/App.js
<img width="513" alt="Screenshot 2023-06-06 at 10 26 31 PM" src="https://github.com/mui/material-ui/assets/60743144/c174d30c-1e47-4ae5-ab38-6ba8c9bd45b7">

after: https://codesandbox.io/s/sharp-sun-7pgg8k?file=/package.json

<img width="498" alt="Screenshot 2023-06-06 at 10 29 44 PM" src="https://github.com/mui/material-ui/assets/60743144/1cfc1d94-e616-46f4-8745-8cf3d5e421e6">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
