### PR TITLE
[base-ui] Fix passing custom handlers to the root of Dialog

### DIFF
--- a/packages/mui-base/src/unstable_useModal/useModal.ts
+++ b/packages/mui-base/src/unstable_useModal/useModal.ts
@@ -166,14 +166,14 @@ export function useModal(parameters: UseModalParameters): UseModalReturnValue {
   ): UseModalRootSlotProps<TOther> => {
     const propsEventHandlers = extractEventHandlers(parameters) as Partial<UseModalParameters>;
 
-    // The custom event handlers shouldn't be spread on the root element
-    delete propsEventHandlers.onTransitionEnter;
-    delete propsEventHandlers.onTransitionExited;
-
     const externalEventHandlers = {
       ...propsEventHandlers,
       ...otherHandlers,
     };
+
+    // The custom event handlers shouldn't be spread on the root element
+    delete externalEventHandlers.onTransitionEnter;
+    delete externalEventHandlers.onTransitionExited;
 
     return {
       role: 'presentation',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As you can see in the following picture there is a warning in the console by `react-dom` about custom event handlers on `Dialog` component:

![Screenshot 2023-08-31 at 17 51 16 (2)](https://github.com/mui/material-ui/assets/33752170/44be472a-74bf-4945-8a66-f29b5f6fc877)


We can fix the warning by filtering the custom event handlers on the props that we are passing to the root component.