### PR TITLE
[system] Take `unit` from theme into accout while calculating `maxWidth`

### DIFF
--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, describeConformance } from 'test/utils';
-import { Box } from '@mui/system';
+import { Box, ThemeProvider, createTheme } from '@mui/system';
 
 describe('<Box />', () => {
   const { render } = createRenderer();
@@ -278,5 +278,26 @@ describe('<Box />', () => {
     const { getByTestId } = render(<Box data-testid="regular-box" />);
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
+  });
+
+  it('should unit in account while computing maxWidth', () => {
+    const theme = createTheme({
+      breakpoints: {
+        unit: 'rem',
+        values: {
+          sm: 20,
+        },
+      },
+    });
+
+    const { getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Box data-testid="regular-box" maxWidth="sm" />
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('regular-box')).toHaveComputedStyle({
+      'max-width': '20rem',
+    });
   });
 });

--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -280,7 +280,7 @@ describe('<Box />', () => {
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
   });
 
-  it('should unit in account while computing maxWidth', () => {
+  it('should take unit in account while computing maxWidth', () => {
     const theme = createTheme({
       breakpoints: {
         unit: 'rem',

--- a/packages/mui-system/src/sizing.js
+++ b/packages/mui-system/src/sizing.js
@@ -15,7 +15,8 @@ export const maxWidth = (props) => {
   if (props.maxWidth !== undefined && props.maxWidth !== null) {
     const styleFromPropValue = (propValue) => {
       const breakpoint =
-        props.theme?.breakpoints?.values?.[propValue] || breakpointsValues[propValue];
+        `${props.theme?.breakpoints?.values?.[propValue]}${props.theme?.breakpoints?.unit || ''}` ||
+        breakpointsValues[propValue];
       return {
         maxWidth: breakpoint || sizingTransform(propValue),
       };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/38594

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
