### PR TITLE
[docs-infra] Fix truncated TOCs scrollbar

### DIFF
--- a/docs/pages/experiments/docs/blog.md
+++ b/docs/pages/experiments/docs/blog.md
@@ -11,7 +11,7 @@ tags: ['Company']
 
 ### Image
 
-<img alt="Satellite image of Tenerife" src="/static/blog/2022-tenerife-retreat/tenerife.jpeg" style="aspect-ratio: 4/3;" loading="lazy" />
+<img alt="Satellite image of Tenerife" src="/static/blog/2022-tenerife-retreat/tenerife.jpeg" width="2560" height="1920" loading="lazy" />
 
 <p class="blog-description">An image description <a href="https://en.wikipedia.org/wiki/Tenerife">with a link</a>.</p>
 

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -12,12 +12,12 @@ import TableOfContentsBanner from 'docs/src/components/banner/TableOfContentsBan
 import featureToggle from 'docs/src/featureToggle';
 
 const Nav = styled('nav')(({ theme }) => ({
-  top: 0,
+  top: 'var(--MuiDocs-header-height)',
   paddingLeft: 2, // Fix truncated focus outline style
   position: 'sticky',
-  height: '100vh',
+  height: 'calc(100vh - var(--MuiDocs-header-height))',
   overflowY: 'auto',
-  paddingTop: `calc(var(--MuiDocs-header-height) + ${theme.spacing(4)})`,
+  paddingTop: theme.spacing(4),
   paddingBottom: theme.spacing(4),
   paddingRight: theme.spacing(4), // We can't use `padding` as stylis-plugin-rtl doesn't swap it
   display: 'none',


### PR DESCRIPTION
This is mostly noticeable on Windows, the truncated scrollbar feels confusing.

It feels like the scroll isn't at the top, so there is more things to scroll up to that his hidden, but once you try to scroll up, you realize that no, you are already at the top 🙈

**Before**:

<img width="327" alt="Screenshot 2023-07-01 at 01 32 51" src="https://github.com/mui/material-ui/assets/3165635/c5cf09e2-6b29-44a0-890d-c7b0b3f874cd">

https://mui.com/joy-ui/react-checkbox/

**After**:

<img width="323" alt="Screenshot 2023-07-01 at 01 33 14" src="https://github.com/mui/material-ui/assets/3165635/e14b61b1-d110-47d6-86b0-fe919a68d44d">

https://deploy-preview-37770--material-ui.netlify.app/joy-ui/react-checkbox/