### PR TITLE
[docs-infra] Fix TypeScrit error in demo export

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -612,7 +612,7 @@ export default function DemoToolbar(props) {
                   data-ga-event-category="demo"
                   data-ga-event-label={demo.gaLabel}
                   data-ga-event-action="codesandbox"
-                  onClick={() => codeSandbox.createReactApp(demoData).openSandbox('/demo')}
+                  onClick={() => codeSandbox.createReactApp(demoData).openSandbox()}
                   {...getControlProps(4)}
                   sx={{ borderRadius: 1 }}
                 >
@@ -626,7 +626,7 @@ export default function DemoToolbar(props) {
                   data-ga-event-category="demo"
                   data-ga-event-label={demo.gaLabel}
                   data-ga-event-action="stackblitz"
-                  onClick={() => stackBlitz.createReactApp(demoData).openSandbox('demo')}
+                  onClick={() => stackBlitz.createReactApp(demoData).openSandbox()}
                   {...getControlProps(5)}
                   sx={{ borderRadius: 1 }}
                 >

--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -44,16 +44,55 @@ describe('CodeSandbox', () => {
         },
       },
       'public/index.html': {
-        content:
-          '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <title>BasicButtons Material Demo</title>\n    <!-- Fonts to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"\n    />\n    <!-- Icons to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/icon?family=Material+Icons"\n    />\n  </head>\n  <body>\n    <div id="root"></div>\n  </body>\n</html>',
+        content: `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>BasicButtons Material Demo</title>
+    <!-- Fonts to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <!-- Icons to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`,
       },
-      'demo.js': {
-        content:
-          'import * as React from \'react\';\nimport Stack from \'@mui/material/Stack\';\nimport Button from \'@mui/material/Button\';\n\nexport default function BasicButtons() {\n  return (\n    <Stack spacing={2} direction="row">\n      <Button variant="text">Text</Button>\n      <Button variant="contained">Contained</Button>\n      <Button variant="outlined">Outlined</Button>\n    </Stack>\n  );\n}\n',
+      'Demo.js': {
+        content: `import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+
+export default function BasicButtons() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button variant="text">Text</Button>
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+    </Stack>
+  );
+}
+`,
       },
       'index.js': {
-        content:
-          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+        content: `import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import { StyledEngineProvider } from '@mui/material/styles';
+import Demo from './Demo';
+
+ReactDOM.createRoot(document.querySelector("#root")).render(
+  <React.StrictMode>
+    <StyledEngineProvider injectFirst>
+      <Demo />
+    </StyledEngineProvider>
+  </React.StrictMode>
+);`,
       },
     });
   });
@@ -92,20 +131,83 @@ describe('CodeSandbox', () => {
         },
       },
       'public/index.html': {
-        content:
-          '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <title>BasicButtons Material Demo</title>\n    <!-- Fonts to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"\n    />\n    <!-- Icons to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/icon?family=Material+Icons"\n    />\n  </head>\n  <body>\n    <div id="root"></div>\n  </body>\n</html>',
+        content: `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>BasicButtons Material Demo</title>
+    <!-- Fonts to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <!-- Icons to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`,
       },
