### PR TITLE
[docs] fix codemod name in changelog of 5.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ A big thanks to the 18 contributors who made this release possible. Here are som
   A codemod is provided to help with the migration:
 
   ```bash
-  npx @mui/codemod v5.0.0/base-use-named-imports <path>
+  npx @mui/codemod v5.0.0/base-use-named-exports <path>
   ```
 
 #### Changes


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

Hello maintainers,

I saw that the release note 5.14.4 in `CHANGELOG.md` invites the developers to run this codemod command:

```
npx @mui/codemod v5.0.0/base-use-named-imports <path>
```

Unfortunately this command doesn't exist. It looks like the correct command ends with "-exports":

```
npx @mui/codemod v5.0.0/base-use-named-exports <path>
```

See:
- https://github.com/mui/material-ui/blob/1e418e64ff2564878bb059a27d4120c3cbdeb9db/packages/mui-codemod/README.md#base-use-named-exports
