### PR TITLE
[docs-infra] Remove deprecated export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,5 @@ These great services sponsor MUI's core infrastructure:
 <img loading="lazy" alt="CodeCov logo" src="https://avatars.githubusercontent.com/u/8226205?s=70" width="35" height="35" style="margin-top: 1rem;">
 
 [CodeCov](https://about.codecov.io/) lets us monitor test coverage.
+
+-

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -14,9 +14,6 @@ const isDeployPreview = Boolean(process.env.PULL_REQUEST_ID);
 const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDeploy;
 
 module.exports = withDocsInfra({
-  experimental: {
-    workerThreads: true,
-  },
   output: 'export',
   distDir: 'export',
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -14,10 +14,6 @@ const isDeployPreview = Boolean(process.env.PULL_REQUEST_ID);
 const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDeploy;
 
 module.exports = withDocsInfra({
-  experimental: {
-    workerThreads: true,
-    cpus: 3,
-  },
   output: 'export',
   distDir: 'export',
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -16,7 +16,6 @@ const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDep
 module.exports = withDocsInfra({
   experimental: {
     workerThreads: true,
-    cpus: 3,
   },
   output: 'export',
   distDir: 'export',

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -14,6 +14,10 @@ const isDeployPreview = Boolean(process.env.PULL_REQUEST_ID);
 const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDeploy;
 
 module.exports = withDocsInfra({
+  experimental: {
+    workerThreads: true,
+    cpus: 3,
+  },
   output: 'export',
   distDir: 'export',
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -3,12 +3,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const pkg = require('../package.json');
 const withDocsInfra = require('./nextConfigDocsInfra');
 const { findPages } = require('./src/modules/utils/find');
-const {
-  LANGUAGES,
-  LANGUAGES_SSR,
-  LANGUAGES_IGNORE_PAGES,
-  LANGUAGES_IN_PROGRESS,
-} = require('./config');
+const { LANGUAGES_SSR, LANGUAGES_IGNORE_PAGES, LANGUAGES_IN_PROGRESS } = require('./config');
 
 const workspaceRoot = path.join(__dirname, '../');
 
@@ -19,6 +14,9 @@ const isDeployPreview = Boolean(process.env.PULL_REQUEST_ID);
 const buildOnlyEnglishLocale = isDeployPreview && !l10nPRInNetlify && !vercelDeploy;
 
 module.exports = withDocsInfra({
+  output: 'export',
+  distDir: 'export',
+
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
 
@@ -232,14 +230,5 @@ module.exports = withDocsInfra({
     }
 
     return map;
-  },
-  // rewrites has no effect when run `next export` for production
-  rewrites: async () => {
-    return [
-      { source: `/:lang(${LANGUAGES.join('|')})?/:rest*`, destination: '/:rest*' },
-      // Make sure to include the trailing slash if `trailingSlash` option is set
-      { source: '/api/:rest*/', destination: '/api-docs/:rest*/' },
-      { source: `/static/x/:rest*`, destination: 'http://0.0.0.0:3001/static/x/:rest*' },
-    ];
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "build-sw": "node ./scripts/buildServiceWorker.js",
     "dev": "next dev",
     "deploy": "git push material-ui-docs master:latest",
-    "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
+    "export": "yarn build-sw",
     "icons": "rimraf --glob public/static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",
     "create-playground": "cpy --cwd=./scripts/ playground.template.tsx ../pages/playground --rename=index.tsx",


### PR DESCRIPTION
Noticed this in the build output 

<img width="955" alt="Screenshot 2023-08-23 at 11 52 10" src="https://github.com/mui/material-ui/assets/2109932/5df66aa1-6bfe-4e2b-a02e-311eafc8de0a">


https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
