### PR TITLE
[joy-ui] Fix typo: Classname -> Class name for consistency

### DIFF
--- a/docs/translations/api-docs-joy/autocomplete-listbox/autocomplete-listbox.json
+++ b/docs/translations/api-docs-joy/autocomplete-listbox/autocomplete-listbox.json
@@ -20,28 +20,44 @@
   "classDescriptions": {
     "root": { "description": "Class name applied to the root element." },
     "sizeSm": {
-      "description": "Classname applied to the root element if <code>size=&quot;sm&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"sm\"</code>"
     },
     "sizeMd": {
-      "description": "Classname applied to the root element if <code>size=&quot;md&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"md\"</code>"
     },
     "sizeLg": {
-      "description": "Classname applied to the root element if <code>size=&quot;lg&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"lg\"</code>"
     },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -49,16 +65,24 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/docs/translations/api-docs-joy/list/list.json
+++ b/docs/translations/api-docs-joy/list/list.json
@@ -23,36 +23,56 @@
     }
   },
   "classDescriptions": {
-    "root": { "description": "Classname applied to the root element." },
+    "root": { "description": "Class name applied to the root element." },
     "nesting": {
-      "description": "Classname applied to the root element if wrapped with nested context."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "wrapped with nested context"
     },
     "scoped": {
-      "description": "Classname applied to the root element if <code>scoped</code> is true."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>scoped</code> is true"
     },
     "sizeSm": {
-      "description": "Classname applied to the root element if <code>size=&quot;sm&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"sm\"</code>"
     },
     "sizeMd": {
-      "description": "Classname applied to the root element if <code>size=&quot;md&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"md\"</code>"
     },
     "sizeLg": {
-      "description": "Classname applied to the root element if <code>size=&quot;lg&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"lg\"</code>"
     },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -60,16 +80,24 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     },
     "horizontal": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs-joy/menu-list/menu-list.json
+++ b/docs/translations/api-docs-joy/menu-list/menu-list.json
@@ -43,19 +43,29 @@
       "conditions": "<code>size=\"lg\"</code>"
     },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -63,16 +73,24 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/docs/translations/api-docs-joy/menu/menu.json
