### PR TITLE
Add use client directive to useSliderElementsOverlap

### DIFF
--- a/packages/mui-material-next/src/Slider/useSliderElementsOverlap.ts
+++ b/packages/mui-material-next/src/Slider/useSliderElementsOverlap.ts
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { Axis } from '@mui/base';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';


### PR DESCRIPTION
Missed this one in https://github.com/mui/material-ui/pull/37656

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
