### PR TITLE
[Docs][Joy][Table] Add `undefined` as an option to `stripe`

### DIFF
--- a/docs/data/joy/components/table/TableUsage.js
+++ b/docs/data/joy/components/table/TableUsage.js
@@ -46,7 +46,7 @@ export default function ButtonUsage() {
         {
           propName: 'stripe',
           knob: 'radio',
-          options: ['odd', 'even'],
+          options: ['undefined', 'odd', 'even'],
         },
       ]}
       getCodeBlock={(code) => `<Sheet>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This adds `undefined` as an option for the `stripe` property so that it can be disabled without resetting all customizations.

<img width="622" alt="image" src="https://github.com/mui/material-ui/assets/1693592/efc060fc-1f7f-4374-a9d2-602ef0efc4ad">