### PR TITLE
[docs] Inline the Base UI demo

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -39,7 +39,7 @@ Please note that [react](https://www.npmjs.com/package/react) and [react-dom](ht
 
 ## Implementing a Button
 
-This is a quick tutorial that goes through the basics of using and styling Base UI components by replicating a button from GitHub's UI, using their [Primer design system](https://primer.style) as a reference.
+This is a quick tutorial that goes through the basics of using and styling Base UI components by replicating a button from GitHub's UI, using their [Primer design system](https://primer.style/design/) as a reference.
 
 {{"demo": "Tutorial.js", "defaultCodeOpen": false, "hideToolbar": true}}
 
@@ -128,7 +128,7 @@ After installing Tailwind CSS, pass its utility classes to `className`, as shown
 
 The demo below shows how to build the Primer button using Tailwind CSS:
 
-{{"demo": "BaseButtonTailwind.js", "hideToolbar": true}}
+{{"demo": "BaseButtonTailwind.js", "hideToolbar": true, "bg": "inline"}}
 
 ### Styling with MUI System
 

--- a/docs/data/joy/guides/using-icon-libraries/using-icon-libraries.md
+++ b/docs/data/joy/guides/using-icon-libraries/using-icon-libraries.md
@@ -205,7 +205,7 @@ Here is a collection of well-known icon libraries that you can use with Joy UI.
 ### Lucide
 
 - [Browse icons](https://icon-sets.iconify.design/)
-- [Installation—React](https://lucide.dev/docs/lucide-react)
+- [Installation—React](https://lucide.dev/guide/packages/lucide-react)
 
 <iframe src="https://codesandbox.io/embed/joy-ui-lucide-sy7hio?fontsize=12&hidenavigation=1&module=%2Fdemo.tsx&theme=dark"
      style="width:100%; height:250px; border:0; border-radius: 12px; overflow:hidden;"

--- a/docs/data/material/components/popover/popover.md
+++ b/docs/data/material/components/popover/popover.md
@@ -54,9 +54,9 @@ Highlight part of the text to see the popover:
 
 For more information on the virtual element's properties, see the following resources:
 
-- [getBoundingClientRect](https://developer.mozilla.org/docs/Web/API/Element/getBoundingClientRect)
+- [getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
 - [DOMRect](https://drafts.fxtf.org/geometry-1/#domrectreadonly)
-- [Node types](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+- [Node types](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
 
 :::warning
 The usage of a virtual element for the Popover component requires the `nodeType` property.

--- a/docs/data/material/getting-started/faq/faq.md
+++ b/docs/data/material/getting-started/faq/faq.md
@@ -165,7 +165,7 @@ page](/material-ui/customization/theming/) to learn about theme customization.
 
 ## Why does component X require a DOM node in a prop instead of a ref object?
 
-Components like the [Portal](/base-ui/api/portal/#props) or [Popper](/material-ui/api/popper/#props) require a DOM node in the `container` or `anchorEl` prop respectively.
+Components like the [Portal](/base-ui/react-portal/components-api/) or [Popper](/material-ui/api/popper/#props) require a DOM node in the `container` or `anchorEl` prop respectively.
 It seems convenient to simply pass a ref object in those props and let Material UI access the current value.
 
 This works in a simple scenario:

--- a/docs/data/material/guides/routing/routing.md
+++ b/docs/data/material/guides/routing/routing.md
@@ -1,6 +1,6 @@
 # Routing libraries
 
-<p class="description">By default, the navigation is performed with a native &lt;a&gt; element. You can customize it to use your own router. For instance, using Next.js's Link or react-router.</p>
+<p class="description">By default, the navigation is performed with a native &lt;a&gt; element. You can customize it, for instance, using Next.js's Link or react-router.</p>
 
 ## Navigation components
 


### PR DESCRIPTION
## Before

<img width="792" alt="Screenshot 2023-06-16 at 02 36 02" src="https://github.com/mui/material-ui/assets/3165635/7d9bbed0-3281-4c9c-b636-1b824ffdb973">
https://mui.com/base-ui/getting-started/quickstart/#styling-with-tailwind-css

## After

<img width="787" alt="Screenshot 2023-06-16 at 02 35 33" src="https://github.com/mui/material-ui/assets/3165635/4cb05499-2951-412c-a915-1505417d9840">
