### PR TITLE
[LoadingButton] Fix HTML rule button > div forbidden nesting

### DIFF
--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -87,7 +87,7 @@ const LoadingButtonRoot = styled(Button, {
     }),
 }));
 
-const LoadingButtonLoadingIndicator = styled('div', {
+const LoadingButtonLoadingIndicator = styled('span', {
   name: 'MuiLoadingButton',
   slot: 'LoadingIndicator',
   overridesResolver: (props, styles) => {


### PR DESCRIPTION
The issue can be seen on https://validator.w3.org/nu/?doc=https%3A%2F%2Fmui.com%2Fmaterial-ui%2Freact-button%2F

<img width="970" alt="Screenshot 2023-08-22 at 00 53 52" src="https://github.com/mui/material-ui/assets/3165635/719f8ba1-403c-46e1-b8a0-f7eb94c311a7">

While I don't know how useful validator.w3 is, I don't think Material UI component should create noise for developers.

Preview: https://deploy-preview-38584--material-ui.netlify.app/material-ui/react-button/.

I have checked if the bug could be reproduced on Joy UI at the same time, it can't, we use span correctly there.

---

*This has been on [my backlog](https://www.notion.so/mui-org/Win-Product-opportunities-408a9771556a4715830d18f3749af753) for almost 2 years. I moved most of the items to Notion tasks, but this one seems so simple to fix that I'm going for it.*

I saw two CSS bugs on this page with Material UI v6 https://mui.com/material-ui/react-button/#material-you-version:

<img width="900" alt="Screenshot 2023-08-22 at 00 57 06" src="https://github.com/mui/material-ui/assets/3165635/23d3d8b0-79e0-4b7a-98dd-879d4793ffe2">

And

<img width="776" alt="Screenshot 2023-08-22 at 00 57 20" src="https://github.com/mui/material-ui/assets/3165635/4f2df405-415b-43c9-9743-919dd3132520">
