### PR TITLE
[Skeleton][joy-ui] Soften the pulse animation

### DIFF
--- a/packages/mui-joy/src/Skeleton/Skeleton.tsx
+++ b/packages/mui-joy/src/Skeleton/Skeleton.tsx
@@ -71,7 +71,7 @@ const SkeletonRoot = styled('span', {
     ownerState.variant !== 'inline' &&
     css`
       &::before {
-        animation: ${pulseKeyframe} 1.5s ease-in-out 0.5s infinite;
+        animation: ${pulseKeyframe} 2s ease-in-out 0.5s infinite;
         background: ${theme.vars.palette.background.level3};
       }
     `,
@@ -80,7 +80,7 @@ const SkeletonRoot = styled('span', {
     ownerState.variant === 'inline' &&
     css`
       &::after {
-        animation: ${pulseKeyframe} 1.5s ease-in-out 0.5s infinite;
+        animation: ${pulseKeyframe} 2s ease-in-out 0.5s infinite;
         background: ${theme.vars.palette.background.level3};
       }
     `,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Increased the pulse animation time from 1.5s to 2.0s to make it softer and more pleasant when used in many places at the same time.

https://deploy-preview-38384--material-ui.netlify.app/joy-ui/react-skeleton/
https://mui.com/joy-ui/react-skeleton/