### PR TITLE
[docs][material] Improve documentation about adding custom colors

### DIFF
--- a/docs/data/material/components/buttons/buttons-pt.md
+++ b/docs/data/material/components/buttons/buttons-pt.md
@@ -71,7 +71,7 @@ Note that the documentation [avoids](/material-ui/guides/api/#native-properties)
 
 {{"demo": "ColorButtons.js"}}
 
-Além de usar as cores de botão padrão, você pode adicionar outras personalizadas ou desativar as que não forem necessárias. See the [Adding new colors](/material-ui/customization/palette/#adding-new-colors) example for more info.
+Além de usar as cores de botão padrão, você pode adicionar outras personalizadas ou desativar as que não forem necessárias. See the [Adding new colors](/material-ui/customization/palette/#custom-colors) examples for more info.
 
 ## Tamanhos
 

--- a/docs/data/material/components/buttons/buttons-zh.md
+++ b/docs/data/material/components/buttons/buttons-zh.md
@@ -71,7 +71,7 @@ Note that the documentation [avoids](/material-ui/guides/api/#native-properties)
 
 {{"demo": "ColorButtons.js"}}
 
-除了使用默认按钮颜色外，您可以添加自定义颜色，或者禁用任何您不需要的颜色。 See the [Adding new colors](/material-ui/customization/palette/#adding-new-colors) example for more info.
+除了使用默认按钮颜色外，您可以添加自定义颜色，或者禁用任何您不需要的颜色。 See the [Adding new colors](/material-ui/customization/palette/#custom-colors) examples for more info.
 
 ## 尺寸
 

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -77,7 +77,7 @@ Note that the documentation [avoids](/material-ui/guides/api/#native-properties)
 
 {{"demo": "ColorButtons.js"}}
 
-In addition to using the default button colors, you can add custom ones, or disable any you don't need. See the [Adding new colors](/material-ui/customization/palette/#adding-new-colors) example for more info.
+In addition to using the default button colors, you can add custom ones, or disable any you don't need. See the [Adding new colors](/material-ui/customization/palette/#custom-colors) examples for more info.
 
 ## Sizes
 

--- a/docs/data/material/customization/palette/AddingColorTokens.js
+++ b/docs/data/material/customization/palette/AddingColorTokens.js
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { blue } from '@mui/material/colors';
+import { Box, Stack } from '@mui/system';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      light: blue[300],
+      main: blue[500],
+      dark: blue[700],
+      darker: blue[900],
+    },
+  },
+});
+
+export default function AddingColorTokens() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack direction="row" gap={1}>
+        <Stack gap={1} alignItems="center">
+          light
+          <Box sx={{ bgcolor: `primary.light`, width: 40, height: 40 }} />
+        </Stack>
+        <Stack gap={1} alignItems="center">
+          main
+          <Box sx={{ bgcolor: `primary.main`, width: 40, height: 40 }} />
+        </Stack>
+        <Stack gap={1} alignItems="center">
+          dark
+          <Box sx={{ bgcolor: `primary.dark`, width: 40, height: 40 }} />
+        </Stack>
+        <Stack gap={1} alignItems="center">
+          darker
+          <Box sx={{ bgcolor: `primary.darker`, width: 40, height: 40 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/AddingColorTokens.js
+++ b/docs/data/material/customization/palette/AddingColorTokens.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { blue } from '@mui/material/colors';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 const theme = createTheme({
   palette: {
@@ -18,21 +19,21 @@ export default function AddingColorTokens() {
   return (
     <ThemeProvider theme={theme}>
       <Stack direction="row" gap={1}>
-        <Stack gap={1} alignItems="center">
-          light
-          <Box sx={{ bgcolor: `primary.light`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">light</Typography>
+          <Box sx={{ bgcolor: `primary.light`, width: 40, height: 20 }} />
         </Stack>
-        <Stack gap={1} alignItems="center">
-          main
-          <Box sx={{ bgcolor: `primary.main`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">main</Typography>
+          <Box sx={{ bgcolor: `primary.main`, width: 40, height: 20 }} />
         </Stack>
-        <Stack gap={1} alignItems="center">
-          dark
-          <Box sx={{ bgcolor: `primary.dark`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">dark</Typography>
+          <Box sx={{ bgcolor: `primary.dark`, width: 40, height: 20 }} />
         </Stack>
-        <Stack gap={1} alignItems="center">
-          darker
-          <Box sx={{ bgcolor: `primary.darker`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">darker</Typography>
+          <Box sx={{ bgcolor: `primary.darker`, width: 40, height: 20 }} />
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/AddingColorTokens.tsx
+++ b/docs/data/material/customization/palette/AddingColorTokens.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { blue } from '@mui/material/colors';
+import { Box, Stack } from '@mui/system';
+
+declare module '@mui/material/styles' {
+  interface PaletteColor {
+    darker?: string;
+  }
+
+  interface SimplePaletteColorOptions {
+    darker?: string;
+  }
+}
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      light: blue[300],
+      main: blue[500],
+      dark: blue[700],
+      darker: blue[900],
+    },
+  },
+});
+
+export default function AddingColorTokens() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack direction="row" gap={1}>
+        <Stack gap={1} alignItems="center">
+          light
+          <Box sx={{ bgcolor: `primary.light`, width: 40, height: 40 }} />
+        </Stack>
+        <Stack gap={1} alignItems="center">
+          main
+          <Box sx={{ bgcolor: `primary.main`, width: 40, height: 40 }} />
+        </Stack>
+        <Stack gap={1} alignItems="center">
+          dark
+          <Box sx={{ bgcolor: `primary.dark`, width: 40, height: 40 }} />
+        </Stack>
+        <Stack gap={1} alignItems="center">
+          darker
+          <Box sx={{ bgcolor: `primary.darker`, width: 40, height: 40 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/AddingColorTokens.tsx
+++ b/docs/data/material/customization/palette/AddingColorTokens.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { blue } from '@mui/material/colors';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 declare module '@mui/material/styles' {
   interface PaletteColor {
@@ -28,21 +29,21 @@ export default function AddingColorTokens() {
   return (
     <ThemeProvider theme={theme}>
       <Stack direction="row" gap={1}>
-        <Stack gap={1} alignItems="center">
-          light
-          <Box sx={{ bgcolor: `primary.light`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">light</Typography>
+          <Box sx={{ bgcolor: `primary.light`, width: 40, height: 20 }} />
         </Stack>
-        <Stack gap={1} alignItems="center">
-          main
-          <Box sx={{ bgcolor: `primary.main`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">main</Typography>
+          <Box sx={{ bgcolor: `primary.main`, width: 40, height: 20 }} />
         </Stack>
-        <Stack gap={1} alignItems="center">
-          dark
-          <Box sx={{ bgcolor: `primary.dark`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">dark</Typography>
+          <Box sx={{ bgcolor: `primary.dark`, width: 40, height: 20 }} />
         </Stack>
-        <Stack gap={1} alignItems="center">
-          darker
-          <Box sx={{ bgcolor: `primary.darker`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">darker</Typography>
+          <Box sx={{ bgcolor: `primary.darker`, width: 40, height: 20 }} />
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/AddingColorTokens.tsx.preview
+++ b/docs/data/material/customization/palette/AddingColorTokens.tsx.preview
@@ -1,0 +1,13 @@
+import { createTheme } from '@mui/material/styles';
+import { blue } from '@mui/material/colors';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      light: blue[300],
+      main: blue[500],
+      dark: blue[700],
+      darker: blue[900],
+    },
+  },
+});

--- a/docs/data/material/customization/palette/ContrastThreshold.js
+++ b/docs/data/material/customization/palette/ContrastThreshold.js
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Stack } from '@mui/system';
+
+const defaultContrastThresholdTheme = createTheme({});
+
+const highContrastThresholdTheme = createTheme({
+  palette: {
+    contrastThreshold: 4.5,
+  },
+});
+
+function ContrastShowcase({ title }) {
+  const theme = useTheme();
+
+  return (
+    <Stack gap={1} alignItems="center">
+      <span>
+        <b>{title}</b>
+      </span>
+      <span>{theme.palette.contrastThreshold}:1</span>
+      <Stack direction="row" gap={1}>
+        <Button variant="contained" color="warning">
+          Warning
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default function contrastThreshold() {
+  return (
+    <Stack direction="row" gap={4}>
+      <ThemeProvider theme={defaultContrastThresholdTheme}>
+        <ContrastShowcase title="Default contrast threshold" />
+      </ThemeProvider>
+      <ThemeProvider theme={highContrastThresholdTheme}>
+        <ContrastShowcase title="Higher contrast threshold" />
+      </ThemeProvider>
+    </Stack>
+  );
+}

--- a/docs/data/material/customization/palette/ContrastThreshold.tsx
+++ b/docs/data/material/customization/palette/ContrastThreshold.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Stack } from '@mui/system';
+
+const defaultContrastThresholdTheme = createTheme({});
+
+const highContrastThresholdTheme = createTheme({
+  palette: {
+    contrastThreshold: 4.5,
+  },
+});
+
+function ContrastShowcase({ title }: { title: string }) {
+  const theme = useTheme();
+
+  return (
+    <Stack gap={1} alignItems="center">
+      <span>
+        <b>{title}</b>
+      </span>
+      <span>{theme.palette.contrastThreshold}:1</span>
+      <Stack direction="row" gap={1}>
+        <Button variant="contained" color="warning">
+          Warning
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default function contrastThreshold() {
+  return (
+    <Stack direction="row" gap={4}>
+      <ThemeProvider theme={defaultContrastThresholdTheme}>
+        <ContrastShowcase title="Default contrast threshold" />
+      </ThemeProvider>
+      <ThemeProvider theme={highContrastThresholdTheme}>
+        <ContrastShowcase title="Higher contrast threshold" />
+      </ThemeProvider>
+    </Stack>
+  );
+}

--- a/docs/data/material/customization/palette/CustomColor.js
+++ b/docs/data/material/customization/palette/CustomColor.js
@@ -5,7 +5,9 @@ import Button from '@mui/material/Button';
 const theme = createTheme({
   palette: {
     neutral: {
-      main: '#64748B',
+      light: '#838fa2',
+      main: '#64748b',
+      dark: '#465161',
       contrastText: '#fff',
     },
   },

--- a/docs/data/material/customization/palette/CustomColor.tsx
+++ b/docs/data/material/customization/palette/CustomColor.tsx
@@ -5,7 +5,9 @@ import Button from '@mui/material/Button';
 const theme = createTheme({
   palette: {
     neutral: {
-      main: '#64748B',
+      light: '#838fa2',
+      main: '#64748b',
+      dark: '#465161',
       contrastText: '#fff',
     },
   },

--- a/docs/data/material/customization/palette/ManuallyProvideCustomColor.js
+++ b/docs/data/material/customization/palette/ManuallyProvideCustomColor.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+
+const theme = createTheme({
+  palette: {
+    ochre: {
+      main: '#E3D026',
+      light: '#E9DB5D',
+      dark: '#A29415',
+      contrastText: '#242105',
+    },
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack gap={1} alignItems="center">
+        <Button variant="contained" color="ochre">
+          Ochre
+        </Button>
+        <Stack direction="row" gap={1}>
+          <Box sx={{ bgcolor: `ochre.light`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `ochre.main`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `ochre.dark`, width: 20, height: 20 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/ManuallyProvideCustomColor.js
+++ b/docs/data/material/customization/palette/ManuallyProvideCustomColor.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 const theme = createTheme({
   palette: {
@@ -17,14 +18,23 @@ const theme = createTheme({
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack gap={1} alignItems="center">
+      <Stack gap={2} alignItems="center">
         <Button variant="contained" color="ochre">
           Ochre
         </Button>
         <Stack direction="row" gap={1}>
-          <Box sx={{ bgcolor: `ochre.light`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `ochre.main`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `ochre.dark`, width: 20, height: 20 }} />
+          <Stack alignItems="center">
+            <Typography variant="body2">light</Typography>
+            <Box sx={{ bgcolor: 'ochre.light', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">main</Typography>
+            <Box sx={{ bgcolor: 'ochre.main', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">dark</Typography>
+            <Box sx={{ bgcolor: 'ochre.dark', width: 40, height: 20 }} />
+          </Stack>
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/ManuallyProvideCustomColor.tsx
+++ b/docs/data/material/customization/palette/ManuallyProvideCustomColor.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 // Augment the palette to include an ochre color
 declare module '@mui/material/styles' {
@@ -35,14 +36,23 @@ const theme = createTheme({
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack gap={1} alignItems="center">
+      <Stack gap={2} alignItems="center">
         <Button variant="contained" color="ochre">
           Ochre
         </Button>
         <Stack direction="row" gap={1}>
-          <Box sx={{ bgcolor: `ochre.light`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `ochre.main`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `ochre.dark`, width: 20, height: 20 }} />
+          <Stack alignItems="center">
+            <Typography variant="body2">light</Typography>
+            <Box sx={{ bgcolor: 'ochre.light', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">main</Typography>
+            <Box sx={{ bgcolor: 'ochre.main', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">dark</Typography>
+            <Box sx={{ bgcolor: 'ochre.dark', width: 40, height: 20 }} />
+          </Stack>
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/ManuallyProvideCustomColor.tsx
+++ b/docs/data/material/customization/palette/ManuallyProvideCustomColor.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+
+// Augment the palette to include an ochre color
+declare module '@mui/material/styles' {
+  interface Palette {
+    ochre: Palette['primary'];
+  }
+
+  interface PaletteOptions {
+    ochre?: PaletteOptions['primary'];
+  }
+}
+
+// Update the Button's color options to include an ochre option
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    ochre: true;
+  }
+}
+
+const theme = createTheme({
+  palette: {
+    ochre: {
+      main: '#E3D026',
+      light: '#E9DB5D',
+      dark: '#A29415',
+      contrastText: '#242105',
+    },
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack gap={1} alignItems="center">
+        <Button variant="contained" color="ochre">
+          Ochre
+        </Button>
+        <Stack direction="row" gap={1}>
+          <Box sx={{ bgcolor: `ochre.light`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `ochre.main`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `ochre.dark`, width: 20, height: 20 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/ManuallyProvideCustomColor.tsx.preview
+++ b/docs/data/material/customization/palette/ManuallyProvideCustomColor.tsx.preview
@@ -1,0 +1,12 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    ochre: {
+      main: '#E3D026',
+      light: '#E9DB5D',
+      dark: '#A29415',
+      contrastText: '#242105',
+    },
+  },
+});

--- a/docs/data/material/customization/palette/ManuallyProvidePaletteColor.js
+++ b/docs/data/material/customization/palette/ManuallyProvidePaletteColor.js
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#FF5733',
+      // light: will be calculated from palette.primary.main,
+      // dark: will be calculated from palette.primary.main,
+      // contrastText: will be calculated to contrast with palette.primary.main
+    },
+    secondary: {
+      main: '#E0C2FF',
+      light: '#F5EBFF',
+      // dark: will be calculated from palette.secondary.main,
+      contrastText: '#47008F',
+    },
+  },
+});
+
+function ColorShowcase({ color }) {
+  return (
+    <Stack gap={1} alignItems="center">
+      <Button variant="contained" color={color}>
+        {capitalize(color)}
+      </Button>
+      <Stack direction="row" gap={1}>
+        <Box sx={{ bgcolor: `${color}.light`, width: 20, height: 20 }} />
+        <Box sx={{ bgcolor: `${color}.main`, width: 20, height: 20 }} />
+        <Box sx={{ bgcolor: `${color}.dark`, width: 20, height: 20 }} />
+      </Stack>
+    </Stack>
+  );
+}
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack direction="row" gap={4}>
+        <ColorShowcase color="primary" />
+        <ColorShowcase color="secondary" />
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/ManuallyProvidePaletteColor.js
+++ b/docs/data/material/customization/palette/ManuallyProvidePaletteColor.js
@@ -3,6 +3,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
 import { unstable_capitalize as capitalize } from '@mui/utils';
+import { Typography } from '@mui/material';
 
 const theme = createTheme({
   palette: {
@@ -23,14 +24,23 @@ const theme = createTheme({
 
 function ColorShowcase({ color }) {
   return (
-    <Stack gap={1} alignItems="center">
+    <Stack gap={2} alignItems="center">
       <Button variant="contained" color={color}>
         {capitalize(color)}
       </Button>
       <Stack direction="row" gap={1}>
-        <Box sx={{ bgcolor: `${color}.light`, width: 20, height: 20 }} />
-        <Box sx={{ bgcolor: `${color}.main`, width: 20, height: 20 }} />
-        <Box sx={{ bgcolor: `${color}.dark`, width: 20, height: 20 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">light</Typography>
+          <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">main</Typography>
+          <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">dark</Typography>
+          <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 20 }} />
+        </Stack>
       </Stack>
     </Stack>
   );
@@ -39,7 +49,7 @@ function ColorShowcase({ color }) {
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack direction="row" gap={4}>
+      <Stack direction="row" gap={8}>
         <ColorShowcase color="primary" />
         <ColorShowcase color="secondary" />
       </Stack>

--- a/docs/data/material/customization/palette/ManuallyProvidePaletteColor.tsx
+++ b/docs/data/material/customization/palette/ManuallyProvidePaletteColor.tsx
@@ -3,6 +3,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
 import { unstable_capitalize as capitalize } from '@mui/utils';
+import { Typography } from '@mui/material';
 
 const theme = createTheme({
   palette: {
@@ -23,14 +24,23 @@ const theme = createTheme({
 
 function ColorShowcase({ color }: { color: 'primary' | 'secondary' }) {
   return (
-    <Stack gap={1} alignItems="center">
+    <Stack gap={2} alignItems="center">
       <Button variant="contained" color={color}>
         {capitalize(color)}
       </Button>
       <Stack direction="row" gap={1}>
-        <Box sx={{ bgcolor: `${color}.light`, width: 20, height: 20 }} />
-        <Box sx={{ bgcolor: `${color}.main`, width: 20, height: 20 }} />
-        <Box sx={{ bgcolor: `${color}.dark`, width: 20, height: 20 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">light</Typography>
+          <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">main</Typography>
+          <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">dark</Typography>
+          <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 20 }} />
+        </Stack>
       </Stack>
     </Stack>
   );
@@ -39,7 +49,7 @@ function ColorShowcase({ color }: { color: 'primary' | 'secondary' }) {
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack direction="row" gap={4}>
+      <Stack direction="row" gap={8}>
         <ColorShowcase color="primary" />
         <ColorShowcase color="secondary" />
       </Stack>

--- a/docs/data/material/customization/palette/ManuallyProvidePaletteColor.tsx
+++ b/docs/data/material/customization/palette/ManuallyProvidePaletteColor.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#FF5733',
+      // light: will be calculated from palette.primary.main,
+      // dark: will be calculated from palette.primary.main,
+      // contrastText: will be calculated to contrast with palette.primary.main
+    },
+    secondary: {
+      main: '#E0C2FF',
+      light: '#F5EBFF',
+      // dark: will be calculated from palette.secondary.main,
+      contrastText: '#47008F',
+    },
+  },
+});
+
+function ColorShowcase({ color }: { color: 'primary' | 'secondary' }) {
+  return (
+    <Stack gap={1} alignItems="center">
+      <Button variant="contained" color={color}>
+        {capitalize(color)}
+      </Button>
+      <Stack direction="row" gap={1}>
+        <Box sx={{ bgcolor: `${color}.light`, width: 20, height: 20 }} />
+        <Box sx={{ bgcolor: `${color}.main`, width: 20, height: 20 }} />
+        <Box sx={{ bgcolor: `${color}.dark`, width: 20, height: 20 }} />
+      </Stack>
+    </Stack>
+  );
+}
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack direction="row" gap={4}>
+        <ColorShowcase color="primary" />
+        <ColorShowcase color="secondary" />
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/ManuallyProvidePaletteColor.tsx.preview
+++ b/docs/data/material/customization/palette/ManuallyProvidePaletteColor.tsx.preview
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#FF5733',
+      // light: will be calculated from palette.primary.main,
+      // dark: will be calculated from palette.primary.main,
+      // contrastText: will be calculated to contrast with palette.primary.main
+    },
+    secondary: {
+      main: '#E0C2FF',
+      light: '#F5EBFF',
+      // dark: will be calculated from palette.secondary.main,
+      contrastText: '#47008F',
+    },
+  },
+});

--- a/docs/data/material/customization/palette/TonalOffset.js
+++ b/docs/data/material/customization/palette/TonalOffset.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
 import { blue } from '@mui/material/colors';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 const defaultTonalOffsetTheme = createTheme({
   palette: {
@@ -51,9 +52,18 @@ function ColorShowcase({ title, color }) {
       </span>
       <span>{caption}</span>
       <Stack direction="row" gap={1}>
-        <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 40 }} />
-        <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 40 }} />
-        <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">light</Typography>
+          <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">main</Typography>
+          <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">dark</Typography>
+          <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 20 }} />
+        </Stack>
       </Stack>
     </Stack>
   );
@@ -61,7 +71,7 @@ function ColorShowcase({ title, color }) {
 
 export default function TonalOffset() {
   return (
-    <Stack direction="row" gap={4}>
+    <Stack direction="row" gap={8}>
       <ThemeProvider theme={defaultTonalOffsetTheme}>
         <ColorShowcase title="Default tonal offset" color="primary" />
       </ThemeProvider>

--- a/docs/data/material/customization/palette/TonalOffset.js
+++ b/docs/data/material/customization/palette/TonalOffset.js
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
+import { blue } from '@mui/material/colors';
+import { Box, Stack } from '@mui/system';
+
+const defaultTonalOffsetTheme = createTheme({
+  palette: {
+    primary: {
+      main: blue[500],
+    },
+  },
+});
+
+const higherTonalOffsetTheme = createTheme({
+  palette: {
+    primary: {
+      main: blue[500],
+    },
+    tonalOffset: 0.5,
+  },
+});
+
+const asymmetricTonalOffsetTheme = createTheme({
+  palette: {
+    primary: {
+      main: blue[500],
+    },
+    tonalOffset: {
+      light: 0.1,
+      dark: 0.9,
+    },
+  },
+});
+
+function ColorShowcase({ title, color }) {
+  const {
+    palette: { tonalOffset },
+  } = useTheme();
+
+  let caption;
+  if (typeof tonalOffset === 'number') {
+    caption = tonalOffset;
+  } else {
+    caption = `{ light: ${tonalOffset.light}, dark: ${tonalOffset.dark} }`;
+  }
+
+  return (
+    <Stack gap={1} alignItems="center">
+      <span>
+        <b>{title}</b>
+      </span>
+      <span>{caption}</span>
+      <Stack direction="row" gap={1}>
+        <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 40 }} />
+        <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 40 }} />
+        <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 40 }} />
+      </Stack>
+    </Stack>
+  );
+}
+
+export default function TonalOffset() {
+  return (
+    <Stack direction="row" gap={4}>
+      <ThemeProvider theme={defaultTonalOffsetTheme}>
+        <ColorShowcase title="Default tonal offset" color="primary" />
+      </ThemeProvider>
+      <ThemeProvider theme={higherTonalOffsetTheme}>
+        <ColorShowcase title="Higher tonal offset" color="primary" />
+      </ThemeProvider>
+      <ThemeProvider theme={asymmetricTonalOffsetTheme}>
+        <ColorShowcase title="Asymmetric tonal offset" color="primary" />
+      </ThemeProvider>
+    </Stack>
+  );
+}

--- a/docs/data/material/customization/palette/TonalOffset.tsx
+++ b/docs/data/material/customization/palette/TonalOffset.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
 import { blue } from '@mui/material/colors';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 const defaultTonalOffsetTheme = createTheme({
   palette: {
@@ -51,9 +52,18 @@ function ColorShowcase({ title, color }: { title: string; color: string }) {
       </span>
       <span>{caption}</span>
       <Stack direction="row" gap={1}>
-        <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 40 }} />
-        <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 40 }} />
-        <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 40 }} />
+        <Stack alignItems="center">
+          <Typography variant="body2">light</Typography>
+          <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">main</Typography>
+          <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 20 }} />
+        </Stack>
+        <Stack alignItems="center">
+          <Typography variant="body2">dark</Typography>
+          <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 20 }} />
+        </Stack>
       </Stack>
     </Stack>
   );
@@ -61,7 +71,7 @@ function ColorShowcase({ title, color }: { title: string; color: string }) {
 
 export default function TonalOffset() {
   return (
-    <Stack direction="row" gap={4}>
+    <Stack direction="row" gap={8}>
       <ThemeProvider theme={defaultTonalOffsetTheme}>
         <ColorShowcase title="Default tonal offset" color="primary" />
       </ThemeProvider>

--- a/docs/data/material/customization/palette/TonalOffset.tsx
+++ b/docs/data/material/customization/palette/TonalOffset.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider, useTheme } from '@mui/material/styles';
+import { blue } from '@mui/material/colors';
+import { Box, Stack } from '@mui/system';
+
+const defaultTonalOffsetTheme = createTheme({
+  palette: {
+    primary: {
+      main: blue[500],
+    },
+  },
+});
+
+const higherTonalOffsetTheme = createTheme({
+  palette: {
+    primary: {
+      main: blue[500],
+    },
+    tonalOffset: 0.5,
+  },
+});
+
+const asymmetricTonalOffsetTheme = createTheme({
+  palette: {
+    primary: {
+      main: blue[500],
+    },
+    tonalOffset: {
+      light: 0.1,
+      dark: 0.9,
+    },
+  },
+});
+
+function ColorShowcase({ title, color }: { title: string; color: string }) {
+  const {
+    palette: { tonalOffset },
+  } = useTheme();
+
+  let caption;
+  if (typeof tonalOffset === 'number') {
+    caption = tonalOffset;
+  } else {
+    caption = `{ light: ${tonalOffset.light}, dark: ${tonalOffset.dark} }`;
+  }
+
+  return (
+    <Stack gap={1} alignItems="center">
+      <span>
+        <b>{title}</b>
+      </span>
+      <span>{caption}</span>
+      <Stack direction="row" gap={1}>
+        <Box sx={{ bgcolor: `${color}.light`, width: 40, height: 40 }} />
+        <Box sx={{ bgcolor: `${color}.main`, width: 40, height: 40 }} />
+        <Box sx={{ bgcolor: `${color}.dark`, width: 40, height: 40 }} />
+      </Stack>
+    </Stack>
+  );
+}
+
+export default function TonalOffset() {
+  return (
+    <Stack direction="row" gap={4}>
+      <ThemeProvider theme={defaultTonalOffsetTheme}>
+        <ColorShowcase title="Default tonal offset" color="primary" />
+      </ThemeProvider>
+      <ThemeProvider theme={higherTonalOffsetTheme}>
+        <ColorShowcase title="Higher tonal offset" color="primary" />
+      </ThemeProvider>
+      <ThemeProvider theme={asymmetricTonalOffsetTheme}>
+        <ColorShowcase title="Asymmetric tonal offset" color="primary" />
+      </ThemeProvider>
+    </Stack>
+  );
+}

--- a/docs/data/material/customization/palette/UsingAugmentColor.js
+++ b/docs/data/material/customization/palette/UsingAugmentColor.js
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+
+let theme = createTheme({
+  // Theme customization goes here as usual, including tonalOffset and/or
+  // contrastThreshold as the augmentColor() function relies on these
+});
+
+theme = createTheme(theme, {
+  // Custom colors created with augmentColor go here
+  palette: {
+    salmon: theme.palette.augmentColor({
+      color: {
+        main: '#FF5733',
+      },
+      name: 'salmon',
+    }),
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack gap={1} alignItems="center">
+        <Button variant="contained" color="salmon">
+          Salmon
+        </Button>
+        <Stack direction="row" gap={1}>
+          <Box sx={{ bgcolor: `salmon.light`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `salmon.main`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `salmon.dark`, width: 20, height: 20 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/UsingAugmentColor.js
+++ b/docs/data/material/customization/palette/UsingAugmentColor.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 let theme = createTheme({
   // Theme customization goes here as usual, including tonalOffset and/or
@@ -23,14 +24,23 @@ theme = createTheme(theme, {
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack gap={1} alignItems="center">
+      <Stack gap={2} alignItems="center">
         <Button variant="contained" color="salmon">
           Salmon
         </Button>
         <Stack direction="row" gap={1}>
-          <Box sx={{ bgcolor: `salmon.light`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `salmon.main`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `salmon.dark`, width: 20, height: 20 }} />
+          <Stack alignItems="center">
+            <Typography variant="body2">light</Typography>
+            <Box sx={{ bgcolor: 'salmon.light', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">main</Typography>
+            <Box sx={{ bgcolor: 'salmon.main', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">dark</Typography>
+            <Box sx={{ bgcolor: 'salmon.dark', width: 40, height: 20 }} />
+          </Stack>
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/UsingAugmentColor.tsx
+++ b/docs/data/material/customization/palette/UsingAugmentColor.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 // Augment the palette to include a salmon color
 declare module '@mui/material/styles' {
@@ -41,14 +42,23 @@ theme = createTheme(theme, {
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack gap={1} alignItems="center">
+      <Stack gap={2} alignItems="center">
         <Button variant="contained" color="salmon">
           Salmon
         </Button>
         <Stack direction="row" gap={1}>
-          <Box sx={{ bgcolor: `salmon.light`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `salmon.main`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `salmon.dark`, width: 20, height: 20 }} />
+          <Stack alignItems="center">
+            <Typography variant="body2">light</Typography>
+            <Box sx={{ bgcolor: 'salmon.light', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">main</Typography>
+            <Box sx={{ bgcolor: 'salmon.main', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">dark</Typography>
+            <Box sx={{ bgcolor: 'salmon.dark', width: 40, height: 20 }} />
+          </Stack>
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/UsingAugmentColor.tsx
+++ b/docs/data/material/customization/palette/UsingAugmentColor.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+
+// Augment the palette to include a salmon color
+declare module '@mui/material/styles' {
+  interface Palette {
+    salmon: Palette['primary'];
+  }
+
+  interface PaletteOptions {
+    salmon?: PaletteOptions['primary'];
+  }
+}
+
+// Update the Button's color options to include a salmon option
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    salmon: true;
+  }
+}
+
+let theme = createTheme({
+  // Theme customization goes here as usual, including tonalOffset and/or
+  // contrastThreshold as the augmentColor() function relies on these
+});
+
+theme = createTheme(theme, {
+  // Custom colors created with augmentColor go here
+  palette: {
+    salmon: theme.palette.augmentColor({
+      color: {
+        main: '#FF5733',
+      },
+      name: 'salmon',
+    }),
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack gap={1} alignItems="center">
+        <Button variant="contained" color="salmon">
+          Salmon
+        </Button>
+        <Stack direction="row" gap={1}>
+          <Box sx={{ bgcolor: `salmon.light`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `salmon.main`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `salmon.dark`, width: 20, height: 20 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/UsingAugmentColor.tsx.preview
+++ b/docs/data/material/customization/palette/UsingAugmentColor.tsx.preview
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles';
+
+let theme = createTheme({
+  // Theme customization goes here as usual, including tonalOffset and/or
+  // contrastThreshold as the augmentColor() function relies on these
+});
+
+theme = createTheme(theme, {
+  // Custom colors created with augmentColor go here
+  palette: {
+    salmon: theme.palette.augmentColor({
+      color: {
+        main: '#FF5733',
+      },
+      name: 'salmon',
+    }),
+  },
+});

--- a/docs/data/material/customization/palette/UsingColorObject.js
+++ b/docs/data/material/customization/palette/UsingColorObject.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { lime, purple } from '@mui/material/colors';
+import Button from '@mui/material/Button';
+import { Stack } from '@mui/system';
+
+const theme = createTheme({
+  palette: {
+    primary: lime,
+    secondary: purple,
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack direction="row" gap={4}>
+        <Button variant="contained">Primary</Button>
+        <Button variant="contained" color="secondary">
+          Secondary
+        </Button>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/UsingColorObject.tsx
+++ b/docs/data/material/customization/palette/UsingColorObject.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { lime, purple } from '@mui/material/colors';
+import Button from '@mui/material/Button';
+import { Stack } from '@mui/system';
+
+const theme = createTheme({
+  palette: {
+    primary: lime,
+    secondary: purple,
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack direction="row" gap={4}>
+        <Button variant="contained">Primary</Button>
+        <Button variant="contained" color="secondary">
+          Secondary
+        </Button>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/UsingColorObject.tsx.preview
+++ b/docs/data/material/customization/palette/UsingColorObject.tsx.preview
@@ -1,0 +1,9 @@
+import { createTheme } from '@mui/material/styles';
+import { lime, purple } from '@mui/material/colors';
+
+const theme = createTheme({
+  palette: {
+    primary: lime,
+    secondary: purple,
+  },
+});

--- a/docs/data/material/customization/palette/UsingStylesUtils.js
+++ b/docs/data/material/customization/palette/UsingStylesUtils.js
@@ -7,6 +7,7 @@ import {
 } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 const violetBase = '#7F00FF';
 const violetMain = alpha(violetBase, 0.7);
@@ -25,14 +26,23 @@ const theme = createTheme({
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack gap={1} alignItems="center">
+      <Stack gap={2} alignItems="center">
         <Button variant="contained" color="violet">
           Violet
         </Button>
         <Stack direction="row" gap={1}>
-          <Box sx={{ bgcolor: `violet.light`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `violet.main`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `violet.dark`, width: 20, height: 20 }} />
+          <Stack alignItems="center">
+            <Typography variant="body2">light</Typography>
+            <Box sx={{ bgcolor: 'violet.light', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">main</Typography>
+            <Box sx={{ bgcolor: 'violet.main', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">dark</Typography>
+            <Box sx={{ bgcolor: 'violet.dark', width: 40, height: 20 }} />
+          </Stack>
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/UsingStylesUtils.js
+++ b/docs/data/material/customization/palette/UsingStylesUtils.js
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {
+  createTheme,
+  ThemeProvider,
+  alpha,
+  getContrastRatio,
+} from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+
+const violetBase = '#7F00FF';
+const violetMain = alpha(violetBase, 0.7);
+
+const theme = createTheme({
+  palette: {
+    violet: {
+      main: violetMain,
+      light: alpha(violetBase, 0.5),
+      dark: alpha(violetBase, 0.9),
+      contrastText: getContrastRatio(violetMain, '#fff') > 4.5 ? '#fff' : '#111',
+    },
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack gap={1} alignItems="center">
+        <Button variant="contained" color="violet">
+          Violet
+        </Button>
+        <Stack direction="row" gap={1}>
+          <Box sx={{ bgcolor: `violet.light`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `violet.main`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `violet.dark`, width: 20, height: 20 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/UsingStylesUtils.tsx
+++ b/docs/data/material/customization/palette/UsingStylesUtils.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {
+  createTheme,
+  ThemeProvider,
+  alpha,
+  getContrastRatio,
+} from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import { Box, Stack } from '@mui/system';
+
+// Augment the palette to include a violet color
+declare module '@mui/material/styles' {
+  interface Palette {
+    violet: Palette['primary'];
+  }
+
+  interface PaletteOptions {
+    violet?: PaletteOptions['primary'];
+  }
+}
+
+// Update the Button's color options to include a violet option
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    violet: true;
+  }
+}
+
+const violetBase = '#7F00FF';
+const violetMain = alpha(violetBase, 0.7);
+
+const theme = createTheme({
+  palette: {
+    violet: {
+      main: violetMain,
+      light: alpha(violetBase, 0.5),
+      dark: alpha(violetBase, 0.9),
+      contrastText: getContrastRatio(violetMain, '#fff') > 4.5 ? '#fff' : '#111',
+    },
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Stack gap={1} alignItems="center">
+        <Button variant="contained" color="violet">
+          Violet
+        </Button>
+        <Stack direction="row" gap={1}>
+          <Box sx={{ bgcolor: `violet.light`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `violet.main`, width: 20, height: 20 }} />
+          <Box sx={{ bgcolor: `violet.dark`, width: 20, height: 20 }} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}

--- a/docs/data/material/customization/palette/UsingStylesUtils.tsx
+++ b/docs/data/material/customization/palette/UsingStylesUtils.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import { Box, Stack } from '@mui/system';
+import { Typography } from '@mui/material';
 
 // Augment the palette to include a violet color
 declare module '@mui/material/styles' {
@@ -43,14 +44,23 @@ const theme = createTheme({
 export default function Palette() {
   return (
     <ThemeProvider theme={theme}>
-      <Stack gap={1} alignItems="center">
+      <Stack gap={2} alignItems="center">
         <Button variant="contained" color="violet">
           Violet
         </Button>
         <Stack direction="row" gap={1}>
-          <Box sx={{ bgcolor: `violet.light`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `violet.main`, width: 20, height: 20 }} />
-          <Box sx={{ bgcolor: `violet.dark`, width: 20, height: 20 }} />
+          <Stack alignItems="center">
+            <Typography variant="body2">light</Typography>
+            <Box sx={{ bgcolor: 'violet.light', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">main</Typography>
+            <Box sx={{ bgcolor: 'violet.main', width: 40, height: 20 }} />
+          </Stack>
+          <Stack alignItems="center">
+            <Typography variant="body2">dark</Typography>
+            <Box sx={{ bgcolor: 'violet.dark', width: 40, height: 20 }} />
+          </Stack>
         </Stack>
       </Stack>
     </ThemeProvider>

--- a/docs/data/material/customization/palette/UsingStylesUtils.tsx.preview
+++ b/docs/data/material/customization/palette/UsingStylesUtils.tsx.preview
@@ -1,0 +1,15 @@
+import { createTheme, alpha, getContrastRatio } from '@mui/material/styles';
+
+const violetBase = '#7F00FF';
+const violetMain = alpha(violetBase, 0.7);
+
+const theme = createTheme({
+  palette: {
+    violet: {
+      main: violetMain,
+      light: alpha(violetBase, 0.5),
+      dark: alpha(violetBase, 0.9),
+      contrastText: getContrastRatio(violetMain, '#fff') > 4.5 ? '#fff' : '#111',
+    },
+  },
+});

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -108,16 +108,37 @@ const theme = createTheme({
 });
 ```
 
-As in the example above, if the palette color contains custom colors using any of the
-"main", "light", "dark" or "contrastText" keys, these map as follows:
+For the default palette colors (the ones listed in the [Default values section](#default-values) above), only the `main` token is required. If the other tokens are not provided their value is calculated as follows:
 
-- If the "dark" and / or "light" keys are omitted, their value(s) will be calculated from "main",
-  according to the "tonalOffset" value.
-- If "contrastText" is omitted, its value will be calculated to contrast with "main",
-  according to the "contrastThreshold" value.
+- The `dark` and `light` tokens are calculated according to the `tonalOffset` value with the `main` color as a starting point.
+- The `contrastText` token is calculated according to the `contrastThreshold` value to contrast with the `main` color.
 
-Both the "tonalOffset" and "contrastThreshold" values may be customized as needed.
-The "tonalOffset" value can either be a number between 0 and 1, which will apply to both light and dark variants, or an object with light and dark variants specified by the following TypeScript type:
+For custom colors, all tokens (`main`, `light`, `dark` and `contrastText`) are required. **Their values won't be automatically calculated** like for the default palette colors. If you wish to calculate the tokens from the `main` color you can use the palette's `augmentColor` utility, you'll have to create the theme in two steps:
+
+```js
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  // Theme customization here as usual, including tonalOffset and/or
+  // contrastThreshold as the augmentColor util relies on these
+});
+
+const themeWithCustomColor = createTheme(theme, {
+  // Custom colors created with augmentColor here
+  palette: {
+    customColor: theme.palette.augmentColor({
+      color: {
+        main: '#FF5733',
+      },
+      name: 'customColor',
+    }),
+  },
+});
+```
+
+Both the `tonalOffset` and `contrastThreshold` values may be customized as needed.
+
+The `tonalOffset` value can either be a number between 0 and 1, which will apply to both light and dark variants, or an object with light and dark variants specified by the following TypeScript type:
 
 ```ts
 type PaletteTonalOffset =
@@ -128,9 +149,10 @@ type PaletteTonalOffset =
     };
 ```
 
-A higher value for "tonalOffset" will make calculated values for "light" lighter, and "dark" darker.
-A higher value for "contrastThreshold" increases the point at which a background color is considered
-light, and given a dark "contrastText". Note that "contrastThreshold" follows a non-linear curve, and
+A higher value for `tonalOffset` will make calculated values for `light` lighter, and `dark` darker.
+
+A higher value for `contrastThreshold` increases the point at which a background color is considered
+light, and given a dark `contrastText`. Note that `contrastThreshold` follows a non-linear curve, and
 starts with a value of 3 (requiring a minimum contrast ratio of 3:1).
 
 ### Accessibility
@@ -170,7 +192,9 @@ const theme = createTheme({
       darker: '#053e85',
     },
     neutral: {
-      main: '#64748B',
+      light: '#838fa2',
+      main: '#64748b',
+      dark: '#465161',
       contrastText: '#fff',
     },
   },

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -28,7 +28,7 @@ See the [Color](/material-ui/customization/color/) documentation for details on 
 
 The theme exposes the following default palette colors (accessible under `theme.palette.*`):
 
-- _primary_ - used to represent primary interface elements for a user. It's the color displayed most frequently across your app's screens and components.
+- `primary` - represents primary interface elements for a user. It's the color displayed most frequently across your app's screens and components.
 - _secondary_ - used to represent secondary interface elements for a user. It provides more ways to accent and distinguish your product. Having it is optional.
 - _error_ - used to represent interface elements that the user should be made aware of.
 - _warning_ - used to represent potentially dangerous actions or important messages.

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -111,7 +111,7 @@ The most straightforward approach is to define all tokens—`main`, `light`, `da
 
 {{"demo": "ManuallyProvideCustomColor.js" }}
 
-If you need to manipulate colors, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) to help with this. 
+If you need to manipulate colors, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) to help with this.
 The following example uses the `alpha` and `getContrastRatio` utilities to define tokens using opacity:
 
 {{"demo": "UsingStylesUtils.js" }}

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -28,12 +28,14 @@ See the [Color](/material-ui/customization/color/) documentation for details on 
 
 The theme exposes the following default palette colors (accessible under `theme.palette.*`):
 
-- `primary` - represents primary interface elements for a user. It's the color displayed most frequently across your app's screens and components.
-- `secondary` - used to represent secondary interface elements for a user. It provides more ways to accent and distinguish your product. Having it is optional.
-- `error` - used to represent interface elements that the user should be made aware of.
-- `warning` - used to represent potentially dangerous actions or important messages.
-- `info` - used to present information to the user that is neutral and not necessarily important.
-- `success` - used to indicate the successful completion of an action that the user triggered.
+- `primary` - for primary interface elements.
+- `secondary` - for secondary interface elements.
+- `error` - for elements that the user should be made aware of.
+- `warning` - for potentially dangerous actions or important messages.
+- `info` - for highlighting neutral information.
+- `success` - for indicating the successful completion of an action that the user triggered.
+
+See Material Design's [Color System](https://m2.material.io/design/color/the-color-system.html) for details on color usage and guidelines.
 
 ### Values
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -9,7 +9,7 @@ Palette colors are represented by four tokens:
 - `main`: The main shade of the color
 - `light`: A lighter shade of `main`
 - `dark`: A darker shade of `main`
-- `contrastText`: A color to be used for text so it contrasts with `main`
+- `contrastText`: Text color, intended to contrast with `main`
 
 For example the default theme primary color tokens are:
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -112,7 +112,7 @@ For the default palette colors (the ones listed in the [Default values section](
 If the other tokens aren't provided, then their values are calculated as follows:
 
 - The `light` and `dark` tokens are calculated according to the `tonalOffset` value, with the `main` color as a starting point.
-- The `contrastText` token is calculated according to the `contrastThreshold` value to contrast with the `main` color.
+- The `contrastText` token is calculated according to the `contrastThreshold` value, to contrast with the `main` color.
 
 **Values for custom palette colors won't be automatically calculated** like for the default palette colors.
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -62,47 +62,36 @@ This can be achieved by either using a color object or by providing the colors d
 
 #### Using a color object
 
-The simplest way to customize a palette color is to import one or more of
-the [color objects](/material-ui/customization/color/#2014-material-design-color-palettes)
-and apply them:
+The most direct way to customize a palette color is to import and apply one or more [color objects](/material-ui/customization/color/#2014-material-design-color-palettes), as shown below:
 
 {{"demo": "UsingColorObject.js", "defaultCodeOpen": true }}
 
 #### Providing the colors directly
 
-You can also modify each color directly.
-For that, you'll have to provide an object with one or more of the color tokens.
-Only the `main` token is required.
-The `light`, `dark`, and `contrastText` tokens are optional and if not provided,
-then their values are calculated automatically:
+To modify each color directly, provide an object with one or more of the color tokens.
+Only the `main` token is required; `light`, `dark`, and `contrastText` are optional, and if not provided, then their values are calculated automatically:
 
 {{"demo": "ManuallyProvidePaletteColor.js" }}
 
-### Contrast Threshold
+### Contrast threshold
 
-The `contrastText` token is calculated using the `contrastThreshold` value,
-to maximize the contrast between the background and the text.
+The `contrastText` token is calculated using the `contrastThreshold` value, to maximize the contrast between the background and the text.
 
-A higher contrast threshold value increases the point at which a background color is considered light,
-and thus given a dark `contrastText`.
-Note that the contrast threshold follows a non-linear curve,
-and defaults to a value of 3 which indicates a minimum contrast ratio of 3:1.
+A higher contrast threshold value increases the point at which a background color is considered light, and thus given a dark `contrastText`.
+Note that the contrast threshold follows a non-linear curve, and defaults to a value of 3 which indicates a minimum contrast ratio of 3:1.
 
 {{"demo": "ContrastThreshold.js" }}
 
 ### Tonal offset
 
-The `light` and `dark` tokens are calculated using the `tonalOffset` value,
-to shift the `main` color's luminance.
+The `light` and `dark` tokens are calculated using the `tonalOffset` value, to shift the `main` color's luminance.
 A higher tonal offset value will make `light` tokens lighter, and `dark` tokens darker.
 
 :::warning
-This only applies when customizing colors,
-it won't have any effect on the [default values](#default-values).
+This only applies when working with custom colors—it won't have any effect on the [default values](#default-values).
 :::
 
-For example, the tonal offset default value `0.2` shifts the luminance by approximately two indexes,
-so if `main` token is `blue[500]`, then `light` token would be `blue[300]` and `dark` token would be `blue[700]`.
+For example, the tonal offset default value `0.2` shifts the luminance by approximately two indexes, so if the `main` token is `blue[500]`, then the `light` token would be `blue[300]` and `dark` would be `blue[700]`.
 
 The tonal offset value can be either a number between 0 and 1 (which would apply to both `light` and `dark` tokens) or an object with `light` and `dark` keys specified:
 
@@ -114,7 +103,7 @@ The tonal offset value can be either a number between 0 and 1 (which would apply
 Unlike [default colors](#default-colors), tokens for custom colors are _not_ automatically calculated.
 :::
 
-To add custom colors either provide the tokens manually or generate them using the `augmentColor` utility:
+To add custom colors, you must either provide the tokens manually, or generate them using the `augmentColor` utility:
 
 ### Provide tokens manually
 
@@ -122,36 +111,33 @@ The most straightforward approach is to define all tokens—`main`, `light`, `da
 
 {{"demo": "ManuallyProvideCustomColor.js" }}
 
-If you need to manipulate colors, then `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) to help with this. The following example uses the `alpha` and `getContrastRatio` utils to define tokens using opacity:
+If you need to manipulate colors, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) to help with this. 
+The following example uses the `alpha` and `getContrastRatio` utilities to define tokens using opacity:
 
 {{"demo": "UsingStylesUtils.js" }}
 
 ### Generate tokens using augmentColor utility
 
-Alternatively, you can generate the `light`, `dark` and `contrastText` tokens using the palette's `augmentColor` utility,
-which is the same function used for the default palette colors.
+Alternatively, you can generate the `light`, `dark` and `contrastText` tokens using the palette's `augmentColor` utility, which is the same function used for the default palette colors.
 This requires creating the theme in two steps and providing the `main` token on which the other will be based on:
 
 {{"demo": "UsingAugmentColor.js" }}
 
-The [contrast threshold](#contrast-threshold) and [tonal offset](#tonal-offset) values
-will apply for the colors defined using this utility.
+The [contrast threshold](#contrast-threshold) and [tonal offset](#tonal-offset) values will apply for the colors defined using this utility.
 
 ### Using in components
 
-After adding a custom color,
-you will be able to use it in components the same way default palette colors are used:
+After adding a custom color, you will be able to use it in components just like you do with default palette colors:
 
 ```js
 <Button color="custom">
 ```
 
-### Typescript
+### TypeScript
 
-If you're using Typescript, then you need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme) for custom colors.
+If you're using TypeScript, then you need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme) for custom colors.
 
-To add a custom color to the palette,
-you'll have to add it to the `Palette` and `PaletteOptions` interfaces:
+To add a custom color to the palette, you must add it to the `Palette` and `PaletteOptions` interfaces:
 
 <!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
 
@@ -167,9 +153,8 @@ declare module '@mui/material/styles' {
 }
 ```
 
-To use the custom color for the `color` prop of a component,
-you'll need to add it to the component's `PropsColorOverrides` interface.
-For example if you need to use it on the `Button` component add it like this:
+To use a custom color for the `color` prop of a component, you must add it to the component's `PropsColorOverrides` interface.
+The example below shows how to do this with a Button component:
 
 <!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
 
@@ -183,14 +168,13 @@ declare module '@mui/material/Button' {
 
 ## Adding color tokens
 
-To add a new [color token](#color-tokens) include it in the color's object as follows:
+To add a new [color token](#color-tokens), include it in the color's object as follows:
 
 {{"demo": "AddingColorTokens.js" }}
 
-### Typescript
+### TypeScript
 
-If you're using Typescript, then you'll need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme)
-to add the new color token to the `PaletteColor` and `SimplePaletteColorOptions` interfaces as follows:
+If you're using TypeScript, then you'll need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme) to add the new color token to the `PaletteColor` and `SimplePaletteColorOptions` interfaces as follows:
 
 <!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
 
@@ -208,13 +192,11 @@ declare module '@mui/material/styles' {
 
 ## Non-palette colors
 
-To add colors outside of `theme.palette`,
-check out the [Custom variables](/material-ui/customization/theming/#custom-variables) section on the Theming page.
+To learn how to add colors outside of `theme.palette`, see [Theming—Custom variables](/material-ui/customization/theming/#custom-variables).
 
 ## Accessibility
 
-To meet the minimum contrast of at least 4.5:1 as defined in [WCAG 2.1 Rule 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html),
-create a custom theme with a [contrast threshold](#contrast-threshold) value of 4.5 as follows:
+To meet the minimum contrast of at least 4.5:1 as defined in [WCAG 2.1 Rule 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html), create a custom theme with a [contrast threshold](#contrast-threshold) value of 4.5 as follows:
 
 ```js
 import { createTheme } from '@mui/material/styles';

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -4,7 +4,7 @@
 
 ## Color tokens
 
-Palette colors are composed by four tokens:
+Palette colors are represented by four tokens:
 
 - `main`: The main shade of the color
 - `light`: A lighter shade of `main`

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -11,7 +11,7 @@ Palette colors are represented by four tokens:
 - `dark`: A darker shade of `main`
 - `contrastText`: Text color, intended to contrast with `main`
 
-For example the default theme primary color tokens are:
+Here's how Material UI's default theme defines the primary color tokens:
 
 ```js
 const primary = {

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -29,11 +29,11 @@ See the [Color](/material-ui/customization/color/) documentation for details on 
 The theme exposes the following default palette colors (accessible under `theme.palette.*`):
 
 - `primary` - represents primary interface elements for a user. It's the color displayed most frequently across your app's screens and components.
-- _secondary_ - used to represent secondary interface elements for a user. It provides more ways to accent and distinguish your product. Having it is optional.
-- _error_ - used to represent interface elements that the user should be made aware of.
-- _warning_ - used to represent potentially dangerous actions or important messages.
-- _info_ - used to present information to the user that is neutral and not necessarily important.
-- _success_ - used to indicate the successful completion of an action that user triggered.
+- `secondary` - used to represent secondary interface elements for a user. It provides more ways to accent and distinguish your product. Having it is optional.
+- `error` - used to represent interface elements that the user should be made aware of.
+- `warning` - used to represent potentially dangerous actions or important messages.
+- `info` - used to present information to the user that is neutral and not necessarily important.
+- `success` - used to indicate the successful completion of an action that the user triggered.
 
 ### Values
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -110,10 +110,14 @@ const theme = createTheme({
 
 For the default palette colors (the ones listed in the [Default values section](#default-values) above), only the `main` token is required. If the other tokens are not provided their value is calculated as follows:
 
-- The `dark` and `light` tokens are calculated according to the `tonalOffset` value with the `main` color as a starting point.
+- The `light` and `dark` tokens are calculated according to the `tonalOffset` value with the `main` color as a starting point.
 - The `contrastText` token is calculated according to the `contrastThreshold` value to contrast with the `main` color.
 
-For custom colors, all tokens (`main`, `light`, `dark` and `contrastText`) are required. **Their values won't be automatically calculated** like for the default palette colors. If you wish to calculate the tokens from the `main` color you can use the palette's `augmentColor` utility, you'll have to create the theme in two steps:
+**Values for custom palette colors won't be automatically calculated** like for the default palette colors.
+
+You can provide all tokens (`main`, `light`, `dark` and `contrastText`) manually, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) for manipulating color values you might find helpful.
+
+Alternatively, you can generate the tokens from a custom `main` color, to do so create the theme in two steps and use the palette's `augmentColor` utility:
 
 ```js
 import { createTheme } from '@mui/material/styles';

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -171,6 +171,8 @@ To use the custom color for the `color` prop of a component,
 you'll need to add it to the component's `PropsColorOverrides` interface.
 For example if you need to use it on the `Button` component add it like this:
 
+<!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
+
 ```ts
 declare module '@mui/material/Button' {
   interface ButtonPropsColorOverrides {
@@ -185,12 +187,12 @@ To add a new [color token](#color-tokens) include it in the color's object as fo
 
 {{"demo": "AddingColorTokens.js" }}
 
-<!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
-
 ### Typescript
 
 If you're using Typescript, then you'll need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme)
 to add the new color token to the `PaletteColor` and `SimplePaletteColorOptions` interfaces as follows:
+
+<!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
 declare module '@mui/material/styles' {

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -111,7 +111,7 @@ const theme = createTheme({
 For the default palette colors (the ones listed in the [Default values section](#default-values) above), only the `main` token is required. 
 If the other tokens aren't provided, then their values are calculated as follows:
 
-- The `light` and `dark` tokens are calculated according to the `tonalOffset` value with the `main` color as a starting point.
+- The `light` and `dark` tokens are calculated according to the `tonalOffset` value, with the `main` color as a starting point.
 - The `contrastText` token is calculated according to the `contrastThreshold` value to contrast with the `main` color.
 
 **Values for custom palette colors won't be automatically calculated** like for the default palette colors.

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -108,7 +108,8 @@ const theme = createTheme({
 });
 ```
 
-For the default palette colors (the ones listed in the [Default values section](#default-values) above), only the `main` token is required. If the other tokens are not provided their value is calculated as follows:
+For the default palette colors (the ones listed in the [Default values section](#default-values) above), only the `main` token is required. 
+If the other tokens aren't provided, then their values are calculated as follows:
 
 - The `light` and `dark` tokens are calculated according to the `tonalOffset` value with the `main` color as a starting point.
 - The `contrastText` token is calculated according to the `contrastThreshold` value to contrast with the `main` color.

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -26,7 +26,7 @@ See the [Color](/material-ui/customization/color/) documentation for details on 
 
 ## Default colors
 
-The theme exposes the following default palette colors (accessible under `theme.palette.`):
+The theme exposes the following default palette colors (accessible under `theme.palette.*`):
 
 - _primary_ - used to represent primary interface elements for a user. It's the color displayed most frequently across your app's screens and components.
 - _secondary_ - used to represent secondary interface elements for a user. It provides more ways to accent and distinguish your product. Having it is optional.

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -126,7 +126,7 @@ If you need to manipulate colors, then `@mui/material/styles` provides [a set of
 
 {{"demo": "UsingStylesUtils.js" }}
 
-### Generate tokens using `augmentColor`
+### Generate tokens using augmentColor utility
 
 Alternatively, you can generate the `light`, `dark` and `contrastText` tokens using the palette's `augmentColor` utility,
 which is the same function used for the default palette colors.

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -22,7 +22,7 @@ const primary = {
 };
 ```
 
-For more information about color check out [the color section](/material-ui/customization/color/).
+See the [Color](/material-ui/customization/color/) documentation for details on the Material Design color system.
 
 ## Default colors
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -114,7 +114,9 @@ If the other tokens aren't provided, then their values are calculated as follows
 - The `light` and `dark` tokens are calculated according to the `tonalOffset` value, with the `main` color as a starting point.
 - The `contrastText` token is calculated according to the `contrastThreshold` value, to contrast with the `main` color.
 
-**Values for custom palette colors won't be automatically calculated** like for the default palette colors.
+:::warning
+Unlike default palette colors, values for custom palette colors are *not* automatically calculated.
+:::
 
 You can provide all tokens (`main`, `light`, `dark` and `contrastText`) manually, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) for manipulating color values you might find helpful.
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -37,7 +37,7 @@ The theme exposes the following default palette colors (accessible under `theme.
 
 ### Values
 
-You can explore the default palette values of the palette using [the theme explorer](/material-ui/customization/default-theme/?expand-path=$.palette) or by opening the dev tools console on this page (`window.theme.palette`).
+You can explore the default palette values using [the theme explorer](/material-ui/customization/default-theme/?expand-path=$.palette), or by opening the dev tools console on this page (`window.theme.palette`).
 
 {{"demo": "Intentions.js", "bg": "inline", "hideToolbar": true}}
 

--- a/docs/data/material/customization/palette/palette.md
+++ b/docs/data/material/customization/palette/palette.md
@@ -2,9 +2,31 @@
 
 <p class="description">The palette enables you to modify the color of the components to suit your brand.</p>
 
-## Palette colors
+## Color tokens
 
-The theme exposes the following palette colors (accessible under `theme.palette.`):
+Palette colors are composed by four tokens:
+
+- `main`: The main shade of the color
+- `light`: A lighter shade of `main`
+- `dark`: A darker shade of `main`
+- `contrastText`: A color to be used for text so it contrasts with `main`
+
+For example the default theme primary color tokens are:
+
+```js
+const primary = {
+  main: '#1976d2',
+  light: '#42a5f5',
+  dark: '#1565c0',
+  contrastText: '#fff',
+};
+```
+
+For more information about color check out [the color section](/material-ui/customization/color/).
+
+## Default colors
+
+The theme exposes the following default palette colors (accessible under `theme.palette.`):
 
 - _primary_ - used to represent primary interface elements for a user. It's the color displayed most frequently across your app's screens and components.
 - _secondary_ - used to represent secondary interface elements for a user. It provides more ways to accent and distinguish your product. Having it is optional.
@@ -13,18 +35,16 @@ The theme exposes the following palette colors (accessible under `theme.palette.
 - _info_ - used to present information to the user that is neutral and not necessarily important.
 - _success_ - used to indicate the successful completion of an action that user triggered.
 
-If you want to learn more about color, you can check out [the color section](/material-ui/customization/color/).
+### Values
 
-## Default values
-
-You can explore the default values of the palette using [the theme explorer](/material-ui/customization/default-theme/?expand-path=$.palette) or by opening the dev tools console on this page (`window.theme.palette`).
+You can explore the default palette values of the palette using [the theme explorer](/material-ui/customization/default-theme/?expand-path=$.palette) or by opening the dev tools console on this page (`window.theme.palette`).
 
 {{"demo": "Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 The default palette uses the shades prefixed with `A` (`A200`, etc.) for the secondary palette color,
 and the un-prefixed shades for the other palette colors.
 
-## Customization
+### Customization
 
 You may override the default palette values by including a palette object as part of your theme.
 If any of the:
@@ -38,204 +58,142 @@ If any of the:
 
 palette color objects are provided, they will replace the default ones.
 
-The palette color value can either be a [color](/material-ui/customization/color/#2014-material-design-color-palettes) object, or an object with one or more of the keys specified by the following TypeScript interface:
+This can be achieved by either using a color object or by providing the colors directly:
 
-```ts
-interface PaletteColor {
-  light?: string;
-  main: string;
-  dark?: string;
-  contrastText?: string;
-}
-```
+#### Using a color object
 
-### Using a color object
-
-The simplest way to customize a palette color is to import one or more of the provided colors
+The simplest way to customize a palette color is to import one or more of
+the [color objects](/material-ui/customization/color/#2014-material-design-color-palettes)
 and apply them:
 
-```js
-import { createTheme } from '@mui/material/styles';
-import blue from '@mui/material/colors/blue';
+{{"demo": "UsingColorObject.js", "defaultCodeOpen": true }}
 
-const theme = createTheme({
-  palette: {
-    primary: blue,
-  },
-});
-```
+#### Providing the colors directly
 
-### Providing the colors directly
+You can also modify each color directly.
+For that, you'll have to provide an object with one or more of the color tokens.
+Only the `main` token is required.
+The `light`, `dark`, and `contrastText` tokens are optional and if not provided,
+then their values are calculated automatically:
 
-If you wish to provide more customized colors, you can either create your own palette color,
-or directly supply colors to some or all of the `theme.palette` keys:
+{{"demo": "ManuallyProvidePaletteColor.js" }}
 
-```js
-import { createTheme } from '@mui/material/styles';
+### Contrast Threshold
 
-const theme = createTheme({
-  palette: {
-    primary: {
-      // light: will be calculated from palette.primary.main,
-      main: '#ff4400',
-      // dark: will be calculated from palette.primary.main,
-      // contrastText: will be calculated to contrast with palette.primary.main
-    },
-    secondary: {
-      light: '#0066ff',
-      main: '#0044ff',
-      // dark: will be calculated from palette.secondary.main,
-      contrastText: '#ffcc00',
-    },
-    // Provide every color token (light, main, dark, and contrastText) when using
-    // custom colors for props in Material UI's components.
-    // Then you will be able to use it like this: `<Button color="custom">`
-    // (For TypeScript, you need to add module augmentation for the `custom` value)
-    custom: {
-      light: '#ffa726',
-      main: '#f57c00',
-      dark: '#ef6c00',
-      contrastText: 'rgba(0, 0, 0, 0.87)',
-    },
-    // Used by `getContrastText()` to maximize the contrast between
-    // the background and the text.
-    contrastThreshold: 3,
-    // Used by the functions below to shift a color's luminance by approximately
-    // two indexes within its tonal palette.
-    // E.g., shift from Red 500 to Red 300 or Red 700.
-    tonalOffset: 0.2,
-  },
-});
-```
+The `contrastText` token is calculated using the `contrastThreshold` value,
+to maximize the contrast between the background and the text.
 
-For the default palette colors (the ones listed in the [Default values section](#default-values) above), only the `main` token is required. 
-If the other tokens aren't provided, then their values are calculated as follows:
+A higher contrast threshold value increases the point at which a background color is considered light,
+and thus given a dark `contrastText`.
+Note that the contrast threshold follows a non-linear curve,
+and defaults to a value of 3 which indicates a minimum contrast ratio of 3:1.
 
-- The `light` and `dark` tokens are calculated according to the `tonalOffset` value, with the `main` color as a starting point.
-- The `contrastText` token is calculated according to the `contrastThreshold` value, to contrast with the `main` color.
+{{"demo": "ContrastThreshold.js" }}
+
+### Tonal offset
+
+The `light` and `dark` tokens are calculated using the `tonalOffset` value,
+to shift the `main` color's luminance.
+A higher tonal offset value will make `light` tokens lighter, and `dark` tokens darker.
 
 :::warning
-Unlike default palette colors, values for custom palette colors are *not* automatically calculated.
+This only applies when customizing colors,
+it won't have any effect on the [default values](#default-values).
 :::
 
-You can provide all tokens (`main`, `light`, `dark` and `contrastText`) manually, `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) for manipulating color values you might find helpful.
+For example, the tonal offset default value `0.2` shifts the luminance by approximately two indexes,
+so if `main` token is `blue[500]`, then `light` token would be `blue[300]` and `dark` token would be `blue[700]`.
 
-Alternatively, you can generate the tokens from a custom `main` color, to do so create the theme in two steps and use the palette's `augmentColor` utility:
+The tonal offset value can be either a number between 0 and 1 (which would apply to both `light` and `dark` tokens) or an object with `light` and `dark` keys specified:
 
-```js
-import { createTheme } from '@mui/material/styles';
+{{"demo": "TonalOffset.js" }}
 
-const theme = createTheme({
-  // Theme customization here as usual, including tonalOffset and/or
-  // contrastThreshold as the augmentColor util relies on these
-});
+## Custom colors
 
-const themeWithCustomColor = createTheme(theme, {
-  // Custom colors created with augmentColor here
-  palette: {
-    customColor: theme.palette.augmentColor({
-      color: {
-        main: '#FF5733',
-      },
-      name: 'customColor',
-    }),
-  },
-});
-```
+:::warning
+Unlike [default colors](#default-colors), tokens for custom colors are _not_ automatically calculated.
+:::
 
-Both the `tonalOffset` and `contrastThreshold` values may be customized as needed.
+To add custom colors either provide the tokens manually or generate them using the `augmentColor` utility:
 
-The `tonalOffset` value can either be a number between 0 and 1, which will apply to both light and dark variants, or an object with light and dark variants specified by the following TypeScript type:
+### Provide tokens manually
 
-```ts
-type PaletteTonalOffset =
-  | number
-  | {
-      light: number;
-      dark: number;
-    };
-```
+The most straightforward approach is to define all tokens—`main`, `light`, `dark`, and `contrastText`—manually:
 
-A higher value for `tonalOffset` will make calculated values for `light` lighter, and `dark` darker.
+{{"demo": "ManuallyProvideCustomColor.js" }}
 
-A higher value for `contrastThreshold` increases the point at which a background color is considered
-light, and given a dark `contrastText`. Note that `contrastThreshold` follows a non-linear curve, and
-starts with a value of 3 (requiring a minimum contrast ratio of 3:1).
+If you need to manipulate colors, then `@mui/material/styles` provides [a set of utilities](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/styles/index.d.ts#L52-L67) to help with this. The following example uses the `alpha` and `getContrastRatio` utils to define tokens using opacity:
 
-### Accessibility
+{{"demo": "UsingStylesUtils.js" }}
 
-To meet the minimum contrast of at least 4.5:1 as defined in [WCAG 2.1 Rule 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html), create a custom theme with `contrastThreshold: 4.5`.
+### Generate tokens using `augmentColor`
+
+Alternatively, you can generate the `light`, `dark` and `contrastText` tokens using the palette's `augmentColor` utility,
+which is the same function used for the default palette colors.
+This requires creating the theme in two steps and providing the `main` token on which the other will be based on:
+
+{{"demo": "UsingAugmentColor.js" }}
+
+The [contrast threshold](#contrast-threshold) and [tonal offset](#tonal-offset) values
+will apply for the colors defined using this utility.
+
+### Using in components
+
+After adding a custom color,
+you will be able to use it in components the same way default palette colors are used:
 
 ```js
-import { createTheme } from '@mui/material/styles';
-
-const theme = createTheme({
-  palette: {
-    // Used by `getContrastText()` to maximize the contrast between
-    // the background and the text.
-    contrastThreshold: 4.5,
-  },
-});
+<Button color="custom">
 ```
 
-### Example
+### Typescript
 
-{{"demo": "Palette.js", "defaultCodeOpen": true}}
+If you're using Typescript, then you need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme) for custom colors.
 
-### Adding new colors
-
-You can add new colors inside and outside the palette of the theme as follows:
-
-```js
-import { createTheme } from '@mui/material/styles';
-
-const theme = createTheme({
-  status: {
-    danger: '#e53e3e',
-  },
-  palette: {
-    primary: {
-      main: '#0971f1',
-      darker: '#053e85',
-    },
-    neutral: {
-      light: '#838fa2',
-      main: '#64748b',
-      dark: '#465161',
-      contrastText: '#fff',
-    },
-  },
-});
-```
-
-### TypeScript
-
-You have to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme) to add new variables to the `Palette` and `PaletteOptions`.
+To add a custom color to the palette,
+you'll have to add it to the `Palette` and `PaletteOptions` interfaces:
 
 <!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
 
 ```ts
 declare module '@mui/material/styles' {
-  interface Theme {
-    status: {
-      danger: React.CSSProperties['color'];
-    };
-  }
-
-  interface ThemeOptions {
-    status: {
-      danger: React.CSSProperties['color'];
-    };
-  }
-
   interface Palette {
-    neutral: Palette['primary'];
+    custom: Palette['primary'];
   }
 
   interface PaletteOptions {
-    neutral: PaletteOptions['primary'];
+    custom?: PaletteOptions['primary'];
   }
+}
+```
 
+To use the custom color for the `color` prop of a component,
+you'll need to add it to the component's `PropsColorOverrides` interface.
+For example if you need to use it on the `Button` component add it like this:
+
+```ts
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    custom: true;
+  }
+}
+```
+
+## Adding color tokens
+
+To add a new [color token](#color-tokens) include it in the color's object as follows:
+
+{{"demo": "AddingColorTokens.js" }}
+
+<!-- tested with packages/mui-material/test/typescript/augmentation/paletteColors.spec.ts -->
+
+### Typescript
+
+If you're using Typescript, then you'll need to use [module augmentation](/material-ui/guides/typescript/#customization-of-theme)
+to add the new color token to the `PaletteColor` and `SimplePaletteColorOptions` interfaces as follows:
+
+```ts
+declare module '@mui/material/styles' {
   interface PaletteColor {
     darker?: string;
   }
@@ -246,7 +204,25 @@ declare module '@mui/material/styles' {
 }
 ```
 
-{{"demo": "CustomColor.js"}}
+## Non-palette colors
+
+To add colors outside of `theme.palette`,
+check out the [Custom variables](/material-ui/customization/theming/#custom-variables) section on the Theming page.
+
+## Accessibility
+
+To meet the minimum contrast of at least 4.5:1 as defined in [WCAG 2.1 Rule 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html),
+create a custom theme with a [contrast threshold](#contrast-threshold) value of 4.5 as follows:
+
+```js
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    contrastThreshold: 4.5,
+  },
+});
+```
 
 ## Picking colors
 

--- a/docs/pages/blog/mui-core-v5.md
+++ b/docs/pages/blog/mui-core-v5.md
@@ -55,7 +55,8 @@ This release features some major highlights:
   - [Unstyled components and hooks](#unstyled-components-and-hooks)
   - [Second design system](#second-design-system)
   - [MUI X](#mui-x)
-  - [Design kits](#design-kits-2)
+  - [Design kits](#design-kits-1)
+- [Thank you](#thank-you)
 
 ## High-level goals for v5
 
@@ -197,7 +198,7 @@ For this reason, v5 comes with the capability to extend the built-in behavior of
 This was one of the most upvoted GitHub issues: [#13875](https://github.com/mui/material-ui/issues/13875).
 In practice, this change makes the MUI Core components extendable placeholders.
 
-**First**, you can use the [existing style mapping](/material-ui/customization/palette/#adding-new-colors) of the components.
+**First**, you can use the [existing style mapping](/material-ui/customization/palette/#custom-colors) of the components.
 For example, you can add a new `neutral` color to the palette, and the Button computes the right derivative colors.
 
 ```jsx

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -13,6 +13,7 @@ const ignoreList = [
   '/pages.ts',
   'docs/data/joy/getting-started/templates',
   'docs/data/base/components/select/UnstyledSelectIntroduction.tsx',
+  'docs/data/material/customization/palette',
 ];
 
 const fse = require('fs-extra');

--- a/packages/mui-material/test/typescript/moduleAugmentation/paletteColors.spec.ts
+++ b/packages/mui-material/test/typescript/moduleAugmentation/paletteColors.spec.ts
@@ -28,6 +28,12 @@ declare module '@mui/material/styles' {
   }
 }
 
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    neutral: true;
+  }
+}
+
 const theme = createTheme({
   status: {
     danger: '#e53e3e',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes: #29595

### Summary
Improve documentation regarding adding new colors using a color object:
- Clearly indicate that for custom colors the `light`, `dark`, and `contrastText` tokens are required and not calculated automatically, which differs from default colors.
- Add an example of how to use the `augmentColor` function to augment custom colors.
- Fix examples so custom colors have all the required tokens

### Note
I also wanted to improve the warning/error that users would get when using a component that requires `light`, `dark`, or `contrastText` (see the `Chip`'s `contrastText` issue: #37676). But after a second thought, it seemed very cumbersome and overhead to do given the small use case for which the warning would be helpful.

If you disagree and think it would be worth it, I would love to discuss approaches to adding the warning 😊 cc: @mui/core 
