### PR TITLE
[useButton][base] Fix onFocusVisible not being handled

### DIFF
--- a/packages/mui-base/src/useButton/useButton.test.tsx
+++ b/packages/mui-base/src/useButton/useButton.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createRenderer, fireEvent } from 'test/utils';
+import { act, createRenderer, fireEvent } from 'test/utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { useButton } from '@mui/base/useButton';
@@ -168,6 +168,32 @@ describe('useButton', () => {
 
         expect(handleClickInternal.callCount).to.equal(1);
         expect(handleClickExternal.callCount).to.equal(0);
+      });
+
+      it('handles onFocusVisible and removes it from props', () => {
+        interface WithFocusVisibleHandler {
+          onFocusVisible: React.FocusEventHandler;
+        }
+
+        function TestComponent(props: WithFocusVisibleHandler) {
+          const ref = React.useRef(null);
+          const { getRootProps } = useButton({ ...props, rootRef: ref });
+
+          // @ts-expect-error onFocusVisible is removed from props
+          expect(getRootProps().onFocusVisible).to.equal(undefined);
+
+          return <button {...getRootProps()} />;
+        }
+
+        const handleFocusVisible = spy();
+
+        const { getByRole } = render(<TestComponent onFocusVisible={handleFocusVisible} />);
+
+        act(() => {
+          getByRole('button').focus();
+        });
+
+        expect(handleFocusVisible.callCount).to.equal(1);
       });
     });
   });

--- a/packages/mui-base/src/useButton/useButton.test.tsx
+++ b/packages/mui-base/src/useButton/useButton.test.tsx
@@ -170,7 +170,7 @@ describe('useButton', () => {
         expect(handleClickExternal.callCount).to.equal(0);
       });
 
-      it('handles onFocusVisible and removes it from props', () => {
+      it('handles onFocusVisible and does not include it in the root props', () => {
         interface WithFocusVisibleHandler {
           onFocusVisible: React.FocusEventHandler;
         }

--- a/packages/mui-base/src/useButton/useButton.ts
+++ b/packages/mui-base/src/useButton/useButton.ts
@@ -214,11 +214,7 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
       ...otherHandlers,
     };
 
-    // onFocusVisible can be present on the props, but since it's not a valid React event handler,
-    // it must not be forwarded to the inner component.
-    delete externalEventHandlers.onFocusVisible;
-
-    return {
+    const props = {
       type,
       ...externalEventHandlers,
       ...buttonProps,
@@ -231,6 +227,13 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
       onMouseLeave: createHandleMouseLeave(externalEventHandlers),
       ref: handleRef,
     };
+
+    // onFocusVisible can be present on the props or parameters,
+    // but it's not a valid React event handler so it must not be forwarded to the inner component.
+    // If present, it will be handled by the focus handler.
+    delete props.onFocusVisible;
+
+    return props;
   };
 
   return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `onFocusVisible` handler was being removed preemptively, causing it to always be undefined on the focus handler, so a provided handler would never be called: https://codesandbox.io/s/focus-visible-deleted-preemptively-h456fp?file=/Demo.tsx

The fix is to remove `onFocusVisible` after it has been passed to the focus handler, not before.