### PR TITLE
[docs][base] Add a Snackbar introduction demo

### DIFF
--- a/docs/data/base/components/snackbar/TransitionComponentSnackbar.js
+++ b/docs/data/base/components/snackbar/TransitionComponentSnackbar.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Transition } from 'react-transition-group';
 import { styled } from '@mui/system';
-import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import CloseIcon from '@mui/icons-material/Close';
 import Snackbar from '@mui/base/Snackbar';
 
@@ -58,20 +57,7 @@ export default function TransitionComponentSnackbar() {
               }}
               ref={nodeRef}
             >
-              <CheckRoundedIcon
-                sx={{
-                  flexShrink: 0,
-                  marginRight: '0.75rem',
-                  width: '1.25rem',
-                  height: '1.5rem',
-                }}
-              />
-              <div className="snackbar-message">
-                <div className="snackbar-title">Notifications sent</div>
-                <div className="snackbar-description">
-                  All your notifications were sent to the desired address.
-                </div>
-              </div>
+              <div className="snackbar-title">Hello World</div>
               <CloseIcon onClick={handleClose} className="snackbar-close-icon" />
             </SnackbarContent>
           )}
@@ -132,8 +118,6 @@ const StyledSnackbar = styled(Snackbar)`
   display: flex;
   bottom: 16px;
   right: 16px;
-  max-width: 560px;
-  min-width: 300px;
 `;
 
 const SnackbarContent = styled('div')(
@@ -155,28 +139,13 @@ const SnackbarContent = styled('div')(
   text-align: start;
   position: relative;
 
-  & .snackbar-message {
-    flex: 1 1 0%;
-    max-width: 100%;
-  }
-
   & .snackbar-title {
-    line-height: 1.5rem;
     margin-right: 0.5rem;
-  }
-
-  & .snackbar-description {
-    line-height: 1.5rem;
-    font-weight: 400;
-    color: ${theme.palette.mode === 'dark' ? grey[400] : grey[800]};
   }
 
   & .snackbar-close-icon {
     cursor: pointer;
     font-size: 10px;
-    position: absolute;
-    top: 0.725rem;
-    right: 0.725rem;
     width: 1.25rem;
     height: 1.5rem;
     display: flex;

--- a/docs/data/base/components/snackbar/TransitionComponentSnackbar.tsx
+++ b/docs/data/base/components/snackbar/TransitionComponentSnackbar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Transition } from 'react-transition-group';
 import { styled } from '@mui/system';
-import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import CloseIcon from '@mui/icons-material/Close';
 import Snackbar from '@mui/base/Snackbar';
 import { SnackbarCloseReason } from '@mui/base/useSnackbar';
@@ -59,20 +58,7 @@ export default function TransitionComponentSnackbar() {
               }}
               ref={nodeRef}
             >
-              <CheckRoundedIcon
-                sx={{
-                  flexShrink: 0,
-                  marginRight: '0.75rem',
-                  width: '1.25rem',
-                  height: '1.5rem',
-                }}
-              />
-              <div className="snackbar-message">
-                <div className="snackbar-title">Notifications sent</div>
-                <div className="snackbar-description">
-                  All your notifications were sent to the desired address.
-                </div>
-              </div>
+              <div className="snackbar-title">Hello World</div>
               <CloseIcon onClick={handleClose} className="snackbar-close-icon" />
             </SnackbarContent>
           )}
