### PR TITLE
[website] Fine-tune the branding theme buttons

### DIFF
--- a/docs/src/components/action/NpmCopyButton.tsx
+++ b/docs/src/components/action/NpmCopyButton.tsx
@@ -52,7 +52,7 @@ const Button = styled('button')(({ theme }) => ({
       duration: theme.transitions.duration.shortest,
     }),
   },
-  '&:focus svg': {
+  '&:focus, &:hover svg': {
     opacity: 1,
   },
 }));

--- a/docs/src/components/action/NpmCopyButton.tsx
+++ b/docs/src/components/action/NpmCopyButton.tsx
@@ -76,8 +76,7 @@ export default function NpmCopyButton(
       }}
       {...other}
     >
-      <strong>$</strong>
-      {installation}
+      $ {installation}
       {copied ? (
         <CheckRounded color="inherit" sx={{ fontSize: 15 }} />
       ) : (

--- a/docs/src/components/home/GetStartedButtons.tsx
+++ b/docs/src/components/home/GetStartedButtons.tsx
@@ -107,7 +107,7 @@ export default function GetStartedButtons(props: GetStartedButtonsProps) {
           </Button>
         ) : null}
       </Box>
-      {altInstallation ? <NpmCopyButton installation={altInstallation} sx={{ mt: 2 }} /> : null}
+      {altInstallation && <NpmCopyButton installation={altInstallation} sx={{ mt: 2 }} />}
     </React.Fragment>
   );
 }

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -465,10 +465,13 @@ export function getThemedComponents(): ThemeOptions {
         styleOverrides: {
           root: ({ theme, ownerState }) => ({
             ...(ownerState.size === 'large' && {
-              padding: theme.spacing('12px', '12px', '12px', '14px'),
               ...theme.typography.body1,
               lineHeight: 21 / 16,
-              fontWeight: 700,
+              fontWeight: theme.typography.fontWeightBold,
+              padding: theme.spacing('12px', '12px', '12px', '14px'),
+              minHeight: 0,
+              '& > span': { transition: '0.2s', marginLeft: 4 },
+              '&:hover > span': { transform: 'translateX(2px)' },
             }),
             ...(ownerState.variant === 'outlined' &&
               ownerState.color === 'secondary' && {
@@ -520,7 +523,7 @@ export function getThemedComponents(): ThemeOptions {
               padding: theme.spacing(0.5, 1),
               fontFamily: theme.typography.fontFamily,
               fontSize: '0.75rem',
-              fontWeight: 600,
+              fontWeight: theme.typography.fontWeightSemiBold,
               borderRadius: '6px',
             }),
             ...(ownerState.variant === 'contained' &&
@@ -530,19 +533,12 @@ export function getThemedComponents(): ThemeOptions {
                   (theme.vars || theme).palette.primary[500]
                 } 0%, ${(theme.vars || theme).palette.primary[600]} 100%)`,
                 border: '1px solid',
-                borderColor: (theme.vars || theme).palette.primary[400],
+                borderColor: alpha(theme.palette.primary[400], 0.6),
                 boxShadow: `0px 2px 4px ${alpha(
                   theme.palette.primary[700],
                   0.2,
-                )}, inset 0px 4px 8px ${alpha(theme.palette.primary[200], 0.4)}`,
+                )}, inset 0px 2px 6px ${alpha(theme.palette.primary[100], 0.5)}`,
                 textShadow: `0px 1px 1px ${alpha(theme.palette.grey[900], 0.3)}`,
-                '&:hover': {
-                  background: `linear-gradient(180deg, ${
-                    (theme.vars || theme).palette.primary[500]
-                  } 0%, ${(theme.vars || theme).palette.primary[400]} 100%)`,
-                  boxShadow:
-                    '0px 0px 8px rgba(0, 127, 255, 0.2), inset 0px 4px 8px rgba(102, 178, 255, 0.4)',
-                },
                 ...theme.applyDarkStyles({
                   boxShadow: `0px 2px 4px ${alpha(
                     theme.palette.common.black,
@@ -978,6 +974,9 @@ export function getThemedComponents(): ThemeOptions {
               '&[href]': {
                 textDecorationLine: 'none',
               },
+              transition: theme.transitions.create(['border', 'box-shadow'], {
+                duration: theme.transitions.duration.shortest,
+              }),
               ...(ownerState.variant === 'outlined' && {
                 display: 'block',
                 borderColor: (theme.vars || theme).palette.grey[100],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes the previously broken without-transition hover styles on the primary button and adds a slight transition to the end icon when hovering over the button. A bonus transition to the paper component was also added (but ommitted from the title for brevity).

**https://deploy-preview-38588--material-ui.netlify.app/base-ui/**