### PR TITLE
[docs-infra][joy] Change Joy UI's playground variant selector 

### DIFF
--- a/docs/data/joy/components/alert/AlertUsage.js
+++ b/docs/data/joy/components/alert/AlertUsage.js
@@ -9,7 +9,7 @@ export default function AlertUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'soft',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/avatar/AvatarUsage.js
+++ b/docs/data/joy/components/avatar/AvatarUsage.js
@@ -10,7 +10,7 @@ export default function AvatarUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'soft',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/badge/BadgeUsage.js
+++ b/docs/data/joy/components/badge/BadgeUsage.js
@@ -10,7 +10,7 @@ export default function BadgeUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'solid',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/button-group/ButtonGroupUsage.js
+++ b/docs/data/joy/components/button-group/ButtonGroupUsage.js
@@ -12,7 +12,7 @@ export default function ButtonUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/button/ButtonUsage.js
+++ b/docs/data/joy/components/button/ButtonUsage.js
@@ -12,7 +12,7 @@ export default function ButtonUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'solid',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/checkbox/CheckboxUsage.js
+++ b/docs/data/joy/components/checkbox/CheckboxUsage.js
@@ -9,7 +9,7 @@ export default function CheckboxUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/chip/ChipUsage.js
+++ b/docs/data/joy/components/chip/ChipUsage.js
@@ -9,7 +9,7 @@ export default function ChipUsages() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'solid',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/circular-progress/CircularProgressUsage.js
+++ b/docs/data/joy/components/circular-progress/CircularProgressUsage.js
@@ -9,7 +9,7 @@ export default function CircularProgressUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'soft',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/input/InputUsage.js
+++ b/docs/data/joy/components/input/InputUsage.js
@@ -9,7 +9,7 @@ export default function InputUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/linear-progress/LinearProgressUsage.js
+++ b/docs/data/joy/components/linear-progress/LinearProgressUsage.js
@@ -10,7 +10,7 @@ export default function LinearProgressUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'soft',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/link/LinkUsage.js
+++ b/docs/data/joy/components/link/LinkUsage.js
@@ -21,7 +21,7 @@ export default function LinkUsage() {
         },
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },
         {

--- a/docs/data/joy/components/list/ListUsage.js
+++ b/docs/data/joy/components/list/ListUsage.js
@@ -17,7 +17,7 @@ export default function ListUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           options: ['plain', 'outlined', 'soft', 'solid'],
           defaultValue: 'plain',
         },

--- a/docs/data/joy/components/menu/MenuUsage.js
+++ b/docs/data/joy/components/menu/MenuUsage.js
@@ -27,7 +27,7 @@ export default function MenuUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/modal/ModalUsage.js
+++ b/docs/data/joy/components/modal/ModalUsage.js
@@ -16,7 +16,7 @@ export default function ModalUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/radio-button/RadioUsage.js
+++ b/docs/data/joy/components/radio-button/RadioUsage.js
@@ -12,7 +12,7 @@ export default function RadioUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'soft',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/select/SelectUsage.js
+++ b/docs/data/joy/components/select/SelectUsage.js
@@ -12,7 +12,7 @@ export default function SelectUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/sheet/SheetUsage.js
+++ b/docs/data/joy/components/sheet/SheetUsage.js
@@ -9,7 +9,7 @@ export default function SheetUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'plain',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/slider/SliderUsage.js
+++ b/docs/data/joy/components/slider/SliderUsage.js
@@ -10,7 +10,7 @@ export default function SliderUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'solid',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/switch/SwitchUsage.js
+++ b/docs/data/joy/components/switch/SwitchUsage.js
@@ -9,7 +9,7 @@ export default function SwitchUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           options: ['plain', 'outlined', 'soft', 'solid'],
           defaultValue: 'solid',
         },

--- a/docs/data/joy/components/table/TableUsage.js
+++ b/docs/data/joy/components/table/TableUsage.js
@@ -12,7 +12,7 @@ export default function ButtonUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'plain',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/tabs/TabsUsage.js
+++ b/docs/data/joy/components/tabs/TabsUsage.js
@@ -12,7 +12,7 @@ export default function TabsUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
           codeBlockDisplay: false,

--- a/docs/data/joy/components/textarea/TextareaUsage.js
+++ b/docs/data/joy/components/textarea/TextareaUsage.js
@@ -9,7 +9,7 @@ export default function TextareaUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'outlined',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/tooltip/TooltipUsage.js
+++ b/docs/data/joy/components/tooltip/TooltipUsage.js
@@ -11,7 +11,7 @@ export default function TooltipUsage() {
       data={[
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'solid',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },

--- a/docs/data/joy/components/typography/TypographyUsage.js
+++ b/docs/data/joy/components/typography/TypographyUsage.js
@@ -35,7 +35,7 @@ export default function TypographyUsages() {
 
         {
           propName: 'variant',
-          knob: 'select',
+          knob: 'radio',
           defaultValue: 'plain',
           options: ['plain', 'outlined', 'soft', 'solid'],
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Following recent contributor feedback, I'm changing the variant selector on Joy UI's playground from a Select component to a Chip (radio button under the hood). If you're interacting with it a lot, it's one less click and a bit more convenient experience! 😊 
