### PR TITLE
[docs-infra] Remove code tags in ToC

### DIFF
--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -244,7 +244,7 @@ function createRender(context) {
       // Remove links to avoid nested links in the TOCs
       let headingText = headingHtml.replace(/<a\b[^>]*>/i, '').replace(/<\/a>/i, '');
       // Remove `code` tags
-      headingText = headingHtml.replace(/<code\b[^>]*>/i, '').replace(/<\/code>/i, '');
+      headingText = headingText.replace(/<code\b[^>]*>/i, '').replace(/<\/code>/i, '');
 
       // Standardizes the hash from the default location (en) to different locations
       // Need english.md file parsed first

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -242,7 +242,9 @@ function createRender(context) {
       }
 
       // Remove links to avoid nested links in the TOCs
-      const headingText = headingHtml.replace(/<a\b[^>]*>/i, '').replace(/<\/a>/i, '');
+      let headingText = headingHtml.replace(/<a\b[^>]*>/i, '').replace(/<\/a>/i, '');
+      // Remove `code` tags
+      headingText = headingHtml.replace(/<code\b[^>]*>/i, '').replace(/<\/code>/i, '');
 
       // Standardizes the hash from the default location (en) to different locations
       // Need english.md file parsed first

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -172,6 +172,7 @@ authors:
 ### Unofficial 👍
 ### Warning ⚠️
 ### Header with Pro plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)
+### Header with \`code\`
 `;
 
       const {
@@ -197,6 +198,11 @@ authors:
               hash: 'header-with-pro-plan',
               level: 3,
               text: 'Header with Pro plan <span class="plan-pro"></span>',
+            },
+            {
+              hash: 'header-with-code',
+              level: 3,
+              text: 'Header with code',
             },
           ],
           hash: 'community-help-free',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Removes `<code>` tags in ToC that were introduced in https://github.com/mui/material-ui/pull/37731#discussion_r1247609607

Preview: https://deploy-preview-37834--material-ui.netlify.app/material-ui/experimental-api/css-theme-variables/usage/

This was raised in https://mui-org.slack.com/archives/C042VP80PT5/p1688497370976729 by @samuelsycamore