### PR TITLE
[docs][material] Add disableInteractive on colorTool grid Tooltips

### DIFF
--- a/docs/data/material/customization/color/ColorTool.js
+++ b/docs/data/material/customization/color/ColorTool.js
@@ -248,7 +248,7 @@ function ColorTool() {
             const backgroundColor = colors[hue][shade];
 
             return (
-              <Tooltip placement="right" title={hue} key={hue}>
+              <Tooltip placement="right" title={hue} key={hue} disableInteractive>
                 <TooltipRadio
                   sx={{ p: 0 }}
                   color="default"


### PR DESCRIPTION
Small tweak I added in https://github.com/mui/mui-toolpad/pull/2260

Moving fast over the grid sometimes gets you on top of the tooltip, and blocks hovering the color panel underneath. We can disable interaction to avoid that situation.

https://deploy-preview-37800--material-ui.netlify.app/material-ui/customization/color/#playground

Before:

https://github.com/mui/material-ui/assets/2109932/814d6e69-48f9-4c4e-b8e3-86ac8d309b42


After:

https://github.com/mui/material-ui/assets/2109932/a7f04553-fedf-46e5-be89-81b66c42f298


