### PR TITLE
[docs] rename product to productId

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -39,7 +39,7 @@ const createReactApp = (demo: {
   raw: string;
   codeVariant: CodeVariant;
   githubLocation: string;
-  product?: Product;
+  productId?: Product;
   codeStyling: CodeStyling;
 }) => {
   const ext = getFileExtension(demo.codeVariant);
@@ -50,7 +50,7 @@ const createReactApp = (demo: {
       content: CRA.getHtml(demo),
     },
     [`index.${ext}`]: {
-      content: CRA.getRootIndex(demo.product),
+      content: CRA.getRootIndex(demo.productId),
     },
     [`demo.${ext}`]: {
       content: demo.raw,

--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -45,8 +45,8 @@ export const getHtml = ({
 </html>`;
 };
 
-export const getRootIndex = (product?: 'joy-ui' | 'base-ui') => {
-  if (product === 'joy-ui') {
+export const getRootIndex = (productId?: 'joy-ui' | 'base-ui') => {
+  if (productId === 'joy-ui') {
     return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider, CssVarsProvider } from '@mui/joy/styles';
@@ -62,7 +62,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
   </React.StrictMode>
 );`;
   }
-  if (product === 'base-ui') {
+  if (productId === 'base-ui') {
     return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import Demo from './demo';

--- a/docs/src/modules/sandbox/StackBlitz.ts
+++ b/docs/src/modules/sandbox/StackBlitz.ts
@@ -11,7 +11,7 @@ const createReactApp = (demo: {
   raw: string;
   codeVariant: CodeVariant;
   githubLocation: string;
-  product?: Product;
+  productId?: Product;
   codeStyling?: CodeStyling;
 }) => {
   const ext = getFileExtension(demo.codeVariant);
@@ -19,7 +19,7 @@ const createReactApp = (demo: {
 
   const files: Record<string, string> = {
     'index.html': CRA.getHtml(demo),
-    [`index.${ext}`]: CRA.getRootIndex(demo.product),
+    [`index.${ext}`]: CRA.getRootIndex(demo.productId),
     [`demo.${ext}`]: demo.raw,
     ...(demo.codeVariant === 'TS' && {
       'tsconfig.json': CRA.getTsconfig(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Regression from #37729

When open a CodeSandbox from any Joy UI component, the `index.tsx` uses `@mui/material`. Turns out it could not pick up the correct product identifier because the name of the variable changed in #37729.

**Before**: open the code sandbox from https://deploy-preview-37729--material-ui.netlify.app/joy-ui/react-button/


https://github.com/mui/material-ui/assets/18292247/e26c3c3a-6014-4b00-98bb-9d350dea2292



**After**: try the deploy preview in this PR

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
