### PR TITLE
[docs][material-ui] Adjust slightly the installation page content

### DIFF
--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -2,7 +2,7 @@
 
 <p class="description">Install Material UI, the world's most popular React UI framework.</p>
 
-:::warning
+:::success
 We are currently working on supporting React Server Components in Material UI.
 
 All components and hooks are exported as [Client Components](https://nextjs.org/docs/getting-started/react-essentials#client-components) with the `"use client"` directive.
@@ -51,9 +51,7 @@ pnpm add @mui/material @mui/styled-engine-sc styled-components
 
 </codeblock>
 
-:::warning
 Visit the [Styled engine guide](/material-ui/guides/styled-engine/) for more information about how to configure styled-components.
-:::
 
 ## Peer dependencies
 
@@ -70,9 +68,8 @@ Please note that [react](https://www.npmjs.com/package/react) and [react-dom](ht
 
 ## Roboto font
 
-Material UI is designed to use the [Roboto](https://fonts.google.com/specimen/Roboto)
-font by default.
-You may add it to your project with npm via [Fontsource](https://fontsource.org/), or with the Google Fonts CDN.
+Material UI uses the [Roboto](https://fonts.google.com/specimen/Roboto) font by default.
+Add it to your project via Fontsource, or with the Google Fonts CDN.
 
 <codeblock storageKey="package-manager">
 
@@ -105,7 +102,7 @@ Fontsource can be configured to load specific subsets, weights and styles. Mater
 
 ### Google Web Fonts
 
-To install the Roboto font in your project using the Google Web Fonts CDN, add the following code snippet inside your project's `<head />` tag:
+To install Roboto through the Google Web Fonts CDN, add the following code inside your project's <head /> tag:
 
 ```html
 <link


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Some small tweaks I thought of doing while quickly browsing the Material UI installation page:
- The callout about the `use client` directive seems more like a recommendation than a warning. Also, there's something psychological about going to the Installation page, and the very first thing you see is a "warning" message... not great, I think. Makes me feel cautious about going in to install this thing.
- Removed the warning callout from a piece of content that could just not be in a callout entirely (recommends going to another page for more details).
- Standardized the font installation copy to be consistent with the Joy UI one.