### PR TITLE
[docs-infra] Hide the SkipLink button if user prefers reduced motion

### DIFF
--- a/docs/src/modules/components/SkipLink.tsx
+++ b/docs/src/modules/components/SkipLink.tsx
@@ -32,10 +32,10 @@ const StyledLink = styled(MuiLink)(({ theme }) => ({
     }),
   },
   '@media (prefers-reduced-motion: reduce)': {
-    top: theme.spacing(2),
     transition: theme.transitions.create('opacity'),
     opacity: 0,
     '&:focus': {
+      top: theme.spacing(2),
       opacity: 1,
       transition: theme.transitions.create('opacity'),
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR will fix the unwanted behavior of the `SkipLink` button if the user has enabled `prefers-reduced-motion` which made it impossible to click the dropdown on the top left of the docs page. 

closes #38546 