### PR TITLE
[docs] Improve page transition speed

### DIFF
--- a/docs/pages/joy-ui/react-button-group.js
+++ b/docs/pages/joy-ui/react-button-group.js
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button-group/button-group.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
+
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/joy-ui/react-button.js
+++ b/docs/pages/joy-ui/react-button.js
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button/button.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
+
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};


### PR DESCRIPTION
## The problem

Open https://mui.com/joy-ui/react-button/ and try to navigate to the Button Group page

<img width="1263" alt="Screenshot 2023-08-09 at 13 09 30" src="https://github.com/mui/material-ui/assets/3165635/87c0ff3d-c15d-4cda-bee2-76a3a0971d27">

560ms. Note that the Material UI Button -> ButtonGroup page transition also feels really bad, it's only 100-150ms faster: 430ms. According to https://web.dev/vitals/ great is at <100ms. I think where it's killing us comes next.

1. Google Search will use a new performance ranking metric, we don't do well: 

<img width="891" alt="Screenshot 2023-08-09 at 13 36 33" src="https://github.com/mui/material-ui/assets/3165635/22d20fee-33c3-467b-b962-493e7e4e1bfa">

https://search.google.com/search-console/core-web-vitals/summary?resource_id=sc-domain%3Amui.com&device=2#inp-table

2. Second, compare the experience to https://www.radix-ui.com/themes/docs/components/button to move to the Checkbox page:

<img width="1283" alt="Screenshot 2023-08-09 at 13 11 44" src="https://github.com/mui/material-ui/assets/3165635/4d0ec48b-ff3f-42a6-a781-1c3b458f518b">

It's x4 better. Same on https://ui.shadcn.com/docs/components/button, it's at about 130ms. So as a developer, my first impression is: **"No, I'm not using Material UI, it's not fast enough"**.

It is to be noted that it's a regression, something significant broke it: v5.0.6 feels so much better https://v5-0-6.mui.com/components/button-group/

<img width="251" alt="Screenshot 2023-08-09 at 13 31 51" src="https://github.com/mui/material-ui/assets/3165635/bd005598-687f-4f0d-bb08-5ecae0827242">

Two ideas of what might have broken it: maybe it's live demo related, maybe it's theme provider related.

## The patch

This PR is not a fix, we should find the root cause of the regression and fix it. I think it's one of the highest ROI tasks we have today. I was triggered by browsing https://www.radix-ui.com/themes/docs/overview/getting-started and feeling this big difference. That's why I'm allocating a bit of time to it to shape the problem and some leads of solution. This PR illustrate how a stable layout between page is beyond performance, and is also a nicer UX.

Preview: https://deploy-preview-38394--material-ui.netlify.app/joy-ui/react-button/

<img width="336" alt="Screenshot 2023-08-09 at 13 31 45" src="https://github.com/mui/material-ui/assets/3165635/bdab7354-f2c3-4b43-8ba6-19c480d3e63a">

We are doing about x2 better.

@alexfauquette From this exploration, I think https://www.notion.so/mui-org/Migrate-all-pages-to-Page-getLayout-212d920a9ab245f08ac3a2aea874f1bc is actually not really so much of the root problem, but more of a side win. I reorganized the Notion tasks to use parent & children tasks.