### PR TITLE
[docs-infra] Fix leaking callout content

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -281,7 +281,7 @@ const Root = styled('div')(
         theme.shape?.borderRadius ?? lightTheme.shape.borderRadius
       }px)`,
       '& .MuiCallout-content': {
-        minWidth: 0,
+        minWidth: 0, // Allows content to shrink. Useful when callout contains code block
         display: 'flex',
         flexDirection: 'column',
         gap: 6,

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -281,11 +281,18 @@ const Root = styled('div')(
         theme.shape?.borderRadius ?? lightTheme.shape.borderRadius
       }px)`,
       '& .MuiCallout-content': {
+        minWidth: 0,
         display: 'flex',
         flexDirection: 'column',
         gap: 6,
         '&>p, ul': {
           marginBottom: 0,
+        },
+        '& .MuiCode-root': {
+          '&>pre': {
+            margin: 0,
+            marginTop: 4,
+          },
         },
         '&>ul': {
           paddingLeft: 22,
@@ -448,9 +455,8 @@ const Root = styled('div')(
       fontWeight: 500,
       borderRadius: 6,
       border: 'none',
-      backgroundColor: 'transparent',
+      backgroundColor: '#0F1924', // using the code block one-off background color (defined in line 23)
       color: '#FFF',
-      opacity: 0.6,
       transition: theme.transitions.create(['background', 'borderColor', 'display'], {
         duration: theme.transitions.duration.shortest,
       }),
@@ -463,12 +469,15 @@ const Root = styled('div')(
         flexShrink: 0,
         fontSize: '18px',
         margin: 'auto',
+        opacity: 0.6,
       },
       '& .MuiCode-copied-icon': {
         display: 'none',
       },
       '&:hover, &:focus': {
-        opacity: 1,
+        '& svg': {
+          opacity: 1,
+        },
         backgroundColor: lightTheme.palette.primaryDark[500],
         '& .MuiCode-copyKeypress': {
           display: 'block',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes a bug happening when there's a code block inside a callout. It was not happening to a bunch of instances, at least as far as I could find, but I recently noticed it on the Joy UI List page. Not sure if this is the ideal fix but it solves the problem for now.

| Before | After |
|--------|--------|
| <img width="731" alt="Screen Shot 2023-08-29 at 11 46 25" src="https://github.com/mui/material-ui/assets/67129314/00179a92-e53b-4094-8e73-73904785c5fe"> | <img width="731" alt="Screen Shot 2023-08-29 at 13 54 09" src="https://github.com/mui/material-ui/assets/67129314/7db18da3-dedc-4378-8ab1-61422479d443"> | 