### PR TITLE
[joy-ui][PoC] Make Joy UI components denser 

### DIFF
--- a/docs/data/joy/components/autocomplete/Sizes.tsx
+++ b/docs/data/joy/components/autocomplete/Sizes.tsx
@@ -8,7 +8,7 @@ export default function Sizes() {
       <Autocomplete
         multiple
         size="sm"
-        placeholder='size="sm"'
+        placeholder='size="sm"(the default)'
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}
@@ -16,7 +16,7 @@ export default function Sizes() {
       <Autocomplete
         multiple
         size="md"
-        placeholder='size="md" (default)'
+        placeholder='size="md"'
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13]]}

--- a/docs/data/joy/components/autocomplete/autocomplete.md
+++ b/docs/data/joy/components/autocomplete/autocomplete.md
@@ -204,7 +204,7 @@ You can use the `limitTags` prop to limit the number of displayed options when n
 
 ### Sizes
 
-The autocomplete component comes with three sizes out of the box: `sm`, `md` (the default), and `lg`. The size is propagated to internal components, including `Input`, `Chip`, and `List`.
+The autocomplete component comes with three sizes out of the box: `sm` (the default), `md`, and `lg`. The size is propagated to internal components, including `Input`, `Chip`, and `List`.
 
 {{"demo": "Sizes.js"}}
 

--- a/docs/data/joy/components/avatar/AvatarUsage.js
+++ b/docs/data/joy/components/avatar/AvatarUsage.js
@@ -23,7 +23,7 @@ export default function AvatarUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
       ]}
       renderDemo={(props) => (

--- a/docs/data/joy/components/avatar/avatar.md
+++ b/docs/data/joy/components/avatar/avatar.md
@@ -67,7 +67,7 @@ Note that you lose the global variants when you add custom variants.
 
 ### Sizes
 
-The Avatar component comes in three sizes: `sm`, `md` (default), and `lg`:
+The Avatar component comes in three sizes: `sm` (default), `md`, and `lg`:
 
 {{"demo": "AvatarSizes.js"}}
 

--- a/docs/data/joy/components/button-group/ButtonGroupUsage.js
+++ b/docs/data/joy/components/button-group/ButtonGroupUsage.js
@@ -29,7 +29,7 @@ export default function ButtonGroupUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'orientation',

--- a/docs/data/joy/components/button/ButtonColors.tsx
+++ b/docs/data/joy/components/button/ButtonColors.tsx
@@ -24,19 +24,19 @@ export default function ButtonColors() {
           gap: 1,
         }}
       >
-        <Button size="md" variant={variant} color="primary">
+        <Button variant={variant} color="primary">
           Primary
         </Button>
-        <Button size="md" variant={variant} color="neutral">
+        <Button variant={variant} color="neutral">
           Neutral
         </Button>
-        <Button size="md" variant={variant} color="danger">
+        <Button variant={variant} color="danger">
           Danger
         </Button>
-        <Button size="md" variant={variant} color="success">
+        <Button variant={variant} color="success">
           Success
         </Button>
-        <Button size="md" variant={variant} color="warning">
+        <Button variant={variant} color="warning">
           Warning
         </Button>
       </Box>

--- a/docs/data/joy/components/button/ButtonUsage.js
+++ b/docs/data/joy/components/button/ButtonUsage.js
@@ -25,7 +25,7 @@ export default function ButtonUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'disabled',

--- a/docs/data/joy/components/chip/ChipUsage.js
+++ b/docs/data/joy/components/chip/ChipUsage.js
@@ -22,7 +22,7 @@ export default function ChipUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'disabled',

--- a/docs/data/joy/components/input/InputDecorators.tsx
+++ b/docs/data/joy/components/input/InputDecorators.tsx
@@ -22,7 +22,7 @@ export default function InputDecorators() {
                 variant: 'outlined',
               },
             }}
