### PR TITLE
[docs] Fix link to Base UI + Next.js App Router example

### DIFF
--- a/docs/data/base/guides/next-js-app-router/next-js-app-router.md
+++ b/docs/data/base/guides/next-js-app-router/next-js-app-router.md
@@ -5,7 +5,7 @@
 :::info
 Starting fresh on a new App Router-based project?
 
-Jump right into the code with this [example repo](https://github.com/mui/material-ui/blob/master/examples/base-next-app-router-ts).
+Jump right into the code with this [example repo](https://github.com/mui/material-ui/blob/master/examples/base-next-app-router-tailwind-ts).
 :::
 
 ## Next.js and React Server Components


### PR DESCRIPTION
Base UI's App Router example includes Tailwind, which wasn't reflected in the link in the how-to guide, so the existing link is a 404.