### PR TITLE
[docs] Skip components and hooks due to duplicate index

### DIFF
--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -92,6 +92,7 @@ export default function ComponentPageTabs(props) {
         />
         {headers.components?.length > 0 && (
           <StyledTab
+            className="skip-algolia-crawler"
             component={Link}
             shallow
             scroll
@@ -102,6 +103,7 @@ export default function ComponentPageTabs(props) {
         )}
         {headers.hooks && headers.hooks.length > 0 && (
           <StyledTab
+            className="skip-algolia-crawler"
             component={Link}
             shallow
             scroll

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -92,7 +92,7 @@ export default function ComponentPageTabs(props) {
         />
         {headers.components?.length > 0 && (
           <StyledTab
-            className="skip-algolia-crawler"
+            className="skip-algolia-crawler" // For more details, see https://github.com/mui/material-ui/pull/37539.
             component={Link}
             shallow
             scroll
@@ -103,7 +103,7 @@ export default function ComponentPageTabs(props) {
         )}
         {headers.hooks && headers.hooks.length > 0 && (
           <StyledTab
-            className="skip-algolia-crawler"
+            className="skip-algolia-crawler" // For more details, see https://github.com/mui/material-ui/pull/37539.
             component={Link}
             shallow
             scroll


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Problem

Go to one of the [Base UI component](https://mui.com/base/react-slider) and then search for `Slider`:

<img width="1440" alt="image" src="https://github.com/mui/material-ui/assets/18292247/fa72f645-2dd7-4557-b814-629961903ffd">

The result has 3 links:
1. link to hook-api
2. link to component-api
3. link to demo

I think the last one is enough. It looks better because it groups the component API and hook API altogether.

## Fix

According to our [crawler](https://crawler.algolia.com/admin/crawlers/739c29c8-99ea-4945-bd27-17a1df391902/configuration/edit), we can skip the DOM from being indexed by adding a className `skip-algolia-crawler`.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
