### PR TITLE
[docs-infra] Update installation commands to use the new tabs code component

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -10,7 +10,21 @@ If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](
 
 `@mui/base` is completely standalone – run one of the following commands to add Base UI to your React project:
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/base", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/base"}, {"tab":"pnpm", "code": "pnpm add @mui/base"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @mui/base
+```
+
+```bash yarn
+yarn add @mui/base
+```
+
+```bash pnpm
+pnpm install @mui/base
+```
+
+</codeblock>
 
 ### Peer dependencies
 

--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -10,23 +10,7 @@ If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](
 
 `@mui/base` is completely standalone – run one of the following commands to add Base UI to your React project:
 
-### With npm
-
-```bash
-npm install @mui/base
-```
-
-### With yarn
-
-```bash
-yarn add @mui/base
-```
-
-### With pnpm
-
-```bash
-pnpm add @mui/base
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/base", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/base"}, {"tab":"pnpm", "code": "pnpm add @mui/base"}]}}
 
 ### Peer dependencies
 

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -4,7 +4,16 @@
 
 Run one of the following commands to add Joy UI to your project:
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/joy @emotion/react @emotion/styled", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/joy @emotion/react @emotion/styled"}]}}
+<codeblock storageKey="package-manager">
+```bash npm
+npm install @mui/joy @emotion/react @emotion/styled
+```
+
+```bash yarn
+yarn add @mui/joy @emotion/react @emotion/styled
+```
+
+</codeblock>
 
 ## Peer dependencies
 
@@ -25,7 +34,17 @@ Joy UI is designed to use the [Public Sans](https://fonts.google.com/specimen/Pu
 font by default.
 You may add it to your project with npm or yarn via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @fontsource/public-sans", "language": "bash"}, {"tab":"yarn", "code": "yarn add @fontsource/public-sans"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @fontsource/public-sans
+```
+
+```bash yarn
+yarn add @fontsource/public-sans
+```
+
+</codeblock>
 
 Then you can import it in your entry point like this:
 

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -4,17 +4,7 @@
 
 Run one of the following commands to add Joy UI to your project:
 
-## npm
-
-```bash
-npm install @mui/joy @emotion/react @emotion/styled
-```
-
-## yarn
-
-```bash
-yarn add @mui/joy @emotion/react @emotion/styled
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/joy @emotion/react @emotion/styled", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/joy @emotion/react @emotion/styled"}]}}
 
 ## Peer dependencies
 
