### PR TITLE
[utils] Add function overload for `useEventCallback`

### DIFF
--- a/packages/mui-utils/src/useEventCallback/useEventCallback.spec.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.spec.ts
@@ -8,4 +8,14 @@ function InferenceTest() {
   useEventCallback((event: MouseEvent) => {
     expectType<MouseEvent, typeof event>(event);
   });
+  useEventCallback<[MouseEvent, number], number>((event, count) => {
+    expectType<MouseEvent, typeof event>(event);
+    expectType<number, typeof count>(count);
+    return count;
+  });
+  useEventCallback<(event: MouseEvent, count: number) => number>((event, count) => {
+    expectType<MouseEvent, typeof event>(event);
+    expectType<number, typeof count>(count);
+    return count;
+  });
 }

--- a/packages/mui-utils/src/useEventCallback/useEventCallback.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.ts
@@ -5,7 +5,7 @@ import useEnhancedEffect from '../useEnhancedEffect';
 /**
  * https://github.com/facebook/react/issues/14099#issuecomment-440013892
  */
-function useEventCallback<Fn extends (...args: any[]) => any = (...args: unknown[]) => any>(
+function useEventCallback<Fn extends (...args: any[]) => any = (...args: unknown[]) => unknown>(
   fn: Fn,
 ): Fn;
 function useEventCallback<Args extends unknown[], Return>(

--- a/packages/mui-utils/src/useEventCallback/useEventCallback.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.ts
@@ -5,9 +5,9 @@ import useEnhancedEffect from '../useEnhancedEffect';
 /**
  * https://github.com/facebook/react/issues/14099#issuecomment-440013892
  */
-function useEventCallback<T extends (...args: any[]) => any = (...args: unknown[]) => any>(
-  fn: T,
-): T;
+function useEventCallback<Fn extends (...args: any[]) => any = (...args: unknown[]) => any>(
+  fn: Fn,
+): Fn;
 function useEventCallback<Args extends unknown[], Return>(
   fn: (...args: Args) => Return,
 ): (...args: Args) => Return;

--- a/packages/mui-utils/src/useEventCallback/useEventCallback.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.ts
@@ -5,7 +5,13 @@ import useEnhancedEffect from '../useEnhancedEffect';
 /**
  * https://github.com/facebook/react/issues/14099#issuecomment-440013892
  */
-export default function useEventCallback<Args extends unknown[], Return>(
+function useEventCallback<T extends (...args: any[]) => any = (...args: unknown[]) => any>(
+  fn: T,
+): T;
+function useEventCallback<Args extends unknown[], Return>(
+  fn: (...args: Args) => Return,
+): (...args: Args) => Return;
+function useEventCallback<Args extends unknown[], Return>(
   fn: (...args: Args) => Return,
 ): (...args: Args) => Return {
   const ref = React.useRef(fn);
@@ -20,3 +26,5 @@ export default function useEventCallback<Args extends unknown[], Return>(
     [],
   );
 }
+
+export default useEventCallback;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In MUI X, we often type `React.useCallback` like this:
```tsx
const callback = React.useCallback<(param1: number) => number>((param1) => param, []);

// Example: https://github.com/mui/mui-x/blob/b3939c9f83296e2958daf091f4788524616775c1/packages/grid/x-data-grid-pro/src/hooks/features/columnReorder/useGridColumnReorder.tsx#L86
```

`useEventCallback` doesn't support the same signature, so when we replace `React.useCallback` with `useEventCallback` we need to change the typing - here is an example: https://github.com/mui/mui-x/pull/9394#discussion_r1252296866

This PR adds a function overload to `useEventCallback` that is compatible with `React.useCallback`, so that it's easier to switch between `React.useCallback` and `useEventCallback`:
```diff
-const handleDragEnter = React.useCallback<
+const handleDragEnter = useEventCallback<
    GridEventListener<'cellDragEnter' | 'columnHeaderDragEnter'>
  >((params, event) => {
```