### PR TITLE
[material] Add missing classes for `Slider` `InputLabel` `InputBase` `Radio` 

### DIFF
--- a/docs/pages/material-ui/api/input-base.json
+++ b/docs/pages/material-ui/api/input-base.json
@@ -88,6 +88,7 @@
       "adornedEnd",
       "error",
       "sizeSmall",
+      "sizeMedium",
       "multiline",
       "colorSecondary",
       "fullWidth",

--- a/docs/pages/material-ui/api/input-label.json
+++ b/docs/pages/material-ui/api/input-label.json
@@ -51,6 +51,7 @@
       "asterisk",
       "formControl",
       "sizeSmall",
+      "sizeNormal",
       "shrink",
       "animated",
       "filled",

--- a/docs/pages/material-ui/api/radio.json
+++ b/docs/pages/material-ui/api/radio.json
@@ -44,7 +44,15 @@
   "name": "Radio",
   "imports": ["import Radio from '@mui/material/Radio';", "import { Radio } from '@mui/material';"],
   "styles": {
-    "classes": ["root", "checked", "disabled", "colorPrimary", "colorSecondary"],
+    "classes": [
+      "root",
+      "checked",
+      "disabled",
+      "colorPrimary",
+      "colorSecondary",
+      "sizeSmall",
+      "sizeMedium"
+    ],
     "globalClasses": { "checked": "Mui-checked", "disabled": "Mui-disabled" },
     "name": "MuiRadio"
   },

--- a/docs/pages/material-ui/api/slider.json
+++ b/docs/pages/material-ui/api/slider.json
@@ -149,6 +149,7 @@
       "markLabel",
       "markLabelActive",
       "sizeSmall",
+      "sizeMedium",
       "thumbColorPrimary",
       "thumbColorSecondary",
       "thumbSizeSmall",

--- a/docs/translations/api-docs/input-base/input-base.json
+++ b/docs/translations/api-docs/input-base/input-base.json
@@ -132,6 +132,11 @@
       "nodeName": "the input element",
       "conditions": "<code>size=\"small\"</code>"
     },
+    "sizeMedium": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the input element",
+      "conditions": "<code>size=\"medium\"</code>"
+    },
     "multiline": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/docs/translations/api-docs/input-label/input-label.json
+++ b/docs/translations/api-docs/input-label/input-label.json
@@ -63,6 +63,11 @@
       "nodeName": "the root element",
       "conditions": "<code>size=\"small\"</code>"
     },
+    "sizeNormal": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"normal\"</code>"
+    },
     "shrink": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the input element",

--- a/docs/translations/api-docs/radio/radio.json
+++ b/docs/translations/api-docs/radio/radio.json
@@ -54,6 +54,16 @@
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
       "conditions": "<code>color=\"secondary\"</code>"
+    },
+    "sizeSmall": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"small\"</code>"
+    },
+    "sizeMedium": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"medium\"</code>"
     }
   }
 }

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -163,6 +163,11 @@
       "nodeName": "the root element",
       "conditions": "<code>size=\"small\"</code>"
     },
