### PR TITLE
[docs-infra] Add design polish to the comment and anchor buttons

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -138,13 +138,15 @@ const Root = styled('div')(
         width: 26,
         backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
         border: '1px solid',
-        borderColor: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
+        borderColor: `var(--muidocs-palette-divider, ${lightTheme.palette.divider})`,
         borderRadius: 8,
         color: `var(--muidocs-palette-text-secondary, ${lightTheme.palette.text.secondary})`,
         cursor: 'pointer',
         display: 'inline-block',
         '&:hover': {
-          color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
+          backgroundColor: alpha(lightTheme.palette.primary[100], 0.4),
+          borderColor: `var(--muidocs-palette-primary-100, ${lightTheme.palette.primary[100]})`,
+          color: `var(--muidocs-palette-primary-main, ${lightTheme.palette.primary.main})`,
         },
         '& svg': {
           width: '0.875rem',
@@ -157,15 +159,16 @@ const Root = styled('div')(
         display: 'none', // So we can have the comment button opt-in.
         top: 0,
         right: 0,
-        opacity: 0.5,
         transition: theme.transitions.create('opacity', {
           duration: theme.transitions.duration.shortest,
         }),
-        '&:hover': {
-          opacity: 1,
-        },
         '& svg': {
+          opacity: 0.6,
+          marginBottom: 2,
           verticalAlign: 'middle',
+        },
+        '&:hover': {
+          '&>svg': { opacity: 1 },
         },
       },
     },
@@ -488,11 +491,13 @@ const Root = styled('div')(
       },
       '& h1, & h2, & h3, & h4': {
         '&:hover .anchor-link, & .comment-link': {
-          color: `var(--muidocs-palette-text-secondary, ${darkTheme.palette.text.secondary})`,
-          backgroundColor: alpha(darkTheme.palette.primaryDark[800], 0.3),
-          borderColor: `var(--muidocs-palette-primaryDark-500, ${darkTheme.palette.primaryDark[500]})`,
+          color: `var(--muidocs-palette-primary-200, ${darkTheme.palette.primary[200]})`,
+          borderColor: `var(--muidocs-palette-primaryDark-600, ${darkTheme.palette.primaryDark[600]})`,
+          backgroundColor: `var(--muidocs-palette-primaryDark-700, ${darkTheme.palette.primaryDark[700]})`,
           '&:hover': {
-            color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
+            borderColor: `var(--muidocs-palette-primaryDark-400, ${darkTheme.palette.primaryDark[400]})`,
+            backgroundColor: `var(--muidocs-palette-primaryDark-600, ${darkTheme.palette.primaryDark[600]})`,
+            color: `var(--muidocs-palette-primary-100, ${darkTheme.palette.primary[100]})`,
           },
         },
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a tiny quality-of-life improvement to these buttons from a design standpoint. Mostly in dark mode, really. Made the comment icon visually centered, which was driving me a bit nuts 😅 

| Before | After |
|--------|--------|
| <img width="754" alt="Screen Shot 2023-06-27 at 01 44 20" src="https://github.com/mui/material-ui/assets/67129314/28b9a775-c992-4bce-922d-3b9123b9f88e"> | <img width="754" alt="Screen Shot 2023-06-27 at 01 44 29" src="https://github.com/mui/material-ui/assets/67129314/0876f6e3-c0b9-4ff6-838c-83f99c81aef6"> |
| <img width="754" alt="Screen Shot 2023-06-27 at 01 44 06" src="https://github.com/mui/material-ui/assets/67129314/450f672b-9ce1-46e8-8c0f-fb6b660ed3f4"> | <img width="754" alt="Screen Shot 2023-06-27 at 01 44 35" src="https://github.com/mui/material-ui/assets/67129314/9a7c2863-aad1-48bc-aa90-2639cc0297ba"> | 



