### PR TITLE
[core] Fix generate Proptypes script skipping unstable items

### DIFF
--- a/packages/mui-system/src/Unstable_Grid/Grid.tsx
+++ b/packages/mui-system/src/Unstable_Grid/Grid.tsx
@@ -139,6 +139,29 @@ Grid.propTypes /* remove-proptypes */ = {
     PropTypes.object,
   ]),
   /**
+   * @internal
+   * The level of the grid starts from `0`
+   * and increases when the grid nests inside another grid regardless of container or item.
+   *
+   * ```js
+   * <Grid> // level 0
+   *   <Grid> // level 1
+   *     <Grid> // level 2
+   *   <Grid> // level 1
+   * ```
+   *
+   * Only consecutive grid is considered nesting.
+   * A grid container will start at `0` if there are non-Grid element above it.
+   *
+   * ```js
+   * <Grid> // level 0
+   *   <div>
+   *     <Grid> // level 0
+   *       <Grid> // level 1
+   * ```
+   */
+  unstable_level: PropTypes.number,
+  /**
    * Defines the `flex-wrap` style property.
    * It's applied for all screen sizes.
    * @default 'wrap'

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -324,14 +324,18 @@ async function run(argv: HandlerArgv) {
 
   const files = _.flatten(allFiles)
     .filter((filePath) => {
-      const folderName = path.basename(path.dirname(filePath));
+      // Filter out files where the directory name and filename doesn't match
+      // Example: Modal/ModalManager.d.ts
+      let folderName = path.basename(path.dirname(filePath));
       const fileName = path.basename(filePath).replace(/(\.d\.ts|\.tsx|\.ts)/g, '');
 
-      return (
-        // Filter out files where the directory name and filename doesn't match
-        // Example: Modal/ModalManager.d.ts
-        fileName === folderName
-      );
+      // An exception is if the folder name starts with Unstable_/unstable_
+      // Example: Unstable_Grid2/Grid2.tsx
+      if (/(u|U)nstable_/g.test(folderName)) {
+        folderName = folderName.slice(9);
+      }
+
+      return fileName === folderName;
     })
     .filter((filePath) => {
       return filePattern.test(filePath);


### PR DESCRIPTION
There is some logic that filter out files where the directory name and filename doesn't match, e.g. `Modal/ModalManager.d.ts`

But we need to make an exception for `Unstable_`/`unstable_`, as we do want Proptypes generated for e.g. `Unstable_Grid/Grid.tsx`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
