### PR TITLE
[Select][Joy-UI] Increase color contrast of the hover state of a list item of select component in material-ui-joy

### DIFF
--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -239,6 +239,10 @@ const SelectListbox = styled(StyledList, {
     ...(!variantStyle?.backgroundColor && {
       backgroundColor: theme.vars.palette.background.popup,
     }),
+    // This is done for an increased color contrast of the select list item while hovering
+    '& li:not(.Mui-selected):hover': {
+      backgroundColor: theme.palette.mode === 'light' ? '#eaeef0' : undefined ,
+    },
   };
 });
 

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -241,7 +241,7 @@ const SelectListbox = styled(StyledList, {
     }),
     // This is done for an increased color contrast of the select list item while hovering
     '& li:not(.Mui-selected):hover': {
-      backgroundColor: theme.palette.mode === 'light' ? '#eaeef0' : undefined ,
+      backgroundColor: theme.palette.mode === 'light' ? '#eaeef0' : undefined,
     },
   };
 });


### PR DESCRIPTION
This pull request updates the Mateirl-UI-Joy Select Component's hover color of the list item of a select component as reported in issue #38705.

## Changes Made
- Updated the hover state color of select option for light mode in Material Joy-UI

Previous Select Component - ![Screenshot 2023-08-30 at 8 53 46 PM](https://github.com/mui/material-ui/assets/35552170/a9edc1b9-a895-4ea5-9087-2510ae242012)

Select component after updating color contrast - ![Screenshot 2023-08-30 at 8 54 12 PM](https://github.com/mui/material-ui/assets/35552170/8735231f-bbfc-48e2-8e7f-7ace015de95e)


@zanivan please do a design review!

