### PR TITLE
[docs-infra] Consider files ending with .types.ts as props files

### DIFF
--- a/packages/mui-base/src/Button/Button.tsx
+++ b/packages/mui-base/src/Button/Button.tsx
@@ -109,6 +109,10 @@ Button.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * If `true`, the component is disabled.
    * @default false
    */

--- a/packages/mui-base/src/FormControl/FormControl.tsx
+++ b/packages/mui-base/src/FormControl/FormControl.tsx
@@ -177,6 +177,10 @@ FormControl.propTypes /* remove-proptypes */ = {
     PropTypes.func,
   ]),
   /**
+   * Class name applied to the root element.
+   */
+  className: PropTypes.string,
+  /**
    * @ignore
    */
   defaultValue: PropTypes.any,

--- a/packages/mui-base/src/Menu/Menu.tsx
+++ b/packages/mui-base/src/Menu/Menu.tsx
@@ -128,6 +128,10 @@ Menu.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
+  className: PropTypes.string,
+  /**
+   * @ignore
+   */
   defaultOpen: PropTypes.bool,
   /**
    * @ignore

--- a/packages/mui-base/src/MenuItem/MenuItem.tsx
+++ b/packages/mui-base/src/MenuItem/MenuItem.tsx
@@ -76,12 +76,20 @@ MenuItem.propTypes /* remove-proptypes */ = {
   /**
    * @ignore
    */
+  className: PropTypes.string,
+  /**
+   * @ignore
+   */
   disabled: PropTypes.bool,
   /**
    * A text representation of the menu item's content.
    * Used for keyboard text navigation matching.
    */
   label: PropTypes.string,
+  /**
+   * @ignore
+   */
+  onClick: PropTypes.func,
   /**
    * The props used for each slot inside the MenuItem.
    * @default {}

--- a/packages/mui-base/src/Option/Option.tsx
+++ b/packages/mui-base/src/Option/Option.tsx
@@ -76,6 +76,10 @@ Option.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * If `true`, the option will be disabled.
    * @default false
    */

--- a/packages/mui-base/src/OptionGroup/OptionGroup.tsx
+++ b/packages/mui-base/src/OptionGroup/OptionGroup.tsx
@@ -88,6 +88,10 @@ OptionGroup.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * If `true` all the options in the group will be disabled.
    * @default false
    */

--- a/packages/mui-base/src/Select/Select.tsx
+++ b/packages/mui-base/src/Select/Select.tsx
@@ -265,6 +265,10 @@ Select.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * If `true`, the select will be initially open.
    * @default false
    */

--- a/packages/mui-base/src/Switch/Switch.tsx
+++ b/packages/mui-base/src/Switch/Switch.tsx
@@ -144,6 +144,10 @@ Switch.propTypes /* remove-proptypes */ = {
    */
   checked: PropTypes.bool,
   /**
+   * Class name applied to the root element.
+   */
+  className: PropTypes.string,
+  /**
    * The default checked state. Use when the component is not controlled.
    */
   defaultChecked: PropTypes.bool,

--- a/packages/mui-base/src/TabPanel/TabPanel.tsx
+++ b/packages/mui-base/src/TabPanel/TabPanel.tsx
@@ -73,6 +73,10 @@ TabPanel.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * The props used for each slot inside the TabPanel.
    * @default {}
    */

--- a/packages/mui-base/src/Tabs/Tabs.tsx
+++ b/packages/mui-base/src/Tabs/Tabs.tsx
@@ -84,6 +84,10 @@ Tabs.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * The default value. Use when the component is not controlled.
    */
   defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/mui-base/src/TabsList/TabsList.tsx
+++ b/packages/mui-base/src/TabsList/TabsList.tsx
@@ -78,6 +78,10 @@ TabsList.propTypes /* remove-proptypes */ = {
    */
   children: PropTypes.node,
   /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
    * The props used for each slot inside the TabsList.
    * @default {}
    */

--- a/packages/mui-material-next/src/Button/Button.tsx
+++ b/packages/mui-material-next/src/Button/Button.tsx
@@ -712,6 +712,14 @@ Button.propTypes /* remove-proptypes */ = {
    */
   startIcon: PropTypes.node,
   /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
    * @default 0
    */
   tabIndex: PropTypes.number,

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -211,6 +211,7 @@ async function generateProptypes(
   const unstyledPropsFile = unstyledFile.replace('.d.ts', '.types.ts');
 
   const propsFile = tsFile.replace(/(\.d\.ts|\.tsx|\.ts)/g, 'Props.ts');
+  const propsFileAlternative = tsFile.replace(/(\.d\.ts|\.tsx|\.ts)/g, '.types.ts');
   const generatedForTypeScriptFile = sourceFile === tsFile;
   const result = ttp.inject(proptypes, sourceContent, {
     disablePropTypesTypeChecking: generatedForTypeScriptFile,
@@ -263,7 +264,7 @@ async function generateProptypes(
         const isExternal = filename !== tsFile;
         const implementedByUnstyledVariant =
           filename === unstyledFile || filename === unstyledPropsFile;
-        const implementedBySelfPropsFile = filename === propsFile;
+        const implementedBySelfPropsFile = filename === propsFile || filename === propsFileAlternative && filename.indexOf('/base/') === -1;
         if (!isExternal || implementedByUnstyledVariant || implementedBySelfPropsFile) {
           shouldDocument = true;
         }


### PR DESCRIPTION
First reported in https://github.com/mui/material-ui/pull/37520. We have currently two conventions for writing types files, .types.ts and Props.ts. This unlocks us for using .types.ts files in @mui/material-next. I noticed that this generated some changes in the Base UI components too, but I would say they are expected. @siriwatknp should we use the same convention in Joy UI too?