### PR TITLE
[docs-infra] Improve disableToc={true} support

### DIFF
--- a/docs/pages/base-ui/all-components/index.js
+++ b/docs/pages/base-ui/all-components/index.js
@@ -5,7 +5,7 @@ import * as pageProps from 'docs/data/base/components/all-components/all-compone
 
 export default function Page(props) {
   const { userLanguage, ...other } = props;
-  return <MarkdownDocs {...pageProps} {...other} disableToc />;
+  return <MarkdownDocs {...pageProps} {...other} />;
 }
 
 Page.getLayout = (page) => {

--- a/docs/pages/base-ui/all-components/index.js
+++ b/docs/pages/base-ui/all-components/index.js
@@ -5,7 +5,7 @@ import * as pageProps from 'docs/data/base/components/all-components/all-compone
 
 export default function Page(props) {
   const { userLanguage, ...other } = props;
-  return <MarkdownDocs {...pageProps} {...other} />;
+  return <MarkdownDocs {...pageProps} {...other} disableToc />;
 }
 
 Page.getLayout = (page) => {

--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -15,6 +15,8 @@ import AdManager from 'docs/src/modules/components/AdManager';
 import AppLayoutDocsFooter from 'docs/src/modules/components/AppLayoutDocsFooter';
 import BackToTop from 'docs/src/modules/components/BackToTop';
 
+const TOC_WIDTH = 242;
+
 const Main = styled('main', {
   shouldForwardProp: (prop) => prop !== 'disableToc',
 })(({ disableToc, theme }) => ({
@@ -22,13 +24,13 @@ const Main = styled('main', {
   width: '100%',
   ...(disableToc
     ? {
-        [theme.breakpoints.up('lg')]: {
-          marginRight: '5%',
+        [theme.breakpoints.up('md')]: {
+          marginRight: TOC_WIDTH / 2,
         },
       }
     : {
         [theme.breakpoints.up('md')]: {
-          gridTemplateColumns: '1fr 242px',
+          gridTemplateColumns: `1fr ${TOC_WIDTH}px`,
         },
       }),
   '& .markdown-body .comment-link': {
@@ -37,13 +39,24 @@ const Main = styled('main', {
 }));
 
 const StyledAppContainer = styled(AppContainer, {
-  shouldForwardProp: (prop) => prop !== 'disableAd' && prop !== 'hasTabs',
-})(({ disableAd, hasTabs, theme }) => {
+  shouldForwardProp: (prop) => prop !== 'disableAd' && prop !== 'hasTabs' && prop !== 'disableToc',
+})(({ disableAd, hasTabs, disableToc, theme }) => {
   return {
     position: 'relative',
     // By default, a grid item cannot be smaller than the size of its content.
     // https://stackoverflow.com/questions/43311943/prevent-content-from-expanding-grid-items
     minWidth: 0,
+    ...(disableToc
+      ? {
+          // 105ch ≈ 930px
+          maxWidth: `calc(105ch + ${TOC_WIDTH / 2}px)`,
+        }
+      : {
+          // We're mostly hosting text content so max-width by px does not make sense considering font-size is system-adjustable.
+          fontFamily: 'Arial',
+          // 105ch ≈ 930px
+          maxWidth: '105ch',
+        }),
     ...(!disableAd && {
       ...(!hasTabs && {
         '&& .description': {
@@ -141,7 +154,7 @@ export default function AppLayoutDocs(props) {
             Render the TOCs first to avoid layout shift when the HTML is streamed.
             See https://jakearchibald.com/2014/dont-use-flexbox-for-page-layout/ for more details.
           */}
-          <StyledAppContainer disableAd={disableAd} hasTabs={hasTabs}>
+          <StyledAppContainer disableAd={disableAd} hasTabs={hasTabs} disableToc={disableToc}>
             <ActionsDiv>
               <EditPage sourceLocation={location} />
             </ActionsDiv>


### PR DESCRIPTION
Something I noticed from https://twitter.com/MUI_hq/status/1678486986137432074

1. Enable disableToc={true} on https://mui.com/base-ui/all-components/ to give it more space (half of the tocs width), same effect on the others page that uses it, like the Material Icon search page, or the template pages.
2. Fix the layout so it's stable when moving from a page that has `disableToc` to a page that doesn't.

https://deploy-preview-37931--material-ui.netlify.app/base-ui/all-components/