### PR TITLE
[docs-infra] Fix search ranking when no productId

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -300,7 +300,7 @@ export default function AppSearch(props) {
 
   const search = `${t('algoliaSearch')}…`;
 
-  const optionalFilters = []
+  const optionalFilters = [];
   if (pageContext.productId !== 'null') {
     optionalFilters.push(`productId:${pageContext.productId}`);
   }

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -300,6 +300,11 @@ export default function AppSearch(props) {
 
   const search = `${t('algoliaSearch')}…`;
 
+  const optionalFilters = []
+  if (pageContext.productId !== 'null') {
+    optionalFilters.push(`productId:${pageContext.productId}`);
+  }
+
   return (
     <React.Fragment>
       <SearchButton
@@ -332,7 +337,7 @@ export default function AppSearch(props) {
             indexName="material-ui"
             searchParameters={{
               facetFilters: ['version:master', facetFilterLanguage],
-              optionalFilters: [`productId:${pageContext.productId}`],
+              optionalFilters,
               attributesToRetrieve: [
                 // Copied from https://github.com/algolia/docsearch/blob/ce0c865cd8767e961ce3088b3155fc982d4c2e2e/packages/docsearch-react/src/DocSearchModal.tsx#L231
                 'hierarchy.lvl0',


### PR DESCRIPTION
I broke this when I refactored the productId logic. The problem is that we were setting `productId:null` as an optional filter in the homepage. Now, Algolia is configured with

```js
      ranking: [
        "words",
        "filters",
        "typo",
        "attribute",
        "proximity",
        "exact",
        "custom",
      ],
```

https://www.algolia.com/doc/guides/managing-results/relevance-overview/in-depth/ranking-criteria/#filters

so it would rank first all the pages without a productId, which is right now the MUI X migration page as we have to refactor a bit these pages to get the productId from the markdown.