### PR TITLE
[docs-infra] Retain side nav animation speed

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import NextLink from 'next/link';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
-import { styled } from '@mui/material/styles';
+import { styled, ThemeProvider } from '@mui/material/styles';
 import List from '@mui/material/List';
 import Drawer from '@mui/material/Drawer';
 import Menu from '@mui/material/Menu';
@@ -293,6 +293,26 @@ function reduceChildRoutes(context) {
   return items;
 }
 
+// TODO: Collapse should expose an API to customize the duration based on the height.
+function transitionTheme(theme) {
+  return {
+    ...theme,
+    transitions: {
+      ...theme.transitions,
+      getAutoHeightDuration: (height) => {
+        if (!height) {
+          return 0;
+        }
+
+        const constant = height / 50;
+
+        // https://www.wolframalpha.com/input/?i=(4+%2B+15+*+(x+%2F+36+)+**+0.25+%2B+(x+%2F+36)+%2F+5)+*+10
+        return Math.round((4 + 15 * constant ** 0.25 + constant / 5) * 10);
+      },
+    },
+  };
+}
+
 // iOS is hosted on high-end devices. We can enable the backdrop transition without
 // dropping frames. The performance will be good enough.
 // So: <SwipeableDrawer disableBackdropTransition={false} />
@@ -430,41 +450,43 @@ export default function AppNavDrawer(props) {
   }
 
   return (
-    <nav className={className} aria-label={t('mainNavigation')}>
-      {disablePermanent || mobile ? (
-        <SwipeableDrawer
-          disableBackdropTransition={!iOS}
-          variant="temporary"
-          open={mobileOpen}
-          onOpen={onOpen}
-          onClose={onClose}
-          ModalProps={{
-            keepMounted: true,
-          }}
-          PaperProps={{
-            className: 'algolia-drawer',
-            component: AppNavPaperComponent,
-          }}
-        >
-          <PersistScroll slot="swipeable" enabled={mobileOpen}>
-            {drawer}
-          </PersistScroll>
-        </SwipeableDrawer>
-      ) : null}
-      {disablePermanent || mobile ? null : (
-        <StyledDrawer
-          variant="permanent"
-          PaperProps={{
-            component: AppNavPaperComponent,
-          }}
-          open
-        >
-          <PersistScroll slot="side" enabled>
-            {drawer}
-          </PersistScroll>
-        </StyledDrawer>
-      )}
-    </nav>
+    <ThemeProvider theme={transitionTheme}>
+      <nav className={className} aria-label={t('mainNavigation')}>
+        {disablePermanent || mobile ? (
+          <SwipeableDrawer
+            disableBackdropTransition={!iOS}
+            variant="temporary"
+            open={mobileOpen}
+            onOpen={onOpen}
+            onClose={onClose}
+            ModalProps={{
+              keepMounted: true,
+            }}
+            PaperProps={{
+              className: 'algolia-drawer',
+              component: AppNavPaperComponent,
+            }}
+          >
+            <PersistScroll slot="swipeable" enabled={mobileOpen}>
+              {drawer}
+            </PersistScroll>
+          </SwipeableDrawer>
+        ) : null}
+        {disablePermanent || mobile ? null : (
+          <StyledDrawer
+            variant="permanent"
+            PaperProps={{
+              component: AppNavPaperComponent,
+            }}
+            open
+          >
+            <PersistScroll slot="side" enabled>
+              {drawer}
+            </PersistScroll>
+          </StyledDrawer>
+        )}
+      </nav>
+    </ThemeProvider>
   );
 }
 

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -330,7 +330,7 @@ export default function AppNavDrawerItem(props) {
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
       </Item>
       {expandable ? (
-        <Collapse in={open} timeout={250} unmountOnExit>
+        <Collapse in={open} timeout="auto" unmountOnExit>
           {children}
         </Collapse>
       ) : (

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -330,7 +330,7 @@ export default function AppNavDrawerItem(props) {
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
       </Item>
       {expandable ? (
-        <Collapse in={open} timeout="auto" unmountOnExit>
+        <Collapse in={open} timeout={150} unmountOnExit>
           {children}
         </Collapse>
       ) : (


### PR DESCRIPTION
It's a continuation of #38259 retaining the general design direction of it, while also making it feel consistent between different side nav that have **different heights**. What do you think, better or worse?

Before 38259: https://64c9260dfe62470008859eb0--material-ui-docs.netlify.app/material-ui/getting-started/
38259: https://deploy-preview-38259--material-ui.netlify.app/material-ui/getting-started/
This PR: https://deploy-preview-38393--material-ui.netlify.app/material-ui/getting-started/

---

As a related topic, I think it connects back to point 1 in https://github.com/mui/material-ui/pull/38164#pullrequestreview-1549831929. 
