### PR TITLE
[core] Potential fix for intermittent ci crashes in e2e test

### DIFF
--- a/packages/mui-material/test/umd/run.js
+++ b/packages/mui-material/test/umd/run.js
@@ -92,14 +92,7 @@ function App() {
 async function startBrowser() {
   // eslint-disable-next-line no-console
   console.info('browser: start');
-  const browser = await playwright.chromium.launch({
-    args: [
-      '--single-process', // Solve mono-thread issue on CircleCI
-      // https://github.com/GoogleChrome/puppeteer/blob/5d6535ca0c82efe2ca50450818d5fb20aa015658/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
-      '--no-sandbox', // Solve user security sandboxing issue.
-      // '--disable-web-security', // Solve weird crossorigin anonymous issue on CircleCI
-    ],
-  });
+  const browser = await playwright.chromium.launch();
   const page = await browser.newPage();
   page.on('pageerror', (err) => {
     throw err;


### PR DESCRIPTION
Seeing a bunch of [crashes](https://app.circleci.com/pipelines/github/mui/material-ui/106207/workflows/e4975e46-68a7-4d17-a0dd-4237a002c8f1/jobs/568252) lately. Modern headless Chrome should be stable enough to work without this flag.

https://bugs.chromium.org/p/chromium/issues/detail?id=1162815#c5

> --single-process was mostly used for debugbing purpose and is not a mode we really supports.

https://web.archive.org/web/20220125002107/https://www.chromium.org/developers/design-documents/process-models/#TOC-Single-process

> The single process model provides a baseline for measuring any overhead that the multi-process architectures impose. It is not a safe or robust architecture, as any renderer crash will cause the loss of the entire browser process. It is designed for testing and development purposes, and it may contain bugs that are not present in the other architectures.


Also removing `--no-sandbox`. It seems to work without it.