### PR TITLE
[docs][joy-ui] Fix the `fullWidth` prop description for the Input

### DIFF
--- a/docs/translations/api-docs-joy/input/input.json
+++ b/docs/translations/api-docs-joy/input/input.json
@@ -10,7 +10,7 @@
       "description": "If <code>true</code>, the <code>input</code> will indicate an error. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     },
     "fullWidth": {
-      "description": "If <code>true</code>, the button will take up the full width of its container."
+      "description": "If <code>true</code>, the input will take up the full width of its container."
     },
     "size": { "description": "The size of the component." },
     "startDecorator": { "description": "Leading adornment for this input." },

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -396,7 +396,7 @@ Input.propTypes /* remove-proptypes */ = {
    */
   error: PropTypes.bool,
   /**
-   * If `true`, the button will take up the full width of its container.
+   * If `true`, the input will take up the full width of its container.
    * @default false
    */
   fullWidth: PropTypes.bool,

--- a/packages/mui-joy/src/Input/InputProps.ts
+++ b/packages/mui-joy/src/Input/InputProps.ts
@@ -84,7 +84,7 @@ export interface InputTypeMap<P = {}, D extends React.ElementType = 'div'> {
        */
       error?: boolean;
       /**
-       * If `true`, the button will take up the full width of its container.
+       * If `true`, the input will take up the full width of its container.
        * @default false
        */
       fullWidth?: boolean;


### PR DESCRIPTION
The documentation and prop type definition for the `fullWidth` prop of the Joy-UI `Input` references a button. I think this was likely a copy paste error, and should instead say input.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview - https://deploy-preview-38545--material-ui.netlify.app/joy-ui/api/input/#Input-prop-fullWidth
