### PR TITLE
[dos][joy] Updated Typography callout at getting started

### DIFF
--- a/docs/data/joy/getting-started/tutorial/tutorial.md
+++ b/docs/data/joy/getting-started/tutorial/tutorial.md
@@ -89,9 +89,13 @@ The [Typography](/joy-ui/react-typography/) component replaces HTML header, para
 
 :::info
 The `level` prop gives you access to a pre-defined scale of typographic values.
-Joy UI provides 13 typographic levels out of the box:
+Joy UI provides 11 typographic levels out of the box.
 
-`display1 | display2 | h1 | h2 | h3 | h4 | h5 | h6 | body1 | body2 | body3 | body4 | body5`
+Four heading levels: `'h1' | 'h2' | 'h3' | 'h4'`
+
+Three title levels: `'title-lg' | 'title-md' | 'title-sm'`
+
+Four body levels: `'body-lg' | 'body-md' | 'body-sm' | 'body-xs'`
 
 :::
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Updated the Typography information on the callout at `joy-ui/getting-started/tutorial/` with the new default theme levels.

### Before
<img width="829" alt="Screenshot 2023-08-02 at 14 23 13" src="https://github.com/mui/material-ui/assets/37222944/e7ec81d6-c23d-4ca8-b275-152c7525669c">


### After
<img width="842" alt="Screenshot 2023-08-02 at 14 21 56" src="https://github.com/mui/material-ui/assets/37222944/9320decf-5666-443c-bf83-9ce2aef41a46">
