### PR TITLE
[core] Port GitHub workflow for ensuring triage label is present

### DIFF
--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -1,5 +1,8 @@
 name: Ensure triage label is present
 on:
+  label:
+    types:
+      - deleted
   issues:
     types:
       - opened
@@ -17,8 +20,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-
-            console.log(JSON.stringify(labels, null, 2))
 
             if (labels.length <= 0) {
               await github.rest.issues.addLabels({

--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -1,0 +1,30 @@
+name: Ensure triage label is present
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            console.log(JSON.stringify(labels, null, 2))
+
+            if (labels.length <= 0) {
+              await github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['status: needs triage']
+              })
+            }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

For context: https://www.notion.so/mui-org/GitHub-Action-to-add-need-triage-label-if-none-is-present-e6357dacba7947a1879d684c7bb63939?d=4912f8bad6af466783a3ef21ac71bad2