### PR TITLE
[Link][Joy UI] Fix font inherit

### DIFF
--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -76,9 +76,7 @@ const LinkRoot = styled('a', {
       '--Icon-fontSize': '1.25em',
       ...(ownerState.level && ownerState.level !== 'inherit' && theme.typography[ownerState.level]),
       ...(ownerState.level === 'inherit' && {
-        fontSize: 'inherit',
-        fontFamily: 'inherit',
-        lineHeight: 'inherit',
+        font: 'inherit',
       }),
       ...(ownerState.underline === 'none' && {
         textDecoration: 'none',


### PR DESCRIPTION
The reproduction https://codesandbox.io/s/nostalgic-solomon-dmwxr3?file=/Demo.tsx

```jsx
import * as React from "react";
import Box from "@mui/joy/Box";
import Link from "@mui/joy/Link";

export default function LinkLevels() {
  return (
    <Box sx={{ fontWeight: 800 }}>
      <Link level="inherit" component="button">
        Link
      </Link>
    </Box>
  );
}
```
Actual

<img width="62" alt="Screenshot 2023-07-23 at 16 51 17" src="https://github.com/mui/material-ui/assets/3165635/abdde5f7-44d8-43fe-a611-3b4ebdf38e3e">

Expected

<img width="53" alt="Screenshot 2023-07-23 at 16 51 46" src="https://github.com/mui/material-ui/assets/3165635/2c873f71-2668-4ec6-bc06-ed67a3072d57">

Same fix as https://github.com/mui/material-ui/pull/38123