### PR TITLE
[Switch][docs] Fix the readOnly class name in docs

### DIFF
--- a/docs/pages/base-ui/api/switch.json
+++ b/docs/pages/base-ui/api/switch.json
@@ -61,7 +61,8 @@
     "globalClasses": {
       "checked": "Mui-checked",
       "disabled": "Mui-disabled",
-      "focusVisible": "Mui-focusVisible"
+      "focusVisible": "Mui-focusVisible",
+      "readOnly": "Mui-readOnly"
     }
   },
   "spread": true,

--- a/docs/pages/joy-ui/api/switch.json
+++ b/docs/pages/joy-ui/api/switch.json
@@ -129,7 +129,8 @@
     "globalClasses": {
       "checked": "Mui-checked",
       "disabled": "Mui-disabled",
-      "focusVisible": "Mui-focusVisible"
+      "focusVisible": "Mui-focusVisible",
+      "readOnly": "Mui-readOnly"
     }
   },
   "spread": true,

--- a/packages/api-docs-builder/utils/parseSlotsAndClasses.ts
+++ b/packages/api-docs-builder/utils/parseSlotsAndClasses.ts
@@ -3,6 +3,8 @@ import { getSymbolDescription, getSymbolJSDocTags } from '../buildApiUtils';
 import { TypeScriptProject } from './createTypeScriptProject';
 import { Classes } from './parseStyles';
 
+// If GLOBAL_STATE_CLASSES is changed, GlobalStateSlot in
+// \packages\mui-utils\src\generateUtilityClass\generateUtilityClass.ts must be updated accordingly.
 const GLOBAL_STATE_CLASSES: string[] = [
   'active',
   'checked',
@@ -10,8 +12,9 @@ const GLOBAL_STATE_CLASSES: string[] = [
   'disabled',
   'error',
   'expanded',
-  'focusVisible',
   'focused',
+  'focusVisible',
+  'readOnly',
   'required',
   'selected',
 ];

--- a/packages/mui-utils/src/generateUtilityClass/generateUtilityClass.ts
+++ b/packages/mui-utils/src/generateUtilityClass/generateUtilityClass.ts
@@ -1,5 +1,7 @@
 import ClassNameGenerator from '../ClassNameGenerator';
 
+// If GlobalStateSlot is changed, GLOBAL_STATE_CLASSES in
+// \packages\api-docs-builder\utils\parseSlotsAndClasses.ts must be updated accordingly.
 export type GlobalStateSlot =
   | 'active'
   | 'checked'


### PR DESCRIPTION
The docs stated that Base's and Joy's Switch has the `.MuiSwitch-readOnly` class, but the components used the `.Mui-readOnly`.
It was caused by a discrepancy between what API builder considered a global state class and what was generated as a state class.

The API docs generation script logic was updated.

Before: https://mui.com/base-ui/react-switch/components-api/#switch-classes
After: https://deploy-preview-38277--material-ui.netlify.app/base-ui/react-switch/components-api/#switch-classes