-            sx={{ mr: -1.5, '&:hover': { bgcolor: 'transparent' } }}
+            sx={{ mr: -1, '&:hover': { bgcolor: 'transparent' } }}
           >
             <Option value="dollar">US dollar</Option>
             <Option value="baht">Thai baht</Option>

--- a/docs/data/joy/components/input/InputSlotProps.tsx
+++ b/docs/data/joy/components/input/InputSlotProps.tsx
@@ -5,7 +5,7 @@ import Stack from '@mui/joy/Stack';
 export default function InputSlotProps() {
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   return (
-    <Stack spacing={1.5} sx={{ minWidth: 300 }}>
+    <Stack spacing={1.5} sx={{ minWidth: 256 }}>
       <Input
         type="number"
         defaultValue={2.5}

--- a/docs/data/joy/components/input/InputUsage.js
+++ b/docs/data/joy/components/input/InputUsage.js
@@ -22,7 +22,7 @@ export default function InputUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'placeholder',

--- a/docs/data/joy/components/select/SelectUsage.js
+++ b/docs/data/joy/components/select/SelectUsage.js
@@ -25,7 +25,7 @@ export default function SelectUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'placeholder',

--- a/docs/data/joy/components/switch/SwitchUsage.js
+++ b/docs/data/joy/components/switch/SwitchUsage.js
@@ -24,7 +24,7 @@ export default function SwitchUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         { propName: 'disabled', knob: 'switch' },
       ]}

--- a/docs/data/joy/components/textarea/TextareaUsage.js
+++ b/docs/data/joy/components/textarea/TextareaUsage.js
@@ -22,7 +22,7 @@ export default function TextareaUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'placeholder',

--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -38,7 +38,7 @@ The textarea component supports the four global variants: solid (default), soft,
 
 ### Sizes
 
-The textarea component comes with three sizes out of the box: `sm`, `md` (the default), and `lg`.
+The textarea component comes with three sizes out of the box: `sm` (the default), `md`, and `lg`.
 
 {{"demo": "TextareaSizes.js"}}
 

