### PR TITLE
Fixing infinite loop re-renders in TextField multiline auto resize

### DIFF
--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.tsx
@@ -220,7 +220,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(
 
   useEnhancedEffect(() => {
     syncHeight();
-  });
+  }, [value]); // To avoid an infinite loop (https://github.com/mui/material-ui/issues/33081)
 
   React.useEffect(() => {
     renders.current = 0;


### PR DESCRIPTION
Fixing #33081  

For the record, a PR was previously made trying to fix this issue: https://github.com/mui/material-ui/pull/33253/files
