### PR TITLE
[joy-ui][MenuButton] Fix disable of `MenuButton`

### DIFF
--- a/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
 import { createRenderer, describeConformance } from 'test/utils';
 import { DropdownContext, DropdownContextValue } from '@mui/base/useDropdown';
 import { ThemeProvider } from '@mui/joy/styles';
@@ -40,4 +42,37 @@ describe('<MenuButton />', () => {
     testVariantProps: { variant: 'soft' },
     ThemeProvider,
   }));
+
+  describe('prop: disabled', () => {
+    it('should render a disabled button', () => {
+      const { getByRole } = render(
+        <DropdownContext.Provider value={testContext}>
+          <MenuButton disabled />
+        </DropdownContext.Provider>,
+      );
+
+      const button = getByRole('button');
+      expect(button).to.have.property('disabled', true);
+    });
+
+    it('should not open the menu when clicked', () => {
+      const dispatchSpy = spy();
+      const context = {
+        ...testContext,
+        state: { open: false },
+        dispatch: dispatchSpy,
+      };
+
+      const { getByRole } = render(
+        <DropdownContext.Provider value={context}>
+          <MenuButton disabled />
+        </DropdownContext.Provider>,
+      );
+
+      const button = getByRole('button');
+      button.click();
+
+      expect(dispatchSpy.called).to.equal(false);
+    });
+  });
 });

--- a/packages/mui-joy/src/MenuButton/MenuButton.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.tsx
@@ -125,7 +125,7 @@ const MenuButton = React.forwardRef(function MenuButton(
   const color = getColor(inProps.color, buttonGroup.color || colorProp);
   const disabled = inProps.disabled ?? (buttonGroup.disabled || disabledProp || loading);
 
-  const { getRootProps, open, active } = useMenuButton({ rootRef: forwardedRef });
+  const { getRootProps, open, active } = useMenuButton({ rootRef: forwardedRef, disabled });
 
   const loadingIndicator = loadingIndicatorProp ?? (
     <CircularProgress
@@ -179,7 +179,7 @@ const MenuButton = React.forwardRef(function MenuButton(
       ownerState,
     },
   );
-
+  // console.log(rootProps,ownerState);
   return (
     <SlotRoot {...rootProps}>
       {(startDecorator || (loading && loadingPosition === 'start')) && (

--- a/packages/mui-joy/src/MenuButton/MenuButton.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.tsx
@@ -179,7 +179,7 @@ const MenuButton = React.forwardRef(function MenuButton(
       ownerState,
     },
   );
-  // console.log(rootProps,ownerState);
+
   return (
     <SlotRoot {...rootProps}>
       {(startDecorator || (loading && loadingPosition === 'start')) && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR makes sure `MenuButton` is disabled when `disabled` prop is set to true

before: https://codesandbox.io/s/loving-leftpad-nrxpvc?file=/Demo.js

after: https://codesandbox.io/s/nostalgic-pond-whrs7p


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
