### PR TITLE
[docs] Fix material two tones icon link of google fonts for styles in CodeSandbox, Stackblitz

### DIFF
--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -4,10 +4,12 @@ export const getHtml = ({
   title,
   language,
   codeStyling,
+  jsxPreview,
 }: {
   title: string;
   language: string;
   codeStyling?: 'Tailwind' | 'MUI System';
+  jsxPreview?: string;
 }) => {
   return `<!DOCTYPE html>
 <html lang="${language}">
@@ -21,7 +23,9 @@ export const getHtml = ({
     <!-- Icons to support Material Design -->
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons${
+        jsxPreview?.includes('material-icons-two-tone') ? '+Two+Tone' : ''
+      }"
     />${
       codeStyling === 'Tailwind'
         ? `


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #37733
