### PR TITLE
[docs–infra] Prevent displaying multiple ads

### DIFF
--- a/docs/src/modules/components/AdCarbon.js
+++ b/docs/src/modules/components/AdCarbon.js
@@ -1,14 +1,32 @@
 import * as React from 'react';
-import GlobalStyles from '@mui/material/GlobalStyles';
+import { styled } from '@mui/material/styles';
 import loadScript from 'docs/src/modules/utils/loadScript';
 import AdDisplay from 'docs/src/modules/components/AdDisplay';
 import { adStylesObject } from 'docs/src/modules/components/ad.styles';
+
+const CarbonRoot = styled('span')(({ theme }) => {
+  const styles = adStylesObject['body-image'](theme);
+
+  return {
+    '& #carbonads': {
+      ...styles.root,
+      '& .carbon-img': styles.imgWrapper,
+      '& img': styles.img,
+      '& a, & a:hover': styles.a,
+      '& .carbon-text': styles.description,
+      '& .carbon-poweredby': styles.poweredby,
+    },
+    '& [id^=carbonads_]': {
+      display: 'none',
+    },
+  };
+});
 
 function AdCarbonImage() {
   const ref = React.useRef(null);
 
   React.useEffect(() => {
-    // The isolation logic of carbonads is flawed.
+    // The isolation logic of carbonads is broken.
     // Once the script starts loading, it will asynchronous resolve, with no way to stop it.
     // This leads to duplication of the ad. To solve the issue, we debounce the load action.
     const load = setTimeout(() => {
@@ -24,27 +42,7 @@ function AdCarbonImage() {
     };
   }, []);
 
-  return (
-    <React.Fragment>
-      <GlobalStyles
-        styles={(theme) => {
-          const styles = adStylesObject['body-image'](theme);
-
-          return {
-            '#carbonads': {
-              ...styles.root,
-              '& .carbon-img': styles.imgWrapper,
-              '& img': styles.img,
-              '& a, & a:hover': styles.a,
-              '& .carbon-text': styles.description,
-              '& .carbon-poweredby': styles.poweredby,
-            },
-          };
-        }}
-      />
-      <span ref={ref} />
-    </React.Fragment>
-  );
+  return <CarbonRoot ref={ref} />;
 }
 
 export function AdCarbonInline(props) {

--- a/docs/src/modules/components/AdCarbon.js
+++ b/docs/src/modules/components/AdCarbon.js
@@ -8,16 +8,22 @@ const CarbonRoot = styled('span')(({ theme }) => {
   const styles = adStylesObject['body-image'](theme);
 
   return {
+    '& > div': {
+      // The isolation logic of carbonads is broken.
+      // Once the script starts loading, it will asynchronous resolve, with no way to stop it.
+      // This leads to duplication of the ad.
+      //
+      // To solve the issue, we only display the #carbonads div
+      display: 'none',
+    },
     '& #carbonads': {
+      display: 'block',
       ...styles.root,
       '& .carbon-img': styles.imgWrapper,
       '& img': styles.img,
       '& a, & a:hover': styles.a,
       '& .carbon-text': styles.description,
       '& .carbon-poweredby': styles.poweredby,
-    },
-    '& [id^=carbonads_]': {
-      display: 'none',
     },
   };
 });
@@ -28,7 +34,9 @@ function AdCarbonImage() {
   React.useEffect(() => {
     // The isolation logic of carbonads is broken.
     // Once the script starts loading, it will asynchronous resolve, with no way to stop it.
-    // This leads to duplication of the ad. To solve the issue, we debounce the load action.
+    // This leads to duplication of the ad.
+    //
+    // To solve the issue, e.g. StrictModel double effect execution, we debounce the load action.
     const load = setTimeout(() => {
       const script = loadScript(
         'https://cdn.carbonads.com/carbon.js?serve=CKYIL27L&placement=material-uicom',


### PR DESCRIPTION
Fix https://www.notion.so/mui-org/Trip-report-React-Summit-2023-18a3abdb83af4284b2d12f4deed18787?pvs=4#4554193ff13e46878e7f8b3e55db5d12, it was reported by a developer at React Summit, and something I experience every now and then too. Typically, it would look like this:

<img width="808" alt="Screenshot 2023-06-25 at 01 56 33" src="https://github.com/mui/material-ui/assets/3165635/8830d3f0-58d0-4ed0-b4c5-7db6130e25cf">

You can be reproduced easily by opening https://mui.com/material-ui/getting-started/overview/ and running `window._carbonads.init()`. In real life, this happens because the script runs asynchronously, so if you have a slow connection, and quickly switch to a different page, you will see it.