### PR TITLE
[docs][base] Fix horizontal scrolling on the mobile input page

### DIFF
--- a/docs/data/base/components/input/InputAdornments.js
+++ b/docs/data/base/components/input/InputAdornments.js
@@ -60,7 +60,16 @@ export default function InputAdornments() {
   };
 
   return (
-    <Box sx={{ display: 'flex', '& > * + *': { ml: 1 } }}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        '@media (min-width: 600px)': {
+          flexDirection: 'row',
+        },
+      }}
+    >
       <CustomInput
         id="outlined-start-adornment"
         startAdornment={<InputAdornment>kg</InputAdornment>}

--- a/docs/data/base/components/input/InputAdornments.js
+++ b/docs/data/base/components/input/InputAdornments.js
@@ -63,11 +63,8 @@ export default function InputAdornments() {
     <Box
       sx={{
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: { xs: 'column', sm: 'row' },
         gap: 2,
-        '@media (min-width: 600px)': {
-          flexDirection: 'row',
-        },
       }}
     >
       <CustomInput

--- a/docs/data/base/components/input/InputAdornments.tsx
+++ b/docs/data/base/components/input/InputAdornments.tsx
@@ -61,11 +61,8 @@ export default function InputAdornments() {
     <Box
       sx={{
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: { xs: 'column', sm: 'row' },
         gap: 2,
-        '@media (min-width: 600px)': {
-          flexDirection: 'row',
-        },
       }}
     >
       <CustomInput

--- a/docs/data/base/components/input/InputAdornments.tsx
+++ b/docs/data/base/components/input/InputAdornments.tsx
@@ -58,7 +58,16 @@ export default function InputAdornments() {
   };
 
   return (
-    <Box sx={{ display: 'flex', '& > * + *': { ml: 1 } }}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        '@media (min-width: 600px)': {
+          flexDirection: 'row',
+        },
+      }}
+    >
       <CustomInput
         id="outlined-start-adornment"
         startAdornment={<InputAdornment>kg</InputAdornment>}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Customization/Adornments demo is causing horizontal scrolling on mobile devices due to its width.

| Before | After |
|--------|--------|
| ![Current](https://github.com/mui/material-ui/assets/37222944/5ce4ce11-15d4-4542-812f-5202c40fede6) | ![new](https://github.com/mui/material-ui/assets/37222944/62bbece4-b584-4fb2-b99f-7819c579fd4b) |
