### PR TITLE
[Checkbox][material] Add size classes

### DIFF
--- a/docs/pages/material-ui/api/checkbox.json
+++ b/docs/pages/material-ui/api/checkbox.json
@@ -45,7 +45,15 @@
   },
   "name": "Checkbox",
   "styles": {
-    "classes": ["root", "checked", "disabled", "indeterminate", "colorPrimary", "colorSecondary"],
+    "classes": [
+      "root",
+      "checked",
+      "disabled",
+      "indeterminate",
+      "colorPrimary",
+      "colorSecondary",
+      "sizeSmall"
+    ],
     "globalClasses": { "checked": "Mui-checked", "disabled": "Mui-disabled" },
     "name": "MuiCheckbox"
   },

--- a/docs/pages/material-ui/api/checkbox.json
+++ b/docs/pages/material-ui/api/checkbox.json
@@ -52,7 +52,8 @@
       "indeterminate",
       "colorPrimary",
       "colorSecondary",
-      "sizeSmall"
+      "sizeSmall",
+      "sizeMedium"
     ],
     "globalClasses": { "checked": "Mui-checked", "disabled": "Mui-disabled" },
     "name": "MuiCheckbox"

--- a/docs/translations/api-docs/checkbox/checkbox.json
+++ b/docs/translations/api-docs/checkbox/checkbox.json
@@ -74,6 +74,11 @@
       "description": "State class applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>size=\"small\"</code>"
+    },
+    "sizeMedium": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"medium\"</code>"
     }
   }
 }

--- a/docs/translations/api-docs/checkbox/checkbox.json
+++ b/docs/translations/api-docs/checkbox/checkbox.json
@@ -44,7 +44,7 @@
     }
   },
   "classDescriptions": {
-    "root": { "description": "Styles applied to the root element." },
+    "root": { "description": "Class name applied to the root element." },
     "checked": {
       "description": "State class applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -61,14 +61,19 @@
       "conditions": "<code>indeterminate={true}</code>"
     },
     "colorPrimary": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>color=\"primary\"</code>"
     },
     "colorSecondary": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>color=\"secondary\"</code>"
+    },
+    "sizeSmall": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"small\"</code>"
     }
   }
 }

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -22,7 +22,7 @@ const useUtilityClasses = (ownerState) => {
       'root',
       indeterminate && 'indeterminate',
       `color${capitalize(color)}`,
-      size === 'small' && 'sizeSmall',
+      `size${capitalize(size)}`,
     ],
   };
 

--- a/packages/mui-material/src/Checkbox/Checkbox.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.js
@@ -15,10 +15,15 @@ import styled, { rootShouldForwardProp } from '../styles/styled';
 import checkboxClasses, { getCheckboxUtilityClass } from './checkboxClasses';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, indeterminate, color } = ownerState;
+  const { classes, indeterminate, color, size } = ownerState;
 
   const slots = {
-    root: ['root', indeterminate && 'indeterminate', `color${capitalize(color)}`],
+    root: [
+      'root',
+      indeterminate && 'indeterminate',
+      `color${capitalize(color)}`,
+      size === 'small' && 'sizeSmall',
+    ],
   };
 
   const composedClasses = composeClasses(slots, getCheckboxUtilityClass, classes);

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -66,6 +66,16 @@ describe('<Checkbox />', () => {
     });
   });
 
+  describe('prop: size', () => {
+    it('add sizeSmall class to the root element when the size prop equals "small"', () => {
+      const { getByRole } = render(<Checkbox size="small" />);
+      const checkbox = getByRole('checkbox');
+      const root = checkbox.parentElement;
+
+      expect(root).to.have.class(classes.sizeSmall);
+    });
+  });
+
   describe('with FormControl', () => {
     describe('enabled', () => {
       it('should not have the disabled class', () => {

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -74,6 +74,22 @@ describe('<Checkbox />', () => {
 
       expect(root).to.have.class(classes.sizeSmall);
     });
+
+    it('add sizeMedium class to the root element when the size prop equals "medium"', () => {
+      const { getByRole } = render(<Checkbox size="medium" />);
+      const checkbox = getByRole('checkbox');
+      const root = checkbox.parentElement;
+
+      expect(root).to.have.class(classes.sizeMedium);
+    });
+
+    it('add sizeMedium class to the root element when the size is not expplicitly provided', () => {
+      const { getByRole } = render(<Checkbox />);
+      const checkbox = getByRole('checkbox');
+      const root = checkbox.parentElement;
+
+      expect(root).to.have.class(classes.sizeMedium);
+    });
   });
 
   describe('with FormControl', () => {

--- a/packages/mui-material/src/Checkbox/checkboxClasses.ts
+++ b/packages/mui-material/src/Checkbox/checkboxClasses.ts
@@ -16,6 +16,8 @@ export interface CheckboxClasses {
   colorSecondary: string;
   /** State class applied to the root element if `size="small"`. */
   sizeSmall: string;
+  /** State class applied to the root element if `size="medium"`. */
+  sizeMedium: string;
 }
 
 export type CheckboxClassKey = keyof CheckboxClasses;
@@ -32,6 +34,7 @@ const checkboxClasses: CheckboxClasses = generateUtilityClasses('MuiCheckbox', [
   'colorPrimary',
   'colorSecondary',
   'sizeSmall',
+  'sizeMedium',
 ]);
 
 export default checkboxClasses;

--- a/packages/mui-material/src/Checkbox/checkboxClasses.ts
+++ b/packages/mui-material/src/Checkbox/checkboxClasses.ts
@@ -2,7 +2,7 @@ import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/
 import generateUtilityClass from '../generateUtilityClass';
 
 export interface CheckboxClasses {
-  /** Styles applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
   /** State class applied to the root element if `checked={true}`. */
   checked: string;
@@ -10,10 +10,12 @@ export interface CheckboxClasses {
   disabled: string;
   /** State class applied to the root element if `indeterminate={true}`. */
   indeterminate: string;
-  /** Styles applied to the root element if `color="primary"`. */
+  /** State class applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Styles applied to the root element if `color="secondary"`. */
+  /** State class applied to the root element if `color="secondary"`. */
   colorSecondary: string;
+  /** State class applied to the root element if `size="small"`. */
+  sizeSmall: string;
 }
 
 export type CheckboxClassKey = keyof CheckboxClasses;
@@ -29,6 +31,7 @@ const checkboxClasses: CheckboxClasses = generateUtilityClasses('MuiCheckbox', [
   'indeterminate',
   'colorPrimary',
   'colorSecondary',
+  'sizeSmall',
 ]);
 
 export default checkboxClasses;


### PR DESCRIPTION
Places the `.MuiCheckbox-sizeSmall` and `.MuiCheckbox-sizeMedium` class on checkboxes where `size="small"` and `size="medium"`, respectively, similarly to how Button behaves.

Closes #38176.