### PR TITLE
[docs-infra] Customize the blockquote design

### DIFF
--- a/docs/data/material/guides/api/api.md
+++ b/docs/data/material/guides/api/api.md
@@ -2,11 +2,8 @@
 
 <p class="description">We have learned a great deal regarding how Material UI is used, and the v1 rewrite allowed us to completely rethink the component API.</p>
 
-:::info
-API design is hard because you can make it seem simple but it's actually deceptively complex, or make it actually simple but seem complex.
-:::
-
-[@sebmarkbage](https://twitter.com/sebmarkbage/status/728433349337841665)
+> API design is hard because you can make it seem simple but it's actually deceptively complex, or make it actually simple but seem complex.
+> [@sebmarkbage](https://twitter.com/sebmarkbage/status/728433349337841665)
 
 As Sebastian Markbage [pointed out](https://2014.jsconf.eu/speakers/sebastian-markbage-minimal-api-surface-area-learning-patterns-instead-of-frameworks.html), no abstraction is superior to wrong abstractions.
 We are providing low-level components to maximize composition capabilities.

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -248,18 +248,26 @@ const Root = styled('div')(
       paddingBottom: 12,
     },
     '& blockquote': {
-      borderRadius: `var(--muidocs-shape-borderRadius, ${
-        theme.shape?.borderRadius ?? lightTheme.shape.borderRadius
-      }px)`,
-      border: '1px solid',
-      borderLeft: '8px solid',
-      borderColor: `var(--muidocs-palette-warning-300, ${lightTheme.palette.warning[300]})`,
-      backgroundColor: `var(--muidocs-palette-warning-50, ${lightTheme.palette.warning[50]})`,
-      padding: '10px 20px',
-      margin: '20px 0',
+      position: 'relative',
+      borderLeft: '1.5px solid',
+      borderColor: `var(--muidocs-palette-grey-300, ${lightTheme.palette.grey[200]})`,
+      padding: '0 16px',
+      margin: 0,
       '& p': {
-        marginTop: 10,
-        color: `var(--muidocs-palette-primaryDark-800, ${lightTheme.palette.primaryDark[800]})`,
+        fontStyle: 'italic',
+        fontSize: theme.typography.pxToRem(13),
+        fontFamily: lightTheme.typography.fontFamilyCode,
+        fontWeight: lightTheme.typography.fontWeightMedium,
+        textIndent: 20,
+      },
+      ':before': {
+        position: 'absolute',
+        content: 'open-quote',
+        color: `var(--muidocs-palette-grey-300, ${lightTheme.palette.grey[300]})`,
+        fontSize: '2.5rem',
+        top: 8,
+        marginLeft: -6,
+        lineHeight: 0.5,
       },
     },
     '& .MuiCallout-root': {
@@ -553,10 +561,9 @@ const Root = styled('div')(
         borderColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
       },
       '& blockquote': {
-        borderColor: `var(--muidocs-palette-warning-500, ${darkTheme.palette.warning[500]})`,
-        backgroundColor: alpha(darkTheme.palette.warning[900], 0.2),
-        '& p': {
-          color: `var(--muidocs-palette-grey-50, ${darkTheme.palette.grey[50]})`,
+        borderColor: `var(--muidocs-palette-primaryDark-700, ${lightTheme.palette.primaryDark[700]})`,
+        ':before': {
+          color: `var(--muidocs-palette-primaryDark-500, ${lightTheme.palette.primaryDark[500]})`,
         },
       },
       '& .MuiCallout-root': {

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -249,10 +249,10 @@ const Root = styled('div')(
     },
     '& blockquote': {
       position: 'relative',
-      borderLeft: '1.5px solid',
-      borderColor: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
       padding: '0 16px',
       margin: 0,
+      borderLeft: '1.5px solid',
+      borderColor: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
       '& p': {
         fontStyle: 'italic',
         fontSize: theme.typography.pxToRem(13),

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -250,7 +250,7 @@ const Root = styled('div')(
     '& blockquote': {
       position: 'relative',
       borderLeft: '1.5px solid',
-      borderColor: `var(--muidocs-palette-grey-300, ${lightTheme.palette.grey[200]})`,
+      borderColor: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
       padding: '0 16px',
       margin: 0,
       '& p': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a little quality-of-life thing. Before we had callouts, we used to use the `blockquote` element for that, and the styles were there sitting outdated. Thought we could have something slightly fancier! 😊

<img width="600" alt="Screen Shot 2023-08-16 at 13 48 05" src="https://github.com/mui/material-ui/assets/67129314/87991039-bf2b-4823-b78b-42812830ab55">

**https://deploy-preview-38503--material-ui.netlify.app/material-ui/guides/api/**
