### PR TITLE
[Input][joy-ui] Fix the `FormHelperText` icon color

### DIFF
--- a/docs/data/joy/components/input/InputFormProps.js
+++ b/docs/data/joy/components/input/InputFormProps.js
@@ -1,33 +1,20 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
 
 export default function InputFormProps() {
   return (
-    <Box
-      sx={{
-        py: 2,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        alignItems: 'center',
-        flexWrap: 'wrap',
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
       }}
     >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-        }}
-      >
-        <Input
-          placeholder="Try to submit with no text!"
-          required
-          sx={{ mb: 1, fontSize: 'var(--joy-fontSize-sm)' }}
-        />
-        <Input placeholder="It is disabled" disabled sx={{ mb: 1 }} />
+      <Stack spacing={1}>
+        <Input placeholder="Try to submit with no text!" required />
+        <Input placeholder="It is disabled" disabled />
         <Button type="submit">Submit</Button>
-      </form>
-    </Box>
+      </Stack>
+    </form>
   );
 }

--- a/docs/data/joy/components/input/InputFormProps.tsx
+++ b/docs/data/joy/components/input/InputFormProps.tsx
@@ -1,33 +1,20 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Input from '@mui/joy/Input';
+import Stack from '@mui/joy/Stack';
 
 export default function InputFormProps() {
   return (
-    <Box
-      sx={{
-        py: 2,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        alignItems: 'center',
-        flexWrap: 'wrap',
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
       }}
     >
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-        }}
-      >
-        <Input
-          placeholder="Try to submit with no text!"
-          required
-          sx={{ mb: 1, fontSize: 'var(--joy-fontSize-sm)' }}
-        />
-        <Input placeholder="It is disabled" disabled sx={{ mb: 1 }} />
+      <Stack spacing={1}>
+        <Input placeholder="Try to submit with no text!" required />
+        <Input placeholder="It is disabled" disabled />
         <Button type="submit">Submit</Button>
-      </form>
-    </Box>
+      </Stack>
+    </form>
   );
 }

--- a/docs/data/joy/components/input/InputFormProps.tsx.preview
+++ b/docs/data/joy/components/input/InputFormProps.tsx.preview
@@ -3,11 +3,9 @@
     event.preventDefault();
   }}
 >
-  <Input
-    placeholder="Try to submit with no text!"
-    required
-    sx={{ mb: 1, fontSize: 'var(--joy-fontSize-sm)' }}
-  />
-  <Input placeholder="It is disabled" disabled sx={{ mb: 1 }} />
-  <Button type="submit">Submit</Button>
+  <Stack spacing={1}>
+    <Input placeholder="Try to submit with no text!" required />
+    <Input placeholder="It is disabled" disabled />
+    <Button type="submit">Submit</Button>
+  </Stack>
 </form>

--- a/docs/data/joy/components/input/InputValidation.js
+++ b/docs/data/joy/components/input/InputValidation.js
@@ -1,11 +1,27 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
 import Input from '@mui/joy/Input';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import FormHelperText from '@mui/joy/FormHelperText';
+import Stack from '@mui/joy/Stack';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 
 export default function InputValidation() {
   return (
-    <Box sx={{ p: 2 }}>
+    <Stack spacing={2}>
       <Input placeholder="Type in here…" error defaultValue="Oh no, error found!" />
-    </Box>
+      <FormControl error>
+        <FormLabel>Label</FormLabel>
+        <Input
+          placeholder="Type in here…"
+          error
+          defaultValue="Oh no, error found!"
+        />
+        <FormHelperText>
+          <InfoOutlined />
+          Opps! something is wrong.
+        </FormHelperText>
+      </FormControl>
+    </Stack>
   );
 }

--- a/docs/data/joy/components/input/InputValidation.tsx
+++ b/docs/data/joy/components/input/InputValidation.tsx
@@ -1,11 +1,27 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
 import Input from '@mui/joy/Input';
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import FormHelperText from '@mui/joy/FormHelperText';
+import Stack from '@mui/joy/Stack';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
 
 export default function InputValidation() {
   return (
-    <Box sx={{ p: 2 }}>
+    <Stack spacing={2}>
       <Input placeholder="Type in here…" error defaultValue="Oh no, error found!" />
-    </Box>
+      <FormControl error>
+        <FormLabel>Label</FormLabel>
+        <Input
+          placeholder="Type in here…"
+          error
+          defaultValue="Oh no, error found!"
+        />
+        <FormHelperText>
+          <InfoOutlined />
+          Opps! something is wrong.
+        </FormHelperText>
+      </FormControl>
+    </Stack>
   );
 }

