### PR TITLE
[docs-infra] Support backticks in the codeblocks

### DIFF
--- a/docs/pages/experiments/docs/installation.md
+++ b/docs/pages/experiments/docs/installation.md
@@ -8,10 +8,12 @@
 
 ```bash npm
 npm install @mui/material @emotion/react @emotion/styled
+# `@emotion/react` and `@emotion/styled` are peer dependencies
 ```
 
 ```bash yarn
 yarn add @mui/material @emotion/react @emotion/styled
+# `@emotion/react` and `@emotion/styled` are peer dependencies
 ```
 
 </codeblock>

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -550,7 +550,7 @@ ${headers.hooks
         }
         if (content.startsWith('<codeblock')) {
           const storageKey = content.match(/^<codeblock [^>]*storageKey=["|'](\S*)["|'].*>/m)?.[1];
-          const blocks = [...content.matchAll(/^```(\S*) (\S*)\n([^`]*)\n```/gmsu)].map(
+          const blocks = [...content.matchAll(/^```(\S*) (\S*)\n(.*?)\n```/gmsu)].map(
             ([, language, tab, code]) => ({ language, tab, code }),
           );
 

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -5,6 +5,7 @@ import {
   getTitle,
   getHeaders,
   prepareMarkdown,
+  getCodeblock,
 } from './parseMarkdown';
 
 describe('parseMarkdown', () => {
@@ -559,6 +560,55 @@ https://developers.google.com/search/docs/advanced/appearance/title-link
 It needs to have fewer than 170 characters—ideally less than 160. For more details, see:
 https://ahrefs.com/blog/meta-description/#4-be-concise
 `);
+    });
+  });
+
+  describe('getCodeblock', () => {
+    it('should return undefined if no codeblock found', () => {
+      const codeblock = getCodeblock('## Tabs');
+      expect(codeblock).to.equal(undefined);
+    });
+
+    it('should return the codeblock', () => {
+      const codeblock = getCodeblock(
+        [
+          '<codeblock storageKey="package-manager">',
+          '',
+          '```bash npm',
+          'npm install @mui/material @emotion/react @emotion/styled',
+          '# `@emotion/react` and `@emotion/styled` are peer dependencies',
+          '```',
+          '',
+          '```sh yarn',
+          'yarn add @mui/material @emotion/react @emotion/styled',
+          '# `@emotion/react` and `@emotion/styled` are peer dependencies',
+          '```',
+          '',
+          '</codeblock>',
+        ].join('\n'),
+      );
+      expect(codeblock).to.deep.equal({
+        type: 'codeblock',
+        storageKey: 'package-manager',
+        data: [
+          {
+            language: 'bash',
+            tab: 'npm',
+            code: [
+              'npm install @mui/material @emotion/react @emotion/styled',
+              '# `@emotion/react` and `@emotion/styled` are peer dependencies',
+            ].join('\n'),
+          },
+          {
+            language: 'sh',
+            tab: 'yarn',
+            code: [
+              'yarn add @mui/material @emotion/react @emotion/styled',
+              '# `@emotion/react` and `@emotion/styled` are peer dependencies',
+            ].join('\n'),
+          },
+        ],
+      });
     });
   });
 

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -158,6 +158,45 @@ authors:
         ]);
       });
     });
+
+    describe('Split markdown into an array, separating codeblocks', () => {
+      it('uses a `<codeblock>` tag to split', () => {
+        expect(
+          getContents(
+            [
+              '## Tabs',
+              '',
+              '<codeblock storageKey="package-manager">',
+              '',
+              '```bash npm',
+              'npm install @mui/material @emotion/react @emotion/styled',
+              '```',
+              '',
+              '```bash yarn',
+              'yarn add @mui/material @emotion/react @emotion/styled',
+              '```',
+              '',
+              '</codeblock>',
+            ].join('\n'),
+          ),
+        ).to.deep.equal([
+          '## Tabs\n\n',
+          [
+            '<codeblock storageKey="package-manager">',
+            '',
+            '```bash npm',
+            'npm install @mui/material @emotion/react @emotion/styled',
+            '```',
+            '',
+            '```bash yarn',
+            'yarn add @mui/material @emotion/react @emotion/styled',
+            '```',
+            '',
+            '</codeblock>',
+          ].join('\n'),
+        ]);
+      });
+    });
   });
 
   describe('prepareMarkdown', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I have noticed that codeblocks do not work if the block contains backticks

Preview: https://deploy-preview-37950--material-ui.netlify.app/experiments/docs/installation/

<img width="550" alt="Screenshot 2023-07-14 at 01 05 57" src="https://github.com/mui/material-ui/assets/3165635/ea7ea487-bbd2-43ad-90b1-f3516e21619b">