### PR TITLE
[docs-infra] Fix layout shift toolbar

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -39,12 +39,15 @@ const DemoToolbarFallbackRoot = styled('div')(({ theme }) => {
   return {
     display: 'none',
     [theme.breakpoints.up('sm')]: {
-      display: 'flex',
-      height: theme.spacing(8),
+      display: 'block',
+      height: 40 + 4 * 2 + 1 * 2,
+      marginTop: -1,
+      marginBottom: 16,
     },
   };
 });
-export function DemoToolbarFallback() {
+
+function DemoToolbarFallback() {
   const t = useTranslate();
 
   return <DemoToolbarFallbackRoot aria-busy aria-label={t('demoToolbarLabel')} role="toolbar" />;

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -104,12 +104,6 @@ ToggleCodeTooltip.propTypes = {
   showSourceHint: PropTypes.bool,
 };
 
-export function DemoToolbarFallback() {
-  const t = useTranslate();
-
-  return <Root aria-busy aria-label={t('demoToolbarLabel')} role="toolbar" />;
-}
-
 const alwaysTrue = () => true;
 
 const ToggleButtonGroup = styled(MDToggleButtonGroup)(({ theme }) => [


### PR DESCRIPTION
We changed the style of the demo toolbar in #37319 but we introduce a regression: CLS: https://web.dev/cls/. This effectively breaks the anchor links, e.g. open https://mui.com/material-ui/react-select/#controlling-the-open-state

actual ❌

<img width="682" alt="Screenshot 2023-06-24 at 23 57 40" src="https://github.com/mui/material-ui/assets/3165635/401d53b5-3c1b-400e-afbc-30309d2c9583">

---

expected ✅

<img width="681" alt="Screenshot 2023-06-24 at 23 57 49" src="https://github.com/mui/material-ui/assets/3165635/c0d05c6e-bea9-4c7c-acc7-5f1aed56e804">

