### PR TITLE
[docs-infra] Improve the heading buttons positioning

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -130,7 +130,8 @@ const Root = styled('div')(
       },
       '& a:not(.anchor-link):hover': {
         color: 'currentColor',
-        borderBottom: '1px solid currentColor',
+        border: 'none',
+        boxShadow: '0 1px 0 0 currentColor',
         textDecoration: 'none',
       },
       '&:hover .anchor-link, & .comment-link': {
@@ -138,6 +139,7 @@ const Root = styled('div')(
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
+        flexShrink: 0,
         textAlign: 'center',
         marginLeft: 8,
         height: 26,
@@ -168,12 +170,7 @@ const Root = styled('div')(
         }),
         '& svg': {
           verticalAlign: 'middle',
-          color: `var(--muidocs-palette-text-secondary, ${lightTheme.palette.text.tertiary})`,
-        },
-        '&:hover': {
-          '&>svg': {
-            color: `var(--muidocs-palette-primary-main, ${lightTheme.palette.primary.main})`,
-          },
+          fill: 'currentColor',
         },
       },
     },

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -116,9 +116,8 @@ const Root = styled('div')(
       paddingLeft: 30,
     },
     '& h1, & h2, & h3, & h4': {
-      position: 'relative',
-      // Reserve space for the end of the line action button
-      paddingRight: 26 * 2 + 10,
+      display: 'flex',
+      alignItems: 'center',
       '& code': {
         fontSize: 'inherit',
         lineHeight: 'inherit',
@@ -135,20 +134,20 @@ const Root = styled('div')(
         textDecoration: 'none',
       },
       '&:hover .anchor-link, & .comment-link': {
-        position: 'absolute',
+        cursor: 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         textAlign: 'center',
         marginLeft: 8,
-        marginTop: 5,
         height: 26,
         width: 26,
-        lineHeight: '21px',
         backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
         border: '1px solid',
         borderColor: `var(--muidocs-palette-divider, ${lightTheme.palette.divider})`,
         borderRadius: 8,
         color: `var(--muidocs-palette-text-secondary, ${lightTheme.palette.text.secondary})`,
-        cursor: 'pointer',
-        display: 'inline-block',
+
         '&:hover': {
           backgroundColor: alpha(lightTheme.palette.primary[100], 0.4),
           borderColor: `var(--muidocs-palette-primary-100, ${lightTheme.palette.primary[100]})`,
@@ -163,18 +162,18 @@ const Root = styled('div')(
       },
       '& .comment-link': {
         display: 'none', // So we can have the comment button opt-in.
-        top: 0,
-        right: 0,
+        marginLeft: 'auto',
         transition: theme.transitions.create('opacity', {
           duration: theme.transitions.duration.shortest,
         }),
         '& svg': {
-          opacity: 0.6,
-          marginBottom: 1,
           verticalAlign: 'middle',
+          color: `var(--muidocs-palette-text-secondary, ${lightTheme.palette.text.tertiary})`,
         },
         '&:hover': {
-          '&>svg': { opacity: 1 },
+          '&>svg': {
+            color: `var(--muidocs-palette-primary-main, ${lightTheme.palette.primary.main})`,
+          },
         },
       },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Was again just browsing the docs looking for improvement opportunities and realized that the anchor button for the heading was again misaligned (this seems to happen whenever changes happen to the heading styles). 😭 Figured that using an `inline-flex` for the button itself and other flex-related properties would ensure the alignment instead of an arbitrary line height ⎯ similarly with the heading itself instead of absolute positioning the two. 

Not _fully_ aware of whether these changes have unintended consequences, so... let me know if this works out!

**https://deploy-preview-38428--material-ui.netlify.app/experiments/docs/headers/**