### PR TITLE
[core] Add priority support issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -1,7 +1,7 @@
 name: 'Priority support: SLA ⏰'
 description: I'm a Premium plan user and I have the priority support add-on, I can't find a solution to my problem with MUI X.
 title: '[question] '
-labels: ['status: needs triage', 'support: commercial', 'support: unknown']
+labels: ['status: needs triage', 'support: unknown']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -10,7 +10,7 @@ body:
   - type: checkboxes
     attributes:
       label: Duplicates
-      description: Please [search the history](https://github.com/mui/mui-x/issues) to see if an issue already exists for the same problem.
+      description: Please [search the history](https://github.com/mui/material-ui/issues) to see if an issue already exists for the same problem.
       options:
         - label: I have searched the existing issues
           required: true

--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -1,0 +1,39 @@
+name: 'Priority support: SLA ⏰'
+description: I'm a Premium plan user and I have the priority support add-on, I can't find a solution to my problem with MUI X.
+title: '[question] '
+labels: ['status: needs triage', 'support: commercial', 'support: unknown']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/mui/mui-x/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Latest version
+      description: We roll bug fixes, performance enhancements, and other improvements into new releases.
+      options:
+        - label: I have tested the latest version
+          required: true
+  - type: textarea
+    attributes:
+      label: The problem in depth 🔍
+  - type: textarea
+    attributes:
+      label: Your environment 🌎
+      description: Run `npx @mui/envinfo` and post the results. If you encounter issues with TypeScript please include the used tsconfig.
+      value: |
+        <details>
+          <summary>`npx @mui/envinfo`</summary>
+
+        ```
+          Don't forget to mention which browser you used.
+          Output from `npx @mui/envinfo` goes here.
+        ```
+        </details>

--- a/.github/workflows/priority-support-validation-prompt.yml
+++ b/.github/workflows/priority-support-validation-prompt.yml
@@ -1,0 +1,46 @@
+name: Priority Support Validation Prompt
+
+on:
+  issues:
+    types:
+      - labeled
+
+permissions: {}
+
+jobs:
+  comment:
+    name: Create or update comment
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Find Comment
+        uses: peter-evans/create-or-update-comment@5f728c3dae25f329afbe34ee4d08eef25569d79f # v3.0.2
+        id: findComment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: You have created a priority support request
+
+      - name: Create comment
+        if: ${{ steps.findComment.outputs.comment-id == '' && contains(github.event.label.name, 'unknown') }}
+        uses: peter-evans/create-or-update-comment@5f728c3dae25f329afbe34ee4d08eef25569d79f # v3.0.2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            You have created a priority support request ⏰. Please validate your support key using the link below:
+
+            https://tools-public.mui.com/prod/pages/jyhs86t?repo=mui-x&issueId=${{ github.event.issue.number }}
+
+            Do not share you support key in this issue!
+
+            Priority support will only be provided to verified customers. Once you have verified your support key, we will remove the `support: unknown` label and add the `support: priority` label to this issue. Only then the time for the SLA will start counting.
+
+      - name: Update comment
+        if: ${{ steps.findComment.outputs.comment-id != '' && contains(github.event.label.name, 'priority') }}
+        uses: peter-evans/create-or-update-comment@5f728c3dae25f329afbe34ee4d08eef25569d79f # v3.0.2
+        with:
+          comment-id: ${{ steps.findComment.outputs.comment-id }}
+          body: |
+            Thank you for verifying your support key 🔑, your SLA starts now.


### PR DESCRIPTION
For context -> https://github.com/mui/mui-x/pull/8928

Part of https://www.notion.so/mui-org/X-General-meeting-2023-04-21-6728feb266d64b0f83e608767c05c8e2

I've already created the missing labels: `support: unknown` and `support: priority`