### PR TITLE
[docs-infra] Remove getLayout duplication

### DIFF
--- a/docs/pages/base-ui/all-components/index.js
+++ b/docs/pages/base-ui/all-components/index.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/all-components/all-components.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableToc />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/all-components/index.js
+++ b/docs/pages/base-ui/all-components/index.js
@@ -4,9 +4,9 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/all-components/all-components.md?@mui/markdown';
 
 export default function Page() {
-  return null;
+  return <MarkdownDocs {...pageProps} disableToc />;
 }
 
-Page.getLayout = () => {
-  return <AppFrame><MarkdownDocs {...pageProps} /></AppFrame>;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
 };

--- a/docs/pages/base-ui/all-components/index.js
+++ b/docs/pages/base-ui/all-components/index.js
@@ -4,9 +4,9 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/all-components/all-components.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} disableToc />;
+  return null;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
+Page.getLayout = () => {
+  return <AppFrame><MarkdownDocs {...pageProps} /></AppFrame>;
 };

--- a/docs/pages/base-ui/all-components/index.js
+++ b/docs/pages/base-ui/all-components/index.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/all-components/all-components.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableToc />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/getting-started/customization.js
+++ b/docs/pages/base-ui/getting-started/customization.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/customization/customization.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/getting-started/customization.js
+++ b/docs/pages/base-ui/getting-started/customization.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/customization/customization.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/getting-started/index.js
+++ b/docs/pages/base-ui/getting-started/index.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/overview/overview.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableAd />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/getting-started/index.js
+++ b/docs/pages/base-ui/getting-started/index.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/overview/overview.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableAd />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/getting-started/quickstart.js
+++ b/docs/pages/base-ui/getting-started/quickstart.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/quickstart/quickstart.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableAd />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/getting-started/quickstart.js
+++ b/docs/pages/base-ui/getting-started/quickstart.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/quickstart/quickstart.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableAd />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/getting-started/usage.js
+++ b/docs/pages/base-ui/getting-started/usage.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/usage/usage.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableAd />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/getting-started/usage.js
+++ b/docs/pages/base-ui/getting-started/usage.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/getting-started/usage/usage.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} disableAd />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-accordion/index.js
+++ b/docs/pages/base-ui/react-accordion/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/accordion/accordion.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-accordion/index.js
+++ b/docs/pages/base-ui/react-accordion/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/accordion/accordion.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-autocomplete/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-autocomplete/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/autocomplete/autocomplete.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import useAutocompleteApiJsonPageContent from '../../api/use-autocomplete.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-autocomplete/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-autocomplete/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/autocomplete/autocomplete.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import useAutocompleteApiJsonPageContent from '../../api/use-autocomplete.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-autocomplete/index.js
+++ b/docs/pages/base-ui/react-autocomplete/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/autocomplete/autocomplete.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-autocomplete/index.js
+++ b/docs/pages/base-ui/react-autocomplete/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/autocomplete/autocomplete.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-badge/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-badge/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/badge/badge.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import BadgeApiJsonPageContent from '../../api/badge.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-badge/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-badge/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/badge/badge.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import BadgeApiJsonPageContent from '../../api/badge.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-badge/index.js
+++ b/docs/pages/base-ui/react-badge/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/badge/badge.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-badge/index.js
+++ b/docs/pages/base-ui/react-badge/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/badge/badge.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-button/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-button/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/button/button.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import ButtonApiJsonPageContent from '../../api/button.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-button/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-button/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/button/button.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import ButtonApiJsonPageContent from '../../api/button.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-button/index.js
+++ b/docs/pages/base-ui/react-button/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/button/button.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-button/index.js
+++ b/docs/pages/base-ui/react-button/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/button/button.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-checkbox/index.js
+++ b/docs/pages/base-ui/react-checkbox/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/checkbox/checkbox.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-checkbox/index.js
+++ b/docs/pages/base-ui/react-checkbox/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/checkbox/checkbox.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-click-away-listener/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-click-away-listener/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/click-away-listener/click-away-listener.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import ClickAwayListenerApiJsonPageContent from '../../api/click-away-listener.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-click-away-listener/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-click-away-listener/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/click-away-listener/click-away-listener.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import ClickAwayListenerApiJsonPageContent from '../../api/click-away-listener.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-click-away-listener/index.js
+++ b/docs/pages/base-ui/react-click-away-listener/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/click-away-listener/click-away-listener.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-click-away-listener/index.js
+++ b/docs/pages/base-ui/react-click-away-listener/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/click-away-listener/click-away-listener.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-drawer/index.js
+++ b/docs/pages/base-ui/react-drawer/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/drawer/drawer.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-drawer/index.js
+++ b/docs/pages/base-ui/react-drawer/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/drawer/drawer.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-focus-trap/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-focus-trap/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/focus-trap/focus-trap.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import FocusTrapApiJsonPageContent from '../../api/focus-trap.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-focus-trap/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-focus-trap/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/focus-trap/focus-trap.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import FocusTrapApiJsonPageContent from '../../api/focus-trap.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-focus-trap/index.js
+++ b/docs/pages/base-ui/react-focus-trap/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/focus-trap/focus-trap.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-focus-trap/index.js
+++ b/docs/pages/base-ui/react-focus-trap/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/focus-trap/focus-trap.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-form-control/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-form-control/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/form-control/form-control.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import FormControlApiJsonPageContent from '../../api/form-control.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-form-control/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-form-control/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/form-control/form-control.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import FormControlApiJsonPageContent from '../../api/form-control.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-form-control/index.js
+++ b/docs/pages/base-ui/react-form-control/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/form-control/form-control.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-form-control/index.js
+++ b/docs/pages/base-ui/react-form-control/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/form-control/form-control.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-input/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-input/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/input/input.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import InputApiJsonPageContent from '../../api/input.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-input/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-input/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/input/input.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import InputApiJsonPageContent from '../../api/input.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-input/index.js
+++ b/docs/pages/base-ui/react-input/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/input/input.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-input/index.js
+++ b/docs/pages/base-ui/react-input/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/input/input.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-menu/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-menu/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/menu/menu.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import DropdownApiJsonPageContent from '../../api/dropdown.json';
@@ -17,9 +17,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-menu/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-menu/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/menu/menu.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import DropdownApiJsonPageContent from '../../api/dropdown.json';
@@ -17,7 +17,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-menu/index.js
+++ b/docs/pages/base-ui/react-menu/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/menu/menu.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-menu/index.js
+++ b/docs/pages/base-ui/react-menu/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/menu/menu.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-modal/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-modal/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/modal/modal.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import ModalApiJsonPageContent from '../../api/modal.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-modal/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-modal/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/modal/modal.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import ModalApiJsonPageContent from '../../api/modal.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-modal/index.js
+++ b/docs/pages/base-ui/react-modal/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/modal/modal.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-modal/index.js
+++ b/docs/pages/base-ui/react-modal/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/modal/modal.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-no-ssr/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-no-ssr/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/no-ssr/no-ssr.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import NoSsrApiJsonPageContent from '../../api/no-ssr.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-no-ssr/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-no-ssr/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/no-ssr/no-ssr.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import NoSsrApiJsonPageContent from '../../api/no-ssr.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-no-ssr/index.js
+++ b/docs/pages/base-ui/react-no-ssr/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/no-ssr/no-ssr.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-no-ssr/index.js
+++ b/docs/pages/base-ui/react-no-ssr/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/no-ssr/no-ssr.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-number-input/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-number-input/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/number-input/number-input.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import NumberInputApiJsonPageContent from '../../api/number-input.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-number-input/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-number-input/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/number-input/number-input.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import NumberInputApiJsonPageContent from '../../api/number-input.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-number-input/index.js
+++ b/docs/pages/base-ui/react-number-input/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/number-input/number-input.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-number-input/index.js
+++ b/docs/pages/base-ui/react-number-input/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/number-input/number-input.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-pagination/index.js
+++ b/docs/pages/base-ui/react-pagination/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/pagination/pagination.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-pagination/index.js
+++ b/docs/pages/base-ui/react-pagination/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/pagination/pagination.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-popper/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-popper/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/popper/popper.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import PopperApiJsonPageContent from '../../api/popper.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-popper/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-popper/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/popper/popper.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import PopperApiJsonPageContent from '../../api/popper.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-popper/index.js
+++ b/docs/pages/base-ui/react-popper/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/popper/popper.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-popper/index.js
+++ b/docs/pages/base-ui/react-popper/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/popper/popper.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-portal/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-portal/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/portal/portal.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import PortalApiJsonPageContent from '../../api/portal.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-portal/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-portal/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/portal/portal.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import PortalApiJsonPageContent from '../../api/portal.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-portal/index.js
+++ b/docs/pages/base-ui/react-portal/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/portal/portal.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-portal/index.js
+++ b/docs/pages/base-ui/react-portal/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/portal/portal.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-radio-button/index.js
+++ b/docs/pages/base-ui/react-radio-button/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/radio-button/radio-button.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-radio-button/index.js
+++ b/docs/pages/base-ui/react-radio-button/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/radio-button/radio-button.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-rating/index.js
+++ b/docs/pages/base-ui/react-rating/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/rating/rating.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-rating/index.js
+++ b/docs/pages/base-ui/react-rating/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/rating/rating.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-select/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-select/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/select/select.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import OptionApiJsonPageContent from '../../api/option.json';
@@ -14,9 +14,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-select/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-select/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/select/select.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import OptionApiJsonPageContent from '../../api/option.json';
@@ -14,7 +14,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-select/index.js
+++ b/docs/pages/base-ui/react-select/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/select/select.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-select/index.js
+++ b/docs/pages/base-ui/react-select/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/select/select.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-slider/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-slider/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/slider/slider.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import SliderApiJsonPageContent from '../../api/slider.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-slider/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-slider/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/slider/slider.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import SliderApiJsonPageContent from '../../api/slider.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-slider/index.js
+++ b/docs/pages/base-ui/react-slider/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/slider/slider.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-slider/index.js
+++ b/docs/pages/base-ui/react-slider/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/slider/slider.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-snackbar/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-snackbar/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/snackbar/snackbar.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import SnackbarApiJsonPageContent from '../../api/snackbar.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-snackbar/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-snackbar/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/snackbar/snackbar.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import SnackbarApiJsonPageContent from '../../api/snackbar.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-snackbar/index.js
+++ b/docs/pages/base-ui/react-snackbar/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/snackbar/snackbar.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-snackbar/index.js
+++ b/docs/pages/base-ui/react-snackbar/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/snackbar/snackbar.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-switch/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-switch/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/switch/switch.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import SwitchApiJsonPageContent from '../../api/switch.json';
@@ -11,7 +11,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-switch/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-switch/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/switch/switch.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import SwitchApiJsonPageContent from '../../api/switch.json';
@@ -11,9 +11,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-switch/index.js
+++ b/docs/pages/base-ui/react-switch/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/switch/switch.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-switch/index.js
+++ b/docs/pages/base-ui/react-switch/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/switch/switch.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-table-pagination/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-table-pagination/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/table-pagination/table-pagination.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import TablePaginationApiJsonPageContent from '../../api/table-pagination.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-table-pagination/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-table-pagination/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/table-pagination/table-pagination.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import TablePaginationApiJsonPageContent from '../../api/table-pagination.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-table-pagination/index.js
+++ b/docs/pages/base-ui/react-table-pagination/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/table-pagination/table-pagination.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-table-pagination/index.js
+++ b/docs/pages/base-ui/react-table-pagination/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/table-pagination/table-pagination.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-tabs/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-tabs/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/tabs/tabs.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import TabApiJsonPageContent from '../../api/tab.json';
@@ -17,7 +17,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-tabs/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-tabs/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/tabs/tabs.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import TabApiJsonPageContent from '../../api/tab.json';
@@ -17,9 +17,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-tabs/index.js
+++ b/docs/pages/base-ui/react-tabs/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/tabs/tabs.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-tabs/index.js
+++ b/docs/pages/base-ui/react-tabs/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/tabs/tabs.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-textarea-autosize/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-textarea-autosize/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/textarea-autosize/textarea-autosize.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import TextareaAutosizeApiJsonPageContent from '../../api/textarea-autosize.json';
@@ -10,7 +10,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-textarea-autosize/[docsTab]/index.js
+++ b/docs/pages/base-ui/react-textarea-autosize/[docsTab]/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/textarea-autosize/textarea-autosize.md?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import TextareaAutosizeApiJsonPageContent from '../../api/textarea-autosize.json';
@@ -10,9 +10,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {

--- a/docs/pages/base-ui/react-textarea-autosize/index.js
+++ b/docs/pages/base-ui/react-textarea-autosize/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/textarea-autosize/textarea-autosize.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-textarea-autosize/index.js
+++ b/docs/pages/base-ui/react-textarea-autosize/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/textarea-autosize/textarea-autosize.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-toggle-button-group/index.js
+++ b/docs/pages/base-ui/react-toggle-button-group/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/toggle-button-group/toggle-button-group.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/base-ui/react-toggle-button-group/index.js
+++ b/docs/pages/base-ui/react-toggle-button-group/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/toggle-button-group/toggle-button-group.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-tooltip/index.js
+++ b/docs/pages/base-ui/react-tooltip/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/tooltip/tooltip.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,4 +8,6 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/base-ui/react-tooltip/index.js
+++ b/docs/pages/base-ui/react-tooltip/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/base/components/tooltip/tooltip.md?@mui/markdown';
 
 export default function Page(props) {
@@ -8,6 +8,4 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/joy-ui/react-button-group.js
+++ b/docs/pages/joy-ui/react-button-group.js
@@ -4,9 +4,9 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button-group/button-group.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return null;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
+Page.getLayout = () => {
+  return <AppFrame><MarkdownDocs {...pageProps} /></AppFrame>;
 };

--- a/docs/pages/joy-ui/react-button-group.js
+++ b/docs/pages/joy-ui/react-button-group.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button-group/button-group.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/joy-ui/react-button-group.js
+++ b/docs/pages/joy-ui/react-button-group.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button-group/button-group.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/joy-ui/react-button-group.js
+++ b/docs/pages/joy-ui/react-button-group.js
@@ -4,9 +4,9 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button-group/button-group.md?@mui/markdown';
 
 export default function Page() {
-  return null;
+  return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = () => {
-  return <AppFrame><MarkdownDocs {...pageProps} /></AppFrame>;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
 };

--- a/docs/pages/joy-ui/react-button.js
+++ b/docs/pages/joy-ui/react-button.js
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button/button.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;

--- a/docs/pages/joy-ui/react-button.js
+++ b/docs/pages/joy-ui/react-button.js
@@ -4,9 +4,9 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button/button.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return null;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
+Page.getLayout = () => {
+  return <AppFrame><MarkdownDocs {...pageProps} /></AppFrame>;
 };

--- a/docs/pages/joy-ui/react-button.js
+++ b/docs/pages/joy-ui/react-button.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button/button.md?@mui/markdown';
 
 export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/pages/joy-ui/react-button.js
+++ b/docs/pages/joy-ui/react-button.js
@@ -4,9 +4,9 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from 'docs/data/joy/components/button/button.md?@mui/markdown';
 
 export default function Page() {
-  return null;
+  return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = () => {
-  return <AppFrame><MarkdownDocs {...pageProps} /></AppFrame>;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
 };

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -245,3 +245,7 @@ AppFrame.propTypes = {
   className: PropTypes.string,
   disableDrawer: PropTypes.bool,
 };
+
+export function getLayout(page) {
+  return <AppFrame>{page}</AppFrame>;
+}

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -245,7 +245,3 @@ AppFrame.propTypes = {
   className: PropTypes.string,
   disableDrawer: PropTypes.bool,
 };
-
-export function getLayout(page) {
-  return <AppFrame>{page}</AppFrame>;
-}

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -595,7 +595,7 @@ export function generateBaseUIApiPages() {
       const demosSource = `
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from '${importStatement}?@mui/markdown';
 
 export default function Page(props) {
@@ -603,7 +603,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
       `;
 
       const componentPageDirectory = `docs/pages/${productName}-ui/react-${componentName}/`;
@@ -679,7 +681,7 @@ Page.getLayout = getLayout;
       const tabsApiSource = `
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import { getLayout } from 'docs/src/modules/components/AppFrame';
+import AppFrame from 'docs/src/modules/components/AppFrame';
 import * as pageProps from '${importStatement}?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 ${apiTabImportStatements}
@@ -689,7 +691,9 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = getLayout;
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};
 
 export const getStaticPaths = () => {
   return {

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -595,7 +595,7 @@ export function generateBaseUIApiPages() {
       const demosSource = `
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from '${importStatement}?@mui/markdown';
 
 export default function Page(props) {
@@ -603,9 +603,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
       `;
 
       const componentPageDirectory = `docs/pages/${productName}-ui/react-${componentName}/`;
@@ -681,7 +679,7 @@ Page.getLayout = (page) => {
       const tabsApiSource = `
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
-import AppFrame from 'docs/src/modules/components/AppFrame';
+import { getLayout } from 'docs/src/modules/components/AppFrame';
 import * as pageProps from '${importStatement}?@mui/markdown';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 ${apiTabImportStatements}
@@ -691,9 +689,7 @@ export default function Page(props) {
   return <MarkdownDocs {...pageProps} {...other} />;
 }
 
-Page.getLayout = (page) => {
-  return <AppFrame>{page}</AppFrame>;
-};
+Page.getLayout = getLayout;
 
 export const getStaticPaths = () => {
   return {


### PR DESCRIPTION
I have tried this, but I'm not sure it makes sense. I suspect we would have better performance if `MarkdownDocs` was rerendered like `AppFrame` instead of remounted. In which case, the abstraction of this PR fails, and we can merge AppFrame and MarkdownDocs to be a single imported component.

~Something else I noticed is that on the marketing pages, all the pages share the same layout. We could use the same getLayout approach to have faster page transition.~ Tried, not so obvious a win, some state needs to be reset.