### PR TITLE
[docs] Add callouts about controlled vs uncontrolled components in Core docs

### DIFF
--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -118,14 +118,14 @@ The useAutocomplete hook has two states that can be controlled:
 1. the "value" state with the `value`/`onChange` props combination. This state represents the value selected by the user, for instance when pressing <kbd class="key">Enter</kbd>.
 2. the "input value" state with the `inputValue`/`onInputChange` props combination. This state represents the value displayed in the textbox.
 
-
 These two states are isolated, and should be controlled independently.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControlledStates.js"}}

--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -125,7 +125,7 @@ These two states are isolated, and should be controlled independently.
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControlledStates.js"}}

--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -118,8 +118,14 @@ The useAutocomplete hook has two states that can be controlled:
 1. the "value" state with the `value`/`onChange` props combination. This state represents the value selected by the user, for instance when pressing <kbd class="key">Enter</kbd>.
 2. the "input value" state with the `inputValue`/`onInputChange` props combination. This state represents the value displayed in the textbox.
 
-:::warning
+
 These two states are isolated, and should be controlled independently.
+
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControlledStates.js"}}

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -93,9 +93,15 @@ The demo below shows how to integrate this hook with its component counterpart:
 
 {{"demo": "UseFormControl.js", "defaultCodeOpen": false}}
 
-Note that even though Form Control supports both controlled and uncontrolled-style APIs
-(i.e. it accepts `value` and `defaultValue` props), `useFormControlContext` returns only the controlled `value`.
+Note that even though Form Control supports both controlled and uncontrolled-style APIs (i.e. it accepts `value` and `defaultValue` props), `useFormControlContext` returns only the controlled `value`.
 This way, you don't have to implement both in your custom input—Form Control does this for you.
+
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
 
 ## Customization
 

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -97,10 +97,11 @@ Note that even though Form Control supports both controlled and uncontrolled-sty
 This way, you don't have to implement both in your custom input—Form Control does this for you.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 ## Customization

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -101,7 +101,7 @@ This way, you don't have to implement both in your custom input—Form Control d
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 ## Customization

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -187,6 +187,13 @@ Select can be used as an uncontrolled or controlled component:
 
 {{"demo": "UnstyledSelectControlled.js", "defaultCodeOpen": false}}
 
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
+
 ### Object values
 
 The Select component can be used with non-string values:

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -188,10 +188,11 @@ Select can be used as an uncontrolled or controlled component:
 {{"demo": "UnstyledSelectControlled.js", "defaultCodeOpen": false}}
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 ### Object values

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -192,7 +192,7 @@ Select can be used as an uncontrolled or controlled component:
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 ### Object values

--- a/docs/data/joy/components/autocomplete/autocomplete.md
+++ b/docs/data/joy/components/autocomplete/autocomplete.md
@@ -105,7 +105,7 @@ These two states are isolated, and should be controlled independently.
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControllableStates.js"}}

--- a/docs/data/joy/components/autocomplete/autocomplete.md
+++ b/docs/data/joy/components/autocomplete/autocomplete.md
@@ -101,10 +101,11 @@ The component has two states that can be controlled:
 These two states are isolated, and should be controlled independently.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControllableStates.js"}}

--- a/docs/data/joy/components/autocomplete/autocomplete.md
+++ b/docs/data/joy/components/autocomplete/autocomplete.md
@@ -98,8 +98,13 @@ The component has two states that can be controlled:
 1. the "value" state with the `value`/`onChange` props combination. This state represents the value selected by the user, for instance when pressing <kbd class="key">Enter</kbd>.
 2. the "input value" state with the `inputValue`/`onInputChange` props combination. This state represents the value displayed in the textbox.
 
-:::warning
 These two states are isolated, and should be controlled independently.
+
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControllableStates.js"}}

--- a/docs/data/joy/components/switch/switch.md
+++ b/docs/data/joy/components/switch/switch.md
@@ -41,7 +41,7 @@ To create a controlled switch, use the `checked` and `onChange` props.
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "SwitchControlled.js"}}

