### PR TITLE
[OutlinedInput] Fix form control properties in `ownerState`

### DIFF
--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -153,7 +153,7 @@ const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {
   const fcs = formControlState({
     props,
     muiFormControl,
-    states: ['required'],
+    states: ['color', 'disabled', 'error', 'focused', 'hiddenLabel', 'size', 'required'],
   });
 
   const ownerState = {


### PR DESCRIPTION
Relevant lines in `ownerState`:
```ts
    color: fcs.color || 'primary',
    disabled: fcs.disabled,
    error: fcs.error,
    focused: fcs.focused,
    hiddenLabel: fcs.hiddenLabel,
    size: fcs.size,
```
Those properties will always be undefined on `fcs` unless they are listed in `states`.