### PR TITLE
[typescript] Rename one letter type parameters

### DIFF
--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -84,8 +84,8 @@ export type AccordionTypeMap<
 declare const Accordion: OverridableComponent<AccordionTypeMap>;
 
 export type AccordionProps<
-  D extends React.ElementType = AccordionTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<AccordionTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = AccordionTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<AccordionTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Accordion;

--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -6,9 +6,12 @@ import { AccordionClasses } from './accordionClasses';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ExtendPaperTypeMap } from '../Paper/Paper';
 
-export type AccordionTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendPaperTypeMap<
+export type AccordionTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> = ExtendPaperTypeMap<
   {
-    props: P & {
+    props: AdditionalProps & {
       /**
        * The content of the component.
        */
@@ -62,7 +65,7 @@ export type AccordionTypeMap<P = {}, D extends React.ElementType = 'div'> = Exte
        */
       TransitionProps?: TransitionProps;
     };
-    defaultComponent: D;
+    defaultComponent: DefaultComponent;
   },
   'onChange' | 'classes'
 >;

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.d.ts
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.d.ts
@@ -6,10 +6,10 @@ import { Theme } from '..';
 import { AccordionSummaryClasses } from './accordionSummaryClasses';
 
 export type AccordionSummaryTypeMap<
-  P = {},
-  D extends React.ElementType = 'div',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
 > = ExtendButtonBaseTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -27,7 +27,7 @@ export type AccordionSummaryTypeMap<
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.d.ts
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.d.ts
@@ -44,8 +44,8 @@ export type AccordionSummaryTypeMap<
 declare const AccordionSummary: ExtendButtonBase<AccordionSummaryTypeMap>;
 
 export type AccordionSummaryProps<
-  D extends React.ElementType = AccordionSummaryTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<AccordionSummaryTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = AccordionSummaryTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<AccordionSummaryTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default AccordionSummary;

--- a/packages/mui-material/src/AppBar/AppBar.d.ts
+++ b/packages/mui-material/src/AppBar/AppBar.d.ts
@@ -8,9 +8,12 @@ import { ExtendPaperTypeMap } from '../Paper/Paper';
 
 export interface AppBarPropsColorOverrides {}
 
-export type AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> = ExtendPaperTypeMap<
+export type AppBarTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'header',
+> = ExtendPaperTypeMap<
   {
-    props: P & {
+    props: AdditionalProps & {
       /**
        * Override or extend the styles applied to the component.
        */
@@ -39,7 +42,7 @@ export type AppBarTypeMap<P = {}, D extends React.ElementType = 'header'> = Exte
        */
       sx?: SxProps<Theme>;
     };
-    defaultComponent: D;
+    defaultComponent: DefaultComponent;
   },
   'position' | 'color' | 'classes'
 >;

--- a/packages/mui-material/src/AppBar/AppBar.d.ts
+++ b/packages/mui-material/src/AppBar/AppBar.d.ts
@@ -62,8 +62,8 @@ export type AppBarTypeMap<
 declare const AppBar: OverridableComponent<AppBarTypeMap>;
 
 export type AppBarProps<
-  D extends React.ElementType = AppBarTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<AppBarTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = AppBarTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<AppBarTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default AppBar;

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -25,12 +25,12 @@ export {
 };
 
 export type AutocompleteOwnerState<
-  T,
+  Value,
   Multiple extends boolean | undefined,
   DisableClearable extends boolean | undefined,
   FreeSolo extends boolean | undefined,
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
-> = AutocompleteProps<T, Multiple, DisableClearable, FreeSolo, ChipComponent> & {
+> = AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent> & {
   disablePortal: boolean;
   expanded: boolean;
   focused: boolean;
@@ -81,12 +81,12 @@ export interface AutocompleteRenderInputParams {
 export interface AutocompletePropsSizeOverrides {}
 
 export interface AutocompleteProps<
-  T,
+  Value,
   Multiple extends boolean | undefined,
   DisableClearable extends boolean | undefined,
   FreeSolo extends boolean | undefined,
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
-> extends UseAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
+> extends UseAutocompleteProps<Value, Multiple, DisableClearable, FreeSolo>,
     StandardProps<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange' | 'children'> {
   /**
    * Props applied to the [`Chip`](/material-ui/api/chip/) element.
@@ -236,29 +236,29 @@ export interface AutocompleteProps<
    * Render the option, use `getOptionLabel` by default.
    *
    * @param {object} props The props to apply on the li element.
-   * @param {T} option The option to render.
+   * @param {Value} option The option to render.
    * @param {object} state The state of each option.
    * @param {object} ownerState The state of the Autocomplete component.
    * @returns {ReactNode}
    */
   renderOption?: (
     props: React.HTMLAttributes<HTMLLIElement>,
-    option: T,
+    option: Value,
     state: AutocompleteRenderOptionState,
-    ownerState: AutocompleteOwnerState<T, Multiple, DisableClearable, FreeSolo, ChipComponent>,
+    ownerState: AutocompleteOwnerState<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>,
   ) => React.ReactNode;
   /**
    * Render the selected value.
    *
-   * @param {T[]} value The `value` provided to the component.
+   * @param {Value[]} value The `value` provided to the component.
    * @param {function} getTagProps A tag props getter.
    * @param {object} ownerState The state of the Autocomplete component.
    * @returns {ReactNode}
    */
   renderTags?: (
-    value: T[],
+    value: Value[],
     getTagProps: AutocompleteRenderGetTagProps,
-    ownerState: AutocompleteOwnerState<T, Multiple, DisableClearable, FreeSolo, ChipComponent>,
+    ownerState: AutocompleteOwnerState<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>,
   ) => React.ReactNode;
   /**
    * The size of the component.
@@ -292,9 +292,11 @@ export interface AutocompleteProps<
  * - [Autocomplete API](https://mui.com/material-ui/api/autocomplete/)
  */
 export default function Autocomplete<
-  T,
+  Value,
   Multiple extends boolean | undefined = false,
   DisableClearable extends boolean | undefined = false,
   FreeSolo extends boolean | undefined = false,
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
->(props: AutocompleteProps<T, Multiple, DisableClearable, FreeSolo, ChipComponent>): JSX.Element;
+>(
+  props: AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>,
+): JSX.Element;

--- a/packages/mui-material/src/Avatar/Avatar.d.ts
+++ b/packages/mui-material/src/Avatar/Avatar.d.ts
@@ -7,8 +7,11 @@ import { AvatarClasses } from './avatarClasses';
 
 export interface AvatarPropsVariantOverrides {}
 
-export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface AvatarTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * Used in combination with `src` or `srcSet` to
      * provide an alt attribute for the rendered `img` element.
@@ -56,7 +59,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
       AvatarPropsVariantOverrides
     >;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Avatar/Avatar.d.ts
+++ b/packages/mui-material/src/Avatar/Avatar.d.ts
@@ -75,8 +75,8 @@ export interface AvatarTypeMap<
 declare const Avatar: OverridableComponent<AvatarTypeMap>;
 
 export type AvatarProps<
-  D extends React.ElementType = AvatarTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<AvatarTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = AvatarTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<AvatarTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Avatar;

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -8,8 +8,11 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 
 export interface BackdropComponentsPropsOverrides {}
 
-export interface BackdropTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
+export interface BackdropTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps &
     Partial<Omit<FadeProps, 'children'>> & {
       /**
        * The content of the component.
@@ -92,7 +95,7 @@ export interface BackdropTypeMap<P = {}, D extends React.ElementType = 'div'> {
         TransitionProps & { children: React.ReactElement<any, any> }
       >;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 type BackdropRootProps = NonNullable<BackdropTypeMap['props']['componentsProps']>['root'];

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -116,8 +116,8 @@ export declare const BackdropRoot: React.FC<BackdropRootProps>;
 declare const Backdrop: OverridableComponent<BackdropTypeMap>;
 
 export type BackdropProps<
-  D extends React.ElementType = BackdropTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<BackdropTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = BackdropTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<BackdropTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Backdrop;

--- a/packages/mui-material/src/Badge/Badge.d.ts
+++ b/packages/mui-material/src/Badge/Badge.d.ts
@@ -106,8 +106,8 @@ export declare const BadgeMark: React.FC<BadgeBadgeProps>;
 declare const Badge: OverridableComponent<BadgeTypeMap>;
 
 export type BadgeProps<
-  D extends React.ElementType = BadgeTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<BadgeTypeMap<D, P>, D>;
+  RootComponent extends React.ElementType = BadgeTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<BadgeTypeMap<RootComponent, AdditionalProps>, RootComponent>;
 
 export default Badge;

--- a/packages/mui-material/src/Badge/Badge.d.ts
+++ b/packages/mui-material/src/Badge/Badge.d.ts
@@ -15,8 +15,11 @@ export interface BadgeOrigin {
   horizontal: 'left' | 'right';
 }
 
-export type BadgeTypeMap<D extends React.ElementType = 'span', P = {}> = ExtendBadgeTypeMap<{
-  props: P & {
+export type BadgeTypeMap<
+  DefaultComponent extends React.ElementType = 'span',
+  AdditionalProps = {},
+> = ExtendBadgeTypeMap<{
+  props: AdditionalProps & {
     /**
      * The anchor of the badge.
      * @default {
@@ -80,7 +83,7 @@ export type BadgeTypeMap<D extends React.ElementType = 'span', P = {}> = ExtendB
      */
     variant?: OverridableStringUnion<'standard' | 'dot', BadgePropsVariantOverrides>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 type BadgeRootProps = NonNullable<BadgeTypeMap['props']['slotProps']>['root'];

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.d.ts
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { BottomNavigationClasses } from './bottomNavigationClasses';
 
-export interface BottomNavigationTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface BottomNavigationTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -36,7 +39,7 @@ export interface BottomNavigationTypeMap<P = {}, D extends React.ElementType = '
      */
     value?: any;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.d.ts
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.d.ts
@@ -54,8 +54,8 @@ export interface BottomNavigationTypeMap<
 declare const BottomNavigation: OverridableComponent<BottomNavigationTypeMap>;
 
 export type BottomNavigationProps<
-  D extends React.ElementType = BottomNavigationTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<BottomNavigationTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = BottomNavigationTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<BottomNavigationTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default BottomNavigation;

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.d.ts
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.d.ts
@@ -63,8 +63,8 @@ declare const BottomNavigationAction: ExtendButtonBase<
 >;
 
 export type BottomNavigationActionProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<BottomNavigationActionTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<BottomNavigationActionTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default BottomNavigationAction;

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.d.ts
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.d.ts
@@ -6,10 +6,10 @@ import { OverrideProps } from '../OverridableComponent';
 import { BottomNavigationActionClasses } from './bottomNavigationActionClasses';
 
 export type BottomNavigationActionTypeMap<
-  P,
-  D extends React.ElementType,
+  AdditionalProps,
+  DefaultComponent extends React.ElementType,
 > = ExtendButtonBaseTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * This prop isn't supported.
      * Use the `component` prop if you need to change the children structure.
@@ -44,7 +44,7 @@ export type BottomNavigationActionTypeMap<
      */
     value?: any;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/Box/Box.d.ts
+++ b/packages/mui-material/src/Box/Box.d.ts
@@ -16,8 +16,8 @@ import { Theme as MaterialTheme } from '../styles';
 declare const Box: OverridableComponent<BoxTypeMap<{}, 'div', MaterialTheme>>;
 
 export type BoxProps<
-  D extends React.ElementType = BoxTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<BoxTypeMap<P, D, MaterialTheme>, D>;
+  RootComponent extends React.ElementType = BoxTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<BoxTypeMap<AdditionalProps, RootComponent, MaterialTheme>, RootComponent>;
 
 export default Box;

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.d.ts
@@ -12,8 +12,11 @@ export interface BreadcrumbsOwnerState extends BreadcrumbsProps {
   expanded: boolean;
 }
 
-export interface BreadcrumbsTypeMap<P = {}, D extends React.ElementType = 'nav'> {
-  props: P & {
+export interface BreadcrumbsTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'nav',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -79,7 +82,7 @@ export interface BreadcrumbsTypeMap<P = {}, D extends React.ElementType = 'nav'>
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.d.ts
@@ -98,8 +98,8 @@ export interface BreadcrumbsTypeMap<
 declare const Breadcrumbs: OverridableComponent<BreadcrumbsTypeMap>;
 
 export type BreadcrumbsProps<
-  D extends React.ElementType = BreadcrumbsTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<BreadcrumbsTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = BreadcrumbsTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<BreadcrumbsTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Breadcrumbs;

--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -13,10 +13,10 @@ export interface ButtonPropsColorOverrides {}
 export interface ButtonPropsSizeOverrides {}
 
 export type ButtonTypeMap<
-  P = {},
-  D extends React.ElementType = 'button',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'button',
 > = ExtendButtonBaseTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -87,7 +87,7 @@ export type ButtonTypeMap<
       ButtonPropsVariantOverrides
     >;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -123,8 +123,8 @@ export type ExtendButton<M extends OverridableTypeMap> = ((
 declare const Button: ExtendButtonBase<ButtonTypeMap>;
 
 export type ButtonProps<
-  D extends React.ElementType = ButtonTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ButtonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ButtonTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Button;

--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -95,18 +95,18 @@ export type ButtonTypeMap<
  * This component has an additional overload if the `href` prop is set which
  * can make extension quite tricky
  */
-export interface ExtendButtonTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] &
-    (M['props'] extends { classes?: Record<string, string> }
+export interface ExtendButtonTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] &
+    (TypeMap['props'] extends { classes?: Record<string, string> }
       ? DistributiveOmit<ButtonTypeMap['props'], 'classes'>
       : ButtonTypeMap['props']);
-  defaultComponent: M['defaultComponent'];
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendButton<M extends OverridableTypeMap> = ((
-  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>,
+export type ExtendButton<TypeMap extends OverridableTypeMap> = ((
+  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<TypeMap>, 'a'>,
 ) => JSX.Element) &
-  OverridableComponent<ExtendButtonBaseTypeMap<M>>;
+  OverridableComponent<ExtendButtonBaseTypeMap<TypeMap>>;
 
 /**
  *

--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -122,9 +122,9 @@ export type ExtendButtonBase<M extends OverridableTypeMap> = ((
 declare const ButtonBase: ExtendButtonBase<ButtonBaseTypeMap>;
 
 export type ButtonBaseProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ButtonBaseTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ButtonBaseTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export interface ButtonBaseActions {
   focusVisible(): void;

--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -5,8 +5,11 @@ import { TouchRippleActions, TouchRippleProps } from './TouchRipple';
 import { OverrideProps, OverridableComponent, OverridableTypeMap } from '../OverridableComponent';
 import { ButtonBaseClasses } from './buttonBaseClasses';
 
-export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button'> {
-  props: P & {
+export interface ButtonBaseTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'button',
+> {
+  props: AdditionalProps & {
     /**
      * A ref for imperative actions.
      * It currently only supports `focusVisible()` action.
@@ -85,7 +88,7 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
      */
     touchRippleRef?: React.Ref<TouchRippleActions>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -96,15 +96,15 @@ export interface ButtonBaseTypeMap<
  * This component has an additional overload if the `href` prop is set which
  * can make extension quite tricky
  */
-export interface ExtendButtonBaseTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & Omit<ButtonBaseTypeMap['props'], 'classes'>;
-  defaultComponent: M['defaultComponent'];
+export interface ExtendButtonBaseTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & Omit<ButtonBaseTypeMap['props'], 'classes'>;
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendButtonBase<M extends OverridableTypeMap> = ((
-  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<M>, 'a'>,
+export type ExtendButtonBase<TypeMap extends OverridableTypeMap> = ((
+  props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<TypeMap>, 'a'>,
 ) => JSX.Element) &
-  OverridableComponent<ExtendButtonBaseTypeMap<M>>;
+  OverridableComponent<ExtendButtonBaseTypeMap<TypeMap>>;
 
 /**
  * `ButtonBase` contains as few styles as possible.

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.d.ts
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.d.ts
@@ -97,8 +97,8 @@ export interface ButtonGroupTypeMap<
 declare const ButtonGroup: OverridableComponent<ButtonGroupTypeMap>;
 
 export type ButtonGroupProps<
-  D extends React.ElementType = ButtonGroupTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ButtonGroupTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonGroupTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ButtonGroupTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ButtonGroup;

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.d.ts
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.d.ts
@@ -9,8 +9,11 @@ export interface ButtonGroupPropsColorOverrides {}
 export interface ButtonGroupPropsVariantOverrides {}
 export interface ButtonGroupPropsSizeOverrides {}
 
-export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface ButtonGroupTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -78,7 +81,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Card/Card.d.ts
+++ b/packages/mui-material/src/Card/Card.d.ts
@@ -47,8 +47,8 @@ export interface CardTypeMap<
 declare const Card: OverridableComponent<CardTypeMap>;
 
 export type CardProps<
-  D extends React.ElementType = CardTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<CardTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = CardTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<CardTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Card;

--- a/packages/mui-material/src/Card/Card.d.ts
+++ b/packages/mui-material/src/Card/Card.d.ts
@@ -9,8 +9,11 @@ import { CardClasses } from './cardClasses';
 // TODO: v6 remove this interface, it is not used
 export interface CardPropsColorOverrides {}
 
-export interface CardTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
+export interface CardTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps &
     DistributiveOmit<PaperProps, 'classes'> & {
       /**
        * Override or extend the styles applied to the component.
@@ -26,7 +29,7 @@ export interface CardTypeMap<P = {}, D extends React.ElementType = 'div'> {
        */
       sx?: SxProps<Theme>;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/CardActionArea/CardActionArea.d.ts
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.d.ts
@@ -5,8 +5,11 @@ import { ButtonBaseTypeMap, ExtendButtonBase, ExtendButtonBaseTypeMap } from '..
 import { OverrideProps } from '../OverridableComponent';
 import { CardActionAreaClasses } from './cardActionAreaClasses';
 
-export type CardActionAreaTypeMap<P, D extends React.ElementType> = ExtendButtonBaseTypeMap<{
-  props: P & {
+export type CardActionAreaTypeMap<
+  AdditionalProps,
+  DefaultComponent extends React.ElementType,
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & {
     /**
      * Override or extend the styles applied to the component.
      */
@@ -17,7 +20,7 @@ export type CardActionAreaTypeMap<P, D extends React.ElementType> = ExtendButton
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/CardActionArea/CardActionArea.d.ts
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.d.ts
@@ -39,8 +39,8 @@ declare const CardActionArea: ExtendButtonBase<
 >;
 
 export type CardActionAreaProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<CardActionAreaTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<CardActionAreaTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default CardActionArea;

--- a/packages/mui-material/src/CardContent/CardContent.d.ts
+++ b/packages/mui-material/src/CardContent/CardContent.d.ts
@@ -37,8 +37,8 @@ export interface CardContentTypeMap<
 declare const CardContent: OverridableComponent<CardContentTypeMap>;
 
 export type CardContentProps<
-  D extends React.ElementType = CardContentTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<CardContentTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = CardContentTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<CardContentTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default CardContent;

--- a/packages/mui-material/src/CardContent/CardContent.d.ts
+++ b/packages/mui-material/src/CardContent/CardContent.d.ts
@@ -4,8 +4,11 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { Theme } from '..';
 import { CardContentClasses } from './cardContentClasses';
 
-export interface CardContentTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface CardContentTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -19,7 +22,7 @@ export interface CardContentTypeMap<P = {}, D extends React.ElementType = 'div'>
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/CardMedia/CardMedia.d.ts
+++ b/packages/mui-material/src/CardMedia/CardMedia.d.ts
@@ -46,9 +46,9 @@ export interface CardMediaTypeMap<AdditionalProps, DefaultComponent extends Reac
  */
 declare const CardMedia: OverridableComponent<CardMediaTypeMap<{}, 'div'>>;
 
-export type CardMediaProps<D extends React.ElementType = 'div', P = {}> = OverrideProps<
-  CardMediaTypeMap<P, D>,
-  D
->;
+export type CardMediaProps<
+  RootComponent extends React.ElementType = 'div',
+  AdditionalProps = {},
+> = OverrideProps<CardMediaTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default CardMedia;

--- a/packages/mui-material/src/CardMedia/CardMedia.d.ts
+++ b/packages/mui-material/src/CardMedia/CardMedia.d.ts
@@ -4,8 +4,8 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { CardMediaClasses } from './cardMediaClasses';
 
-export interface CardMediaTypeMap<P, D extends React.ElementType> {
-  props: P & {
+export interface CardMediaTypeMap<AdditionalProps, DefaultComponent extends React.ElementType> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -31,7 +31,7 @@ export interface CardMediaTypeMap<P, D extends React.ElementType> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Chip/Chip.d.ts
+++ b/packages/mui-material/src/Chip/Chip.d.ts
@@ -112,8 +112,8 @@ export interface ChipTypeMap<
 declare const Chip: OverridableComponent<ChipTypeMap>;
 
 export type ChipProps<
-  D extends React.ElementType = ChipTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ChipTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ChipTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Chip;

--- a/packages/mui-material/src/Chip/Chip.d.ts
+++ b/packages/mui-material/src/Chip/Chip.d.ts
@@ -11,8 +11,11 @@ export interface ChipPropsSizeOverrides {}
 
 export interface ChipPropsColorOverrides {}
 
-export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface ChipTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The Avatar element to display.
      */
@@ -92,7 +95,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     variant?: OverridableStringUnion<'filled' | 'outlined', ChipPropsVariantOverrides>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Container/Container.d.ts
+++ b/packages/mui-material/src/Container/Container.d.ts
@@ -54,8 +54,8 @@ export interface ContainerTypeMap<
 declare const Container: OverridableComponent<ContainerTypeMap>;
 
 export type ContainerProps<
-  D extends React.ElementType = ContainerTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ContainerTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ContainerTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ContainerTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Container;

--- a/packages/mui-material/src/Container/Container.d.ts
+++ b/packages/mui-material/src/Container/Container.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ContainerClasses } from './containerClasses';
 
-export interface ContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface ContainerTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     children?: React.ReactNode;
     /**
      * Override or extend the styles applied to the component.
@@ -36,7 +39,7 @@ export interface ContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/DialogContentText/DialogContentText.d.ts
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.d.ts
@@ -6,10 +6,10 @@ import { Theme } from '../styles';
 import { DialogContentTextClasses } from './dialogContentTextClasses';
 
 export interface DialogContentTextTypeMap<
-  P = {},
-  D extends React.ElementType = TypographyTypeMap['defaultComponent'],
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = TypographyTypeMap['defaultComponent'],
 > {
-  props: P & {
+  props: AdditionalProps & {
     /**
      * Override or extend the styles applied to the component.
      */
@@ -19,7 +19,7 @@ export interface DialogContentTextTypeMap<
      */
     sx?: SxProps<Theme>;
   } & Omit<TypographyTypeMap['props'], 'classes'>;
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/DialogContentText/DialogContentText.d.ts
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.d.ts
@@ -36,8 +36,8 @@ export interface DialogContentTextTypeMap<
 declare const DialogContentText: OverridableComponent<DialogContentTextTypeMap>;
 
 export type DialogContentTextProps<
-  D extends React.ElementType = DialogContentTextTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<DialogContentTextTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = DialogContentTextTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<DialogContentTextTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default DialogContentText;

--- a/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
@@ -39,8 +39,8 @@ export interface DialogTitleTypeMap<
 declare const DialogTitle: OverridableComponent<DialogTitleTypeMap>;
 
 export type DialogTitleProps<
-  D extends React.ElementType = DialogTitleTypeMap['defaultComponent'],
-  P = { component?: React.ElementType },
-> = OverrideProps<DialogTitleTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = DialogTitleTypeMap['defaultComponent'],
+  AdditionalProps = { component?: React.ElementType },
+> = OverrideProps<DialogTitleTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default DialogTitle;

--- a/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.d.ts
@@ -6,10 +6,10 @@ import { TypographyTypeMap } from '../Typography';
 import { DialogTitleClasses } from './dialogTitleClasses';
 
 export interface DialogTitleTypeMap<
-  P = {},
-  D extends React.ElementType = TypographyTypeMap['defaultComponent'],
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = TypographyTypeMap['defaultComponent'],
 > {
-  props: P & {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -23,7 +23,7 @@ export interface DialogTitleTypeMap<
      */
     sx?: SxProps<Theme>;
   } & Omit<TypographyTypeMap['props'], 'classes'>;
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Divider/Divider.d.ts
+++ b/packages/mui-material/src/Divider/Divider.d.ts
@@ -7,8 +7,11 @@ import { DividerClasses } from './dividerClasses';
 
 export interface DividerPropsVariantOverrides {}
 
-export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
-  props: P & {
+export interface DividerTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'hr',
+> {
+  props: AdditionalProps & {
     /**
      * Absolutely position the element.
      * @default false
@@ -56,7 +59,7 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
       DividerPropsVariantOverrides
     >;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Divider/Divider.d.ts
+++ b/packages/mui-material/src/Divider/Divider.d.ts
@@ -76,8 +76,8 @@ export interface DividerTypeMap<
 declare const Divider: OverridableComponent<DividerTypeMap>;
 
 export type DividerProps<
-  D extends React.ElementType = DividerTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<DividerTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = DividerTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<DividerTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Divider;

--- a/packages/mui-material/src/Fab/Fab.d.ts
+++ b/packages/mui-material/src/Fab/Fab.d.ts
@@ -11,8 +11,11 @@ export interface FabPropsSizeOverrides {}
 
 export interface FabPropsColorOverrides {}
 
-export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendButtonBaseTypeMap<{
-  props: P & {
+export type FabTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'button',
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -66,7 +69,7 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/Fab/Fab.d.ts
+++ b/packages/mui-material/src/Fab/Fab.d.ts
@@ -86,8 +86,8 @@ export type FabTypeMap<
 declare const Fab: ExtendButtonBase<FabTypeMap>;
 
 export type FabProps<
-  D extends React.ElementType = FabTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<FabTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = FabTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FabTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Fab;

--- a/packages/mui-material/src/FormControl/FormControl.d.ts
+++ b/packages/mui-material/src/FormControl/FormControl.d.ts
@@ -8,8 +8,11 @@ import { FormControlClasses } from './formControlClasses';
 export interface FormControlPropsSizeOverrides {}
 export interface FormControlPropsColorOverrides {}
 
-export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface FormControlTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -79,7 +82,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
      */
     variant?: 'standard' | 'outlined' | 'filled';
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/FormControl/FormControl.d.ts
+++ b/packages/mui-material/src/FormControl/FormControl.d.ts
@@ -123,8 +123,8 @@ export interface FormControlTypeMap<
 declare const FormControl: OverridableComponent<FormControlTypeMap>;
 
 export type FormControlProps<
-  D extends React.ElementType = FormControlTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<FormControlTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = FormControlTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FormControlTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default FormControl;

--- a/packages/mui-material/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.d.ts
@@ -7,8 +7,11 @@ import { FormHelperTextClasses } from './formHelperTextClasses';
 
 export interface FormHelperTextPropsVariantOverrides {}
 
-export interface FormHelperTextTypeMap<P = {}, D extends React.ElementType = 'p'> {
-  props: P & {
+export interface FormHelperTextTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'p',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      *
@@ -56,7 +59,7 @@ export interface FormHelperTextTypeMap<P = {}, D extends React.ElementType = 'p'
       FormHelperTextPropsVariantOverrides
     >;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.d.ts
@@ -74,8 +74,8 @@ export interface FormHelperTextTypeMap<
 declare const FormHelperText: OverridableComponent<FormHelperTextTypeMap>;
 
 export type FormHelperTextProps<
-  D extends React.ElementType = FormHelperTextTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<FormHelperTextTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = FormHelperTextTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FormHelperTextTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default FormHelperText;

--- a/packages/mui-material/src/FormLabel/FormLabel.d.ts
+++ b/packages/mui-material/src/FormLabel/FormLabel.d.ts
@@ -81,8 +81,8 @@ export interface ExtendFormLabelTypeMap<M extends OverridableTypeMap> {
 }
 
 export type FormLabelProps<
-  D extends React.ElementType = FormLabelTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<FormLabelTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = FormLabelTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FormLabelTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default FormLabel;

--- a/packages/mui-material/src/FormLabel/FormLabel.d.ts
+++ b/packages/mui-material/src/FormLabel/FormLabel.d.ts
@@ -51,9 +51,12 @@ export interface FormLabelOwnProps {
   sx?: SxProps<Theme>;
 }
 
-export interface FormLabelTypeMap<P = {}, D extends React.ElementType = 'label'> {
-  props: P & FormLabelBaseProps & FormLabelOwnProps;
-  defaultComponent: D;
+export interface FormLabelTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'label',
+> {
+  props: AdditionalProps & FormLabelBaseProps & FormLabelOwnProps;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/FormLabel/FormLabel.d.ts
+++ b/packages/mui-material/src/FormLabel/FormLabel.d.ts
@@ -75,9 +75,9 @@ declare const FormLabel: OverridableComponent<FormLabelTypeMap>;
 
 export type FormLabelBaseProps = React.LabelHTMLAttributes<HTMLLabelElement>;
 
-export interface ExtendFormLabelTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & Pick<FormLabelOwnProps, 'filled' | 'color'>;
-  defaultComponent: M['defaultComponent'];
+export interface ExtendFormLabelTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & Pick<FormLabelOwnProps, 'filled' | 'color'>;
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
 export type FormLabelProps<

--- a/packages/mui-material/src/Grid/Grid.d.ts
+++ b/packages/mui-material/src/Grid/Grid.d.ts
@@ -83,8 +83,11 @@ type Breakpoints = IfEquals<
   CustomBreakpoints
 >;
 
-export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
+export interface GridTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps &
     SystemProps<Theme> & {
       /**
        * The content of the component.
@@ -150,7 +153,7 @@ export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
        */
       zeroMinWidth?: boolean;
     } & Breakpoints;
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Grid/Grid.d.ts
+++ b/packages/mui-material/src/Grid/Grid.d.ts
@@ -169,8 +169,8 @@ export interface GridTypeMap<
 declare const Grid: OverridableComponent<GridTypeMap>;
 
 export type GridProps<
-  D extends React.ElementType = GridTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<GridTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = GridTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<GridTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Grid;

--- a/packages/mui-material/src/Icon/Icon.d.ts
+++ b/packages/mui-material/src/Icon/Icon.d.ts
@@ -75,8 +75,8 @@ export interface IconTypeMap<
 declare const Icon: OverridableComponent<IconTypeMap> & { muiName: string };
 
 export type IconProps<
-  D extends React.ElementType = IconTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<IconTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = IconTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<IconTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Icon;

--- a/packages/mui-material/src/Icon/Icon.d.ts
+++ b/packages/mui-material/src/Icon/Icon.d.ts
@@ -9,8 +9,11 @@ export interface IconPropsSizeOverrides {}
 
 export interface IconPropsColorOverrides {}
 
-export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
-  props: P & {
+export interface IconTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'span',
+> {
+  props: AdditionalProps & {
     /**
      * The base class applied to the icon. Defaults to 'material-icons', but can be changed to any
      * other base class that suits the icon font you're using (e.g. material-icons-rounded, fas, etc).
@@ -56,7 +59,7 @@ export interface IconTypeMap<P = {}, D extends React.ElementType = 'span'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/IconButton/IconButton.d.ts
+++ b/packages/mui-material/src/IconButton/IconButton.d.ts
@@ -81,8 +81,8 @@ export type IconButtonTypeMap<
 declare const IconButton: ExtendButtonBase<IconButtonTypeMap>;
 
 export type IconButtonProps<
-  D extends React.ElementType = IconButtonTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<IconButtonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = IconButtonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<IconButtonTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default IconButton;

--- a/packages/mui-material/src/IconButton/IconButton.d.ts
+++ b/packages/mui-material/src/IconButton/IconButton.d.ts
@@ -11,10 +11,10 @@ export interface IconButtonPropsColorOverrides {}
 export interface IconButtonPropsSizeOverrides {}
 
 export type IconButtonTypeMap<
-  P = {},
-  D extends React.ElementType = 'button',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'button',
 > = ExtendButtonBaseTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * The icon to display.
      */
@@ -62,7 +62,7 @@ export type IconButtonTypeMap<
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/ImageList/ImageList.d.ts
+++ b/packages/mui-material/src/ImageList/ImageList.d.ts
@@ -7,8 +7,11 @@ import { ImageListClasses } from './imageListClasses';
 
 export interface ImageListPropsVariantOverrides {}
 
-export interface ImageListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
-  props: P & {
+export interface ImageListTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'ul',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component, normally `ImageListItem`s.
      */
@@ -45,7 +48,7 @@ export interface ImageListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
       ImageListPropsVariantOverrides
     >;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/ImageList/ImageList.d.ts
+++ b/packages/mui-material/src/ImageList/ImageList.d.ts
@@ -63,8 +63,8 @@ export interface ImageListTypeMap<
 declare const ImageList: OverridableComponent<ImageListTypeMap>;
 
 export type ImageListProps<
-  D extends React.ElementType = ImageListTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ImageListTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ImageListTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ImageListTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ImageList;

--- a/packages/mui-material/src/ImageListItem/ImageListItem.d.ts
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.d.ts
@@ -47,8 +47,8 @@ export interface ImageListItemTypeMap<
 declare const ImageListItem: OverridableComponent<ImageListItemTypeMap>;
 
 export type ImageListItemProps<
-  D extends React.ElementType = ImageListItemTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ImageListItemTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ImageListItemTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ImageListItemTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ImageListItem;

--- a/packages/mui-material/src/ImageListItem/ImageListItem.d.ts
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ImageListItemClasses } from './imageListItemClasses';
 
-export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'> {
-  props: P & {
+export interface ImageListItemTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'li',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component, normally an `<img>`.
      */
@@ -29,7 +32,7 @@ export interface ImageListItemTypeMap<P = {}, D extends React.ElementType = 'li'
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.d.ts
@@ -58,8 +58,8 @@ export interface InputAdornmentTypeMap<
 declare const InputAdornment: OverridableComponent<InputAdornmentTypeMap>;
 
 export type InputAdornmentProps<
-  D extends React.ElementType = InputAdornmentTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<InputAdornmentTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = InputAdornmentTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<InputAdornmentTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default InputAdornment;

--- a/packages/mui-material/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.d.ts
@@ -4,8 +4,11 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { Theme } from '..';
 import { InputAdornmentClasses } from './inputAdornmentClasses';
 
-export interface InputAdornmentTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface InputAdornmentTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * Override or extend the styles applied to the component.
      */
@@ -40,7 +43,7 @@ export interface InputAdornmentTypeMap<P = {}, D extends React.ElementType = 'di
      */
     variant?: 'standard' | 'outlined' | 'filled';
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/InputLabel/InputLabel.d.ts
+++ b/packages/mui-material/src/InputLabel/InputLabel.d.ts
@@ -83,8 +83,8 @@ export type InputLabelTypeMap<
 declare const InputLabel: OverridableComponent<InputLabelTypeMap>;
 
 export type InputLabelProps<
-  D extends React.ElementType = InputLabelTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<InputLabelTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = InputLabelTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<InputLabelTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default InputLabel;

--- a/packages/mui-material/src/InputLabel/InputLabel.d.ts
+++ b/packages/mui-material/src/InputLabel/InputLabel.d.ts
@@ -9,10 +9,10 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 export interface InputLabelPropsSizeOverrides {}
 
 export type InputLabelTypeMap<
-  P = {},
-  D extends React.ElementType = 'label',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'label',
 > = ExtendFormLabelTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -66,7 +66,7 @@ export type InputLabelTypeMap<
      */
     variant?: 'standard' | 'outlined' | 'filled';
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/Link/Link.d.ts
+++ b/packages/mui-material/src/Link/Link.d.ts
@@ -6,8 +6,11 @@ import { Theme } from '../styles';
 import { TypographyProps } from '../Typography';
 import { LinkClasses } from './linkClasses';
 
-export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
-  props: P &
+export interface LinkTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'a',
+> {
+  props: AdditionalProps &
     DistributiveOmit<LinkBaseProps, 'classes'> & {
       /**
        * The content of the component.
@@ -41,7 +44,7 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
        */
       variant?: TypographyProps['variant'];
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Link/Link.d.ts
+++ b/packages/mui-material/src/Link/Link.d.ts
@@ -65,8 +65,8 @@ export type LinkBaseProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 
   DistributiveOmit<TypographyProps, 'children' | 'component' | 'color' | 'ref' | 'variant'>;
 
 export type LinkProps<
-  D extends React.ElementType = LinkTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<LinkTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = LinkTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<LinkTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Link;

--- a/packages/mui-material/src/List/List.d.ts
+++ b/packages/mui-material/src/List/List.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverridableTypeMap, OverrideProps } from '../OverridableComponent';
 import { ListClasses } from './listClasses';
 
-export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
-  props: P & {
+export interface ListTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'ul',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -35,7 +38,7 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/List/List.d.ts
+++ b/packages/mui-material/src/List/List.d.ts
@@ -44,12 +44,14 @@ export interface ListTypeMap<
 /**
  * utility to create component types that inherit props from List.
  */
-export interface ExtendListTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & ListTypeMap['props'];
-  defaultComponent: M['defaultComponent'];
+export interface ExtendListTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & ListTypeMap['props'];
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendList<M extends OverridableTypeMap> = OverridableComponent<ExtendListTypeMap<M>>;
+export type ExtendList<TypeMap extends OverridableTypeMap> = OverridableComponent<
+  ExtendListTypeMap<TypeMap>
+>;
 
 /**
  *

--- a/packages/mui-material/src/List/List.d.ts
+++ b/packages/mui-material/src/List/List.d.ts
@@ -65,8 +65,8 @@ export type ExtendList<M extends OverridableTypeMap> = OverridableComponent<Exte
 declare const List: ExtendList<ListTypeMap>;
 
 export type ListProps<
-  D extends React.ElementType = ListTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ListTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ListTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ListTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default List;

--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -177,9 +177,9 @@ declare const ListItem: ExtendButtonBase<
     >
   >;
 
-export type ListItemProps<D extends React.ElementType = 'li', P = {}> = OverrideProps<
-  ListItemTypeMap<P, D>,
-  D
->;
+export type ListItemProps<
+  RootComponent extends React.ElementType = 'li',
+  AdditionalProps = {},
+> = OverrideProps<ListItemTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ListItem;

--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -84,8 +84,8 @@ export interface ListItemBaseProps {
   sx?: SxProps<Theme>;
 }
 
-export interface ListItemTypeMap<P, D extends React.ElementType> {
-  props: P &
+export interface ListItemTypeMap<AdditionalProps, DefaultComponent extends React.ElementType> {
+  props: AdditionalProps &
     ListItemBaseProps & {
       /**
        * The components used for each slot inside.
@@ -132,7 +132,7 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
         root?: React.ElementType;
       };
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
@@ -80,8 +80,8 @@ export type ListItemButtonTypeMap<
 declare const ListItemButton: ExtendButtonBase<ListItemButtonTypeMap>;
 
 export type ListItemButtonProps<
-  D extends React.ElementType = ListItemButtonTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ListItemButtonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ListItemButtonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ListItemButtonTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ListItemButton;

--- a/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.d.ts
@@ -59,11 +59,11 @@ export interface ListItemButtonBaseProps {
 }
 
 export type ListItemButtonTypeMap<
-  P = {},
-  D extends React.ElementType = 'div',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
 > = ExtendButtonBaseTypeMap<{
-  props: P & ListItemButtonBaseProps;
-  defaultComponent: D;
+  props: AdditionalProps & ListItemButtonBaseProps;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/ListSubheader/ListSubheader.d.ts
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.d.ts
@@ -58,8 +58,8 @@ export interface ListSubheaderTypeMap<
 declare const ListSubheader: OverridableComponent<ListSubheaderTypeMap>;
 
 export type ListSubheaderProps<
-  D extends React.ElementType = ListSubheaderTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ListSubheaderTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ListSubheaderTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ListSubheaderTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ListSubheader;

--- a/packages/mui-material/src/ListSubheader/ListSubheader.d.ts
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ListSubheaderClasses } from './listSubheaderClasses';
 
-export interface ListSubheaderTypeMap<P = {}, D extends React.ElementType = 'li'> {
-  props: P & {
+export interface ListSubheaderTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'li',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -39,7 +42,7 @@ export interface ListSubheaderTypeMap<P = {}, D extends React.ElementType = 'li'
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/MenuItem/MenuItem.d.ts
+++ b/packages/mui-material/src/MenuItem/MenuItem.d.ts
@@ -4,8 +4,11 @@ import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { MenuItemClasses } from './menuItemClasses';
 
-export type MenuItemTypeMap<P = {}, D extends React.ElementType = 'li'> = ExtendButtonBaseTypeMap<{
-  props: P & {
+export type MenuItemTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'li',
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & {
     /**
      * If `true`, the list item is focused during the first mount.
      * Focus will also be triggered if the value changes from false to true.
@@ -47,7 +50,7 @@ export type MenuItemTypeMap<P = {}, D extends React.ElementType = 'li'> = Extend
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/MenuItem/MenuItem.d.ts
+++ b/packages/mui-material/src/MenuItem/MenuItem.d.ts
@@ -67,8 +67,8 @@ export type MenuItemTypeMap<
 declare const MenuItem: ExtendButtonBase<MenuItemTypeMap>;
 
 export type MenuItemProps<
-  D extends React.ElementType = MenuItemTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<MenuItemTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = MenuItemTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<MenuItemTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default MenuItem;

--- a/packages/mui-material/src/MenuList/MenuList.d.ts
+++ b/packages/mui-material/src/MenuList/MenuList.d.ts
@@ -62,8 +62,8 @@ export type MenuListClassKey = keyof NonNullable<MenuListTypeMap['props']['class
 declare const MenuList: ExtendList<MenuListTypeMap>;
 
 export type MenuListProps<
-  D extends React.ElementType = MenuListTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<MenuListTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = MenuListTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<MenuListTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default MenuList;

--- a/packages/mui-material/src/MenuList/MenuList.d.ts
+++ b/packages/mui-material/src/MenuList/MenuList.d.ts
@@ -2,8 +2,11 @@ import * as React from 'react';
 import { ExtendList, ExtendListTypeMap } from '../List';
 import { OverrideProps } from '../OverridableComponent';
 
-export type MenuListTypeMap<P = {}, D extends React.ElementType = 'ul'> = ExtendListTypeMap<{
-  props: P & {
+export type MenuListTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'ul',
+> = ExtendListTypeMap<{
+  props: AdditionalProps & {
     /**
      * If `true`, will focus the `[role="menu"]` container and move into tab order.
      * @default false
@@ -36,7 +39,7 @@ export type MenuListTypeMap<P = {}, D extends React.ElementType = 'ul'> = Extend
      */
     variant?: 'menu' | 'selectedMenu';
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 export type MenuListClassKey = keyof NonNullable<MenuListTypeMap['props']['classes']>;

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -16,8 +16,11 @@ export interface ModalOwnerState extends ModalProps {
   exited: boolean;
 }
 
-export interface ModalTypeMap<D extends React.ElementType = 'div', P = {}> {
-  props: P & {
+export interface ModalTypeMap<
+  DefaultComponent extends React.ElementType = 'div',
+  AdditionalProps = {},
+> {
+  props: AdditionalProps & {
     /**
      * A backdrop component. This prop enables custom backdrop rendering.
      * @deprecated Use `slots.backdrop` instead. While this prop currently works, it will be removed in the next major version.
@@ -92,7 +95,7 @@ export interface ModalTypeMap<D extends React.ElementType = 'div', P = {}> {
      */
     sx?: SxProps<Theme>;
   } & Omit<BaseModalTypeMap['props'], 'slotProps'>;
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 type ModalRootProps = NonNullable<ModalTypeMap['props']['slotProps']>['root'];

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -132,8 +132,8 @@ export type ModalClasses = Record<ModalClassKey, string>;
 export declare const modalClasses: ModalClasses;
 
 export type ModalProps<
-  D extends React.ElementType = ModalTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ModalTypeMap<D, P>, D>;
+  RootComponent extends React.ElementType = ModalTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ModalTypeMap<RootComponent, AdditionalProps>, RootComponent>;
 
 export default Modal;

--- a/packages/mui-material/src/OverridableComponent.d.ts
+++ b/packages/mui-material/src/OverridableComponent.d.ts
@@ -7,21 +7,21 @@ import { StyledComponentProps } from './styles';
  *
  * Adjusts valid props based on the type of `component`.
  */
-export interface OverridableComponent<M extends OverridableTypeMap> {
+export interface OverridableComponent<TypeMap extends OverridableTypeMap> {
   // If you make any changes to this interface, please make sure to update the
   // `OverridableComponent` type in `mui-types/index.d.ts` as well.
   // Also, there are types in Base UI that have a similar shape to this interface
   // (e.g. SelectType, OptionType, etc.).
-  <C extends React.ElementType>(
+  <RootComponent extends React.ElementType>(
     props: {
       /**
        * The component used for the root node.
        * Either a string to use a HTML element or a component.
        */
-      component: C;
-    } & OverrideProps<M, C>,
+      component: RootComponent;
+    } & OverrideProps<TypeMap, RootComponent>,
   ): JSX.Element | null;
-  (props: DefaultComponentProps<M>): JSX.Element | null;
+  (props: DefaultComponentProps<TypeMap>): JSX.Element | null;
 }
 
 /**
@@ -29,27 +29,27 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
  */
 // prettier-ignore
 export type OverrideProps<
-  M extends OverridableTypeMap,
-  C extends React.ElementType
+  TypeMap extends OverridableTypeMap,
+  RootComponent extends React.ElementType
 > = (
-  & BaseProps<M>
-  & DistributiveOmit<React.ComponentPropsWithRef<C>, keyof BaseProps<M>>
+  & BaseProps<TypeMap>
+  & DistributiveOmit<React.ComponentPropsWithRef<RootComponent>, keyof BaseProps<TypeMap>>
 );
 
 /**
  * Props if `component={Component}` is NOT used.
  */
 // prettier-ignore
-export type DefaultComponentProps<M extends OverridableTypeMap> =
-  & BaseProps<M>
-  & DistributiveOmit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
+export type DefaultComponentProps<TypeMap extends OverridableTypeMap> =
+  & BaseProps<TypeMap>
+  & DistributiveOmit<React.ComponentPropsWithRef<TypeMap['defaultComponent']>, keyof BaseProps<TypeMap>>;
 
 /**
  * Props defined on the component (+ common material-ui props).
  */
 // prettier-ignore
-export type BaseProps<M extends OverridableTypeMap> =
-  & M['props']
+export type BaseProps<TypeMap extends OverridableTypeMap> =
+  & TypeMap['props']
   & CommonProps;
 
 /**

--- a/packages/mui-material/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.d.ts
@@ -12,8 +12,11 @@ export interface PaginationItemPropsSizeOverrides {}
 
 export interface PaginationItemPropsColorOverrides {}
 
-export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface PaginationItemTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * Override or extend the styles applied to the component.
      */
@@ -94,7 +97,7 @@ export interface PaginationItemTypeMap<P = {}, D extends React.ElementType = 'di
      */
     variant?: OverridableStringUnion<'text' | 'outlined', PaginationItemPropsVariantOverrides>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/PaginationItem/PaginationItem.d.ts
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.d.ts
@@ -113,8 +113,8 @@ export interface PaginationItemTypeMap<
 declare const PaginationItem: OverridableComponent<PaginationItemTypeMap>;
 
 export type PaginationItemProps<
-  D extends React.ElementType = PaginationItemTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<PaginationItemTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = PaginationItemTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<PaginationItemTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default PaginationItem;

--- a/packages/mui-material/src/Paper/Paper.d.ts
+++ b/packages/mui-material/src/Paper/Paper.d.ts
@@ -57,9 +57,9 @@ export interface PaperTypeMap<
  */
 declare const Paper: OverridableComponent<PaperTypeMap>;
 
-export interface ExtendPaperTypeMap<M extends OverridableTypeMap, Keys extends string = ''> {
-  props: M['props'] & Omit<PaperTypeMap['props'], Keys>;
-  defaultComponent: M['defaultComponent'];
+export interface ExtendPaperTypeMap<TypeMap extends OverridableTypeMap, Keys extends string = ''> {
+  props: TypeMap['props'] & Omit<PaperTypeMap['props'], Keys>;
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
 export type PaperProps<

--- a/packages/mui-material/src/Paper/Paper.d.ts
+++ b/packages/mui-material/src/Paper/Paper.d.ts
@@ -7,8 +7,11 @@ import { PaperClasses } from './paperClasses';
 
 export interface PaperPropsVariantOverrides {}
 
-export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface PaperTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -38,7 +41,7 @@ export interface PaperTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     variant?: OverridableStringUnion<'elevation' | 'outlined', PaperPropsVariantOverrides>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Paper/Paper.d.ts
+++ b/packages/mui-material/src/Paper/Paper.d.ts
@@ -63,8 +63,8 @@ export interface ExtendPaperTypeMap<M extends OverridableTypeMap, Keys extends s
 }
 
 export type PaperProps<
-  D extends React.ElementType = PaperTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<PaperTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = PaperTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<PaperTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Paper;

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.d.ts
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ScopedCssBaselineClasses } from './scopedCssBaselineClasses';
 
-export interface ScopedCssBaselineTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface ScopedCssBaselineTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -25,7 +28,7 @@ export interface ScopedCssBaselineTypeMap<P = {}, D extends React.ElementType = 
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.d.ts
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.d.ts
@@ -43,9 +43,9 @@ export interface ScopedCssBaselineTypeMap<
 declare const ScopedCssBaseline: OverridableComponent<ScopedCssBaselineTypeMap>;
 
 export type ScopedCssBaselineProps<
-  D extends React.ElementType = ScopedCssBaselineTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ScopedCssBaselineTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ScopedCssBaselineTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ScopedCssBaselineTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 /**
  *

--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -9,10 +9,10 @@ import { OutlinedInputProps } from '../OutlinedInput';
 
 export { SelectChangeEvent };
 
-export interface SelectProps<T = unknown>
+export interface SelectProps<Value = unknown>
   extends StandardProps<InputProps, 'value' | 'onChange'>,
     Omit<OutlinedInputProps, 'value' | 'onChange'>,
-    Pick<SelectInputProps<T>, 'onChange'> {
+    Pick<SelectInputProps<Value>, 'onChange'> {
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.
@@ -40,7 +40,7 @@ export interface SelectProps<T = unknown>
   /**
    * The default value. Use when the component is not controlled.
    */
-  defaultValue?: T;
+  defaultValue?: Value;
   /**
    * If `true`, a value is displayed even if no items are selected.
    *
@@ -96,12 +96,12 @@ export interface SelectProps<T = unknown>
   /**
    * Callback fired when a menu item is selected.
    *
-   * @param {SelectChangeEvent<T>} event The event source of the callback.
+   * @param {SelectChangeEvent<Value>} event The event source of the callback.
    * You can pull out the new value by accessing `event.target.value` (any).
    * **Warning**: This is a generic event, not a change event, unless the change event is caused by browser autofill.
    * @param {object} [child] The react element that was selected when `native` is `false` (default).
    */
-  onChange?: SelectInputProps<T>['onChange'];
+  onChange?: SelectInputProps<Value>['onChange'];
   /**
    * Callback fired when the component requests to be closed.
    * Use it in either controlled (see the `open` prop), or uncontrolled mode (to detect when the Select collapses).
@@ -128,7 +128,7 @@ export interface SelectProps<T = unknown>
    * @param {any} value The `value` provided to the component.
    * @returns {ReactNode}
    */
-  renderValue?: (value: T) => React.ReactNode;
+  renderValue?: (value: Value) => React.ReactNode;
   /**
    * Props applied to the clickable div element.
    */
@@ -144,7 +144,7 @@ export interface SelectProps<T = unknown>
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    */
-  value?: T | '';
+  value?: Value | '';
   /**
    * The variant to use.
    * @default 'outlined'
@@ -163,7 +163,7 @@ export interface SelectProps<T = unknown>
  * - [Select API](https://mui.com/material-ui/api/select/)
  * - inherits [OutlinedInput API](https://mui.com/material-ui/api/outlined-input/)
  */
-declare const Select: (<T>(props: SelectProps<T>) => JSX.Element) & {
+declare const Select: (<Value>(props: SelectProps<Value>) => JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-material/src/Select/SelectInput.d.ts
+++ b/packages/mui-material/src/Select/SelectInput.d.ts
@@ -8,11 +8,11 @@ import { MenuProps } from '../Menu';
  * The type of event depends on what caused the change.
  * For example, when the browser auto-fills the `Select` you'll receive a `React.ChangeEvent`.
  */
-export type SelectChangeEvent<T = string> =
-  | (Event & { target: { value: T; name: string } })
+export type SelectChangeEvent<Value = string> =
+  | (Event & { target: { value: Value; name: string } })
   | React.ChangeEvent<HTMLInputElement>;
 
-export interface SelectInputProps<T = unknown> {
+export interface SelectInputProps<Value = unknown> {
   autoFocus?: boolean;
   autoWidth: boolean;
   defaultOpen?: boolean;
@@ -20,24 +20,24 @@ export interface SelectInputProps<T = unknown> {
   error?: boolean;
   IconComponent?: React.ElementType;
   inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<T>['value'] },
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<Value>['value'] },
   ) => void;
   MenuProps?: Partial<MenuProps>;
   multiple: boolean;
   name?: string;
   native: boolean;
   onBlur?: React.FocusEventHandler<any>;
-  onChange?: (event: SelectChangeEvent<T>, child: React.ReactNode) => void;
+  onChange?: (event: SelectChangeEvent<Value>, child: React.ReactNode) => void;
   onClose?: (event: React.SyntheticEvent) => void;
   onFocus?: React.FocusEventHandler<any>;
   onOpen?: (event: React.SyntheticEvent) => void;
   open?: boolean;
   readOnly?: boolean;
-  renderValue?: (value: SelectInputProps<T>['value']) => React.ReactNode;
+  renderValue?: (value: SelectInputProps<Value>['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   sx?: SxProps<Theme>;
   tabIndex?: number;
-  value?: T;
+  value?: Value;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/mui-material/src/Skeleton/Skeleton.d.ts
+++ b/packages/mui-material/src/Skeleton/Skeleton.d.ts
@@ -65,8 +65,8 @@ export interface SkeletonTypeMap<
 declare const Skeleton: OverridableComponent<SkeletonTypeMap>;
 
 export type SkeletonProps<
-  D extends React.ElementType = SkeletonTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<SkeletonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = SkeletonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<SkeletonTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Skeleton;

--- a/packages/mui-material/src/Skeleton/Skeleton.d.ts
+++ b/packages/mui-material/src/Skeleton/Skeleton.d.ts
@@ -7,8 +7,11 @@ import { SkeletonClasses } from './skeletonClasses';
 
 export interface SkeletonPropsVariantOverrides {}
 
-export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
-  props: P & {
+export interface SkeletonTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'span',
+> {
+  props: AdditionalProps & {
     /**
      * The animation.
      * If `false` the animation effect is disabled.
@@ -46,7 +49,7 @@ export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
      */
     width?: number | string;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -307,8 +307,8 @@ export declare const SliderValueLabel: React.FC<SliderValueLabelProps>;
 declare const Slider: OverridableComponent<SliderTypeMap>;
 
 export type SliderProps<
-  D extends React.ElementType = SliderTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<SliderTypeMap<D, P>, D>;
+  RootComponent extends React.ElementType = SliderTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<SliderTypeMap<RootComponent, AdditionalProps>, RootComponent>;
 
 export default Slider;

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -20,8 +20,11 @@ export interface SliderOwnerState extends SliderProps {
   focusedThumbIndex: number;
 }
 
-export interface SliderTypeMap<D extends React.ElementType = 'span', P = {}> {
-  props: P & {
+export interface SliderTypeMap<
+  DefaultComponent extends React.ElementType = 'span',
+  AdditionalProps = {},
+> {
+  props: AdditionalProps & {
     /**
      * The label of the slider.
      */
@@ -266,7 +269,7 @@ export interface SliderTypeMap<D extends React.ElementType = 'span', P = {}> {
      */
     valueLabelFormat?: string | ((value: number, index: number) => React.ReactNode);
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 export interface SliderValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {

--- a/packages/mui-material/src/Stack/Stack.d.ts
+++ b/packages/mui-material/src/Stack/Stack.d.ts
@@ -58,8 +58,8 @@ export interface StackTypeMap<
 declare const Stack: OverridableComponent<StackTypeMap>;
 
 export type StackProps<
-  D extends React.ElementType = StackTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<StackTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = StackTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<StackTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Stack;

--- a/packages/mui-material/src/Stack/Stack.d.ts
+++ b/packages/mui-material/src/Stack/Stack.d.ts
@@ -3,8 +3,11 @@ import { ResponsiveStyleValue, SxProps, SystemProps } from '@mui/system';
 import { OverrideProps, OverridableComponent } from '../OverridableComponent';
 import { Theme } from '../styles/createTheme';
 
-export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
+export interface StackTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps &
     SystemProps<Theme> & {
       /**
        * The content of the component.
@@ -40,7 +43,7 @@ export interface StackTypeMap<P = {}, D extends React.ElementType = 'div'> {
        */
       sx?: SxProps<Theme>;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/Step/Step.d.ts
+++ b/packages/mui-material/src/Step/Step.d.ts
@@ -54,9 +54,9 @@ export interface StepTypeMap<
 }
 
 export type StepProps<
-  D extends React.ElementType = StepTypeMap['defaultComponent'],
-  P = { component?: React.ElementType },
-> = OverrideProps<StepTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = StepTypeMap['defaultComponent'],
+  AdditionalProps = { component?: React.ElementType },
+> = OverrideProps<StepTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export type StepClasskey = keyof NonNullable<StepProps['classes']>;
 

--- a/packages/mui-material/src/Step/Step.d.ts
+++ b/packages/mui-material/src/Step/Step.d.ts
@@ -4,8 +4,11 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { Theme } from '../styles';
 import { StepClasses } from './stepClasses';
 
-export interface StepTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface StepTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * Sets the step as active. Is passed to child components.
      */
@@ -47,7 +50,7 @@ export interface StepTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 export type StepProps<

--- a/packages/mui-material/src/StepButton/StepButton.d.ts
+++ b/packages/mui-material/src/StepButton/StepButton.d.ts
@@ -59,8 +59,8 @@ declare const StepButton: ExtendButtonBase<
 export type StepButtonClasskey = keyof NonNullable<StepButtonProps['classes']>;
 
 export type StepButtonProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<StepButtonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<StepButtonTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default StepButton;

--- a/packages/mui-material/src/StepButton/StepButton.d.ts
+++ b/packages/mui-material/src/StepButton/StepButton.d.ts
@@ -10,8 +10,11 @@ import { StepButtonClasses } from './stepButtonClasses';
  */
 export type StepButtonIcon = React.ReactNode;
 
-export type StepButtonTypeMap<P, D extends React.ElementType> = ExtendButtonBaseTypeMap<{
-  props: P & {
+export type StepButtonTypeMap<
+  AdditionalProps,
+  DefaultComponent extends React.ElementType,
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & {
     /**
      * Can be a `StepLabel` or a node to place inside `StepLabel` as children.
      */
@@ -33,7 +36,7 @@ export type StepButtonTypeMap<P, D extends React.ElementType> = ExtendButtonBase
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 
   ignoredProps: 'disabled';
 }>;

--- a/packages/mui-material/src/Stepper/Stepper.d.ts
+++ b/packages/mui-material/src/Stepper/Stepper.d.ts
@@ -57,9 +57,9 @@ export interface StepperTypeMap<
 }
 
 export type StepperProps<
-  D extends React.ElementType = StepperTypeMap['defaultComponent'],
-  P = { component?: React.ElementType },
-> = OverrideProps<StepperTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = StepperTypeMap['defaultComponent'],
+  AdditionalProps = { component?: React.ElementType },
+> = OverrideProps<StepperTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export type StepperClasskey = keyof NonNullable<StepperProps['classes']>;
 

--- a/packages/mui-material/src/Stepper/Stepper.d.ts
+++ b/packages/mui-material/src/Stepper/Stepper.d.ts
@@ -7,8 +7,11 @@ import { StepperClasses } from './stepperClasses';
 
 export type Orientation = 'horizontal' | 'vertical';
 
-export interface StepperTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P &
+export interface StepperTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps &
     Pick<PaperProps, 'elevation' | 'square' | 'variant'> & {
       /**
        * Set the active step (zero based index).
@@ -50,7 +53,7 @@ export interface StepperTypeMap<P = {}, D extends React.ElementType = 'div'> {
        */
       sx?: SxProps<Theme>;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 export type StepperProps<

--- a/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
@@ -9,8 +9,11 @@ export interface SvgIconPropsSizeOverrides {}
 
 export interface SvgIconPropsColorOverrides {}
 
-export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
-  props: P & {
+export interface SvgIconTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'svg',
+> {
+  props: AdditionalProps & {
     /**
      * Node passed into the SVG element.
      */
@@ -83,7 +86,7 @@ export interface SvgIconTypeMap<P = {}, D extends React.ElementType = 'svg'> {
      */
     viewBox?: string;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.d.ts
@@ -102,8 +102,8 @@ export interface SvgIconTypeMap<
 declare const SvgIcon: OverridableComponent<SvgIconTypeMap> & { muiName: string };
 
 export type SvgIconProps<
-  D extends React.ElementType = SvgIconTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<SvgIconTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = SvgIconTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<SvgIconTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default SvgIcon;

--- a/packages/mui-material/src/Tab/Tab.d.ts
+++ b/packages/mui-material/src/Tab/Tab.d.ts
@@ -74,8 +74,8 @@ export type TabTypeMap<
 declare const Tab: ExtendButtonBase<TabTypeMap>;
 
 export type TabProps<
-  D extends React.ElementType = TabTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TabTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TabTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TabTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Tab;

--- a/packages/mui-material/src/Tab/Tab.d.ts
+++ b/packages/mui-material/src/Tab/Tab.d.ts
@@ -5,8 +5,11 @@ import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase';
 import { OverrideProps } from '../OverridableComponent';
 import { TabClasses } from './tabClasses';
 
-export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButtonBaseTypeMap<{
-  props: P & {
+export type TabTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & {
     /**
      * This prop isn't supported.
      * Use the `component` prop if you need to change the children structure.
@@ -54,7 +57,7 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
      */
     wrapped?: boolean;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/Table/Table.d.ts
+++ b/packages/mui-material/src/Table/Table.d.ts
@@ -7,8 +7,11 @@ import { TableClasses } from './tableClasses';
 
 export interface TablePropsSizeOverrides {}
 
-export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
-  props: P & {
+export interface TableTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'table',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the table, normally `TableHead` and `TableBody`.
      */
@@ -39,7 +42,7 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/Table/Table.d.ts
+++ b/packages/mui-material/src/Table/Table.d.ts
@@ -57,8 +57,8 @@ export interface TableTypeMap<
 declare const Table: OverridableComponent<TableTypeMap>;
 
 export type TableProps<
-  D extends React.ElementType = TableTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Table;

--- a/packages/mui-material/src/TableBody/TableBody.d.ts
+++ b/packages/mui-material/src/TableBody/TableBody.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { TableBodyClasses } from './tableBodyClasses';
 
-export interface TableBodyTypeMap<P = {}, D extends React.ElementType = 'tbody'> {
-  props: P & {
+export interface TableBodyTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'tbody',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component, normally `TableRow`.
      */
@@ -19,7 +22,7 @@ export interface TableBodyTypeMap<P = {}, D extends React.ElementType = 'tbody'>
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/TableBody/TableBody.d.ts
+++ b/packages/mui-material/src/TableBody/TableBody.d.ts
@@ -37,8 +37,8 @@ export interface TableBodyTypeMap<
 declare const TableBody: OverridableComponent<TableBodyTypeMap>;
 
 export type TableBodyProps<
-  D extends React.ElementType = TableBodyTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableBodyTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableBodyTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableBodyTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TableBody;

--- a/packages/mui-material/src/TableContainer/TableContainer.d.ts
+++ b/packages/mui-material/src/TableContainer/TableContainer.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { TableContainerClasses } from './tableContainerClasses';
 
-export interface TableContainerTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface TableContainerTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component, normally `Table`.
      */
@@ -19,7 +22,7 @@ export interface TableContainerTypeMap<P = {}, D extends React.ElementType = 'di
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/TableContainer/TableContainer.d.ts
+++ b/packages/mui-material/src/TableContainer/TableContainer.d.ts
@@ -37,8 +37,8 @@ export interface TableContainerTypeMap<
 declare const TableContainer: OverridableComponent<TableContainerTypeMap>;
 
 export type TableContainerProps<
-  D extends React.ElementType = TableContainerTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableContainerTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableContainerTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableContainerTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TableContainer;

--- a/packages/mui-material/src/TableFooter/TableFooter.d.ts
+++ b/packages/mui-material/src/TableFooter/TableFooter.d.ts
@@ -37,8 +37,8 @@ export interface TableFooterTypeMap<
 declare const TableFooter: OverridableComponent<TableFooterTypeMap>;
 
 export type TableFooterProps<
-  D extends React.ElementType = TableFooterTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableFooterTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableFooterTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableFooterTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TableFooter;

--- a/packages/mui-material/src/TableFooter/TableFooter.d.ts
+++ b/packages/mui-material/src/TableFooter/TableFooter.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { TableFooterClasses } from './tableFooterClasses';
 
-export interface TableFooterTypeMap<P = {}, D extends React.ElementType = 'tfoot'> {
-  props: P & {
+export interface TableFooterTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'tfoot',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component, normally `TableRow`.
      */
@@ -19,7 +22,7 @@ export interface TableFooterTypeMap<P = {}, D extends React.ElementType = 'tfoot
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/TableHead/TableHead.d.ts
+++ b/packages/mui-material/src/TableHead/TableHead.d.ts
@@ -37,8 +37,8 @@ export interface TableHeadTypeMap<
 declare const TableHead: OverridableComponent<TableHeadTypeMap>;
 
 export type TableHeadProps<
-  D extends React.ElementType = TableHeadTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableHeadTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableHeadTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableHeadTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TableHead;

--- a/packages/mui-material/src/TableHead/TableHead.d.ts
+++ b/packages/mui-material/src/TableHead/TableHead.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { TableHeadClasses } from './tableHeadClasses';
 
-export interface TableHeadTypeMap<P = {}, D extends React.ElementType = 'thead'> {
-  props: P & {
+export interface TableHeadTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'thead',
+> {
+  props: AdditionalProps & {
     /**
      * The content of the component, normally `TableRow`.
      */
@@ -19,7 +22,7 @@ export interface TableHeadTypeMap<P = {}, D extends React.ElementType = 'thead'>
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material/src/TablePagination/TablePagination.d.ts
@@ -15,8 +15,11 @@ export interface LabelDisplayedRowsArgs {
   page: number;
 }
 
-export interface TablePaginationTypeMap<P, D extends React.ElementType> {
-  props: P &
+export interface TablePaginationTypeMap<
+  AdditionalProps,
+  DefaultComponent extends React.ElementType,
+> {
+  props: AdditionalProps &
     TablePaginationBaseProps & {
       /**
        * The component used for displaying the actions.
@@ -121,7 +124,7 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
        */
       sx?: SxProps<Theme>;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material/src/TablePagination/TablePagination.d.ts
@@ -146,8 +146,8 @@ declare const TablePagination: OverridableComponent<
 export type TablePaginationBaseProps = Omit<TableCellProps, 'classes' | 'component' | 'children'>;
 
 export type TablePaginationProps<
-  D extends React.ElementType = React.JSXElementConstructor<TablePaginationBaseProps>,
-  P = {},
-> = OverrideProps<TablePaginationTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = React.JSXElementConstructor<TablePaginationBaseProps>,
+  AdditionalProps = {},
+> = OverrideProps<TablePaginationTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TablePagination;

--- a/packages/mui-material/src/TableRow/TableRow.d.ts
+++ b/packages/mui-material/src/TableRow/TableRow.d.ts
@@ -4,8 +4,11 @@ import { Theme } from '..';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { TableRowClasses } from './tableRowClasses';
 
-export interface TableRowTypeMap<P = {}, D extends React.ElementType = 'tr'> {
-  props: P & {
+export interface TableRowTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'tr',
+> {
+  props: AdditionalProps & {
     /**
      * Should be valid <tr> children such as `TableCell`.
      */
@@ -29,7 +32,7 @@ export interface TableRowTypeMap<P = {}, D extends React.ElementType = 'tr'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  * Will automatically set dynamic row height

--- a/packages/mui-material/src/TableRow/TableRow.d.ts
+++ b/packages/mui-material/src/TableRow/TableRow.d.ts
@@ -49,8 +49,8 @@ export interface TableRowTypeMap<
 declare const TableRow: OverridableComponent<TableRowTypeMap>;
 
 export type TableRowProps<
-  D extends React.ElementType = TableRowTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableRowTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableRowTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableRowTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TableRow;

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.d.ts
@@ -6,10 +6,10 @@ import { OverrideProps } from '../OverridableComponent';
 import { TableSortLabelClasses } from './tableSortLabelClasses';
 
 export type TableSortLabelTypeMap<
-  P = {},
-  D extends React.ElementType = 'span',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'span',
 > = ExtendButtonBaseTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * If `true`, the label will have the active styling (should be true for the sorted column).
      * @default false
@@ -43,7 +43,7 @@ export type TableSortLabelTypeMap<
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.d.ts
@@ -61,8 +61,8 @@ export type TableSortLabelTypeMap<
 declare const TableSortLabel: ExtendButtonBase<TableSortLabelTypeMap>;
 
 export type TableSortLabelProps<
-  D extends React.ElementType = TableSortLabelTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TableSortLabelTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TableSortLabelTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TableSortLabelTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TableSortLabel;

--- a/packages/mui-material/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material/src/Tabs/Tabs.d.ts
@@ -24,8 +24,11 @@ export interface TabsOwnerState extends TabsProps {
   scrollButtonsHideMobile: boolean;
 }
 
-export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof ButtonBase> {
-  props: P & {
+export interface TabsTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = typeof ButtonBase,
+> {
+  props: AdditionalProps & {
     /**
      * Callback fired when the component mounts.
      * This is useful when you want to trigger an action programmatically.
@@ -172,7 +175,7 @@ export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof Button
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material/src/Tabs/Tabs.d.ts
@@ -196,8 +196,8 @@ export interface TabsActions {
 }
 
 export type TabsProps<
-  D extends React.ElementType = TabsTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TabsTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TabsTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TabsTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Tabs;

--- a/packages/mui-material/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.d.ts
@@ -11,10 +11,10 @@ export interface ToggleButtonPropsSizeOverrides {}
 export interface ToggleButtonPropsColorOverrides {}
 
 export type ToggleButtonTypeMap<
-  P = {},
-  D extends React.ElementType = 'button',
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'button',
 > = ExtendButtonBaseTypeMap<{
-  props: P & {
+  props: AdditionalProps & {
     /**
      * The content of the component.
      */
@@ -82,7 +82,7 @@ export type ToggleButtonTypeMap<
      */
     value: NonNullable<unknown>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**

--- a/packages/mui-material/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.d.ts
@@ -99,8 +99,8 @@ export type ToggleButtonTypeMap<
 declare const ToggleButton: ExtendButtonBase<ToggleButtonTypeMap>;
 
 export type ToggleButtonProps<
-  D extends React.ElementType = ToggleButtonTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ToggleButtonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ToggleButtonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ToggleButtonTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default ToggleButton;

--- a/packages/mui-material/src/Toolbar/Toolbar.d.ts
+++ b/packages/mui-material/src/Toolbar/Toolbar.d.ts
@@ -7,8 +7,11 @@ import { ToolbarClasses } from './toolbarClasses';
 
 export interface ToolbarPropsVariantOverrides {}
 
-export interface ToolbarTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & {
+export interface ToolbarTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & {
     /**
      * The Toolbar children, usually a mixture of `IconButton`, `Button` and `Typography`.
      * The Toolbar is a flex container, allowing flex item properties to be used to lay out the children.
@@ -33,7 +36,7 @@ export interface ToolbarTypeMap<P = {}, D extends React.ElementType = 'div'> {
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 /**
  *

--- a/packages/mui-material/src/Toolbar/Toolbar.d.ts
+++ b/packages/mui-material/src/Toolbar/Toolbar.d.ts
@@ -51,8 +51,8 @@ export interface ToolbarTypeMap<
 declare const Toolbar: OverridableComponent<ToolbarTypeMap>;
 
 export type ToolbarProps<
-  D extends React.ElementType = ToolbarTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ToolbarTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ToolbarTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ToolbarTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Toolbar;

--- a/packages/mui-material/src/Typography/Typography.d.ts
+++ b/packages/mui-material/src/Typography/Typography.d.ts
@@ -8,8 +8,11 @@ import { TypographyClasses } from './typographyClasses';
 
 export interface TypographyPropsVariantOverrides {}
 
-export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'> {
-  props: P &
+export interface TypographyTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'span',
+> {
+  props: AdditionalProps &
     SystemProps<Theme> & {
       /**
        * Set the text-align on the component.
@@ -74,7 +77,7 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
         Record<OverridableStringUnion<Variant | 'inherit', TypographyPropsVariantOverrides>, string>
       >;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**

--- a/packages/mui-material/src/Typography/Typography.d.ts
+++ b/packages/mui-material/src/Typography/Typography.d.ts
@@ -94,8 +94,8 @@ export interface TypographyTypeMap<
 declare const Typography: OverridableComponent<TypographyTypeMap>;
 
 export type TypographyProps<
-  D extends React.ElementType = TypographyTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TypographyTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TypographyTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TypographyTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Typography;

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -11,13 +11,13 @@ export { StyledComponentProps };
  * @deprecated will be removed in v5 for internal usage only
  */
 export type StandardProps<
-  C,
+  ComponentProps,
   ClassKey extends string,
-  Removals extends keyof C = never,
-> = DistributiveOmit<C, 'classes' | Removals> &
+  Removals extends keyof ComponentProps = never,
+> = DistributiveOmit<ComponentProps, 'classes' | Removals> &
   StyledComponentProps<ClassKey> & {
     className?: string;
-    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
+    ref?: ComponentProps extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
     style?: React.CSSProperties;
   };
 
@@ -29,13 +29,13 @@ export type StandardProps<
  * However, we don't declare classes on this type.
  * It is recommended to declare them manually with an interface so that each class can have a separate JSDoc.
  */
-export type InternalStandardProps<C, Removals extends keyof C = never> = DistributiveOmit<
-  C,
-  'classes' | Removals
-> &
+export type InternalStandardProps<
+  ComponentProps,
+  Removals extends keyof ComponentProps = never,
+> = DistributiveOmit<ComponentProps, 'classes' | Removals> &
   // each component declares it's classes in a separate interface for proper JSDoc
   StyledComponentProps<never> & {
-    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
+    ref?: ComponentProps extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
     // TODO: Remove implicit props. Up to each component.
     className?: string;
     style?: React.CSSProperties;

--- a/packages/mui-material/src/styles/ThemeProvider.d.ts
+++ b/packages/mui-material/src/styles/ThemeProvider.d.ts
@@ -12,6 +12,6 @@ export interface ThemeProviderProps<Theme = DefaultTheme> {
  *
  * - [ThemeProvider API](https://mui.com/material-ui/customization/theming/#themeprovider)
  */
-export default function ThemeProvider<T = DefaultTheme>(
-  props: ThemeProviderProps<T>,
-): React.ReactElement<ThemeProviderProps<T>>;
+export default function ThemeProvider<Theme = DefaultTheme>(
+  props: ThemeProviderProps<Theme>,
+): React.ReactElement<ThemeProviderProps<Theme>>;


### PR DESCRIPTION
One letter type parameters of generic functions are meaningless and makes code harder to read. For some time, our new code uses more meaningful names, but Material UI still used one letter names in some places. This PR changes this.

Similar PRs with changes will be created for other packages.

One issue I found while doing this is that our TypeMap types have their type parameters in random order. We could unify this (but since this will be a breaking change, let's do it with v6).