### PR TITLE
[docs] Add styles to styled argument list

### DIFF
--- a/docs/data/system/styled/styled.md
+++ b/docs/data/system/styled/styled.md
@@ -40,6 +40,9 @@ It aims to solve the same problem, but also provides the following benefits:
    - `options.skipSx` (_bool_ [optional]): Disables the `sx` prop on the component.
    - The other keys are forwarded to the `options` argument of emotion's [`styled([Component], [options])`](https://emotion.sh/docs/styled).
 
+3. `styles` (_object | `({ ...props, theme }) => object`_ [optional]): A styles object or a function returning a styles object.
+   The function receives the theme and component's props in an object which is its single argument.
+
 #### Returns
 
 `Component`: The new component created.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related issues:
- https://github.com/mui/material-ui/issues/37397
- https://github.com/mui/material-ui/issues/33412

The `styles` argument is not listed in the `styled` function arguments list. Adding it will help with its usage.

**A few questions**
- styled` can receive multiple arguments, all with the same type, should we document it? I think it would create more confusion, so my answer is no, but if you disagree please let me know
- I used `({ ...props, theme }) => object` as the function signature because that's the most concise way I could come up with to explain it, but I would appreciate alternatives if you think of some
- Is there anything else that we should add to the explanation?