--- a/docs/data/joy/components/switch/switch.md
+++ b/docs/data/joy/components/switch/switch.md
@@ -36,6 +36,13 @@ export default function MyApp() {
 
 To create a controlled switch, use the `checked` and `onChange` props.
 
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
+
 {{"demo": "SwitchControlled.js"}}
 
 :::info

--- a/docs/data/joy/components/switch/switch.md
+++ b/docs/data/joy/components/switch/switch.md
@@ -37,10 +37,11 @@ export default function MyApp() {
 To create a controlled switch, use the `checked` and `onChange` props.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "SwitchControlled.js"}}

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -25,7 +25,15 @@ This component is no longer documented in the [Material Design guidelines](https
 
 ## Controlled accordion
 
-Extend the default behavior to create an accordion with the `Accordion` component.
+The Accordion component can be controlled or uncontrolled.
+
+:::info
+
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
 
 {{"demo": "ControlledAccordions.js", "bg": true}}
 

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -72,10 +72,11 @@ The component has two states that can be controlled:
 These two states are isolated, and should be controlled independently.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControllableStates.js"}}

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -76,7 +76,7 @@ These two states are isolated, and should be controlled independently.
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControllableStates.js"}}

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -69,8 +69,13 @@ The component has two states that can be controlled:
 1. the "value" state with the `value`/`onChange` props combination. This state represents the value selected by the user, for instance when pressing <kbd class="key">Enter</kbd>.
 2. the "input value" state with the `inputValue`/`onInputChange` props combination. This state represents the value displayed in the textbox.
 
-:::warning
 These two states are isolated, and should be controlled independently.
+
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControllableStates.js"}}

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -114,10 +114,11 @@ Like with the single selection, you can pull out the new value by accessing `eve
 You can control the open state of the select with the `open` prop. Alternatively, it is also possible to set the initial (uncontrolled) open state of the component with the `defaultOpen` prop.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControlledOpenSelect.js"}}

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -118,7 +118,7 @@ You can control the open state of the select with the `open` prop. Alternatively
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControlledOpenSelect.js"}}

--- a/docs/data/material/components/selects/selects.md
+++ b/docs/data/material/components/selects/selects.md
@@ -113,6 +113,13 @@ Like with the single selection, you can pull out the new value by accessing `eve
 
 You can control the open state of the select with the `open` prop. Alternatively, it is also possible to set the initial (uncontrolled) open state of the component with the `defaultOpen` prop.
 
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
+
 {{"demo": "ControlledOpenSelect.js"}}
 
 ## With a dialog

--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -96,6 +96,13 @@ Using `none` (default) doesn't apply margins to the `FormControl` whereas `dense
 
 The component can be controlled or uncontrolled.
 
+:::info
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
+
 {{"demo": "StateTextFields.js"}}
 
 ## Components

--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -101,7 +101,7 @@ The component can be controlled or uncontrolled.
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "StateTextFields.js"}}

--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -97,10 +97,11 @@ Using `none` (default) doesn't apply margins to the `FormControl` whereas `dense
 The component can be controlled or uncontrolled.
 
 :::info
+
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the *Controlled and uncontrolled pattern* in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "StateTextFields.js"}}

--- a/docs/data/material/components/tree-view/tree-view.md
+++ b/docs/data/material/components/tree-view/tree-view.md
@@ -29,6 +29,14 @@ Tree views also support multi-selection.
 
 The tree view also offers a controlled API.
 
+:::info
+
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
+
 {{"demo": "ControlledTreeView.js"}}
 
 ## Rich object

--- a/docs/data/material/components/tree-view/tree-view.md
+++ b/docs/data/material/components/tree-view/tree-view.md
@@ -34,7 +34,7 @@ The tree view also offers a controlled API.
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 {{"demo": "ControlledTreeView.js"}}

--- a/docs/data/material/guides/api/api.md
+++ b/docs/data/material/guides/api/api.md
@@ -111,9 +111,17 @@ Nested components inside a component have:
 
 ### Controlled components
 
-Most of the controlled component are controlled via the `value` and the `onChange` props,
-however, the `open` / `onClose` / `onOpen` combination is used for display related state.
-In the cases where there are more events, we put the noun first, and then the verb, for example: `onPageChange`, `onRowsChange`.
+Most controlled components are controlled by the `value` and the `onChange` props.
+The `open` / `onClose` / `onOpen` combination is also used for displaying related state.
+In the cases where there are more events, the noun comes first, and then the verb—for example: `onPageChange`, `onRowsChange`.
+
+:::info
+
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+
+Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+:::
 
 ### boolean vs. enum
 

--- a/docs/data/material/guides/api/api.md
+++ b/docs/data/material/guides/api/api.md
@@ -120,7 +120,7 @@ In the cases where there are more events, the noun comes first, and then the ver
 - A component is **controlled** when it's managed by its parent using props.
 - A component is **uncontrolled** when it's managed by its own local state.
 
-Learn more about the _Controlled and uncontrolled pattern_ in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
 :::
 
 ### boolean vs. enum


### PR DESCRIPTION
Users consistently express confusion about our usage of the terms "controlled" vs "uncontrolled"—many developers seem to be unaware of this React concept.

This has been resolved in the X docs by adding a callout everywhere it comes up to direct readers to the official React documentation on the topic. This PR does the same for the Core docs.

![Screenshot 2023-07-06 at 1 50 28 PM](https://github.com/mui/material-ui/assets/71297412/97052082-0a2a-4b8f-996b-f97c79813c29)

I think I caught all instances where the concept is mentioned. (I imagine the community will tell us soon enough if I missed any!)