### PR TITLE
[test] Remove unnecessary `async` keyword from test

### DIFF
--- a/packages/mui-base/src/Unstable_NumberInput/NumberInput.test.tsx
+++ b/packages/mui-base/src/Unstable_NumberInput/NumberInput.test.tsx
@@ -142,7 +142,7 @@ describe('<NumberInput />', () => {
       expect(input.value).to.equal('9');
     });
 
-    it('clicking the increment and decrement buttons changes the value based on shiftMultiplier if the Shift key is held', async () => {
+    it('clicking the increment and decrement buttons changes the value based on shiftMultiplier if the Shift key is held', () => {
       const handleChange = spy();
 
       const { getByTestId } = render(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
