### PR TITLE
[website] Update roadmap page

### DIFF
--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -42,6 +42,7 @@ Here are the top priorities:
 
 Here are the components we will work on being supported in the MUI ecosystem:
 
+- ✅ Released as stable
 - 🧪 Close to becoming stable, already released as unstable
 - 🛠 Work in progress, will be or already released as unstable
 - ⏳ Planning to build
@@ -51,9 +52,9 @@ Here are the components we will work on being supported in the MUI ecosystem:
 | Advanced Layout            | MUI X    | ⏳     |
 | Carousel                   | MUI X    | ⏳     |
 | Charts                     | MUI X    | ⏳     |
-| Data Grid                  | MUI X    | 🧪     |
-| Date Picker                | MUI X    | 🧪     |
-| Date Range Picker          | MUI X    | 🧪     |
+| Data Grid                  | MUI X    | ✅     |
+| Date Picker                | MUI X    | ✅     |
+| Date Range Picker          | MUI X    | ✅     |
 | Dropdown                   | MUI Core | ⏳     |
 | Dropzone                   | MUI X    | ⏳     |
 | File Upload                | MUI X    | ⏳     |

--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -47,37 +47,37 @@ Here are the components we will work on being supported in the MUI ecosystem:
 - 🛠 Work in progress, will be or already released as unstable
 - ⏳ Planning to build
 
