### PR TITLE
[Autocomplete] Make touch and click behavior on an option consistent

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -378,10 +378,14 @@ export default function useAutocomplete(props) {
 
     // Scroll active descendant into view.
     // Logic copied from https://www.w3.org/WAI/content-assets/wai-aria-practices/patterns/combobox/examples/js/select-only.js
-    //
+    // In case of mouse clicks and touch (in mobile devices) we avoid scrolling the element and keep both behaviors same.
     // Consider this API instead once it has a better browser support:
     // .scrollIntoView({ scrollMode: 'if-needed', block: 'nearest' });
-    if (listboxNode.scrollHeight > listboxNode.clientHeight && reason !== 'mouse') {
+    if (
+      listboxNode.scrollHeight > listboxNode.clientHeight &&
+      reason !== 'mouse' &&
+      reason !== 'touch'
+    ) {
       const element = option;
 
       const scrollBottom = listboxNode.clientHeight + listboxNode.scrollTop;


### PR DESCRIPTION
fixes https://github.com/mui/material-ui/issues/37848

## Description

Here the bug on mobile devices was due to the fact that we were calculating and scrolling the element / option into the view before selecting it, which selected an incorrect element.

I have made the functionality consistent with what is present in mobile devices.

Demo: https://codesandbox.io/s/nice-bush-mqzcpf?file=/demo.tsx

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
