### PR TITLE
[core] Update to Node.js v18 for `test-dev` CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           # fetch all tags which are required for `yarn release:changelog`
           fetch-depth: 0
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version: 14
+          node-version: 18
           cache: 'yarn' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: yarn install
         env:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The developer scripts currently use Node v14 on the test-dev CI. However, now that the pull request https://github.com/mui/material-ui/pull/37173 is completed, we should switch to using Node v18 for consistency. It runs the `yarn install` step.

This should unblock dependencies updates such as https://github.com/mui/material-ui/pull/37349 and others as they require Node `>=16`.
