### PR TITLE
[website] Improve button look

### DIFF
--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -436,7 +436,7 @@ export function getThemedComponents(): ThemeOptions {
         styleOverrides: {
           root: ({ theme, ownerState }) => ({
             ...(ownerState.size === 'large' && {
-              padding: theme.spacing(1.5, 1.25, 1.5, 1.5), // 12px 10px
+              padding: theme.spacing('12px', '11px', '12px', '14px'),
               ...theme.typography.body1,
               lineHeight: 21 / 16,
               fontWeight: 700,

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -436,7 +436,7 @@ export function getThemedComponents(): ThemeOptions {
         styleOverrides: {
           root: ({ theme, ownerState }) => ({
             ...(ownerState.size === 'large' && {
-              padding: theme.spacing('12px', '11px', '12px', '14px'),
+              padding: theme.spacing('12px', '12px', '12px', '14px'),
               ...theme.typography.body1,
               lineHeight: 21 / 16,
               fontWeight: 700,


### PR DESCRIPTION
Before

<img width="395" alt="Screenshot 2023-07-19 at 18 31 25" src="https://github.com/mui/material-ui/assets/3165635/f27d3de4-9cc9-4be2-a8fe-4fbdc0f0e586">

https://master--material-ui.netlify.app/base-ui/

After

https://deploy-preview-38052--material-ui.netlify.app/base-ui/

It feels like there should be more y padding on the button, to have it "balanced".