### PR TITLE
[base] Remove the legacy Extend* types

### DIFF
--- a/packages/mui-base/src/Badge/Badge.types.ts
+++ b/packages/mui-base/src/Badge/Badge.types.ts
@@ -77,9 +77,7 @@ export interface BadgeTypeMap<
 
 export type BadgeProps<
   RootComponentType extends React.ElementType = BadgeTypeMap['defaultComponent'],
-> = OverrideProps<BadgeTypeMap<{}, RootComponentType>, RootComponentType> & {
-  component?: RootComponentType;
-};
+> = OverrideProps<BadgeTypeMap<{}, RootComponentType>, RootComponentType>;
 
 export type BadgeRootSlotProps = {
   children?: React.ReactNode;

--- a/packages/mui-base/src/Badge/Badge.types.ts
+++ b/packages/mui-base/src/Badge/Badge.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { OverrideProps, OverridableTypeMap, OverridableComponent, Simplify } from '@mui/types';
+import { OverrideProps, Simplify } from '@mui/types';
 import { SlotComponentProps } from '../utils';
 
 export interface BadgeRootSlotPropsOverrides {}
@@ -74,18 +74,6 @@ export interface BadgeTypeMap<
   props: BadgeOwnProps & AdditionalProps;
   defaultComponent: RootComponentType;
 }
-
-/**
- * Utility to create component types that inherit props from Badge.
- */
-export interface ExtendBadgeTypeMap<TypeMap extends OverridableTypeMap> {
-  props: TypeMap['props'] & BadgeTypeMap['props'];
-  defaultComponent: TypeMap['defaultComponent'];
-}
-
-export type ExtendBadge<TypeMap extends OverridableTypeMap> = OverridableComponent<
-  ExtendBadgeTypeMap<TypeMap>
->;
 
 export type BadgeProps<
   RootComponentType extends React.ElementType = BadgeTypeMap['defaultComponent'],

--- a/packages/mui-base/src/Modal/Modal.types.ts
+++ b/packages/mui-base/src/Modal/Modal.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { OverridableComponent, OverridableTypeMap, Simplify } from '@mui/types';
+import { Simplify } from '@mui/types';
 import { PortalProps } from '../Portal';
 import { PolymorphicProps, SlotComponentProps } from '../utils';
 
@@ -137,18 +137,6 @@ export interface ModalTypeMap<
   props: ModalOwnProps & AdditionalProps;
   defaultComponent: RootComponentType;
 }
-
-/**
- * Utility to create component types that inherit props from Modal.
- */
-export interface ExtendModalTypeMap<TypeMap extends OverridableTypeMap> {
-  props: TypeMap['props'] & ModalTypeMap['props'];
-  defaultComponent: TypeMap['defaultComponent'];
-}
-
-export type ExtendModal<TypeMap extends OverridableTypeMap> = OverridableComponent<
-  ExtendModalTypeMap<TypeMap>
->;
 
 export type ModalProps<
   RootComponentType extends React.ElementType = ModalTypeMap['defaultComponent'],

--- a/packages/mui-base/src/Slider/Slider.types.ts
+++ b/packages/mui-base/src/Slider/Slider.types.ts
@@ -1,4 +1,4 @@
-import { OverridableComponent, OverridableTypeMap, Simplify } from '@mui/types';
+import { Simplify } from '@mui/types';
 import * as React from 'react';
 import { PolymorphicProps, SlotComponentProps, SlotComponentPropsWithSlotState } from '../utils';
 import {
@@ -168,18 +168,6 @@ export interface SliderTypeMap<
   props: SliderOwnProps & AdditionalProps;
   defaultComponent: RootComponentType;
 }
