### PR TITLE
[utils] Handle circular reference of objects in `deepMerge`

### DIFF
--- a/packages/mui-utils/src/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { styled } from '@mui/system';
 import deepmerge from './deepmerge';
 
 describe('deepmerge', () => {
@@ -9,6 +10,21 @@ describe('deepmerge', () => {
     });
 
     expect({}).not.to.have.property('isAdmin');
+  });
+
+  it('should handle circular references by avoiding infinite recursion during deep cloning', () => {
+    const circularObj = {
+      prop1: 'value1',
+    };
+    // @ts-ignore
+    circularObj.circularRef = circularObj;
+
+    const result = deepmerge({}, circularObj);
+
+    expect(result).to.deep.equal({
+      prop1: 'value1',
+      circularRef: { prop1: 'value1', circularRef: { prop1: 'value1' } },
+    });
   });
 
   // https://github.com/mui/material-ui/issues/20095

--- a/packages/mui-utils/src/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { styled } from '@mui/system';
 import deepmerge from './deepmerge';
 
 describe('deepmerge', () => {

--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -6,7 +6,7 @@ export interface DeepmergeOptions {
   clone?: boolean;
 }
 
-function deepClone<T>(source: T): T | Record<keyof any, unknown> {
+function deepClone<T>(source: T, seen = new Set()): T | Record<keyof any, unknown> {
   if (!isPlainObject(source)) {
     return source;
   }
@@ -14,8 +14,11 @@ function deepClone<T>(source: T): T | Record<keyof any, unknown> {
   const output: Record<keyof any, unknown> = {};
 
   Object.keys(source).forEach((key) => {
-    if (key !== '__emotion_real') {
-      output[key] = deepClone(source[key]);
+    if (!seen.has(source[key])) {
+      if (typeof source[key] === 'object') {
+        seen.add(source[key]);
+      }
+      output[key] = deepClone(source[key], seen);
     }
   });
 

--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -14,7 +14,9 @@ function deepClone<T>(source: T): T | Record<keyof any, unknown> {
   const output: Record<keyof any, unknown> = {};
 
   Object.keys(source).forEach((key) => {
-    output[key] = deepClone(source[key]);
+    if (key !== '__emotion_real') {
+      output[key] = deepClone(source[key]);
+    }
   });
 
   return output;

--- a/packages/mui-utils/src/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge.ts
@@ -6,7 +6,7 @@ export interface DeepmergeOptions {
   clone?: boolean;
 }
 
-function deepClone<T>(source: T, seen = new Set()): T | Record<keyof any, unknown> {
+function deepClone<T>(source: T, visited = new Set()): T | Record<keyof any, unknown> {
   if (!isPlainObject(source)) {
     return source;
   }
@@ -14,11 +14,11 @@ function deepClone<T>(source: T, seen = new Set()): T | Record<keyof any, unknow
   const output: Record<keyof any, unknown> = {};
 
   Object.keys(source).forEach((key) => {
-    if (!seen.has(source[key])) {
+    if (!visited.has(source[key])) {
       if (typeof source[key] === 'object') {
-        seen.add(source[key]);
+        visited.add(source[key]);
       }
-      output[key] = deepClone(source[key], seen);
+      output[key] = deepClone(source[key], visited);
     }
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/38489

reason for crashing of `Autocomplete` in `before` sandbox is explained here: https://github.com/mui/material-ui/issues/38489#issuecomment-1681291716

before: https://codesandbox.io/s/late-wind-9fzfmw?file=/Demo.js
after: https://codesandbox.io/s/still-framework-57wl4g?file=/Demo.js

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
