### PR TITLE
[docs][App Bar]: AppBarWithResponsiveMenu logo href link

### DIFF
--- a/docs/data/material/components/app-bar/ResponsiveAppBar.js
+++ b/docs/data/material/components/app-bar/ResponsiveAppBar.js
@@ -44,7 +44,7 @@ function ResponsiveAppBar() {
             variant="h6"
             noWrap
             component="a"
-            href="/"
+            href="#app-bar-with-responsive-menu"
             sx={{
               mr: 2,
               display: { xs: 'none', md: 'flex' },
@@ -99,7 +99,7 @@ function ResponsiveAppBar() {
             variant="h5"
             noWrap
             component="a"
-            href="/"
+            href="#app-bar-with-responsive-menu"
             sx={{
               mr: 2,
               display: { xs: 'flex', md: 'none' },

--- a/docs/data/material/components/app-bar/ResponsiveAppBar.tsx
+++ b/docs/data/material/components/app-bar/ResponsiveAppBar.tsx
@@ -44,7 +44,7 @@ function ResponsiveAppBar() {
             variant="h6"
             noWrap
             component="a"
-            href="/"
+            href="#app-bar-with-responsive-menu"
             sx={{
               mr: 2,
               display: { xs: 'none', md: 'flex' },
@@ -99,7 +99,7 @@ function ResponsiveAppBar() {
             variant="h5"
             noWrap
             component="a"
-            href="/"
+            href="#app-bar-with-responsive-menu"
             sx={{
               mr: 2,
               display: { xs: 'flex', md: 'none' },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Error when clicked  LOGO in below example Appbar
https://mui.com/material-ui/react-app-bar/#app-bar-with-responsive-menu

<img width="1438" alt="uncaught typeerror when clicked on Appbar LOGO - mui website" src="https://github.com/mui/material-ui/assets/60656977/b4a74b58-4a39-4097-9f39-040e58f9c686">


-


Replicated the error in local
<img width="1432" alt="uncaught typeerror when clicked on Appbar LOGO - local " src="https://github.com/mui/material-ui/assets/60656977/cc95241b-a257-4db7-a420-1fd35f9996b4">

