### PR TITLE
[core] Remove the deprecation rule in tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
   "extends": ["dtslint/dtslint.json"],
   "jsRules": {},
   "rules": {
-    "deprecation": true,
     // $ExpectError -> @ts-expect-error
     // $ExpectType -> `expectType` from `@mui/types`
     // Don't disable this rule unless you made sure `tsc` runs on the same files


### PR DESCRIPTION
The TSLint's `deprecation` rule is broken, spamming the console with errors like `message.trim() is not a function`. Indeed the rule's code makes wrong assumptions about what gets returned from the parser.
The fix is theoretically very simple, but since TSLint is no longer maintained, it is not an option.

I tried to replace it with https://github.com/gund/eslint-plugin-deprecation, but it's insanely slow, so it's a no-go.