### PR TITLE
[docs-infra] Add light tweaks to the ad container

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -218,8 +218,7 @@ export default function Ad() {
       sx={{
         position: 'relative',
         display: 'block',
-        mt: 4,
-        mb: 3,
+        my: 3,
         ...(adShape === 'image' && {
           minHeight: 126,
         }),

--- a/docs/src/modules/components/ad.styles.js
+++ b/docs/src/modules/components/ad.styles.js
@@ -5,7 +5,7 @@ const adBodyImageStyles = (theme) => ({
   root: {
     display: 'block',
     overflow: 'hidden',
-    border: `1px solid ${alpha(theme.palette.action.active, 0.12)}`,
+    border: `1px dashed divider`,
     padding: '12px 12px 12px calc(12px + 130px)',
     borderRadius: theme.shape.borderRadius,
   },

--- a/docs/src/modules/components/ad.styles.js
+++ b/docs/src/modules/components/ad.styles.js
@@ -5,7 +5,8 @@ const adBodyImageStyles = (theme) => ({
   root: {
     display: 'block',
     overflow: 'hidden',
-    border: `1px dashed divider`,
+    border: '1px dashed',
+    borderColor: 'divider',
     padding: '12px 12px 12px calc(12px + 130px)',
     borderRadius: theme.shape.borderRadius,
   },

--- a/docs/src/modules/components/ad.styles.js
+++ b/docs/src/modules/components/ad.styles.js
@@ -6,7 +6,7 @@ const adBodyImageStyles = (theme) => ({
     display: 'block',
     overflow: 'hidden',
     border: '1px dashed',
-    borderColor: 'divider',
+    borderColor: theme.palette.divider,
     padding: '12px 12px 12px calc(12px + 130px)',
     borderRadius: theme.shape.borderRadius,
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a small spacing, fine-tuning, and border styles tweak. Given that the docs have many lines/dividers going on, the more subtle dashed border seems to fit well here, considering the ads already stand out due to their imagery.

<img width="500" alt="Screen Shot 2023-08-16 at 14 01 13" src="https://github.com/mui/material-ui/assets/67129314/a2c2f30b-b911-48ad-9860-cf10c91263a0">


**https://deploy-preview-38504--material-ui.netlify.app/material-ui/guides/themeable-component/**