### PR TITLE
[docs-infra] Fix code parser

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "marked": "^4.3.0",
-    "marked-highlight": "^2.0.1",
+    "marked": "^5.1.0",
     "prismjs": "^1.29.0"
   }
 }

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -1,5 +1,4 @@
 const { marked } = require('marked');
-const { markedHighlight } = require('marked-highlight');
 const kebabCase = require('lodash/kebabCase');
 const textToHash = require('./textToHash');
 const prism = require('./prism');
@@ -355,10 +354,7 @@ function createRender(context) {
       headerPrefix: false,
       headerIds: false,
       mangle: false,
-      ...markedHighlight({
-        highlight: prism,
-      }),
-      renderer, // Should be after markedHighlight since it overrides `renderer.code`
+      renderer,
     };
 
     marked.use({

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -454,7 +454,7 @@ authors:
 
 See https://ahrefs.com/blog/trailing-slash/ for more details.
 
-Please report this to https://github.com/markedjs/marked.`);
+Please report this to https://github.com/markedjs/this.`);
     });
 
     it('should report missing leading splashes', () => {
@@ -475,7 +475,7 @@ Please report this to https://github.com/markedjs/marked.`);
       }).to.throw(`docs-infra: Missing leading slash. The following link:
 [foo](foo/) in /test/bar/index.md is missing a leading slash, please add it.
 
-Please report this to https://github.com/markedjs/marked.`);
+Please report this to https://github.com/markedjs/this.`);
     });
 
     it('should report title too long', () => {

--- a/packages/markdown/textToHash.test.js
+++ b/packages/markdown/textToHash.test.js
@@ -17,7 +17,7 @@ describe('textToHash', () => {
     ];
     table.forEach((entry, index) => {
       const [markdown, expected] = entry;
-      const text = renderInlineMarkdown(markdown);
+      const text = renderInlineMarkdown(markdown, { mangle: false, headerIds: false });
       const actual = textToHash(text);
 
       expect(actual).to.equal(expected, `snapshot #${index} matches`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11129,15 +11129,10 @@ markdownlint@0.29.0:
     markdown-it "13.0.1"
     markdownlint-micromark "0.1.5"
 
-marked-highlight@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/marked-highlight/-/marked-highlight-2.0.1.tgz#a2b48533df77ea73bec3895be98bae6160dceec3"
-  integrity sha512-LDUfR/zDvD+dJ+lQOWHkxvBLNxiXcaN8pBtwJ/i4pI0bkDC/Ef6Mz1qUrAuHXfnpdr2rabdMpVFhqFuU+5Mskg==
-
-marked@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
-  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+marked@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-5.1.0.tgz#cf51f03ba04dfb3469774029fd0106d258658767"
+  integrity sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==
 
 material-ui-popup-state@^5.0.9:
   version "5.0.9"


### PR DESCRIPTION
For a reason I ignore, it was parsing the code already parsed 🫠

Just updated `marked` to v5