### PR TITLE
[docs]: Fix the empty /components page

### DIFF
--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -11,16 +11,16 @@ import AppHeader from 'docs/src/layouts/AppHeader';
 import AppFooter from 'docs/src/layouts/AppFooter';
 import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import Section from 'docs/src/layouts/Section';
-import PageContext from 'docs/src/modules/components/PageContext';
 import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import Link from 'docs/src/modules/components/Link';
 import { MuiPage } from 'docs/src/pages';
+import materialPages from 'docs/data/material/pages';
 
 export default function Components() {
-  const { pages } = React.useContext(PageContext);
   const t = useTranslate();
-  const componentPageData = pages.find(({ pathname }) => pathname === '/components');
+  const pages = materialPages;
+  const componentPageData = pages.find(({ title }) => title === 'Components');
   function renderItem(aPage: MuiPage) {
     return (
       <ListItem key={aPage.pathname} disablePadding>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes #38008

Since top level `/components/` doesn't have any `productId`, I am using `material-ui`'s pages to list all the components. Maybe we can provide a `Select` component to change the listing and also add the `productId` to the url param.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
