### PR TITLE
[useButton][base-ui] Accept arbitrary props in getRootProps and forward them

### DIFF
--- a/docs/pages/base-ui/api/use-button.json
+++ b/docs/pages/base-ui/api/use-button.json
@@ -32,8 +32,8 @@
     "focusVisible": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "getRootProps": {
       "type": {
-        "name": "&lt;TOther extends Record&lt;string, any&gt; = {}&gt;(externalProps?: TOther) =&gt; UseButtonRootSlotProps&lt;TOther&gt;",
-        "description": "&lt;TOther extends Record&lt;string, any&gt; = {}&gt;(externalProps?: TOther) =&gt; UseButtonRootSlotProps&lt;TOther&gt;"
+        "name": "&lt;ExternalProps extends Record&lt;string, any&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseButtonRootSlotProps&lt;ExternalProps&gt;",
+        "description": "&lt;ExternalProps extends Record&lt;string, any&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseButtonRootSlotProps&lt;ExternalProps&gt;"
       },
       "required": true
     },

--- a/docs/pages/base-ui/api/use-button.json
+++ b/docs/pages/base-ui/api/use-button.json
@@ -32,8 +32,8 @@
     "focusVisible": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "getRootProps": {
       "type": {
-        "name": "&lt;TOther extends EventHandlers = {}&gt;(otherHandlers?: TOther) =&gt; UseButtonRootSlotProps&lt;TOther&gt;",
-        "description": "&lt;TOther extends EventHandlers = {}&gt;(otherHandlers?: TOther) =&gt; UseButtonRootSlotProps&lt;TOther&gt;"
+        "name": "&lt;TOther extends Record&lt;string, any&gt; = {}&gt;(externalProps?: TOther) =&gt; UseButtonRootSlotProps&lt;TOther&gt;",
+        "description": "&lt;TOther extends Record&lt;string, any&gt; = {}&gt;(externalProps?: TOther) =&gt; UseButtonRootSlotProps&lt;TOther&gt;"
       },
       "required": true
     },

--- a/packages/mui-base/src/useButton/useButton.test.tsx
+++ b/packages/mui-base/src/useButton/useButton.test.tsx
@@ -239,4 +239,17 @@ describe('useButton', () => {
       expect(getByRole('button')).to.have.property('tabIndex', customTabIndex);
     });
   });
+
+  describe('arbitrary props', () => {
+    it('are passed to the host component', () => {
+      const buttonTestId = 'button-test-id';
+      function TestComponent() {
+        const { getRootProps } = useButton({});
+        return <button {...getRootProps({ 'data-testid': buttonTestId })} />;
+      }
+
+      const { getByRole } = render(<TestComponent />);
+      expect(getByRole('button')).to.have.attribute('data-testid', buttonTestId);
+    });
+  });
 });

--- a/packages/mui-base/src/useButton/useButton.ts
+++ b/packages/mui-base/src/useButton/useButton.ts
@@ -219,9 +219,9 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
 
     const props = {
       type,
-      ...externalProps,
       ...externalEventHandlers,
       ...buttonProps,
+      ...externalProps,
       onBlur: createHandleBlur(externalEventHandlers),
       onClick: createHandleClick(externalEventHandlers),
       onFocus: createHandleFocus(externalEventHandlers),

--- a/packages/mui-base/src/useButton/useButton.ts
+++ b/packages/mui-base/src/useButton/useButton.ts
@@ -209,9 +209,9 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
     }
   }
 
-  const getRootProps = <TOther extends Record<string, any> = {}>(
-    externalProps: TOther = {} as TOther,
-  ): UseButtonRootSlotProps<TOther> => {
+  const getRootProps = <ExternalProps extends Record<string, any> = {}>(
+    externalProps: ExternalProps = {} as ExternalProps,
+  ): UseButtonRootSlotProps<ExternalProps> => {
     const externalEventHandlers = {
       ...extractEventHandlers(parameters),
       ...extractEventHandlers(externalProps),

--- a/packages/mui-base/src/useButton/useButton.ts
+++ b/packages/mui-base/src/useButton/useButton.ts
@@ -209,17 +209,17 @@ export function useButton(parameters: UseButtonParameters = {}): UseButtonReturn
     }
   }
 
-  const getRootProps = <TOther extends EventHandlers = {}>(
-    otherHandlers: TOther = {} as TOther,
+  const getRootProps = <TOther extends Record<string, any> = {}>(
+    externalProps: TOther = {} as TOther,
   ): UseButtonRootSlotProps<TOther> => {
-    const propsEventHandlers = extractEventHandlers(parameters) as Partial<UseButtonParameters>;
     const externalEventHandlers = {
-      ...propsEventHandlers,
-      ...otherHandlers,
+      ...extractEventHandlers(parameters),
+      ...extractEventHandlers(externalProps),
     };
 
     const props = {
       type,
+      ...externalProps,
       ...externalEventHandlers,
       ...buttonProps,
       onBlur: createHandleBlur(externalEventHandlers),

--- a/packages/mui-base/src/useButton/useButton.types.ts
+++ b/packages/mui-base/src/useButton/useButton.types.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { EventHandlers } from '../utils/types';
 import { MuiCancellableEventHandler } from '../utils/MuiCancellableEvent';
 
 export interface UseButtonParameters {
@@ -48,8 +47,8 @@ export interface UseButtonReturnValue {
    * @param otherHandlers event handlers for the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <TOther extends EventHandlers = {}>(
-    otherHandlers?: TOther,
+  getRootProps: <TOther extends Record<string, any> = {}>(
+    externalProps?: TOther,
   ) => UseButtonRootSlotProps<TOther>;
   /**
    * If `true`, the component is being focused using keyboard.

--- a/packages/mui-base/src/useButton/useButton.types.ts
+++ b/packages/mui-base/src/useButton/useButton.types.ts
@@ -39,17 +39,17 @@ export interface UseButtonRootSlotOwnProps {
   ref: React.RefCallback<Element> | null;
 }
 
-export type UseButtonRootSlotProps<TOther = {}> = TOther & UseButtonRootSlotOwnProps;
+export type UseButtonRootSlotProps<ExternalProps = {}> = ExternalProps & UseButtonRootSlotOwnProps;
 
 export interface UseButtonReturnValue {
   /**
    * Resolver for the root slot's props.
-   * @param otherHandlers event handlers for the root slot
+   * @param externalProps additional props for the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <TOther extends Record<string, any> = {}>(
-    externalProps?: TOther,
-  ) => UseButtonRootSlotProps<TOther>;
+  getRootProps: <ExternalProps extends Record<string, any> = {}>(
+    externalProps?: ExternalProps,
+  ) => UseButtonRootSlotProps<ExternalProps>;
   /**
    * If `true`, the component is being focused using keyboard.
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Applies changes proposed in https://github.com/mui/material-ui/issues/38186 for the `useButton` hook. This was also raised in https://github.com/mui/material-ui/pull/38392#discussion_r1291787457 to keep a consistent API regarding the `useInput` hook.