--- a/docs/data/joy/components/toggle-button-group/ToggleGroupUsage.js
+++ b/docs/data/joy/components/toggle-button-group/ToggleGroupUsage.js
@@ -29,7 +29,7 @@ export default function ToggleGroupUsage() {
           propName: 'size',
           knob: 'radio',
           options: ['sm', 'md', 'lg'],
-          defaultValue: 'md',
+          defaultValue: 'sm',
         },
         {
           propName: 'children',

--- a/docs/data/joy/components/toggle-button-group/toggle-button-group.md
+++ b/docs/data/joy/components/toggle-button-group/toggle-button-group.md
@@ -54,7 +54,7 @@ Note that you lose the global variants when you add custom variants.
 
 ### Sizes
 
-The Toggle Button Group component comes in three sizes: `sm`, `md` (default), and `lg`.
+The Toggle Button Group component comes in three sizes: `sm` (default), `md`, and `lg`.
 
 {{"demo": "ToggleGroupSizes.js"}}
 

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -342,7 +342,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(
     required,
     type,
     startDecorator,
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     color: colorProp = 'neutral',
     variant = 'outlined',
     value: valueProp,
@@ -1063,7 +1063,7 @@ Autocomplete.propTypes /* remove-proptypes */ = {
   required: PropTypes.bool,
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts
+++ b/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts
@@ -331,7 +331,7 @@ type AutocompleteOwnProps<
     required?: boolean;
     /**
      * The size of the component.
-     * @default 'md'
+     * @default 'sm'
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', AutocompletePropsSizeOverrides>;
     /**

--- a/packages/mui-joy/src/AutocompleteListbox/AutocompleteListbox.tsx
+++ b/packages/mui-joy/src/AutocompleteListbox/AutocompleteListbox.tsx
@@ -109,7 +109,7 @@ const AutocompleteListbox = React.forwardRef(function AutocompleteListbox(inProp
     component,
     color: colorProp = 'neutral',
     variant = 'outlined',
-    size = 'md',
+    size = 'sm',
     slots = {},
     slotProps = {},
     ...otherProps
@@ -178,7 +178,7 @@ AutocompleteListbox.propTypes /* remove-proptypes */ = {
   component: PropTypes.elementType,
   /**
    * The size of the component (affect other nested list* components).
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   /**

--- a/packages/mui-joy/src/AutocompleteListbox/AutocompleteListboxProps.ts
+++ b/packages/mui-joy/src/AutocompleteListbox/AutocompleteListboxProps.ts
@@ -38,7 +38,7 @@ export interface AutocompleteListboxTypeMap<P = {}, D extends React.ElementType 
     variant?: OverridableStringUnion<VariantProp, AutocompleteListboxPropsVariantOverrides>;
     /**
      * The size of the component (affect other nested list* components).
-     * @default 'md'
+     * @default 'sm'
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', AutocompleteListboxPropsSizeOverrides>;
     /**

--- a/packages/mui-joy/src/Avatar/Avatar.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.tsx
@@ -158,7 +158,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
   const {
     alt,
     color: colorProp = 'neutral',
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     variant: variantProp = 'soft',
     src,
     srcSet,
@@ -268,7 +268,7 @@ Avatar.propTypes /* remove-proptypes */ = {
   /**
    * The size of the component.
    * It accepts theme values between 'sm' and 'lg'.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['lg', 'md', 'sm']),

--- a/packages/mui-joy/src/Avatar/AvatarProps.ts
+++ b/packages/mui-joy/src/Avatar/AvatarProps.ts
@@ -57,7 +57,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
       /**
        * The size of the component.
        * It accepts theme values between 'sm' and 'lg'.
-       * @default 'md'
+       * @default 'sm'
        */
       size?: OverridableStringUnion<'sm' | 'md' | 'lg', AvatarPropsSizeOverrides>;
       /**

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -113,8 +113,8 @@ export const getButtonStyles = ({
       }),
       ...(ownerState.size === 'md' && {
         '--Icon-fontSize': theme.vars.fontSize.xl,
-        '--CircularProgress-size': '24px', // must be `px` unit, otherwise the CircularProgress is broken in Safari
-        '--CircularProgress-thickness': '3px',
+        '--CircularProgress-size': '20px', // must be `px` unit, otherwise the CircularProgress is broken in Safari
+        '--CircularProgress-thickness': '2px',
         '--Button-gap': '0.5rem',
         minHeight: 'var(--Button-minHeight, 2.5rem)', // use min-height instead of height to make the button resilient to its content
         fontSize: theme.vars.fontSize.sm,
@@ -123,8 +123,8 @@ export const getButtonStyles = ({
       }),
       ...(ownerState.size === 'lg' && {
         '--Icon-fontSize': theme.vars.fontSize.xl2,
-        '--CircularProgress-size': '28px', // must be `px` unit, otherwise the CircularProgress is broken in Safari
-        '--CircularProgress-thickness': '4px',
+        '--CircularProgress-size': '24px', // must be `px` unit, otherwise the CircularProgress is broken in Safari
+        '--CircularProgress-thickness': '3px',
         '--Button-gap': '0.75rem',
         minHeight: 'var(--Button-minHeight, 3rem)',
         fontSize: theme.vars.fontSize.md,
@@ -196,7 +196,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
     action,
     color: colorProp = 'primary',
     variant: variantProp = 'solid',
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     fullWidth = false,
     startDecorator,
     endDecorator,
@@ -385,7 +385,7 @@ Button.propTypes /* remove-proptypes */ = {
   loadingPosition: PropTypes.oneOf(['center', 'end', 'start']),
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -86,7 +86,7 @@ export interface ButtonTypeMap<P = {}, D extends React.ElementType = 'button'> {
       fullWidth?: boolean;
       /**
        * The size of the component.
-       * @default 'md'
+       * @default 'sm'
        */
       size?: OverridableStringUnion<'sm' | 'md' | 'lg', ButtonPropsSizeOverrides>;
       /**

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
@@ -191,7 +191,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(inProps, ref) {
     className,
     component = 'div',
     disabled = false,
-    size = 'md',
+    size = 'sm',
     color = 'neutral',
     variant = 'outlined',
     children,
@@ -309,7 +309,7 @@ ButtonGroup.propTypes /* remove-proptypes */ = {
   /**
    * The size of the component.
    * It accepts theme values between 'sm' and 'lg'.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['lg', 'md', 'sm']),

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroupProps.ts
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroupProps.ts
@@ -57,7 +57,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
     /**
      * The size of the component.
      * It accepts theme values between 'sm' and 'lg'.
-     * @default 'md'
+     * @default 'sm'
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', ButtonGroupPropsSizeOverrides>;
     /**

--- a/packages/mui-joy/src/Chip/Chip.tsx
+++ b/packages/mui-joy/src/Chip/Chip.tsx
@@ -223,7 +223,7 @@ const Chip = React.forwardRef(function Chip(inProps, ref) {
     color: colorProp = 'neutral',
     onClick,
     disabled = false,
-    size = 'md',
+    size = 'sm',
     variant = 'soft',
     startDecorator,
     endDecorator,
@@ -372,7 +372,7 @@ Chip.propTypes /* remove-proptypes */ = {
   /**
    * The size of the component.
    * It accepts theme values between 'sm' and 'lg'.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['lg', 'md', 'sm']),

--- a/packages/mui-joy/src/Chip/ChipProps.ts
+++ b/packages/mui-joy/src/Chip/ChipProps.ts
@@ -83,7 +83,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
       /**
        * The size of the component.
        * It accepts theme values between 'sm' and 'lg'.
-       * @default 'md'
+       * @default 'sm'
        */
       size?: OverridableStringUnion<'sm' | 'md' | 'lg', ChipPropsSizeOverrides>;
       /**

--- a/packages/mui-joy/src/FormControl/FormControl.tsx
+++ b/packages/mui-joy/src/FormControl/FormControl.tsx
@@ -108,7 +108,7 @@ const FormControl = React.forwardRef(function FormControl(inProps, ref) {
     required = false,
     error = false,
     color,
-    size = 'md',
+    size = 'sm',
     orientation = 'vertical',
     slots = {},
     slotProps = {},
@@ -236,7 +236,7 @@ FormControl.propTypes /* remove-proptypes */ = {
   required: PropTypes.bool,
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/FormControl/FormControlProps.ts
+++ b/packages/mui-joy/src/FormControl/FormControlProps.ts
@@ -56,7 +56,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
     required?: boolean;
     /**
      * The size of the component.
-     * @default 'md'
+     * @default 'sm'
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', FormControlPropsSizeOverrides>;
     /**

--- a/packages/mui-joy/src/IconButton/IconButton.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.tsx
@@ -56,8 +56,8 @@ export const StyledIconButton = styled('button')<{ ownerState: IconButtonOwnerSt
       }),
       ...(ownerState.size === 'md' && {
         '--Icon-fontSize': 'calc(var(--IconButton-size, 2.5rem) / 1.667)', // 1.5rem by default
-        '--CircularProgress-size': '24px',
-        '--CircularProgress-thickness': '3px',
+        '--CircularProgress-size': '20px',
+        '--CircularProgress-thickness': '2px',
         minWidth: 'var(--IconButton-size, 2.5rem)',
         minHeight: 'var(--IconButton-size, 2.5rem)',
         fontSize: theme.vars.fontSize.md,
@@ -65,8 +65,8 @@ export const StyledIconButton = styled('button')<{ ownerState: IconButtonOwnerSt
       }),
       ...(ownerState.size === 'lg' && {
         '--Icon-fontSize': 'calc(var(--IconButton-size, 3rem) / 1.714)', // 1.75rem by default
-        '--CircularProgress-size': '28px',
-        '--CircularProgress-thickness': '4px',
+        '--CircularProgress-size': '24px',
+        '--CircularProgress-thickness': '3px',
         minWidth: 'var(--IconButton-size, 3rem)',
         minHeight: 'var(--IconButton-size, 3rem)',
         fontSize: theme.vars.fontSize.lg,
@@ -138,7 +138,7 @@ const IconButton = React.forwardRef(function IconButton(inProps, ref) {
     color: colorProp = 'neutral',
     disabled: disabledProp,
     variant: variantProp = 'plain',
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     slots = {},
     slotProps = {},
     ...other
@@ -245,7 +245,7 @@ IconButton.propTypes /* remove-proptypes */ = {
   focusVisibleClassName: PropTypes.string,
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/IconButton/IconButtonProps.ts
+++ b/packages/mui-joy/src/IconButton/IconButtonProps.ts
@@ -58,7 +58,7 @@ export interface IconButtonTypeMap<P = {}, D extends React.ElementType = 'button
     focusVisibleClassName?: string;
     /**
      * The size of the component.
-     * @default 'md'
+     * @default 'sm'
      */
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', IconButtonPropsSizeOverrides>;
     /**

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -252,7 +252,7 @@ const Input = React.forwardRef(function Input(inProps, ref) {
     error: errorProp = false,
     disabled,
     fullWidth = false,
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     color: colorProp = 'neutral',
     variant = 'outlined',
     startDecorator,
@@ -426,7 +426,7 @@ Input.propTypes /* remove-proptypes */ = {
   required: PropTypes.bool,
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/Input/InputProps.ts
+++ b/packages/mui-joy/src/Input/InputProps.ts
@@ -94,7 +94,7 @@ export interface InputTypeMap<P = {}, D extends React.ElementType = 'div'> {
       startDecorator?: React.ReactNode;
       /**
        * The size of the component.
-       * @default 'md'
+       * @default 'sm'
        */
       size?: OverridableStringUnion<'sm' | 'md' | 'lg', InputPropsSizeOverrides>;
       /**

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -345,7 +345,7 @@ const Select = React.forwardRef(function Select<TValue extends {}>(
     onClose,
     renderValue: renderValueProp,
     value: valueProp,
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     variant = 'outlined',
     color: colorProp = 'neutral',
     startDecorator,

--- a/packages/mui-joy/src/Switch/Switch.tsx
+++ b/packages/mui-joy/src/Switch/Switch.tsx
@@ -243,7 +243,7 @@ const Switch = React.forwardRef(function Switch(inProps, ref) {
     id,
     color: colorProp,
     variant = 'solid',
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     startDecorator,
     endDecorator,
     component,
@@ -463,7 +463,7 @@ Switch.propTypes /* remove-proptypes */ = {
   required: PropTypes.bool,
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/Switch/SwitchProps.ts
+++ b/packages/mui-joy/src/Switch/SwitchProps.ts
@@ -82,7 +82,7 @@ export interface SwitchTypeMap<P = {}, D extends React.ElementType = 'div'> {
       endDecorator?: React.ReactNode | ((ownerState: SwitchOwnerState) => React.ReactNode);
       /**
        * The size of the component.
-       * @default 'md'
+       * @default 'sm'
        */
       size?: OverridableStringUnion<'sm' | 'md' | 'lg', SwitchPropsSizeOverrides>;
       /**

--- a/packages/mui-joy/src/Textarea/Textarea.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.tsx
@@ -221,7 +221,7 @@ const Textarea = React.forwardRef(function Textarea(inProps, ref) {
     focused,
     error: errorProp = false,
     disabled: disabledProp = false,
-    size: sizeProp = 'md',
+    size: sizeProp = 'sm',
     color: colorProp = 'neutral',
     variant = 'outlined',
     startDecorator,
@@ -360,7 +360,7 @@ Textarea.propTypes /* remove-proptypes */ = {
   minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * The size of the component.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.oneOf(['sm', 'md', 'lg']),

--- a/packages/mui-joy/src/Textarea/TextareaProps.ts
+++ b/packages/mui-joy/src/Textarea/TextareaProps.ts
@@ -94,7 +94,7 @@ export interface TextareaTypeMap<P = {}, D extends React.ElementType = 'div'> {
       startDecorator?: React.ReactNode;
       /**
        * The size of the component.
-       * @default 'md'
+       * @default 'sm'
        */
       size?: OverridableStringUnion<'sm' | 'md' | 'lg', TextareaPropsSizeOverrides>;
       /**

--- a/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -69,7 +69,7 @@ const ToggleButtonGroup = React.forwardRef(function ToggleButtonGroup<
     className,
     component = 'div',
     disabled = false,
-    size = 'md',
+    size = 'sm',
     color = 'neutral',
     variant = 'outlined',
     children,
@@ -246,7 +246,7 @@ ToggleButtonGroup.propTypes /* remove-proptypes */ = {
   /**
    * The size of the component.
    * It accepts theme values between 'sm' and 'lg'.
-   * @default 'md'
+   * @default 'sm'
    */
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   /**

--- a/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroupProps.ts
+++ b/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroupProps.ts
@@ -58,7 +58,7 @@ export interface ToggleButtonGroupStaticProps {
   /**
    * The size of the component.
    * It accepts theme values between 'sm' and 'lg'.
-   * @default 'md'
+   * @default 'sm'
    */
   size?: OverridableStringUnion<'sm' | 'md' | 'lg', ToggleButtonGroupPropsSizeOverrides>;
   /**

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -141,14 +141,14 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
     softActiveColor: getCssVarColor(`palette-${color}-800`),
     softActiveBg: getCssVarColor(`palette-${color}-300`),
     softDisabledColor: getCssVarColor(`palette-neutral-400`),
-    softDisabledBg: getCssVarColor(`palette-${color}-50`),
+    softDisabledBg: getCssVarColor(`palette-neutral-50`),
 
     solidColor: getCssVarColor(`palette-common-white`),
     solidBg: getCssVarColor(`palette-${color}-500`),
     solidHoverBg: getCssVarColor(`palette-${color}-600`),
     solidActiveBg: getCssVarColor(`palette-${color}-700`),
     solidDisabledColor: getCssVarColor(`palette-neutral-400`),
-    solidDisabledBg: getCssVarColor(`palette-${color}-100`),
+    solidDisabledBg: getCssVarColor(`palette-neutral-50`),
   });
 
   const createDarkModeVariantVariables = (color: ColorPaletteProp) => ({
@@ -170,14 +170,14 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
     softActiveColor: getCssVarColor(`palette-${color}-100`),
     softActiveBg: getCssVarColor(`palette-${color}-600`),
     softDisabledColor: getCssVarColor(`palette-neutral-500`),
-    softDisabledBg: getCssVarColor(`palette-${color}-900`),
+    softDisabledBg: getCssVarColor(`palette-neutral-900`),
 
     solidColor: getCssVarColor(`palette-common-white`),
     solidBg: getCssVarColor(`palette-${color}-500`),
     solidHoverBg: getCssVarColor(`palette-${color}-600`),
     solidActiveBg: getCssVarColor(`palette-${color}-700`),
     solidDisabledColor: getCssVarColor(`palette-neutral-500`),
-    solidDisabledBg: getCssVarColor(`palette-${color}-800`),
+    solidDisabledBg: getCssVarColor(`palette-neutral-900`),
   });
 
   const lightColorSystem = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Testing some visual changes to the Joy UI default theme, mostly making some components use the `sm` variant by default

### Components set to `sm` as default:
- **Button**
- **IconButton**
- **Input**
- **FormControl**
- **Select**
- **ButtonGroup**
- **Autocomplete**
- **Chip**
- **Avatar**
- Switch
- **TextArea**
- **ToggleButtonGroup**


### Learnings
1. When Avatars, IconButtons or other components are inside the input/select, it ends up with `38px` height. I wonder if we should make the `md` components `38px` height than changing variants to `sm`.
2. Visually, it only makes sense if all these components have the same height or variants set.