### PR TITLE
[TabContext] Introduced new prop to allow deterministic idPrefix

### DIFF
--- a/packages/mui-lab/src/TabContext/TabContext.d.ts
+++ b/packages/mui-lab/src/TabContext/TabContext.d.ts
@@ -14,6 +14,10 @@ export interface TabContextProps {
    * The value of the currently selected `Tab`.
    */
   value: string;
+  /**
+   * The optional id prefix, internally used to render buttons
+   */
+  idPrefix?: string;
 }
 /**
  *

--- a/packages/mui-lab/src/TabContext/TabContext.js
+++ b/packages/mui-lab/src/TabContext/TabContext.js
@@ -9,17 +9,17 @@ if (process.env.NODE_ENV !== 'production') {
   Context.displayName = 'TabContext';
 }
 
-function useUniquePrefix() {
-  const [id, setId] = React.useState(null);
-  React.useEffect(() => {
-    setId(`mui-p-${Math.round(Math.random() * 1e5)}`);
-  }, []);
-  return id;
+function useUniquePrefix(idPrefix) {
+  const ref = React.useRef()
+  if (!ref.current || (typeof idPrefix === 'string' && ref.current !== idPrefix)) {
+    ref.current = idPrefix || `mui-p-${Math.round(Math.random() * 1e5)}`
+  }
+  return ref.current;
 }
 
 export default function TabContext(props) {
-  const { children, value } = props;
-  const idPrefix = useUniquePrefix();
+  const { children, value, idPrefix: idPrefixProp } = props;
+  const idPrefix = useUniquePrefix(idPrefixProp);
 
   const context = React.useMemo(() => {
     return { idPrefix, value };
@@ -41,6 +41,10 @@ TabContext.propTypes /* remove-proptypes */ = {
    * The value of the currently selected `Tab`.
    */
   value: PropTypes.string.isRequired,
+  /**
+   * The optional id prefix, internally used to render buttons
+   */
+  idPrefix: PropTypes.string,
 };
 
 /**


### PR DESCRIPTION
I am facing a problem on my tests, where I am not able to use snapshoting matching due to the internal id prefix used by the tab context being randomly generated:

![image](https://github.com/mui/material-ui/assets/6686134/66971bf4-9186-4e74-bf12-2436c053cc29)

So on this PR I have:
-  added a new prop to allow for a custom idPrefix
- replaced the previous useState/useEffect for a useRef that won't cause useless re-renders

I haven't written tests for this as I want first some sort of tentative ok/feeback from the reviwers before putting the effort.

Please let me know if I should do any changes.

In case someone wants to change this behaviour right away, this is my current workaround, using jest, typescript and very brittle on purpose:

```typescript
import React, { type FC, useLayoutEffect } from 'react'

import { TabContext } from '@mui/lab'

import { dependencies } from '../../../package.json'

/**
 * The tabs component as it is does not provide a constant internally used unique prefix
 * This makes it a constant, using the given parameter
 * Which then allows for snapshots to be used in testing
 */
export const TabsContextUniquePrefixFixer: FC<Readonly<{ uniquePrefixGenerator: () => number }>> = ({ uniquePrefixGenerator: uniquePrefix, children }) => {
    const supported = '^5.0.0-alpha.131'

    if (dependencies['@mui/lab'] !== supported) {
        /**
         * This check is here to make sure you don't forget to check if anything has changed making this dangerous fix obsolete
         * Please go check 'node_modules/mui-lab/src/TabContext/TabContext.js' and make sure the fix down below still applies
         */
        throw new Error(
            `The ${TabsContextUniquePrefixFixer.name} fix does not support @mui/lab '${dependencies['@mui/lab']}' version, only '${supported}', please check '${__filename}' for more tips on how to fix this`
        )
    }

    useLayoutEffect(() => {
        const originalRound = Math.round

        const randomSpy = jest.spyOn(Math, 'random')
        const roundSpy = jest.spyOn(Math, 'round').mockImplementation((...args) => {
            const lastRandomValue = randomSpy.mock.results[randomSpy.mock.results.length - 1]?.value
            /**
             * Constant comes from https://github.com/mui/material-ui/blob/e6e5012f1dc0534a19c99a8a437fba144413862e/packages/mui-lab/src/TabContext/TabContext.js#L15
             */
            const valuePossiblyPassedToRound = Number(lastRandomValue) * 1e5
            if (valuePossiblyPassedToRound === args[0]) {
                return uniquePrefix()
            }
            return originalRound.apply(Math, args)
        })

        return () => {
            roundSpy.mockClear()
            randomSpy.mockClear()
        }
    }, [])

    return <>{children}</>
}

export const example = (
    <TabsContextUniquePrefixFixer uniquePrefixGenerator={() => ++id}>
        <TabContext value="foo" />
    </TabsContextUniquePrefixFixer>
)
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