-| Name                                                          | Product  | Status |
-| :------------------------------------------------------------ | :------- | :----- |
-| Advanced Layout                                               | MUI X    | ⏳     |
-| Carousel                                                      | MUI X    | ⏳     |
-| Charts                                                        | MUI X    | ⏳     |
-| [Data Grid](/x/react-data-grid/)                              | MUI X    | ✅     |
-| [Date Picker](/x/react-date-pickers/date-picker/)             | MUI X    | ✅     |
-| [Date Range Picker](/x/react-date-pickers/date-range-picker/) | MUI X    | ✅     |
-| Dropdown                                                      | MUI Core | ⏳     |
-| Dropzone                                                      | MUI X    | ⏳     |
-| File Upload                                                   | MUI X    | ⏳     |
-| Gantt Chart                                                   | MUI X    | ⏳     |
-| Gauge                                                         | MUI X    | ⏳     |
-| Image                                                         | MUI Core | ⏳     |
-| Masonry                                                       | MUI Core | 🧪     |
-| Navbar                                                        | MUI Core | ⏳     |
-| Nested Menu                                                   | MUI X    | ⏳     |
-| NProgress                                                     | MUI Core | ⏳     |
-| Numeric Input                                                 | MUI Core | ⏳     |
-| Rich Text Editor                                              | MUI X    | ⏳     |
-| Scheduler                                                     | MUI X    | ⏳     |
-| Scrollspy                                                     | MUI Core | ⏳     |
-| Sparkline                                                     | MUI X    | ⏳     |
-| Timeline                                                      | MUI Core | 🧪     |
-| Tree select                                                   | MUI X    | ⏳     |
-| Tree View                                                     | MUI X    | 🧪     |
-| Tree View - Checkbox                                          | MUI X    | ⏳     |
-| Tree View - Drag & Drop                                       | MUI X    | ⏳     |
-| Tree View - Multiselect                                       | MUI X    | 🧪     |
-| Tree View - Virtualization                                    | MUI X    | ⏳     |
-| Window Splitter                                               | MUI X    | ⏳     |
+| Name                                                                     | Product  | Status |
+| :----------------------------------------------------------------------- | :------- | :----- |
+| Advanced Layout                                                          | MUI X    | ⏳     |
+| Carousel                                                                 | MUI X    | ⏳     |
+| Charts                                                                   | MUI X    | ⏳     |
+| [Data Grid](/x/react-data-grid/)                                         | MUI X    | ✅     |
+| [Date Picker](/x/react-date-pickers/date-picker/)                        | MUI X    | ✅     |
+| [Date Range Picker](/x/react-date-pickers/date-range-picker/)            | MUI X    | ✅     |
+| Dropdown                                                                 | MUI Core | ⏳     |
+| Dropzone                                                                 | MUI X    | ⏳     |
+| File Upload                                                              | MUI X    | ⏳     |
+| Gantt Chart                                                              | MUI X    | ⏳     |
+| Gauge                                                                    | MUI X    | ⏳     |
+| Image                                                                    | MUI Core | ⏳     |
+| [Masonry](/material-ui/react-masonry/)                                   | MUI Core | 🧪     |
+| Navbar                                                                   | MUI Core | ⏳     |
+| Nested Menu                                                              | MUI X    | ⏳     |
+| NProgress                                                                | MUI Core | ⏳     |
+| Numeric Input                                                            | MUI Core | ⏳     |
+| Rich Text Editor                                                         | MUI X    | ⏳     |
+| Scheduler                                                                | MUI X    | ⏳     |
+| Scrollspy                                                                | MUI Core | ⏳     |
+| Sparkline                                                                | MUI X    | ⏳     |
+| [Timeline](/material-ui/react-timeline/)                                 | MUI Core | 🧪     |
+| Tree select                                                              | MUI X    | ⏳     |
+| [Tree View](/material-ui/react-tree-view/)                               | MUI X    | 🧪     |
+| Tree View - Checkbox                                                     | MUI X    | ⏳     |
+| Tree View - Drag & Drop                                                  | MUI X    | ⏳     |
+| [Tree View - Multiselect](/material-ui/react-tree-view/#multi-selection) | MUI X    | 🧪     |
+| Tree View - Virtualization                                               | MUI X    | ⏳     |
+| Window Splitter                                                          | MUI X    | ⏳     |
 
 :::warning
 **Disclaimer**: We operate in a dynamic environment, and things are subject to change. The information provided is intended to outline the general framework direction, for informational purposes only. We may decide to add or remove new items at any time, depending on our capability to deliver while meeting our quality standards. The development, releases, and timing of any features or functionality remains at the sole discretion of MUI. The roadmap does not represent a commitment, obligation, or promise to deliver at any time.

--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -54,7 +54,11 @@ Here are the components we will work on being supported in the MUI ecosystem:
 | Charts                                                                   | MUI X    | ⏳     |
 | [Data Grid](/x/react-data-grid/)                                         | MUI X    | ✅     |
 | [Date Picker](/x/react-date-pickers/date-picker/)                        | MUI X    | ✅     |
+| [Time Picker](/x/react-date-pickers/time-picker/)                        | MUI X    | ✅     |
+| [Date Time Picker](/x/react-date-pickers/date-time-picker/)              | MUI X    | ✅     |
 | [Date Range Picker](/x/react-date-pickers/date-range-picker/)            | MUI X    | ✅     |
+| Time Range Picker                                                        | MUI X    | ⏳     |
+| Date Time Range Picker                                                   | MUI X    | ⏳     |
 | Dropdown                                                                 | MUI Core | ⏳     |
 | Dropzone                                                                 | MUI X    | ⏳     |
 | File Upload                                                              | MUI X    | ⏳     |

--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -47,37 +47,37 @@ Here are the components we will work on being supported in the MUI ecosystem:
 - 🛠 Work in progress, will be or already released as unstable
 - ⏳ Planning to build
 
-| Name                       | Product  | Status |
-| :------------------------- | :------- | :----- |
-| Advanced Layout            | MUI X    | ⏳     |
-| Carousel                   | MUI X    | ⏳     |
-| Charts                     | MUI X    | ⏳     |
-| Data Grid                  | MUI X    | ✅     |
-| Date Picker                | MUI X    | ✅     |
-| Date Range Picker          | MUI X    | ✅     |
-| Dropdown                   | MUI Core | ⏳     |
-| Dropzone                   | MUI X    | ⏳     |
-| File Upload                | MUI X    | ⏳     |
-| Gantt Chart                | MUI X    | ⏳     |
-| Gauge                      | MUI X    | ⏳     |
-| Image                      | MUI Core | ⏳     |
-| Masonry                    | MUI Core | 🧪     |
-| Navbar                     | MUI Core | ⏳     |
-| Nested Menu                | MUI X    | ⏳     |
-| NProgress                  | MUI Core | ⏳     |
-| Numeric Input              | MUI Core | ⏳     |
-| Rich Text Editor           | MUI X    | ⏳     |
-| Scheduler                  | MUI X    | ⏳     |
-| Scrollspy                  | MUI Core | ⏳     |
-| Sparkline                  | MUI X    | ⏳     |
-| Timeline                   | MUI Core | 🧪     |
-| Tree select                | MUI X    | ⏳     |
-| Tree View                  | MUI X    | 🧪     |
-| Tree View - Checkbox       | MUI X    | ⏳     |
-| Tree View - Drag & Drop    | MUI X    | ⏳     |
-| Tree View - Multiselect    | MUI X    | 🧪     |
-| Tree View - Virtualization | MUI X    | ⏳     |
-| Window Splitter            | MUI X    | ⏳     |
+| Name                                                          | Product  | Status |
+| :------------------------------------------------------------ | :------- | :----- |
+| Advanced Layout                                               | MUI X    | ⏳     |
+| Carousel                                                      | MUI X    | ⏳     |
+| Charts                                                        | MUI X    | ⏳     |
+| [Data Grid](/x/react-data-grid/)                              | MUI X    | ✅     |
+| [Date Picker](/x/react-date-pickers/date-picker/)             | MUI X    | ✅     |
+| [Date Range Picker](/x/react-date-pickers/date-range-picker/) | MUI X    | ✅     |
+| Dropdown                                                      | MUI Core | ⏳     |
+| Dropzone                                                      | MUI X    | ⏳     |
+| File Upload                                                   | MUI X    | ⏳     |
+| Gantt Chart                                                   | MUI X    | ⏳     |
+| Gauge                                                         | MUI X    | ⏳     |
+| Image                                                         | MUI Core | ⏳     |
+| Masonry                                                       | MUI Core | 🧪     |
+| Navbar                                                        | MUI Core | ⏳     |
+| Nested Menu                                                   | MUI X    | ⏳     |
+| NProgress                                                     | MUI Core | ⏳     |
+| Numeric Input                                                 | MUI Core | ⏳     |
+| Rich Text Editor                                              | MUI X    | ⏳     |
+| Scheduler                                                     | MUI X    | ⏳     |
+| Scrollspy                                                     | MUI Core | ⏳     |
+| Sparkline                                                     | MUI X    | ⏳     |
+| Timeline                                                      | MUI Core | 🧪     |
+| Tree select                                                   | MUI X    | ⏳     |
+| Tree View                                                     | MUI X    | 🧪     |
+| Tree View - Checkbox                                          | MUI X    | ⏳     |
+| Tree View - Drag & Drop                                       | MUI X    | ⏳     |
+| Tree View - Multiselect                                       | MUI X    | 🧪     |
+| Tree View - Virtualization                                    | MUI X    | ⏳     |
+| Window Splitter                                               | MUI X    | ⏳     |
 
 :::warning
 **Disclaimer**: We operate in a dynamic environment, and things are subject to change. The information provided is intended to outline the general framework direction, for informational purposes only. We may decide to add or remove new items at any time, depending on our capability to deliver while meeting our quality standards. The development, releases, and timing of any features or functionality remains at the sole discretion of MUI. The roadmap does not represent a commitment, obligation, or promise to deliver at any time.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I noticed that the first result for the "Data Grid" search in Material UI links to the [roadmap page](https://mui.com/material-ui/discover-more/roadmap/#new-components) which is a bit outdated:

<img width="600" src="https://github.com/mui/material-ui/assets/13808724/197b931f-846b-44e5-99ee-2ad0fff83f18">

I marked grid and pickers components as released and added links to their docs.
I also added links to components from the Lab for easier navigation.

Preview: https://deploy-preview-37587--material-ui.netlify.app/material-ui/discover-more/roadmap/#new-components

| Before | After |
| --- | --- |
| <img width="627" src="https://github.com/mui/material-ui/assets/13808724/e8f90409-d6b8-476b-b108-a27a513a1ba9"> | <img width="624" src="https://github.com/mui/material-ui/assets/13808724/684d0875-86ee-4ba8-af50-1a5ac07a670c"> |
