### PR TITLE
[docs] Link Material UI from the landing page

### DIFF
--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -19,7 +19,7 @@ export default function GetStartedButtons(props: GetStartedButtonsProps) {
 
   const handleCopy = () => {
     setCopied(true);
-    copy(installation as any).then(() => {
+    copy(installation!).then(() => {
       setTimeout(() => setCopied(false), 2000);
     });
   };

--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -19,7 +19,7 @@ export default function GetStartedButtons(props: GetStartedButtonsProps) {
 
   const handleCopy = () => {
     setCopied(true);
-    copy(installation!).then(() => {
+    copy(installation as any).then(() => {
       setTimeout(() => setCopied(false), 2000);
     });
   };

--- a/docs/src/components/home/Hero.tsx
+++ b/docs/src/components/home/Hero.tsx
@@ -8,7 +8,6 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import GradientText from 'docs/src/components/typography/GradientText';
 import GetStartedButtons from 'docs/src/components/home/GetStartedButtons';
 import HeroContainer from 'docs/src/layouts/HeroContainer';
-import ROUTES from 'docs/src/route';
 
 function createLoading(sx: BoxProps['sx']) {
   return function Loading() {
@@ -101,10 +100,7 @@ export default function Hero() {
             with Material UI, our fully-loaded component library, or bring your own design system to
             our production-ready components.
           </Typography>
-          <GetStartedButtons
-            to={ROUTES.documentation}
-            installation="npm install @mui/material @emotion/react @emotion/styled"
-          />
+          <GetStartedButtons callToAction="Discover Material UI" to="/material-ui/" />
         </Box>
       }
       rightSx={{

--- a/docs/src/components/home/Hero.tsx
+++ b/docs/src/components/home/Hero.tsx
@@ -100,7 +100,7 @@ export default function Hero() {
             with Material UI, our fully-loaded component library, or bring your own design system to
             our production-ready components.
           </Typography>
-          <GetStartedButtons callToAction="Discover Material UI" to="/material-ui/" />
+          <GetStartedButtons callToAction="Discover the Core libraries" to="/core/" />
         </Box>
       }
       rightSx={{

--- a/docs/src/components/home/StartToday.tsx
+++ b/docs/src/components/home/StartToday.tsx
@@ -22,7 +22,7 @@ export default function StartToday() {
           }
           description="Find out why MUI's tools are trusted by thousands of open-source developers and teams around the world."
         />
-        <GetStartedButtons callToAction="Discover Material UI" to="/material-ui/" />
+        <GetStartedButtons callToAction="Discover the Core libraries" to="/core/" />
       </Grid>
       <Grid item xs={12} sm={6} md={6} container spacing={2}>
         <Grid item xs={12} md={6}>

--- a/docs/src/components/home/StartToday.tsx
+++ b/docs/src/components/home/StartToday.tsx
@@ -22,10 +22,7 @@ export default function StartToday() {
           }
           description="Find out why MUI's tools are trusted by thousands of open-source developers and teams around the world."
         />
-        <GetStartedButtons
-          to={ROUTES.documentation}
-          installation="npm install @mui/material @emotion/react @emotion/styled"
-        />
+        <GetStartedButtons callToAction="Discover Material UI" to="/material-ui/" />
       </Grid>
       <Grid item xs={12} sm={6} md={6} container spacing={2}>
         <Grid item xs={12} md={6}>

--- a/docs/src/components/productMaterial/MaterialHero.tsx
+++ b/docs/src/components/productMaterial/MaterialHero.tsx
@@ -245,7 +245,7 @@ export default function MaterialHero() {
             make it easy to implement your own custom design system.
           </Typography>
           <GetStartedButtons
-            to={ROUTES.documentation}
+            to="/material-ui/getting-started/"
             installation="npm install @mui/material @emotion/react @emotion/styled"
           />
         </Box>


### PR DESCRIPTION
## Problem

Take https://search.google.com/search-console/performance/search-analytics, developers were quick to jump into the opportunity to replace their search for "material ui" to "mui", I imagine because it's faster to type:

<img width="675" alt="Screenshot 2023-07-15 at 01 02 45" src="https://github.com/mui/material-ui/assets/3165635/ebebe1e3-b390-4c42-8c71-e0cfcc633465">

Noooo

## Solution 

1. Make landing on https://mui.com/material-ui/ from Google a faster way to reach Material UI docs than landing on https://mui.com/. So reduce the advantage of the shorter "mui" search query over typing "material ui".
2. Break the narrative of MUI homepage hosting the installation instructions of Material UI

<img width="340" alt="Screenshot 2023-07-15 at 00 55 10" src="https://github.com/mui/material-ui/assets/3165635/01cadf5c-eb59-40ac-a8c5-e21ec59c9a68">

Preview: https://deploy-preview-37971--material-ui.netlify.app/

It will be even better with #37608