### PR TITLE
[docs][material-ui][joy-ui] Simplify the Quickstart section on the Usage page

### DIFF
--- a/docs/data/joy/getting-started/usage/ButtonUsage.js
+++ b/docs/data/joy/getting-started/usage/ButtonUsage.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Button from '@mui/joy/Button';
+
+export default function ButtonUsage() {
+  return <Button variant="solid">Hello world</Button>;
+}

--- a/docs/data/joy/getting-started/usage/ButtonUsage.tsx
+++ b/docs/data/joy/getting-started/usage/ButtonUsage.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Button from '@mui/joy/Button';
+
+export default function ButtonUsage() {
+  return <Button variant="solid">Hello world</Button>;
+}

--- a/docs/data/joy/getting-started/usage/ButtonUsage.tsx.preview
+++ b/docs/data/joy/getting-started/usage/ButtonUsage.tsx.preview
@@ -1,0 +1,1 @@
+<Button variant="solid">Hello world</Button>

--- a/docs/data/joy/getting-started/usage/usage.md
+++ b/docs/data/joy/getting-started/usage/usage.md
@@ -4,21 +4,10 @@
 
 ## Quickstart
 
-The following code snippet demonstrates a simple app that uses the Joy UI [Button](/joy-ui/react-button/) component:
+After [installation](/joy-ui/getting-started/installation/), import any Joy UI component and start playing around with them.
+For example, try changing the `variant` on the [Button](/joy-ui/react-button/) to `soft` to see how the style changes:
 
-```jsx
-import * as React from 'react';
-import Button from '@mui/joy/Button';
-
-export default function MyApp() {
-  return <Button variant="solid">Hello World</Button>;
-}
-```
-
-You can play around with this code in the interactive Code Sandbox demo below.
-Try changing the `variant` on the Button to `soft` to see how the style changes:
-
-{{"demo": "Usage.js", "hideToolbar": true, "bg": true}}
+{{"demo": "ButtonUsage.js"}}
 
 ### CssVarsProvider
 

--- a/docs/data/joy/getting-started/usage/usage.md
+++ b/docs/data/joy/getting-started/usage/usage.md
@@ -4,7 +4,7 @@
 
 ## Quickstart
 
-After [installation](/joy-ui/getting-started/installation/), import any Joy UI component and start playing around with them.
+After [installation](/joy-ui/getting-started/installation/), you can import any Joy UI component and start playing around.
 For example, try changing the `variant` on the [Button](/joy-ui/react-button/) to `soft` to see how the style changes:
 
 {{"demo": "ButtonUsage.js"}}

--- a/docs/data/material/getting-started/usage/ButtonUsage.js
+++ b/docs/data/material/getting-started/usage/ButtonUsage.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+
+export default function ButtonUsage() {
+  return <Button variant="contained">Hello world</Button>;
+}

--- a/docs/data/material/getting-started/usage/ButtonUsage.tsx
+++ b/docs/data/material/getting-started/usage/ButtonUsage.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+
+export default function ButtonUsage() {
+  return <Button variant="contained">Hello world</Button>;
+}

--- a/docs/data/material/getting-started/usage/ButtonUsage.tsx.preview
+++ b/docs/data/material/getting-started/usage/ButtonUsage.tsx.preview
@@ -1,0 +1,1 @@
+<Button variant="contained">Hello world</Button>

--- a/docs/data/material/getting-started/usage/usage.md
+++ b/docs/data/material/getting-started/usage/usage.md
@@ -4,25 +4,10 @@
 
 ## Quickstart
 
-The following code snippet demonstrates a simple app that uses the Material UI [Button](/material-ui/react-button/) component:
+After [installation](/material-ui/getting-started/installation/), import any Material UI component and start playing around with them.
+For example, try changing the `variant` on the [Button](/material-ui/react-button/) to `outlined` to see how the style changes:
 
-```jsx
-import * as React from 'react';
-import Button from '@mui/material/Button';
-
-export default function MyApp() {
-  return (
-    <div>
-      <Button variant="contained">Hello World</Button>
-    </div>
-  );
-}
-```
-
-You can play around with this code in the interactive Code Sandbox demo below.
-Try changing the `variant` on the Button to `outlined` to see how the style changes:
-
-{{"demo": "Usage.js", "hideToolbar": true, "bg": true}}
+{{"demo": "ButtonUsage.js"}}
 
 ## Globals
 

--- a/docs/data/material/getting-started/usage/usage.md
+++ b/docs/data/material/getting-started/usage/usage.md
@@ -4,7 +4,7 @@
 
 ## Quickstart
 
-After [installation](/material-ui/getting-started/installation/), import any Material UI component and start playing around with them.
+After [installation](/material-ui/getting-started/installation/), you can import any Material UI component and start playing around.
 For example, try changing the `variant` on the [Button](/material-ui/react-button/) to `outlined` to see how the style changes:
 
 {{"demo": "ButtonUsage.js"}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

From the series of "just browsing around looking for improvement opportunities", I realized we could be simpler and more polished on the Quickstart section of the Usage page now that the documentation code snippets are editable. Given that wasn't the case previously, we have a Code Sandbox iframe which always looks a bit clunky with their UI. Figured it'd be much cleaner with a built-in demo. Also, took the liberty to simplify the copy a lot, too!

- **https://deploy-preview-38385--material-ui.netlify.app/material-ui/getting-started/usage/**
- **https://deploy-preview-38385--material-ui.netlify.app/joy-ui/getting-started/usage/**