### PR TITLE
[docs-infra] Fix info callout border color

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -567,7 +567,7 @@ const Root = styled('div')(
         '&.MuiCallout-info': {
           color: `var(--muidocs-palette-primary-50, ${darkTheme.palette.primary[50]})`,
           backgroundColor: alpha(darkTheme.palette.grey[700], 0.2),
-          borderColor: `var(--muidocs-palette-primary-800, ${darkTheme.palette.grey[800]})`,
+          borderColor: `var(--muidocs-palette-grey-800, ${darkTheme.palette.grey[800]})`,
           '& strong': {
             color: `var(--muidocs-palette-primary-200, ${darkTheme.palette.primary[200]})`,
           },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes the info callout border color that had as a variable the `primary` palette but is using the `grey` one instead, which is the correct option.

| Before | After |
|--------|--------|
| <img width="712" alt="Screen Shot 2023-08-07 at 20 58 54" src="https://github.com/mui/material-ui/assets/67129314/8a00984d-9c5e-4362-82a3-327495c638d2"> | <img width="712" alt="Screen Shot 2023-08-07 at 20 58 39" src="https://github.com/mui/material-ui/assets/67129314/1e0d379b-5859-466f-b473-43518e6a1e9f"> | 




