### PR TITLE
[docs][material] Revise the Support page

### DIFF
--- a/docs/data/material/getting-started/support/support.md
+++ b/docs/data/material/getting-started/support/support.md
@@ -1,84 +1,67 @@
 # Support
 
-<p class="description">From community help to premium critical business support, we're here to help.</p>
+<p class="description">From community guidance to critical business support, we're here to help.</p>
 
-## Community help (free)
+## Community help
 
-The community is your first stop for questions and advice about the framework. Welcome to the community!
+Welcome to the MUI community!
+Our tools are used by thousands of developers and teams all around the world, many of whom actively engage with the community through various online platforms.
+These are the best places to start asking questions and looking for answers when you need help.
 
 ### Stack Overflow
 
-For crowdsourced answers from expert Material UI developers in our community.
-Stack Overflow is also visited from time to time by the maintainers of Material UI.
-
-[Post a question](https://stackoverflow.com/questions/tagged/mui)
+[Stack Overflow](https://stackoverflow.com/) contains a wealth of information about Material UI and other MUI products, spanning many years and countless discussion threads.
+Head here to see if your problem has already been resolved by the community, or else [post a question](https://stackoverflow.com/questions/tagged/mui) to get help from community experts as well as MUI maintainers.
 
 :::success
-If you're using an older version and use external resources (such as Stack Overflow) for help with it, you may find answers with links that direct you to content that no longer exists in the latest version of the documentation. To easily access any previous version of the docs, simply add `v[number]` at the beginning of the URL, like so: [v4.mui.com](https://v4.mui.com/).
-
+If you're using an older version of Material UI, you may find answers on SO with links to content that no longer exists in the latest version of the documentation.
+To access any previous version of the docs, add `v[number]` at the beginning of the URL—for example, [v4.mui.com](https://v4.mui.com/) takes you to the v4 docs.
 :::
 
 ### GitHub
 
-MUI uses GitHub issues as a bug and feature request tracker.
-If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported or fixed](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed). You can search through existing issues and pull requests to see if someone has reported one similar to yours.
+MUI uses GitHub issues to track bug reports and feature requests.
+If you think you've found a bug, or you have an idea for a new feature, please [search the issues on GitHub](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed) before opening a new one, to ensure you're not creating a duplicate.
 
-- [Open an issue on MUI Core](https://github.com/mui/material-ui/issues/new/choose)
-- [Open an issue on MUI X](https://github.com/mui/mui-x/issues/new/choose)
+- [Open an issue on MUI Core](https://github.com/mui/material-ui/issues/new/choose): for issues related to Material UI, Base UI, Joy UI, and MUI System.
+- [Open an issue on MUI X](https://github.com/mui/mui-x/issues/new/choose): for issues related to the Data Grid, Date and Time Pickers, and Charts.
 
 #### New issue guidelines
 
-- Please follow the issue template.
-- Please begin the title with '[ComponentName]' where appropriate, and use a succinct description that helps others find similar issues.
-  - "doesn't work" ❌
-  - "[Button] Add support for <some feature>" ✅
-- Please don't group multiple topics in one issue – each should have its own issue instead.
+- Please follow one the issue templates provided on GitHub.
+- Please begin the title with "[ComponentName]" (if relevant), and use a succinct description that helps others find similar issues.
+  - ❌ _"It doesn't work"_
+  - ✅ _"[Button] Add support for {{new feature}}"_
+- Please don't group multiple topics in one issue.
 - Please don't comment "+1" on an issue. It spams the maintainers and doesn't help move the issue forward. Use GitHub reactions instead (👍).
 
-### Blog 📝
+### Social media
 
-Stay up to date with the development of the library by following the blog.
+The MUI community is active on both [Twitter](https://twitter.com/MUI_hq) and [LinkedIn](https://www.linkedin.com/company/11290418/).
+These are great platforms to share what you're working on and seek guidance from others.
 
-[Read the latest posts](https://mui.com/blog/)
-
-### Resources 📖
-
-New to Material UI? It's easy to learn if you know where to start!
-
-[Learn Material UI](/material-ui/getting-started/learn/)
-
-### Twitter
-
-Receive the latest news on MUI.
-
-[Follow us](https://twitter.com/MUI_hq)
-
-### Supported versions
-
-Find details on the [supported versions](/versions/#supported-versions).
+Please keep in mind that we don't actively monitor direct messages on the company's social media accounts, so this is _not_ a good way to get in touch with us directly.
 
 ## Paid support
 
-### Pro/Premium plans
+MUI does _not_ offer paid support for Core libraries like Material UI.
+The section below covers support for MUI X components—see the [MUI X Support page](https://mui.com/x/introduction/support/#technical-support) for complete details.
 
-MUI X comes in [three plans](https://mui.com/pricing/).
-The support available under the Community plan is made possible thanks to people like you: the community.
-This is described in more detail in the section above.
-MUI X maintainers focus on solving root issues rather than offering direct support to the community at large.
+### Pro and Premium plans
 
-The paid plans offer developers advanced components and extra features that are challenging to find in OSS.
-To provide a similar quality of experience to the one provided by the community for MIT licensed code,
-the developers of MUI X provide support for the advanced components only.
-Technical support for MUI Core components is **not** included.
+MUI X is available through one of [three pricing plans](https://mui.com/pricing/): Community, Pro, and Premium.
+
+Support for the (free) Community plan is limited to the public channels outlined above—the same as what's available for MUI Core libraries.
+
+Pro and Premium users can receive direct support from MUI X maintainers, but keep in mind that this support does _not_ extend to MUI Core libraries.
+Please make use of community support for non-MUI X components.
 
 The Premium plan provides developers with the highest priority for support tickets.
-No SLAs are provided yet; it's coming.
-
-Please visit [the MUI X Support page](https://mui.com/x/introduction/support/#technical-support) for more detailed information on technical support.
+We don't currently offer service-level agreements (SLAs), but we plan to in the future.
 
 ### Tidelift subscription
 
-MUI and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open-source you use.
+MUI and the maintainers of thousands of other packages work with Tidelift to deliver one enterprise subscription that covers all of the open-source you use.
 
 If you want the flexibility of open-source and the confidence of commercial-grade software, this is worth looking at.
 
@@ -87,35 +70,22 @@ The Tidelift Subscription manages your dependencies for you:
 - Get the tools you need to continuously catalog and understand the open-source software that your application depends on.
 - Your subscription helps pay the open-source community maintainers of the packages you use, to ensure they meet the standards you require.
 - Address issues proactively, with tools that scan for new security, licensing, and maintenance issues, and alert participating open-source maintainers so they can resolve them on your behalf.
-- Tidelift helps measure and improve your open-source dependencies' health – which improves your app's health – and gives a shortlist of high-impact steps your team can take to improve them even more.
+- Tidelift helps measure and improve your open-source dependencies' health—which improves your app's health—and gives a shortlist of high-impact steps your team can take to improve them even more.
 - Get commercial assurances that don't come for free with open-source packages, such as intellectual property indemnification and support under a service level agreement. You expect these guarantees from proprietary software, and you can get them when using open-source as well.
 
-The end result? All of the capabilities you expect from commercial-grade software, for the full breadth of open-source you use. That means less time grappling with esoteric open-source trivia, and more time building your own applications – and your business.
+The end result? All of the capabilities you expect from commercial-grade software, for the full breadth of open-source you use.
+That means less time grappling with esoteric open-source trivia, and more time building your own applications—and your business.
 
 <a
   data-ga-event-category="support"
   data-ga-event-action="tidelift"
   href="https://tidelift.com/subscription/pkg/npm-material-ui?utm_source=npm-material-ui&utm_medium=referral&utm_campaign=enterprise">
-Get more details
+Learn more about Tidelift
 </a>
-
+and
 <a
   data-ga-event-category="support"
   data-ga-event-action="tidelift"
   href="https://tidelift.com/subscription/request-a-demo?utm_source=npm-material-ui&utm_medium=referral&utm_campaign=enterprise">
-Request a demo
-</a>
-
-### Custom work 🛠
-
-Tweak MUI's component libraries to meet specific requirements. Give us a summary of your needs and we'll help you if we can. We might:
-
-- Give you an estimate of time and price if the work is straightforward
-- Suggest alternatives that might not require MUI components
-- Decline the work due to timing or relevancy
-
-Note that work must be MUI-related.
-We don't accept general React development work.
-Our contracting price is $200/hour or $1,500/day.
-
-[Send us an email](mailto:custom-work@mui.com)
+request a demo today
+</a>.


### PR DESCRIPTION
- revised copy throughout
- removed emoji from headers
- removed Blog link - we don't really offer any "support" there per se
- revised CTA for Twitter/social media
- removed Supported Versions sections - not sure why that's here
- removed a lot of unnecessary text attempting to justify why MUI X is a paid product 😅
- removed Custom Work section - nobody's got time for that!