### PR TITLE
[docs-infra] Remove leftover standardNavIcon

### DIFF
--- a/docs/data/joy/pages.ts
+++ b/docs/data/joy/pages.ts
@@ -164,7 +164,6 @@ const pages: readonly MuiPage[] = [
   {
     pathname: '/joy-ui/migration',
     title: 'Migration',
-    icon: standardNavIcons.BookIcon,
     children: [
       {
         pathname: '/joy-ui/migration/migrating-default-theme',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Following up on: https://github.com/mui/material-ui/pull/38174, there is one leftover nav icon that is making the CI fail (`ReferenceError: standardNavIcons is not defined`)
