### PR TITLE
[docs] Cover pnpm in more places

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -21,7 +21,7 @@ yarn add @mui/base
 ```
 
 ```bash pnpm
-pnpm install @mui/base
+pnpm add @mui/base
 ```
 
 </codeblock>

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -13,6 +13,10 @@ npm install @mui/joy @emotion/react @emotion/styled
 yarn add @mui/joy @emotion/react @emotion/styled
 ```
 
+```bash pnpm
+pnpm add @mui/joy @emotion/react @emotion/styled
+```
+
 </codeblock>
 
 ## Peer dependencies
@@ -32,7 +36,7 @@ Please note that [react](https://www.npmjs.com/package/react) and [react-dom](ht
 
 Joy UI is designed to use the [Public Sans](https://fonts.google.com/specimen/Public+Sans)
 font by default.
-You may add it to your project with npm or yarn via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
+You may add it to your project with npm via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
 
 <codeblock storageKey="package-manager">
 
@@ -41,6 +45,10 @@ npm install @fontsource/public-sans
 ```
 
 ```bash yarn
+yarn add @fontsource/public-sans
+```
+
+```bash pnpm
 yarn add @fontsource/public-sans
 ```
 

--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -29,6 +29,10 @@ npm install @mui/lab @mui/material
 yarn add @mui/lab @mui/material
 ```
 
+```bash pnpm
+pnpm add @mui/lab @mui/material
+```
+
 </codeblock>
 
 Note that the lab has a peer dependency on the Material UI components.

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -28,6 +28,10 @@ npm install @mui/icons-material @mui/material @emotion/styled @emotion/react
 yarn add @mui/icons-material @mui/material @emotion/styled @emotion/react
 ```
 
+```bash pnpm
+pnpm add @mui/icons-material @mui/material @emotion/styled @emotion/react
+```
+
 </codeblock>
 
 See the [Installation](/material-ui/getting-started/installation/) page for additional docs about how to make sure everything is set up correctly.

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -72,7 +72,7 @@ Please note that [react](https://www.npmjs.com/package/react) and [react-dom](ht
 
 Material UI is designed to use the [Roboto](https://fonts.google.com/specimen/Roboto)
 font by default.
-You may add it to your project with npm or yarn via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
+You may add it to your project with npm via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
 
 <codeblock storageKey="package-manager">
 
@@ -117,7 +117,7 @@ To install the Roboto font in your project using the Google Web Fonts CDN, add t
 ## Icons
 
 To use the [font Icon component](/material-ui/icons/#icon-font-icons) or the prebuilt SVG Material Icons (such as those found in the [icon demos](/material-ui/icons/)), you must first install the [Material Icons](https://fonts.google.com/icons?icon.set=Material+Icons) font.
-You can do so with npm or yarn, or with the Google Web Fonts CDN.
+You can do so with npm, or with the Google Web Fonts CDN.
 
 <codeblock storageKey="package-manager">
 

--- a/docs/data/material/migration/migration-v4/migration-v4.md
+++ b/docs/data/material/migration/migration-v4/migration-v4.md
@@ -78,6 +78,7 @@ The minimum supported version of React has been increased from v16.8.0 to v17.0.
 If you are using a React version below 17.0.0, update your packages to at least v4.11.2 for Material UI and v17.0.0 for React.
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
 npm install @material-ui/core@^4.11.2 react@^17.0.0
 ```
@@ -196,6 +197,7 @@ See [Migration from the lab](https://mui.com/x/migration/migration-pickers-lab/)
 Next, add the Emotion packages.
 
 <codeblock storageKey="package-manager">
+
 ```bash npm
 npm install @emotion/react @emotion/styled
 ```

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -16,6 +16,10 @@ npm install @mui/system @emotion/react @emotion/styled
 yarn add @mui/system @emotion/react @emotion/styled
 ```
 
+```bash pnpm
+pnpm add @mui/system @emotion/react @emotion/styled
+```
+
 </codeblock>
 
 ## With styled-components
@@ -31,6 +35,10 @@ npm install @mui/system @mui/styled-engine-sc styled-components
 
 ```bash yarn
 yarn add @mui/system @mui/styled-engine-sc styled-components
+```
+
+```bash pnpm
+pnpm add @mui/system @mui/styled-engine-sc styled-components
 ```
 
 </codeblock>

--- a/docs/pages/experiments/docs/codeblock.md
+++ b/docs/pages/experiments/docs/codeblock.md
@@ -16,6 +16,11 @@ yarn add @mui/material @emotion/react @emotion/styled
 # `@emotion/react` and `@emotion/styled` are peer dependencies
 ```
 
+```bash pnpm
+pnpm add @mui/material @emotion/react @emotion/styled
+# `@emotion/react` and `@emotion/styled` are peer dependencies
+```
+
 </codeblock>
 
 <codeblock storageKey="license">


### PR DESCRIPTION
#36650 but for the whole docs. I noticed this here https://mui.com/material-ui/material-icons/. We should have updated everything.

Preview: https://deploy-preview-38161--material-ui.netlify.app/material-ui/material-icons/?query=a