+++ b/docs/translations/api-docs-joy/menu/menu.json
@@ -40,23 +40,40 @@
     }
   },
   "classDescriptions": {
-    "root": { "description": "Classname applied to the root element." },
-    "listbox": { "description": "Classname applied to the listbox element." },
-    "expanded": { "description": "Classname applied to the root element when the menu open." },
+    "root": { "description": "Class name applied to the root element." },
+    "listbox": {
+      "description": "Class name applied to {{nodeName}}.",
+      "nodeName": "the listbox element"
+    },
+    "expanded": {
+      "description": "Class name applied to {{nodeName}} when {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "the menu open"
+    },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -64,25 +81,39 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     },
     "sizeSm": {
-      "description": "Classname applied to the root element if <code>size=&quot;sm&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"sm\"</code>"
     },
     "sizeMd": {
-      "description": "Classname applied to the root element if <code>size=&quot;md&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"md\"</code>"
     },
     "sizeLg": {
-      "description": "Classname applied to the root element if <code>size=&quot;lg&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"lg\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/docs/translations/api-docs-joy/tab-list/tab-list.json
+++ b/docs/translations/api-docs-joy/tab-list/tab-list.json
@@ -29,19 +29,29 @@
   "classDescriptions": {
     "root": { "description": "Class name applied to the root element." },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -49,25 +59,39 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     },
     "sizeSm": {
-      "description": "Classname applied to the root element if <code>size=&quot;sm&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"sm\"</code>"
     },
     "sizeMd": {
-      "description": "Classname applied to the root element if <code>size=&quot;md&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"md\"</code>"
     },
     "sizeLg": {
-      "description": "Classname applied to the root element if <code>size=&quot;lg&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"lg\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/docs/translations/api-docs-joy/tab-panel/tab-panel.json
+++ b/docs/translations/api-docs-joy/tab-panel/tab-panel.json
@@ -23,16 +23,26 @@
     }
   },
   "classDescriptions": {
-    "root": { "description": "Classname applied to the root element." },
-    "hidden": { "description": "Classname applied to the root element if the tab is not active." },
+    "root": { "description": "Class name applied to the root element." },
+    "hidden": {
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "the tab is not active"
+    },
     "sizeSm": {
-      "description": "Classname applied to the root element if <code>size=&quot;sm&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"sm\"</code>"
     },
     "sizeMd": {
-      "description": "Classname applied to the root element if <code>size=&quot;md&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"md\"</code>"
     },
     "sizeLg": {
-      "description": "Classname applied to the root element if <code>size=&quot;lg&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"lg\"</code>"
     },
     "horizontal": {
       "description": "Class name applied to {{nodeName}} if {{conditions}}.",
@@ -45,19 +55,29 @@
       "conditions": "<code>orientation=\"vertical\"</code>"
     },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -65,16 +85,24 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/docs/translations/api-docs-joy/tab/tab.json
+++ b/docs/translations/api-docs-joy/tab/tab.json
@@ -35,34 +35,56 @@
     }
   },
   "classDescriptions": {
-    "root": { "description": "Classname applied to the root element." },
+    "root": { "description": "Class name applied to the root element." },
     "disabled": {
-      "description": "Classname applied to the root element if <code>disabled={true}</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>disabled={true}</code>"
     },
     "focusVisible": {
-      "description": "Classname applied to the root element when its focus is visible."
+      "description": "Class name applied to {{nodeName}} when {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "its focus is visible"
     },
-    "selected": { "description": "Classname applied to the root element when it is selected." },
+    "selected": {
+      "description": "Class name applied to {{nodeName}} when {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "it is selected"
+    },
     "horizontal": {
-      "description": "Classname applied to the root element if <code>orientation=&quot;horizontal&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>orientation=\"horizontal\"</code>"
     },
     "vertical": {
-      "description": "Classname applied to the root element if <code>orientation=&quot;vertical&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>orientation=\"vertical\"</code>"
     },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -70,16 +92,24 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/docs/translations/api-docs-joy/tabs/tabs.json
+++ b/docs/translations/api-docs-joy/tabs/tabs.json
@@ -31,27 +31,41 @@
     }
   },
   "classDescriptions": {
-    "root": { "description": "Classname applied to the root element." },
+    "root": { "description": "Class name applied to the root element." },
     "horizontal": {
-      "description": "Classname applied to the root element if <code>orientation=&quot;horizontal&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>orientation=\"horizontal\"</code>"
     },
     "vertical": {
-      "description": "Classname applied to the root element if <code>orientation=&quot;vertical&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>orientation=\"vertical\"</code>"
     },
     "colorPrimary": {
-      "description": "Classname applied to the root element if <code>color=&quot;primary&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"primary\"</code>"
     },
     "colorNeutral": {
-      "description": "Classname applied to the root element if <code>color=&quot;neutral&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"neutral\"</code>"
     },
     "colorDanger": {
-      "description": "Classname applied to the root element if <code>color=&quot;danger&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"danger\"</code>"
     },
     "colorSuccess": {
-      "description": "Classname applied to the root element if <code>color=&quot;success&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"success\"</code>"
     },
     "colorWarning": {
-      "description": "Classname applied to the root element if <code>color=&quot;warning&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>color=\"warning\"</code>"
     },
     "colorContext": {
       "description": "Class name applied to {{nodeName}} when {{conditions}}.",
@@ -59,25 +73,39 @@
       "conditions": "color inversion is triggered"
     },
     "variantPlain": {
-      "description": "Classname applied to the root element if <code>variant=&quot;plain&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"plain\"</code>"
     },
     "variantOutlined": {
-      "description": "Classname applied to the root element if <code>variant=&quot;outlined&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"outlined\"</code>"
     },
     "variantSoft": {
-      "description": "Classname applied to the root element if <code>variant=&quot;soft&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"soft\"</code>"
     },
     "variantSolid": {
-      "description": "Classname applied to the root element if <code>variant=&quot;solid&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>variant=\"solid\"</code>"
     },
     "sizeSm": {
-      "description": "Classname applied to the root element if <code>size=&quot;sm&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"sm\"</code>"
     },
     "sizeMd": {
-      "description": "Classname applied to the root element if <code>size=&quot;md&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"md\"</code>"
     },
     "sizeLg": {
-      "description": "Classname applied to the root element if <code>size=&quot;lg&quot;</code>."
+      "description": "Class name applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"lg\"</code>"
     }
   },
   "slotDescriptions": { "root": "The component that renders the root." }

--- a/packages/mui-joy/src/AutocompleteListbox/autocompleteListboxClasses.ts
+++ b/packages/mui-joy/src/AutocompleteListbox/autocompleteListboxClasses.ts
@@ -3,31 +3,31 @@ import { generateUtilityClass, generateUtilityClasses } from '../className';
 export interface AutocompleteListboxClasses {
   /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
 }
 

