### PR TITLE
[Modal] Remove deprecated `BackdropComponent` and `BackdropProps ` from tests

### DIFF
--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -132,7 +132,7 @@ describe('<Modal />', () => {
       }
 
       render(
-        <Modal open BackdropComponent={TestBackdrop}>
+        <Modal open slots={{ backdrop: TestBackdrop }}>
           <div />
         </Modal>,
       );
@@ -165,7 +165,15 @@ describe('<Modal />', () => {
         return <div data-testid="backdrop" data-timeout={transitionDuration} />;
       }
       render(
-        <Modal open BackdropComponent={TestBackdrop} BackdropProps={{ transitionDuration: 200 }}>
+        <Modal
+          open
+          slots={{ backdrop: TestBackdrop }}
+          slotProps={{
+            backdrop: {
+              transitionDuration: 200,
+            },
+          }}
+        >
           <div />
         </Modal>,
       );
@@ -176,7 +184,15 @@ describe('<Modal />', () => {
     it('should attach a handler to the backdrop that fires onClose', () => {
       const onClose = spy();
       const { getByTestId } = render(
-        <Modal onClose={onClose} open BackdropProps={{ 'data-testid': 'backdrop' }}>
+        <Modal
+          onClose={onClose}
+          open
+          slotProps={{
+            backdrop: {
+              'data-testid': 'backdrop',
+            },
+          }}
+        >
           <div />
         </Modal>,
       );
@@ -220,7 +236,15 @@ describe('<Modal />', () => {
     it('should call through to the user specified onBackdropClick callback', () => {
       const onBackdropClick = spy();
       const { getByTestId } = render(
-        <Modal onBackdropClick={onBackdropClick} open BackdropProps={{ 'data-testid': 'backdrop' }}>
+        <Modal
+          onClose={(event, reason) => {
+            if (reason === 'backdropClick') {
+              onBackdropClick();
+            }
+          }}
+          open
+          slotProps={{ backdrop: { 'data-testid': 'backdrop' } }}
+        >
           <div />
         </Modal>,
       );
@@ -241,7 +265,15 @@ describe('<Modal />', () => {
       }
       const onBackdropClick = spy();
       const { getByTestId } = render(
-        <Modal onBackdropClick={onBackdropClick} open BackdropComponent={CustomBackdrop}>
+        <Modal
+          onClose={(event, reason) => {
+            if (reason === 'backdropClick') {
+              onBackdropClick();
+            }
+          }}
+          open
+          slots={{ backdrop: CustomBackdrop }}
+        >
           <div />
         </Modal>,
       );

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -87,7 +87,17 @@ describe('<Popover />', () => {
         return <div data-testid="backdrop" data-invisible={invisible} />;
       }
       render(
-        <Popover open anchorEl={document.createElement('div')} BackdropComponent={TestBackdrop}>
+        <Popover
+          open
+          anchorEl={document.createElement('div')}
+          slotProps={{
+            root: {
+              slots: {
+                backdrop: TestBackdrop,
+              },
+            },
+          }}
+        >
           <div />
         </Popover>,
       );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

`BackdropComponent` and `BackdropProps ` are `deprecated` but those are still used in few tests, This PR removes those instances.

current documentation for these props : https://mui.com/material-ui/api/modal/#props

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
