### PR TITLE
[docs][Button][joy] Improve `loading` prop documentation

### DIFF
--- a/docs/translations/api-docs-joy/button/button.json
+++ b/docs/translations/api-docs-joy/button/button.json
@@ -15,7 +15,9 @@
     "fullWidth": {
       "description": "If <code>true</code>, the button will take up the full width of its container."
     },
-    "loading": { "description": "If <code>true</code>, the loading indicator is shown." },
+    "loading": {
+      "description": "If <code>true</code>, the loading indicator is shown and the button becomes disabled."
+    },
     "loadingIndicator": {
       "description": "The node should contain an element with <code>role=&quot;progressbar&quot;</code> with an accessible name. By default we render a <code>CircularProgress</code> that is labelled by the button itself."
     },

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -362,7 +362,7 @@ Button.propTypes /* remove-proptypes */ = {
    */
   fullWidth: PropTypes.bool,
   /**
-   * If `true`, the loading indicator is shown.
+   * If `true`, the loading indicator is shown and the button becomes disabled.
    * @default false
    */
   loading: PropTypes.bool,

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -107,7 +107,7 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
        */
       variant?: OverridableStringUnion<VariantProp, ButtonPropsVariantOverrides>;
       /**
-       * If `true`, the loading indicator is shown.
+       * If `true`, the loading indicator is shown and the button becomes disabled.
        * @default false
        */
       loading?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Opened PR based on https://github.com/mui/material-ui/issues/38101#issuecomment-1650042136

preview: https://deploy-preview-38156--material-ui.netlify.app/joy-ui/api/button/#prop-loading

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
