### PR TITLE
[Theme][material] Add missing styleOverrides type for theme MuiStack

### DIFF
--- a/packages/mui-material/src/styles/components.d.ts
+++ b/packages/mui-material/src/styles/components.d.ts
@@ -443,6 +443,7 @@ export interface Components<Theme = unknown> {
   };
   MuiStack?: {
     defaultProps?: ComponentsProps['MuiStack'];
+    styleOverrides?: ComponentsOverrides<Theme>['MuiStack'];
     variants?: ComponentsVariants['MuiStack'];
   };
   MuiStep?: {

--- a/packages/mui-material/src/styles/overrides.d.ts
+++ b/packages/mui-material/src/styles/overrides.d.ts
@@ -86,6 +86,7 @@ import { SnackbarContentClassKey } from '../SnackbarContent';
 import { SpeedDialClassKey } from '../SpeedDial';
 import { SpeedDialActionClassKey } from '../SpeedDialAction';
 import { SpeedDialIconClassKey } from '../SpeedDialIcon';
+import { StackClassKey } from '../Stack';
 import { StepButtonClasskey } from '../StepButton';
 import { StepClasskey } from '../Step';
 import { StepConnectorClasskey } from '../StepConnector';
@@ -225,6 +226,7 @@ export interface ComponentNameToClassKey {
   MuiSpeedDial: SpeedDialClassKey;
   MuiSpeedDialAction: SpeedDialActionClassKey;
   MuiSpeedDialIcon: SpeedDialIconClassKey;
+  MuiStack: StackClassKey;
   MuiStep: StepClasskey;
   MuiStepButton: StepButtonClasskey;
   MuiStepConnector: StepConnectorClasskey;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes: #38151

The `styleOverrides` `MuiStack` key type was missing from the overrides `Components` type: https://github.com/mui/material-ui/pull/28843#issuecomment-939481966
