### PR TITLE
[Menu] Add MuiMenuList to createTheme components key

### DIFF
--- a/packages/mui-material/src/styles/components.d.ts
+++ b/packages/mui-material/src/styles/components.d.ts
@@ -338,6 +338,11 @@ export interface Components<Theme = unknown> {
     styleOverrides?: ComponentsOverrides<Theme>['MuiMenuItem'];
     variants?: ComponentsVariants['MuiMenuItem'];
   };
+  MuiMenuList?: {
+    defaultProps?: ComponentsProps['MuiMenuList'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiMenuList'];
+    variants?: ComponentsVariants['MuiMenuList'];
+  };
   MuiMobileStepper?: {
     defaultProps?: ComponentsProps['MuiMobileStepper'];
     styleOverrides?: ComponentsOverrides<Theme>['MuiMobileStepper'];

--- a/packages/mui-material/src/styles/overrides.d.ts
+++ b/packages/mui-material/src/styles/overrides.d.ts
@@ -66,6 +66,7 @@ import { ListItemTextClassKey } from '../ListItemText';
 import { ListSubheaderClassKey } from '../ListSubheader';
 import { MenuClassKey } from '../Menu';
 import { MenuItemClassKey } from '../MenuItem';
+import { MenuListClassKey } from '../MenuList';
 import { MobileStepperClassKey } from '../MobileStepper';
 import { ModalClassKey } from '../Modal';
 import { NativeSelectClassKey } from '../NativeSelect';
@@ -204,6 +205,7 @@ export interface ComponentNameToClassKey {
   MuiListSubheader: ListSubheaderClassKey;
   MuiMenu: MenuClassKey;
   MuiMenuItem: MenuItemClassKey;
+  MuiMenuList: MenuListClassKey;
   MuiMobileStepper: MobileStepperClassKey;
   MuiModal: ModalClassKey;
   MuiNativeSelect: NativeSelectClassKey;


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/37949

The fix allows this to work without a TS error:

```js
const theme = createTheme({
  components: {
    MuiMenuList: {
      defaultProps: {
        dense: true,
      },
    },
  },
});
```

Sandbox: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-37956-st5yhg?file=/src/index.tsx:221-351

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
