### PR TITLE
[docs-infra] Fix skip to content design

### DIFF
--- a/docs/src/modules/components/SkipLink.tsx
+++ b/docs/src/modules/components/SkipLink.tsx
@@ -6,12 +6,12 @@ import { useTranslate } from 'docs/src/modules/utils/i18n';
 const StyledLink = styled(MuiLink)(({ theme }) => ({
   position: 'fixed',
   padding: theme.spacing(1, 2),
-  backgroundColor: (theme.vars || theme).palette.secondary[700],
-  color: '#fff',
-  outlineOffset: 2,
-  '&:hover': {
-    color: '#fff',
-  },
+  backgroundColor: (theme.vars || theme).palette.primary[50],
+  border: '1px solid',
+  borderColor: (theme.vars || theme).palette.primary[100],
+  color: (theme.vars || theme).palette.primary[600],
+  outlineOffset: 5,
+  outlineColor: (theme.vars || theme).palette.primary[300],
   borderRadius: theme.shape.borderRadius,
   left: theme.spacing(2),
   zIndex: theme.zIndex.tooltip + 1,
@@ -20,6 +20,10 @@ const StyledLink = styled(MuiLink)(({ theme }) => ({
     easing: theme.transitions.easing.easeIn,
     duration: theme.transitions.duration.leavingScreen,
   }),
+  '&:hover': {
+    backgroundColor: (theme.vars || theme).palette.primary[100],
+    color: (theme.vars || theme).palette.primary[700],
+  },
   '&:focus': {
     top: theme.spacing(2),
     transition: theme.transitions.create('top', {
@@ -39,6 +43,16 @@ const StyledLink = styled(MuiLink)(({ theme }) => ({
   '@media print': {
     display: 'none',
   },
+  ...theme.applyDarkStyles({
+    backgroundColor: (theme.vars || theme).palette.primaryDark[600],
+    borderColor: (theme.vars || theme).palette.primaryDark[400],
+    color: (theme.vars || theme).palette.grey[100],
+    outlineColor: (theme.vars || theme).palette.primary[500],
+    '&:hover': {
+      backgroundColor: (theme.vars || theme).palette.primaryDark[500],
+      color: (theme.vars || theme).palette.grey[50],
+    },
+  }),
 }));
 
 export default function SkipLink() {

--- a/docs/src/modules/components/SkipLink.tsx
+++ b/docs/src/modules/components/SkipLink.tsx
@@ -5,21 +5,36 @@ import { useTranslate } from 'docs/src/modules/utils/i18n';
 
 const StyledLink = styled(MuiLink)(({ theme }) => ({
   position: 'fixed',
-  padding: theme.spacing(1),
-  background: (theme.vars || theme).palette.background.paper,
+  padding: theme.spacing(1, 2),
+  backgroundColor: (theme.vars || theme).palette.secondary[700],
+  color: '#fff',
+  outlineOffset: 2,
+  '&:hover': {
+    color: '#fff',
+  },
+  borderRadius: theme.shape.borderRadius,
+  left: theme.spacing(2),
+  zIndex: theme.zIndex.tooltip + 1,
+  top: theme.spacing(-10),
   transition: theme.transitions.create('top', {
     easing: theme.transitions.easing.easeIn,
     duration: theme.transitions.duration.leavingScreen,
   }),
-  left: theme.spacing(2),
-  top: theme.spacing(-10),
-  zIndex: theme.zIndex.tooltip + 1,
   '&:focus': {
     top: theme.spacing(2),
     transition: theme.transitions.create('top', {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
     }),
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    top: theme.spacing(2),
+    transition: theme.transitions.create('opacity'),
+    opacity: 0,
+    '&:focus': {
+      opacity: 1,
+      transition: theme.transitions.create('opacity'),
+    },
   },
   '@media print': {
     display: 'none',
@@ -29,9 +44,5 @@ const StyledLink = styled(MuiLink)(({ theme }) => ({
 export default function SkipLink() {
   const t = useTranslate();
 
-  return (
-    <StyledLink color="secondary" href="#main-content">
-      {t('appFrame.skipToContent')}
-    </StyledLink>
-  );
+  return <StyledLink href="#main-content">{t('appFrame.skipToContent')}</StyledLink>;
 }


### PR DESCRIPTION
Something that I noticed running the [Wave Evaluation Tool](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh). Go to the https://mui.com/ site and press <kbd>Tab</kbd>, you will see it. 🙃

<img width="250" alt="Screenshot 2023-08-03 at 18 13 14" src="https://github.com/mui/material-ui/assets/3165635/d4ec6bdb-62c1-46cc-be22-a469196d2af8">

It got broken in #36622, with the change of the secondary color in `docs/src/modules/brandingTheme.ts`. This feature is explained at https://webaim.org/techniques/skipnav/.

<img width="500" alt="Screen Shot 2023-08-03 at 14 30 59" src="https://github.com/mui/material-ui/assets/67129314/c696367d-290a-4693-9bc6-4a28c2185826">

I also used the opportunity to support motion reduction `@media (prefers-reduced-motion: reduce)`.