### PR TITLE
[docs] Fix Joy UI demo background color

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -292,7 +292,7 @@ const DemoRootJoy = joyStyled('div', {
     borderColor: grey[100],
     borderLeftWidth: 0,
     borderRightWidth: 0,
-    backgroundColor: alpha(grey[50], 0.2),
+    backgroundColor: '#fff',
     ...theme.applyDarkStyles({
       borderColor: alpha(grey[700], 0.3),
       backgroundColor: alpha(blueDark[800], 0.2),
@@ -538,9 +538,9 @@ export default function Demo(props) {
           {demoElement}
         </DemoSandbox>
       </DemoRoot>
-      {/* TODO: BrandingProvider shouldn't be needed, it should already be at the top of the docs page */}
+      {/* TODO: Wrapper shouldn't be needed, it should already be at the top of the docs page */}
       {demoOptions.hideToolbar ? null : (
-        <BrandingProvider {...(demoData.productId === 'joy-ui' ? { mode } : {})}>
+        <Wrapper {...(demoData.productId === 'joy-ui' ? { mode } : {})}>
           {Object.keys(stylingSolutionMapping).map((key) => (
             <React.Fragment key={key}>
               <AnchorLink id={`${stylingSolutionMapping[key]}-${demoName}.js`} />
@@ -616,7 +616,7 @@ export default function Demo(props) {
             )}
           </Collapse>
           {adVisibility ? <AdCarbonInline /> : null}
-        </BrandingProvider>
+        </Wrapper>
       )}
     </Root>
   );

--- a/docs/src/modules/components/DemoSandbox.js
+++ b/docs/src/modules/components/DemoSandbox.js
@@ -119,7 +119,7 @@ DemoIframe.propTypes = {
   name: PropTypes.string.isRequired,
 };
 
-// Use the default MUI theme for the demos
+// Use the default Material UI theme for the demos
 function getTheme(outerTheme) {
   const brandingDesignTokens = getDesignTokens(outerTheme.palette.mode);
   const isCustomized =


### PR DESCRIPTION
This greyed-ish background shifts the color contrast, it makes a bit more challenge to experience the components in real life.

Before

<img width="450" alt="Screenshot 2023-08-04 at 01 42 29" src="https://github.com/mui/material-ui/assets/3165635/2e1db6af-dbad-450c-80f2-0b14464762df">

https://64cc13af167c35000826fb16--material-ui.netlify.app/joy-ui/react-button/#basics

After

<img width="444" alt="Screenshot 2023-08-04 at 01 42 33" src="https://github.com/mui/material-ui/assets/3165635/de98c1cf-0e0c-4282-8935-a38abb4e18ec">

https://deploy-preview-38307--material-ui.netlify.app/joy-ui/react-button/#basics


(*For those that the color difference is not visible on their screen, I think we need to find them a new screen, for me it's close to the limit of what I can perceive as a color difference, but it's noticeable, so I think for exigent users, it matters*)