### PR TITLE
[Autocomplete] Fix listbox opened unexpectedly when component is `disabled`

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -1049,7 +1049,7 @@ export function useAutocomplete(props) {
   };
 
   const handleInputMouseDown = (event) => {
-    if (inputValue === '' || !open) {
+    if (!disabledProp && (inputValue === '' || !open)) {
       handlePopupIndicator(event);
     }
   };

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -20,6 +20,7 @@ import Autocomplete, {
 } from '@mui/material/Autocomplete';
 import { paperClasses } from '@mui/material/Paper';
 import { iconButtonClasses } from '@mui/material/IconButton';
+import { inputBaseClasses } from '@mui/material/InputBase';
 import InputAdornment from '@mui/material/InputAdornment';
 import Tooltip from '@mui/material/Tooltip';
 
@@ -1383,6 +1384,30 @@ describe('<Autocomplete />', () => {
         />,
       );
       expect(queryByTitle('Open').disabled).to.equal(true);
+    });
+
+    it('clicks should not toggle the listbox open state when disabled', () => {
+      const { container, queryByRole } = render(
+        <Autocomplete
+          disabled
+          // multiple
+          options={['one', 'two', 'three']}
+          // value={['one']}
+          value="one"
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const textbox = queryByRole('combobox');
+      const listbox = queryByRole('listbox', { hidden: true });
+
+      expect(textbox).to.have.attribute('aria-expanded', 'false');
+      expect(listbox).to.equal(null);
+
+      const inputBase = container.querySelector(`.${inputBaseClasses.root}`);
+      fireEvent.click(inputBase);
+
+      expect(textbox).to.have.attribute('aria-expanded', 'false');
+      expect(listbox).to.equal(null);
     });
 
     it('should not render the clear button', () => {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -10,6 +10,7 @@ import {
   strictModeDoubleLoggingSuppressed,
 } from 'test/utils';
 import { spy } from 'sinon';
+import userEvent from '@testing-library/user-event';
 import Box from '@mui/system/Box';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
@@ -20,7 +21,6 @@ import Autocomplete, {
 } from '@mui/material/Autocomplete';
 import { paperClasses } from '@mui/material/Paper';
 import { iconButtonClasses } from '@mui/material/IconButton';
-import { inputBaseClasses } from '@mui/material/InputBase';
 import InputAdornment from '@mui/material/InputAdornment';
 import Tooltip from '@mui/material/Tooltip';
 
@@ -1387,14 +1387,19 @@ describe('<Autocomplete />', () => {
     });
 
     it('clicks should not toggle the listbox open state when disabled', () => {
-      const { container, queryByRole } = render(
+      const { getByTestId, queryByRole } = render(
         <Autocomplete
           disabled
-          // multiple
           options={['one', 'two', 'three']}
-          // value={['one']}
-          value="one"
-          renderInput={(params) => <TextField {...params} />}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              InputProps={{
+                ...params.InputProps,
+                'data-testid': 'test-input-root',
+              }}
+            />
+          )}
         />,
       );
       const textbox = queryByRole('combobox');
@@ -1403,8 +1408,43 @@ describe('<Autocomplete />', () => {
       expect(textbox).to.have.attribute('aria-expanded', 'false');
       expect(listbox).to.equal(null);
 
-      const inputBase = container.querySelector(`.${inputBaseClasses.root}`);
+      const inputBase = getByTestId('test-input-root');
       fireEvent.click(inputBase);
+
+      expect(textbox).to.have.attribute('aria-expanded', 'false');
+      expect(listbox).to.equal(null);
+    });
+
+    it('mouseup should not toggle the listbox open state when disabled', async () => {
+      const { container, queryByRole } = render(
+        <Autocomplete
+          disabled
+          options={['one', 'two', 'three']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+
+      const textbox = queryByRole('combobox');
+      const listbox = queryByRole('listbox', { hidden: true });
+
+      expect(textbox).to.have.attribute('aria-expanded', 'false');
+      expect(listbox).to.equal(null);
+
+      // userEvent will fail at releasing MouseLeft if we target the
+      // <button> since it has "pointer-events: none"
+      const popupIndicator = container.querySelector(`.${classes.endAdornment}`);
+
+      // TODO v6: refactor using userEvent.setup() which doesn't work until we drop
+      //  iOS Safari 12.x support, see: https://github.com/mui/material-ui/pull/38325
+      await userEvent.pointer([
+        // this sequence does not work with fireEvent
+        // 1. point the cursor somewhere in the textbox and hold down MouseLeft
+        { keys: '[MouseLeft>]', target: textbox },
+        // 2. move the cursor over the popupIndicator
+        { pointerName: 'mouse', target: popupIndicator },
+        // 3. release MouseLeft
+        { keys: '[/MouseLeft]' },
+      ]);
 
       expect(textbox).to.have.attribute('aria-expanded', 'false');
       expect(listbox).to.equal(null);


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/36867

Here is a sandbox with the original repro and a simplified one that shows the fix: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-38611-3hygqs?file=/demo.tsx

I can hardly believe how simple this fix could be, but it make sense to block the popup from opening if the component is `disabled`:

```diff
   const handleInputMouseDown = (event) => {
-    if (inputValue === '' || !open) {
+    if (!disabledProp && (inputValue === '' || !open)) {
       handlePopupIndicator(event);
     }
   };
```

Here is the simplified repro (I colored different parts of it) showing the bug: https://codesandbox.io/s/https-github-com-mui-material-ui-issues-36867-m25xds?file=/demo.tsx

![IMG_8EDEEC6DD982-1](https://github.com/mui/material-ui/assets/4997971/717c7268-8c61-4985-8e60-1825d1c77e31)

Both cases are reproducible:
1. Click on any part of the component that doesn't overlap (green area) with the `input` slot or the `popupIndicator`- it will open the popup.

Seems that when the click handler on the `InputBase` fires (it will even though the Autocomplete is disabled, reason [here](https://github.com/mui/material-ui/pull/36892#discussion_r1293560474)), it will trigger the `handleInputMouseDown` ([here](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Autocomplete/Autocomplete.js#L596-L600)), and [open the popup](https://github.com/mui/material-ui/blob/master/packages/mui-base/src/useAutocomplete/useAutocomplete.js#L1051-L1055).

2. Press and hold the left mouse button anywhere on the component except for the `popupIndicator` (green or blue area), move the cursor until it is over the popup indicator (red area) then release the mouse button - it will open the popup. 

Not 100% sure what's going on but since fixing case 1 automatically fixed this one, I guess it's still triggering the click handler of `InputBase` even though the cursor is no longer directly over it, and the `disabled` popup button doesn't block the mouseup/click phase of the user action 🤔 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
