### PR TITLE
[Button][material-next] Fix some event handlers being ignored

### DIFF
--- a/packages/mui-material-next/src/Button/Button.tsx
+++ b/packages/mui-material-next/src/Button/Button.tsx
@@ -542,7 +542,13 @@ const Button = React.forwardRef(function Button<
       as={ComponentProp}
       className={clsx(classes.root, className)}
       ownerState={ownerState}
-      {...getRootProps(getRippleHandlers(props) as unknown as EventHandlers)}
+      {...getRootProps({
+        onClick,
+        onFocus,
+        onKeyDown,
+        onKeyUp,
+        ...(getRippleHandlers(props) as unknown as EventHandlers),
+      })}
       {...other}
     >
       {startIcon}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes: https://github.com/mui/material-ui/issues/37645

Four event handlers were not being handled in `getRippleHandlers`, so those were lost:

- `onClick`
- `onFocus`
- `onKeyUp`
- `onKeyDown`

I also added tests for those events.
