### PR TITLE
[typescript][base] Rename one letter type parameters

### DIFF
--- a/docs/pages/base-ui/api/use-autocomplete.json
+++ b/docs/pages/base-ui/api/use-autocomplete.json
@@ -1,7 +1,7 @@
 {
   "parameters": {
     "options": {
-      "type": { "name": "ReadonlyArray&lt;T&gt;", "description": "ReadonlyArray&lt;T&gt;" },
+      "type": { "name": "ReadonlyArray&lt;Value&gt;", "description": "ReadonlyArray&lt;Value&gt;" },
       "required": true
     },
     "autoComplete": { "type": { "name": "boolean", "description": "boolean" }, "default": "false" },
@@ -28,8 +28,8 @@
     "componentName": { "type": { "name": "string", "description": "string" } },
     "defaultValue": {
       "type": {
-        "name": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;",
-        "description": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;"
+        "name": "AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;",
+        "description": "AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;"
       },
       "default": "props.multiple ? [] : null"
     },
@@ -52,8 +52,8 @@
     },
     "filterOptions": {
       "type": {
-        "name": "(options: T[], state: FilterOptionsState&lt;T&gt;) =&gt; T[]",
-        "description": "(options: T[], state: FilterOptionsState&lt;T&gt;) =&gt; T[]"
+        "name": "(options: Value[], state: FilterOptionsState&lt;Value&gt;) =&gt; Value[]",
+        "description": "(options: Value[], state: FilterOptionsState&lt;Value&gt;) =&gt; Value[]"
       },
       "default": "createFilterOptions()"
     },
@@ -63,17 +63,23 @@
     },
     "freeSolo": { "type": { "name": "FreeSolo", "description": "FreeSolo" }, "default": "false" },
     "getOptionDisabled": {
-      "type": { "name": "(option: T) =&gt; boolean", "description": "(option: T) =&gt; boolean" }
+      "type": {
+        "name": "(option: Value) =&gt; boolean",
+        "description": "(option: Value) =&gt; boolean"
+      }
     },
     "getOptionLabel": {
       "type": {
-        "name": "(option: T | AutocompleteFreeSoloValueMapping&lt;FreeSolo&gt;) =&gt; string",
-        "description": "(option: T | AutocompleteFreeSoloValueMapping&lt;FreeSolo&gt;) =&gt; string"
+        "name": "(option: Value | AutocompleteFreeSoloValueMapping&lt;FreeSolo&gt;) =&gt; string",
+        "description": "(option: Value | AutocompleteFreeSoloValueMapping&lt;FreeSolo&gt;) =&gt; string"
       },
       "default": "(option) => option.label ?? option"
     },
     "groupBy": {
-      "type": { "name": "(option: T) =&gt; string", "description": "(option: T) =&gt; string" }
+      "type": {
+        "name": "(option: Value) =&gt; string",
+        "description": "(option: Value) =&gt; string"
+      }
     },
     "handleHomeEndKeys": {
       "type": { "name": "boolean", "description": "boolean" },
@@ -87,15 +93,15 @@
     "inputValue": { "type": { "name": "string", "description": "string" } },
     "isOptionEqualToValue": {
       "type": {
-        "name": "(option: T, value: T) =&gt; boolean",
-        "description": "(option: T, value: T) =&gt; boolean"
+        "name": "(option: Value, value: Value) =&gt; boolean",
+        "description": "(option: Value, value: Value) =&gt; boolean"
       }
     },
     "multiple": { "type": { "name": "Multiple", "description": "Multiple" }, "default": "false" },
     "onChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, value: AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails&lt;T&gt;) =&gt; void",
-        "description": "(event: React.SyntheticEvent, value: AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails&lt;T&gt;) =&gt; void"
+        "name": "(event: React.SyntheticEvent, value: AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails&lt;Value&gt;) =&gt; void",
+        "description": "(event: React.SyntheticEvent, value: AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;, reason: AutocompleteChangeReason, details?: AutocompleteChangeDetails&lt;Value&gt;) =&gt; void"
       }
     },
     "onClose": {
@@ -106,8 +112,8 @@
     },
     "onHighlightChange": {
       "type": {
-        "name": "(event: React.SyntheticEvent, option: T | null, reason: AutocompleteHighlightChangeReason) =&gt; void",
-        "description": "(event: React.SyntheticEvent, option: T | null, reason: AutocompleteHighlightChangeReason) =&gt; void"
+        "name": "(event: React.SyntheticEvent, option: Value | null, reason: AutocompleteHighlightChangeReason) =&gt; void",
+        "description": "(event: React.SyntheticEvent, option: Value | null, reason: AutocompleteHighlightChangeReason) =&gt; void"
       }
     },
     "onInputChange": {
@@ -141,8 +147,8 @@
     },
     "value": {
       "type": {
-        "name": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;",
-        "description": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;"
+        "name": "AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;",
+        "description": "AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;"
       }
     }
   },
