### PR TITLE
[docs] More space for theme builder

### DIFF
--- a/docs/pages/joy-ui/customization/theme-builder.js
+++ b/docs/pages/joy-ui/customization/theme-builder.js
@@ -3,5 +3,5 @@ import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 import * as pageProps from 'docs/data/joy/customization/theme-builder/theme-builder.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} disableCssVarsProvider />;
+  return <MarkdownDocs {...pageProps} disableCssVarsProvider disableToc />;
 }


### PR DESCRIPTION
Give more space for https://mui.com/joy-ui/customization/theme-builder/.

Preview https://deploy-preview-38532--material-ui.netlify.app/joy-ui/customization/theme-builder/ 

---

In hindsight, compared to https://www.radix-ui.com/themes/playground and https://ui.shadcn.com/themes, it feels like we missed the product priority. This demo feels too advanced, not too far from the point where the persona it targets would prefer to do this in code or in Figma. I think the more important use case is quick high-level customization. And the most important: how do you even know if these values make sense? I think Developers should be able to better previous how values impact the look of the components.

So, I would be in favor of:

- create a https://www.radix-ui.com/themes/playground for Material UI and Joy UI
- For the sake of simplicity:
  - remove global docs change in https://mui.com/material-ui/customization/density/#explore-theme-density
  - remove https://mui.com/material-ui/customization/color/#playground
  - remove https://mui.com/joy-ui/customization/theme-builder/ or at minimum remove the global color customizer, and only keep the global variant tool

We would also have the Figma theme editor that @DavidCnoops is working on, but it's for advanced use cases. I think here the goal is when you create a side project, and internal tools (50% of the use cases?) you don't care so much, you want a quick easy way to customize the look & feel.