--- a/packages/mui-joy/src/List/listClasses.ts
+++ b/packages/mui-joy/src/List/listClasses.ts
@@ -1,37 +1,37 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface ListClasses {
-  /** Classname applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the root element if wrapped with nested context. */
+  /** Class name applied to the root element if wrapped with nested context. */
   nesting: string;
-  /** Classname applied to the root element if `scoped` is true. */
+  /** Class name applied to the root element if `scoped` is true. */
   scoped: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
   /** Class name applied to the root element if `orientation="horizontal"`. */
   horizontal: string;

--- a/packages/mui-joy/src/Menu/menuClasses.ts
+++ b/packages/mui-joy/src/Menu/menuClasses.ts
@@ -1,37 +1,37 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface MenuClasses {
-  /** Classname applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the listbox element. */
+  /** Class name applied to the listbox element. */
   listbox: string;
-  /** Classname applied to the root element when the menu open. */
+  /** Class name applied to the root element when the menu open. */
   expanded: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
 }
 

--- a/packages/mui-joy/src/MenuList/menuListClasses.ts
+++ b/packages/mui-joy/src/MenuList/menuListClasses.ts
@@ -9,25 +9,25 @@ export interface MenuListClasses {
   sizeMd: string;
   /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
 }
 

--- a/packages/mui-joy/src/Tab/tabClasses.ts
+++ b/packages/mui-joy/src/Tab/tabClasses.ts
@@ -1,37 +1,37 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface TabClasses {
-  /** Classname applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the root element if `disabled={true}`. */
+  /** Class name applied to the root element if `disabled={true}`. */
   disabled: string;
-  /** Classname applied to the root element when its focus is visible. */
+  /** Class name applied to the root element when its focus is visible. */
   focusVisible: string;
-  /** Classname applied to the root element when it is selected. */
+  /** Class name applied to the root element when it is selected. */
   selected: string;
-  /** Classname applied to the root element if `orientation="horizontal"`. */
+  /** Class name applied to the root element if `orientation="horizontal"`. */
   horizontal: string;
-  /** Classname applied to the root element if `orientation="vertical"`. */
+  /** Class name applied to the root element if `orientation="vertical"`. */
   vertical: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
 }
 

--- a/packages/mui-joy/src/TabList/tabListClasses.ts
+++ b/packages/mui-joy/src/TabList/tabListClasses.ts
@@ -3,31 +3,31 @@ import { generateUtilityClass, generateUtilityClasses } from '../className';
 export interface TabListClasses {
   /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
 }
 

--- a/packages/mui-joy/src/TabPanel/tabPanelClasses.ts
+++ b/packages/mui-joy/src/TabPanel/tabPanelClasses.ts
@@ -1,39 +1,39 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface TabPanelClasses {
-  /** Classname applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the root element if the tab is not active. */
+  /** Class name applied to the root element if the tab is not active. */
   hidden: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
   /** Class name applied to the root element if `orientation="horizontal"`. */
   horizontal: string;
   /** Class name applied to the root element if `orientation="vertical"`. */
   vertical: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
 }
 

--- a/packages/mui-joy/src/Tabs/tabsClasses.ts
+++ b/packages/mui-joy/src/Tabs/tabsClasses.ts
@@ -1,37 +1,37 @@
 import { generateUtilityClass, generateUtilityClasses } from '../className';
 
 export interface TabsClasses {
-  /** Classname applied to the root element. */
+  /** Class name applied to the root element. */
   root: string;
-  /** Classname applied to the root element if `orientation="horizontal"`. */
+  /** Class name applied to the root element if `orientation="horizontal"`. */
   horizontal: string;
-  /** Classname applied to the root element if `orientation="vertical"`. */
+  /** Class name applied to the root element if `orientation="vertical"`. */
   vertical: string;
-  /** Classname applied to the root element if `color="primary"`. */
+  /** Class name applied to the root element if `color="primary"`. */
   colorPrimary: string;
-  /** Classname applied to the root element if `color="neutral"`. */
+  /** Class name applied to the root element if `color="neutral"`. */
   colorNeutral: string;
-  /** Classname applied to the root element if `color="danger"`. */
+  /** Class name applied to the root element if `color="danger"`. */
   colorDanger: string;
-  /** Classname applied to the root element if `color="success"`. */
+  /** Class name applied to the root element if `color="success"`. */
   colorSuccess: string;
-  /** Classname applied to the root element if `color="warning"`. */
+  /** Class name applied to the root element if `color="warning"`. */
   colorWarning: string;
   /** Class name applied to the root element when color inversion is triggered. */
   colorContext: string;
-  /** Classname applied to the root element if `variant="plain"`. */
+  /** Class name applied to the root element if `variant="plain"`. */
   variantPlain: string;
-  /** Classname applied to the root element if `variant="outlined"`. */
+  /** Class name applied to the root element if `variant="outlined"`. */
   variantOutlined: string;
-  /** Classname applied to the root element if `variant="soft"`. */
+  /** Class name applied to the root element if `variant="soft"`. */
   variantSoft: string;
-  /** Classname applied to the root element if `variant="solid"`. */
+  /** Class name applied to the root element if `variant="solid"`. */
   variantSolid: string;
-  /** Classname applied to the root element if `size="sm"`. */
+  /** Class name applied to the root element if `size="sm"`. */
   sizeSm: string;
-  /** Classname applied to the root element if `size="md"`. */
+  /** Class name applied to the root element if `size="md"`. */
   sizeMd: string;
-  /** Classname applied to the root element if `size="lg"`. */
+  /** Class name applied to the root element if `size="lg"`. */
   sizeLg: string;
 }
 


### PR DESCRIPTION
Classes description was using `Classname` without space. I'm adding the space for consistency wit the rest of the docs