--- a/docs/data/joy/components/input/InputValidation.tsx.preview
+++ b/docs/data/joy/components/input/InputValidation.tsx.preview
@@ -1,1 +1,13 @@
 <Input placeholder="Type in here…" error defaultValue="Oh no, error found!" />
+<FormControl error>
+  <FormLabel>Label</FormLabel>
+  <Input
+    placeholder="Type in here…"
+    error
+    defaultValue="Oh no, error found!"
+  />
+  <FormHelperText>
+    <InfoOutlined />
+    Opps! something is wrong.
+  </FormHelperText>
+</FormControl>

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -98,9 +98,15 @@ To trigger the focus ring programmatically, set the CSS variable `--Input-focuse
 💡 The focus ring still appear on focus even though you set `--Input-focused: 0`.
 :::
 
+### Label and helper text
+
+Group Input with the Form label and Form helper text in a Form control component to create a text field.
+
+{{"demo": "InputField.js"}}
+
 ### Validation
 
-Use the `error` prop to toggle the error state:
+Use the `error` prop on Input or Form Control to toggle the error state:
 
 {{"demo": "InputValidation.js"}}
 

--- a/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
+++ b/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
@@ -38,7 +38,7 @@ const FormHelperTextRoot = styled('div', {
     '--FormHelperText-margin': '0px', // remove the margin if the helper text is next to the form label.
   },
   [`.${formControlClasses.error} &`]: {
-       '--Icon-color': 'currentColor',
+    '--Icon-color': 'currentColor',
   },
 }));
 /**

--- a/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
+++ b/packages/mui-joy/src/FormHelperText/FormHelperText.tsx
@@ -8,6 +8,7 @@ import { styled, useThemeProps } from '../styles';
 import { FormHelperTextProps, FormHelperTextTypeMap } from './FormHelperTextProps';
 import { getFormHelperTextUtilityClass } from './formHelperTextClasses';
 import FormControlContext from '../FormControl/FormControlContext';
+import formControlClasses from '../FormControl/formControlClasses';
 import formLabelClasses from '../FormLabel/formLabelClasses';
 import useSlot from '../utils/useSlot';
 
@@ -24,8 +25,10 @@ const FormHelperTextRoot = styled('div', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: FormHelperTextProps }>(({ theme }) => ({
+  '--Icon-fontSize': 'calc(var(--FormHelperText-lineHeight) * 1em)',
   display: 'flex',
   alignItems: 'center',
+  gap: '2px',
   fontFamily: theme.vars.fontFamily.body,
   fontSize: `var(--FormHelperText-fontSize, ${theme.vars.fontSize.sm})`,
   lineHeight: `var(--FormHelperText-lineHeight, ${theme.vars.lineHeight.sm})`,
@@ -33,6 +36,9 @@ const FormHelperTextRoot = styled('div', {
   margin: 'var(--FormHelperText-margin, 0px)',
   [`.${formLabelClasses.root} + &`]: {
     '--FormHelperText-margin': '0px', // remove the margin if the helper text is next to the form label.
+  },
+  [`.${formControlClasses.error} &`]: {
+       '--Icon-color': 'currentColor',
   },
 }));
 /**

--- a/packages/mui-joy/src/FormLabel/FormLabel.tsx
+++ b/packages/mui-joy/src/FormLabel/FormLabel.tsx
@@ -23,9 +23,11 @@ const FormLabelRoot = styled('label', {
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: FormLabelProps }>(({ theme }) => ({
+  '--Icon-fontSize': 'calc(var(--FormLabel-lineHeight) * 1em)',
   WebkitTapHighlightColor: 'transparent',
   alignSelf: 'var(--FormLabel-alignSelf)', // to not fill the block space. It seems like a bug when clicking on empty space (within the label area), even though it is not.
   display: 'flex',
+  gap: '2px',
   alignItems: 'center',
   flexWrap: 'wrap',
   userSelect: 'none',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixed issue: #38353
just fixed icons inside the FormHelperText now these icons would inherit the danger color [Issue](https://github.com/mui/material-ui/issues/38353#issuecomment-1668920751).
