### PR TITLE
[website] Update the pricing page to reflect sales

### DIFF
--- a/docs/src/components/pricing/EarlyBird.tsx
+++ b/docs/src/components/pricing/EarlyBird.tsx
@@ -59,6 +59,7 @@ export default function EarlyBird() {
           endIcon={<KeyboardArrowRightRounded />}
           sx={{
             py: 1,
+            flexShrink: 0,
             ml: { xs: 0, sm: 2 },
             mt: { xs: 3, sm: 0 },
             width: { xs: '100%', sm: '50%', md: '15%' },

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -165,7 +165,7 @@ function Info(props: { value: React.ReactNode; metadata?: React.ReactNode }) {
   return (
     <React.Fragment>
       {typeof value === 'string' ? (
-        <Typography variant="body2" color="text.secondary">
+        <Typography variant="body2" sx={{ color: 'text.secondary', textAlign: 'center' }}>
           {value}
         </Typography>
       ) : (
@@ -315,8 +315,9 @@ function Cell({ highlighted = false, ...props }: BoxProps & { highlighted?: bool
       {...props}
       sx={[
         {
-          py: '18px',
-          px: 2,
+          py: '16px',
+          minHeight: 54,
+          px: 1,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
@@ -616,7 +617,7 @@ const rowHeaders: Record<string, React.ReactNode> = {
       {...{
         label: (
           <React.Fragment>
-            Security questionnaire & <br />
+            Security questionnaire & <Box sx={{ display: ['none', 'block'] }} />
             custom agreements
           </React.Fragment>
         ),
@@ -750,8 +751,8 @@ const proData: Record<string, React.ReactNode> = {
   'issue-escalation': no,
   'security-questionnaire': (
     <Info
-      value="Available from 10+ devs"
-      metadata={'Not available under the "Capped at 10 licenses" policy'}
+      value="Available from 10+ devs"
+      metadata={'Not available under the "Capped at 10 licenses" policy'}
     />
   ),
 };

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -192,7 +192,7 @@ function ColumnHead({
   nested = false,
   href,
 }: {
-  label: string;
+  label: React.ReactNode;
   metadata?: string;
   tooltip?: string;
   nested?: boolean;
@@ -614,7 +614,12 @@ const rowHeaders: Record<string, React.ReactNode> = {
   'security-questionnaire': (
     <ColumnHead
       {...{
-        label: 'Security questionnaire',
+        label: (
+          <React.Fragment>
+            Security questionnaire & <br />
+            custom agreements
+          </React.Fragment>
+        ),
       }}
     />
   ),
@@ -743,7 +748,12 @@ const proData: Record<string, React.ReactNode> = {
   'response-time': no,
   'pre-screening': no,
   'issue-escalation': no,
-  'security-questionnaire': no,
+  'security-questionnaire': (
+    <Info
+      value="Available from 10+ devs"
+      metadata={'Invalidate the "Capped at 10 licenses" policy'}
+    />
+  ),
 };
 
 const premiumData: Record<string, React.ReactNode> = {

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -751,7 +751,7 @@ const proData: Record<string, React.ReactNode> = {
   'security-questionnaire': (
     <Info
       value="Available from 10+ devs"
-      metadata={'Invalidate the "Capped at 10 licenses" policy'}
+      metadata={'Not available under the "Capped at 10 licenses" policy'}
     />
   ),
 };

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -317,7 +317,7 @@ function Cell({ highlighted = false, ...props }: BoxProps & { highlighted?: bool
         {
           py: '16px',
           minHeight: 54,
-          px: 1,
+          px: [1, 2],
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
@@ -617,7 +617,7 @@ const rowHeaders: Record<string, React.ReactNode> = {
       {...{
         label: (
           <React.Fragment>
-            Security questionnaire & <Box sx={{ display: ['none', 'block'] }} />
+            Security questionnaire & <Box component="span" sx={{ display: ['none', 'block'] }} />
             custom agreements
           </React.Fragment>
         ),


### PR DESCRIPTION
It's a sales policy that we have been following for some time to prepare the new pricing plan:

<img width="1182" alt="Screenshot 2023-06-29 at 01 31 25" src="https://github.com/mui/material-ui/assets/3165635/8c760e57-9550-40e9-bc98-0c7b84416f26">

https://deploy-preview-37751--material-ui.netlify.app/pricing/

I propose we reflect it on the pricing page.