### PR TITLE
[docs-infra] Mark unstable components with a chip in the nav drawer

### DIFF
--- a/docs/data/base/pages.ts
+++ b/docs/data/base/pages.ts
@@ -25,7 +25,7 @@ const pages: readonly MuiPage[] = [
           { pathname: '/base-ui/react-button', title: 'Button' },
           { pathname: '/base-ui/react-checkbox', title: 'Checkbox', planned: true },
           { pathname: '/base-ui/react-input', title: 'Input' },
-          { pathname: '/base-ui/react-number-input', title: 'Number Input' },
+          { pathname: '/base-ui/react-number-input', title: 'Number Input', unstable: true },
           { pathname: '/base-ui/react-radio-button', title: 'Radio Button', planned: true },
           { pathname: '/base-ui/react-rating', title: 'Rating', planned: true },
           { pathname: '/base-ui/react-select', title: 'Select' },

--- a/docs/src/MuiPage.ts
+++ b/docs/src/MuiPage.ts
@@ -49,6 +49,10 @@ export interface MuiPage {
    * @default false
    */
   planned?: boolean;
+  /**
+   * Indicates if the component/hook is not stable yet.
+   */
+  unstable?: boolean;
 }
 
 export interface OrderedMuiPage extends MuiPage {

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -239,6 +239,7 @@ function reduceChildRoutes(context) {
         legacy={page.legacy}
         newFeature={page.newFeature}
         planned={page.planned}
+        unstable={page.unstable}
         plan={page.plan}
         icon={page.icon}
         subheader={subheader}
@@ -271,6 +272,7 @@ function reduceChildRoutes(context) {
         legacy={page.legacy}
         newFeature={page.newFeature}
         planned={page.planned}
+        unstable={page.unstable}
         plan={page.plan}
         icon={page.icon}
         subheader={Boolean(page.subheader)}

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -329,7 +329,7 @@ export default function AppNavDrawerItem(props) {
         {legacy && <Chip label="Legacy" sx={sxChip('warning')} />}
         {newFeature && <Chip label="New" sx={sxChip('success')} />}
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
-        {unstable && <Chip label="Unstable" sx={sxChip('warning')} />}
+        {unstable && <Chip label="Preview" sx={sxChip('success')} />}
       </Item>
       {expandable ? (
         <Collapse in={open} timeout={250} unmountOnExit>

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -329,7 +329,7 @@ export default function AppNavDrawerItem(props) {
         {legacy && <Chip label="Legacy" sx={sxChip('warning')} />}
         {newFeature && <Chip label="New" sx={sxChip('success')} />}
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
-        {unstable && <Chip label="Preview" sx={sxChip('success')} />}
+        {unstable && <Chip label="Preview" sx={sxChip('primary')} />}
       </Item>
       {expandable ? (
         <Collapse in={open} timeout={250} unmountOnExit>

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -260,6 +260,7 @@ export default function AppNavDrawerItem(props) {
     legacy,
     newFeature,
     planned,
+    unstable,
     linkProps,
     onClick,
     initiallyExpanded = false,
@@ -328,6 +329,7 @@ export default function AppNavDrawerItem(props) {
         {legacy && <Chip label="Legacy" sx={sxChip('warning')} />}
         {newFeature && <Chip label="New" sx={sxChip('success')} />}
         {planned && <Chip label="Planned" sx={sxChip('grey')} />}
+        {unstable && <Chip label="Unstable" sx={sxChip('warning')} />}
       </Item>
       {expandable ? (
         <Collapse in={open} timeout={250} unmountOnExit>
@@ -356,4 +358,5 @@ AppNavDrawerItem.propTypes = {
   subheader: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
   topLevel: PropTypes.bool,
+  unstable: PropTypes.bool,
 };


### PR DESCRIPTION
Realizing we don't have any way of showing unstable components, I added a chip (similarly to "planned") to the app nav drawer entries.
I marked Base UI's Number Input as such:

<img width="187" alt="image" src="https://github.com/mui/material-ui/assets/4696105/090b70b1-e0b9-43f2-ac70-30885d0e70a0">
