### PR TITLE
[docs-infra] Fix emotion :first-child console log

### DIFF
--- a/docs/src/modules/components/HighlightedCodeWithTabs.tsx
+++ b/docs/src/modules/components/HighlightedCodeWithTabs.tsx
@@ -44,7 +44,7 @@ const StyledTab = styled(Tab)<{ ownerState: { mounted: boolean } }>(({ theme, ow
     cursor: 'pointer',
     borderRadius: '8px',
     position: 'relative',
-    '&:not(:first-child)': {
+    '&:not(:first-of-type)': {
       marginLeft: 0.5,
     },
     ...(ownerState.mounted && {


### PR DESCRIPTION
I wanted to try something on a demo in the docs, turns out I was not using the right prop based on a console log.

However, there is crap in the console I had to scroll paste:

<img width="1250" alt="Screenshot 2023-08-29 at 01 02 09" src="https://github.com/mui/material-ui/assets/3165635/8014acfb-6990-46f8-a8ca-5536f1da1419">

Introduced in #37643.