### PR TITLE
[core] Fix the link-check script on Windows

### DIFF
--- a/docs/scripts/reportBrokenLinks.js
+++ b/docs/scripts/reportBrokenLinks.js
@@ -28,7 +28,7 @@ const getJsFilesInFolder = (folderPath) => {
       return [...acc, ...filesInFolder];
     }
     if (file.name.endsWith('.js') || file.name.endsWith('.tsx')) {
-      return [...acc, path.join(folderPath, file.name)];
+      return [...acc, path.join(folderPath, file.name).replace(/\\/g, '/')];
     }
     return acc;
   }, []);


### PR DESCRIPTION
The link-check script was crashing on Windows as it wasn't expecting forward slashes as path separators.
