### PR TITLE
[docs][AppBar] Fix `ResponsiveAppBar` demo logo href

### DIFF
--- a/docs/data/material/components/app-bar/ResponsiveAppBar.js
+++ b/docs/data/material/components/app-bar/ResponsiveAppBar.js
@@ -99,7 +99,7 @@ function ResponsiveAppBar() {
             variant="h5"
             noWrap
             component="a"
-            href=""
+            href="/"
             sx={{
               mr: 2,
               display: { xs: 'flex', md: 'none' },

--- a/docs/data/material/components/app-bar/ResponsiveAppBar.tsx
+++ b/docs/data/material/components/app-bar/ResponsiveAppBar.tsx
@@ -99,7 +99,7 @@ function ResponsiveAppBar() {
             variant="h5"
             noWrap
             component="a"
-            href=""
+            href="/"
             sx={{
               mr: 2,
               display: { xs: 'flex', md: 'none' },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

user is not able to navigate to the root page when clicking on the logo in small screen view 
<img width="200" alt="image" src="https://github.com/mui/material-ui/assets/1487369/40e68fb7-1f7a-465b-8767-8f4d631a8b64">

while it works in big screen view
<img width="500" alt="image" src="https://github.com/mui/material-ui/assets/1487369/b17bd115-64a7-4720-9325-46a6bb1a7e0e">

