### PR TITLE
[TextField] Fix to handle `onClick` on root element

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -441,6 +441,9 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
       inputRef.current.focus();
     }
     if (onClick && !fcs.disabled) {
+      // The `onClick` is also registered on the `TextField` root element.
+      // Without stopping the propagation, the even could be triggered twice.
+      event.stopPropagation();
       onClick(event);
     }
   };

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -441,9 +441,6 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
       inputRef.current.focus();
     }
     if (onClick && !fcs.disabled) {
-      // The `onClick` is also registered on the `TextField` root element.
-      // Without stopping the propagation, the even could be triggered twice.
-      event.stopPropagation();
       onClick(event);
     }
   };

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -147,6 +147,15 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
     InputMore['aria-describedby'] = undefined;
   }
 
+  const handleClick = (event) => {
+    if (!disabled && onClick) {
+      // The `onClick` is registered both on the root and the input elements.
+      // Without stopping the propagation, the event could be triggered twice.
+      event.stopPropagation();
+      onClick(event);
+    }
+  };
+
   const id = useId(idOverride);
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
   const inputLabelId = label && id ? `${id}-label` : undefined;
@@ -170,7 +179,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
       onBlur={onBlur}
       onChange={onChange}
       onFocus={onFocus}
-      onClick={onClick}
+      onClick={handleClick}
       placeholder={placeholder}
       inputProps={inputProps}
       {...InputMore}
@@ -189,7 +198,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
       color={color}
       variant={variant}
       ownerState={ownerState}
-      onClick={!disabled ? onClick : undefined}
+      onClick={handleClick}
       {...other}
     >
       {label != null && label !== '' && (

--- a/packages/mui-material/src/TextField/TextField.js
+++ b/packages/mui-material/src/TextField/TextField.js
@@ -189,6 +189,7 @@ const TextField = React.forwardRef(function TextField(inProps, ref) {
       color={color}
       variant={variant}
       ownerState={ownerState}
+      onClick={!disabled ? onClick : undefined}
       {...other}
     >
       {label != null && label !== '' && (

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -243,4 +243,13 @@ describe('<TextField />', () => {
       expect(getByRole('button')).toHaveAccessibleDescription('Foo bar');
     });
   });
+
+  it('should trigger `onClick` only once', () => {
+    const handleClick = spy();
+    const { getByRole } = render(
+      <TextField variant="outlined" label="Test" onClick={handleClick} />,
+    );
+    fireEvent.click(getByRole('textbox'));
+    expect(handleClick.callCount).to.equal(1);
+  });
 });

--- a/test/e2e/fixtures/TextField/TextFieldWithOnClick.tsx
+++ b/test/e2e/fixtures/TextField/TextFieldWithOnClick.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import TextField from '@mui/material/TextField';
+
+export default function TextFieldWithOnClick() {
+  const [isClicked, setIsClicked] = React.useState(false);
+  return (
+    <TextField
+      id="outlined-basic"
+      label="Outlined"
+      error={isClicked}
+      variant="outlined"
+      onClick={() => {
+        setIsClicked(true);
+      }}
+    />
+  );
+}

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -254,4 +254,14 @@ describe('e2e', () => {
       expect(pageErrors.length).to.equal(0);
     });
   });
+
+  describe('<TextField />', () => {
+    it('should handle `onClick` when clicking on the focused label position', async () => {
+      await renderFixture('TextField/TextFieldWithOnClick');
+
+      // execute the click on the focused label position
+      await page.getByRole('textbox').click({ position: { x: 10, y: 10 } });
+      await page.waitForSelector('.MuiInputBase-root.Mui-error');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

https://github.com/mui/material-ui/pull/36892 changed the `onClick` handling behavior on the `TextField` component.
Previously the callback used to be registered on the root element and pickers relied on it (https://github.com/mui/mui-x/pull/6074) to correctly handle click -> open behavior regardless of where the click has been done.
Now we have a regression https://github.com/mui/mui-x/issues/9386 on the mentioned behavior because the fix has basically been negated.

Closes https://github.com/mui/mui-x/issues/9386

If you have any better suggestions on how to solve this conundrum—I'm open to suggestions.

We have considered and tried using `onMouseDown`, but it has its drawbacks and interferes with other component behavior.
One other easy fix would be to remove the `z-index: 1` on the label and figure out another way to achieve the [same fix](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/InputLabel/InputLabel.js#L85C15-L85C15).