### PR TITLE
[docs-infra] Fix anchor scroll without tabs

### DIFF
--- a/docs/src/modules/components/MarkdownDocsV2.js
+++ b/docs/src/modules/components/MarkdownDocsV2.js
@@ -254,7 +254,9 @@ export default function MarkdownDocsV2(props) {
     >
       <div
         style={{
-          '--MuiDocs-header-height': `${AppFrameHeight + TabsHeight}px`,
+          '--MuiDocs-header-height': hasTabs
+            ? `${AppFrameHeight + TabsHeight}px`
+            : `${AppFrameHeight}px`,
         }}
       >
         {disableAd ? null : (


### PR DESCRIPTION
I noticed this bug: Open https://mui.com/material-ui/react-button/#basic-button the anchor offset is wrong. It got annoyed, a trivial fix, so why not? This regression originates from moving from `MarkdownDocs` to `MarkdownDocsV2`.

Preview: https://deploy-preview-38586--material-ui.netlify.app/material-ui/react-button/#basic-button