### PR TITLE
[core] Lock `@types/node` to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "**/@definitelytyped/header-parser": "^0.0.163",
     "**/@definitelytyped/typescript-versions": "^0.0.163",
     "**/@definitelytyped/utils": "^0.0.163",
+    "**/@types/node": "<19",
     "**/@types/react": "^18.2.14",
     "**/cross-fetch": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "**/@definitelytyped/header-parser": "^0.0.163",
     "**/@definitelytyped/typescript-versions": "^0.0.163",
     "**/@definitelytyped/utils": "^0.0.163",
-    "**/@types/node": "<19",
+    "**/@types/node": "^18.16.19",
     "**/@types/react": "^18.2.14",
     "**/cross-fetch": "^4.0.0"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -76,6 +76,11 @@
       "matchPackagePatterns": "@typescript-eslint/*"
     },
     {
+      "groupName": "@types/node",
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "< 19.0.0"
+    },
+    {
       "groupName": "bundling fixtures",
       "matchPaths": ["test/bundling/fixtures/**/package.json"],
       "schedule": "every 6 months on the first day of the month"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3444,20 +3444,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.1.tgz#2f4f65bb08bc368ac39c96da7b2f09140b26851b"
   integrity sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@^18.16.19":
+"@types/node@*", "@types/node@18.16.0", "@types/node@<19", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@^14.0.1", "@types/node@^14.14.35", "@types/node@^18.16.19":
   version "18.16.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.19.tgz#cb03fca8910fdeb7595b755126a8a78144714eea"
   integrity sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==
-
-"@types/node@18.16.0":
-  version "18.16.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.0.tgz#4668bc392bb6938637b47e98b1f2ed5426f33316"
-  integrity sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==
-
-"@types/node@^14.0.1", "@types/node@^14.14.35":
-  version "14.18.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.29.tgz#a0c58d67a42f8953c13d32f0acda47ed26dfce40"
-  integrity sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==
 
 "@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.1":
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3444,7 +3444,7 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.1.tgz#2f4f65bb08bc368ac39c96da7b2f09140b26851b"
   integrity sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==
 
-"@types/node@*", "@types/node@18.16.0", "@types/node@<19", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@^14.0.1", "@types/node@^14.14.35", "@types/node@^18.16.19":
+"@types/node@*", "@types/node@18.16.0", "@types/node@>=10.0.0", "@types/node@>=12", "@types/node@>=12.0.0", "@types/node@^14.0.1", "@types/node@^14.14.35", "@types/node@^18.16.19":
   version "18.16.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.19.tgz#cb03fca8910fdeb7595b755126a8a78144714eea"
   integrity sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Similar to https://github.com/mui/mui-x/pull/9107. 

Closes #37880.

Despite the statement in https://github.com/mui/material-ui/pull/37793#issuecomment-1617635461, Renovate still opened a pull request (#37880) for the update. See the discussion in #37793. 