@@ -185,8 +191,8 @@
     },
     "getOptionProps": {
       "type": {
-        "name": "(renderedOption: UseAutocompleteRenderedOption&lt;T&gt;) =&gt; React.HTMLAttributes&lt;HTMLLIElement&gt;",
-        "description": "(renderedOption: UseAutocompleteRenderedOption&lt;T&gt;) =&gt; React.HTMLAttributes&lt;HTMLLIElement&gt;"
+        "name": "(renderedOption: UseAutocompleteRenderedOption&lt;Value&gt;) =&gt; React.HTMLAttributes&lt;HTMLLIElement&gt;",
+        "description": "(renderedOption: UseAutocompleteRenderedOption&lt;Value&gt;) =&gt; React.HTMLAttributes&lt;HTMLLIElement&gt;"
       },
       "required": true
     },
@@ -210,8 +216,8 @@
     },
     "groupedOptions": {
       "type": {
-        "name": "T[] | Array&lt;AutocompleteGroupedOption&lt;T&gt;&gt;",
-        "description": "T[] | Array&lt;AutocompleteGroupedOption&lt;T&gt;&gt;"
+        "name": "Value[] | Array&lt;AutocompleteGroupedOption&lt;Value&gt;&gt;",
+        "description": "Value[] | Array&lt;AutocompleteGroupedOption&lt;Value&gt;&gt;"
       },
       "required": true
     },
@@ -224,8 +230,8 @@
     },
     "value": {
       "type": {
-        "name": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;",
-        "description": "AutocompleteValue&lt;T, Multiple, DisableClearable, FreeSolo&gt;"
+        "name": "AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;",
+        "description": "AutocompleteValue&lt;Value, Multiple, DisableClearable, FreeSolo&gt;"
       },
       "required": true
     }

--- a/docs/pages/joy-ui/api/autocomplete.json
+++ b/docs/pages/joy-ui/api/autocomplete.json
@@ -28,7 +28,7 @@
       "type": { "name": "func" },
       "default": "createFilterOptions()",
       "signature": {
-        "type": "function(options: Array<T>, state: object) => Array<T>",
+        "type": "function(options: Array<Value>, state: object) => Array<Value>",
         "describedArgs": ["options", "state"]
       }
     },
@@ -47,23 +47,23 @@
     },
     "getOptionDisabled": {
       "type": { "name": "func" },
-      "signature": { "type": "function(option: T) => boolean", "describedArgs": ["option"] }
+      "signature": { "type": "function(option: Value) => boolean", "describedArgs": ["option"] }
     },
     "getOptionLabel": {
       "type": { "name": "func" },
       "default": "(option) => option.label ?? option",
-      "signature": { "type": "function(option: T) => string", "describedArgs": [] }
+      "signature": { "type": "function(option: Value) => string", "describedArgs": [] }
     },
     "groupBy": {
       "type": { "name": "func" },
-      "signature": { "type": "function(options: T) => string", "describedArgs": ["options"] }
+      "signature": { "type": "function(options: Value) => string", "describedArgs": ["options"] }
     },
     "id": { "type": { "name": "string" } },
     "inputValue": { "type": { "name": "string" } },
     "isOptionEqualToValue": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(option: T, value: T) => boolean",
+        "type": "function(option: Value, value: Value) => boolean",
         "describedArgs": ["option", "value"]
       }
     },
@@ -76,7 +76,7 @@
     "onChange": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.SyntheticEvent, value: T | Array<T>, reason: string, details?: string) => void",
