### PR TITLE
[docs][joy] Add design and consistency tweaks to the Playground

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -273,7 +273,7 @@ const DemoRootJoy = joyStyled('div', {
     overflow: 'auto',
     backgroundColor: alpha(blue[50], 0.5),
     border: `1px solid`,
-    borderColor: alpha(blue[100], 0.5),
+    borderColor: `rgba(${theme.vars.palette.neutral.mainChannel} / 0.1)`,
     backgroundImage: `radial-gradient(at 51% 52%, ${alpha(blue[50], 0.5)} 0px, transparent 50%),
       radial-gradient(at 80% 0%, #FFFFFF 0px, transparent 20%),
       radial-gradient(at 0% 95%, ${alpha(blue[100], 0.3)}, transparent 40%),
@@ -282,7 +282,7 @@ const DemoRootJoy = joyStyled('div', {
       url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Cg fill-rule='evenodd'%3E%3Cg fill='%23003A75' fill-opacity='0.03'%3E%3Cpath opacity='.5' d='M96 95h4v1h-4v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15v-9H0v-1h15V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h9V0h1v15h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9zm-1 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm9-10v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm9-10v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm9-10v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-10 0v-9h-9v9h9zm-9-10h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9zm10 0h9v-9h-9v9z'/%3E%3Cpath d='M6 5V0H5v5H0v1h5v94h1V6h94V5H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");`,
     ...theme.applyDarkStyles({
       backgroundColor: blueDark[800],
-      borderColor: alpha(blueDark[500], 0.7),
+      borderColor: `rgba(${theme.vars.palette.neutral.mainChannel} / 0.1)`,
       backgroundImage: `radial-gradient(at 51% 52%, ${alpha(
         blueDark[700],
         0.5,

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -228,7 +228,9 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
           flexShrink: 0,
           gap: 2,
           p: 3,
-          background: (theme) => `rgba(${theme.vars.palette.neutral.mainChannel} / 0.1)`,
+          borderLeft: '1px solid',
+          borderColor: (theme) => `rgba(${theme.vars.palette.neutral.mainChannel} / 0.1)`,
+          background: (theme) => `rgba(${theme.vars.palette.primary.mainChannel} / 0.02)`,
           backdropFilter: 'blur(8px)',
           minWidth: '280px',
         }}
@@ -246,8 +248,8 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
           </Typography>
           <IconButton
             aria-label="Reset all"
-            variant="outlined"
-            color="neutral"
+            variant="soft"
+            color="primary"
             size="sm"
             onClick={() => setProps(initialProps as T)}
             sx={{
@@ -290,18 +292,8 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                         [propName]: event.target.checked,
                       }))
                     }
-                    endDecorator={resolvedValue ? 'True' : 'False'}
-                    slotProps={{
-                      endDecorator: {
-                        sx: {
-                          minWidth: 30,
-                        },
-                      },
-                    }}
                     sx={{
-                      fontSize: 'xs',
-                      color: 'text.secondary',
-                      textTransform: 'capitalize',
+                      '--Switch-trackWidth': '32px',
                       '--Switch-trackBackground': (theme) =>
                         `rgba(${theme.vars.palette.neutral.mainChannel} / 0.3)`,
                       '&:hover': {
@@ -444,7 +436,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
                             sx={{
                               width: 28,
                               height: 28,
-                              borderRadius: 'sm',
+                              borderRadius: 'lg',
                               textTransform: 'capitalize',
                             }}
                           >

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -537,7 +537,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
             if (knob === 'input') {
               return (
                 <FormControl key={propName} size="sm">
-                  <FormLabel>{propName}</FormLabel>
+                  <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
                   <Input
                     size="sm"
                     value={props[propName] ?? ''}
@@ -560,7 +560,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
             if (knob === 'number') {
               return (
                 <FormControl key={propName} size="sm">
-                  <FormLabel>{propName}</FormLabel>
+                  <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
                   <Input
                     size="sm"
                     type="number"

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -536,7 +536,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
             }
             if (knob === 'input') {
               return (
-                <FormControl key={propName}>
+                <FormControl key={propName} size="sm">
                   <FormLabel>{propName}</FormLabel>
                   <Input
                     size="sm"
@@ -559,7 +559,7 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
             }
             if (knob === 'number') {
               return (
-                <FormControl key={propName}>
+                <FormControl key={propName} size="sm">
                   <FormLabel>{propName}</FormLabel>
                   <Input
                     size="sm"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just fine-tuning the design and making it a bit more consistent. I removed the unnecessary "False/True" label from the switch (I guess the component conveys this idea clearly already) and also refined the colors from the Playground panel and the container's border. The more true black-tinted dark mode from Joy still doesn't riff perfectly with the docs blue-tinted dark mode but that will soon change and make this component better (🙌)(the Selects, Inputs, & Chips are clashing a bit).  

| Before | After |
|--------|--------|
| <img width="837" alt="Screen Shot 2023-06-13 at 16 29 56" src="https://github.com/mui/material-ui/assets/67129314/e4c72854-7350-4be1-ba08-441f9d284b0e"> | <img width="837" alt="Screen Shot 2023-06-13 at 16 29 52" src="https://github.com/mui/material-ui/assets/67129314/d1738375-26fc-4008-a4a7-13275639a50e"> |
| <img width="837" alt="Screen Shot 2023-06-13 at 16 30 14" src="https://github.com/mui/material-ui/assets/67129314/fbec5d04-4164-4248-a567-9fb46a55bc74"> | <img width="837" alt="Screen Shot 2023-06-13 at 16 30 05" src="https://github.com/mui/material-ui/assets/67129314/fe5ca486-61c7-4969-a4d4-75b9faa3a78f"> | 





