### PR TITLE
[system] Fix maxWidth incorrectly resolving breakpoints with non-pixel units

### DIFF
--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { createRenderer, describeConformance } from 'test/utils';
-import { Box } from '@mui/system';
+import { Box, createTheme, ThemeProvider } from '@mui/system';
 
 describe('<Box />', () => {
   const { render } = createRenderer();
@@ -278,5 +278,28 @@ describe('<Box />', () => {
     const { getByTestId } = render(<Box data-testid="regular-box" />);
 
     expect(getByTestId('regular-box')).to.have.class('MuiBox-root');
+  });
+
+  describe('prop: maxWidth', () => {
+    it('should resolve breakpoints with custom units', () => {
+      const theme = createTheme({
+        breakpoints: {
+          unit: 'rem',
+          values: {
+            xs: 10,
+          },
+        },
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Box maxWidth="xs" />
+        </ThemeProvider>,
+      );
+
+      expect(container.firstChild).toHaveComputedStyle({
+        maxWidth: '10rem',
+      });
+    });
   });
 });

--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -281,7 +281,13 @@ describe('<Box />', () => {
   });
 
   describe('prop: maxWidth', () => {
-    it('should resolve breakpoints with custom units', () => {
+    it('should resolve breakpoints with custom units', function test() {
+      const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
+      if (isJSDOM) {
+        this.skip();
+      }
+
       const theme = createTheme({
         breakpoints: {
           unit: 'rem',
@@ -293,12 +299,13 @@ describe('<Box />', () => {
 
       const { container } = render(
         <ThemeProvider theme={theme}>
-          <Box maxWidth="xs" />
+          <Box maxWidth="xs" />,
         </ThemeProvider>,
       );
 
       expect(container.firstChild).toHaveComputedStyle({
-        maxWidth: '10rem',
+        // 10rem x 16px = 160px
+        maxWidth: '160px',
       });
     });
   });

--- a/packages/mui-system/src/sizing.js
+++ b/packages/mui-system/src/sizing.js
@@ -17,11 +17,20 @@ export const maxWidth = (props) => {
       const breakpoint =
         props.theme?.breakpoints?.values?.[propValue] || breakpointsValues[propValue];
 
+      if (!breakpoint) {
+        return {
+          maxWidth: sizingTransform(propValue),
+        };
+      }
+
+      if (props.theme?.breakpoints?.unit !== 'px') {
+        return {
+          maxWidth: `${breakpoint}${props.theme.breakpoints.unit}`,
+        };
+      }
+
       return {
-        maxWidth:
-          (props.theme?.breakpoints?.unit === 'px'
-            ? breakpoint
-            : `${breakpoint}${props.theme.breakpoints.unit}`) || sizingTransform(propValue),
+        maxWidth: breakpoint,
       };
     };
     return handleBreakpoints(props, props.maxWidth, styleFromPropValue);

--- a/packages/mui-system/src/sizing.js
+++ b/packages/mui-system/src/sizing.js
@@ -16,8 +16,12 @@ export const maxWidth = (props) => {
     const styleFromPropValue = (propValue) => {
       const breakpoint =
         props.theme?.breakpoints?.values?.[propValue] || breakpointsValues[propValue];
+
       return {
-        maxWidth: breakpoint || sizingTransform(propValue),
+        maxWidth:
+          (props.theme?.breakpoints?.unit === 'px'
+            ? breakpoint
+            : `${breakpoint}${props.theme.breakpoints.unit}`) || sizingTransform(propValue),
       };
     };
     return handleBreakpoints(props, props.maxWidth, styleFromPropValue);

--- a/packages/mui-system/src/sizing.test.js
+++ b/packages/mui-system/src/sizing.test.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { createTheme } from '@mui/system';
 import sizing from './sizing';
 
 describe('sizing', () => {
@@ -17,6 +18,28 @@ describe('sizing', () => {
     });
     expect(output).to.deep.equal({
       maxWidth: 0,
+    });
+  });
+
+  describe('maxWidth', () => {
+    it('should work with custom units', () => {
+      const theme = createTheme({
+        breakpoints: {
+          unit: 'rem',
+          values: {
+            xs: 10,
+          },
+        },
+      });
+
+      const output = sizing({
+        maxWidth: 'xs',
+        theme,
+      });
+
+      expect(output).to.deep.equal({
+        maxWidth: '10rem',
+      });
     });
   });
 });

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -20,11 +20,11 @@ describe('styleFunctionSx', () => {
     breakpoints: {
       keys: ['xs', 'sm', 'md', 'lg', 'xl'],
       values: breakpointsValues,
+      unit: 'px',
       up: (key) => {
         return `@media (min-width:${breakpointsValues[key]}px)`;
       },
     },
-    unit: 'px',
     palette: {
       primary: {
         main: 'rgb(0, 0, 255)',


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/38594

Here's a sandbox showing the fix: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-38633-6ry8rx?file=/src/App.tsx

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
