### PR TITLE
[useButton][base] Fix tabIndex not being forwarded

### DIFF
--- a/packages/mui-base/src/useButton/useButton.test.tsx
+++ b/packages/mui-base/src/useButton/useButton.test.tsx
@@ -197,4 +197,46 @@ describe('useButton', () => {
       });
     });
   });
+
+  describe('tabIndex', () => {
+    it('does not return tabIndex in getRootProps when host component is BUTTON', () => {
+      function TestComponent() {
+        const ref = React.useRef(null);
+        const { getRootProps } = useButton({ rootRef: ref });
+
+        expect(getRootProps().tabIndex).to.equal(undefined);
+
+        return <button {...getRootProps()} />;
+      }
+
+      const { getByRole } = render(<TestComponent />);
+      expect(getByRole('button')).to.have.property('tabIndex', 0);
+    });
+
+    it('returns tabIndex in getRootProps when host component is not BUTTON', () => {
+      function TestComponent() {
+        const ref = React.useRef(null);
+        const { getRootProps } = useButton({ rootRef: ref });
+
+        expect(getRootProps().tabIndex).to.equal(ref.current ? 0 : undefined);
+
+        return <span {...getRootProps()} />;
+      }
+
+      const { getByRole } = render(<TestComponent />);
+      expect(getByRole('button')).to.have.property('tabIndex', 0);
+    });
+
+    it('returns provided tabIndex', () => {
+      const customTabIndex = 3;
+      function TestComponent() {
+        const ref = React.useRef(null);
+        const { getRootProps } = useButton({ rootRef: ref, tabIndex: customTabIndex });
+        return <button {...getRootProps()} />;
+      }
+
+      const { getByRole } = render(<TestComponent />);
+      expect(getByRole('button')).to.have.property('tabIndex', customTabIndex);
+    });
+  });
 });

--- a/packages/mui-base/src/useButton/useButton.test.tsx
+++ b/packages/mui-base/src/useButton/useButton.test.tsx
@@ -227,7 +227,7 @@ describe('useButton', () => {
       expect(getByRole('button')).to.have.property('tabIndex', 0);
     });
 
-    it('returns provided tabIndex', () => {
+    it('returns tabIndex in getRootProps if it is explicitly provided', () => {
       const customTabIndex = 3;
       function TestComponent() {
         const ref = React.useRef(null);

--- a/packages/mui-base/src/useButton/useButton.ts
+++ b/packages/mui-base/src/useButton/useButton.ts
@@ -185,9 +185,11 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
     tabIndex?: number;
   }
 
-  const buttonProps: AdditionalButtonProps = {
-    tabIndex,
-  };
+  const buttonProps: AdditionalButtonProps = {};
+
+  if (tabIndex !== undefined) {
+    buttonProps.tabIndex = tabIndex;
+  }
 
   if (hostElementName === 'BUTTON') {
     buttonProps.type = type ?? 'button';

--- a/packages/mui-base/src/useButton/useButton.ts
+++ b/packages/mui-base/src/useButton/useButton.ts
@@ -185,7 +185,9 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
     tabIndex?: number;
   }
 
-  const buttonProps: AdditionalButtonProps = {};
+  const buttonProps: AdditionalButtonProps = {
+    tabIndex,
+  };
 
   if (hostElementName === 'BUTTON') {
     buttonProps.type = type ?? 'button';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #38368

The `tabIndex` value was only taken into consideration for certain cases, so its value would be lost when not taken into consideration: https://codesandbox.io/s/usebutton-tabindex-lost-sd37h8?file=/Demo.tsx

This fix adds the `tabIndex` value to the `getRootProps` return value initialization. This way, if explicitly provided, then it will be included in `getRootProps` return value. The previous behavior is maintained as the `tabIndex` is only added as a starting point.
