### PR TITLE
[docs] Link charts in the roadmap

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -3,7 +3,7 @@
 <p class="description">Get started with Base UI, a library of headless ("unstyled") React UI components and low-level hooks.</p>
 
 :::info
-If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](/base-ui/guides/next-js-app-router/)
+If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](/base-ui/guides/next-js-app-router/).
 :::
 
 ## Installation

--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -43,7 +43,7 @@ Here are the top priorities:
 Here are the components we will work on being supported in the MUI ecosystem:
 
 - ✅ Released as stable
-- 🧪 Close to becoming stable, already released as unstable
+- 🧪 Not too far from becoming stable, already released as unstable
 - 🛠 Work in progress, will be or already released as unstable
 - ⏳ Planning to build
 
@@ -51,7 +51,7 @@ Here are the components we will work on being supported in the MUI ecosystem:
 | :----------------------------------------------------------------------- | :------- | :----- |
 | Advanced Layout                                                          | MUI X    | ⏳     |
 | Carousel                                                                 | MUI X    | ⏳     |
-| Charts                                                                   | MUI X    | ⏳     |
+| [Charts](https://mui.com/x/react-charts/)                                | MUI X    | 🧪     |
 | [Data Grid](/x/react-data-grid/)                                         | MUI X    | ✅     |
 | [Date Picker](/x/react-date-pickers/date-picker/)                        | MUI X    | ✅     |
 | [Time Picker](/x/react-date-pickers/time-picker/)                        | MUI X    | ✅     |

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -6,7 +6,7 @@
 We are currently working on supporting React Server Components in Material UI.
 
 All components and hooks are exported as [Client Components](https://nextjs.org/docs/getting-started/react-essentials#client-components) with the `"use client"` directive.
-If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](/material-ui/guides/next-js-app-router/)
+If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](/material-ui/guides/next-js-app-router/).
 
 :::
 

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -881,7 +881,10 @@ function AboutContent() {
                 </li>
                 <li>
                   Answer questions on{' '}
-                  <Link href="https://stackoverflow.com/questions/tagged/mui">Stack Overflow</Link>.
+                  <Link href="https://stackoverflow.com/questions/tagged/material-ui">
+                    Stack Overflow
+                  </Link>
+                  .
                 </li>
               </Box>
               <Button

--- a/docs/pages/material-ui.tsx
+++ b/docs/pages/material-ui.tsx
@@ -15,8 +15,8 @@ export default function Core() {
   return (
     <BrandingCssVarsProvider>
       <Head
-        title="Material UI: An open-source React component library that implements Google's Material Design"
-        description="A comprehensive collection of prebuilt components that are ready for use in production right out of the box."
+        title="Material UI: React components based on Material Design"
+        description="Material UI is an open-source React component library that implements Google's Material Design. It's comprehensive and can be used in production right out of the box."
         card="/static/social-previews/core-preview.jpg"
       />
       <AppHeaderBanner />


### PR DESCRIPTION
To update https://mui.com/material-ui/discover-more/roadmap/#new-components, the rest is side small fixes (e.g. title too long).

Preview: https://deploy-preview-37944--material-ui.netlify.app/material-ui/discover-more/roadmap/#new-components

I found this by searching for "charts" in Algolia. @alexfauquette shouldn't we instruct Algolia to index the charts pages? I think that you can go ahead and update the config.