@@ -35,17 +25,7 @@ Joy UI is designed to use the [Public Sans](https://fonts.google.com/specimen/Pu
 font by default.
 You may add it to your project with npm or yarn via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
 
-### npm
-
-```bash
-npm install @fontsource/public-sans
-```
-
-### yarn
-
-```bash
-yarn add @fontsource/public-sans
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @fontsource/public-sans", "language": "bash"}, {"tab":"yarn", "code": "yarn add @fontsource/public-sans"}]}}
 
 Then you can import it in your entry point like this:
 

--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -17,17 +17,19 @@ For a component to be ready to move to the core, the following criteria are cons
 
 ## Installation
 
-To install and save in your `package.json` dependencies, run the command below using **npm**:
+To install and save in your `package.json` dependencies, run one of the following commands:
 
-```bash
+<codeblock storageKey="package-manager">
+
+```bash npm
 npm install @mui/lab @mui/material
 ```
 
-Or **yarn**:
-
-```bash
+```bash yarn
 yarn add @mui/lab @mui/material
 ```
+
+</codeblock>
 
 Note that the lab has a peer dependency on the Material UI components.
 

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -16,11 +16,19 @@ githubLabel: 'package: icons'
 [@mui/icons-material](https://www.npmjs.com/package/@mui/icons-material)
 includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) converted to [`SvgIcon`](/material-ui/api/svg-icon/) components.
 It depends on `@mui/material`, which requires Emotion packages.
-Use the following command to install it:
+Use one of the following commands to install it:
 
-```bash
+<codeblock storageKey="package-manager">
+
+```bash npm
 npm install @mui/icons-material @mui/material @emotion/styled @emotion/react
 ```
+
+```bash yarn
+yarn add @mui/icons-material @mui/material @emotion/styled @emotion/react
+```
+
+</codeblock>
 
 See the [Installation](/material-ui/getting-started/installation/) page for additional docs about how to make sure everything is set up correctly.
 

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -14,14 +14,34 @@ If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](
 
 Run one of the following commands to add Material UI to your project:
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/material @emotion/react @emotion/styled", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/material @emotion/react @emotion/styled"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @mui/material @emotion/react @emotion/styled
+```
+
+```bash yarn
+yarn add @mui/material @emotion/react @emotion/styled
+```
+
+</codeblock>
 
 ## With styled-components
 
 Material UI uses [Emotion](https://emotion.sh/) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/material @mui/styled-engine-sc styled-components", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/material @mui/styled-engine-sc styled-components"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @mui/material @mui/styled-engine-sc styled-components
+```
+
+```bash yarn
+yarn add @mui/material @mui/styled-engine-sc styled-components
+```
+
+</codeblock>
 
 :::warning
 Visit the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure styled-components.
@@ -77,7 +97,17 @@ To install the Roboto font in your project using the Google Web Fonts CDN, add t
 To use the [font Icon component](/material-ui/icons/#icon-font-icons) or the prebuilt SVG Material Icons (such as those found in the [icon demos](/material-ui/icons/)), you must first install the [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) font.
 You can do so with npm or yarn, or with the Google Web Fonts CDN.
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/icons-material", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/icons-material"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @mui/icons-material
+```
+
+```bash yarn
+yarn add @mui/icons-material
+```
+
+</codeblock>
 
 ### Google Web Fonts
 

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -14,34 +14,14 @@ If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](
 
 Run one of the following commands to add Material UI to your project:
 
-### npm
-
-```bash
-npm install @mui/material @emotion/react @emotion/styled
-```
-
-### yarn
-
-```bash
-yarn add @mui/material @emotion/react @emotion/styled
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/material @emotion/react @emotion/styled", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/material @emotion/react @emotion/styled"}]}}
 
 ## With styled-components
 
 Material UI uses [Emotion](https://emotion.sh/) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
-### npm
-
-```bash
-npm install @mui/material @mui/styled-engine-sc styled-components
-```
-
-### yarn
-
-```bash
-yarn add @mui/material @mui/styled-engine-sc styled-components
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/material @mui/styled-engine-sc styled-components", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/material @mui/styled-engine-sc styled-components"}]}}
 
 :::warning
 Visit the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure styled-components.
@@ -66,17 +46,7 @@ Material UI is designed to use the [Roboto](https://fonts.google.com/specimen/Ro
 font by default.
 You may add it to your project with npm or yarn via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
 
-### npm
-
-```bash
-npm install @fontsource/roboto
-```
-
-### yarn
-
-```bash
-yarn add @fontsource/roboto
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @fontsource/roboto", "language": "bash"}, {"tab":"yarn", "code": "yarn add @fontsource/roboto"}]}}
 
 Then you can import it in your entry point like this:
 
@@ -107,17 +77,7 @@ To install the Roboto font in your project using the Google Web Fonts CDN, add t
 To use the [font Icon component](/material-ui/icons/#icon-font-icons) or the prebuilt SVG Material Icons (such as those found in the [icon demos](/material-ui/icons/)), you must first install the [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) font.
 You can do so with npm or yarn, or with the Google Web Fonts CDN.
 
-### npm
-
-```bash
-npm install @mui/icons-material
-```
-
-### yarn
-
-```bash
-yarn add @mui/icons-material
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/icons-material", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/icons-material"}]}}
 
 ### Google Web Fonts
 

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -6,14 +6,34 @@
 
 Run one of the following commands to add MUI System to your project:
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/system @emotion/react @emotion/styled", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/system @emotion/react @emotion/styled"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @mui/system @emotion/react @emotion/styled
+```
+
+```bash yarn
+yarn add @mui/system @emotion/react @emotion/styled
+```
+
+</codeblock>
 
 ## With styled-components
 
 MUI System uses [Emotion](https://emotion.sh/) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
-{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/system @mui/styled-engine-sc styled-components", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/system @mui/styled-engine-sc styled-components"}]}}
+<codeblock storageKey="package-manager">
+
+```bash npm
+npm install @mui/system @mui/styled-engine-sc styled-components
+```
+
+```bash yarn
+yarn add @mui/system @mui/styled-engine-sc styled-components
+```
+
+</codeblock>
 
 :::warning
 Visit the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure styled-components.

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -6,34 +6,14 @@
 
 Run one of the following commands to add MUI System to your project:
 
