### PR TITLE
[docs] Fix pickers product name

### DIFF
--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -417,7 +417,7 @@ function resolveComponentApiUrl(product, componentPkg, component) {
   if (!product) {
     return `/api/${kebabCase(component)}/`;
   }
-  if (product === 'date-pickers') {
+  if (product === 'x-date-pickers') {
     return `/x/api/date-pickers/${kebabCase(component)}/`;
   }
   if (componentPkg === 'mui-base' || BaseUIReexportedComponents.indexOf(component) >= 0) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `productId` for pickers is used as `x-date-pickers` everywhere else.
It makes sense to align it here as well in order to avoid having discrepancy, between, which `productId` to add to the `md` file when. 🤷 
