### PR TITLE
[Docs][Joy][Link] Set `variant` and `color` defaults for the playground

### DIFF
--- a/docs/data/joy/components/link/LinkUsage.js
+++ b/docs/data/joy/components/link/LinkUsage.js
@@ -22,7 +22,6 @@ export default function LinkUsage() {
         {
           propName: 'variant',
           knob: 'select',
-          defaultValue: 'plain',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },
         {

--- a/docs/data/joy/components/link/LinkUsage.js
+++ b/docs/data/joy/components/link/LinkUsage.js
@@ -28,6 +28,7 @@ export default function LinkUsage() {
         {
           propName: 'color',
           knob: 'color',
+          defaultValue: 'primary',
         },
         { propName: 'disabled', knob: 'switch' },
       ]}

--- a/docs/data/joy/components/link/LinkUsage.js
+++ b/docs/data/joy/components/link/LinkUsage.js
@@ -21,7 +21,7 @@ export default function LinkUsage() {
         },
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },
         {

--- a/docs/data/joy/components/link/LinkUsage.js
+++ b/docs/data/joy/components/link/LinkUsage.js
@@ -22,6 +22,7 @@ export default function LinkUsage() {
         {
           propName: 'variant',
           knob: 'select',
+          defaultValue: 'plain',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },
         {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This sets the default variant in the `Link` playground to `plain` and the default color to `primary` to keep `variant="null"` from showing and to make sure the current style is properly reflected in the playground options.

| Before | After |
| ------ | ----- |
| <img width="624" alt="image" src="https://github.com/mui/material-ui/assets/1693592/710e7390-b2c2-4e6c-a460-1e3ff44c1152"> | <img width="619" alt="image" src="https://github.com/mui/material-ui/assets/1693592/5e989784-ffe9-41d6-ba9b-606bdb9d65dc"> |