### PR TITLE
[docs-infra] Fix the anchor link on headings

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -123,6 +123,7 @@ const Root = styled('div')(
     '& h1, & h2, & h3, & h4': {
       display: 'flex',
       alignItems: 'center',
+      gap: 6,
       '& code': {
         fontSize: 'inherit',
         lineHeight: 'inherit',
@@ -131,7 +132,8 @@ const Root = styled('div')(
       },
       '& .anchor-link': {
         // To prevent the link to get the focus.
-        display: 'none',
+        display: 'inline-flex',
+        visibility: 'hidden',
       },
       '& a:not(.anchor-link):hover': {
         color: 'currentColor',
@@ -139,14 +141,13 @@ const Root = styled('div')(
         boxShadow: '0 1px 0 0 currentColor',
         textDecoration: 'none',
       },
-      '&:hover .anchor-link, & .comment-link': {
+      '& .anchor-link, & .comment-link': {
         cursor: 'pointer',
-        display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
         flexShrink: 0,
         textAlign: 'center',
-        marginLeft: 8,
+        marginLeft: 4,
         height: 26,
         width: 26,
         backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
@@ -154,7 +155,6 @@ const Root = styled('div')(
         borderColor: `var(--muidocs-palette-divider, ${lightTheme.palette.divider})`,
         borderRadius: 8,
         color: `var(--muidocs-palette-text-secondary, ${lightTheme.palette.text.secondary})`,
-
         '&:hover': {
           backgroundColor: alpha(lightTheme.palette.primary[100], 0.4),
           borderColor: `var(--muidocs-palette-primary-100, ${lightTheme.palette.primary[100]})`,
@@ -166,6 +166,9 @@ const Root = styled('div')(
           fill: 'currentColor',
           pointerEvents: 'none',
         },
+      },
+      '&:hover .anchor-link': {
+        visibility: 'visible',
       },
       '& .comment-link': {
         display: 'none', // So we can have the comment button opt-in.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes an unintended leftover of the previous PR about the same components (https://github.com/mui/material-ui/pull/38428) that was causing a layout shift on the headings by particularly implementing the suggestion @alexfauquette dropped here: https://github.com/mui/material-ui/pull/38428#issuecomment-1682307116

| Before | After |
|--------|--------|
| <img width="500" alt="Screen Shot 2023-08-16 at 14 01 13" src="https://github.com/mui/material-ui/assets/67129314/30c3f7b3-63d6-49ed-81d1-8aea1d68d116"> | <img width="500" alt="Screen Shot 2023-08-16 at 14 01 13" src="https://github.com/mui/material-ui/assets/67129314/cc921481-5ba2-4e1f-b8f8-2680ef0e90e7"> | 

**https://deploy-preview-38528--material-ui.netlify.app/material-ui/getting-started/faq/#why-are-the-colors-i-am-seeing-different-from-what-i-see-here**