### PR TITLE
[ButtonGroup] Mixing anchor and button elements within the ButtonGroup the styling is incorrect

### DIFF
--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.js
@@ -81,7 +81,7 @@ const ButtonGroupRoot = styled('div', {
   }),
   [`& .${buttonGroupClasses.grouped}`]: {
     minWidth: 40,
-    '&:not(:first-of-type)': {
+    '&:not(:nth-child(1))': {
       ...(ownerState.orientation === 'horizontal' && {
         borderTopLeftRadius: 0,
         borderBottomLeftRadius: 0,
@@ -99,7 +99,7 @@ const ButtonGroupRoot = styled('div', {
           marginTop: -1,
         }),
     },
-    '&:not(:last-of-type)': {
+    '&:not(:nth-last-child(1))': {
       ...(ownerState.orientation === 'horizontal' && {
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,


### PR DESCRIPTION
Update selector to use `nth-child(1)` and `nth-last-child(1)` apply to all subelements not just onese of the same type

<img width="385" alt="Screen Shot 2023-08-10 at 10 37 08 am" src="https://github.com/mui/material-ui/assets/924528/bc39a77a-d6e6-4962-aec8-31205093af82">

https://codesandbox.io/s/jovial-sid-dcyl3p?file=/Demo.tsx

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
