### PR TITLE
[docs-infra] Cleanup code on demo code block expansion

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -412,11 +412,6 @@ export default function Demo(props) {
 
   const hasNonSystemDemos = demo.rawTailwind || demo.rawTailwindTS || demo.rawCSS || demo.rawCSSTs;
 
-  const [demoHovered, setDemoHovered] = React.useState(false);
-  const handleDemoHover = (event) => {
-    setDemoHovered(event.type === 'mouseenter');
-  };
-
   const demoName = getDemoName(demoData.githubLocation);
   const demoSandboxedStyle = React.useMemo(
     () => ({
@@ -517,8 +512,6 @@ export default function Demo(props) {
         hideToolbar={demoOptions.hideToolbar}
         bg={demoOptions.bg}
         id={demoId}
-        onMouseEnter={handleDemoHover}
-        onMouseLeave={handleDemoHover}
       >
         <Wrapper {...(demoData.productId === 'joy-ui' && { mode })}>
           <InitialFocus
@@ -558,7 +551,6 @@ export default function Demo(props) {
                   hasNonSystemDemos={hasNonSystemDemos}
                   demo={demo}
                   demoData={demoData}
-                  demoHovered={demoHovered}
                   demoId={demoId}
                   demoName={demoName}
                   demoOptions={demoOptions}

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -508,11 +508,7 @@ export default function Demo(props) {
   return (
     <Root>
       <AnchorLink id={demoName} />
-      <DemoRoot
-        hideToolbar={demoOptions.hideToolbar}
-        bg={demoOptions.bg}
-        id={demoId}
-      >
+      <DemoRoot hideToolbar={demoOptions.hideToolbar} bg={demoOptions.bg} id={demoId}>
         <Wrapper {...(demoData.productId === 'joy-ui' && { mode })}>
           <InitialFocus
             aria-label={t('initialFocusLabel')}

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -344,10 +344,6 @@ export default function DemoToolbar(props) {
     }
   };
 
-  const handleCodeOpenClick = () => {
-    onCodeOpenChange();
-  };
-
   const handleResetFocusClick = () => {
     initialFocusRef.current.focusVisible();
   };
@@ -533,7 +529,7 @@ export default function DemoToolbar(props) {
             data-ga-event-category="demo"
             data-ga-event-label={demo.gaLabel}
             data-ga-event-action="expand"
-            onClick={handleCodeOpenClick}
+            onClick={onCodeOpenChange}
             {...getControlProps(3)}
           >
             {showCodeLabel}

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -4,7 +4,6 @@ import copy from 'clipboard-copy';
 import { useTheme, styled, alpha } from '@mui/material/styles';
 import IconButton from '@mui/material/IconButton';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import CheckIcon from '@mui/icons-material/Check';
 import Fade from '@mui/material/Fade';
 import MDButton from '@mui/material/Button';
@@ -22,7 +21,6 @@ import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded';
 import ResetFocusIcon from '@mui/icons-material/CenterFocusWeak';
 import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 import { useRouter } from 'next/router';
-import { getCookie } from 'docs/src/modules/utils/helpers';
 import { CODE_VARIANTS, CODE_STYLING } from 'docs/src/modules/constants';
 import { useSetCodeVariant } from 'docs/src/modules/utils/codeVariant';
 import { useSetCodeStyling, useCodeStyling } from 'docs/src/modules/utils/codeStylingSolution';
@@ -64,24 +62,6 @@ function DemoTooltip(props) {
     />
   );
 }
-
-function ToggleCodeTooltip(props) {
-  const { showSourceHint, ...other } = props;
-  const atLeastSmallViewport = useMediaQuery((theme) => theme.breakpoints.up('sm'));
-  const [open, setOpen] = React.useState(false);
-
-  return (
-    <DemoTooltip
-      {...other}
-      onClose={() => setOpen(false)}
-      onOpen={() => setOpen(true)}
-      open={showSourceHint && atLeastSmallViewport ? true : open}
-    />
-  );
-}
-ToggleCodeTooltip.propTypes = {
-  showSourceHint: PropTypes.bool,
-};
 
 const alwaysTrue = () => true;
 
@@ -297,7 +277,6 @@ export default function DemoToolbar(props) {
     demo,
     demoData,
     demoId,
-    demoHovered,
     demoName,
     demoOptions,
     demoSourceId,
@@ -365,21 +344,14 @@ export default function DemoToolbar(props) {
     }
   };
 
-  const [sourceHintSeen, setSourceHintSeen] = React.useState(false);
-  React.useEffect(() => {
-    setSourceHintSeen(getCookie('sourceHintSeen'));
-  }, []);
   const handleCodeOpenClick = () => {
-    document.cookie = `sourceHintSeen=true;path=/;max-age=31536000`;
     onCodeOpenChange();
-    setSourceHintSeen(true);
   };
 
   const handleResetFocusClick = () => {
     initialFocusRef.current.focusVisible();
   };
 
-  const showSourceHint = demoHovered && !sourceHintSeen;
   let showCodeLabel;
   if (codeOpen) {
     showCodeLabel = showPreview ? t('hideFullSource') : t('hideSource');
@@ -562,7 +534,6 @@ export default function DemoToolbar(props) {
             data-ga-event-label={demo.gaLabel}
             data-ga-event-action="expand"
             onClick={handleCodeOpenClick}
-            showSourceHint={showSourceHint}
             {...getControlProps(3)}
           >
             {showCodeLabel}
@@ -757,7 +728,6 @@ DemoToolbar.propTypes = {
   codeVariant: PropTypes.string.isRequired,
   demo: PropTypes.object.isRequired,
   demoData: PropTypes.object.isRequired,
-  demoHovered: PropTypes.bool.isRequired,
   demoId: PropTypes.string,
   demoName: PropTypes.string.isRequired,
   demoOptions: PropTypes.object.isRequired,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

A warning is being thrown in docs while running it locally regarding `showSourceHint` prop not being recognized by React on a DOM element. This might be due to the replacement of the `ToggleCodeTooltip` component with Material UI's `Button` component in pull request #38421, which is now forwarding the prop.

Noticed while running the docs locally.
