### PR TITLE
[ButtonGroup][joy] Missing border when spacing is more than zero

### DIFF
--- a/docs/data/joy/components/button-group/GroupOrientation.js
+++ b/docs/data/joy/components/button-group/GroupOrientation.js
@@ -5,7 +5,9 @@ import Stack from '@mui/joy/Stack';
 
 const buttons = [
   <Button key="one">One</Button>,
-  <Button key="two">Two</Button>,
+  <Button key="two" disabled>
+    Two
+  </Button>,
   <Button key="three">Three</Button>,
 ];
 

--- a/docs/data/joy/components/button-group/GroupOrientation.tsx
+++ b/docs/data/joy/components/button-group/GroupOrientation.tsx
@@ -5,7 +5,9 @@ import Stack from '@mui/joy/Stack';
 
 const buttons = [
   <Button key="one">One</Button>,
-  <Button key="two">Two</Button>,
+  <Button key="two" disabled>
+    Two
+  </Button>,
   <Button key="three">Three</Button>,
 ];
 

--- a/docs/data/joy/components/button-group/SpacingButtonGroup.js
+++ b/docs/data/joy/components/button-group/SpacingButtonGroup.js
@@ -8,7 +8,7 @@ export default function SpacingButtonGroup() {
   return (
     <ButtonGroup spacing="0.5rem" aria-label="spacing button group">
       <Button>One</Button>
-      <Button>Two</Button>
+      <Button disabled>Two</Button>
       <Button>Three</Button>
       <IconButton>
         <Settings />

--- a/docs/data/joy/components/button-group/SpacingButtonGroup.tsx
+++ b/docs/data/joy/components/button-group/SpacingButtonGroup.tsx
@@ -8,7 +8,7 @@ export default function SpacingButtonGroup() {
   return (
     <ButtonGroup spacing="0.5rem" aria-label="spacing button group">
       <Button>One</Button>
-      <Button>Two</Button>
+      <Button disabled>Two</Button>
       <Button>Three</Button>
       <IconButton>
         <Settings />

--- a/docs/data/joy/components/button-group/SpacingButtonGroup.tsx.preview
+++ b/docs/data/joy/components/button-group/SpacingButtonGroup.tsx.preview
@@ -1,6 +1,6 @@
 <ButtonGroup spacing="0.5rem" aria-label="spacing button group">
   <Button>One</Button>
-  <Button>Two</Button>
+  <Button disabled>Two</Button>
   <Button>Three</Button>
   <IconButton>
     <Settings />

--- a/docs/pages/joy-ui/api/button-group.json
+++ b/docs/pages/joy-ui/api/button-group.json
@@ -70,7 +70,6 @@
       "colorPrimary",
       "colorSuccess",
       "colorWarning",
-      "detached",
       "horizontal",
       "sizeLg",
       "sizeMd",

--- a/docs/translations/api-docs-joy/button-group/button-group.json
+++ b/docs/translations/api-docs-joy/button-group/button-group.json
@@ -95,11 +95,6 @@
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>orientation=\"vertical\"</code>"
-    },
-    "detached": {
-      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>detached={true}</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
@@ -75,13 +75,6 @@ const ButtonGroupRoot = styled('div', {
           '--ButtonGroup-separatorColor': theme.vars.palette[ownerState.color!]?.[400],
         }),
       }),
-      ...(ownerState.variant === 'outlined' &&
-        ownerState.color !== 'context' && {
-          '&:hover': {
-            '--ButtonGroup-separatorColor':
-              theme.vars.palette[ownerState.color!]?.outlinedHoverBorder,
-          },
-        }),
       '--ButtonGroup-radius': theme.vars.radius.sm,
       '--Divider-inset': '0.5rem',
       '--unstable_childRadius':
@@ -131,9 +124,23 @@ const ButtonGroupRoot = styled('div', {
         '--IconButton-margin': margin,
       },
       [`& .${buttonClasses.root}, & .${iconButtonClasses.root}`]: {
-        [`&:hover, ${theme.focus.selector}`]: {
-          zIndex: 1, // to make borders appear above sibling.
+        '&:not(:disabled)': {
+          zIndex: 1, // to make borders appear above disabled buttons.
         },
+        [`&:hover, ${theme.focus.selector}`]: {
+          zIndex: 2, // to make borders appear above sibling.
+        },
+        ...(ownerState.color !== 'context' &&
+          ownerState.variant === 'outlined' && {
+            '&:hover': {
+              '--ButtonGroup-separatorColor':
+                theme.vars.palette[ownerState.color!]?.outlinedHoverBorder,
+            },
+            '&:disabled': {
+              '--ButtonGroup-separatorColor':
+                theme.vars.palette[ownerState.color!]?.outlinedDisabledBorder,
+            },
+          }),
       },
       ...(ownerState.buttonFlex && {
         [`& > *:not(.${iconButtonClasses.root})`]: {

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
@@ -67,7 +67,8 @@ const ButtonGroupRoot = styled('div', {
 
   return [
     {
-      '--ButtonGroup-separatorSize': 'calc(var(--ButtonGroup-connected) * 1px)',
+      '--ButtonGroup-separatorSize':
+        ownerState.variant === 'outlined' ? '1px' : 'calc(var(--ButtonGroup-connected) * 1px)',
       ...(ownerState.color !== 'context' && {
         '--ButtonGroup-separatorColor': theme.vars.palette[ownerState.color!]?.outlinedBorder,
         ...(ownerState.variant === 'solid' && {

--- a/packages/mui-joy/src/ButtonGroup/buttonGroupClasses.ts
+++ b/packages/mui-joy/src/ButtonGroup/buttonGroupClasses.ts
@@ -35,8 +35,6 @@ export interface ButtonGroupClasses {
   horizontal: string;
   /** Class name applied to the root element if `orientation="vertical"`. */
   vertical: string;
-  /** Class name applied to the root element if `detached={true}`. */
-  detached: string;
 }
 
 export type ButtonGroupClassKey = keyof ButtonGroupClasses;
@@ -63,7 +61,6 @@ const buttonGroupClasses: ButtonGroupClasses = generateUtilityClasses('MuiButton
   'sizeLg',
   'horizontal',
   'vertical',
-  'detached',
 ]);
 
 export default buttonGroupClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #37574

**Before**: https://mui.com/joy-ui/react-button-group/#spacing
**After**: https://deploy-preview-37577--material-ui.netlify.app/joy-ui/react-button-group/#spacing

<img width="802" alt="image" src="https://github.com/mui/material-ui/assets/18292247/044ca728-5e04-4718-9f65-fb11d76942a3">

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
