### PR TITLE
[docs] Number Input docs fixes

### DIFF
--- a/docs/data/base/components/number-input/NumberInputIntroduction.js
+++ b/docs/data/base/components/number-input/NumberInputIntroduction.js
@@ -16,10 +16,10 @@ const CustomNumberInput = React.forwardRef(function CustomNumberInput(props, ref
       }}
       slotProps={{
         incrementButton: {
-          children: '▴',
+          children: <span className="arrow">▴</span>,
         },
         decrementButton: {
-          children: '▾',
+          children: <span className="arrow">▾</span>,
         },
       }}
       {...props}
@@ -116,8 +116,8 @@ const StyledButton = styled('button')(
   height: 19px;
   font-family: system-ui, sans-serif;
   font-size: 0.875rem;
+  line-height: 1;
   box-sizing: border-box;
-  line-height: 1.2;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 0;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
@@ -140,6 +140,10 @@ const StyledButton = styled('button')(
   &.${numberInputClasses.decrementButton} {
     grid-column: 2/3;
     grid-row: 2/3;
+  }
+
+  & .arrow {
+    transform: translateY(-1px);
   }
 `,
 );

--- a/docs/data/base/components/number-input/NumberInputIntroduction.tsx
+++ b/docs/data/base/components/number-input/NumberInputIntroduction.tsx
@@ -20,10 +20,10 @@ const CustomNumberInput = React.forwardRef(function CustomNumberInput(
       }}
       slotProps={{
         incrementButton: {
-          children: '▴',
+          children: <span className="arrow">▴</span>,
         },
         decrementButton: {
-          children: '▾',
+          children: <span className="arrow">▾</span>,
         },
       }}
       {...props}
@@ -120,8 +120,8 @@ const StyledButton = styled('button')(
   height: 19px;
   font-family: system-ui, sans-serif;
   font-size: 0.875rem;
+  line-height: 1;
   box-sizing: border-box;
-  line-height: 1.2;
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
   border: 0;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
@@ -144,6 +144,10 @@ const StyledButton = styled('button')(
   &.${numberInputClasses.decrementButton} {
     grid-column: 2/3;
     grid-row: 2/3;
+  }
+
+  & .arrow {
+    transform: translateY(-1px);
   }
 `,
 );

--- a/docs/data/base/components/number-input/number-input.md
+++ b/docs/data/base/components/number-input/number-input.md
@@ -50,10 +50,10 @@ The following demo shows how to create a number input component, apply some styl
 The `min` and `max` props can be used to define a range of accepted values. You can pass only one of them to define an open-ended range.
 
 ```tsx
-  <NumberInput min={-10} max={10} />
+<NumberInput min={-10} max={10} />
 
-  // Open-ended
-  <NumberInput min={0} />
+// Open-ended
+<NumberInput min={0} />
 ```
 
 The `step` prop can be used to defined the granularity of the change in value when incrementing or decrementing. For example, if `min={0}` and `step={2}`, valid values for the component would be 0, 2, 4… since the value can only be changed in increments of 2.
@@ -62,6 +62,10 @@ The `step` prop can be used to defined the granularity of the change in value wh
 // valid values: 0, 2, 4, 6, 8...
 <NumberInput min={0} step={2} />
 ```
+
+:::warning
+Support for decimal values or step sizes isn't available yet, but you can upvote [this GitHub issue](https://github.com/mui/material-ui/issues/38518) to see it arrive sooner!
+:::
 
 When the input field is in focus, you can enter values that fall outside the valid range. The value will be clamped based on `min`, `max` and `step` once the input field is blurred.
 

--- a/docs/data/base/pages.ts
+++ b/docs/data/base/pages.ts
@@ -25,7 +25,7 @@ const pages: readonly MuiPage[] = [
           { pathname: '/base-ui/react-button', title: 'Button' },
           { pathname: '/base-ui/react-checkbox', title: 'Checkbox', planned: true },
           { pathname: '/base-ui/react-input', title: 'Input' },
-          { pathname: '/base-ui/react-number-input', title: 'Number Input' },
+          { pathname: '/base-ui/react-number-input', title: 'Number Input', newFeature: true },
           { pathname: '/base-ui/react-radio-button', title: 'Radio Button', planned: true },
           { pathname: '/base-ui/react-rating', title: 'Rating', planned: true },
           { pathname: '/base-ui/react-select', title: 'Select' },

--- a/docs/data/base/pages.ts
+++ b/docs/data/base/pages.ts
@@ -25,7 +25,7 @@ const pages: readonly MuiPage[] = [
           { pathname: '/base-ui/react-button', title: 'Button' },
           { pathname: '/base-ui/react-checkbox', title: 'Checkbox', planned: true },
           { pathname: '/base-ui/react-input', title: 'Input' },
-          { pathname: '/base-ui/react-number-input', title: 'Number Input', newFeature: true },
+          { pathname: '/base-ui/react-number-input', title: 'Number Input' },
           { pathname: '/base-ui/react-radio-button', title: 'Radio Button', planned: true },
           { pathname: '/base-ui/react-rating', title: 'Rating', planned: true },
           { pathname: '/base-ui/react-select', title: 'Select' },


### PR DESCRIPTION
Fixes several issues raised in https://github.com/mui/material-ui/pull/36119#issuecomment-1678269343

1. Arrow aligment in the intro & basic demos:

<img width="590" alt="Screenshot 2023-08-18 at 12 27 28 AM" src="https://github.com/mui/material-ui/assets/4997971/24028002-5d62-48ad-92f4-6a097936d96e">

2. Fixed indentation in a snippet in the [Basics section](https://deploy-preview-38521--material-ui.netlify.app/base-ui/react-number-input/#basics)

3. Step rounding - I've added a callout about decimals not being supported yet and linking to an issue to upvote

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview https://deploy-preview-38521--material-ui.netlify.app/base-ui/react-number-input/ 