+        "type": "function(event: React.SyntheticEvent, value: Value | Array<Value>, reason: string, details?: string) => void",
         "describedArgs": ["event", "value", "reason"]
       }
     },
@@ -90,7 +90,7 @@
     "onHighlightChange": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.SyntheticEvent, option: T, reason: string) => void",
+        "type": "function(event: React.SyntheticEvent, option: Value, reason: string) => void",
         "describedArgs": ["event", "option", "reason"]
       }
     },

--- a/docs/pages/material-ui/api/autocomplete.json
+++ b/docs/pages/material-ui/api/autocomplete.json
@@ -44,7 +44,7 @@
       "type": { "name": "func" },
       "default": "createFilterOptions()",
       "signature": {
-        "type": "function(options: Array<T>, state: object) => Array<T>",
+        "type": "function(options: Array<Value>, state: object) => Array<Value>",
         "describedArgs": ["options", "state"]
       }
     },
@@ -62,16 +62,16 @@
     },
     "getOptionDisabled": {
       "type": { "name": "func" },
-      "signature": { "type": "function(option: T) => boolean", "describedArgs": ["option"] }
+      "signature": { "type": "function(option: Value) => boolean", "describedArgs": ["option"] }
     },
     "getOptionLabel": {
       "type": { "name": "func" },
       "default": "(option) => option.label ?? option",
-      "signature": { "type": "function(option: T) => string", "describedArgs": [] }
+      "signature": { "type": "function(option: Value) => string", "describedArgs": [] }
     },
     "groupBy": {
       "type": { "name": "func" },
-      "signature": { "type": "function(options: T) => string", "describedArgs": ["options"] }
+      "signature": { "type": "function(options: Value) => string", "describedArgs": ["options"] }
     },
     "handleHomeEndKeys": { "type": { "name": "bool" }, "default": "!props.freeSolo" },
     "id": { "type": { "name": "string" } },
@@ -80,7 +80,7 @@
     "isOptionEqualToValue": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(option: T, value: T) => boolean",
+        "type": "function(option: Value, value: Value) => boolean",
         "describedArgs": ["option", "value"]
       }
     },
@@ -94,7 +94,7 @@
     "onChange": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.SyntheticEvent, value: T | Array<T>, reason: string, details?: string) => void",
+        "type": "function(event: React.SyntheticEvent, value: Value | Array<Value>, reason: string, details?: string) => void",
         "describedArgs": ["event", "value", "reason"]
       }
     },
@@ -108,7 +108,7 @@
     "onHighlightChange": {
       "type": { "name": "func" },
       "signature": {
-        "type": "function(event: React.SyntheticEvent, option: T, reason: string) => void",
+        "type": "function(event: React.SyntheticEvent, option: Value, reason: string) => void",
         "describedArgs": ["event", "option", "reason"]
       }
     },

--- a/docs/translations/api-docs/use-autocomplete/use-autocomplete.json
+++ b/docs/translations/api-docs/use-autocomplete/use-autocomplete.json
@@ -111,7 +111,7 @@
     "getRootProps": { "description": "Resolver for the root slot&#39;s props." },
     "getTagProps": { "description": "A tag props getter." },
     "groupedOptions": {
-      "description": "The options to render. It&#39;s either <code>T[]</code> or <code>AutocompleteGroupedOption&lt;T&gt;[]</code> if the groupBy prop is provided."
+      "description": "The options to render. It&#39;s either <code>Value[]</code> or <code>AutocompleteGroupedOption&lt;Value&gt;[]</code> if the groupBy prop is provided."
     },
     "id": { "description": "Id for the Autocomplete." },
     "inputValue": { "description": "The input value." },

--- a/packages/mui-base/src/Badge/Badge.types.ts
+++ b/packages/mui-base/src/Badge/Badge.types.ts
@@ -78,12 +78,14 @@ export interface BadgeTypeMap<
 /**
  * Utility to create component types that inherit props from Badge.
  */
