### PR TITLE
[docs-infra] Make the side nav collapse animation snappier

### DIFF
--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -330,7 +330,7 @@ export default function AppNavDrawerItem(props) {
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
       </Item>
       {expandable ? (
-        <Collapse in={open} timeout="auto" unmountOnExit>
+        <Collapse in={open} timeout={200} unmountOnExit>
           {children}
         </Collapse>
       ) : (

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -330,7 +330,7 @@ export default function AppNavDrawerItem(props) {
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
       </Item>
       {expandable ? (
-        <Collapse in={open} timeout={200} unmountOnExit>
+        <Collapse in={open} timeout={250} unmountOnExit>
           {children}
         </Collapse>
       ) : (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Was browsing [the Obsidian documentation](https://help.obsidian.md/Home) for inspiration and felt like their side nav is super snappy. Made me realize how I always sort of felt ours was a bit too slow. So, this PR makes it a bit snappier/faster!

**https://deploy-preview-38259--material-ui.netlify.app/material-ui/getting-started/**