### PR TITLE
 [docs][base] FocusTrap not focusing back to the Box in Firefox

### DIFF
--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -22,6 +22,16 @@ const candidatesSelector = [
   '[contenteditable]:not([contenteditable="false"])',
 ].join(',');
 
+/**
+ * These are the configuration options that bring the element into view, once focussed.
+ * The Node will be rendered in the center of the screen and scroll behavior would be instantaneous.
+ */
+const scrollIntoViewOptions: ScrollIntoViewOptions = {
+  behavior: 'auto',
+  block: 'center',
+  inline: 'center',
+};
+
 interface OrderedTabNode {
   documentOrder: number;
   tabIndex: number;
@@ -187,7 +197,8 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
       }
 
       if (activated.current) {
-        rootRef.current.focus();
+        rootRef.current.scrollIntoView(scrollIntoViewOptions);
+        rootRef.current.focus({ preventScroll: true });
       }
     }
 
@@ -200,7 +211,9 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
         // Once IE11 support is dropped the focus() call can be unconditional.
         if (nodeToRestore.current && (nodeToRestore.current as HTMLElement).focus) {
           ignoreNextEnforceFocus.current = true;
-          (nodeToRestore.current as HTMLElement).focus();
+          const restoredNode = nodeToRestore.current as HTMLElement;
+          restoredNode.scrollIntoView(scrollIntoViewOptions);
+          restoredNode.focus({ preventScroll: true });
         }
 
         nodeToRestore.current = null;
@@ -277,7 +290,12 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
             }
           }
         } else {
-          rootElement.focus();
+          /**
+           * Here we bring the element into view, and then focus it.
+           * In Mozilla, and chrome, the position of element when called with `focus()` is very different. To make that consistent we've done so.
+           */
+          rootElement.scrollIntoView(scrollIntoViewOptions);
+          rootElement.focus({ preventScroll: true });
         }
       }
     };
@@ -296,7 +314,8 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
         // it will try to move the focus back to the rootRef element.
         ignoreNextEnforceFocus.current = true;
         if (sentinelEnd.current) {
-          sentinelEnd.current.focus();
+          sentinelEnd.current.scrollIntoView(scrollIntoViewOptions);
+          sentinelEnd.current.focus({ preventScroll: true });
         }
       }
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes https://github.com/mui/material-ui/issues/37866#issue-1794776081 

## Description

The reason why in Firefox, doesn't focus back / bring the relevant component in view in the docs section is rather how the `focus()` event works in Firefox. For reference check this video on how the focus works when we manually bring an element into view - 

- Firefox

https://github.com/mui/material-ui/assets/40322760/1ac1de8a-70e6-4deb-9564-28ead1918e62

- Chrome

https://github.com/mui/material-ui/assets/40322760/bf9efd9f-7b2b-4116-9711-3d93fb520e0e

## Solution - 1

In my fix I've broken down the focus in 2 parts
- First we scroll the element into the view, which is centered
- Then we focus it with `preventScroll` to reset the focus

## Solution - 2

Since, this is a desired outcome of Firefox, instead of this fix we can instead, also update the documentation highlighting the fact that this is expected in Firefox.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