+    "sizeMedium": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"medium\"</code>"
+    },
     "thumbColorPrimary": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the thumb element",

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -23,7 +23,7 @@ import inputBaseClasses, { getInputBaseUtilityClass } from './inputBaseClasses';
 
 export const rootOverridesResolver = (props, styles) => {
   const { ownerState } = props;
-  console.log(styles);
+
   return [
     styles.root,
     ownerState.formControl && styles.formControl,
@@ -41,7 +41,7 @@ export const rootOverridesResolver = (props, styles) => {
 export const inputOverridesResolver = (props, styles) => {
   const { ownerState } = props;
 
-  const a = [
+  return [
     styles.input,
     ownerState.size === 'small' && styles.inputSizeSmall,
     ownerState.multiline && styles.inputMultiline,
@@ -50,8 +50,6 @@ export const inputOverridesResolver = (props, styles) => {
     ownerState.endAdornment && styles.inputAdornedEnd,
     ownerState.hiddenLabel && styles.inputHiddenLabel,
   ];
-  console.log(styles);
-  return a;
 };
 
 const useUtilityClasses = (ownerState) => {

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -23,7 +23,7 @@ import inputBaseClasses, { getInputBaseUtilityClass } from './inputBaseClasses';
 
 export const rootOverridesResolver = (props, styles) => {
   const { ownerState } = props;
-
+  console.log(styles);
   return [
     styles.root,
     ownerState.formControl && styles.formControl,
@@ -41,7 +41,7 @@ export const rootOverridesResolver = (props, styles) => {
 export const inputOverridesResolver = (props, styles) => {
   const { ownerState } = props;
 
-  return [
+  const a = [
     styles.input,
     ownerState.size === 'small' && styles.inputSizeSmall,
     ownerState.multiline && styles.inputMultiline,
@@ -50,6 +50,8 @@ export const inputOverridesResolver = (props, styles) => {
     ownerState.endAdornment && styles.inputAdornedEnd,
     ownerState.hiddenLabel && styles.inputHiddenLabel,
   ];
+  console.log(styles);
+  return a;
 };
 
 const useUtilityClasses = (ownerState) => {
@@ -78,7 +80,7 @@ const useUtilityClasses = (ownerState) => {
       fullWidth && 'fullWidth',
       focused && 'focused',
       formControl && 'formControl',
-      size === 'small' && 'sizeSmall',
+      size && `size${capitalize(size)}`,
       multiline && 'multiline',
       startAdornment && 'adornedStart',
       endAdornment && 'adornedEnd',

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -131,6 +131,22 @@ describe('<InputBase />', () => {
     });
   });
 
+  describe('prop: size', () => {
+    it('add sizeSmall class to the root element when the size prop equals "small"', () => {
+      const { getByRole } = render(<InputBase size="small" />);
+      const input = getByRole('textbox');
+      const root = input.parentElement;
+      expect(root).to.have.class(classes.sizeSmall);
+    });
+
+    it('add sizeMedium class to the root element when the size prop equals "medium"', () => {
+      const { getByRole } = render(<InputBase size="medium" />);
+      const input = getByRole('textbox');
+      const root = input.parentElement;
+      expect(root).to.have.class(classes.sizeMedium);
+    });
+  });
+
   describe('prop: readonly', () => {
     it('should render a readonly <input />', () => {
       const { getByRole } = render(<InputBase readOnly />);

--- a/packages/mui-material/src/InputBase/inputBaseClasses.ts
+++ b/packages/mui-material/src/InputBase/inputBaseClasses.ts
@@ -18,6 +18,8 @@ export interface InputBaseClasses {
   error: string;
   /** Styles applied to the input element if `size="small"`. */
   sizeSmall: string;
+  /** Styles applied to the input element if `size="medium"`. */
+  sizeMedium: string;
   /** Styles applied to the root element if `multiline={true}`. */
   multiline: string;
   /** Styles applied to the root element if the color is secondary. */
@@ -59,6 +61,7 @@ const inputBaseClasses: InputBaseClasses = generateUtilityClasses('MuiInputBase'
   'adornedEnd',
   'error',
   'sizeSmall',
+  'sizeMedium',
   'multiline',
   'colorSecondary',
   'fullWidth',

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -7,6 +7,7 @@ import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import FormLabel, { formLabelClasses } from '../FormLabel';
 import useThemeProps from '../styles/useThemeProps';
+import capitalize from '../utils/capitalize';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 import { getInputLabelUtilityClasses } from './inputLabelClasses';
 
@@ -18,7 +19,7 @@ const useUtilityClasses = (ownerState) => {
       formControl && 'formControl',
       !disableAnimation && 'animated',
       shrink && 'shrink',
-      size === 'small' && 'sizeSmall',
+      size && `size${capitalize(size)}`,
       variant,
     ],
     asterisk: [required && 'asterisk'],

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -121,6 +121,20 @@ describe('<InputLabel />', () => {
     });
   });
 
+  describe('prop: size', () => {
+    it('add sizeSmall class to the root element when the size prop equals "small"', () => {
+      const { getByTestId } = render(<InputLabel data-testid="root" size="small" />);
+      const input = getByTestId('root');
+      expect(input).to.have.class(classes.sizeSmall);
+    });
+
+    it('add sizeNormal class to the root element when the size prop equals "medium"', () => {
+      const { getByTestId } = render(<InputLabel data-testid="root" size="normal" />);
+      const input = getByTestId('root');
+      expect(input).to.have.class(classes.sizeNormal);
+    });
+  });
+
   describe('Emotion compatibility', () => {
     it('classes.root should overwrite built-in styles.', () => {
       const text = 'The label';

--- a/packages/mui-material/src/InputLabel/inputLabelClasses.ts
+++ b/packages/mui-material/src/InputLabel/inputLabelClasses.ts
@@ -18,6 +18,8 @@ export interface InputLabelClasses {
   formControl: string;
   /** Styles applied to the root element if `size="small"`. */
   sizeSmall: string;
+  /** Styles applied to the root element if `size="normal"`. */
+  sizeNormal: string;
   /** Styles applied to the input element if `shrink={true}`. */
   shrink: string;
   /** Styles applied to the input element unless `disableAnimation={true}`. */
@@ -45,6 +47,7 @@ const inputLabelClasses: InputLabelClasses = generateUtilityClasses('MuiInputLab
   'asterisk',
   'formControl',
   'sizeSmall',
+  'sizeNormal',
   'shrink',
   'animated',
   'standard',

--- a/packages/mui-material/src/Radio/Radio.js
+++ b/packages/mui-material/src/Radio/Radio.js
@@ -15,10 +15,10 @@ import radioClasses, { getRadioUtilityClass } from './radioClasses';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, color } = ownerState;
+  const { classes, color, size } = ownerState;
 
   const slots = {
-    root: ['root', `color${capitalize(color)}`],
+    root: ['root', `color${capitalize(color)}`, `size${capitalize(size)}`],
   };
 
   return {

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -40,6 +40,29 @@ describe('<Radio />', () => {
     });
   });
 
+  describe('prop: size', () => {
+    it('add sizeSmall class to the root element when the size prop equals "small"', () => {
+      const { getByRole } = render(<Radio size="small" />);
+      const radio = getByRole('radio');
+      const root = radio.parentElement;
+      expect(root).to.have.class(classes.sizeSmall);
+    });
+
+    it('add sizeMedium class to the root element when the size prop equals "medium"', () => {
+      const { getByRole } = render(<Radio size="medium" />);
+      const radio = getByRole('radio');
+      const root = radio.parentElement;
+      expect(root).to.have.class(classes.sizeMedium);
+    });
+
+    it('add sizeMedium class to the root element when the size is not explicitly provided', () => {
+      const { getByRole } = render(<Radio />);
+      const radio = getByRole('radio');
+      const root = radio.parentElement;
+      expect(root).to.have.class(classes.sizeMedium);
+    });
+  });
+
   describe('with FormControl', () => {
     describe('enabled', () => {
       it('should not have the disabled class', () => {

--- a/packages/mui-material/src/Radio/radioClasses.ts
+++ b/packages/mui-material/src/Radio/radioClasses.ts
@@ -12,6 +12,10 @@ export interface RadioClasses {
   colorPrimary: string;
   /** Styles applied to the root element if `color="secondary"`. */
   colorSecondary: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the root element if `size="medium"`. */
+  sizeMedium: string;
 }
 
 export type RadioClassKey = keyof RadioClasses;
@@ -26,6 +30,8 @@ const radioClasses: RadioClasses = generateUtilityClasses('MuiRadio', [
   'disabled',
   'colorPrimary',
   'colorSecondary',
+  'sizeSmall',
+  'sizeMedium',
 ]);
 
 export default radioClasses;

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -1354,6 +1354,25 @@ describe('<Slider />', () => {
       expect(root).to.have.class(classes.sizeSmall);
       expect(thumb).to.have.class(classes.thumbSizeSmall);
     });
+
+    it('add sizeSmall class to the root element when the size prop equals "small"', () => {
+      render(<Slider size="small" />);
+
+      const root = document.querySelector(`.${classes.root}`);
+      expect(root).to.have.class(classes.sizeSmall);
+    });
+
+    it('add sizeMedium class to the root element when the size prop equals "medium"', () => {
+      render(<Slider size="medium" />);
+      const root = document.querySelector(`.${classes.root}`);
+      expect(root).to.have.class(classes.sizeMedium);
+    });
+
+    it('add sizeMedium class to the root element when the size is not explicitly provided', () => {
+      render(<Slider />);
+      const root = document.querySelector(`.${classes.root}`);
+      expect(root).to.have.class(classes.sizeMedium);
+    });
   });
 
   describe('prop: components', () => {

--- a/packages/mui-material/src/Slider/sliderClasses.ts
+++ b/packages/mui-material/src/Slider/sliderClasses.ts
@@ -40,6 +40,8 @@ export interface SliderClasses {
   markLabelActive: string;
   /** Styles applied to the root element if `size="small"`. */
   sizeSmall: string;
+  /** Styles applied to the root element if `size="medium"`. */
+  sizeMedium: string;
   /** Styles applied to the thumb element if `color="primary"`. */
   thumbColorPrimary: string;
   /** Styles applied to the thumb element if `color="secondary"`. */
@@ -77,6 +79,7 @@ const sliderClasses: SliderClasses = generateUtilityClasses('MuiSlider', [
   'markLabelActive',
   'rail',
   'sizeSmall',
+  'sizeMedium',
   'thumb',
   'thumbColorPrimary',
   'thumbColorSecondary',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
