### PR TITLE
[docs][joy] Add typography introduction demo component

### DIFF
--- a/docs/data/joy/components/typography/TypographyUsage.js
+++ b/docs/data/joy/components/typography/TypographyUsage.js
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
+import Typography from '@mui/joy/Typography';
+import { Box } from '@mui/joy';
+
+export default function TypographyUsages() {
+  return (
+    <JoyUsageDemo
+      componentName="Typography"
+      data={[
+        {
+          propName: 'level',
+          knob: 'select',
+          defaultValue: 'h1',
+          options: [
+            'display1',
+            'display2',
+            'h1',
+            'h2',
+            'h3',
+            'h4',
+            'h5',
+            'h6',
+            'body1',
+            'body2',
+            'body3',
+          ],
+        },
+
+        {
+          propName: 'color',
+          knob: 'color',
+          defaultValue: 'neutral',
+        },
+
+        {
+          propName: 'variant',
+          knob: 'select',
+          defaultValue: 'plain',
+          options: ['plain', 'outlined', 'soft', 'solid'],
+        },
+
+        {
+          propName: 'children',
+          knob: 'input',
+          defaultValue: 'Typography',
+        },
+
+        {
+          propName: 'noWrap',
+          knob: 'switch',
+          defaultValue: false,
+        },
+      ]}
+      renderDemo={(props) => (
+        <Box sx={{ maxWidth: '400px' }}>
+          <Typography {...props}>{props.children}</Typography>
+        </Box>
+      )}
+    />
+  );
+}

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -13,7 +13,7 @@ githubLabel: 'component: Typography'
 
 The Typography component helps maintain a consistent design by providing a limited set of values to choose from and convenient props for building common designs faster.
 
-{{"demo": "TypographyUsage.js"}}
+{{"demo": "TypographyUsage.js" "hideToolbar": true, "bg": "gradient"}}
 
 ## Basics
 

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -13,7 +13,7 @@ githubLabel: 'component: Typography'
 
 The Typography component helps maintain a consistent design by providing a limited set of values to choose from and convenient props for building common designs faster.
 
-{{"demo": "TypographyUsage.js" "hideToolbar": true, "bg": "gradient"}}
+{{"demo": "TypographyUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
 ## Basics
 

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -13,6 +13,8 @@ githubLabel: 'component: Typography'
 
 The Typography component helps maintain a consistent design by providing a limited set of values to choose from and convenient props for building common designs faster.
 
+{{"demo": "TypographyUsage.js"}}
+
 ## Basics
 
 ```jsx


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<img width="885" alt="Screenshot 2023-06-09 at 7 59 45 AM" src="https://github.com/mui/material-ui/assets/7228039/b062b441-582b-496f-b89c-6b23af909d19">

As I was building a few templates, I was watching out for things that could improve DX. Typography is missing a playground (usage component), so I built one out.