### PR TITLE
[docs] Add stray design adjustments to the docs

### DIFF
--- a/docs/pages/pricing.tsx
+++ b/docs/pages/pricing.tsx
@@ -37,7 +37,6 @@ export default function Pricing() {
             <PricingTable />
           </Container>
         </LicensingModelProvider>
-        <Divider />
         <PricingWhatToExpect />
         <Divider />
         <PricingFAQ />

--- a/docs/src/components/footer/EmailSubscribe.tsx
+++ b/docs/src/components/footer/EmailSubscribe.tsx
@@ -119,35 +119,43 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
               borderRadius: 1,
               border: '1px solid',
               bgcolor: '#fff',
-              boxShadow: '0 1px 2px 0 rgba(0 0 0 / 0.1)',
-              borderColor: 'grey.300',
+              boxShadow: `inset 0 1px 2px ${
+                (theme.vars || theme).palette.grey[50]
+              }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
+              borderColor: 'grey.200',
               typography: 'body2',
               '&:hover': {
-                borderColor: 'grey.400',
-                boxShadow: '0 1px 2px 0 rgba(0 0 0 / 0.2)',
+                borderColor: 'grey.300',
+                boxShadow: `inset 0 1px 2px ${(theme.vars || theme).palette.grey[50]}, 0 1px 2px ${
+                  (theme.vars || theme).palette.grey[100]
+                }`,
               },
               [`&.${inputBaseClasses.focused}`]: {
                 boxShadow: `0 0 0 3px ${(theme.vars || theme).palette.primary[200]}`,
-                borderColor: 'primary.500',
+                borderColor: 'primary.300',
               },
               [`& .${inputBaseClasses.input}`]: {
                 borderRadius: `calc(${theme.shape.borderRadius}px - 1px)`,
-                py: '11px',
+                py: 1,
                 px: 1.5,
               },
             }),
             (theme) =>
               theme.applyDarkStyles({
                 bgcolor: 'primaryDark.900',
-                boxShadow: '0 1px 2px 0 rgba(0 0 0 / 1)',
+                boxShadow: `inset 0 1px 1px ${
+                  (theme.vars || theme).palette.primaryDark[900]
+                }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
                 borderColor: 'primaryDark.500',
                 '&:hover': {
-                  borderColor: 'primaryDark.300',
-                  boxShadow: '0 1px 2px 0 rgba(0 0 0 / 1)',
+                  borderColor: 'primaryDark.400',
+                  boxShadow: `inset 0 1px 1px ${
+                    (theme.vars || theme).palette.primaryDark[900]
+                  }, 0 1px 2px ${(theme.vars || theme).palette.common.black}`,
                 },
                 [`&.${inputBaseClasses.focused}`]: {
-                  boxShadow: `0 0 0 3px ${(theme.vars || theme).palette.primaryDark[500]}`,
-                  borderColor: 'primaryDark.300',
+                  boxShadow: `0 0 0 3px ${(theme.vars || theme).palette.primary[800]}`,
+                  borderColor: 'primary.600',
                 },
               }),
           ]}
@@ -161,16 +169,25 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
               color: 'primary.600',
               py: 1,
               px: 1.5,
+              border: '1px solid',
+              borderColor: 'primary.100',
+              boxShadow: `inset 0 1px 2px ${
+                (theme.vars || theme).palette.grey[50]
+              }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
               '&:hover': {
                 bgcolor: alpha(theme.palette.primary[100], 1),
               },
             }),
             (theme) =>
               theme.applyDarkStyles({
-                bgcolor: 'primaryDark.500',
+                bgcolor: alpha(theme.palette.primary[800], 0.3),
                 color: 'primaryDark.100',
+                borderColor: 'primary.800',
+                boxShadow: `inset 0 1px 1px ${
+                  (theme.vars || theme).palette.primary[900]
+                }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
                 '&:hover': {
-                  bgcolor: 'primaryDark.600',
+                  bgcolor: 'primary.800',
                 },
               }),
           ]}

