### PR TITLE
[TextareaAutosize] Simplify logic and add test

### DIFF
--- a/docs/data/joy/components/autocomplete/Asynchronous.js
+++ b/docs/data/joy/components/autocomplete/Asynchronous.js
@@ -4,9 +4,11 @@ import FormLabel from '@mui/joy/FormLabel';
 import Autocomplete from '@mui/joy/Autocomplete';
 import CircularProgress from '@mui/joy/CircularProgress';
 
-function sleep(delay = 0) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(resolve, delay);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/docs/data/joy/components/autocomplete/Asynchronous.tsx
+++ b/docs/data/joy/components/autocomplete/Asynchronous.tsx
@@ -4,9 +4,11 @@ import FormLabel from '@mui/joy/FormLabel';
 import Autocomplete from '@mui/joy/Autocomplete';
 import CircularProgress from '@mui/joy/CircularProgress';
 
-function sleep(delay = 0) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, delay);
+function sleep(duration: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/docs/data/material/components/autocomplete/Asynchronous.js
+++ b/docs/data/material/components/autocomplete/Asynchronous.js
@@ -3,9 +3,11 @@ import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 
-function sleep(delay = 0) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(resolve, delay);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/docs/data/material/components/autocomplete/Asynchronous.tsx
+++ b/docs/data/material/components/autocomplete/Asynchronous.tsx
@@ -8,9 +8,11 @@ interface Film {
   year: number;
 }
 
-function sleep(delay = 0) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, delay);
+function sleep(duration: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -103,6 +103,43 @@ describe('<TextareaAutosize />', () => {
     });
   });
 
+  // For https://github.com/mui/material-ui/pull/37135
+  it('should update height without delay', async function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // It depends on ResizeObserver
+      this.skip();
+    }
+
+    function App() {
+      const ref = React.useRef<HTMLTextAreaElement>(null);
+      return (
+        <div>
+          <button
+            onClick={() => {
+              ref.current!.style.width = '250px';
+            }}
+          >
+            change
+          </button>
+          <div>
+            <TextareaAutosize
+              ref={ref}
+              style={{ width: 150, padding: 0 }}
+              defaultValue="qdzqzd qzd qzd qzd qz dqz"
+            />
+          </div>
+        </div>
+      );
+    }
+    const { container } = render(<App />);
+    const input = container.querySelector<HTMLTextAreaElement>('textarea')!;
+    const button = screen.getByRole('button');
+    expect(input.style).to.have.property('height', '30px');
+    fireEvent.click(button);
+    await sleep(10);
+    expect(input.style).to.have.property('height', '15px');
+  });
+
   describe('layout', () => {
     const getComputedStyleStub = new Map<Element, Partial<CSSStyleDeclaration>>();
     function setLayout(

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -17,9 +17,9 @@ function getStyleValue(value: string) {
   return parseInt(value, 10) || 0;
 }
 
-function sleep(time: number): Promise<void> {
+function sleep(duration: number): Promise<void> {
   return new Promise<void>((res) => {
-    setTimeout(res, time);
+    setTimeout(res, duration);
   });
 }
 

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -287,7 +287,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
     const resizeObserver = new ResizeObserver(() => {
       // see https://github.com/mui/material-ui/issues/36909
-      animationFrame = window.requestAnimationFrame(handleResize);
+      animationFrame = requestAnimationFrame(handleResize);
     });
 
     if (masonryRef.current) {

--- a/packages/waterfall/sleep.mjs
+++ b/packages/waterfall/sleep.mjs
@@ -1,6 +1,8 @@
-function sleep(delay = 0) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(resolve, delay);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/bundling/fixtures/create-react-app/testCreateReactAppIntegration.js
+++ b/test/bundling/fixtures/create-react-app/testCreateReactAppIntegration.js
@@ -4,9 +4,11 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/bundling/fixtures/esbuild/testEsbuildIntegration.js
+++ b/test/bundling/fixtures/esbuild/testEsbuildIntegration.js
@@ -4,12 +4,13 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
-
 /**
  * Attempts page.goto with retries
  *

--- a/test/bundling/fixtures/gatsby/testGatsbyIntegration.js
+++ b/test/bundling/fixtures/gatsby/testGatsbyIntegration.js
@@ -4,9 +4,11 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/bundling/fixtures/next-webpack4/testNextWebpack4Integration.js
+++ b/test/bundling/fixtures/next-webpack4/testNextWebpack4Integration.js
@@ -4,9 +4,11 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/bundling/fixtures/next-webpack5/testNextWebpack5Integration.js
+++ b/test/bundling/fixtures/next-webpack5/testNextWebpack5Integration.js
@@ -4,9 +4,11 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/bundling/fixtures/snowpack/testSnowpackIntegration.js
+++ b/test/bundling/fixtures/snowpack/testSnowpackIntegration.js
@@ -4,9 +4,11 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/bundling/fixtures/vite/testViteIntegration.js
+++ b/test/bundling/fixtures/vite/testViteIntegration.js
@@ -4,9 +4,11 @@ const playwright = require('playwright');
  * @param {number} timeoutMS
  * @returns {Promise<void>}
  */
-function sleep(timeoutMS) {
+function sleep(duration) {
   return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -9,9 +9,11 @@ import type {
 } from '@testing-library/dom';
 import '../utils/initPlaywrightMatchers';
 
-function sleep(timeoutMS: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(), timeoutMS);
+function sleep(duration: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, duration);
   });
 }
 


### PR DESCRIPTION
A quick continuation of #37135. I was triggered because I saw 3 PRs that fix bugs without tests on the same component:

1. https://github.com/mui/material-ui/pull/33238.
2. https://github.com/mui/material-ui/pull/33253
3. https://github.com/mui/material-ui/pull/37135. I have tried to add tests on this one, but the problem is that in Karma, the browser gets confused, It triggers `ResizeObserver loop completed with undelivered notifications` but it's an hallucination https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors. More details in https://github.com/WICG/resize-observer/issues/38, also faced in https://github.com/mui/mui-x/issues/8733.

I'm also removing these `if (inputRef.current) {` defensive checks. Sebastian was asking the right question in https://github.com/mui/material-ui/pull/33238#issuecomment-1162696735. As far as I know, the origin is React 17 https://github.com/facebook/react/pull/17925 which doesn't run the effect cleanup synchronously anymore.

@mnajdova could we make the same change in https://github.com/mui/material-ui/pull/33277/files, moving to a layout effect? Thanks

--- 