### PR TITLE
[Menu][Joy] Improve UX of `Menu` usage demo

### DIFF
--- a/docs/data/joy/components/menu/MenuUsage.js
+++ b/docs/data/joy/components/menu/MenuUsage.js
@@ -77,7 +77,6 @@ export default function MenuUsage() {
             id="menu-usage-demo"
             anchorEl={buttonRef.current}
             open={open}
-            onClose={() => setOpen(false)}
             slotProps={{
               listbox: {
                 'aria-labelledby': 'menu-usage-button',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Right now whenever user wants to test different variants of props for `Menu` they have open menu everytime and remember old version and current version to compare. I belive this process has lot of friction, so i kept `Menu` open all the time, so that user need not to open `Menu` everytime they want to try different variants of props.

before: 

https://github.com/mui/material-ui/assets/60743144/621744b0-9996-4073-aac1-02ffc6452958


after:

https://github.com/mui/material-ui/assets/60743144/6df02666-d666-428e-be85-683fd07f236c




- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