-export interface ExtendBadgeTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & BadgeTypeMap['props'];
-  defaultComponent: M['defaultComponent'];
+export interface ExtendBadgeTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & BadgeTypeMap['props'];
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendBadge<M extends OverridableTypeMap> = OverridableComponent<ExtendBadgeTypeMap<M>>;
+export type ExtendBadge<TypeMap extends OverridableTypeMap> = OverridableComponent<
+  ExtendBadgeTypeMap<TypeMap>
+>;
 
 export type BadgeProps<
   RootComponentType extends React.ElementType = BadgeTypeMap['defaultComponent'],

--- a/packages/mui-base/src/Modal/Modal.types.ts
+++ b/packages/mui-base/src/Modal/Modal.types.ts
@@ -141,12 +141,14 @@ export interface ModalTypeMap<
 /**
  * Utility to create component types that inherit props from Modal.
  */
-export interface ExtendModalTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & ModalTypeMap['props'];
-  defaultComponent: M['defaultComponent'];
+export interface ExtendModalTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & ModalTypeMap['props'];
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendModal<M extends OverridableTypeMap> = OverridableComponent<ExtendModalTypeMap<M>>;
+export type ExtendModal<TypeMap extends OverridableTypeMap> = OverridableComponent<
+  ExtendModalTypeMap<TypeMap>
+>;
 
 export type ModalProps<
   RootComponentType extends React.ElementType = ModalTypeMap['defaultComponent'],

--- a/packages/mui-base/src/Slider/Slider.types.ts
+++ b/packages/mui-base/src/Slider/Slider.types.ts
@@ -172,13 +172,13 @@ export interface SliderTypeMap<
 /**
  * Utility to create component types that inherit props from Slider.
  */
-export interface ExtendSliderTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & Omit<SliderTypeMap['props'], 'isRtl'>;
-  defaultComponent: M['defaultComponent'];
+export interface ExtendSliderTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & Omit<SliderTypeMap['props'], 'isRtl'>;
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendSlider<M extends OverridableTypeMap> = OverridableComponent<
-  ExtendSliderTypeMap<M>
+export type ExtendSlider<TypeMap extends OverridableTypeMap> = OverridableComponent<
+  ExtendSliderTypeMap<TypeMap>
 >;
 
 export type SliderProps<

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
@@ -1,40 +1,40 @@
 import * as React from 'react';
 
