### PR TITLE
[docs] Add missing Portal elements to Tailwind CSS interoperability guide

### DIFF
--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -707,6 +707,16 @@ const theme = createTheme({
         container: rootElement,
       },
     },
+    MuiDialog: {
+      defaultProps: {
+        container: rootElement,
+      },
+    },
+    MuiModal: {
+      defaultProps: {
+        container: rootElement,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/36390

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

While implementing interoperability with Tailwind I was having issues with components inside my Dialog component. Turns out the guide is missing some Portal elements according to [this comment](https://github.com/mui/material-ui/issues/36390#issuecomment-1461312169). This PR adds the missing elements to the documentation so others don't waste time looking at this issue and wondering why it's not working.