### PR TITLE
[docs][base-ui] Correct the MUI System quickstart example

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -146,22 +146,27 @@ import { styled } from '@mui/system';
 import { Button } from '@mui/base/Button';
 
 const theme = {
-  colors: {
+  palette: {
     primary: 'green',
+    text: '#fff',
   },
 };
 
 const GitHubButton = styled(Button)(
   ({ theme }) => `
-    background-color: ${theme.colors.primary /* => 'green' */};
+    background-color: ${theme.palette.primary /* => 'green' */};
+    ${/* ... the rest of the styles */}
   `,
 );
 
-render(
-  <ThemeProvider theme={theme}>
-    <GitHubButton>Create Repository</GitHubButton>
-  </ThemeProvider>,
-);
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <GitHubButton>Create Repository</GitHubButton>
+    </ThemeProvider>
+  );
+}
+
 ```
 
 Most of the demos in the Base UI docs are styled with MUI System in this way.


### PR DESCRIPTION
As noted in https://discord.com/channels/1131323012554174485/1138806202080432178/1140872718712062075, the MUI System quick start demo in Base UI docs incorrectly used `theme.colors` and the `render` function instead of a component.