### PR TITLE
[website] Make get started buttons reusable

### DIFF
--- a/docs/src/components/home/GetStartedButtons2.tsx
+++ b/docs/src/components/home/GetStartedButtons2.tsx
@@ -7,14 +7,26 @@ import Link from 'docs/src/modules/components/Link';
 import NpmCopyButton from 'docs/src/components/action/NpmCopyButton';
 
 interface GetStartedButtons2Props extends BoxProps {
-  getStartedUrl?: string;
-  learnUrl?: string;
-  learnLabel?: string;
+  primaryUrl?: string;
+  primaryLabel?: string;
+  secondaryUrl?: string;
+  secondaryLabel?: string;
   installation?: string;
+  targetPrimary?: string;
+  targetSecondary?: string;
 }
 
 export default function GetStartedButtons2(props: GetStartedButtons2Props) {
-  const { getStartedUrl = ROUTES.documentation, learnUrl, learnLabel, ...other } = props;
+  const {
+    primaryLabel,
+    primaryUrl = ROUTES.documentation,
+    secondaryUrl,
+    secondaryLabel,
+    installation,
+    targetPrimary = '_self',
+    targetSecondary = '_self',
+    ...other
+  } = props;
   return (
     <React.Fragment>
       <Box
@@ -29,33 +41,35 @@ export default function GetStartedButtons2(props: GetStartedButtons2Props) {
         }}
       >
         <Button
-          href={getStartedUrl}
+          href={primaryUrl}
           component={Link}
           noLinkStyle
           size="large"
           variant="contained"
           endIcon={<KeyboardArrowRightRounded />}
+          target={targetPrimary}
           sx={{
             flexShrink: 0,
             mr: { xs: 0, md: 1.5 },
             mb: { xs: 2, md: 0 },
           }}
         >
-          Get started
+          {primaryLabel}
         </Button>
         <Button
-          href={learnUrl}
+          href={secondaryUrl}
           component={Link}
           noLinkStyle
           variant="outlined"
           size="large"
+          target={targetSecondary}
           color="secondary"
           endIcon={<KeyboardArrowRightRounded />}
         >
-          {learnLabel}
+          {secondaryLabel}
         </Button>
       </Box>
-      <NpmCopyButton installation="npm install @mui/base" sx={{ mt: 2 }} />
+      {installation ? <NpmCopyButton installation={installation} sx={{ mt: 2 }} /> : null}
     </React.Fragment>
   );
 }

--- a/docs/src/components/productBaseUI/BaseUIHero.tsx
+++ b/docs/src/components/productBaseUI/BaseUIHero.tsx
@@ -83,9 +83,10 @@ export default function BaseUIHero() {
             engine or theme.
           </Typography>
           <GetStartedButtons2
-            getStartedUrl={ROUTES.baseDocs}
-            learnUrl={ROUTES.baseQuickstart}
-            learnLabel="Learn Base UI"
+            primaryUrl={ROUTES.baseDocs}
+            primaryLabel="Get started"
+            secondaryUrl={ROUTES.baseQuickstart}
+            secondaryLabel="Learn Base UI"
             installation="npm install @mui/base"
           />
         </Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I intend to reuse the `GetStartedButtons2` component on the Toolpad landing page, so I've added some changes to allow reuse. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

