### PR TITLE
[docs-infra] Adjust heading styles

### DIFF
--- a/docs/data/docs-infra/pages.ts
+++ b/docs/data/docs-infra/pages.ts
@@ -10,8 +10,8 @@ const pages: readonly MuiPage[] = [
     pathname: '/experiments/docs/components',
     children: [
       { pathname: '/experiments/docs/callouts' },
-      { pathname: '/experiments/docs/demos' },
       { pathname: '/experiments/docs/codeblock' },
+      { pathname: '/experiments/docs/demos' },
     ],
   },
   {

--- a/docs/pages/experiments/docs/headers.md
+++ b/docs/pages/experiments/docs/headers.md
@@ -1,11 +1,17 @@
-# Headers
+# Header styles
 
 <p class="description">Headers.</p>
 
-## h2
+## What is Lorem Ipsum?
 
-### h3
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
 
-#### h4
+### Where does it come from?
+
+Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+
+#### Why do we use it?
+
+It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English.
 
 ## Header with Pro plan [<span class="plan-pro"></span>](/x/introduction/licensing/#pro-plan)

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -80,7 +80,7 @@ const Root = styled('div')(
     '& h2': {
       ...lightTheme.typography.h5,
       fontFamily: `"General Sans", ${lightTheme.typography.fontFamilySystem}`,
-      fontSize: theme.typography.pxToRem(24),
+      fontSize: theme.typography.pxToRem(26),
       fontWeight: lightTheme.typography.fontWeightSemiBold,
       color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
       margin: '40px 0 4px',

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -80,6 +80,7 @@ const Root = styled('div')(
     '& h2': {
       ...lightTheme.typography.h5,
       fontFamily: `"General Sans", ${lightTheme.typography.fontFamilySystem}`,
+      fontSize: theme.typography.pxToRem(24),
       fontWeight: lightTheme.typography.fontWeightSemiBold,
       color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
       margin: '40px 0 4px',
@@ -87,16 +88,17 @@ const Root = styled('div')(
     '& h3': {
       ...lightTheme.typography.h6,
       fontFamily: `"General Sans", ${lightTheme.typography.fontFamilySystem}`,
+      fontSize: theme.typography.pxToRem(20),
       fontWeight: lightTheme.typography.fontWeightSemiBold,
       color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
-      margin: '24px 0 8px',
+      margin: '24px 0 4px',
     },
     '& h4': {
       ...lightTheme.typography.subtitle1,
       fontFamily: `"General Sans", ${lightTheme.typography.fontFamilySystem}`,
       fontWeight: lightTheme.typography.fontWeightSemiBold,
       color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
-      margin: '24px 0 8px',
+      margin: '20px 0 6px',
     },
     '& h5': {
       ...lightTheme.typography.subtitle2,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Experimenting with tweaking font size and spacing on the docs' headings to separate them visually a bit more.
- https://deploy-preview-38365--material-ui.netlify.app/experiments/docs/headers/
- https://deploy-preview-38365--material-ui.netlify.app/blog/mui-x-v6/ (this one has a lot of headings that are useful to see how it feels like!).
