### PR TITLE
[docs-infra] Fix `marked` deprecation warning

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "marked": "^4.3.0",
+    "marked-highlight": "^2.0.1",
     "prismjs": "^1.29.0"
   }
 }

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -1,4 +1,5 @@
 const { marked } = require('marked');
+const { markedHighlight } = require('marked-highlight');
 const kebabCase = require('lodash/kebabCase');
 const textToHash = require('./textToHash');
 const prism = require('./prism');
@@ -354,8 +355,13 @@ function createRender(context) {
       sanitize: false,
       smartLists: true,
       smartypants: false,
-      highlight: prism,
-      renderer,
+      headerPrefix: false,
+      headerIds: false,
+      mangle: false,
+      ...markedHighlight({
+        highlight: prism,
+      }),
+      renderer, // Should be after markedHighlight since it overrides `renderer.code`
     };
 
     marked.use({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11174,6 +11174,11 @@ markdownlint@0.29.0:
     markdown-it "13.0.1"
     markdownlint-micromark "0.1.5"
 
+marked-highlight@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/marked-highlight/-/marked-highlight-2.0.1.tgz#a2b48533df77ea73bec3895be98bae6160dceec3"
+  integrity sha512-LDUfR/zDvD+dJ+lQOWHkxvBLNxiXcaN8pBtwJ/i4pI0bkDC/Ef6Mz1qUrAuHXfnpdr2rabdMpVFhqFuU+5Mskg==
+
 marked@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"


### PR DESCRIPTION
Fix the following warnings about deprecation from marked

>4:41:30 PM: marked(): headerIds and headerPrefix parameters enabled by default, but are deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install  https://www.npmjs.com/package/marked-gfm-heading-id, or disable by setting `{headerIds: false}`.
4:41:30 PM: marked(): highlight and langPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-highlight.
4:41:30 PM: marked(): mangle parameter is enabled by default, but is deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install https://www.npmjs.com/package/marked-mangle, or disable by setting `{mangle: false}`.
