### PR TITLE
[docs-infra] Fix demos border radius

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -210,6 +210,7 @@ const DemoRootMaterial = styled('div', {
   display: 'flex',
   justifyContent: 'center',
   [theme.breakpoints.up('sm')]: {
+    borderRadius: '12px 12px 0 0',
     ...(bg === 'outlined' && {
       borderLeftWidth: 1,
       borderRightWidth: 1,
@@ -225,16 +226,15 @@ const DemoRootMaterial = styled('div', {
   /* Isolate the demo with an outline. */
   ...(bg === 'outlined' && {
     padding: theme.spacing(3),
-    borderRadius: '12px 12px 0 0',
     backgroundColor: (theme.vars || theme).palette.background.paper,
     border: `1px solid ${(theme.vars || theme).palette.divider}`,
+    borderLeftWidth: 0,
+    borderRightWidth: 0,
   }),
   /* Prepare the background to display an inner elevation. */
   ...(bg === true && {
     padding: theme.spacing(4),
     backgroundColor: (theme.vars || theme).palette.grey[100],
-    borderRadius: '12px 12px 0 0',
-    border: `1px solid ${(theme.vars || theme).palette.divider}`,
     ...theme.applyDarkStyles({
       backgroundColor: (theme.vars || theme).palette.grey[900],
     }),
@@ -244,7 +244,6 @@ const DemoRootMaterial = styled('div', {
     padding: theme.spacing(20, 8),
     border: `1px solid`,
     borderColor: (theme.vars || theme).palette.divider,
-    borderRadius: '12px 12px 0 0',
     overflow: 'hidden',
     backgroundColor: alpha(theme.palette.primary[50], 0.5),
     backgroundClip: 'padding-box',
@@ -293,6 +292,7 @@ const DemoRootJoy = joyStyled('div', {
   display: 'flex',
   justifyContent: 'center',
   [theme.breakpoints.up('sm')]: {
+    borderRadius: '12px 12px 0 0',
     ...(bg === 'outlined' && {
       borderLeftWidth: 1,
       borderRightWidth: 1,
@@ -305,7 +305,6 @@ const DemoRootJoy = joyStyled('div', {
   /* Isolate the demo with an outline. */
   ...(bg === 'outlined' && {
     padding: theme.spacing(3),
-    borderRadius: '12px 12px 0 0',
     border: `1px solid`,
     borderColor: grey[100],
     borderLeftWidth: 0,
@@ -323,7 +322,6 @@ const DemoRootJoy = joyStyled('div', {
   /* Prepare the background to display an inner elevation. */
   ...(bg === true && {
     padding: theme.spacing(3),
-    borderRadius: '12px 12px 0 0',
     backgroundColor: theme.vars.palette.background.level2,
   }),
   /* Mostly meant for introduction demos. */


### PR DESCRIPTION
Fix visual bug from #37319, it's most noticeable when using `"bg": true`

<img width="431" alt="Screenshot 2023-06-20 at 23 59 52" src="https://github.com/mui/material-ui/assets/3165635/b1318707-9998-4a49-b3eb-dba303247670">

https://deploy-preview-37319--material-ui.netlify.app/material-ui/react-grid/

After 

<img width="416" alt="Screenshot 2023-06-21 at 00 00 46" src="https://github.com/mui/material-ui/assets/3165635/ba206767-e02d-46e9-b698-36d17d593f96">

https://deploy-preview-37658--material-ui.netlify.app/material-ui/react-grid/

It's hard to really appreciate the difference from the above screenshots seen on a desktop. It's more noticeable opening the after/before links on a mobile phone.