--- a/docs/src/components/pricing/HeroPricing.tsx
+++ b/docs/src/components/pricing/HeroPricing.tsx
@@ -9,7 +9,7 @@ export default function HeroPricing() {
     <Container>
       <Box
         sx={{
-          height: '30vh',
+          height: '34vh',
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
@@ -19,8 +19,8 @@ export default function HeroPricing() {
         <Typography component="h1" variant="body2" color="primary.main" fontWeight="bold">
           Pricing
         </Typography>
-        <Typography variant="h2" sx={{ my: 1 }}>
-          Start using <GradientText>MUI</GradientText> for free!
+        <Typography variant="h2" textAlign="center" sx={{ my: 1 }}>
+          Start using MUI&apos;s products <GradientText>for free!</GradientText>
         </Typography>
         <Typography color="text.secondary" textAlign="center" sx={{ maxWidth: 500 }}>
           Switch to a commercial plan to access advanced

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -666,6 +666,9 @@ export function getThemedComponents(): ThemeOptions {
                 borderColor: (theme.vars || theme).palette.grey[200],
                 color: (theme.vars || theme).palette.primary[500],
                 borderRadius: theme.shape.borderRadius,
+                boxShadow: `inset 0 1px 2px ${
+                  (theme.vars || theme).palette.grey[50]
+                }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
                 '&:hover': {
                   borderColor: (theme.vars || theme).palette.grey[300],
                   background: (theme.vars || theme).palette.grey[50],
@@ -674,6 +677,9 @@ export function getThemedComponents(): ThemeOptions {
               theme.applyDarkStyles({
                 borderColor: (theme.vars || theme).palette.primaryDark[700],
                 color: (theme.vars || theme).palette.primary[300],
+                boxShadow: `inset 0 1px 1px ${
+                  (theme.vars || theme).palette.primaryDark[900]
+                }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
                 '&:hover': {
                   borderColor: (theme.vars || theme).palette.primaryDark[600],
                   background: alpha(theme.palette.primaryDark[700], 0.4),
@@ -948,6 +954,9 @@ export function getThemedComponents(): ThemeOptions {
                 borderColor: (theme.vars || theme).palette.grey[100],
                 '&[href]': {
                   textDecorationLine: 'none',
+                  boxShadow: `inset 0 1px 2px ${
+                    (theme.vars || theme).palette.grey[50]
+                  }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
                   '&:hover': {
                     borderColor: (theme.vars || theme).palette.primary[300],
                     boxShadow: `0px 4px 16px ${(theme.vars || theme).palette.grey[200]}`,
@@ -968,6 +977,9 @@ export function getThemedComponents(): ThemeOptions {
                 backgroundColor: alpha(theme.palette.primaryDark[700], 0.5),
                 '&[href]': {
                   textDecorationLine: 'none',
+                  boxShadow: `inset 0 1px 1px ${
+                    (theme.vars || theme).palette.primaryDark[900]
+                  }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
                   '&:hover': {
                     boxShadow: `0px 4px 24px ${(theme.vars || theme).palette.common.black}`,
                   },

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -47,6 +47,10 @@ const SearchButton = styled('button')(({ theme }) => [
     cursor: 'pointer',
     transitionProperty: 'all',
     transitionDuration: '150ms',
+    boxShadow: `inset 0 1px 1px ${(theme.vars || theme).palette.grey[100]}, 0 1px 0.5px ${alpha(
+      theme.palette.grey[100],
+      0.6,
+    )}`,
     '&:hover': {
       background: (theme.vars || theme).palette.grey[100],
       borderColor: (theme.vars || theme).palette.grey[300],
@@ -55,6 +59,9 @@ const SearchButton = styled('button')(({ theme }) => [
   theme.applyDarkStyles({
     backgroundColor: alpha(theme.palette.primaryDark[700], 0.4),
     borderColor: (theme.vars || theme).palette.primaryDark[700],
+    boxShadow: `inset 0 1px 1px ${(theme.vars || theme).palette.primaryDark[900]}, 0 1px 0.5px ${
+      (theme.vars || theme).palette.common.black
+    }`,
     '&:hover': {
       background: (theme.vars || theme).palette.primaryDark[700],
       borderColor: (theme.vars || theme).palette.primaryDark[600],

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -54,7 +54,7 @@ export default function ComponentPageTabs(props) {
         sx={{
           position: 'sticky',
           top: 65, // to be positioned below the app bar
-          mt: 3,
+          mt: 1,
           pt: 1,
           mx: {
             xs: -2,

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
@@ -58,6 +59,9 @@ export default function DiamondSponsors() {
               borderRadius: '12px',
               boxSizing: 'border-box', // TODO have CssBaseline in the Next.js layout
               transition: theme.transitions.create(['color', 'border-color']),
+              boxShadow: `inset 0 1px 2px ${
+                (theme.vars || theme).palette.grey[50]
+              }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
               '&:hover': {
                 backgroundColor: 'grey.50',
               },
@@ -69,6 +73,9 @@ export default function DiamondSponsors() {
           (theme) =>
             theme.applyDarkStyles({
               '& a': {
+                boxShadow: `inset 0 1px 1px ${
+                  (theme.vars || theme).palette.primaryDark[900]
+                }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
                 '&:hover': {
                   backgroundColor: (theme.vars || theme).palette.primaryDark[800],
                   borderColor: (theme.vars || theme).palette.primaryDark[600],

--- a/docs/src/modules/components/MaterialFreeTemplatesCollection.js
+++ b/docs/src/modules/components/MaterialFreeTemplatesCollection.js
@@ -127,7 +127,7 @@ function Templates() {
               })}
             />
             <CardContent sx={{ flexGrow: 1, p: 0 }}>
-              <Typography component="h2" variant="h6" fontWeight={600} gutterBottom>
+              <Typography component="h2" fontWeight={600} gutterBottom>
                 {layout.title}
               </Typography>
               <Typography component="p" variant="body2" color="text.secondary">
@@ -135,7 +135,7 @@ function Templates() {
               </Typography>
             </CardContent>
             <CardActions sx={{ p: 0, ml: -1 }}>
-              <Button component="a" href={layout.source} size="small">
+              <Button component="a" href={layout.source}>
                 {t('sourceCode')}
               </Button>
             </CardActions>

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -97,10 +97,9 @@
   "feedbackMessageUp": "What did you like about this page? (optional)",
   "feedbackSectionSpecific": "How can we improve the <strong>{{sectionName}}</strong> section? (optional)",
   "feedbackMessageToGitHub": {
-    "usecases": "Is something broken? Do you need a reply to a problem you've encountered?",
+    "usecases": "If something is broken or if you need an answer about a problem you've encountered, please",
     "callToAction": {
-      "text": "Please ",
-      "link": "open an issue."
+      "link": "open an issue instead."
     }
   },
   "feedbackNo": "No",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -97,9 +97,10 @@
   "feedbackMessageUp": "What did you like about this page? (optional)",
   "feedbackSectionSpecific": "How can we improve the <strong>{{sectionName}}</strong> section? (optional)",
   "feedbackMessageToGitHub": {
-    "usecases": "If something is broken or if you need an answer about a problem you've encountered, please",
+    "usecases": "Is something broken? Do you need a reply to a problem you've encountered?",
     "callToAction": {
-      "link": "open an issue instead."
+      "text": "Please ",
+      "link": "open an issue."
     }
   },
   "feedbackNo": "No",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just some quality-of-life improvements here ⎯ doing a general polish on spacing and, most notably, adding a subtle box shadow to clickable buttons and links to give that elevated look we've been using now in some demos as well as the new website/docs button styles.

**https://deploy-preview-38501--material-ui.netlify.app/**