-
-/**
- * Utility to create component types that inherit props from Slider.
- */
-export interface ExtendSliderTypeMap<TypeMap extends OverridableTypeMap> {
-  props: TypeMap['props'] & Omit<SliderTypeMap['props'], 'isRtl'>;
-  defaultComponent: TypeMap['defaultComponent'];
-}
-
-export type ExtendSlider<TypeMap extends OverridableTypeMap> = OverridableComponent<
-  ExtendSliderTypeMap<TypeMap>
->;
 
 export type SliderProps<
   RootComponentType extends React.ElementType = SliderTypeMap['defaultComponent'],

--- a/packages/mui-material/src/Badge/Badge.d.ts
+++ b/packages/mui-material/src/Badge/Badge.d.ts
@@ -1,90 +1,158 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { OverridableStringUnion } from '@mui/types';
-import { BadgeTypeMap as BaseBadgeTypeMap, ExtendBadgeTypeMap } from '@mui/base/Badge';
+import { OverridableStringUnion, Simplify } from '@mui/types';
+import { SlotComponentProps } from '@mui/base/utils';
 import { Theme } from '../styles';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { BadgeClasses } from './badgeClasses';
 
 export interface BadgePropsVariantOverrides {}
-
 export interface BadgePropsColorOverrides {}
+export interface BadgeRootSlotPropsOverrides {}
+export interface BadgeBadgeSlotPropsOverrides {}
+
+export type BadgeOwnerState = Simplify<
+  BadgeOwnProps & {
+    badgeContent: React.ReactNode;
+    invisible: boolean;
+    max: number;
+    displayValue: React.ReactNode;
+    showZero: boolean;
+    anchorOrigin: BadgeOrigin;
+    color: OverridableStringUnion<
+      'primary' | 'secondary' | 'default' | 'error' | 'info' | 'success' | 'warning',
+      BadgePropsColorOverrides
+    >;
+    overlap: 'rectangular' | 'circular';
+    variant: OverridableStringUnion<'standard' | 'dot', BadgePropsVariantOverrides>;
+  }
+>;
 
 export interface BadgeOrigin {
   vertical: 'top' | 'bottom';
   horizontal: 'left' | 'right';
 }
 
-export type BadgeTypeMap<
+export interface BadgeOwnProps {
+  /**
+   * The anchor of the badge.
+   * @default {
+   *   vertical: 'top',
+   *   horizontal: 'right',
+   * }
+   */
+  anchorOrigin?: BadgeOrigin;
+  /**
+   * The content rendered within the badge.
+   */
+  badgeContent?: React.ReactNode;
+  /**
+   * The badge will be added relative to this node.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<BadgeClasses>;
+  /**
+   * @ignore
+   */
+  className?: string;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   * @default 'default'
+   */
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'default' | 'error' | 'info' | 'success' | 'warning',
+    BadgePropsColorOverrides
+  >;
+  /**
+   * The extra props for the slot components.
+   * You can override the existing props or add new ones.
+   *
+   * This prop is an alias for the `slotProps` prop.
+   * It's recommended to use the `slotProps` prop instead, as `componentsProps` will be deprecated in the future.
+   *
+   * @default {}
+   */
+  componentsProps?: BadgeOwnProps['slotProps'];
+  /**
+   * The components used for each slot inside.
+   *
+   * This prop is an alias for the `slots` prop.
+   * It's recommended to use the `slots` prop instead.
+   *
+   * @default {}
+   */
+  components?: {
+    Root?: React.ElementType;
+    Badge?: React.ElementType;
+  };
+  /**
+   * If `true`, the badge is invisible.
+   * @default false
+   */
+  invisible?: boolean;
+  /**
+   * Max count to show.
+   * @default 99
+   */
+  max?: number;
+  /**
+   * Wrapped shape the badge should overlap.
+   * @default 'rectangular'
+   */
+  overlap?: 'rectangular' | 'circular';
+  /**
+   * The props used for each slot inside the Badge.
+   * @default {}
+   */
+  slotProps?: {
+    root?: SlotComponentProps<'span', BadgeRootSlotPropsOverrides, BadgeOwnerState>;
+    badge?: SlotComponentProps<'span', BadgeBadgeSlotPropsOverrides, BadgeOwnerState>;
+  };
+  /**
+   * The components used for each slot inside the Badge.
+   * Either a string to use a HTML element or a component.
+   * @default {}
+   */
+  slots?: {
+    /**
+     * The component that renders the root.
+     * @default 'span'
+     */
+    root?: React.ElementType;
+    /**
+     * The component that renders the badge.
+     * @default 'span'
+     */
+    badge?: React.ElementType;
+  };
+  /**
+   * Controls whether the badge is hidden when `badgeContent` is zero.
+   * @default false
+   */
+  showZero?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The variant to use.
+   * @default 'standard'
+   */
+  variant?: OverridableStringUnion<'standard' | 'dot', BadgePropsVariantOverrides>;
+}
+
+export interface BadgeTypeMap<
   DefaultComponent extends React.ElementType = 'span',
   AdditionalProps = {},
