### PR TITLE
[docs-infra] Square drawer corners

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -184,12 +184,6 @@ const AppNavPaperComponent = styled('div')(({ theme }) => {
     boxShadow: 'none',
     boxSizing: 'border-box', // TODO have CssBaseline in the Next.js layout
     paddingBottom: theme.spacing(5),
-    [theme.breakpoints.up('xs')]: {
-      borderRadius: '0px 10px 10px 0px',
-    },
-    [theme.breakpoints.up('sm')]: {
-      borderRadius: '0px',
-    },
   };
 });
 


### PR DESCRIPTION
Google Calendar has a round corder https://m3.material.io/components/navigation-drawer/overview, Gmail has a square corner on my phone. Gmail feels much better, I feel like we could do the same for the docs

Before

<img width="499" alt="Screenshot 2023-07-15 at 00 33 10" src="https://github.com/mui/material-ui/assets/3165635/bb2729e3-15a8-4b15-a0dc-67ba8437726c">

After

<img width="528" alt="Screenshot 2023-07-15 at 00 33 20" src="https://github.com/mui/material-ui/assets/3165635/49c7871d-abda-40ba-8d35-938657bbc436">
