### PR TITLE
[docs-infra] Remove icons and tweak the design of the side nav

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -38,7 +38,8 @@ const Item = styled(
       width: '100%',
       padding: 6,
       justifyContent: 'flex-start',
-      fontWeight: theme.typography.fontWeightSemiBold,
+      fontWeight:
+        depth === 0 ? theme.typography.fontWeightSemiBold : theme.typography.fontWeightMedium,
       transition: theme.transitions.create(['color', 'background-color'], {
         duration: theme.transitions.duration.shortest,
       }),
@@ -54,7 +55,7 @@ const Item = styled(
         height: '100%',
         width: 1,
         opacity: depth === 0 ? 0 : 1,
-        background: alpha(theme.palette.primaryDark[700], 0.6),
+        background: (theme.vars || theme).palette.grey[100],
       },
       ...color,
       ...(subheader && {
@@ -73,7 +74,7 @@ const Item = styled(
           top: 16,
           width: 1,
           opacity: depth === 0 ? 0 : 1,
-          background: alpha(theme.palette.primaryDark[700], 0.6),
+          background: (theme.vars || theme).palette.grey[100],
         },
         '&:after': {
           content: '""',
@@ -85,9 +86,9 @@ const Item = styled(
           width: 8,
           borderRadius: 99,
           opacity: depth === 0 ? 0 : 1,
-          background: alpha(theme.palette.primaryDark[700], 0.6),
+          background: (theme.vars || theme).palette.grey[50],
           border: '1px solid',
-          borderColor: alpha(theme.palette.primaryDark[400], 0.5),
+          borderColor: (theme.vars || theme).palette.grey[200],
         },
       }),
       ...(hasIcon && {
@@ -120,7 +121,7 @@ const Item = styled(
               ),
         },
         '&:before': {
-          background: (theme.vars || theme).palette.primary[600],
+          background: (theme.vars || theme).palette.primary[400],
         },
       },
       '& .MuiChip-root': {
@@ -156,10 +157,25 @@ const Item = styled(
     },
     theme.applyDarkStyles({
       ...color,
+      '&:before': {
+        background: alpha(theme.palette.primaryDark[700], 0.6),
+      },
       '&.app-drawer-active': {
         color: (theme.vars || theme).palette.primary[300],
         backgroundColor: (theme.vars || theme).palette.primaryDark[700],
+        '&:before': {
+          background: (theme.vars || theme).palette.primary[600],
+        },
       },
+      ...(subheader && {
+        '&:before': {
+          background: alpha(theme.palette.primaryDark[700], 0.6),
+        },
+        '&:after': {
+          background: alpha(theme.palette.primaryDark[700], 0.6),
+          borderColor: alpha(theme.palette.primaryDark[400], 0.5),
+        },
+      }),
       ...(!subheader && {
         '&:hover': {
           color: '#fff',

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Box from '@mui/material/Box';
 import KeyboardArrowRightRoundedIcon from '@mui/icons-material/KeyboardArrowRightRounded';
 import { alpha, styled } from '@mui/material/styles';
 import Collapse from '@mui/material/Collapse';

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -84,7 +84,7 @@ const Item = styled(
           left: 8,
           height: 8,
           width: 8,
-          borderRadius: 99,
+          borderRadius: 2,
           opacity: depth === 0 ? 0 : 1,
           background: (theme.vars || theme).palette.grey[50],
           border: '1px solid',

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -86,7 +86,7 @@ const Item = styled(
           width: 8,
           borderRadius: 2,
           opacity: depth === 0 ? 0 : 1,
-          background: (theme.vars || theme).palette.grey[50],
+          background: alpha(theme.palette.grey[50], 0.5),
           border: '1px solid',
           borderColor: (theme.vars || theme).palette.grey[200],
         },
@@ -173,7 +173,7 @@ const Item = styled(
         },
         '&:after': {
           background: alpha(theme.palette.primaryDark[700], 0.6),
-          borderColor: alpha(theme.palette.primaryDark[400], 0.5),
+          borderColor: alpha(theme.palette.primaryDark[600], 0.5),
         },
       }),
       ...(!subheader && {

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -283,22 +283,6 @@ export default function AppNavDrawerItem(props) {
   };
 
   const hasIcon = icon && (typeof icon !== 'string' || !!standardNavIcons[icon]);
-  const IconComponent = typeof icon === 'string' ? standardNavIcons[icon] : icon;
-  const iconElement = hasIcon ? (
-    <Box
-      component="span"
-      sx={{
-        '& svg': { fontSize: (theme) => theme.typography.pxToRem(16.5) },
-        display: 'flex',
-        alignItems: 'center',
-        height: '100%',
-        marginRight: 1.5,
-        py: '2px',
-      }}
-    >
-      <IconComponent fontSize="small" color="primary" />
-    </Box>
-  ) : null;
 
   return (
     <StyledLi {...other} depth={depth}>
@@ -315,7 +299,6 @@ export default function AppNavDrawerItem(props) {
         onClick={handleClick}
         {...linkProps}
       >
-        {/* {iconElement} */}
         {expandable && !subheader && <ItemButtonIcon className="ItemButtonIcon" open={open} />}
         {title}
         {plan === 'pro' && <span className="plan-pro" title="Pro plan" />}

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -30,21 +30,32 @@ const Item = styled(
   return [
     {
       ...theme.typography.body2,
+      position: 'relative',
       display: 'flex',
       alignItems: 'center',
-      borderRadius: 5,
+      borderRadius: 6,
       outline: 0,
       width: '100%',
-      paddingTop: 5,
-      paddingBottom: 5,
+      padding: 6,
       justifyContent: 'flex-start',
-      fontWeight: theme.typography.fontWeightMedium,
+      fontWeight: theme.typography.fontWeightSemiBold,
       transition: theme.transitions.create(['color', 'background-color'], {
         duration: theme.transitions.duration.shortest,
       }),
       fontSize: theme.typography.pxToRem(14),
       textDecoration: 'none',
       paddingLeft: 31 + (depth > 1 ? (depth - 1) * 10 : 0),
+      '&:before': {
+        content: '""',
+        display: 'block',
+        position: 'absolute',
+        zIndex: 1,
+        left: 11.5,
+        height: '100%',
+        width: 1,
+        opacity: depth === 0 ? 0 : 1,
+        background: alpha(theme.palette.primaryDark[700], 0.6),
+      },
       ...color,
       ...(subheader && {
         marginTop: theme.spacing(1),
@@ -52,6 +63,32 @@ const Item = styled(
         letterSpacing: '.08rem',
         fontWeight: theme.typography.fontWeightBold,
         fontSize: theme.typography.pxToRem(11),
+        '&:before': {
+          content: '""',
+          display: 'block',
+          position: 'absolute',
+          zIndex: 1,
+          left: 11.5,
+          height: '55%',
+          top: 16,
+          width: 1,
+          opacity: depth === 0 ? 0 : 1,
+          background: alpha(theme.palette.primaryDark[700], 0.6),
+        },
+        '&:after': {
+          content: '""',
+          display: 'block',
+          position: 'absolute',
+          zIndex: 5,
+          left: 8,
+          height: 8,
+          width: 8,
+          borderRadius: 99,
+          opacity: depth === 0 ? 0 : 1,
+          background: alpha(theme.palette.primaryDark[700], 0.6),
+          border: '1px solid',
+          borderColor: alpha(theme.palette.primaryDark[400], 0.5),
+        },
       }),
       ...(hasIcon && {
         paddingLeft: 2,
@@ -82,6 +119,9 @@ const Item = styled(
                 theme.palette.action.selectedOpacity + theme.palette.action.focusOpacity,
               ),
         },
+        '&:before': {
+          background: (theme.vars || theme).palette.primary[600],
+        },
       },
       '& .MuiChip-root': {
         marginTop: '2px',
@@ -100,11 +140,10 @@ const Item = styled(
         backgroundColor: (theme.vars || theme).palette.action.focus,
       },
       [theme.breakpoints.up('md')]: {
-        paddingTop: 3,
-        paddingBottom: 3,
+        paddingTop: 4,
+        paddingBottom: 4,
       },
       '& .ItemButtonIcon': {
-        marginLeft: 'auto !important',
         marginRight: '5px',
         color: (theme.vars || theme).palette.primary.main,
       },
@@ -145,7 +184,7 @@ const ItemButtonIcon = styled(KeyboardArrowRightRoundedIcon, {
 const StyledLi = styled('li', { shouldForwardProp: (prop) => prop !== 'depth' })(
   ({ theme, depth }) => ({
     display: 'block',
-    padding: depth === 0 ? theme.spacing(1, '10px', 0, '10px') : '2px 0',
+    padding: depth === 0 ? theme.spacing(1, '10px', 0, '10px') : 0,
   }),
 );
 
@@ -260,14 +299,14 @@ export default function AppNavDrawerItem(props) {
         onClick={handleClick}
         {...linkProps}
       >
-        {iconElement}
+        {/* {iconElement} */}
+        {expandable && !subheader && <ItemButtonIcon className="ItemButtonIcon" open={open} />}
         {title}
         {plan === 'pro' && <span className="plan-pro" title="Pro plan" />}
         {plan === 'premium' && <span className="plan-premium" title="Premium plan" />}
         {legacy && <Chip label="Legacy" sx={sxChip('warning')} />}
         {newFeature && <Chip label="New" sx={sxChip('success')} />}
         {comingSoon && <Chip label="Coming soon" sx={sxChip('grey')} />}
-        {expandable && !subheader && <ItemButtonIcon className="ItemButtonIcon" open={open} />}
       </Item>
       {expandable ? (
         <Collapse in={open} timeout="auto" unmountOnExit>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

After a few days of sleeping on this, I'm enjoying this design. It removes some of the visual weight of the whole docs, simplifies things, and makes it easier to identify subheaders in the side nav. Here's how it looks:

<img width="600" alt="Screen Shot 2023-07-10 at 20 42 53" src="https://github.com/mui/material-ui/assets/67129314/e42a8e24-1b35-46e8-bdc1-a2fa73e46649">


**https://deploy-preview-37860--material-ui.netlify.app/base-ui/getting-started/**
