### PR TITLE
[typescript][material-next] Rename one letter type parameters

### DIFF
--- a/packages/mui-material-next/src/Button/Button.types.ts
+++ b/packages/mui-material-next/src/Button/Button.types.ts
@@ -19,8 +19,11 @@ export interface ButtonActions {
   focusVisible(): void;
 }
 
-export type ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> = {
-  props: P & {
+export type ButtonTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'button',
+> = {
+  props: AdditionalProps & {
     /**
      * A ref for imperative actions.
      * It currently only supports `focusVisible()` action.
@@ -131,7 +134,7 @@ export type ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> = {
       ButtonPropsVariantOverrides
     >;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 };
 
 export interface ButtonOwnerState extends ButtonProps {
@@ -150,17 +153,17 @@ export interface ButtonOwnerState extends ButtonProps {
  * This component has an additional overload if the `href` prop is set which
  * can make extension quite tricky
  */
-export interface ExtendButtonTypeMap<M extends OverridableTypeMap> {
-  props: M['props'] & ButtonTypeMap['props'];
-  defaultComponent: M['defaultComponent'];
+export interface ExtendButtonTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & ButtonTypeMap['props'];
+  defaultComponent: TypeMap['defaultComponent'];
 }
 
-export type ExtendButton<M extends OverridableTypeMap> = ((
-  props: { href: string } & OverrideProps<ExtendButtonTypeMap<M>, 'a'>,
+export type ExtendButton<TypeMap extends OverridableTypeMap> = ((
+  props: { href: string } & OverrideProps<ExtendButtonTypeMap<TypeMap>, 'a'>,
 ) => JSX.Element) &
-  OverridableComponent<ExtendButtonTypeMap<M>> & { propTypes?: any };
+  OverridableComponent<ExtendButtonTypeMap<TypeMap>> & { propTypes?: any };
 
 export type ButtonProps<
-  D extends React.ElementType = ButtonTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<ButtonTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = ButtonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<ButtonTypeMap<AdditionalProps, RootComponent>, RootComponent>;

--- a/packages/mui-material-next/src/Input/Input.d.ts
+++ b/packages/mui-material-next/src/Input/Input.d.ts
@@ -201,21 +201,24 @@ export interface InputOwnProps {
   value?: unknown;
 }
 
-export interface InputTypeMap<P = {}, D extends React.ElementType = 'div'> {
-  props: P & InputOwnProps;
-  defaultComponent: D;
+export interface InputTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & InputOwnProps;
+  defaultComponent: DefaultComponent;
 }
 
 export type InputProps<
-  D extends React.ElementType = InputTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<InputTypeMap<P, D>, D> & {
+  RootComponent extends React.ElementType = InputTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<InputTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
   /**
    * The component used for the Root slot.
    * Either a string to use a HTML element or a component.
    * This is equivalent to `components.Root`. If both are provided, the `component` is used.
    */
-  component?: D;
+  component?: RootComponent;
 };
 
 /**

--- a/packages/mui-material-next/src/Slider/Slider.types.ts
+++ b/packages/mui-material-next/src/Slider/Slider.types.ts
@@ -18,8 +18,11 @@ export interface SliderOwnerState extends SliderProps {
   focusedThumbIndex: number;
 }
 
-export interface SliderTypeMap<D extends React.ElementType = 'span', P = {}> {
-  props: P & {
+export interface SliderTypeMap<
+  DefaultComponent extends React.ElementType = 'span',
+  AdditionalProps = {},
+> {
+  props: AdditionalProps & {
     /**
      * The label of the slider.
      */
@@ -219,7 +222,7 @@ export interface SliderTypeMap<D extends React.ElementType = 'span', P = {}> {
      */
     valueLabelFormat?: string | ((value: number, index: number) => React.ReactNode);
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 export type SliderValueLabelProps = NonNullable<SliderTypeMap['props']['slotProps']>['valueLabel'] &
@@ -267,8 +270,8 @@ export declare const SliderValueLabel: React.FC<SliderValueLabelProps>;
 declare const Slider: OverridableComponent<SliderTypeMap>;
 
 export type SliderProps<
-  D extends React.ElementType = SliderTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<SliderTypeMap<D, P>, D>;
+  RootComponent extends React.ElementType = SliderTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<SliderTypeMap<RootComponent, AdditionalProps>, RootComponent>;
 
 export default Slider;

--- a/packages/mui-material-next/src/Tab/Tab.d.ts
+++ b/packages/mui-material-next/src/Tab/Tab.d.ts
@@ -5,8 +5,11 @@ import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '@mui/material/ButtonB
 import { OverrideProps } from '@mui/material/OverridableComponent';
 import { TabClasses } from './tabClasses';
 
-export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButtonBaseTypeMap<{
-  props: P & {
+export type TabTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = 'div',
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & {
     /**
      * This prop isn't supported.
      * Use the `component` prop if you need to change the children structure.
@@ -54,7 +57,7 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
      */
     wrapped?: boolean;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }>;
 
 /**
@@ -71,8 +74,8 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
 declare const Tab: ExtendButtonBase<TabTypeMap>;
 
 export type TabProps<
-  D extends React.ElementType = TabTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TabTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TabTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TabTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Tab;

--- a/packages/mui-material-next/src/TablePagination/TablePagination.d.ts
+++ b/packages/mui-material-next/src/TablePagination/TablePagination.d.ts
@@ -38,8 +38,11 @@ export interface TablePaginationActionsProps extends React.HTMLAttributes<HTMLDi
   showLastButton: boolean;
 }
 
-export interface TablePaginationTypeMap<P, D extends React.ElementType> {
-  props: P &
+export interface TablePaginationTypeMap<
+  AdditionalProps,
+  DefaultComponent extends React.ElementType,
+> {
+  props: AdditionalProps &
     TablePaginationBaseProps & {
       /**
        * The component used for displaying the actions.
@@ -144,7 +147,7 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
        */
       sx?: SxProps<Theme>;
     };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**
@@ -166,8 +169,8 @@ declare const TablePagination: OverridableComponent<
 export type TablePaginationBaseProps = Omit<TableCellProps, 'classes' | 'component' | 'children'>;
 
 export type TablePaginationProps<
-  D extends React.ElementType = React.JSXElementConstructor<TablePaginationBaseProps>,
-  P = {},
-> = OverrideProps<TablePaginationTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = React.JSXElementConstructor<TablePaginationBaseProps>,
+  AdditionalProps = {},
+> = OverrideProps<TablePaginationTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default TablePagination;

--- a/packages/mui-material-next/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material-next/src/Tabs/Tabs.d.ts
@@ -6,8 +6,11 @@ import { OverridableComponent, OverrideProps } from '@mui/material/OverridableCo
 import { TabScrollButtonProps } from '../TabScrollButton';
 import { TabsClasses } from './tabsClasses';
 
-export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof ButtonBase> {
-  props: P & {
+export interface TabsTypeMap<
+  AdditionalProps = {},
+  DefaultComponent extends React.ElementType = typeof ButtonBase,
+> {
+  props: AdditionalProps & {
     /**
      * Callback fired when the component mounts.
      * This is useful when you want to trigger an action programmatically.
@@ -126,7 +129,7 @@ export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof Button
      */
     sx?: SxProps<Theme>;
   };
-  defaultComponent: D;
+  defaultComponent: DefaultComponent;
 }
 
 /**
@@ -147,8 +150,8 @@ export interface TabsActions {
 }
 
 export type TabsProps<
-  D extends React.ElementType = TabsTypeMap['defaultComponent'],
-  P = {},
-> = OverrideProps<TabsTypeMap<P, D>, D>;
+  RootComponent extends React.ElementType = TabsTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<TabsTypeMap<AdditionalProps, RootComponent>, RootComponent>;
 
 export default Tabs;

--- a/packages/mui-material-next/src/styles/useThemeProps.ts
+++ b/packages/mui-material-next/src/styles/useThemeProps.ts
@@ -3,11 +3,11 @@ import { useThemeProps as systemUseThemeProps } from '@mui/system';
 import defaultTheme from './defaultTheme';
 import THEME_ID from './identifier';
 
-export default function useThemeProps<T extends {}>({
+export default function useThemeProps<Props extends {}>({
   props,
   name,
 }: {
-  props: T & {};
+  props: Props & {};
   name: string;
 }) {
   return systemUseThemeProps({


### PR DESCRIPTION
Similarly to #38155, in this PR I renamed one-letter type parameters in Material-next's type maps and props to something more meaningful.