-export interface CreateFilterOptionsConfig<T> {
+export interface CreateFilterOptionsConfig<Value> {
   ignoreAccents?: boolean;
   ignoreCase?: boolean;
   limit?: number;
   matchFrom?: 'any' | 'start';
-  stringify?: (option: T) => string;
+  stringify?: (option: Value) => string;
   trim?: boolean;
 }
 
-export interface FilterOptionsState<T> {
+export interface FilterOptionsState<Value> {
   inputValue: string;
-  getOptionLabel: (option: T) => string;
+  getOptionLabel: (option: Value) => string;
 }
 
-export interface AutocompleteGroupedOption<T = string> {
+export interface AutocompleteGroupedOption<Value = string> {
   key: number;
   index: number;
   group: string;
-  options: T[];
+  options: Value[];
 }
 
-export function createFilterOptions<T>(
-  config?: CreateFilterOptionsConfig<T>,
-): (options: T[], state: FilterOptionsState<T>) => T[];
+export function createFilterOptions<Value>(
+  config?: CreateFilterOptionsConfig<Value>,
+): (options: Value[], state: FilterOptionsState<Value>) => Value[];
 
 export type AutocompleteFreeSoloValueMapping<FreeSolo> = FreeSolo extends true ? string : never;
 
-export type AutocompleteValue<T, Multiple, DisableClearable, FreeSolo> = Multiple extends true
-  ? Array<T | AutocompleteFreeSoloValueMapping<FreeSolo>>
+export type AutocompleteValue<Value, Multiple, DisableClearable, FreeSolo> = Multiple extends true
+  ? Array<Value | AutocompleteFreeSoloValueMapping<FreeSolo>>
   : DisableClearable extends true
-  ? NonNullable<T | AutocompleteFreeSoloValueMapping<FreeSolo>>
-  : T | null | AutocompleteFreeSoloValueMapping<FreeSolo>;
+  ? NonNullable<Value | AutocompleteFreeSoloValueMapping<FreeSolo>>
+  : Value | null | AutocompleteFreeSoloValueMapping<FreeSolo>;
 
 export interface UseAutocompleteProps<
-  T,
+  Value,
   Multiple extends boolean | undefined,
   DisableClearable extends boolean | undefined,
   FreeSolo extends boolean | undefined,
@@ -103,7 +103,7 @@ export interface UseAutocompleteProps<
    * The default value. Use when the component is not controlled.
    * @default props.multiple ? [] : null
    */
-  defaultValue?: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
+  defaultValue?: AutocompleteValue<Value, Multiple, DisableClearable, FreeSolo>;
   /**
    * If `true`, the input can't be cleared.
    * @default false
@@ -133,11 +133,11 @@ export interface UseAutocompleteProps<
    * A function that determines the filtered options to be rendered on search.
    *
    * @default createFilterOptions()
-   * @param {T[]} options The options to render.
+   * @param {Value[]} options The options to render.
    * @param {object} state The state of the component.
-   * @returns {T[]}
+   * @returns {Value[]}
    */
-  filterOptions?: (options: T[], state: FilterOptionsState<T>) => T[];
+  filterOptions?: (options: Value[], state: FilterOptionsState<Value>) => Value[];
   /**
    * If `true`, hide the selected options from the list box.
    * @default false
@@ -151,29 +151,29 @@ export interface UseAutocompleteProps<
   /**
    * Used to determine the disabled state for a given option.
    *
-   * @param {T} option The option to test.
+   * @param {Value} option The option to test.
    * @returns {boolean}
    */
-  getOptionDisabled?: (option: T) => boolean;
+  getOptionDisabled?: (option: Value) => boolean;
   /**
    * Used to determine the string value for a given option.
    * It's used to fill the input (and the list box options if `renderOption` is not provided).
    *
    * If used in free solo mode, it must accept both the type of the options and a string.
    *
-   * @param {T} option
+   * @param {Value} option
    * @returns {string}
    * @default (option) => option.label ?? option
    */
-  getOptionLabel?: (option: T | AutocompleteFreeSoloValueMapping<FreeSolo>) => string;
+  getOptionLabel?: (option: Value | AutocompleteFreeSoloValueMapping<FreeSolo>) => string;
   /**
    * If provided, the options will be grouped under the returned string.
    * The groupBy value is also used as the text for group headings when `renderGroup` is not provided.
    *
-   * @param {T} options The options to group.
+   * @param {Value} options The options to group.
    * @returns {string}
    */
-  groupBy?: (option: T) => string;
+  groupBy?: (option: Value) => string;
 
   /**
    * If `true`, the component handles the "Home" and "End" keys when the popup is open.
@@ -200,11 +200,11 @@ export interface UseAutocompleteProps<
    * Uses strict equality by default.
    * ⚠️ Both arguments need to be handled, an option can only match with one value.
    *
-   * @param {T} option The option to test.
-   * @param {T} value The value to test against.
+   * @param {Value} option The option to test.
+   * @param {Value} value The value to test against.
    * @returns {boolean}
    */
-  isOptionEqualToValue?: (option: T, value: T) => boolean;
+  isOptionEqualToValue?: (option: Value, value: Value) => boolean;
   /**
    * If `true`, `value` must be an array and the menu will support multiple selections.
    * @default false
@@ -214,15 +214,15 @@ export interface UseAutocompleteProps<
    * Callback fired when the value changes.
    *
    * @param {React.SyntheticEvent} event The event source of the callback.
-   * @param {T|T[]} value The new value of the component.
+   * @param {Value|Value[]} value The new value of the component.
    * @param {string} reason One of "createOption", "selectOption", "removeOption", "blur" or "clear".
    * @param {string} [details]
    */
   onChange?: (
     event: React.SyntheticEvent,
-    value: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>,
+    value: AutocompleteValue<Value, Multiple, DisableClearable, FreeSolo>,
     reason: AutocompleteChangeReason,
-    details?: AutocompleteChangeDetails<T>,
+    details?: AutocompleteChangeDetails<Value>,
   ) => void;
   /**
    * Callback fired when the popup requests to be closed.
@@ -236,12 +236,12 @@ export interface UseAutocompleteProps<
    * Callback fired when the highlight option changes.
    *
    * @param {React.SyntheticEvent} event The event source of the callback.
-   * @param {T} option The highlighted option.
+   * @param {Value} option The highlighted option.
    * @param {string} reason Can be: `"keyboard"`, `"auto"`, `"mouse"`, `"touch"`.
    */
   onHighlightChange?: (
     event: React.SyntheticEvent,
-    option: T | null,
+    option: Value | null,
     reason: AutocompleteHighlightChangeReason,
   ) => void;
   /**
@@ -275,7 +275,7 @@ export interface UseAutocompleteProps<
   /**
    * Array of options.
    */
-  options: ReadonlyArray<T>;
+  options: ReadonlyArray<Value>;
   /**
    * If `true`, the component becomes readonly. It is also supported for multiple tags where the tag cannot be deleted.
    * @default false
@@ -293,15 +293,15 @@ export interface UseAutocompleteProps<
    * The value must have reference equality with the option in order to be selected.
    * You can customize the equality behavior with the `isOptionEqualToValue` prop.
    */
-  value?: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
+  value?: AutocompleteValue<Value, Multiple, DisableClearable, FreeSolo>;
 }
 
 export interface UseAutocompleteParameters<
-  T,
+  Value,
   Multiple extends boolean | undefined,
   DisableClearable extends boolean | undefined,
   FreeSolo extends boolean | undefined,
-> extends UseAutocompleteProps<T, Multiple, DisableClearable, FreeSolo> {}
+> extends UseAutocompleteProps<Value, Multiple, DisableClearable, FreeSolo> {}
 
 export type AutocompleteHighlightChangeReason = 'keyboard' | 'mouse' | 'auto' | 'touch';
 
@@ -311,8 +311,8 @@ export type AutocompleteChangeReason =
   | 'removeOption'
   | 'clear'
   | 'blur';
-export interface AutocompleteChangeDetails<T = string> {
-  option: T;
+export interface AutocompleteChangeDetails<Value = string> {
+  option: Value;
 }
 export type AutocompleteCloseReason =
   | 'createOption'
@@ -340,21 +340,21 @@ export type AutocompleteGetTagProps = ({ index }: { index: number }) => {
  * - [useAutocomplete API](https://mui.com/base-ui/react-autocomplete/hooks-api/#use-autocomplete)
  */
 export default function useAutocomplete<
-  T,
+  Value,
   Multiple extends boolean | undefined = false,
   DisableClearable extends boolean | undefined = false,
   FreeSolo extends boolean | undefined = false,
 >(
-  props: UseAutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
-): UseAutocompleteReturnValue<T, Multiple, DisableClearable, FreeSolo>;
+  props: UseAutocompleteProps<Value, Multiple, DisableClearable, FreeSolo>,
+): UseAutocompleteReturnValue<Value, Multiple, DisableClearable, FreeSolo>;
 
-export interface UseAutocompleteRenderedOption<T> {
-  option: T;
+export interface UseAutocompleteRenderedOption<Value> {
+  option: Value;
   index: number;
 }
 
 export interface UseAutocompleteReturnValue<
-  T,
+  Value,
   Multiple extends boolean | undefined = false,
   DisableClearable extends boolean | undefined = false,
   FreeSolo extends boolean | undefined = false,
@@ -400,7 +400,7 @@ export interface UseAutocompleteReturnValue<
    * @returns props that should be spread on the li element
    */
   getOptionProps: (
-    renderedOption: UseAutocompleteRenderedOption<T>,
+    renderedOption: UseAutocompleteRenderedOption<Value>,
   ) => React.HTMLAttributes<HTMLLIElement>;
   /**
    * Id for the Autocomplete.
@@ -413,7 +413,7 @@ export interface UseAutocompleteReturnValue<
   /**
    * The value of the autocomplete.
    */
-  value: AutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
+  value: AutocompleteValue<Value, Multiple, DisableClearable, FreeSolo>;
   /**
    * If `true`, the component input has some values.
    */
@@ -444,7 +444,7 @@ export interface UseAutocompleteReturnValue<
    */
   focusedTag: number;
   /**
-   * The options to render. It's either `T[]` or `AutocompleteGroupedOption<T>[]` if the groupBy prop is provided.
+   * The options to render. It's either `Value[]` or `AutocompleteGroupedOption<Value>[]` if the groupBy prop is provided.
    */
-  groupedOptions: T[] | Array<AutocompleteGroupedOption<T>>;
+  groupedOptions: Value[] | Array<AutocompleteGroupedOption<Value>>;
 }

--- a/packages/mui-base/src/utils/areArraysEqual.ts
+++ b/packages/mui-base/src/utils/areArraysEqual.ts
@@ -1,9 +1,9 @@
-type ItemComparer<T> = (a: T, b: T) => boolean;
+type ItemComparer<Item> = (a: Item, b: Item) => boolean;
 
-export default function areArraysEqual<T>(
-  array1: T[],
-  array2: T[],
-  itemComparer: ItemComparer<T> = (a, b) => a === b,
+export default function areArraysEqual<Item>(
+  array1: Item[],
+  array2: Item[],
+  itemComparer: ItemComparer<Item> = (a, b) => a === b,
 ) {
   return (
     array1.length === array2.length &&

--- a/packages/mui-base/src/utils/mergeSlotProps.ts
+++ b/packages/mui-base/src/utils/mergeSlotProps.ts
@@ -5,7 +5,7 @@ import { EventHandlers } from './types';
 import extractEventHandlers from './extractEventHandlers';
 import omitEventHandlers from './omitEventHandlers';
 
-export type WithCommonProps<T> = T & {
+export type WithCommonProps<OtherProps> = OtherProps & {
   className?: string;
   style?: React.CSSProperties;
   ref?: React.Ref<any>;

--- a/packages/mui-base/src/utils/omitEventHandlers.ts
+++ b/packages/mui-base/src/utils/omitEventHandlers.ts
@@ -5,14 +5,14 @@
  * @param object Object to remove event handlers from.
  * @returns Object with event handlers removed.
  */
-export default function omitEventHandlers<T extends Record<string, unknown>>(
-  object: T | undefined,
+export default function omitEventHandlers<Props extends Record<string, unknown>>(
+  object: Props | undefined,
 ) {
   if (object === undefined) {
     return {};
   }
 
-  const result = {} as Partial<T>;
+  const result = {} as Partial<Props>;
 
   Object.keys(object)
     .filter((prop) => !(prop.match(/^on[A-Z]/) && typeof object[prop] === 'function'))

--- a/packages/mui-base/src/utils/types.ts
+++ b/packages/mui-base/src/utils/types.ts
@@ -2,8 +2,11 @@ import * as React from 'react';
 
 export type EventHandlers = Record<string, React.EventHandler<any>>;
 
-export type WithOptionalOwnerState<T extends { ownerState: unknown }> = Omit<T, 'ownerState'> &
-  Partial<Pick<T, 'ownerState'>>;
+export type WithOptionalOwnerState<Props extends { ownerState: unknown }> = Omit<
+  Props,
+  'ownerState'
+> &
+  Partial<Pick<Props, 'ownerState'>>;
 
 export type SlotComponentProps<TSlotComponent extends React.ElementType, TOverrides, TOwnerState> =
   | (Partial<React.ComponentPropsWithRef<TSlotComponent>> & TOverrides)

--- a/packages/mui-base/src/utils/useLatest.ts
+++ b/packages/mui-base/src/utils/useLatest.ts
@@ -14,8 +14,8 @@ import * as React from 'react';
  *
  * - [useLatest API](https://mui.com/base-ui/api/use-latest/)
  */
-export default function useLatest<T>(value: T, deps?: React.DependencyList) {
-  const ref = React.useRef<T>(value);
+export default function useLatest<Value>(value: Value, deps?: React.DependencyList) {
+  const ref = React.useRef<Value>(value);
 
   React.useEffect(() => {
     ref.current = value;

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -849,9 +849,9 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * A function that determines the filtered options to be rendered on search.
    *
    * @default createFilterOptions()
-   * @param {T[]} options The options to render.
+   * @param {Value[]} options The options to render.
    * @param {object} state The state of the component.
-   * @returns {T[]}
+   * @returns {Value[]}
    */
   filterOptions: PropTypes.func,
   /**
@@ -875,7 +875,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * Used to determine the disabled state for a given option.
    *
-   * @param {T} option The option to test.
+   * @param {Value} option The option to test.
    * @returns {boolean}
    */
   getOptionDisabled: PropTypes.func,
@@ -885,7 +885,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    *
    * If used in free solo mode, it must accept both the type of the options and a string.
    *
-   * @param {T} option
+   * @param {Value} option
    * @returns {string}
    * @default (option) => option.label ?? option
    */
@@ -894,7 +894,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * If provided, the options will be grouped under the returned string.
    * The groupBy value is also used as the text for group headings when `renderGroup` is not provided.
    *
-   * @param {T} options The options to group.
+   * @param {Value} options The options to group.
    * @returns {string}
    */
   groupBy: PropTypes.func,
@@ -912,8 +912,8 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Uses strict equality by default.
    * ⚠️ Both arguments need to be handled, an option can only match with one value.
    *
-   * @param {T} option The option to test.
-   * @param {T} value The value to test against.
+   * @param {Value} option The option to test.
+   * @param {Value} value The value to test against.
    * @returns {boolean}
    */
   isOptionEqualToValue: PropTypes.func,
@@ -956,7 +956,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Callback fired when the value changes.
    *
    * @param {React.SyntheticEvent} event The event source of the callback.
-   * @param {T|T[]} value The new value of the component.
+   * @param {Value|Value[]} value The new value of the component.
    * @param {string} reason One of "createOption", "selectOption", "removeOption", "blur" or "clear".
    * @param {string} [details]
    */
@@ -973,7 +973,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Callback fired when the highlight option changes.
    *
    * @param {React.SyntheticEvent} event The event source of the callback.
-   * @param {T} option The highlighted option.
+   * @param {Value} option The highlighted option.
    * @param {string} reason Can be: `"keyboard"`, `"auto"`, `"mouse"`, `"touch"`.
    */
   onHighlightChange: PropTypes.func,

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -842,9 +842,9 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * A function that determines the filtered options to be rendered on search.
    *
    * @default createFilterOptions()
-   * @param {T[]} options The options to render.
+   * @param {Value[]} options The options to render.
    * @param {object} state The state of the component.
-   * @returns {T[]}
+   * @returns {Value[]}
    */
   filterOptions: PropTypes.func,
   /**
@@ -878,7 +878,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   /**
    * Used to determine the disabled state for a given option.
    *
-   * @param {T} option The option to test.
+   * @param {Value} option The option to test.
    * @returns {boolean}
    */
   getOptionDisabled: PropTypes.func,
@@ -888,7 +888,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    *
    * If used in free solo mode, it must accept both the type of the options and a string.
    *
-   * @param {T} option
+   * @param {Value} option
    * @returns {string}
    * @default (option) => option.label ?? option
    */
@@ -897,7 +897,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * If provided, the options will be grouped under the returned string.
    * The groupBy value is also used as the text for group headings when `renderGroup` is not provided.
    *
-   * @param {T} options The options to group.
+   * @param {Value} options The options to group.
    * @returns {string}
    */
   groupBy: PropTypes.func,
@@ -926,8 +926,8 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Uses strict equality by default.
    * ⚠️ Both arguments need to be handled, an option can only match with one value.
    *
-   * @param {T} option The option to test.
-   * @param {T} value The value to test against.
+   * @param {Value} option The option to test.
+   * @param {Value} value The value to test against.
    * @returns {boolean}
    */
   isOptionEqualToValue: PropTypes.func,
@@ -975,7 +975,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Callback fired when the value changes.
    *
    * @param {React.SyntheticEvent} event The event source of the callback.
-   * @param {T|T[]} value The new value of the component.
+   * @param {Value|Value[]} value The new value of the component.
    * @param {string} reason One of "createOption", "selectOption", "removeOption", "blur" or "clear".
    * @param {string} [details]
    */
@@ -992,7 +992,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    * Callback fired when the highlight option changes.
    *
    * @param {React.SyntheticEvent} event The event source of the callback.
-   * @param {T} option The highlighted option.
+   * @param {Value} option The highlighted option.
    * @param {string} reason Can be: `"keyboard"`, `"auto"`, `"mouse"`, `"touch"`.
    */
   onHighlightChange: PropTypes.func,


### PR DESCRIPTION
Similarly to #38155, in this PR I renamed one-letter type parameters in Base's type maps and props to something more meaningful.
