### PR TITLE
[docs-infra] Adjust the Material You playground demo design

### DIFF
--- a/docs/data/material/components/badges/badges.md
+++ b/docs/data/material/components/badges/badges.md
@@ -72,15 +72,15 @@ You should provide a full description, for instance, with `aria-label`:
 
 {{"demo": "AccessibleBadges.js"}}
 
-## Experimental API
+## Experimental APIs
 
 ### Material You version
 
-The default Badge component follows the Material Design 2 specs.
-For the Material Design 3 ([Material You](https://m3.material.io/)) version, you can use the new experimental `@mui/material-next` package:
+The default Material UI Badge component follows the Material Design 2 specs.
+To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Badge from '@mui/material-next/Badge';
 ```
 
-{{"demo": "BadgeMaterialYouPlayground.js", "hideToolbar": true}}
+{{"demo": "BadgeMaterialYouPlayground.js", "hideToolbar": true, "bg": "playground"}}

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -202,4 +202,4 @@ For the Material Design 3 ([Material You](https://m3.material.io/)) version, you
 import Button from '@mui/material-next/Button';
 ```
 
-{{"demo": "ButtonMaterialYouPlayground.js", "hideToolbar": true}}
+{{"demo": "ButtonMaterialYouPlayground.js", "hideToolbar": true, "bg": "playground"}}

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -168,7 +168,7 @@ However:
 
 This has the advantage of supporting any element, for instance, a link `<a>` element.
 
-## Experimental API
+## Experimental APIs
 
 ### Loading button
 
@@ -195,8 +195,8 @@ To prevent this, ensure that the contents of the Loading Button are nested insid
 
 ### Material You version
 
-The default Button component follows the Material Design 2 specs.
-For the Material Design 3 ([Material You](https://m3.material.io/)) version, you can use the new experimental `@mui/material-next` package:
+The default Material UI Button component follows the Material Design 2 specs.
+To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Button from '@mui/material-next/Button';

--- a/docs/data/material/components/slider/slider.md
+++ b/docs/data/material/components/slider/slider.md
@@ -159,15 +159,15 @@ You can solve the issue with:
 }
 ```
 
-## Experimental API
+## Experimental APIs
 
 ### Material You version
 
-The default Slider component follows the Material Design 2 specs.
-For the Material Design 3 ([Material You](https://m3.material.io/)) version, you can use the new experimental `@mui/material-next` package:
+The default Material UI Slider component follows the Material Design 2 specs.
+To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Slider from '@mui/material-next/Slider';
 ```
 
-{{"demo": "SliderMaterialYouPlayground.js", "hideToolbar": true}}
+{{"demo": "SliderMaterialYouPlayground.js", "hideToolbar": true, "bg": "playground"}}

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -221,6 +221,12 @@ const DemoRootMaterial = styled('div', {
     borderLeftWidth: 0,
     borderRightWidth: 0,
   }),
+  /* Similar to the outlined one but without padding. Ideal for playground demos. */
+  ...(bg === 'playground' && {
+    backgroundColor: (theme.vars || theme).palette.background.paper,
+    border: `1px solid ${(theme.vars || theme).palette.divider}`,
+    overflow: 'auto',
+  }),
   /* Prepare the background to display an inner elevation. */
   ...(bg === true && {
     padding: theme.spacing(3),

--- a/docs/src/modules/components/MaterialYouUsageDemo.tsx
+++ b/docs/src/modules/components/MaterialYouUsageDemo.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { useTheme as md2UseTheme } from '@mui/material/styles';
+import { useTheme as md2UseTheme, alpha } from '@mui/material/styles';
 import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded';
 import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
 import FormControl from '@mui/material/FormControl';
 import FormLabel, { formLabelClasses } from '@mui/material/FormLabel';
 import IconButton from '@mui/material/IconButton';
@@ -208,7 +209,9 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
         },
       }}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 999, minWidth: 0, p: 3 }}>
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', flexGrow: 999, minWidth: 0, p: 3, gap: 3 }}
+      >
         <Box
           sx={{
             flexGrow: 1,
@@ -238,26 +241,34 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
         </BrandingProvider>
       </Box>
       <Box
-        sx={{
+        sx={(theme) => ({
           flexShrink: 0,
           gap: 2,
-          p: 3,
-          mt: 1,
           borderLeft: '1px solid',
-          borderColor: 'divider',
-          backdropFilter: 'blur(8px)',
-          minWidth: '280px',
-        }}
+          borderColor: theme.palette.grey[200],
+          background: alpha(theme.palette.grey[50], 0.5),
+          minWidth: '250px',
+          [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
+            borderColor: alpha(theme.palette.grey[900], 0.8),
+            backgroundColor: alpha(theme.palette.grey[900], 0.3),
+          },
+        })}
       >
         <Box
           sx={{
-            mb: 2,
+            px: 3,
+            py: 2,
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
           }}
         >
-          <Typography id="usage-props" component="h3" fontWeight="lg" sx={{ scrollMarginTop: 160 }}>
+          <Typography
+            id="usage-props"
+            component="h3"
+            fontWeight="600"
+            sx={{ scrollMarginTop: 160, fontFamily: 'General Sans' }}
+          >
             Playground
           </Typography>
           <IconButton
@@ -271,11 +282,13 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
             <ReplayRoundedIcon />
           </IconButton>
         </Box>
+        <Divider sx={{ opacity: 0.5 }} />
         <Box
           sx={{
+            p: 3,
             display: 'flex',
             flexDirection: 'column',
-            gap: 2.5,
+            gap: 2,
             [`& .${formLabelClasses.root}`]: {
               fontWeight: 'lg',
             },
@@ -291,8 +304,12 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
                 <FormControl
                   key={propName}
                   size="small"
-                  // orientation="horizontal"
-                  sx={{ justifyContent: 'space-between' }}
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
                 >
                   <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
                   <Switch
@@ -316,7 +333,16 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
             if (knob === 'select') {
               return (
                 <FormControl key={propName} size="small">
-                  <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
+                  <FormLabel
+                    sx={{
+                      textTransform: 'capitalize',
+                      fontWeight: 'medium',
+                      fontSize: '0.875rem',
+                      mb: 0.5,
+                    }}
+                  >
+                    {propName}
+                  </FormLabel>
                   <Select
                     placeholder="Select a variant..."
                     value={(resolvedValue || 'none') as string}

--- a/docs/src/modules/components/MaterialYouUsageDemo.tsx
+++ b/docs/src/modules/components/MaterialYouUsageDemo.tsx
@@ -311,8 +311,18 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
                     justifyContent: 'space-between',
                   }}
                 >
-                  <FormLabel sx={{ textTransform: 'capitalize' }}>{propName}</FormLabel>
+                  <FormLabel
+                    sx={{
+                      textTransform: 'capitalize',
+                      fontWeight: 'medium',
+                      fontSize: '0.875rem',
+                      color: 'text.secondary',
+                    }}
+                  >
+                    {propName}
+                  </FormLabel>
                   <Switch
+                    size="small"
                     checked={Boolean(resolvedValue)}
                     onChange={(event) => {
                       setProps((latestProps) => ({
@@ -320,11 +330,6 @@ export default function MaterialYouUsageDemo<T extends { [k: string]: any } = {}
                         [propName]: event.target.checked,
                       }));
                       onChange?.(event);
-                    }}
-                    sx={{
-                      fontSize: 'xs',
-                      color: 'text.secondary',
-                      textTransform: 'capitalize',
                     }}
                   />
                 </FormControl>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As I was recently tweaking the Joy UI version of the Playground demos, I bumped into the Material You one and figured it had a lot that could be polished up. Additionally, created a new variant of the `Demo` component to account for exactly the Playground demos.

- **https://deploy-preview-38636--material-ui.netlify.app/material-ui/react-button/#material-you-version**
- **https://deploy-preview-38636--material-ui.netlify.app/material-ui/react-slider/#material-you-version**
- **https://deploy-preview-38636--material-ui.netlify.app/material-ui/react-badge/#material-you-version**

| Before | After |
|--------|--------|
| <img width="841" alt="Screen Shot 2023-08-24 at 20 04 49" src="https://github.com/mui/material-ui/assets/67129314/9d8f93b3-523d-4c0f-9592-500e5c1fad22"> | <img width="841" alt="Screen Shot 2023-08-24 at 20 04 32" src="https://github.com/mui/material-ui/assets/67129314/63703e6c-e07a-4d20-978d-d1ab1c4ce806"> | 
