### PR TITLE
[docs][base] Add Tailwind CSS & plain CSS demos on the Textarea page

### DIFF
--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { useTheme } from '@mui/system';
+
+export default function UnstyledTextareaAutosize() {
+  return (
+    <React.Fragment>
+      <TextareaAutosize aria-label="empty textarea" placeholder="Empty" />
+      <Styles />
+    </React.Fragment>
+  );
+}
+const cyan = {
+  50: '#E9F8FC',
+  100: '#BDEBF4',
+  200: '#99D8E5',
+  300: '#66BACC',
+  400: '#1F94AD',
+  500: '#0D5463',
+  600: '#094855',
+  700: '#063C47',
+  800: '#043039',
+  900: '#022127',
+};
+
+const grey = {
+  50: '#f6f8fa',
+  100: '#eaeef2',
+  200: '#d0d7de',
+  300: '#afb8c1',
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+  700: '#424a53',
+  800: '#32383f',
+  900: '#24292f',
+};
+
+function useIsDarkMode() {
+  const theme = useTheme();
+  return theme.palette.mode === 'dark';
+}
+
+function Styles() {
+  // Replace this with your app logic for determining dark mode
+  const isDarkMode = useIsDarkMode();
+
+  return (
+    <style>
+      {`
+        .CustomTextarea {
+        width: 320px;
+        font-family: IBM Plex Sans, sans-serif;
+        font-size: 0.875rem;
+        font-weight: 400;
+        line-height: 1.5;
+        padding: 12px;
+        border-radius: 12px;
+        color: ${isDarkMode ? grey[300] : grey[900]};
+        background: ${isDarkMode ? grey[900] : '#fff'};
+        border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
+        box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
+    
+        &:hover {
+        border-color: ${cyan[400]};
+        }
+    
+        &:focus {
+        border-color: ${cyan[400]};
+        box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+        }
+    
+        // firefox
+        &:focus-visible {
+        outline: 0;
+        }
+        }
+    `}
+    </style>
+  );
+}

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
@@ -52,7 +52,7 @@ function Styles() {
   return (
     <style>
       {`
-        .CustomTextarea {
+       .CustomTextarea {
         width: 320px;
         font-family: IBM Plex Sans, sans-serif;
         font-size: 0.875rem;
@@ -64,20 +64,21 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
-    
-        &:hover {
-        border-color: ${cyan[400]};
         }
-    
-        &:focus {
-        border-color: ${cyan[400]};
-        box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+
+        .CustomTextarea:hover {
+          border-color: ${cyan[400]};
         }
-            
+
+        .CustomTextarea:focus {
+          border-color: ${cyan[400]};
+          box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+          outline: none;
+        }
+        
         // firefox
-        &:focus-visible {
+        .CustomTextarea:focus-visible {
         outline: 0;
-        }
         }
     `}
     </style>

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
@@ -5,7 +5,11 @@ import { useTheme } from '@mui/system';
 export default function UnstyledTextareaAutosize() {
   return (
     <React.Fragment>
-      <TextareaAutosize aria-label="empty textarea" placeholder="Empty" />
+      <TextareaAutosize
+        className="CustomTextarea"
+        aria-label="empty textarea"
+        placeholder="Empty"
+      />
       <Styles />
     </React.Fragment>
   );
@@ -55,7 +59,7 @@ function Styles() {
         font-weight: 400;
         line-height: 1.5;
         padding: 12px;
-        border-radius: 12px;
+        border-radius: 12px 12px 0 12px;
         color: ${isDarkMode ? grey[300] : grey[900]};
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
@@ -69,7 +73,7 @@ function Styles() {
         border-color: ${cyan[400]};
         box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
         }
-    
+            
         // firefox
         &:focus-visible {
         outline: 0;

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.js
@@ -52,7 +52,7 @@ function Styles() {
   return (
     <style>
       {`
-       .CustomTextarea {
+      .CustomTextarea {
         width: 320px;
         font-family: IBM Plex Sans, sans-serif;
         font-size: 0.875rem;
@@ -64,22 +64,22 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
-        }
+      }
 
-        .CustomTextarea:hover {
-          border-color: ${cyan[400]};
-        }
+     .CustomTextarea:hover {
+        border-color: ${cyan[400]};
+      }
 
-        .CustomTextarea:focus {
-          border-color: ${cyan[400]};
-          box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
-          outline: none;
-        }
-        
-        // firefox
-        .CustomTextarea:focus-visible {
-        outline: 0;
-        }
+     .CustomTextarea:focus {
+        border-color: ${cyan[400]};
+        box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+        outline: none;
+      }
+      
+      // firefox
+      .CustomTextarea:focus-visible {
+      outline: 0;
+      }
     `}
     </style>
   );

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { useTheme } from '@mui/system';
+
+export default function UnstyledTextareaAutosize() {
+  return (
+    <React.Fragment>
+      <TextareaAutosize aria-label="empty textarea" placeholder="Empty" />
+      <Styles />
+    </React.Fragment>
+  );
+}
+const cyan = {
+  50: '#E9F8FC',
+  100: '#BDEBF4',
+  200: '#99D8E5',
+  300: '#66BACC',
+  400: '#1F94AD',
+  500: '#0D5463',
+  600: '#094855',
+  700: '#063C47',
+  800: '#043039',
+  900: '#022127',
+};
+
+const grey = {
+  50: '#f6f8fa',
+  100: '#eaeef2',
+  200: '#d0d7de',
+  300: '#afb8c1',
+  400: '#8c959f',
+  500: '#6e7781',
+  600: '#57606a',
+  700: '#424a53',
+  800: '#32383f',
+  900: '#24292f',
+};
+
+function useIsDarkMode() {
+  const theme = useTheme();
+  return theme.palette.mode === 'dark';
+}
+
+function Styles() {
+  // Replace this with your app logic for determining dark mode
+  const isDarkMode = useIsDarkMode();
+
+  return (
+    <style>
+      {`
+        .CustomTextarea {
+        width: 320px;
+        font-family: IBM Plex Sans, sans-serif;
+        font-size: 0.875rem;
+        font-weight: 400;
+        line-height: 1.5;
+        padding: 12px;
+        border-radius: 12px;
+        color: ${isDarkMode ? grey[300] : grey[900]};
+        background: ${isDarkMode ? grey[900] : '#fff'};
+        border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
+        box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
+    
+        &:hover {
+        border-color: ${cyan[400]};
+        }
+    
+        &:focus {
+        border-color: ${cyan[400]};
+        box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+        }
+    
+        // firefox
+        &:focus-visible {
+        outline: 0;
+        }
+        }
+    `}
+    </style>
+  );
+}

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
@@ -5,7 +5,11 @@ import { useTheme } from '@mui/system';
 export default function UnstyledTextareaAutosize() {
   return (
     <React.Fragment>
-      <TextareaAutosize aria-label="empty textarea" placeholder="Empty" />
+      <TextareaAutosize
+        className="CustomTextarea"
+        aria-label="empty textarea"
+        placeholder="Empty"
+      />
       <Styles />
     </React.Fragment>
   );

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
@@ -59,7 +59,7 @@ function Styles() {
         font-weight: 400;
         line-height: 1.5;
         padding: 12px;
-        border-radius: 12px;
+        border-radius: 12px 12px 0 12px;
         color: ${isDarkMode ? grey[300] : grey[900]};
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
@@ -73,7 +73,7 @@ function Styles() {
         border-color: ${cyan[400]};
         box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
         }
-    
+            
         // firefox
         &:focus-visible {
         outline: 0;

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
@@ -64,21 +64,23 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
-    
-        &:hover {
-        border-color: ${cyan[400]};
         }
-    
-        &:focus {
-        border-color: ${cyan[400]};
-        box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+
+        .CustomTextarea:hover {
+          border-color: ${cyan[400]};
         }
-            
+
+        .CustomTextarea:focus {
+          border-color: ${cyan[400]};
+          box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+          outline: none;
+        }
+        
         // firefox
-        &:focus-visible {
+        .CustomTextarea:focus-visible {
         outline: 0;
         }
-        }
+    
     `}
     </style>
   );

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx
@@ -52,7 +52,7 @@ function Styles() {
   return (
     <style>
       {`
-        .CustomTextarea {
+      .CustomTextarea {
         width: 320px;
         font-family: IBM Plex Sans, sans-serif;
         font-size: 0.875rem;
@@ -64,23 +64,22 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
-        }
+      }
 
-        .CustomTextarea:hover {
-          border-color: ${cyan[400]};
-        }
+     .CustomTextarea:hover {
+        border-color: ${cyan[400]};
+      }
 
-        .CustomTextarea:focus {
-          border-color: ${cyan[400]};
-          box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
-          outline: none;
-        }
-        
-        // firefox
-        .CustomTextarea:focus-visible {
-        outline: 0;
-        }
-    
+     .CustomTextarea:focus {
+        border-color: ${cyan[400]};
+        box-shadow: 0 0 0 3px ${isDarkMode ? cyan[500] : cyan[200]};
+        outline: none;
+      }
+      
+      // firefox
+      .CustomTextarea:focus-visible {
+      outline: 0;
+      }
     `}
     </style>
   );

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx.preview
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx.preview
@@ -1,4 +1,8 @@
 <React.Fragment>
-  <TextareaAutosize aria-label="empty textarea" placeholder="Empty" />
+  <TextareaAutosize
+    className="CustomTextarea"
+    aria-label="empty textarea"
+    placeholder="Empty"
+  />
   <Styles />
 </React.Fragment>

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx.preview
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/css/index.tsx.preview
@@ -1,0 +1,4 @@
+<React.Fragment>
+  <TextareaAutosize aria-label="empty textarea" placeholder="Empty" />
+  <Styles />
+</React.Fragment>

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.js
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { styled } from '@mui/system';
+
+export default function EmptyTextarea() {
+  const blue = {
+    100: '#DAECFF',
+    200: '#b6daff',
+    400: '#3399FF',
+    500: '#007FFF',
+    600: '#0072E5',
+    900: '#003A75',
+  };
+
+  const grey = {
+    50: '#f6f8fa',
+    100: '#eaeef2',
+    200: '#d0d7de',
+    300: '#afb8c1',
+    400: '#8c959f',
+    500: '#6e7781',
+    600: '#57606a',
+    700: '#424a53',
+    800: '#32383f',
+    900: '#24292f',
+  };
+
+  const StyledTextarea = styled(TextareaAutosize)(
+    ({ theme }) => `
+    width: 320px;
+    font-family: IBM Plex Sans, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.5;
+    padding: 12px;
+    border-radius: 12px;
+    color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+    background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+    border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+    box-shadow: 0px 2px 2px ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
+  
+    &:hover {
+      border-color: ${blue[400]};
+    }
+  
+    &:focus {
+      border-color: ${blue[400]};
+      box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[500] : blue[200]};
+    }
+  
+    // firefox
+    &:focus-visible {
+      outline: 0;
+    }
+  `,
+  );
+
+  return <StyledTextarea aria-label="empty textarea" placeholder="Empty" />;
+}

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.js
@@ -33,7 +33,7 @@ export default function EmptyTextarea() {
     font-weight: 400;
     line-height: 1.5;
     padding: 12px;
-    border-radius: 12px;
+    border-radius: 12px 12px 0 12px;
     color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
     background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
     border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { styled } from '@mui/system';
+
+export default function EmptyTextarea() {
+  const blue = {
+    100: '#DAECFF',
+    200: '#b6daff',
+    400: '#3399FF',
+    500: '#007FFF',
+    600: '#0072E5',
+    900: '#003A75',
+  };
+
+  const grey = {
+    50: '#f6f8fa',
+    100: '#eaeef2',
+    200: '#d0d7de',
+    300: '#afb8c1',
+    400: '#8c959f',
+    500: '#6e7781',
+    600: '#57606a',
+    700: '#424a53',
+    800: '#32383f',
+    900: '#24292f',
+  };
+
+  const StyledTextarea = styled(TextareaAutosize)(
+    ({ theme }) => `
+    width: 320px;
+    font-family: IBM Plex Sans, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.5;
+    padding: 12px;
+    border-radius: 12px;
+    color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+    background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+    border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+    box-shadow: 0px 2px 2px ${theme.palette.mode === 'dark' ? grey[900] : grey[50]};
+  
+    &:hover {
+      border-color: ${blue[400]};
+    }
+  
+    &:focus {
+      border-color: ${blue[400]};
+      box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[500] : blue[200]};
+    }
+  
+    // firefox
+    &:focus-visible {
+      outline: 0;
+    }
+  `,
+  );
+
+  return <StyledTextarea aria-label="empty textarea" placeholder="Empty" />;
+}

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.tsx
@@ -33,7 +33,7 @@ export default function EmptyTextarea() {
     font-weight: 400;
     line-height: 1.5;
     padding: 12px;
-    border-radius: 12px;
+    border-radius: 12px 12px 0 12px;
     color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
     background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
     border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.tsx.preview
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/system/index.tsx.preview
@@ -1,0 +1,1 @@
+<StyledTextarea aria-label="empty textarea" placeholder="Empty" />

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { useTheme } from '@mui/system';
+
+function useIsDarkMode() {
+  const theme = useTheme();
+  return theme.palette.mode === 'dark';
+}
+
+export default function UnstyledTextareaAutosize() {
+  // Replace this with your app logic for determining dark modes
+  const isDarkMode = useIsDarkMode();
+
+  return (
+    <div className={isDarkMode ? 'dark' : ''}>
+      <TextareaAutosize
+        className="w-80 text-sm font-normal leading-5 px-3 py-2 rounded-lg shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+        aria-label="Demo input"
+        placeholder="Type something…"
+      />
+    </div>
+  );
+}

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.js
@@ -14,9 +14,9 @@ export default function UnstyledTextareaAutosize() {
   return (
     <div className={isDarkMode ? 'dark' : ''}>
       <TextareaAutosize
-        className="w-80 text-sm font-normal leading-5 px-3 py-2 rounded-lg shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+        className="w-80 text-sm font-normal leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
         aria-label="Demo input"
-        placeholder="Type something…"
+        placeholder="Empty"
       />
     </div>
   );

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.js
@@ -14,7 +14,7 @@ export default function UnstyledTextareaAutosize() {
   return (
     <div className={isDarkMode ? 'dark' : ''}>
       <TextareaAutosize
-        className="w-80 text-sm font-normal leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+        className="w-80 text-sm font-normal font-sans leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
         aria-label="Demo input"
         placeholder="Empty"
       />

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import TextareaAutosize from '@mui/base/TextareaAutosize';
+import { useTheme } from '@mui/system';
+
+function useIsDarkMode() {
+  const theme = useTheme();
+  return theme.palette.mode === 'dark';
+}
+
+export default function UnstyledTextareaAutosize() {
+  // Replace this with your app logic for determining dark modes
+  const isDarkMode = useIsDarkMode();
+
+  return (
+    <div className={isDarkMode ? 'dark' : ''}>
+      <TextareaAutosize
+        className="w-80 text-sm font-normal leading-5 px-3 py-2 rounded-lg shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+        aria-label="Demo input"
+        placeholder="Type something…"
+      />
+    </div>
+  );
+}

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx
@@ -14,9 +14,9 @@ export default function UnstyledTextareaAutosize() {
   return (
     <div className={isDarkMode ? 'dark' : ''}>
       <TextareaAutosize
-        className="w-80 text-sm font-normal leading-5 px-3 py-2 rounded-lg shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+        className="w-80 text-sm font-normal leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
         aria-label="Demo input"
-        placeholder="Type something…"
+        placeholder="Empty"
       />
     </div>
   );

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx
@@ -14,7 +14,7 @@ export default function UnstyledTextareaAutosize() {
   return (
     <div className={isDarkMode ? 'dark' : ''}>
       <TextareaAutosize
-        className="w-80 text-sm font-normal leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+        className="w-80 text-sm font-normal font-sans leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
         aria-label="Demo input"
         placeholder="Empty"
       />

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx.preview
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx.preview
@@ -1,0 +1,5 @@
+<TextareaAutosize
+  className="w-80 text-sm font-normal leading-5 px-3 py-2 rounded-lg shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+  aria-label="Demo input"
+  placeholder="Type something…"
+/>

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx.preview
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx.preview
@@ -1,5 +1,5 @@
 <TextareaAutosize
-  className="w-80 text-sm font-normal leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+  className="w-80 text-sm font-normal font-sans leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
   aria-label="Demo input"
   placeholder="Empty"
 />

--- a/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx.preview
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextarea/tailwind/index.tsx.preview
@@ -1,5 +1,5 @@
 <TextareaAutosize
-  className="w-80 text-sm font-normal leading-5 px-3 py-2 rounded-lg shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
+  className="w-80 text-sm font-normal leading-5 p-3 rounded-xl rounded-br-none shadow-md shadow-slate-100 dark:shadow-slate-900 focus:shadow-outline-purple dark:focus:shadow-outline-purple focus:shadow-lg border border-solid border-slate-300 hover:border-purple-500 dark:hover:border-purple-500 focus:border-purple-500 dark:focus:border-purple-500 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-300 focus-visible:outline-0"
   aria-label="Demo input"
-  placeholder="Type something…"
+  placeholder="Empty"
 />

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -45,7 +45,7 @@ By default, an empty Textarea Autosize component renders as a single row, as sho
 
 The next demo shows how to apply custom styles to the Textarea:
 
-{{"demo": "EmptyTextarea.js"}}
+{{"demo": "UnstyledTextarea", "defaultCodeOpen": false}}
 
 ## Customization
 

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -39,11 +39,7 @@ export default function MyApp() {
 
 Textarea Autosize behaves similarly to the native HTML`<textarea>`.
 
-By default, an empty Textarea Autosize component renders as a single row, as shown in the following demo:
-
-{{"demo": "EmptyTextarea.js"}}
-
-The next demo shows how to apply custom styles to the Textarea:
+By default, the Textarea Autosize component renders as a single row when it is empty. In the following demo, you can observe this behavior and learn how to apply custom styles to the component.
 
 {{"demo": "UnstyledTextarea", "defaultCodeOpen": false}}
 

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -43,6 +43,10 @@ By default, an empty Textarea Autosize component renders as a single row, as sho
 
 {{"demo": "EmptyTextarea.js"}}
 
+The next demo shows how to apply custom styles to the Textarea:
+
+{{"demo": "EmptyTextarea.js"}}
+
 ## Customization
 
 ### Minimum height

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -39,7 +39,7 @@ export default function MyApp() {
 
 Textarea Autosize behaves similarly to the native HTML`<textarea>`.
 
-By default, the Textarea Autosize component renders as a single row when it is empty. In the following demo, you can observe this behavior and learn how to apply custom styles to the component.
+By default, an empty Textarea Autosize component renders as a single row, as shown in the following demo:
 
 {{"demo": "UnstyledTextarea", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of https://github.com/mui/material-ui/issues/37222