### PR TITLE
[joy-ui][docs] Changed bgcolor of the Playground demo

### DIFF
--- a/docs/pages/base-ui/api/number-input.json
+++ b/docs/pages/base-ui/api/number-input.json
@@ -75,7 +75,12 @@
   ],
   "classes": {
     "classes": ["disabled", "error", "focused", "formControl", "readOnly"],
-    "globalClasses": { "focused": "Mui-focused", "disabled": "Mui-disabled", "error": "Mui-error" }
+    "globalClasses": {
+      "focused": "Mui-focused",
+      "disabled": "Mui-disabled",
+      "readOnly": "Mui-readOnly",
+      "error": "Mui-error"
+    }
   },
   "spread": true,
   "muiName": "MuiNumberInput",

--- a/docs/pages/base-ui/api/use-modal.json
+++ b/docs/pages/base-ui/api/use-modal.json
@@ -90,5 +90,9 @@
   },
   "name": "useModal",
   "filename": "/packages/mui-base/src/unstable_useModal/useModal.ts",
+  "imports": [
+    "import { unstable_useModal as useModal } from '@mui/base/unstable_useModal';",
+    "import { unstable_useModal as useModal } from '@mui/base';"
+  ],
   "demos": "<ul><li><a href=\"/base-ui/react-modal/#hook\">Modal</a></li></ul>"
 }

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -202,7 +202,16 @@ export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({
         },
       }}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 999, minWidth: 0, p: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexGrow: 999,
+          minWidth: 0,
+          p: 3,
+          bgcolor: 'var(--joy-palette-background-surface)',
+        }}
+      >
         <Box
           sx={{
             flexGrow: 1,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The Playground bgColor was [getting in the way of some Joy UI demos](https://www.notion.so/mui-org/Olivier-design-review-on-Joy-Design-3ada9a7bcfa44b9fab1fe5032dfb33bb?pvs=4#0b37e7c1e6964af2a53886d67638bbfa), due to the gradient and the blue tone:


<img width="600" alt="Screenshot 2023-08-16 at 11 47 06" src="https://github.com/mui/material-ui/assets/37222944/8a82b119-93cc-4186-9f7d-2286c8589416">

<img width="600" alt="Screenshot 2023-08-16 at 11 49 09" src="https://github.com/mui/material-ui/assets/37222944/7620d2e8-f656-4260-a8df-ab5db91d61ea">


So I added the `bgcolor: 'var(--joy-palette-background-surface)'`, making it closer to the context where it'll be applied by the users.
<img width="600" alt="Screenshot 2023-08-16 at 11 51 08" src="https://github.com/mui/material-ui/assets/37222944/2e2c17f8-5184-4498-ac8e-8587e4720d40">
<img width="600" alt="Screenshot 2023-08-16 at 11 51 40" src="https://github.com/mui/material-ui/assets/37222944/a00e3350-5c9f-4c0f-ad9b-ffa2045e8dd3">