@@ -133,8 +119,6 @@ const StyledSnackbar = styled(Snackbar)`
   display: flex;
   bottom: 16px;
   right: 16px;
-  max-width: 560px;
-  min-width: 300px;
 `;
 
 const SnackbarContent = styled('div')(
@@ -156,28 +140,13 @@ const SnackbarContent = styled('div')(
   text-align: start;
   position: relative;
 
-  & .snackbar-message {
-    flex: 1 1 0%;
-    max-width: 100%;
-  }
-
   & .snackbar-title {
-    line-height: 1.5rem;
     margin-right: 0.5rem;
-  }
-
-  & .snackbar-description {
-    line-height: 1.5rem;
-    font-weight: 400;
-    color: ${theme.palette.mode === 'dark' ? grey[400] : grey[800]};
   }
 
   & .snackbar-close-icon {
     cursor: pointer;
     font-size: 10px;
-    position: absolute;
-    top: 0.725rem;
-    right: 0.725rem;
     width: 1.25rem;
     height: 1.5rem;
     display: flex;

--- a/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.js
+++ b/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.js
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import { Transition } from 'react-transition-group';
+import { styled } from '@mui/system';
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
+import CloseIcon from '@mui/icons-material/Close';
+import Snackbar from '@mui/base/Snackbar';
+
+export default function TransitionComponentSnackbar() {
+  const [open, setOpen] = React.useState(false);
+  const [exited, setExited] = React.useState(true);
+  const nodeRef = React.useRef(null);
+
+  const handleClose = (_, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleOnEnter = () => {
+    setExited(false);
+  };
+
+  const handleOnExited = () => {
+    setExited(true);
+  };
+
+  return (
+    <React.Fragment>
+      <TriggerButton type="button" onClick={handleClick}>
+        Open snackbar
+      </TriggerButton>
+      <StyledSnackbar
+        autoHideDuration={5000}
+        open={open}
+        onClose={handleClose}
+        exited={exited}
+      >
+        <Transition
+          timeout={{ enter: 400, exit: 400 }}
+          in={open}
+          appear
+          unmountOnExit
+          onEnter={handleOnEnter}
+          onExited={handleOnExited}
+          nodeRef={nodeRef}
+        >
+          {(status) => (
+            <SnackbarContent
+              style={{
+                transform: positioningStyles[status],
+                transition: 'transform 300ms ease',
+              }}
+              ref={nodeRef}
+            >
+              <CheckRoundedIcon
+                sx={{
+                  flexShrink: 0,
+                  marginRight: '0.75rem',
+                  width: '1.25rem',
+                  height: '1.5rem',
+                }}
+              />
+              <div className="snackbar-message">
+                <div className="snackbar-title">Notifications sent</div>
+                <div className="snackbar-description">
+                  All your notifications were sent to the desired address.
+                </div>
+              </div>
+              <CloseIcon onClick={handleClose} className="snackbar-close-icon" />
+            </SnackbarContent>
+          )}
+        </Transition>
+      </StyledSnackbar>
+    </React.Fragment>
+  );
+}
+
+const grey = {
+  50: '#f6f8fa',
+  100: '#eaeef2',
+  200: '#d0d7de',
+  300: '#afb8c1',
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+  700: '#424a53',
+  800: '#32383f',
+  900: '#24292f',
+};
+
+const blue = {
+  200: '#99CCF3',
+  400: '#3399FF',
+  500: '#007FFF',
+};
+
+const TriggerButton = styled('button')(
+  ({ theme }) => `
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-sizing: border-box;
+  min-height: calc(1.5em + 22px);
+  border-radius: 12px;
+  padding: 6px 12px;
+  line-height: 1.5;
+  background: transparent;
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[800] : grey[200]};
+  color: ${theme.palette.mode === 'dark' ? grey[100] : grey[900]};
+
+  &:hover {
+    background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
+    border-color: ${theme.palette.mode === 'dark' ? grey[600] : grey[300]};
+  }
+
+  &:focus-visible {
+    border-color: ${blue[400]};
+    outline: 3px solid ${theme.palette.mode === 'dark' ? blue[500] : blue[200]};
+  }
+  `,
+);
+
+const StyledSnackbar = styled(Snackbar)`
+  position: fixed;
+  z-index: 5500;
+  display: flex;
+  bottom: 16px;
+  right: 16px;
+  max-width: 560px;
+  min-width: 300px;
+`;
+
+const SnackbarContent = styled('div')(
+  ({ theme }) => `
+  display: flex;
+  overflow: hidden;
+  background-color: ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
+  border-radius: 8px;
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: ${
+    theme.palette.mode === 'dark'
+      ? `0 2px 8px rgba(0,0,0,0.5)`
+      : `0 2px 8px ${grey[200]}`
+  };
+  padding: 0.75rem;
+  color: ${theme.palette.mode === 'dark' ? grey[50] : grey[900]};
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: 500;
+  text-align: start;
+  position: relative;
+
+  & .snackbar-message {
+    flex: 1 1 0%;
+    max-width: 100%;
+  }
+
+  & .snackbar-title {
+    line-height: 1.5rem;
+    margin-right: 0.5rem;
+  }
+
+  & .snackbar-description {
+    line-height: 1.5rem;
+    font-weight: 400;
+    color: ${theme.palette.mode === 'dark' ? grey[400] : grey[800]};
+  }
+
+  & .snackbar-close-icon {
+    cursor: pointer;
+    font-size: 10px;
+    position: absolute;
+    top: 0.725rem;
+    right: 0.725rem;
+    width: 1.25rem;
+    height: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  `,
+);
+
+const positioningStyles = {
+  entering: 'translateX(0)',
+  entered: 'translateX(0)',
+  exiting: 'translateX(500px)',
+  exited: 'translateX(500px)',
+  unmounted: 'translateX(500px)',
+};

--- a/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.js
+++ b/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.js
@@ -60,17 +60,17 @@ export default function TransitionComponentSnackbar() {
             >
               <CheckRoundedIcon
                 sx={{
+                  color: 'success.main',
                   flexShrink: 0,
-                  marginRight: '0.75rem',
                   width: '1.25rem',
                   height: '1.5rem',
                 }}
               />
               <div className="snackbar-message">
-                <div className="snackbar-title">Notifications sent</div>
-                <div className="snackbar-description">
-                  All your notifications were sent to the desired address.
-                </div>
+                <p className="snackbar-title">Notifications sent</p>
+                <p className="snackbar-description">
+                  Everything was sent to the desired address.
+                </p>
               </div>
               <CloseIcon onClick={handleClose} className="snackbar-close-icon" />
             </SnackbarContent>
@@ -98,6 +98,9 @@ const blue = {
   200: '#99CCF3',
   400: '#3399FF',
   500: '#007FFF',
+  700: '#0059B2',
+  800: '#004C99',
+  900: '#003A75',
 };
 
 const TriggerButton = styled('button')(
@@ -110,13 +113,18 @@ const TriggerButton = styled('button')(
   border-radius: 12px;
   padding: 6px 12px;
   line-height: 1.5;
-  background: transparent;
-  border: 1px solid ${theme.palette.mode === 'dark' ? grey[800] : grey[200]};
+  background: ${theme.palette.mode === 'dark' ? blue[900] : '#FFF'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? blue[800] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[100] : grey[900]};
+  box-shadow: ${
+    theme.palette.mode === 'dark'
+      ? '0px 2px 2px rgba(0, 0, 0, 0.2), inset 0px 4px 4px rgba(0, 0, 0, 0.1)'
+      : '0px 2px 2px rgba(205, 210, 215, 0.2), inset 0px 4px 4px rgba(205, 210, 215, 0.1)'
+  };
 
   &:hover {
-    background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
-    border-color: ${theme.palette.mode === 'dark' ? grey[600] : grey[300]};
+    background: ${theme.palette.mode === 'dark' ? blue[800] : grey[50]};
+    border-color: ${theme.palette.mode === 'dark' ? blue[700] : grey[300]};
   }
 
   &:focus-visible {
@@ -139,14 +147,15 @@ const StyledSnackbar = styled(Snackbar)`
 const SnackbarContent = styled('div')(
   ({ theme }) => `
   display: flex;
+  gap: 8px;
   overflow: hidden;
   background-color: ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
   border-radius: 8px;
   border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   box-shadow: ${
     theme.palette.mode === 'dark'
-      ? `0 2px 8px rgba(0,0,0,0.5)`
-      : `0 2px 8px ${grey[200]}`
+      ? `0 2px 16px rgba(0,0,0, 0.5)`
+      : `0 2px 16px ${grey[200]}`
   };
   padding: 0.75rem;
   color: ${theme.palette.mode === 'dark' ? grey[50] : grey[900]};
@@ -161,11 +170,13 @@ const SnackbarContent = styled('div')(
   }
 
   & .snackbar-title {
+    margin: 0;
     line-height: 1.5rem;
     margin-right: 0.5rem;
   }
 
   & .snackbar-description {
+    margin: 0;
     line-height: 1.5rem;
     font-weight: 400;
     color: ${theme.palette.mode === 'dark' ? grey[400] : grey[800]};
@@ -173,15 +184,13 @@ const SnackbarContent = styled('div')(
 
   & .snackbar-close-icon {
     cursor: pointer;
-    font-size: 10px;
-    position: absolute;
-    top: 0.725rem;
-    right: 0.725rem;
-    width: 1.25rem;
-    height: 1.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    flex-shrink: 0;
+    padding: 2px;
+    border-radius: 4px;
+
+    &:hover {
+      background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
+    }
   }
   `,
 );

--- a/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.tsx
+++ b/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react';
+import { Transition } from 'react-transition-group';
+import { styled } from '@mui/system';
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
+import CloseIcon from '@mui/icons-material/Close';
+import Snackbar from '@mui/base/Snackbar';
+import { SnackbarCloseReason } from '@mui/base/useSnackbar';
+
+export default function TransitionComponentSnackbar() {
+  const [open, setOpen] = React.useState(false);
+  const [exited, setExited] = React.useState(true);
+  const nodeRef = React.useRef(null);
+
+  const handleClose = (_: any, reason: SnackbarCloseReason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleOnEnter = () => {
+    setExited(false);
+  };
+
+  const handleOnExited = () => {
+    setExited(true);
+  };
+
+  return (
+    <React.Fragment>
+      <TriggerButton type="button" onClick={handleClick}>
+        Open snackbar
+      </TriggerButton>
+      <StyledSnackbar
+        autoHideDuration={5000}
+        open={open}
+        onClose={handleClose}
+        exited={exited}
+      >
+        <Transition
+          timeout={{ enter: 400, exit: 400 }}
+          in={open}
+          appear
+          unmountOnExit
+          onEnter={handleOnEnter}
+          onExited={handleOnExited}
+          nodeRef={nodeRef}
+        >
+          {(status) => (
+            <SnackbarContent
+              style={{
+                transform: positioningStyles[status],
+                transition: 'transform 300ms ease',
+              }}
+              ref={nodeRef}
+            >
+              <CheckRoundedIcon
+                sx={{
+                  color: 'success.main',
+                  flexShrink: 0,
+                  width: '1.25rem',
+                  height: '1.5rem',
+                }}
+              />
+              <div className="snackbar-message">
+                <p className="snackbar-title">Notifications sent</p>
+                <p className="snackbar-description">
+                  Everything was sent to the desired address.
+                </p>
+              </div>
+              <CloseIcon onClick={handleClose} className="snackbar-close-icon" />
+            </SnackbarContent>
+          )}
+        </Transition>
+      </StyledSnackbar>
+    </React.Fragment>
+  );
+}
+
+const grey = {
+  50: '#f6f8fa',
+  100: '#eaeef2',
+  200: '#d0d7de',
+  300: '#afb8c1',
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+  700: '#424a53',
+  800: '#32383f',
+  900: '#24292f',
+};
+
+const blue = {
+  200: '#99CCF3',
+  400: '#3399FF',
+  500: '#007FFF',
+  700: '#0059B2',
+  800: '#004C99',
+};
+
+const TriggerButton = styled('button')(
+  ({ theme }) => `
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-sizing: border-box;
+  min-height: calc(1.5em + 22px);
+  border-radius: 12px;
+  padding: 6px 12px;
+  line-height: 1.5;
+  background: transparent;
+  border: 1px solid ${theme.palette.mode === 'dark' ? blue[800] : grey[200]};
+  color: ${theme.palette.mode === 'dark' ? grey[100] : grey[900]};
+
+  &:hover {
+    background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
+    border-color: ${theme.palette.mode === 'dark' ? grey[600] : grey[300]};
+  }
+
+  &:focus-visible {
+    border-color: ${blue[400]};
+    outline: 3px solid ${theme.palette.mode === 'dark' ? blue[500] : blue[200]};
+  }
+  `,
+);
+
+const StyledSnackbar = styled(Snackbar)`
+  position: fixed;
+  z-index: 5500;
+  display: flex;
+  bottom: 16px;
+  right: 16px;
+  max-width: 560px;
+  min-width: 300px;
+`;
+
+const SnackbarContent = styled('div')(
+  ({ theme }) => `
+  display: flex;
+  gap: 8px;
+  overflow: hidden;
+  background-color: ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
+  border-radius: 8px;
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: ${
+    theme.palette.mode === 'dark'
+      ? `0 2px 16px rgba(0,0,0, 0.5)`
+      : `0 2px 16px ${grey[200]}`
+  };
+  padding: 0.75rem;
+  color: ${theme.palette.mode === 'dark' ? grey[50] : grey[900]};
+  font-family: IBM Plex Sans, sans-serif;
+  font-weight: 500;
+  text-align: start;
+  position: relative;
+
+  & .snackbar-message {
+    flex: 1 1 0%;
+    max-width: 100%;
+  }
+
+  & .snackbar-title {
+    margin: 0;
+    line-height: 1.5rem;
+    margin-right: 0.5rem;
+  }
+
+  & .snackbar-description {
+    margin: 0;
+    line-height: 1.5rem;
+    font-weight: 400;
+    color: ${theme.palette.mode === 'dark' ? grey[400] : grey[800]};
+  }
+
+  & .snackbar-close-icon {
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 2px;
+    border-radius: 4px;
+
+    &:hover {
+      background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
+    }
+  }
+  `,
+);
+
+const positioningStyles = {
+  entering: 'translateX(0)',
+  entered: 'translateX(0)',
+  exiting: 'translateX(500px)',
+  exited: 'translateX(500px)',
+  unmounted: 'translateX(500px)',
+};

--- a/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.tsx
+++ b/docs/data/base/components/snackbar/UnstyledSnackbarIntroduction.tsx
@@ -101,6 +101,7 @@ const blue = {
   500: '#007FFF',
   700: '#0059B2',
   800: '#004C99',
+  900: '#003A75',
 };
 
 const TriggerButton = styled('button')(
@@ -113,13 +114,18 @@ const TriggerButton = styled('button')(
   border-radius: 12px;
   padding: 6px 12px;
   line-height: 1.5;
-  background: transparent;
+  background: ${theme.palette.mode === 'dark' ? blue[900] : '#FFF'};
   border: 1px solid ${theme.palette.mode === 'dark' ? blue[800] : grey[200]};
   color: ${theme.palette.mode === 'dark' ? grey[100] : grey[900]};
+  box-shadow: ${
+    theme.palette.mode === 'dark'
+      ? '0px 2px 2px rgba(0, 0, 0, 0.2), inset 0px 4px 4px rgba(0, 0, 0, 0.1)'
+      : '0px 2px 2px rgba(205, 210, 215, 0.2), inset 0px 4px 4px rgba(205, 210, 215, 0.1)'
+  };
 
   &:hover {
-    background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
-    border-color: ${theme.palette.mode === 'dark' ? grey[600] : grey[300]};
+    background: ${theme.palette.mode === 'dark' ? blue[800] : grey[50]};
+    border-color: ${theme.palette.mode === 'dark' ? blue[700] : grey[300]};
   }
 
   &:focus-visible {

--- a/docs/data/base/components/snackbar/snackbar.md
+++ b/docs/data/base/components/snackbar/snackbar.md
@@ -20,6 +20,8 @@ A snackbar provides users with a brief, temporary message about app processes wi
 
 The Snackbar component is built to appear on-screen to inform users about an action that the app is taking.
 
+{{"demo": "UnstyledSnackbarIntroduction.js", "defaultCodeOpen": false, "bg": "gradient"}}
+
 ## Component
 
 ### Usage


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

While browsing through the documentation yesterday, I realized we were lacking an intro demo for the Snackbar, which feels a bit inconsistent with all the other components. Usually, for these intro demos, it's nice to have a more fleshed-out example rather than a simpler one, to which point I again realized that the "Transitions" demo was really polished.

So, what I did was add an intro demo with the example that was being used in the Transitions section and then I simplified that to use the format all other demos were using just so we don't have two repeating polished examples.

Also took the opportunity to refine a bit the trigger button here and will eventually, in another PR, make sure all components that rely on a trigger button to be shown (menu, popper, modal, etc.) have consistent styles for it 🤙 

<img width="500" alt="Screen Shot 2023-06-15 at 19 05 31" src="https://github.com/mui/material-ui/assets/67129314/68b23316-3428-4342-840d-1975e805db27">

