### PR TITLE
[docs] fix links to standardized examples

### DIFF
--- a/docs/data/base/guides/working-with-tailwind-css/PlayerFinal.js
+++ b/docs/data/base/guides/working-with-tailwind-css/PlayerFinal.js
@@ -4,7 +4,7 @@ export default function PlayerFinal() {
   return (
     <iframe
       title="codesandbox"
-      src="https://codesandbox.io/embed/github/mui/material-ui/tree/master/examples/base-cra-tailwind-ts?hidenavigation=1&fontsize=14&view=preview"
+      src="https://codesandbox.io/embed/github/mui/material-ui/tree/master/examples/base-cra-ts?hidenavigation=1&fontsize=14&view=preview"
       style={{
         width: '100%',
         height: 400,

--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css-pt.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css-pt.md
@@ -489,4 +489,4 @@ These are the things we covered in this guide:
 ✅ How to create custom components for specific slots in more complex customization scenarios. We used the `component` prop to pass them into the parent component.\
 ✅ How to apply conditional styling based on the owner component's state using a callback as value for the `componentsProps` prop.
 
-Get all the code used in this guide in the [Base UI with Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/base-cra-tailwind-ts) example project.
+Get all the code used in this guide in the [Base UI with Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/base-cra-ts) example project.

--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css-zh.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css-zh.md
@@ -489,4 +489,4 @@ These are the things we covered in this guide:
 ✅ How to create custom components for specific slots in more complex customization scenarios. We used the `component` prop to pass them into the parent component.\
 ✅ How to apply conditional styling based on the owner component's state using a callback as value for the `componentsProps` prop.
 
-Get all the code used in this guide in the [Base UI with Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/mui-base-with-tailwind-css) example project.
+Get all the code used in this guide in the [Base UI with Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/base-cra-ts) example project.

--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
@@ -510,4 +510,4 @@ These are the things we covered in this guide:
 We used the `component` prop to pass them into the parent component.\
 ✅ How to apply conditional styling based on the owner component's state using a callback as value for the `slotProps` prop.
 
-Get all the code used in this guide in the [Base UI with Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/base-cra-tailwind-ts) example project.
+Get all the code used in this guide in the [Base UI with Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/base-cra-ts) example project.

--- a/docs/data/material/getting-started/example-projects/example-projects-zh.md
+++ b/docs/data/material/getting-started/example-projects/example-projects-zh.md
@@ -8,17 +8,17 @@
 
 <!-- #default-branch-switch -->
 
-- [Next.js](https://github.com/mui/material-ui/tree/next/examples/nextjs) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/nextjs-with-typescript)）
-- [Create React App](https://github.com/mui/material-ui/tree/next/examples/create-react-app) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/create-react-app-with-typescript)）
-- [Remix](https://github.com/mui/material-ui/tree/master/examples/remix-with-typescript)
-- [Gatsby](https://github.com/mui/material-ui/tree/master/examples/gatsby)
-- [Preact](https://github.com/mui/material-ui/tree/master/examples/preact)
-- [CDN](https://github.com/mui/material-ui/tree/master/examples/cdn)
-- [Plain server-side](https://github.com/mui/material-ui/tree/master/examples/ssr)
-- [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/tailwind-css)
-- [Vite.js](https://github.com/mui/material-ui/tree/master/examples/vitejs)
-- [Use styled-components as style engine](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components) ([TypeScript version](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript))
-- [Next.js + @mui/styles (v4 migration helper)](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration)
+- [Next.js](https://github.com/mui/material-ui/tree/next/examples/material-next) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/nextjs-with-typescript)）
+- [Create React App](https://github.com/mui/material-ui/tree/next/examples/create-react-app) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/material-cra-ts)）
+- [Remix](https://github.com/mui/material-ui/tree/master/examples/material-remix-ts)
+- [Gatsby](https://github.com/mui/material-ui/tree/master/examples/material-gatsby)
+- [Preact](https://github.com/mui/material-ui/tree/master/examples/material-preact)
+- [CDN](https://github.com/mui/material-ui/tree/master/examples/material-via-cdn)
+- [Plain server-side](https://github.com/mui/material-ui/tree/master/examples/material-express-ssr)
+- [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/material-cra-tailwind-ts)
+- [Vite.js](https://github.com/mui/material-ui/tree/master/examples/material-vite)
+- [Use styled-components as style engine](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components) ([TypeScript version](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components-ts))
+- [Next.js + @mui/styles (v4 migration helper)](https://github.com/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration)
 
 Create React App 是一个很棒的学习 React 的项目。 Have a look at [the alternatives available](https://github.com/facebook/create-react-app/blob/HEAD/README.md#popular-alternatives) to see which project best fits your needs.
 

--- a/docs/data/material/getting-started/example-projects/example-projects-zh.md
+++ b/docs/data/material/getting-started/example-projects/example-projects-zh.md
@@ -8,8 +8,8 @@
 
 <!-- #default-branch-switch -->
 
-- [Next.js](https://github.com/mui/material-ui/tree/next/examples/material-next) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/nextjs-with-typescript)）
-- [Create React App](https://github.com/mui/material-ui/tree/next/examples/create-react-app) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/material-cra-ts)）
+- [Next.js](https://github.com/mui/material-ui/tree/next/examples/nextjs) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/nextjs-with-typescript)）
+- [Create React App](https://github.com/mui/material-ui/tree/next/examples/create-react-app) （[TypeScript 版本](https://github.com/mui/material-ui/tree/next/examples/create-react-app-with-typescript)）
 - [Remix](https://github.com/mui/material-ui/tree/master/examples/material-remix-ts)
 - [Gatsby](https://github.com/mui/material-ui/tree/master/examples/material-gatsby)
 - [Preact](https://github.com/mui/material-ui/tree/master/examples/material-preact)

--- a/docs/data/material/getting-started/installation/installation-pt.md
+++ b/docs/data/material/getting-started/installation/installation-pt.md
@@ -85,7 +85,7 @@ Dois arquivos do Universal Module Definition (**UMD**) são fornecidos:
 - um para desenvolvimento: https://unpkg.com/@mui/material@latest/umd/material-ui.development.js
 - um para produção: https://unpkg.com/@mui/material@latest/umd/material-ui.production.min.js
 
-You can follow [this CDN example](https://github.com/mui/material-ui/tree/master/examples/cdn) to quickly get started.
+You can follow [this CDN example](https://github.com/mui/material-ui/tree/master/examples/material-via-cdn) to quickly get started.
 
 ⚠️ Using this approach in **production** is **discouraged** though - the client has to download the entire library, regardless of which components are actually used, affecting performance and bandwidth utilization.
 

--- a/docs/data/material/getting-started/installation/installation-zh.md
+++ b/docs/data/material/getting-started/installation/installation-zh.md
@@ -85,7 +85,7 @@ Two Universal Module Definition (**UMD**) files are provided:
 - 您可以在开发环境调试：https://unpkg.com/@mui/material@latest/umd/material-ui.development.js
 - 也可放心地在生产环境使用: https://unpkg.com/@mui/material@latest/umd/material-ui.production.min.js
 
-You can follow [this CDN example](https://github.com/mui/material-ui/tree/master/examples/cdn) to quickly get started.
+You can follow [this CDN example](https://github.com/mui/material-ui/tree/master/examples/material-via-cdn) to quickly get started.
 
 ⚠️ Using this approach in **production** is **discouraged** though - the client has to download the entire library, regardless of which components are actually used, affecting performance and bandwidth utilization.
 

--- a/docs/data/material/guides/interoperability/interoperability-pt.md
+++ b/docs/data/material/guides/interoperability/interoperability-pt.md
@@ -294,8 +294,8 @@ By default, MUI components come with Emotion as their style engine. If, however,
 
 <!-- #default-branch-switch -->
 
-- [Create React App with styled-components](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components)
-- [Create React App with styled-components and typescript](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript)
+- [Create React App with styled-components](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components)
+- [Create React App with styled-components and typescript](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components-ts)
 
 After the style engine is configured properly, you can use the [`styled()`](/system/styled/) utility from `@material-ui/core/styles` and have direct access to the theme.
 
@@ -598,7 +598,7 @@ It works exactly like styled components. You can [use the same guide](/material-
 
 ### Setup
 
-If you are used to Tailwind CSS and want to use it together with the MUI components, you can start by cloning the [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/tailwind-css) example project. If you use a different framework, or already have set up your project, follow these steps:
+If you are used to Tailwind CSS and want to use it together with the MUI components, you can start by cloning the [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/material-cra-tailwind-ts) example project. If you use a different framework, or already have set up your project, follow these steps:
 
 1. Add Tailwind CSS to your project, following the instructions in https://tailwindcss.com/docs/installation.
 2. Remove [Tailwind CSS's preflight](https://tailwindcss.com/docs/preflight) style so it can use the MUI's preflight instead ([CssBaseline](/material-ui/react-css-baseline/)).

--- a/docs/data/material/guides/interoperability/interoperability-zh.md
+++ b/docs/data/material/guides/interoperability/interoperability-zh.md
@@ -291,8 +291,8 @@ By default, MUI components come with Emotion as their style engine. If, however,
 
 <!-- #default-branch-switch -->
 
-- [Create React App with styled-components](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components)
-- [Create React App with styled-components and typescript](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript)
+- [Create React App with styled-components](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components)
+- [Create React App with styled-components and typescript](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components-ts)
 
 After the style engine is configured properly, you can use the [`styled()`](/system/styled/) utility from `@mui/core/styles` and have direct access to the theme.
 
@@ -592,7 +592,7 @@ It works exactly like styled components. You can [use the same guide](/material-
 
 ### Setup
 
-If you are used to Tailwind CSS and want to use it together with the MUI components, you can start by cloning the [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/tailwind-css) example project. If you use a different framework, or already have set up your project, follow these steps:
+If you are used to Tailwind CSS and want to use it together with the MUI components, you can start by cloning the [Tailwind CSS](https://github.com/mui/material-ui/tree/master/examples/material-cra-tailwind-ts) example project. If you use a different framework, or already have set up your project, follow these steps:
 
 1. Add Tailwind CSS to your project, following the instructions in https://tailwindcss.com/docs/installation.
 2. Remove [Tailwind CSS's preflight](https://tailwindcss.com/docs/preflight) style so it can use the MUI's preflight instead ([CssBaseline](/material-ui/react-css-baseline/)).

--- a/docs/data/material/guides/routing/routing-pt.md
+++ b/docs/data/material/guides/routing/routing-pt.md
@@ -85,9 +85,9 @@ const LinkBehavior = React.forwardRef((props, ref) => (
 
 ### Next.js
 
-Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link). The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript) provides adapters for usage with MUI.
+Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link). The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-next-ts) provides adapters for usage with MUI.
 
-- The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/blob/HEAD/examples/nextjs-with-typescript/src/Link.tsx) component. Este componente não tem estilo e é o único responsável pelo manuseio da navegação. The prop `href` was renamed `to` to avoid a naming conflict. This is similar to react-router's Link component.
+- The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/blob/HEAD/examples/material-next-ts/src/Link.tsx) component. Este componente não tem estilo e é o único responsável pelo manuseio da navegação. The prop `href` was renamed `to` to avoid a naming conflict. This is similar to react-router's Link component.
 
   ```tsx
   import Button from '@material-ui/core/Button';

--- a/docs/data/material/guides/routing/routing-zh.md
+++ b/docs/data/material/guides/routing/routing-zh.md
@@ -83,9 +83,9 @@ In real-life applications, using a native <code><a></code> element is rarely eno
 
 ### Next.js
 
-Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link). The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript) provides adapters for usage with MUI.
+Next.js has [a custom Link component](https://nextjs.org/docs/api-reference/next/link). The [example folder](https://github.com/mui/material-ui/tree/HEAD/examples/material-next-ts) provides adapters for usage with MUI.
 
-- The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/blob/HEAD/examples/nextjs-with-typescript/src/Link.tsx) component. This component is unstyled and only responsible for handling the navigation. The prop `href` was renamed `to` to avoid a naming conflict. This is similar to react-router's Link component.
+- The first version of the adapter is the [`NextLinkComposed`](https://github.com/mui/material-ui/tree/HEAD/examples/material-next-ts/src/Link.tsx) component. This component is unstyled and only responsible for handling the navigation. The prop `href` was renamed `to` to avoid a naming conflict. This is similar to react-router's Link component.
 
   ```tsx
   import Button from '@mui/material/Button';

--- a/docs/data/material/guides/server-rendering/server-rendering-pt.md
+++ b/docs/data/material/guides/server-rendering/server-rendering-pt.md
@@ -206,9 +206,9 @@ function Main() {
 
 We host different reference implementations which you can find in the [GitHub repository](https://github.com/mui/material-ui) under the [`/examples`](https://github.com/mui/material-ui/tree/HEAD/examples) folder:
 
-- [A implementação de referência deste tutorial](https://github.com/mui/material-ui/tree/HEAD/examples/ssr)
-- [Gatsby](https://github.com/mui/material-ui/tree/HEAD/examples/gatsby)
-- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript))
+- [A implementação de referência deste tutorial](https://github.com/mui/material-ui/tree/HEAD/examples/material-express-ssr)
+- [Gatsby](https://github.com/mui/material-ui/tree/HEAD/examples/material-gatsby)
+- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/material-next) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript))
 
 ## Resolução de problemas
 

--- a/docs/data/material/guides/server-rendering/server-rendering-pt.md
+++ b/docs/data/material/guides/server-rendering/server-rendering-pt.md
@@ -208,7 +208,7 @@ We host different reference implementations which you can find in the [GitHub re
 
 - [A implementação de referência deste tutorial](https://github.com/mui/material-ui/tree/HEAD/examples/material-express-ssr)
 - [Gatsby](https://github.com/mui/material-ui/tree/HEAD/examples/material-gatsby)
-- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/material-next) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript))
+- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/material-next) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/material-next-ts))
 
 ## Resolução de problemas
 

--- a/docs/data/material/guides/server-rendering/server-rendering-zh.md
+++ b/docs/data/material/guides/server-rendering/server-rendering-zh.md
@@ -284,7 +284,7 @@ We host different reference implementations which you can find in the [GitHub re
 
 - [本教程的参考实现](https://github.com/mui/material-ui/tree/HEAD/examples/material-express-ssr)
 - [Gatsby](https://github.com/mui/material-ui/tree/HEAD/examples/material-gatsby)
-- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/material-next) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript))
+- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/material-next) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/material-next-ts))
 
 ## 故障排除（Troubleshooting）
 

--- a/docs/data/material/guides/server-rendering/server-rendering-zh.md
+++ b/docs/data/material/guides/server-rendering/server-rendering-zh.md
@@ -282,9 +282,9 @@ ReactDOM.hydrate(<Main />, document.querySelector('#root'));
 
 We host different reference implementations which you can find in the [GitHub repository](https://github.com/mui/material-ui) under the [`/examples`](https://github.com/mui/material-ui/tree/HEAD/examples) folder:
 
-- [本教程的参考实现](https://github.com/mui/material-ui/tree/HEAD/examples/ssr)
-- [Gatsby](https://github.com/mui/material-ui/tree/HEAD/examples/gatsby)
-- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript))
+- [本教程的参考实现](https://github.com/mui/material-ui/tree/HEAD/examples/material-express-ssr)
+- [Gatsby](https://github.com/mui/material-ui/tree/HEAD/examples/material-gatsby)
+- [Next.js](https://github.com/mui/material-ui/tree/HEAD/examples/material-next) ([TypeScript version](https://github.com/mui/material-ui/tree/HEAD/examples/nextjs-with-typescript))
 
 ## 故障排除（Troubleshooting）
 

--- a/docs/data/material/guides/styled-engine/styled-engine-pt.md
+++ b/docs/data/material/guides/styled-engine/styled-engine-pt.md
@@ -98,8 +98,8 @@ If you are using create-react-app, there is a ready-to-use template in the examp
 
 <!-- #default-branch-switch -->
 
-- [create-react-app](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components)
-- [create-react-app with TypeScript](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript)
+- [create-react-app](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components)
+- [create-react-app with TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components-ts)
 - [and many others](https://github.com/mui/material-ui/tree/master/examples)
 
 :::warning

--- a/docs/data/material/guides/styled-engine/styled-engine-zh.md
+++ b/docs/data/material/guides/styled-engine/styled-engine-zh.md
@@ -83,8 +83,8 @@ If you are using create-react-app, there is a ready-to-use template in the examp
 
 <!-- #default-branch-switch -->
 
-- [create-react-app](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components)
-- [使用 TypeScript 来 create-react-app](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-styled-components-typescript)
+- [create-react-app](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components)
+- [使用 TypeScript 来 create-react-app](https://github.com/mui/material-ui/tree/master/examples/material-cra-styled-components-ts)
 - [其他模板](https://github.com/mui/material-ui/tree/master/examples)
 
 :::warning

--- a/docs/data/material/guides/typescript/typescript-pt.md
+++ b/docs/data/material/guides/typescript/typescript-pt.md
@@ -6,9 +6,9 @@
 
 <!-- #default-branch-switch -->
 
-Material-UI requires a minimum version of TypeScript 3.5. Have a look at the [Create React App with TypeScript](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-typescript) example.
+Material-UI requires a minimum version of TypeScript 3.5. Have a look at the [Create React App with TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-cra-ts) example.
 
-Dê uma olhada no exemplo [Create React App com TypeScript](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-typescript).
+Dê uma olhada no exemplo [Create React App com TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-cra-ts).
 
 ```json
 {

--- a/docs/data/material/guides/typescript/typescript-zh.md
+++ b/docs/data/material/guides/typescript/typescript-zh.md
@@ -8,7 +8,7 @@
 
 MUI requires a minimum version of TypeScript 3.5. Material-UI requires a minimum version of TypeScript 3.5. 请查看一下 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-cra-ts) 的例子。
 
-请查看 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/next/examples/material-cra-ts) 的例子。
+请查看 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/next/examples/create-react-app-with-typescript) 的例子。
 
 ```json
 {

--- a/docs/data/material/guides/typescript/typescript-zh.md
+++ b/docs/data/material/guides/typescript/typescript-zh.md
@@ -6,9 +6,9 @@
 
 <!-- #default-branch-switch -->
 
-MUI requires a minimum version of TypeScript 3.5. Material-UI requires a minimum version of TypeScript 3.5. 请查看一下 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/master/examples/create-react-app-with-typescript) 的例子。
+MUI requires a minimum version of TypeScript 3.5. Material-UI requires a minimum version of TypeScript 3.5. 请查看一下 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/master/examples/material-cra-ts) 的例子。
 
-请查看 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/next/examples/create-react-app-with-typescript) 的例子。
+请查看 [Create React App with TypeScript](https://github.com/mui/material-ui/tree/next/examples/material-cra-ts) 的例子。
 
 ```json
 {

--- a/docs/data/material/migration/migration-v4/migrating-from-jss-pt.md
+++ b/docs/data/material/migration/migration-v4/migrating-from-jss-pt.md
@@ -17,7 +17,7 @@ One of the biggest changes in v5 is the replacement of JSS for [Emotion](https:/
 Note that you may continue to use JSS for adding overrides for the components (e.g. `makeStyles`, `withStyles`) even after migrating to v5. Then, if at any point you want to move over to the new styling engine, you can refactor your components progressively.
 
 :::info
-If you are using Next.js and you are not sure how to configure SSR to work with both Emotion & JSS, take a look a this [example project](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration).
+If you are using Next.js and you are not sure how to configure SSR to work with both Emotion & JSS, take a look a this [example project](https://github.com/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration).
 :::
 
 This document reviews all the steps necessary to migrate away from JSS.

--- a/docs/data/material/migration/migration-v4/migrating-from-jss-zh.md
+++ b/docs/data/material/migration/migration-v4/migrating-from-jss-zh.md
@@ -17,7 +17,7 @@ v5中最大的变化之一是将JSS替换为[Emotion](https://emotion.sh/docs/in
 请注意，你可以继续使用JSS为组件添加重写（例如`makeStyles`, `withStyles`），即使在迁移到v5之后。 然后，如果在任何时候你想转移到新的样式引擎，你可以逐步重构你的组件。
 
 :::info
-如果你正在使用Next.js，并且不确定如何配置SSR以与Emotion和JSS一起工作，可以看一下这个[例子项目](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration)。
+如果你正在使用Next.js，并且不确定如何配置SSR以与Emotion和JSS一起工作，可以看一下这个[例子项目](https://github.com/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration)。
 :::
 
 本文档回顾了从JSS迁移的所有必要步骤。

--- a/docs/data/material/migration/migration-v4/migration-v4-pt.md
+++ b/docs/data/material/migration/migration-v4/migration-v4-pt.md
@@ -27,7 +27,7 @@ Need to refer back to an older version of the docs? Check out [the v4 documentat
 :::
 
 :::info
-If you are using Next.js and you are not sure how to configure SSR to work with both Emotion & JSS, take a look a this [example project](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration).
+If you are using Next.js and you are not sure how to configure SSR to work with both Emotion & JSS, take a look a this [example project](https://github.com/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration).
 :::
 
 ## Why you should migrate

--- a/docs/data/material/migration/migration-v4/migration-v4-zh.md
+++ b/docs/data/material/migration/migration-v4/migration-v4-zh.md
@@ -26,7 +26,7 @@ V5最大的变化之一是将JSS替换为[Emotion](https://emotion.sh/docs/intro
 需要参考旧版本的文档吗？ 在这里查看[v4的文档](https://v4.mui.com/)
 :::
 
-如果你正在使用Next.js，并且不确定如何配置SSR以与Emotion 和 JSS一起工作，请看这个[例子项目](https://github.com/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration)
+如果你正在使用Next.js，并且不确定如何配置SSR以与Emotion 和 JSS一起工作，请看这个[例子项目](https://github.com/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration)
 :::
 
 ## 为什么你应该迁移

--- a/docs/data/styles/advanced/advanced-pt.md
+++ b/docs/data/styles/advanced/advanced-pt.md
@@ -394,7 +394,7 @@ Existe [um plugin oficial Gatsby](https://github.com/hupe1980/gatsby-plugin-mate
 
 <!-- #default-branch-switch -->
 
-Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/master/examples/gatsby) for an up-to-date usage example.
+Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/master/examples/material-gatsby) for an up-to-date usage example.
 
 ### Next.js
 
@@ -402,7 +402,7 @@ Você precisa ter um `pages/_document.js` customizado, então copie [esta lógic
 
 <!-- #default-branch-switch -->
 
-Refer to [this example project](https://github.com/mui/material-ui/tree/master/examples/nextjs) for an up-to-date usage example.
+Refer to [this example project](https://github.com/mui/material-ui/tree/master/examples/material-next) for an up-to-date usage example.
 
 ## Nomes de classes
 

--- a/docs/data/styles/advanced/advanced-zh.md
+++ b/docs/data/styles/advanced/advanced-zh.md
@@ -407,7 +407,7 @@ function render() {
 
 <!-- #default-branch-switch -->
 
-请参考 [这个Gatsby项目的例子](https://github.com/mui/material-ui/tree/master/examples/gatsby)，了解最新的使用范例。
+请参考 [这个Gatsby项目的例子](https://github.com/mui/material-ui/tree/master/examples/material-gatsby)，了解最新的使用范例。
 
 ### Next.js
 
@@ -415,7 +415,7 @@ function render() {
 
 <!-- #default-branch-switch -->
 
-请参考[这个例子项目](https://github.com/mui/material-ui/tree/master/examples/nextjs)，了解最新的使用范例。
+请参考[这个例子项目](https://github.com/mui/material-ui/tree/master/examples/material-next)，了解最新的使用范例。
 
 ## 类名（Class names）
 

--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -411,7 +411,7 @@ Refer to the plugin's page for setup and usage instructions.
 
 <!-- #default-branch-switch -->
 
-Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/v4.x/examples/gatsby) for an usage example.
+Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/v4.x/examples/material-gatsby) for an usage example.
 
 ### Next.js
 
@@ -419,7 +419,7 @@ You need to have a custom `pages/_document.js`, then copy [this logic](https://g
 
 <!-- #default-branch-switch -->
 
-Refer to [this example project](https://github.com/mui/material-ui/tree/v4.x/examples/nextjs) for an up-to-date usage example.
+Refer to [this example project](https://github.com/mui/material-ui/tree/v4.x/examples/material-next) for an up-to-date usage example.
 
 ## Class names
 

--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -411,7 +411,7 @@ Refer to the plugin's page for setup and usage instructions.
 
 <!-- #default-branch-switch -->
 
-Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/v4.x/examples/material-gatsby) for an usage example.
+Refer to [this example Gatsby project](https://github.com/mui/material-ui/tree/v4.x/examples/gatsby) for an usage example.
 
 ### Next.js
 
@@ -419,7 +419,7 @@ You need to have a custom `pages/_document.js`, then copy [this logic](https://g
 
 <!-- #default-branch-switch -->
 
-Refer to [this example project](https://github.com/mui/material-ui/tree/v4.x/examples/material-next) for an up-to-date usage example.
+Refer to [this example project](https://github.com/mui/material-ui/tree/v4.x/examples/nextjs) for an up-to-date usage example.
 
 ## Class names
 

--- a/examples/material-next-ts-v4-v5-migration/README.md
+++ b/examples/material-next-ts-v4-v5-migration/README.md
@@ -22,9 +22,9 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration)
+[![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration)
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui/material-ui/tree/master/examples/nextjs-with-typescript-v4-migration)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui/material-ui/tree/master/examples/material-next-ts-v4-v5-migration)
 
 ## The idea behind the example
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The PR fixes broken links to examples caused by PR #36112 and #36825, which renamed the `examples` directories for standardization. The proposed changes in the current PR resolve these broken links.