### PR TITLE
[core] Remove unnecessary `Required` utility type from Typography font style type

### DIFF
--- a/packages/mui-material/src/styles/createTypography.d.ts
+++ b/packages/mui-material/src/styles/createTypography.d.ts
@@ -17,16 +17,15 @@ export type Variant =
   | 'button'
   | 'overline';
 
-export interface FontStyle
-  extends Required<{
-    fontFamily: React.CSSProperties['fontFamily'];
-    fontSize: number;
-    fontWeightLight: React.CSSProperties['fontWeight'];
-    fontWeightRegular: React.CSSProperties['fontWeight'];
-    fontWeightMedium: React.CSSProperties['fontWeight'];
-    fontWeightBold: React.CSSProperties['fontWeight'];
-    htmlFontSize: number;
-  }> {}
+export interface FontStyle {
+  fontFamily: React.CSSProperties['fontFamily'];
+  fontSize: number;
+  fontWeightLight: React.CSSProperties['fontWeight'];
+  fontWeightRegular: React.CSSProperties['fontWeight'];
+  fontWeightMedium: React.CSSProperties['fontWeight'];
+  fontWeightBold: React.CSSProperties['fontWeight'];
+  htmlFontSize: number;
+}
 
 export type NormalCssProperties = CSS.Properties<number | string>;
 export type Fontface = CSS.AtRule.FontFace & { fallbacks?: CSS.AtRule.FontFace[] };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

All of the `FontStyle` type's properties are already required, so using the `Required` utility type is unnecessary. This was noticed while working on https://github.com/mui/material-ui/pull/38123.
