### PR TITLE
[core] Make rimraf work after a major update

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev",
     "deploy": "git push material-ui-docs master:latest",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
-    "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
+    "icons": "rimraf --glob public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",
     "create-playground": "cpy --cwd=./scripts/ playground.template.tsx ../pages/playground --rename=index.tsx",
     "typescript": "tsc -p tsconfig.json && tsc -p scripts/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release:publish": "lerna publish from-package --dist-tag latest --contents build",
     "release:publish:dry-run": "lerna publish from-package --dist-tag latest --contents build --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag.mjs",
-    "docs:api": "rimraf ./docs/pages/**/api-docs ./docs/pages/**/api && yarn docs:api:build",
+    "docs:api": "rimraf --glob ./docs/pages/**/api-docs ./docs/pages/**/api && yarn docs:api:build",
     "docs:api:build": "ts-node ./packages/api-docs-builder/buildApi.ts",
     "docs:build": "yarn workspace docs build",
     "docs:build-sw": "yarn workspace docs build-sw",

--- a/packages/mui-icons-material/builder.mjs
+++ b/packages/mui-icons-material/builder.mjs
@@ -1,7 +1,7 @@
 import fse from 'fs-extra';
 import yargs from 'yargs';
 import path from 'path';
-import rimraf from 'rimraf';
+import { rimrafSync } from 'rimraf';
 import Mustache from 'mustache';
 import globAsync from 'fast-glob';
 import * as svgo from 'svgo';
@@ -237,7 +237,7 @@ async function worker({ progress, svgPath, options, renameFilter, template }) {
 export async function handler(options) {
   const progress = options.disableLog ? () => {} : () => process.stdout.write('.');
 
-  rimraf.sync(`${options.outputDir}/*.js`); // Clean old files
+  rimrafSync(`${options.outputDir}/*.js`, { glob: true }); // Clean old files
 
   let renameFilter = options.renameFilter;
   if (typeof renameFilter === 'string') {


### PR DESCRIPTION
As noted in https://github.com/mui/material-ui/pull/37889#issuecomment-1630940642, updating rimraf to the latest version caused some problems as globs are not recognized now. This PR updates the call sites to fix this.