### PR TITLE
[docs-infra] Remove legacy GA

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -132,21 +132,9 @@ const Icons = React.memo(function Icons(props) {
 
   const handleIconClick = (icon) => () => {
     if (Math.random() < 0.1) {
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: 'material-icons',
-        eventAction: 'click',
-        eventLabel: icon.name,
-      });
       window.gtag('event', 'material-icons', {
         eventAction: 'click',
         eventLabel: icon.name,
-      });
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: 'material-icons-theme',
-        eventAction: 'click',
-        eventLabel: icon.theme,
       });
       window.gtag('event', 'material-icons-theme', {
         eventAction: 'click',
@@ -505,12 +493,6 @@ export default function SearchIcons() {
 
             // Keep track of the no results so we can add synonyms in the future.
             if (value.length >= 4 && results.length === 0) {
-              window.ga('send', {
-                hitType: 'event',
-                eventCategory: 'material-icons',
-                eventAction: 'no-results',
-                eventLabel: value,
-              });
               window.gtag('event', 'material-icons', {
                 eventAction: 'no-results',
                 eventLabel: value,

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -359,13 +359,6 @@ export function reportWebVitals({ id, name, label, delta, value }) {
     return;
   }
 
-  window.ga('send', 'event', {
-    eventCategory: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',
-    eventAction: name,
-    eventValue: Math.round(name === 'CLS' ? value * 1000 : value), // values must be integers
-    eventLabel: id, // id unique to current page load
-    nonInteraction: true, // avoids affecting bounce rate.
-  });
   window.gtag('event', name, {
     value: delta,
     metric_label: label === 'web-vital' ? 'Web Vitals' : 'Next.js custom metric',

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -34,9 +34,6 @@ if (process.env.NODE_ENV === 'production') {
 const PRODUCTION_GA =
   process.env.DEPLOY_ENV === 'production' || process.env.DEPLOY_ENV === 'staging';
 
-// TODO remove https://support.google.com/analytics/answer/11986666
-const GOOGLE_ANALYTICS_ID = PRODUCTION_GA ? 'UA-106598593-2' : 'UA-106598593-3';
-
 const GOOGLE_ANALYTICS_ID_V4 = PRODUCTION_GA ? 'G-5NXDQLC2ZK' : 'G-XJ83JQEK7J';
 
 export default class MyDocument extends Document {
@@ -176,11 +173,6 @@ export default class MyDocument extends Document {
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-window.ga('create','${GOOGLE_ANALYTICS_ID}',{
-  sampleRate: ${PRODUCTION_GA ? 80 : 100},
-});
-
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 window.gtag = gtag;

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -88,12 +88,7 @@ class AdErrorBoundary extends React.Component {
     // send explicit `'null'`
     const eventLabel = String(this.props.eventLabel);
     // TODO: Use proper error monitoring service (e.g. Sentry) instead
-    window.ga('send', {
-      hitType: 'event',
-      eventCategory: 'ad',
-      eventAction: 'crash',
-      eventLabel,
-    });
+
     window.gtag('event', 'ad', {
       eventAction: 'crash',
       eventLabel,
@@ -199,12 +194,6 @@ export default function Ad() {
     }
 
     const delay = setTimeout(() => {
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: 'ad',
-        eventAction: 'display',
-        eventLabel,
-      });
       window.gtag('event', 'ad', {
         eventAction: 'display',
         eventLabel,

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -55,7 +55,6 @@ function GoogleAnalytics() {
       document.addEventListener('click', handleClick);
     }
   }, []);
-  
   const router = useRouter();
   const timeout = React.useRef();
 

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -56,8 +56,6 @@ let boundDataGaListener = false;
  */
 function GoogleAnalytics() {
   React.useEffect(() => {
-    loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
-
     if (!boundDataGaListener) {
       boundDataGaListener = true;
       document.addEventListener('click', handleClick);

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -30,12 +30,6 @@ function handleClick(event) {
         return;
       }
 
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: category,
-        eventAction: element.getAttribute('data-ga-event-action'),
-        eventLabel: element.getAttribute('data-ga-event-label'),
-      });
       window.gtag('event', category, {
         eventAction: element.getAttribute('data-ga-event-action'),
         eventLabel: element.getAttribute('data-ga-event-label'),
@@ -61,7 +55,7 @@ function GoogleAnalytics() {
       document.addEventListener('click', handleClick);
     }
   }, []);
-
+  
   const router = useRouter();
   const timeout = React.useRef();
 
@@ -71,8 +65,6 @@ function GoogleAnalytics() {
     clearTimeout(timeout.current);
     timeout.current = setTimeout(() => {
       const { canonicalAsServer } = pathnameToLanguage(window.location.pathname);
-      window.ga('set', { page: canonicalAsServer });
-      window.ga('send', { hitType: 'pageview' });
 
       // https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag
       window.gtag('event', 'page_view', {
@@ -86,7 +78,6 @@ function GoogleAnalytics() {
 
   const codeVariant = useNoSsrCodeVariant();
   React.useEffect(() => {
-    window.ga('set', 'dimension1', codeVariant);
     window.gtag('set', 'user_properties', {
       codeVariant,
     });
@@ -94,7 +85,6 @@ function GoogleAnalytics() {
 
   const userLanguage = useUserLanguage();
   React.useEffect(() => {
-    window.ga('set', 'dimension2', userLanguage);
     window.gtag('set', 'user_properties', {
       userLanguage,
     });
@@ -107,7 +97,6 @@ function GoogleAnalytics() {
      */
     function trackDevicePixelRation() {
       const devicePixelRatio = Math.round(window.devicePixelRatio * 10) / 10;
-      window.ga('set', 'dimension3', devicePixelRatio);
       window.gtag('set', 'user_properties', {
         devicePixelRatio,
       });
@@ -133,14 +122,12 @@ function GoogleAnalytics() {
   const colorScheme = theme.palette.mode;
 
   React.useEffect(() => {
-    window.ga('set', 'dimension4', colorSchemeOS);
     window.gtag('set', 'user_properties', {
       colorSchemeOS,
     });
   }, [colorSchemeOS]);
 
   React.useEffect(() => {
-    window.ga('set', 'dimension5', colorScheme);
     window.gtag('set', 'user_properties', {
       colorScheme,
     });

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useRouter } from 'next/router';
-import loadScript from 'docs/src/modules/utils/loadScript';
 import { useNoSsrCodeVariant } from 'docs/src/modules/utils/codeVariant';
 import { useNoSsrCodeStyling } from 'docs/src/modules/utils/codeStylingSolution';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';


### PR DESCRIPTION
To merge only after July 1, 2023.

Remove the call to UA when Google will drop its support: https://support.google.com/analytics/answer/9964640.

See https://www.notion.so/Migrate-to-Google-Analytics-v4-8a38a284e9d04507a5d6f108dc72829c for more details.

Preview: https://deploy-preview-37579--material-ui.netlify.app/material-ui/react-alert/