### PR TITLE
[icons-material] Add types to ESM icons

### DIFF
--- a/packages/mui-icons-material/scripts/create-typings.mjs
+++ b/packages/mui-icons-material/scripts/create-typings.mjs
@@ -8,19 +8,20 @@ import url from 'url';
 const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
 
 const SRC_DIR = path.resolve(currentDirectory, '../lib/esm');
-const TARGET_DIR = path.resolve(currentDirectory, '../build');
+const CJS_TARGET_DIR = path.resolve(currentDirectory, '../build');
+const ESM_TARGET_DIR = path.resolve(currentDirectory, '../build/esm');
 
 function normalizeFileName(file) {
   return path.parse(file).name;
 }
 
-function createIconTyping(file) {
+function createIconTyping(file, targetDir) {
   const name = normalizeFileName(file);
   const contents = `export { default } from '@mui/material/SvgIcon';`;
-  return fse.writeFile(path.resolve(TARGET_DIR, `${name}.d.ts`), contents, 'utf8');
+  return fse.writeFile(path.resolve(targetDir, `${name}.d.ts`), contents, 'utf8');
 }
 
-function createIndexTyping(files) {
+function createIndexTyping(files, targetDir) {
   const contents = `
 import SvgIcon from '@mui/material/SvgIcon';
 
@@ -29,17 +30,26 @@ type SvgIconComponent = typeof SvgIcon;
 ${files.map((file) => `export const ${normalizeFileName(file)}: SvgIconComponent;`).join('\n')}
 `;
 
-  return fse.writeFile(path.resolve(TARGET_DIR, 'index.d.ts'), contents, 'utf8');
+  return fse.writeFile(path.resolve(targetDir, 'index.d.ts'), contents, 'utf8');
 }
 
 // Generate TypeScript.
 async function run() {
-  await fse.ensureDir(TARGET_DIR);
+  await fse.ensureDir(CJS_TARGET_DIR);
+  await fse.ensureDir(ESM_TARGET_DIR);
   console.log(`\u{1f52c}  Searching for modules inside "${chalk.dim(SRC_DIR)}".`);
   const files = await glob('!(index)*.js', { cwd: SRC_DIR });
-  const typings = files.map((file) => createIconTyping(file));
-  await Promise.all([...typings, createIndexTyping(files)]);
-  console.log(`\u{1F5C4}  Written typings to ${chalk.dim(TARGET_DIR)}.`);
+  const cjsTypings = files.map((file) => createIconTyping(file, CJS_TARGET_DIR));
+  const esmTypings = files.map((file) => createIconTyping(file, ESM_TARGET_DIR));
+  await Promise.all([
+    ...cjsTypings,
+    ...esmTypings,
+    createIndexTyping(files, CJS_TARGET_DIR),
+    createIndexTyping(files, ESM_TARGET_DIR),
+  ]);
+  console.log(
+    `\u{1F5C4}  Written typings to ${chalk.dim(CJS_TARGET_DIR)} and ${chalk.dim(ESM_TARGET_DIR)}.`,
+  );
 }
 
 run();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

### Context

I am encountering [this issue](https://github.com/mui/material-ui/issues/32727). I have narrowed it down to [an issue](https://github.com/evanw/esbuild/issues/3357) with esbuild that only occurs in this case when CJS and ESM are mixed. In order to workaround this I would like to switch to using the icons in `@mui/icons-material/esm`, but they have no types.

### Changes

Add types to the icons in `@mui/icons-material/esm` directory so they can be imported in a TypeScript project.