### PR TITLE
fix(Box): replace barrel file import

### DIFF
--- a/packages/mui-material/src/Box/Box.js
+++ b/packages/mui-material/src/Box/Box.js
@@ -1,7 +1,7 @@
 import { createBox } from '@mui/system';
 import PropTypes from 'prop-types';
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '../className';
-import { createTheme } from '../styles';
+import createTheme from '../styles/createTheme';
 import THEME_ID from '../styles/identifier';
 
 const defaultTheme = createTheme();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Solves problem of barrel file import with 
```
Box.js:5 Uncaught TypeError: createTheme_default is not a function
       at Box.js:5:22
```
which leads to some circulars which are not so obvious to figure out at first look

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
