### PR TITLE
[core] Fix docs demo export function consistency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -285,10 +285,7 @@ module.exports = {
     },
     // demos
     {
-      files: [
-        'docs/src/pages/**/*{.tsx,.js}',
-        'docs/data/**/*{.tsx,.js}',
-      ],
+      files: ['docs/src/pages/**/*{.tsx,.js}', 'docs/data/**/*{.tsx,.js}'],
       rules: {
         // This most often reports data that is defined after the component definition.
         // This is safe to do and helps readability of the demo code since the data is mostly irrelevant.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -276,6 +276,7 @@ module.exports = {
         ],
       },
     },
+    // Next.js entry points pages
     {
       files: ['docs/pages/**/*.js'],
       rules: {
@@ -285,10 +286,8 @@ module.exports = {
     // demos
     {
       files: [
-        'docs/src/pages/**/*.js',
-        'docs/src/pages/**/*.tsx',
-        'docs/data/**/*.js',
-        'docs/data/**/*.tsx',
+        'docs/src/pages/**/*{.tsx,.js}',
+        'docs/data/**/*{.tsx,.js}',
       ],
       rules: {
         // This most often reports data that is defined after the component definition.
@@ -300,12 +299,12 @@ module.exports = {
       },
     },
     {
-      files: ['docs/data/**/*.tsx'],
+      files: ['docs/data/**/*{.tsx,.js}'],
       excludedFiles: [
         'docs/data/joy/getting-started/templates/**/*.tsx',
-        'docs/data/**/css/*.tsx',
-        'docs/data/**/system/*.tsx',
-        'docs/data/**/tailwind/*.tsx',
+        'docs/data/**/css/*{.tsx,.js}',
+        'docs/data/**/system/*{.tsx,.js}',
+        'docs/data/**/tailwind/*{.tsx,.js}',
       ],
       rules: {
         'filenames/match-exported': ['error'],

--- a/docs/data/base/components/textarea-autosize/UnstyledTextareaIntroduction.js
+++ b/docs/data/base/components/textarea-autosize/UnstyledTextareaIntroduction.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TextareaAutosize } from '@mui/base/TextareaAutosize';
 import { styled } from '@mui/system';
 
-export default function EmptyTextarea() {
+export default function UnstyledTextareaIntroduction() {
   const blue = {
     100: '#DAECFF',
     200: '#b6daff',
@@ -40,16 +40,16 @@ export default function EmptyTextarea() {
     box-shadow: 0px 2px 24px ${
       theme.palette.mode === 'dark' ? blue[900] : blue[100]
     };
-  
+
     &:hover {
       border-color: ${blue[400]};
     }
-  
+
     &:focus {
       border-color: ${blue[400]};
       box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
     }
-  
+
     // firefox
     &:focus-visible {
       outline: 0;

--- a/docs/data/joy/components/autocomplete/AutocompleteVariables.js
+++ b/docs/data/joy/components/autocomplete/AutocompleteVariables.js
@@ -4,7 +4,7 @@ import Stack from '@mui/joy/Stack';
 import LiveTv from '@mui/icons-material/LiveTv';
 import JoyVariablesDemo from 'docs/src/modules/components/JoyVariablesDemo';
 
-export default function ButtonVariables() {
+export default function AutocompleteVariables() {
   return (
     <JoyVariablesDemo
       componentName="Autocomplete"

--- a/docs/data/joy/components/button-group/ButtonGroupUsage.js
+++ b/docs/data/joy/components/button-group/ButtonGroupUsage.js
@@ -5,7 +5,7 @@ import IconButton from '@mui/joy/IconButton';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
 import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
 
-export default function ButtonUsage() {
+export default function ButtonGroupUsage() {
   return (
     <JoyUsageDemo
       componentName="ButtonGroup"

--- a/docs/data/joy/components/button/ButtonsSimple.js
+++ b/docs/data/joy/components/button/ButtonsSimple.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Button from '@mui/joy/Button';
 import Box from '@mui/joy/Box';
 
-export default function UnstyledButtonsSimple() {
+export default function ButtonsSimple() {
   return (
     <Box>
       <Button>Button</Button>

--- a/docs/data/joy/components/chip/ChipUsage.js
+++ b/docs/data/joy/components/chip/ChipUsage.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Chip from '@mui/joy/Chip';
 import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
 
-export default function ChipUsages() {
+export default function ChipUsage() {
   return (
     <JoyUsageDemo
       componentName="Chip"

--- a/docs/data/joy/components/table/TableUsage.js
+++ b/docs/data/joy/components/table/TableUsage.js
@@ -5,7 +5,7 @@ import Sheet from '@mui/joy/Sheet';
 import Typography from '@mui/joy/Typography';
 import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
 
-export default function ButtonUsage() {
+export default function TableUsage() {
   return (
     <JoyUsageDemo
       componentName="Table"

--- a/docs/data/joy/components/tabs/TabsVariables.js
+++ b/docs/data/joy/components/tabs/TabsVariables.js
@@ -5,7 +5,7 @@ import Tab from '@mui/joy/Tab';
 import TabPanel from '@mui/joy/TabPanel';
 import JoyVariablesDemo from 'docs/src/modules/components/JoyVariablesDemo';
 
-export default function ListVariables() {
+export default function TabsVariables() {
   return (
     <JoyVariablesDemo
       componentName="Tabs"

--- a/docs/data/joy/components/typography/TypographyUsage.js
+++ b/docs/data/joy/components/typography/TypographyUsage.js
@@ -3,7 +3,7 @@ import Box from '@mui/joy/Box';
 import Typography from '@mui/joy/Typography';
 import JoyUsageDemo from 'docs/src/modules/components/JoyUsageDemo';
 
-export default function TypographyUsages() {
+export default function TypographyUsage() {
   return (
     <JoyUsageDemo
       componentName="Typography"

--- a/docs/data/joy/customization/theme-colors/RemoveActiveTokens.js
+++ b/docs/data/joy/customization/theme-colors/RemoveActiveTokens.js
@@ -26,7 +26,7 @@ const theme = extendTheme({
 const useEnhancedEffect =
   typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
-export default function BootstrapVariantTokens() {
+export default function RemoveActiveTokens() {
   // the `node` is used for attaching CSS variables to this demo, you might not need it in your application.
   const [node, setNode] = React.useState(null);
   useEnhancedEffect(() => {

--- a/docs/data/joy/getting-started/tutorial/LoginFinal.js
+++ b/docs/data/joy/getting-started/tutorial/LoginFinal.js
@@ -33,7 +33,7 @@ function ModeToggle() {
   );
 }
 
-export default function App() {
+export default function LoginFinal() {
   return (
     <CssVarsProvider>
       <main>

--- a/docs/data/joy/main-features/automatic-adjustment/InputVariables.js
+++ b/docs/data/joy/main-features/automatic-adjustment/InputVariables.js
@@ -6,7 +6,7 @@ import Input from '@mui/joy/Input';
 import FormControl from '@mui/joy/FormControl';
 import FormLabel from '@mui/joy/FormLabel';
 
-export default function InputIntegration() {
+export default function InputVariables() {
   const [radius, setRadius] = React.useState(16);
   const [childHeight, setChildHeight] = React.useState(32);
   return (

--- a/docs/data/joy/main-features/automatic-adjustment/ListThemes.js
+++ b/docs/data/joy/main-features/automatic-adjustment/ListThemes.js
@@ -12,7 +12,7 @@ import ToggleOffRoundedIcon from '@mui/icons-material/ToggleOffRounded';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import BrandingProvider from 'docs/src/BrandingProvider';
 
-export default function ButtonThemes() {
+export default function ListThemes() {
   const [preset, setPreset] = React.useState('');
   const rootPresets = {
     dense: {

--- a/docs/data/material/components/buttons/ButtonMaterialYouPlayground.js
+++ b/docs/data/material/components/buttons/ButtonMaterialYouPlayground.js
@@ -4,7 +4,7 @@ import Button from '@mui/material-next/Button';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
 import MaterialYouUsageDemo from 'docs/src/modules/components/MaterialYouUsageDemo';
 
-export default function ButtonUsage() {
+export default function ButtonMaterialYouPlayground() {
   const [variant, setVariant] = React.useState('text');
   return (
     <MaterialYouUsageDemo

--- a/docs/data/material/components/slider/SliderMaterialYouPlayground.js
+++ b/docs/data/material/components/slider/SliderMaterialYouPlayground.js
@@ -3,7 +3,7 @@ import Slider from '@mui/material-next/Slider';
 import Box from '@mui/material/Box';
 import MaterialYouUsageDemo from 'docs/src/modules/components/MaterialYouUsageDemo';
 
-export default function ButtonUsage() {
+export default function SliderMaterialYouPlayground() {
   return (
     <MaterialYouUsageDemo
       componentName="Slider"

--- a/docs/data/material/customization/typography/ResponsiveFontSizesChart.js
+++ b/docs/data/material/customization/typography/ResponsiveFontSizesChart.js
@@ -30,7 +30,7 @@ const colors = [
 ];
 const variants = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1'];
 
-export default function ResponsiveFontSizes() {
+export default function ResponsiveFontSizesChart() {
   const convert = convertLength(theme.typography.htmlFontSize);
   const toPx = (rem) => parseFloat(convert(rem, 'px'));
 

--- a/docs/data/material/experimental-api/css-variables/CssVariablesCustomization.js
+++ b/docs/data/material/experimental-api/css-variables/CssVariablesCustomization.js
@@ -25,7 +25,7 @@ const CssVarsCustomButton = styled(Button)({
 const useEnhancedEffect =
   typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
 
-export default function App() {
+export default function CssVariablesCustomization() {
   // the `node` is used for attaching CSS variables to this demo, you might not need it in your application.
   const [node, setNode] = React.useState(null);
   useEnhancedEffect(() => {

--- a/docs/data/material/migration/migration-grid-v2/GridDisableEqualOverflow.js
+++ b/docs/data/material/migration/migration-grid-v2/GridDisableEqualOverflow.js
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import Grid2 from '@mui/material/Unstable_Grid2';
 import Typography from '@mui/material/Typography';
 
-export default function GridsDiff() {
+export default function GridDisableEqualOverflow() {
   return (
     <Box sx={{ pt: 3 }}>
       <Box sx={{ border: '1px solid', borderColor: 'primary.main' }}>


### PR DESCRIPTION
Same as #37278 but also for JavaScript demos. We still have demos that are JS only (e.g. in Joy UI so we can focus on more important topics). I noticed this having a look at a PR on Joy UI.