### PR TITLE
[docs-infra] Improve tab contrast in codeblock

### DIFF
--- a/docs/src/modules/components/HighlightedCodeWithTabs.tsx
+++ b/docs/src/modules/components/HighlightedCodeWithTabs.tsx
@@ -35,7 +35,7 @@ const StyledTab = styled(Tab)<{ ownerState: { mounted: boolean } }>(({ theme, ow
     p: 0.8,
     border: 'none',
     bgcolor: 'transparent',
-    color: (theme.vars || theme).palette.grey[600],
+    color: (theme.vars || theme).palette.grey[500],
     fontSize: theme.typography.pxToRem(12),
     fontWeight: theme.typography.fontWeightSemiBold,
     fontFamily: theme.typography.fontFamilyCode,


### PR DESCRIPTION
Open https://master--material-ui.netlify.app/material-ui/getting-started/installation/#default-installation and struggle to read each tab, it also feels a bit like they were disabled tabs:

<img width="502" alt="Screenshot 2023-07-16 at 16 29 24" src="https://github.com/mui/material-ui/assets/3165635/22f78bd6-5ae2-4cec-a355-22e1da61796a">

Open PR https://deploy-preview-38000--material-ui.netlify.app/material-ui/getting-started/installation/#default-installation and enjoy:

<img width="504" alt="Screenshot 2023-07-16 at 16 29 57" src="https://github.com/mui/material-ui/assets/3165635/535b86d8-b728-463c-8dbd-19afab0195e7">

