### PR TITLE
[core] Remove redundant `@material-ui/` aliases from regression test webpack config

### DIFF
--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = {
     ],
   },
   resolve: {
+    ...webpackBaseConfig.resolve,
     fallback: {
       // Exclude polyfill and treat 'fs' as an empty module since it is not required. next -> gzip-size relies on it.
       fs: false,

--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -50,12 +50,6 @@ module.exports = {
     ],
   },
   resolve: {
-    ...webpackBaseConfig.resolve,
-    alias: {
-      ...webpackBaseConfig.resolve.alias,
-      '@material-ui/core': path.resolve(__dirname, '../../packages/mui-material/src'),
-      '@material-ui/styles': path.resolve(__dirname, '../../packages/mui-styles/src'),
-    },
     fallback: {
       // Exclude polyfill and treat 'fs' as an empty module since it is not required. next -> gzip-size relies on it.
       fs: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
