### PR TITLE
[docs][joy] Add playground for Card component

### DIFF
--- a/docs/data/joy/components/card/CardUsage.js
+++ b/docs/data/joy/components/card/CardUsage.js
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import AspectRatio from '@mui/joy/AspectRatio';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import Card from '@mui/joy/Card';
+import Typography from '@mui/joy/Typography';
+import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
+import { CardActions, CardContent } from '@mui/joy';
+
+export default function CardUsage() {
+  return (
+    <JoyUsageDemo
+      componentName="Card"
+      data={[
+        {
+          propName: 'variant',
+          knob: 'select',
+          defaultValue: 'plain',
+          options: ['plain', 'outlined', 'soft', 'solid'],
+        },
+        {
+          propName: 'color',
+          knob: 'color',
+          defaultValue: 'neutral',
+        },
+        {
+          propName: 'size',
+          knob: 'radio',
+          options: ['sm', 'md', 'lg'],
+          defaultValue: 'md',
+        },
+        {
+          propName: 'orientation',
+          knob: 'radio',
+          defaultValue: 'vertical',
+          options: ['horizontal', 'vertical'],
+        },
+        { propName: 'invertedColors', knob: 'switch' },
+      ]}
+      renderDemo={(props) => (
+        <Card
+          {...props}
+          sx={{
+            m: 1,
+            mb: 4
+          }}
+        >
+          <AspectRatio ratio="1" sx={{ width: 160 }}>
+            <img
+              src="https://images.unsplash.com/photo-1527549993586-dff825b37782?auto=format&fit=crop&w=286"
+              srcSet="https://images.unsplash.com/photo-1527549993586-dff825b37782?auto=format&fit=crop&w=286&dpr=2 2x"
+              loading="lazy"
+              alt=""
+            />
+          </AspectRatio>
+          <CardContent>
+            <Typography level="h4">Yosemite</Typography>
+            <Typography level="body2">April 24 to May 02, 2021</Typography>
+            <CardActions>
+              <Button>Explore</Button>
+            </CardActions>
+          </CardContent>
+        </Card>
+      )}
+    />
+  );
+}

--- a/docs/data/joy/components/card/CardUsage.js
+++ b/docs/data/joy/components/card/CardUsage.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import AspectRatio from '@mui/joy/AspectRatio';
-import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Card from '@mui/joy/Card';
 import Typography from '@mui/joy/Typography';
@@ -33,7 +32,7 @@ export default function CardUsage() {
           propName: 'orientation',
           knob: 'radio',
           defaultValue: 'vertical',
-          options: ['horizontal', 'vertical'],
+          options: ['vertical', 'horizontal'],
         },
         { propName: 'invertedColors', knob: 'switch' },
       ]}
@@ -42,10 +41,10 @@ export default function CardUsage() {
           {...props}
           sx={{
             m: 1,
-            mb: 4
+            mb: 4,
           }}
         >
-          <AspectRatio ratio="1" sx={{ width: 160 }}>
+          <AspectRatio ratio="16/9" sx={{ width: 160 }}>
             <img
               src="https://images.unsplash.com/photo-1527549993586-dff825b37782?auto=format&fit=crop&w=286"
               srcSet="https://images.unsplash.com/photo-1527549993586-dff825b37782?auto=format&fit=crop&w=286&dpr=2 2x"
@@ -54,10 +53,12 @@ export default function CardUsage() {
             />
           </AspectRatio>
           <CardContent>
-            <Typography level="h4">Yosemite</Typography>
+            <Typography fontWeight="lg" textColor="inherit">
+              Yosemite
+            </Typography>
             <Typography level="body2">April 24 to May 02, 2021</Typography>
             <CardActions>
-              <Button>Explore</Button>
+              <Button size="sm">Explore</Button>
             </CardActions>
           </CardContent>
         </Card>

--- a/docs/data/joy/components/card/card.md
+++ b/docs/data/joy/components/card/card.md
@@ -19,6 +19,8 @@ The Joy UI Card component includes several complementary utility components to h
 - [Card Content](#card-layers): an optional wrapper that brings content to the front (commonly but not always used with the Card Cover).
 - [Card Actions](#actions): an optional wrapper that groups a set of buttons.
 
+{{"demo": "CardUsage.js", "hideToolbar": true, "bg": "gradient"}}
+
 ## Basics
 
 ```jsx


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This adds a playground to the introduction section of the `Card` component to demo its variants, colors, size, orientation and inverted colors.

<img width="620" alt="image" src="https://github.com/mui/material-ui/assets/1693592/c06ee31e-3681-43e7-b536-901aeba5fccc">

My apologies if this was omitted for a reason. Should there be documentation about the variants and colors? Most components have demos for variants and colors, this is also absent from the Card documentation.