### PR TITLE
[docs][material] fix type error in SplitButton.tsx

### DIFF
--- a/docs/data/material/components/button-group/SplitButton.tsx
+++ b/docs/data/material/components/button-group/SplitButton.tsx
@@ -21,7 +21,7 @@ export default function SplitButton() {
   };
 
   const handleMenuItemClick = (
-    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    event: React.MouseEvent<HTMLLIElement>,
     index: number,
   ) => {
     setSelectedIndex(index);


### PR DESCRIPTION
```
Argument of type 'MouseEvent<HTMLLIElement, MouseEvent>' is not assignable to parameter of type 'MouseEvent<HTMLLIElement, MouseEvent<Element, MouseEvent>>'. Type 'MouseEvent' is missing the following properties from type 'MouseEvent<Element, MouseEvent>': nativeEvent, isDefaultPrevented, isPropagationStopped, persist
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
