### PR TITLE
[docs-infra] Add a general round of polish to the API content display

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -371,7 +371,6 @@ import { ${pageContent.name} } from '${source}';`}
               componentName={pageContent.name}
               classDescriptions={classDescriptions}
             />
-            <Divider />
           </React.Fragment>
         ) : null}
         <DesignInfo />

--- a/docs/src/modules/components/ApiPage/ApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/ApiItem.tsx
@@ -61,7 +61,6 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
       },
       '& .MuiApi-item-description': {
         padding: '4px 6px',
-        flexGrow: 1,
         textOverflow: 'ellipsis',
         overflow: 'hidden',
         whiteSpace: 'nowrap',
@@ -77,9 +76,10 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
         placeItems: 'end',
       },
       '& .MuiApi-item-note': {
-        padding: '2px 6px',
+        paddingTop: 5,
         fontSize: 11,
         letterSpacing: '1px',
+        lineHeight: 1.6,
         textTransform: 'uppercase',
         color: `var(--muidocs-palette-success-800, ${lightTheme.palette.success[800]})`,
         fontWeight: theme.typography.fontWeightBold,
@@ -135,7 +135,7 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
       backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
     },
     '&>hr': {
-      margin: '20px 0',
+      margin: '24px 0',
     },
   }),
   ({ theme }) => ({

--- a/docs/src/modules/components/ApiPage/ApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/ApiItem.tsx
@@ -135,7 +135,7 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
       backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
     },
     '&>hr': {
-      margin: '24px 0',
+      margin: '18px 0',
     },
   }),
   ({ theme }) => ({

--- a/docs/src/modules/components/ApiPage/SlotsList.tsx
+++ b/docs/src/modules/components/ApiPage/SlotsList.tsx
@@ -10,12 +10,7 @@ const StyledApiItem = styled(ApiItem)(
     '.slot-classname, .slot-default-element': {
       ...theme.typography.body2,
       fontWeight: theme.typography.fontWeightSemiBold,
-    },
-    '& .slot-description-title': {
-      ...theme.typography.body2,
-      fontWeight: theme.typography.fontWeightSemiBold,
-      paddingRight: 5,
-      whiteSpace: 'nowrap',
+      marginBottom: 8,
     },
   }),
   ({ theme }) => ({
@@ -50,24 +45,20 @@ export default function SlotsList(props: SlotsListProps) {
             note=""
             type="slots"
           >
+            {slotDescriptions[name] && (
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: slotDescriptions[name] || '',
+                }}
+              />
+            )}
             <p className="slot-default-element">
               <span>{t('api-docs.default')}:</span> <code className="Api-code">{defaultValue}</code>
             </p>
-
             {className && (
               <p className="slot-classname">
                 <span>{t('api-docs.globalClass')}:</span>{' '}
                 <code dangerouslySetInnerHTML={{ __html: className }} className="Api-code" />
-              </p>
-            )}
-            {slotDescriptions[name] && (
-              <p>
-                <span className="slot-description-title">{t('api-docs.description')}:</span>{' '}
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: slotDescriptions[name] || '',
-                  }}
-                />
               </p>
             )}
           </StyledApiItem>

--- a/docs/src/modules/components/PropertiesTable.js
+++ b/docs/src/modules/components/PropertiesTable.js
@@ -69,7 +69,6 @@ const StyledApiItem = styled(ApiItem)(
         backgroundColor: `var(--muidocs-palette-primaryDark-800, ${lightTheme.palette.primaryDark[800]})`,
       },
     },
-    marginBottom: 36,
   }),
   ({ theme }) => ({
     [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR adds some small changes to further polish the API content display:
- Delegate spacing to the Divider by removing the unnecessary `marginBottom: 36` and therefore balancing it out more.
- Alignment tweaks on the item note (i.e. "Required", "State").
- Remove the "Description" heading from Slot descriptions to make it consistent with prop descriptions.
- Remove the duplicate divider on the Slots section.

**https://deploy-preview-38282--material-ui.netlify.app/joy-ui/api/aspect-ratio/**

| Before | After |
|--------|--------|
| <img width="851" alt="Screen Shot 2023-08-02 at 09 40 37" src="https://github.com/mui/material-ui/assets/67129314/0873e417-2efc-4a38-a360-16dd07b2f697"> | <img width="851" alt="Screen Shot 2023-08-02 at 09 40 57" src="https://github.com/mui/material-ui/assets/67129314/d401debf-a0b6-477c-9779-4d72f83a7117"> |
| <img width="851" alt="Screen Shot 2023-08-02 at 09 41 40" src="https://github.com/mui/material-ui/assets/67129314/8a37f586-4fed-4851-9936-d8b6e2962c2e"> | <img width="851" alt="Screen Shot 2023-08-02 at 09 41 25" src="https://github.com/mui/material-ui/assets/67129314/be4dd47b-532f-4a08-b1db-1f1fee622412"> |
| <img width="743" alt="Screen Shot 2023-08-02 at 09 47 56" src="https://github.com/mui/material-ui/assets/67129314/ac0e42a7-518f-47ca-bc67-536973de846d"> | <img width="743" alt="Screen Shot 2023-08-02 at 09 48 03" src="https://github.com/mui/material-ui/assets/67129314/ab9341dc-5a17-44ed-ac88-c305fe57d404"> | 