### PR TITLE
[blog] Update Discord invite link in Toolpad beta announcement

### DIFF
--- a/docs/pages/blog/2023-toolpad-beta-announcement.md
+++ b/docs/pages/blog/2023-toolpad-beta-announcement.md
@@ -105,6 +105,6 @@ We plan to continue to iterate on our vision of helping you as a developer to in
 
 The best places to stay up-to-date about what we're currently working on are [GitHub issues](https://github.com/mui/mui-toolpad) and our [public roadmap](https://github.com/orgs/mui/projects/9/views/1).
 
-If you have any questions or would like to share feedback, you can directly contact the team at toolpad@mui.com or reach us on [Twitter](https://twitter.com/MUI_Toolpad). You can also engage in conversation in our [Discord](https://discord.gg/Rqwf7Ddez9) server.
+If you have any questions or would like to share feedback, you can directly contact the team at toolpad@mui.com or reach us on [Twitter](https://twitter.com/MUI_Toolpad). You can also engage in conversation in our [Discord](https://discord.gg/tewQuNeUyS) server.
 
 If you'd like an in-depth demo and to discuss your use case, please feel free to [schedule a meeting with me on Calendly](https://calendly.com/prakhar-mui).


### PR DESCRIPTION
We moved the MUI Discord to a new location since this blog post got merged. Updated to https://discord.gg/tewQuNeUyS