### PR TITLE
[docs] Show all the code in the usage section

### DIFF
--- a/docs/data/joy/getting-started/usage/usage.md
+++ b/docs/data/joy/getting-started/usage/usage.md
@@ -7,7 +7,7 @@
 After [installation](/joy-ui/getting-started/installation/), you can import any Joy UI component and start playing around.
 For example, try changing the `variant` on the [Button](/joy-ui/react-button/) to `soft` to see how the style changes:
 
-{{"demo": "ButtonUsage.js"}}
+{{"demo": "ButtonUsage.js", "defaultCodeOpen": true}}
 
 ### CssVarsProvider
 

--- a/docs/data/material/getting-started/usage/usage.md
+++ b/docs/data/material/getting-started/usage/usage.md
@@ -7,7 +7,7 @@
 After [installation](/material-ui/getting-started/installation/), you can import any Material UI component and start playing around.
 For example, try changing the `variant` on the [Button](/material-ui/react-button/) to `outlined` to see how the style changes:
 
-{{"demo": "ButtonUsage.js"}}
+{{"demo": "ButtonUsage.js", "defaultCodeOpen": true}}
 
 ## Globals
 


### PR DESCRIPTION
Fix https://mui-org.slack.com/archives/C041SDSF32L/p1693255905957869

<img width="542" alt="Screenshot 2023-08-29 at 01 25 31" src="https://github.com/mui/material-ui/assets/3165635/3090657e-00a0-4fd0-b020-b854f946b481">