-> = ExtendBadgeTypeMap<{
-  props: AdditionalProps & {
-    /**
-     * The anchor of the badge.
-     * @default {
-     *   vertical: 'top',
-     *   horizontal: 'right',
-     * }
-     */
-    anchorOrigin?: BadgeOrigin;
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes?: Partial<BadgeClasses>;
-    /**
-     * @ignore
-     */
-    className?: string;
-    /**
-     * The color of the component.
-     * It supports both default and custom theme colors, which can be added as shown in the
-     * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
-     * @default 'default'
-     */
-    color?: OverridableStringUnion<
-      'primary' | 'secondary' | 'default' | 'error' | 'info' | 'success' | 'warning',
-      BadgePropsColorOverrides
-    >;
-    /**
-     * The extra props for the slot components.
-     * You can override the existing props or add new ones.
-     *
-     * This prop is an alias for the `slotProps` prop.
-     * It's recommended to use the `slotProps` prop instead, as `componentsProps` will be deprecated in the future.
-     *
-     * @default {}
-     */
-    componentsProps?: BaseBadgeTypeMap['props']['slotProps'];
-    /**
-     * The components used for each slot inside.
-     *
-     * This prop is an alias for the `slots` prop.
-     * It's recommended to use the `slots` prop instead.
-     *
-     * @default {}
-     */
-    components?: {
-      Root?: React.ElementType;
-      Badge?: React.ElementType;
-    };
-    /**
-     * Wrapped shape the badge should overlap.
-     * @default 'rectangular'
-     */
-    overlap?: 'rectangular' | 'circular';
-    /**
-     * The system prop that allows defining system overrides as well as additional CSS styles.
-     */
-    sx?: SxProps<Theme>;
-    /**
-     * The variant to use.
-     * @default 'standard'
-     */
-    variant?: OverridableStringUnion<'standard' | 'dot', BadgePropsVariantOverrides>;
-  };
+> {
+  props: AdditionalProps & BadgeOwnProps;
   defaultComponent: DefaultComponent;
-}>;
+}
 
 type BadgeRootProps = NonNullable<BadgeTypeMap['props']['slotProps']>['root'];
 type BadgeBadgeProps = NonNullable<BadgeTypeMap['props']['slotProps']>['badge'];


### PR DESCRIPTION
Removed the old `Extend*` types from Badge, Modal, and Slider.
Also changed the Material UI Badge that was incorrectly using the `ExtendBadgeTypeMap` (its implementation isn't tied or related to Base UI's Badge, so it shouldn't reuse its types).

Base UI components' props can be extended using the `*OwnProps` interface:

```ts
import { BadgeOwnProps } from '@mui/base/Badge';

interface MyExtendedBadgeTypeMap<AdditionalProps = {}, DefaultComponent = 'span'> {
  props: AdditionalProps & BadgeOwnProps & {
    // ... your props here
  },
  defaultComponent: DefaultComponent
}
```