### PR TITLE
[examples] Fix material-next-app-router Font Usage with next/font

### DIFF
--- a/examples/material-next-app-router-ts/src/app/layout.tsx
+++ b/examples/material-next-app-router-ts/src/app/layout.tsx
@@ -26,7 +26,11 @@ export const metadata = {
   description: 'Next.js App Router + Material UI v5',
 };
 
-const roboto = Roboto({ weight: ['300', '400', '500', '700'], subsets: ['latin'] });
+const roboto = Roboto({
+  variable: '--font-roboto',
+  weight: ['300', '400', '500', '700'],
+  subsets: ['latin'],
+});
 
 const DRAWER_WIDTH = 240;
 
@@ -44,7 +48,7 @@ const PLACEHOLDER_LINKS = [
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className={roboto.variable}>
       <body className={roboto.className}>
         <ThemeRegistry>
           <AppBar position="fixed" sx={{ zIndex: 2000 }}>

--- a/examples/material-next-app-router-ts/src/components/ThemeRegistry/theme.ts
+++ b/examples/material-next-app-router-ts/src/components/ThemeRegistry/theme.ts
@@ -4,6 +4,9 @@ const defaultTheme = createTheme({
   palette: {
     mode: 'light',
   },
+  typography: {
+    fontFamily: 'var(--font-roboto)',
+  },
   components: {
     MuiAlert: {
       styleOverrides: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR aims to align all the used `font-family` styles of MUI components when `next/font` is used.

With the current approach, `className` which contains `font-family` from `next/font` is added to `body` and the `font-family` from `next/font` is applied to generic HTML elements.

But MUI components still use the default `font-family` from `theme` and since we don't install Roboto font with CDN etc., they don't use this font and they fall back to next fonts like `Helvetica`.

For example, we can check the "On This Page" text. It is a `Typography` component and it uses the default `"Roboto", "Helvetiva", "Arial", sans-serif` `font-family` even if we set the `className` of `body`.
<img width="834" alt="image" src="https://github.com/mui/material-ui/assets/50423574/1bfe9491-1df7-4cfa-9228-755b70abf9f3">

But after this change, it will start using `--font-roboto` CSS variable, which we got from `next/font` and set on `html` element.
<img width="834" alt="image" src="https://github.com/mui/material-ui/assets/50423574/9d51a99f-06c9-422e-87f6-490371ea8c42">
<img width="514" alt="image" src="https://github.com/mui/material-ui/assets/50423574/09a5a80b-5fdd-46d9-bbd2-74f71633b217">

And here are the fullpage screenshots.

**Before:**
![image](https://github.com/mui/material-ui/assets/50423574/1decc5e1-14e1-42e0-9b17-7adada677933)

**After:**
![image](https://github.com/mui/material-ui/assets/50423574/64d0a72a-cfd0-44dc-8595-a7434956739e)
