### PR TITLE
[ignore] Try removing babel macros

### DIFF
--- a/apps/zero-runtime-vite-app/src/utils/colorManipulator.js
+++ b/apps/zero-runtime-vite-app/src/utils/colorManipulator.js
@@ -66,9 +66,8 @@ export function decomposeColor(color) {
 
   if (['rgb', 'rgba', 'hsl', 'hsla', 'color'].indexOf(type) === -1) {
     throw new Error(
-      'MUI: Unsupported `%s` color.\n' +
+      `MUI: Unsupported \`${color}\` color.\n` +
         'The following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().',
-      color,
     );
   }
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,5 @@
 const path = require('path');
 
-const errorCodesPath = path.resolve(__dirname, './docs/public/static/error-codes.json');
-const missingError = process.env.MUI_EXTRACT_ERROR_CODES === 'true' ? 'write' : 'annotate';
-
 function resolveAliasPath(relativeToBabelConf) {
   const resolvedPath = path.relative(process.cwd(), path.resolve(__dirname, relativeToBabelConf));
   return `./${resolvedPath.replace('\\', '/')}`;
@@ -52,15 +49,6 @@ module.exports = function getBabelConfig(api) {
   ];
 
   const plugins = [
-    [
-      'babel-plugin-macros',
-      {
-        muiError: {
-          errorCodesPath,
-          missingError,
-        },
-      },
-    ],
     'babel-plugin-optimize-clsx',
     // Need the following 3 proposals for all targets in .browserslistrc.
     // With our usage the transpiled loose mode is equivalent to spec mode.

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.ts
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import MuiError from '@mui/utils/macros/MuiError.macro';
 import { unstable_useForkRef as useForkRef, unstable_useId as useId } from '@mui/utils';
 import { FormControlState, useFormControlContext } from '../FormControl';
 import {
@@ -139,7 +138,7 @@ export function useNumberInput(parameters: UseNumberInputParameters): UseNumberI
     (otherHandlers: Record<string, React.EventHandler<any> | undefined>) =>
     (event: React.ChangeEvent<HTMLInputElement>) => {
       if (!isControlled && event.target === null) {
-        throw new MuiError(
+        throw new Error(
           'MUI: Expected valid input target. ' +
             'Did you use a custom `slots.input` and forget to forward refs? ' +
             'See https://mui.com/r/input-component-ref-interface for more info.',

--- a/packages/mui-base/src/useInput/useInput.ts
+++ b/packages/mui-base/src/useInput/useInput.ts
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import MuiError from '@mui/utils/macros/MuiError.macro';
 import { unstable_useForkRef as useForkRef } from '@mui/utils';
 import { FormControlState, useFormControlContext } from '../FormControl';
 import { extractEventHandlers } from '../utils/extractEventHandlers';
@@ -140,7 +139,7 @@ export function useInput(parameters: UseInputParameters): UseInputReturnValue {
       if (!isControlled) {
         const element = event.target || inputRef.current;
         if (element == null) {
-          throw new MuiError(
+          throw new Error(
             'MUI: Expected valid input target. ' +
               'Did you use a custom `slots.input` and forget to forward refs? ' +
               'See https://mui.com/r/input-component-ref-interface for more info.',

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { refType, elementTypeAcceptingRef } from '@mui/utils';
-import MuiError from '@mui/utils/macros/MuiError.macro';
+
 import {
   unstable_composeClasses as composeClasses,
   isHostComponent,
@@ -407,7 +407,7 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
     if (!isControlled) {
       const element = event.target || inputRef.current;
       if (element == null) {
-        throw new MuiError(
+        throw new Error(
           'MUI: Expected valid input target. ' +
             'Did you use a custom `inputComponent` and forget to forward refs? ' +
             'See https://mui.com/r/input-component-ref-interface for more info.',

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { isFragment } from 'react-is';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import MuiError from '@mui/utils/macros/MuiError.macro';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { refType } from '@mui/utils';
 import ownerDocument from '../utils/ownerDocument';

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -371,7 +371,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
     if (multiple) {
       if (!Array.isArray(value)) {
-        throw new MuiError(
+        throw new Error(
           'MUI: The `value` prop must be an array ' +
             'when using the `Select` component with `multiple`.',
         );

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -1,5 +1,5 @@
 import { deepmerge } from '@mui/utils';
-import MuiError from '@mui/utils/macros/MuiError.macro';
+
 import { darken, getContrastRatio, lighten } from '@mui/system';
 import common from '../colors/common';
 import grey from '../colors/grey';
@@ -223,7 +223,7 @@ export default function createPalette(palette) {
     }
 
     if (!color.hasOwnProperty('main')) {
-      throw new MuiError(
+      throw new Error(
         'MUI: The color%s provided to augmentColor(color) is invalid.\n' +
           'The color object needs to have a `main` property or a `%s` property.',
         name ? ` (${name})` : '',
@@ -232,7 +232,7 @@ export default function createPalette(palette) {
     }
 
     if (typeof color.main !== 'string') {
-      throw new MuiError(
+      throw new Error(
         'MUI: The color%s provided to augmentColor(color) is invalid.\n' +
           '`color.main` should be a string, but `%s` was provided instead.\n' +
           '\n' +

--- a/packages/mui-material/src/styles/createPalette.js
+++ b/packages/mui-material/src/styles/createPalette.js
@@ -224,17 +224,17 @@ export default function createPalette(palette) {
 
     if (!color.hasOwnProperty('main')) {
       throw new Error(
-        'MUI: The color%s provided to augmentColor(color) is invalid.\n' +
-          'The color object needs to have a `main` property or a `%s` property.',
-        name ? ` (${name})` : '',
-        mainShade,
+        `MUI: The color${name ? ` (${name})` : ''} provided to augmentColor(color) is invalid.\n` +
+          `The color object needs to have a \`main\` property or a \`${mainShade}\` property.`,
       );
     }
 
     if (typeof color.main !== 'string') {
       throw new Error(
-        'MUI: The color%s provided to augmentColor(color) is invalid.\n' +
-          '`color.main` should be a string, but `%s` was provided instead.\n' +
+        `MUI: The color${name ? ` (${name})` : ''} provided to augmentColor(color) is invalid.\n` +
+          `\`color.main\` should be a string, but \`${JSON.stringify(
+            color.main,
+          )}\` was provided instead.\n` +
           '\n' +
           'Did you intend to use one of the following approaches?\n' +
           '\n' +
@@ -247,8 +247,6 @@ export default function createPalette(palette) {
           'const theme2 = createTheme({ palette: {\n' +
           '  primary: { main: green[500] },\n' +
           '} });',
-        name ? ` (${name})` : '',
-        JSON.stringify(color.main),
       );
     }
 

--- a/packages/mui-material/src/styles/createTheme.js
+++ b/packages/mui-material/src/styles/createTheme.js
@@ -4,7 +4,7 @@ import {
   unstable_defaultSxConfig as defaultSxConfig,
   unstable_styleFunctionSx as styleFunctionSx,
 } from '@mui/system';
-import MuiError from '@mui/utils/macros/MuiError.macro';
+
 import generateUtilityClass from '../generateUtilityClass';
 import createMixins from './createMixins';
 import createPalette from './createPalette';
@@ -26,7 +26,7 @@ function createTheme(options = {}, ...args) {
   } = options;
 
   if (options.vars) {
-    throw new MuiError(
+    throw new Error(
       'MUI: `vars` is a private field used for CSS variables support.\n' +
         'Please use another name.',
     );

--- a/packages/mui-material/src/styles/index.js
+++ b/packages/mui-material/src/styles/index.js
@@ -1,5 +1,4 @@
 'use client';
-import MuiError from '@mui/utils/macros/MuiError.macro';
 
 export { default as THEME_ID } from './identifier';
 export { default as adaptV4Theme } from './adaptV4Theme';
@@ -21,7 +20,7 @@ export {
 // TODO: Remove this function in v6.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function experimental_sx() {
-  throw new MuiError(
+  throw new Error(
     'MUI: The `experimental_sx` has been moved to `theme.unstable_sx`.' +
       'For more details, see https://github.com/mui/material-ui/pull/35150.',
   );

--- a/packages/mui-material/src/styles/makeStyles.js
+++ b/packages/mui-material/src/styles/makeStyles.js
@@ -1,7 +1,5 @@
-import MuiError from '@mui/utils/macros/MuiError.macro';
-
 export default function makeStyles() {
-  throw new MuiError(
+  throw new Error(
     'MUI: makeStyles is no longer exported from @mui/material/styles.\n' +
       'You have to import it from @mui/styles.\n' +
       'See https://mui.com/r/migration-v4/#mui-material-styles for more details.',

--- a/packages/mui-material/src/styles/responsiveFontSizes.js
+++ b/packages/mui-material/src/styles/responsiveFontSizes.js
@@ -1,4 +1,3 @@
-import MuiError from '@mui/utils/macros/MuiError.macro';
 import { isUnitless, convertLength, responsiveProperty, alignProperty, fontGrid } from './cssUtils';
 
 export default function responsiveFontSizes(themeInput, options = {}) {
@@ -46,7 +45,7 @@ export default function responsiveFontSizes(themeInput, options = {}) {
     let { lineHeight } = style;
 
     if (!isUnitless(lineHeight) && !disableAlign) {
-      throw new MuiError(
+      throw new Error(
         'MUI: Unsupported non-unitless line height with grid alignment.\n' +
           'Use unitless line heights instead.',
       );

--- a/packages/mui-material/src/styles/withStyles.js
+++ b/packages/mui-material/src/styles/withStyles.js
@@ -1,7 +1,5 @@
-import MuiError from '@mui/utils/macros/MuiError.macro';
-
 export default function withStyles() {
-  throw new MuiError(
+  throw new Error(
     'MUI: withStyles is no longer exported from @mui/material/styles.\n' +
       'You have to import it from @mui/styles.\n' +
       'See https://mui.com/r/migration-v4/#mui-material-styles for more details.',

--- a/packages/mui-material/src/styles/withTheme.js
+++ b/packages/mui-material/src/styles/withTheme.js
@@ -1,7 +1,5 @@
-import MuiError from '@mui/utils/macros/MuiError.macro';
-
 export default function withTheme() {
-  throw new MuiError(
+  throw new Error(
     'MUI: withTheme is no longer exported from @mui/material/styles.\n' +
       'You have to import it from @mui/styles.\n' +
       'See https://mui.com/r/migration-v4/#mui-material-styles for more details.',

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import MuiError from '@mui/utils/macros/MuiError.macro';
 
 /**
  * Returns a number whose value is limited to the given range.
@@ -68,7 +67,7 @@ export function decomposeColor(color) {
   const type = color.substring(0, marker);
 
   if (['rgb', 'rgba', 'hsl', 'hsla', 'color'].indexOf(type) === -1) {
-    throw new MuiError(
+    throw new Error(
       'MUI: Unsupported `%s` color.\n' +
         'The following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().',
       color,
@@ -85,7 +84,7 @@ export function decomposeColor(color) {
       values[3] = values[3].slice(1);
     }
     if (['srgb', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec-2020'].indexOf(colorSpace) === -1) {
-      throw new MuiError(
+      throw new Error(
         'MUI: unsupported `%s` color space.\n' +
           'The following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rgb, rec-2020.',
         colorSpace,

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -68,9 +68,8 @@ export function decomposeColor(color) {
 
   if (['rgb', 'rgba', 'hsl', 'hsla', 'color'].indexOf(type) === -1) {
     throw new Error(
-      'MUI: Unsupported `%s` color.\n' +
+      `MUI: Unsupported \`${color}\` color.n` +
         'The following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().',
-      color,
     );
   }
 
@@ -85,9 +84,8 @@ export function decomposeColor(color) {
     }
     if (['srgb', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec-2020'].indexOf(colorSpace) === -1) {
       throw new Error(
-        'MUI: unsupported `%s` color space.\n' +
+        `MUI: unsupported \`${colorSpace}\` color space.\n` +
           'The following color spaces are supported: srgb, display-p3, a98-rgb, prophoto-rgb, rec-2020.',
-        colorSpace,
       );
     }
   } else {

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.js
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import MuiError from '@mui/utils/macros/MuiError.macro';
+
 import { deepmerge } from '@mui/utils';
 import { GlobalStyles } from '@mui/styled-engine';
 import { useTheme as muiUseTheme } from '@mui/private-theming';
@@ -51,7 +51,7 @@ export default function createCssVarsProvider(options) {
   const useColorScheme = () => {
     const value = React.useContext(ColorSchemeContext);
     if (!value) {
-      throw new MuiError('MUI: `useColorScheme` must be called under <CssVarsProvider />');
+      throw new Error('MUI: `useColorScheme` must be called under <CssVarsProvider />');
     }
     return value;
   };

--- a/packages/mui-system/src/index.js
+++ b/packages/mui-system/src/index.js
@@ -1,5 +1,4 @@
 'use client';
-import MuiError from '@mui/utils/macros/MuiError.macro';
 
 export { css, keyframes, StyledEngineProvider } from '@mui/styled-engine';
 export { default as GlobalStyles } from './GlobalStyles';
@@ -38,7 +37,7 @@ export {
 // TODO: Remove this function in v6
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function experimental_sx() {
-  throw new MuiError(
+  throw new Error(
     'MUI: The `experimental_sx` has been moved to `theme.unstable_sx`.' +
       'For more details, see https://github.com/mui/material-ui/pull/35150.',
   );

--- a/packages/mui-utils/macros/MuiError.macro.js
+++ b/packages/mui-utils/macros/MuiError.macro.js
@@ -98,7 +98,7 @@ function muiError({ references, babel, config, source }) {
     const newExpressionPath = babelPath.parentPath;
     if (!newExpressionPath.isNewExpression()) {
       throw new MacroError(
-        'Encountered `MuiError` outside of a "new expression" i.e. `new MuiError()`. Use `throw new MuiError(message)` over `throw MuiError(message)`.',
+        'Encountered `MuiError` outside of a "new expression" i.e. `new Error()`. Use `throw new Error(message)` over `throw MuiError(message)`.',
       );
     }
 

--- a/packages/mui-utils/src/capitalize/capitalize.ts
+++ b/packages/mui-utils/src/capitalize/capitalize.ts
@@ -1,12 +1,10 @@
-import MuiError from '../../macros/MuiError.macro';
-
 // It should to be noted that this function isn't equivalent to `text-transform: capitalize`.
 //
 // A strict capitalization should uppercase the first letter of each word in the sentence.
 // We only handle the first word.
 export default function capitalize(string: string): string {
   if (typeof string !== 'string') {
-    throw new MuiError('MUI: `capitalize(string)` expects a string argument.');
+    throw new Error('MUI: `capitalize(string)` expects a string argument.');
   }
 
   return string.charAt(0).toUpperCase() + string.slice(1);

--- a/packages/mui-utils/src/capitalize/capitalize.ts
+++ b/packages/mui-utils/src/capitalize/capitalize.ts
@@ -1,3 +1,5 @@
+import MuiError from '../../macros/MuiError.macro';
+
 // It should to be noted that this function isn't equivalent to `text-transform: capitalize`.
 //
 // A strict capitalization should uppercase the first letter of each word in the sentence.

--- a/packages/mui-utils/src/capitalize/capitalize.ts
+++ b/packages/mui-utils/src/capitalize/capitalize.ts
@@ -1,5 +1,3 @@
-import MuiError from '../../macros/MuiError.macro';
-
 // It should to be noted that this function isn't equivalent to `text-transform: capitalize`.
 //
 // A strict capitalization should uppercase the first letter of each word in the sentence.


### PR DESCRIPTION
Trying this out as a canary on CI. Just to check the effect on bundle sizes.
babel macros is probably the biggest hurdle to overcome for moving to SWC. It's also one of those things that's being painful in moving Toolpad on pnpm. Is this even still doing anything in the first place? It explains us that we have to run `yarn extract-errors` but where is that script?