### PR TITLE
[docs][Joy] Replace JoyInput with Input component in JoyUI Text Field documentation

### DIFF
--- a/docs/data/joy/components/text-field/text-field.md
+++ b/docs/data/joy/components/text-field/text-field.md
@@ -62,7 +62,7 @@ Replace the `TextField` with composition:
 +  <FormLabel>
 +    Label
 +  </FormLabel>
-+  <JoyInput
++  <Input
 +    placeholder="Placeholder"
 +    name="Name"
 +    type="tel"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Replaced JoyInput with Input in the documentation file. The previous [documentation](https://mui.com/joy-ui/react-text-field/#manual) referenced JoyInput instead of Input as the component to use. This led to confusion when trying to implement the example in the projects.