### PR TITLE
[docs-infra] Use icons instead of words for the code copy button

### DIFF
--- a/docs/src/modules/components/CodeCopyButton.tsx
+++ b/docs/src/modules/components/CodeCopyButton.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import useClipboardCopy from 'docs/src/modules/utils/useClipboardCopy';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import LibraryAddCheckRoundedIcon from '@mui/icons-material/LibraryAddCheckRounded';
 
 interface CodeCopyButtonProps {
   code: string;
@@ -24,7 +26,11 @@ export default function CodeCopyButton(props: CodeCopyButtonProps) {
       }}
     >
       {/* material-ui/no-hardcoded-labels */}
-      {isCopied ? 'Copied' : 'Copy'}&nbsp;
+      {isCopied ? (
+        <LibraryAddCheckRoundedIcon sx={{ fontSize: 18 }} />
+      ) : (
+        <ContentCopyRoundedIcon sx={{ fontSize: 18 }} />
+      )}
       <span className="MuiCode-copyKeypress">
         <span>(or</span> {key}C<span>)</span>
       </span>

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -380,31 +380,31 @@ const Root = styled('div')(
       fontSize: 10,
       '&:hover': {
         '& .MuiCode-copy': {
-          display: 'block',
+          display: 'inline-flex',
+          flexDirection: 'row-reverse',
         },
       },
     },
     '& .MuiCode-copy': {
-      minWidth: 64,
       display: 'none',
-      backgroundColor: alpha(lightTheme.palette.primaryDark[600], 0.5),
+      width: 30,
       cursor: 'pointer',
       position: 'absolute',
       top: theme.spacing(1),
       right: theme.spacing(1),
       fontFamily: 'inherit',
-      fontSize: lightTheme.typography.pxToRem(13),
       fontWeight: 500,
-      padding: theme.spacing(0.5, 1),
-      borderRadius: 4,
+      padding: theme.spacing(0.5),
+      borderRadius: 6,
       border: `1px solid`,
       borderColor: lightTheme.palette.primaryDark[500],
+      backgroundColor: lightTheme.palette.primaryDark[600],
       color: lightTheme.palette.primaryDark[50],
       '&:hover, &:focus': {
         opacity: 1,
         color: '#fff',
-        backgroundColor: alpha(lightTheme.palette.primaryDark[600], 0.7),
-        borderColor: lightTheme.palette.primaryDark[500],
+        backgroundColor: lightTheme.palette.primaryDark[500],
+        borderColor: lightTheme.palette.primaryDark[400],
         '& .MuiCode-copyKeypress': {
           display: 'block',
           // Approximate no hover capabilities with no keyboard
@@ -432,15 +432,11 @@ const Root = styled('div')(
     '& .MuiCode-copyKeypress': {
       pointerEvents: 'none',
       userSelect: 'none',
-      position: 'absolute',
-      left: '50%',
-      top: '100%',
       minWidth: '100%',
-      marginTop: theme.spacing(0.5),
+      marginRight: theme.spacing(4),
       whiteSpace: 'nowrap',
-      transform: 'translateX(-50%)',
       '& > span': {
-        opacity: 0.72,
+        opacity: 0.8,
       },
     },
     '& li': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

What the title says 😅 Thought we could swap that out for icons to make less use of space in code blocks. What triggered me to do that was the code snippet within Joy's intro demos, which could use more space.

| Before | After |
|--------|--------|
| <img width="300" alt="Screen Shot 2023-06-21 at 09 12 42" src="https://github.com/mui/material-ui/assets/67129314/31d3c818-7664-4be7-8b9c-5f59f5937195"> | <img width="300" alt="Screen Shot 2023-06-21 at 09 12 54" src="https://github.com/mui/material-ui/assets/67129314/579e4002-795a-4f98-a5e9-a8c31a2a325e"> |