-### npm
-
-```bash
-npm install @mui/system @emotion/react @emotion/styled
-```
-
-### yarn
-
-```bash
-yarn add @mui/system @emotion/react @emotion/styled
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/system @emotion/react @emotion/styled", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/system @emotion/react @emotion/styled"}]}}
 
 ## With styled-components
 
 MUI System uses [Emotion](https://emotion.sh/) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
-### npm
-
-```bash
-npm install @mui/system @mui/styled-engine-sc styled-components
-```
-
-### yarn
-
-```bash
-yarn add @mui/system @mui/styled-engine-sc styled-components
-```
+{{"component": "modules/components/HighlightedCodeWithTabs", "tabs": [{"tab":"npm", "code":"npm install @mui/system @mui/styled-engine-sc styled-components", "language": "bash"}, {"tab":"yarn", "code": "yarn add @mui/system @mui/styled-engine-sc styled-components"}]}}
 
 :::warning
 Visit the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure styled-components.

--- a/docs/src/modules/components/ExampleCollection.js
+++ b/docs/src/modules/components/ExampleCollection.js
@@ -96,13 +96,13 @@ export default function ExampleCollection() {
                 backgroundImage: 'none',
                 borderRadius: 1,
                 border: '1px solid',
-                borderColor: 'grey.200',
+                borderColor: 'divider',
                 boxShadow: 'none',
               },
               (theme) =>
                 theme.applyDarkStyles({
                   bgcolor: 'transparent',
-                  borderColor: 'primaryDark.700',
+                  borderColor: 'divider',
                 }),
             ]}
           >

--- a/docs/src/modules/components/HighlightedCodeWithTabs.tsx
+++ b/docs/src/modules/components/HighlightedCodeWithTabs.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
-import { styled } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import Tabs, { TabsOwnProps } from '@mui/base/Tabs';
 import TabsList from '@mui/base/TabsList';
 import TabPanel from '@mui/base/TabPanel';
@@ -8,18 +7,21 @@ import Tab from '@mui/base/Tab';
 import HighlightedCode from './HighlightedCode';
 
 const StyledTabList = styled(TabsList)(({ theme }) => ({
+  padding: 6,
   display: 'flex',
-  backgroundColor: (theme.vars || theme).palette.primaryDark[600],
+  border: '1px solid',
+  borderColor: (theme.vars || theme).palette.primaryDark[700],
+  backgroundColor: (theme.vars || theme).palette.primaryDark[900],
   borderTopLeftRadius: (theme.vars || theme).shape.borderRadius,
   borderTopRightRadius: (theme.vars || theme).shape.borderRadius,
   ...theme.applyDarkStyles({
-    backgroundColor: (theme.vars || theme).palette.primaryDark[700],
+    backgroundColor: alpha(theme.palette.primaryDark[800], 0.5),
   }),
 }));
 
 const StyledTabPanel = styled(TabPanel)<{ ownerState: { mounted: boolean } }>(({ ownerState }) => ({
   '& pre': {
-    marginTop: 0,
+    marginTop: -1,
     borderTopLeftRadius: 0,
     borderTopRightRadius: 0,
     '& code': {
@@ -30,41 +32,42 @@ const StyledTabPanel = styled(TabPanel)<{ ownerState: { mounted: boolean } }>(({
 
 const StyledTab = styled(Tab)<{ ownerState: { mounted: boolean } }>(({ theme, ownerState }) =>
   theme.unstable_sx({
-    py: 1.5,
-    px: 2,
+    p: 0.8,
     border: 'none',
-    borderBottom: '2px solid transparent',
-    bgcolor: 'primaryDark.800',
-    color: 'rgba(255 255 255 / 0.6)',
-    fontSize: '0.75rem',
-    fontWeight: 'semiBold',
+    bgcolor: 'transparent',
+    color: (theme.vars || theme).palette.grey[600],
+    fontSize: theme.typography.pxToRem(12),
+    fontWeight: theme.typography.fontWeightSemiBold,
     fontFamily: theme.typography.fontFamilyCode,
     outline: 'none',
-    minWidth: 80,
+    minWidth: 52,
     cursor: 'pointer',
-    '&:first-child /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */':
-      {
-        borderTopLeftRadius: (theme.vars || theme).shape.borderRadius,
-      },
+    borderRadius: '8px',
+    position: 'relative',
     '&:not(:first-child)': {
-      marginLeft: '1px',
-    },
-    '&:last-child': {
-      borderTopRightRadius: (theme.vars || theme).shape.borderRadius,
+      marginLeft: 0.5,
     },
     ...(ownerState.mounted && {
       '&.Mui-selected': {
-        color: '#fff',
-        borderColor: (theme.vars || theme).palette.primary.light,
+        color: '#FFF',
+        '&:after': {
+          content: "''",
+          position: 'absolute',
+          left: 0,
+          bottom: '-6px',
+          height: 2,
+          width: '100%',
+          bgcolor: (theme.vars || theme).palette.primary.light,
+        },
       },
     }),
     '&:hover': {
-      backgroundColor: 'rgba(255 255 255 / 0.08)',
+      backgroundColor: alpha(theme.palette.primaryDark[500], 0.5),
     },
     '&:focus-visible': {
       outline: '2px solid',
       outlineOffset: '-2px',
-      outlineColor: (theme.vars || theme).palette.primary.main,
+      outlineColor: (theme.vars || theme).palette.primary.light,
     },
   }),
 );
@@ -123,7 +126,6 @@ export default function HighlightedCodeWithTabs({
             {tab}
           </StyledTab>
         ))}
-        <Box sx={{ ml: 'auto' }} />
       </StyledTabList>
       {tabs.map(({ tab, language, code }) => (
         <StyledTabPanel ownerState={ownerState} key={tab} value={tab}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR updates installation commands with the new `HighlightedCodeWithTabs` component, adding tabs to the code blocks. Picking up from a fantastic work by @alexfauquette on the component; here, I've refined the styles & updated the Core libraries docs.

**https://deploy-preview-37927--material-ui.netlify.app/material-ui/getting-started/installation/**

| Before | After |
|--------|--------|
| <img width="839" alt="Screen Shot 2023-07-11 at 15 11 52" src="https://github.com/mui/material-ui/assets/67129314/7e67762b-3290-4c03-84eb-9cb891fe820b"> | <img width="839" alt="Screen Shot 2023-07-11 at 15 12 04" src="https://github.com/mui/material-ui/assets/67129314/c6416b18-fd59-4d32-9495-2912717a0a44"> | 