-      'demo.tsx': {
-        content:
-          'import * as React from \'react\';\nimport Stack from \'@mui/material/Stack\';\nimport Button from \'@mui/material/Button\';\n\nexport default function BasicButtons() {\n  return (\n    <Stack spacing={2} direction="row">\n      <Button variant="text">Text</Button>\n      <Button variant="contained">Contained</Button>\n      <Button variant="outlined">Outlined</Button>\n    </Stack>\n  );\n}\n',
+      'Demo.tsx': {
+        content: `import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+
+export default function BasicButtons() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button variant="text">Text</Button>
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+    </Stack>
+  );
+}
+`,
       },
       'index.tsx': {
-        content:
-          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+        content: `import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import { StyledEngineProvider } from '@mui/material/styles';
+import Demo from './Demo';
+
+ReactDOM.createRoot(document.querySelector("#root")!).render(
+  <React.StrictMode>
+    <StyledEngineProvider injectFirst>
+      <Demo />
+    </StyledEngineProvider>
+  </React.StrictMode>
+);`,
       },
       'tsconfig.json': {
-        content:
-          '{\n  "compilerOptions": {\n    "target": "es5",\n    "lib": [\n      "dom",\n      "dom.iterable",\n      "esnext"\n    ],\n    "allowJs": true,\n    "skipLibCheck": true,\n    "esModuleInterop": true,\n    "allowSyntheticDefaultImports": true,\n    "strict": true,\n    "forceConsistentCasingInFileNames": true,\n    "module": "esnext",\n    "moduleResolution": "node",\n    "resolveJsonModule": true,\n    "isolatedModules": true,\n    "noEmit": true,\n    "jsx": "react"\n  },\n  "include": [\n    "src"\n  ]\n}\n',
+        content: `{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": [
+    "src"
+  ]
+}
+`,
       },
     });
     expect(result.dependencies).to.deep.equal({

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -13,7 +13,7 @@ function compress(object: any) {
     .replace(/=+$/, ''); // Remove ending '='
 }
 
-function openSandbox({ files, codeVariant, initialFile = '/App' }: any) {
+function openSandbox({ files, codeVariant, initialFile }: any) {
   const extension = codeVariant === 'TS' ? '.tsx' : '.js';
   const parameters = compress({ files });
 
@@ -80,10 +80,10 @@ const createReactApp = (demoData: DemoData) => {
     devDependencies,
     /**
      * @param {string} initialFile
-     * @description should start with `/`, e.g. `/demo.tsx`. If the extension is not provided,
+     * @description should start with `/`, e.g. `/Demo.tsx`. If the extension is not provided,
      * it will be appended based on the code variant.
      */
-    openSandbox: (initialFile?: string) =>
+    openSandbox: (initialFile: string = `/Demo.${ext}`) =>
       openSandbox({ files, codeVariant: demoData.codeVariant, initialFile }),
   };
 };
@@ -169,7 +169,7 @@ ReactDOM.createRoot(document.querySelector("#root")${type}).render(
     files,
     dependencies,
     devDependencies,
-    openSandbox: (initialFile?: string) =>
+    openSandbox: (initialFile: string = '/App') =>
       openSandbox({ files, codeVariant: templateData.codeVariant, initialFile }),
   };
 };

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -1,10 +1,10 @@
 // @ts-ignore
 import LZString from 'lz-string';
 import addHiddenInput from 'docs/src/modules/utils/addHiddenInput';
-import SandboxDependencies from './Dependencies';
-import * as CRA from './CreateReactApp';
-import getFileExtension from './FileExtension';
-import { CodeVariant, Product, CodeStyling } from './types';
+import SandboxDependencies from 'docs/src/modules/sandbox/Dependencies';
+import * as CRA from 'docs/src/modules/sandbox/CreateReactApp';
+import getFileExtension from 'docs/src/modules/sandbox/FileExtension';
+import { DemoData, CodeVariant, CodeStyling } from 'docs/src/modules/sandbox/types';
 
 function compress(object: any) {
   return LZString.compressToBase64(JSON.stringify(object))
@@ -33,36 +33,28 @@ function openSandbox({ files, codeVariant, initialFile = '/App' }: any) {
   document.body.removeChild(form);
 }
 
-const createReactApp = (demo: {
-  title: string;
-  language: string;
-  raw: string;
-  codeVariant: CodeVariant;
-  githubLocation: string;
-  productId?: Product;
-  codeStyling: CodeStyling;
-}) => {
-  const ext = getFileExtension(demo.codeVariant);
-  const { title, githubLocation: description } = demo;
+const createReactApp = (demoData: DemoData) => {
+  const ext = getFileExtension(demoData.codeVariant);
+  const { title, githubLocation: description } = demoData;
 
   const files: Record<string, object> = {
     'public/index.html': {
-      content: CRA.getHtml(demo),
+      content: CRA.getHtml(demoData),
     },
     [`index.${ext}`]: {
-      content: CRA.getRootIndex(demo.productId),
+      content: CRA.getRootIndex(demoData),
     },
     [`demo.${ext}`]: {
-      content: demo.raw,
+      content: demoData.raw,
     },
-    ...(demo.codeVariant === 'TS' && {
+    ...(demoData.codeVariant === 'TS' && {
       'tsconfig.json': {
         content: CRA.getTsconfig(),
       },
     }),
   };
 
-  const { dependencies, devDependencies } = SandboxDependencies(demo, {
+  const { dependencies, devDependencies } = SandboxDependencies(demoData, {
     commitRef: process.env.PULL_REQUEST_ID ? process.env.COMMIT_REF : undefined,
   });
 
@@ -71,7 +63,7 @@ const createReactApp = (demo: {
       description,
       dependencies,
       devDependencies,
-      ...(demo.codeVariant === 'TS' && {
+      ...(demoData.codeVariant === 'TS' && {
         main: 'index.tsx',
         scripts: {
           start: 'react-scripts start',
@@ -92,26 +84,29 @@ const createReactApp = (demo: {
      * it will be appended based on the code variant.
      */
     openSandbox: (initialFile?: string) =>
-      openSandbox({ files, codeVariant: demo.codeVariant, initialFile }),
+      openSandbox({ files, codeVariant: demoData.codeVariant, initialFile }),
   };
 };
 
-const createJoyTemplate = (demo: {
+const createJoyTemplate = (templateData: {
   title: string;
   files: Record<string, string>;
   githubLocation: string;
-  codeVariant: 'TS' | 'JS';
-  codeStyling?: 'Tailwind' | 'MUI System';
+  codeVariant: CodeVariant;
+  codeStyling?: CodeStyling;
 }) => {
-  const ext = getFileExtension(demo.codeVariant);
-  const { title, githubLocation: description } = demo;
+  const ext = getFileExtension(templateData.codeVariant);
+  const { title, githubLocation: description } = templateData;
+
+  // document.querySelector returns 'Element | null' but createRoot expects 'Element | DocumentFragment'.
+  const type = templateData.codeVariant === 'TS' ? '!' : '';
 
   const files: Record<string, object> = {
     'public/index.html': {
       content: CRA.getHtml({
-        title: demo.title,
+        title: templateData.title,
         language: 'en',
-        codeStyling: demo.codeStyling ?? 'MUI System',
+        codeStyling: templateData.codeStyling ?? 'MUI System',
       }),
     },
     [`index.${ext}`]: {
@@ -120,7 +115,7 @@ import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/joy/styles';
 import App from './App';
 
-ReactDOM.createRoot(document.querySelector("#root")).render(
+ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>
     <StyledEngineProvider injectFirst>
       <App />
@@ -128,7 +123,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
   </React.StrictMode>
 );`,
     },
-    ...Object.entries(demo.files).reduce(
+    ...Object.entries(templateData.files).reduce(
       (prev, curr) => ({
         ...prev,
         [curr[0]]: {
@@ -137,7 +132,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
       }),
       {},
     ),
-    ...(demo.codeVariant === 'TS' && {
+    ...(templateData.codeVariant === 'TS' && {
       'tsconfig.json': {
         content: CRA.getTsconfig(),
       },
@@ -146,8 +141,8 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
 
   const { dependencies, devDependencies } = SandboxDependencies(
     {
-      codeVariant: demo.codeVariant,
-      raw: Object.entries(demo.files).reduce((prev, curr) => `${prev}\n${curr}`, ''),
+      codeVariant: templateData.codeVariant,
+      raw: Object.entries(templateData.files).reduce((prev, curr) => `${prev}\n${curr}`, ''),
       productId: 'joy-ui',
     },
     {
@@ -160,7 +155,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
       description,
       dependencies,
       devDependencies,
-      ...(demo.codeVariant === 'TS' && {
+      ...(templateData.codeVariant === 'TS' && {
         main: 'index.tsx',
         scripts: {
           start: 'react-scripts start',
@@ -175,7 +170,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
     dependencies,
     devDependencies,
     openSandbox: (initialFile?: string) =>
-      openSandbox({ files, codeVariant: demo.codeVariant, initialFile }),
+      openSandbox({ files, codeVariant: templateData.codeVariant, initialFile }),
   };
 };
 

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -44,7 +44,7 @@ const createReactApp = (demoData: DemoData) => {
     [`index.${ext}`]: {
       content: CRA.getRootIndex(demoData),
     },
-    [`demo.${ext}`]: {
+    [`Demo.${ext}`]: {
       content: demoData.raw,
     },
     ...(demoData.codeVariant === 'TS' && {

--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -1,3 +1,5 @@
+import { DemoData } from 'docs/src/modules/sandbox/types';
+
 export const getHtml = ({
   title,
   language,
@@ -45,14 +47,17 @@ export const getHtml = ({
 </html>`;
 };
 
-export const getRootIndex = (productId?: 'joy-ui' | 'base-ui') => {
-  if (productId === 'joy-ui') {
+export function getRootIndex(demoData: DemoData) {
+  // document.querySelector returns 'Element | null' but createRoot expects 'Element | DocumentFragment'.
+  const type = demoData.codeVariant === 'TS' ? '!' : '';
+
+  if (demoData.productId === 'joy-ui') {
     return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider, CssVarsProvider } from '@mui/joy/styles';
 import Demo from './demo';
 
-ReactDOM.createRoot(document.querySelector("#root")).render(
+ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>
     <StyledEngineProvider injectFirst>
       <CssVarsProvider>
@@ -62,12 +67,12 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
   </React.StrictMode>
 );`;
   }
-  if (productId === 'base-ui') {
+  if (demoData.productId === 'base-ui') {
     return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import Demo from './demo';
 
-ReactDOM.createRoot(document.querySelector("#root")).render(
+ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>
     <Demo />
   </React.StrictMode>
@@ -78,14 +83,14 @@ import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';
 import Demo from './demo';
 
-ReactDOM.createRoot(document.querySelector("#root")).render(
+ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>
     <StyledEngineProvider injectFirst>
       <Demo />
     </StyledEngineProvider>
   </React.StrictMode>
 );`;
-};
+}
 
 export const getTsconfig = () => `{
   "compilerOptions": {

--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -55,7 +55,7 @@ export function getRootIndex(demoData: DemoData) {
     return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider, CssVarsProvider } from '@mui/joy/styles';
-import Demo from './demo';
+import Demo from './Demo';
 
 ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>
@@ -70,7 +70,7 @@ ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   if (demoData.productId === 'base-ui') {
     return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
-import Demo from './demo';
+import Demo from './Demo';
 
 ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>
@@ -81,7 +81,7 @@ ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   return `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';
-import Demo from './demo';
+import Demo from './Demo';
 
 ReactDOM.createRoot(document.querySelector("#root")${type}).render(
   <React.StrictMode>

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -1,4 +1,5 @@
-import { CODE_VARIANTS } from '../constants';
+import { CODE_VARIANTS } from 'docs/src/modules/constants';
+import type { MuiProductId } from 'docs/src/modules/utils/getProductInfoFromUrl';
 
 type RegExpMatchArrayWithGroupsOnly<T> = {
   groups?: {
@@ -10,7 +11,7 @@ type RegExpMatchArrayWithGroups<T> = (RegExpMatchArray & RegExpMatchArrayWithGro
 export default function SandboxDependencies(
   demo: {
     raw: string;
-    productId?: 'joy-ui' | 'base-ui';
+    productId?: MuiProductId;
     codeVariant: keyof typeof CODE_VARIANTS;
   },
   options?: { commitRef?: string },

--- a/docs/src/modules/sandbox/StackBlitz.test.js
+++ b/docs/src/modules/sandbox/StackBlitz.test.js
@@ -17,7 +17,7 @@ export default function BasicButtons() {
 `;
 
 describe('StackBlitz', () => {
-  it('generate the correct javascript result', () => {
+  it('generate the correct JavaScript result', () => {
     const { openSandbox, ...result } = StackBlitz.createReactApp({
       title: 'BasicButtons Material Demo',
       githubLocation:
@@ -31,12 +31,51 @@ describe('StackBlitz', () => {
       description:
         'https://github.com/mui/material-ui/blob/v5.7.0/docs/data/material/components/buttons/BasicButtons.js',
       files: {
-        'index.html':
-          '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <title>BasicButtons Material Demo</title>\n    <!-- Fonts to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"\n    />\n    <!-- Icons to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/icon?family=Material+Icons"\n    />\n  </head>\n  <body>\n    <div id="root"></div>\n  </body>\n</html>',
-        'demo.js':
-          'import * as React from \'react\';\nimport Stack from \'@mui/material/Stack\';\nimport Button from \'@mui/material/Button\';\n\nexport default function BasicButtons() {\n  return (\n    <Stack spacing={2} direction="row">\n      <Button variant="text">Text</Button>\n      <Button variant="contained">Contained</Button>\n      <Button variant="outlined">Outlined</Button>\n    </Stack>\n  );\n}\n',
-        'index.js':
-          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
+        'index.html': `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>BasicButtons Material Demo</title>
+    <!-- Fonts to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <!-- Icons to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`,
+        'Demo.js': `import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+
+export default function BasicButtons() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button variant="text">Text</Button>
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+    </Stack>
+  );
+}
+`,
+        'index.js': `import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import { StyledEngineProvider } from '@mui/material/styles';
+import Demo from './Demo';
+
+ReactDOM.createRoot(document.querySelector("#root")).render(
+  <React.StrictMode>
+    <StyledEngineProvider injectFirst>
+      <Demo />
+    </StyledEngineProvider>
+  </React.StrictMode>
+);`,
       },
       dependencies: {
         react: 'latest',
@@ -51,7 +90,7 @@ describe('StackBlitz', () => {
     });
   });
 
-  it('generate the correct typescript result', () => {
+  it('generate the correct TypeScript result', () => {
     const { openSandbox, ...result } = StackBlitz.createReactApp({
       title: 'BasicButtons Material Demo',
       githubLocation:
@@ -65,14 +104,77 @@ describe('StackBlitz', () => {
       description:
         'https://github.com/mui/material-ui/blob/v5.7.0/docs/data/material/components/buttons/BasicButtons.tsx',
       files: {
-        'index.html':
-          '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <title>BasicButtons Material Demo</title>\n    <!-- Fonts to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"\n    />\n    <!-- Icons to support Material Design -->\n    <link\n      rel="stylesheet"\n      href="https://fonts.googleapis.com/icon?family=Material+Icons"\n    />\n  </head>\n  <body>\n    <div id="root"></div>\n  </body>\n</html>',
-        'demo.tsx':
-          'import * as React from \'react\';\nimport Stack from \'@mui/material/Stack\';\nimport Button from \'@mui/material/Button\';\n\nexport default function BasicButtons() {\n  return (\n    <Stack spacing={2} direction="row">\n      <Button variant="text">Text</Button>\n      <Button variant="contained">Contained</Button>\n      <Button variant="outlined">Outlined</Button>\n    </Stack>\n  );\n}\n',
-        'index.tsx':
-          "import * as React from 'react';\nimport * as ReactDOM from 'react-dom/client';\nimport { StyledEngineProvider } from '@mui/material/styles';\nimport Demo from './demo';\n\nReactDOM.createRoot(document.querySelector(\"#root\")).render(\n  <React.StrictMode>\n    <StyledEngineProvider injectFirst>\n      <Demo />\n    </StyledEngineProvider>\n  </React.StrictMode>\n);",
-        'tsconfig.json':
-          '{\n  "compilerOptions": {\n    "target": "es5",\n    "lib": [\n      "dom",\n      "dom.iterable",\n      "esnext"\n    ],\n    "allowJs": true,\n    "skipLibCheck": true,\n    "esModuleInterop": true,\n    "allowSyntheticDefaultImports": true,\n    "strict": true,\n    "forceConsistentCasingInFileNames": true,\n    "module": "esnext",\n    "moduleResolution": "node",\n    "resolveJsonModule": true,\n    "isolatedModules": true,\n    "noEmit": true,\n    "jsx": "react"\n  },\n  "include": [\n    "src"\n  ]\n}\n',
+        'index.html': `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>BasicButtons Material Demo</title>
+    <!-- Fonts to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <!-- Icons to support Material Design -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`,
+        'Demo.tsx': `import * as React from 'react';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+
+export default function BasicButtons() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button variant="text">Text</Button>
+      <Button variant="contained">Contained</Button>
+      <Button variant="outlined">Outlined</Button>
+    </Stack>
+  );
+}
+`,
+        'index.tsx': `import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import { StyledEngineProvider } from '@mui/material/styles';
+import Demo from './Demo';
+
+ReactDOM.createRoot(document.querySelector("#root")!).render(
+  <React.StrictMode>
+    <StyledEngineProvider injectFirst>
+      <Demo />
+    </StyledEngineProvider>
+  </React.StrictMode>
+);`,
+        'tsconfig.json': `{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": [
+    "src"
+  ]
+}
+`,
       },
       dependencies: {
         react: 'latest',

--- a/docs/src/modules/sandbox/StackBlitz.ts
+++ b/docs/src/modules/sandbox/StackBlitz.ts
@@ -29,7 +29,7 @@ const createReactApp = (demoData: DemoData) => {
     files,
     dependencies,
     devDependencies,
-    openSandbox: (initialFile = 'App') => {
+    openSandbox: (initialFile = `Demo.${ext}`) => {
       const extension = demoData.codeVariant === CODE_VARIANTS.TS ? '.tsx' : '.js';
       // ref: https://developer.stackblitz.com/docs/platform/post-api/
       const form = document.createElement('form');

--- a/docs/src/modules/sandbox/StackBlitz.ts
+++ b/docs/src/modules/sandbox/StackBlitz.ts
@@ -1,32 +1,24 @@
 import addHiddenInput from 'docs/src/modules/utils/addHiddenInput';
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
-import SandboxDependencies from './Dependencies';
-import * as CRA from './CreateReactApp';
-import getFileExtension from './FileExtension';
-import { CodeVariant, Product, CodeStyling } from './types';
+import SandboxDependencies from 'docs/src/modules/sandbox/Dependencies';
+import * as CRA from 'docs/src/modules/sandbox/CreateReactApp';
+import getFileExtension from 'docs/src/modules/sandbox/FileExtension';
+import { DemoData } from 'docs/src/modules/sandbox/types';
 
-const createReactApp = (demo: {
-  title: string;
-  language: string;
-  raw: string;
-  codeVariant: CodeVariant;
-  githubLocation: string;
-  productId?: Product;
-  codeStyling?: CodeStyling;
-}) => {
-  const ext = getFileExtension(demo.codeVariant);
-  const { title, githubLocation: description } = demo;
+const createReactApp = (demoData: DemoData) => {
+  const ext = getFileExtension(demoData.codeVariant);
+  const { title, githubLocation: description } = demoData;
 
   const files: Record<string, string> = {
-    'index.html': CRA.getHtml(demo),
-    [`index.${ext}`]: CRA.getRootIndex(demo.productId),
-    [`demo.${ext}`]: demo.raw,
-    ...(demo.codeVariant === 'TS' && {
+    'index.html': CRA.getHtml(demoData),
+    [`index.${ext}`]: CRA.getRootIndex(demoData),
+    [`demo.${ext}`]: demoData.raw,
+    ...(demoData.codeVariant === 'TS' && {
       'tsconfig.json': CRA.getTsconfig(),
     }),
   };
 
-  const { dependencies, devDependencies } = SandboxDependencies(demo, {
+  const { dependencies, devDependencies } = SandboxDependencies(demoData, {
     // Waiting for https://github.com/stackblitz/core/issues/437
     // commitRef: process.env.PULL_REQUEST_ID ? process.env.COMMIT_REF : undefined,
   });
@@ -38,7 +30,7 @@ const createReactApp = (demo: {
     dependencies,
     devDependencies,
     openSandbox: (initialFile = 'App') => {
-      const extension = demo.codeVariant === CODE_VARIANTS.TS ? '.tsx' : '.js';
+      const extension = demoData.codeVariant === CODE_VARIANTS.TS ? '.tsx' : '.js';
       // ref: https://developer.stackblitz.com/docs/platform/post-api/
       const form = document.createElement('form');
       form.method = 'POST';

--- a/docs/src/modules/sandbox/StackBlitz.ts
+++ b/docs/src/modules/sandbox/StackBlitz.ts
@@ -12,7 +12,7 @@ const createReactApp = (demoData: DemoData) => {
   const files: Record<string, string> = {
     'index.html': CRA.getHtml(demoData),
     [`index.${ext}`]: CRA.getRootIndex(demoData),
-    [`demo.${ext}`]: demoData.raw,
+    [`Demo.${ext}`]: demoData.raw,
     ...(demoData.codeVariant === 'TS' && {
       'tsconfig.json': CRA.getTsconfig(),
     }),

--- a/docs/src/modules/sandbox/types.ts
+++ b/docs/src/modules/sandbox/types.ts
@@ -1,3 +1,13 @@
-export type Product = 'joy-ui' | 'base-ui';
+import type { MuiProductId } from 'docs/src/modules/utils/getProductInfoFromUrl';
+
 export type CodeStyling = 'Tailwind' | 'MUI System';
 export type CodeVariant = 'TS' | 'JS';
+export interface DemoData {
+  title: string;
+  language: string;
+  raw: string;
+  codeVariant: CodeVariant;
+  githubLocation: string;
+  productId?: Exclude<MuiProductId, 'null'>;
+  codeStyling: CodeStyling;
+}

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -405,7 +405,7 @@ function createRender(context) {
 const BaseUIReexportedComponents = ['ClickAwayListener', 'NoSsr', 'Portal', 'TextareaAutosize'];
 
 /**
- * @param {string} product
+ * @param {string} productId
  * @example 'material'
  * @param {string} componentPkg
  * @example 'mui-base'
@@ -413,17 +413,17 @@ const BaseUIReexportedComponents = ['ClickAwayListener', 'NoSsr', 'Portal', 'Tex
  * @example 'Button'
  * @returns {string}
  */
-function resolveComponentApiUrl(product, componentPkg, component) {
-  if (!product) {
+function resolveComponentApiUrl(productId, componentPkg, component) {
+  if (!productId) {
     return `/api/${kebabCase(component)}/`;
   }
-  if (product === 'x-date-pickers') {
+  if (productId === 'x-date-pickers') {
     return `/x/api/date-pickers/${kebabCase(component)}/`;
   }
   if (componentPkg === 'mui-base' || BaseUIReexportedComponents.indexOf(component) >= 0) {
     return `/base-ui/react-${kebabCase(component)}/components-api/#${kebabCase(component)}`;
   }
-  return `/${product}/api/${kebabCase(component)}/`;
+  return `/${productId}/api/${kebabCase(component)}/`;
 }
 
 /**


### PR DESCRIPTION
When you export any of the demos with TypeScript to CodeSandbox, StackBlitz, you will get:

<img width="915" alt="Screenshot 2023-07-05 at 15 33 05" src="https://github.com/mui/material-ui/assets/3165635/7c246599-5314-4742-9cd3-de25d6d3bbb7">

which breaks `yarn build`.

I have found thing working on https://www.notion.so/mui-org/Monthly-meeting-2023-07-04-de26e366aa4148c6ae9cb7bdd55165c0?pvs=4#f4df5a41fc35401d9eb049710c872ea6.

Preview: https://deploy-preview-37830--material-ui.netlify.app/material-ui/react-alert/#basic-alerts