### PR TITLE
[Skeleton][joy] Fix WebkitMaskImage CSS property

### DIFF
--- a/packages/mui-joy/src/Skeleton/Skeleton.tsx
+++ b/packages/mui-joy/src/Skeleton/Skeleton.tsx
@@ -217,7 +217,7 @@ const SkeletonRoot = styled('span', {
         ...(ownerState.level !== 'inherit' && {
           ...theme.typography[ownerState.level!],
         }),
-        '-webkit-mask-image': '-webkit-radial-gradient(white, black)',
+        WebkitMaskImage: '-webkit-radial-gradient(white, black)',
         '&::before': {
           position: 'absolute',
           zIndex: 'var(--unstable_pseudo-zIndex)',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes the error displayed in the console reported in #38051

> Using kebab-case for css properties in objects is not supported. Did you mean WebkitMaskImage?
> in JoySkeletonRoot (created by Skeleton)
> in Skeleton (created by InlineSkeleton)
> in InlineSkeleton