### PR TITLE
[joy-ui][docs] Add `FileUpload` demo

### DIFF
--- a/docs/data/joy/components/button/InputFileUpload.js
+++ b/docs/data/joy/components/button/InputFileUpload.js
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import SvgIcon from '@mui/joy/SvgIcon';
+
+export default function InputFileUpload() {
+  return (
+    <Button
+      component="label"
+      role={undefined}
+      tabIndex={-1}
+      variant="outlined"
+      color="neutral"
+      startDecorator={
+        <SvgIcon>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z"
+            />
+          </svg>
+        </SvgIcon>
+      }
+    >
+      Upload a file
+      <Box
+        component="input"
+        type="file"
+        sx={{
+          clip: 'rect(0 0 0 0)',
+          clipPath: 'inset(50%)',
+          height: '1px',
+          overflow: 'hidden',
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          whiteSpace: 'nowrap',
+          width: '1px',
+        }}
+      />
+    </Button>
+  );
+}

--- a/docs/data/joy/components/button/InputFileUpload.js
+++ b/docs/data/joy/components/button/InputFileUpload.js
@@ -1,7 +1,19 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import SvgIcon from '@mui/joy/SvgIcon';
+import { styled } from '@mui/joy';
+
+const VisuallyHiddenInput = styled('input')`
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  white-space: nowrap;
+  width: 1px;
+`;
 
 export default function InputFileUpload() {
   return (
@@ -30,21 +42,7 @@ export default function InputFileUpload() {
       }
     >
       Upload a file
-      <Box
-        component="input"
-        type="file"
-        sx={{
-          clip: 'rect(0 0 0 0)',
-          clipPath: 'inset(50%)',
-          height: '1px',
-          overflow: 'hidden',
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          whiteSpace: 'nowrap',
-          width: '1px',
-        }}
-      />
+      <VisuallyHiddenInput type="file" />
     </Button>
   );
 }

--- a/docs/data/joy/components/button/InputFileUpload.tsx
+++ b/docs/data/joy/components/button/InputFileUpload.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import Box from '@mui/joy/Box';
+import Button from '@mui/joy/Button';
+import SvgIcon from '@mui/joy/SvgIcon';
+
+export default function InputFileUpload() {
+  return (
+    <Button
+      component="label"
+      role={undefined}
+      tabIndex={-1}
+      variant="outlined"
+      color="neutral"
+      startDecorator={
+        <SvgIcon>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z"
+            />
+          </svg>
+        </SvgIcon>
+      }
+    >
+      Upload a file
+      <Box
+        component="input"
+        type="file"
+        sx={{
+          clip: 'rect(0 0 0 0)',
+          clipPath: 'inset(50%)',
+          height: '1px',
+          overflow: 'hidden',
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          whiteSpace: 'nowrap',
+          width: '1px',
+        }}
+      />
+    </Button>
+  );
+}

--- a/docs/data/joy/components/button/InputFileUpload.tsx
+++ b/docs/data/joy/components/button/InputFileUpload.tsx
@@ -1,7 +1,19 @@
 import * as React from 'react';
-import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import SvgIcon from '@mui/joy/SvgIcon';
+import { styled } from '@mui/joy';
+
+const VisuallyHiddenInput = styled('input')`
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  white-space: nowrap;
+  width: 1px;
+`;
 
 export default function InputFileUpload() {
   return (
@@ -30,21 +42,7 @@ export default function InputFileUpload() {
       }
     >
       Upload a file
-      <Box
-        component="input"
-        type="file"
-        sx={{
-          clip: 'rect(0 0 0 0)',
-          clipPath: 'inset(50%)',
-          height: '1px',
-          overflow: 'hidden',
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          whiteSpace: 'nowrap',
-          width: '1px',
-        }}
-      />
+      <VisuallyHiddenInput type="file" />
     </Button>
   );
 }

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -118,7 +118,7 @@ If you need the style of a button with the functionality of a link, then you can
 
 {{"demo": "ButtonLink.js"}}
 
-## File Upload
+## File upload
 
 To create a file upload button, turn the button into a label using `component="label"` and then create a visually-hidden input with type `file`.
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -100,6 +100,20 @@ It supports three values:
 
 {{"demo": "ButtonLoadingPosition.js"}}
 
+### Link Button
+
+Buttons let users take actions, but if that action is to navigate to a new page, then an anchor tag is generally preferable over a button tag.
+
+If you need the style of a button with the functionality of a link, then you can use the `component` prop to replace the default `<button>` with an `<a>`, as shown below:
+
+{{"demo": "ButtonLink.js"}}
+
+### File upload
+
+To create a file upload button, turn the button into a label using `component="label"` and then create a visually-hidden input with type `file`.
+
+{{"demo": "InputFileUpload.js"}}
+
 ## Icon Button
 
 ```jsx
@@ -109,20 +123,6 @@ import IconButton from '@mui/joy/IconButton';
 Use the Icon Button component for a square button to house an icon with no text content.
 
 {{"demo": "IconButtons.js"}}
-
-## Link Button
-
-Buttons let users take actions, but if that action is to navigate to a new page, then an anchor tag is generally preferable over a button tag.
-
-If you need the style of a button with the functionality of a link, then you can use the `component` prop to replace the default `<button>` with an `<a>`, as shown below:
-
-{{"demo": "ButtonLink.js"}}
-
-## File upload
-
-To create a file upload button, turn the button into a label using `component="label"` and then create a visually-hidden input with type `file`.
-
-{{"demo": "InputFileUpload.js"}}
 
 ## CSS variable playground
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -120,7 +120,7 @@ If you need the style of a button with the functionality of a link, then you can
 
 ## File Upload
 
-Following demo shows how to turn `Button` component to `input` with type as `file`
+To create a file upload button, turn the button into a label using `component="label"` and then create a visually-hidden input with type `file`.
 
 {{"demo": "InputFileUpload.js"}}
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -118,6 +118,12 @@ If you need the style of a button with the functionality of a link, then you can
 
 {{"demo": "ButtonLink.js"}}
 
+## File Upload
+
+Following demo shows how to turn `Button` component to `input` with type as `file`
+
+{{"demo": "InputFileUpload.js"}}
+
 ## CSS variable playground
 
 Play around with the CSS variables available to the Button and Icon Button components to see how the design changes.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR adds a new demo which showcases how to turn `Button` component to `input` component with type as `file`.

preview: https://deploy-preview-38420--material-ui.netlify.app/joy-ui/react-button/#file-upload

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
