### PR TITLE
[docs-infra] Add analyticsTags to Algolia

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -321,6 +321,7 @@ export default function AppSearch(props) {
             searchParameters={{
               facetFilters: ['version:master', facetFilterLanguage],
               optionalFilters: [`product:${productId}`],
+              analyticsTags: [facetFilterLanguage, `product:${productId}`],
               hitsPerPage: 40,
             }}
             placeholder={search}


### PR DESCRIPTION
Add `analyticsTags` to enable filtering Algolia analytics by product. One of #16502.
