### PR TITLE
[test] Fail the CI when new unexpected files are created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
           steps:
             - run:
                 name: Should not have any git not staged
-                command: git diff --exit-code
+                command: git add -A && git diff --exit-code --staged
             - run:
                 name: Check for duplicated packages
                 command: yarn deduplicate
@@ -222,35 +222,35 @@ jobs:
           command: yarn proptypes
       - run:
           name: '`yarn proptypes` changes committed?'
-          command: git diff --exit-code
+          command: git add -A && git diff --exit-code --staged
       - run:
           name: 'Write "use client" directive'
           command: yarn rsc:build
       - run:
           name: '`yarn rsc:build` changes detected, "use client" missing from exports'
-          command: git diff --exit-code
+          command: git add -A && git diff --exit-code --staged
       - run:
           name: Generate the documentation
           command: yarn docs:api
       - run:
           name: '`yarn docs:api` changes committed?'
-          command: git diff --exit-code
+          command: git add -A && git diff --exit-code --staged
       - run:
           name: Update the navigation translations
           command: yarn docs:i18n
       - run:
           name: '`yarn docs:i18n` changes committed?'
-          command: git diff --exit-code
+          command: git add -A && git diff --exit-code --staged
       - run:
           name: '`yarn extract-error-codes` changes committed?'
           command: |
             yarn extract-error-codes
-            git diff --exit-code
+            git add -A && git diff --exit-code --staged
       - run:
           name: '`yarn docs:link-check` changes committed?'
           command: |
             yarn docs:link-check
-            git diff --exit-code
+            git add -A && git diff --exit-code --staged
   test_types:
     <<: *defaults
     resource_class: 'medium+'

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -589,6 +589,39 @@ export function generateBaseUIApiPages() {
     ) {
       const { components, hooks } = markdownHeaders;
 
+      const tokens = markdown.pathname.split('/');
+      const name = tokens[tokens.length - 1];
+      const importStatement = `docs/data${markdown.pathname}/${name}.md`;
+      const demosSource = `
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
+import AppFrame from 'docs/src/modules/components/AppFrame';
+import * as pageProps from '${importStatement}?@mui/markdown';
+
+export default function Page(props) {
+  const { userLanguage, ...other } = props;
+  return <MarkdownDocs {...pageProps} {...other} />;
+}
+
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
+      `;
+
+      const componentPageDirectory = `docs/pages/${productName}-ui/react-${componentName}/`;
+      if (!fs.existsSync(componentPageDirectory)) {
+        fs.mkdirSync(componentPageDirectory, { recursive: true });
+      }
+      writePrettifiedFile(
+        path.join(process.cwd(), `${componentPageDirectory}/index.js`),
+        demosSource,
+      );
+
+      if ((!components || components.length === 0) && (!hooks || hooks.length === 0)) {
+        // Early return if it's a markdown file without components/hooks.
+        return;
+      }
+
       let apiTabImportStatements = '';
       let staticProps = 'export const getStaticProps = () => {';
       let componentsApiDescriptions = '';
@@ -596,7 +629,7 @@ export function generateBaseUIApiPages() {
       let hooksApiDescriptions = '';
       let hooksPageContents = '';
 
-      if (components) {
+      if (components && components.length > 0) {
         components.forEach((component: string) => {
           const componentNameKebabCase = kebabCase(component);
           apiTabImportStatements += `import ${component}ApiJsonPageContent from '../../api/${componentNameKebabCase}.json';`;
@@ -613,7 +646,7 @@ export function generateBaseUIApiPages() {
         });
       }
 
-      if (hooks) {
+      if (hooks && hooks.length > 0) {
         hooks.forEach((hook: string) => {
           const hookNameKebabCase = kebabCase(hook);
           apiTabImportStatements += `import ${hook}ApiJsonPageContent from '../../api/${hookNameKebabCase}.json';`;
@@ -645,25 +678,6 @@ export function generateBaseUIApiPages() {
 
       staticProps += ` },},};};`;
 
-      const tokens = markdown.pathname.split('/');
-      const name = tokens[tokens.length - 1];
-      const importStatement = `docs/data${markdown.pathname}/${name}.md`;
-      const demosSource = `
-import * as React from 'react';
-import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
-import * as pageProps from '${importStatement}?@mui/markdown';
-
-export default function Page(props) {
-  const { userLanguage, ...other } = props;
-  return <MarkdownDocs {...pageProps} {...other} />;
-}
-
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
-      `;
-
       const tabsApiSource = `
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
@@ -691,24 +705,14 @@ export const getStaticPaths = () => {
 ${staticProps}
       `;
 
-      const componentPageDirectory = `docs/pages/${productName}-ui/react-${componentName}/`;
-      if (!fs.existsSync(componentPageDirectory)) {
-        fs.mkdirSync(componentPageDirectory, { recursive: true });
-      }
-      const demosSourcePath = path.join(process.cwd(), `${componentPageDirectory}/index.js`);
-      writePrettifiedFile(demosSourcePath, demosSource);
-
-      if ((components ?? []).length === 0 && (hooks ?? []).length === 0) {
-        // Early return if it's a markdown file without components/hooks.
-        return;
-      }
-
       const docsTabsPagesDirectory = `${componentPageDirectory}/[docsTab]`;
       if (!fs.existsSync(docsTabsPagesDirectory)) {
         fs.mkdirSync(docsTabsPagesDirectory, { recursive: true });
       }
-      const tabsApiPath = path.join(process.cwd(), `${docsTabsPagesDirectory}/index.js`);
-      writePrettifiedFile(tabsApiPath, tabsApiSource);
+      writePrettifiedFile(
+        path.join(process.cwd(), `${docsTabsPagesDirectory}/index.js`),
+        tabsApiSource,
+      );
     }
   });
 }


### PR DESCRIPTION
This is a follow-up on https://github.com/mui/material-ui/pull/37813#discussion_r1260995356.

1. First the most important: I could break `yarn docs:api` without knowing it. The CI should now fail, see the first commit. I have copied `git add -A && git diff --exit-code --staged` from an existing test we have.
2. Second, the fix of `yarn docs:api`, see the second commit.