### PR TITLE
[NumberInput][base-ui] Warn when changing control mode with `useControlled` 

### DIFF
--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
@@ -271,24 +271,25 @@ describe('useNumberInput', () => {
     });
   });
 
-  describe('warnings', () => {
-    // it('should warn when switching from uncontrolled to controlled', () => {
-    //   const handleChange = spy();
-    //   function NumberInput({ value }: { value?: number }) {
-    //     const { getInputProps } = useNumberInput({
-    //       onChange: handleChange,
-    //     });
+  describe('warn - uncontrol to control', () => {
+    it('should warn when switching from uncontrolled to controlled', () => {
+      const handleChange = spy();
+      function NumberInput({ value }: { value?: number }) {
+        const { getInputProps } = useNumberInput({
+          onChange: handleChange,
+        });
 
-    //     return <input {...getInputProps()} value={value} />;
-    //   }
-    //   const { setProps } = render(<NumberInput />);
-    //   expect(() => {
-    //     setProps({ value: 5 });
-    //   }).to.toErrorDev(
-    //     ['Warning: A component is changing an uncontrolled input to be controlled'].join('\n'),
-    //   );
-    // });
-
+        return <input {...getInputProps()} value={value} />;
+      }
+      const { setProps } = render(<NumberInput />);
+      expect(() => {
+        setProps({ value: 5 });
+      }).to.toErrorDev(
+        ['Warning: A component is changing an uncontrolled input to be controlled'].join('\n'),
+      );
+    });
+  });
+  describe('warn - control to uncontrol', () => {
     it('should warn when switching from controlled to uncontrolled', () => {
       const handleChange = spy();
       function NumberInput({ value }: { value?: number }) {

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
@@ -271,7 +271,7 @@ describe('useNumberInput', () => {
     });
   });
 
-  describe('warn - uncontrol to control', () => {
+  describe('warnings', () => {
     it('should warn when switching from uncontrolled to controlled', () => {
       const handleChange = spy();
       function NumberInput({ value }: { value?: number }) {
@@ -289,22 +289,22 @@ describe('useNumberInput', () => {
         'MUI: A component is changing the uncontrolled value state of NumberInput to be controlled',
       );
     });
-  });
-  describe('warn - control to uncontrol', () => {
+
     it('should warn when switching from controlled to uncontrolled', () => {
       const handleChange = spy();
       function NumberInput({ value }: { value?: number }) {
         const { getInputProps } = useNumberInput({
           onChange: handleChange,
+          value,
         });
 
-        return <input {...getInputProps()} value={value} />;
+        return <input {...getInputProps()} />;
       }
       const { setProps } = render(<NumberInput value={5} />);
       expect(() => {
         setProps({ value: undefined });
       }).to.toErrorDev(
-        ['Warning: A component is changing a controlled input to be uncontrolled'].join('\n'),
+        'MUI: A component is changing the controlled value state of NumberInput to be uncontrolled',
       );
     });
   });

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
@@ -272,22 +272,22 @@ describe('useNumberInput', () => {
   });
 
   describe('warnings', () => {
-    it('should warn when switching from uncontrolled to controlled', () => {
-      const handleChange = spy();
-      function NumberInput({ value }: { value?: number }) {
-        const { getInputProps } = useNumberInput({
-          onChange: handleChange,
-        });
+    // it('should warn when switching from uncontrolled to controlled', () => {
+    //   const handleChange = spy();
+    //   function NumberInput({ value }: { value?: number }) {
+    //     const { getInputProps } = useNumberInput({
+    //       onChange: handleChange,
+    //     });
 
-        return <input {...getInputProps()} value={value} />;
-      }
-      const { setProps } = render(<NumberInput />);
-      expect(() => {
-        setProps({ value: 5 });
-      }).to.toErrorDev(
-        ['Warning: A component is changing an uncontrolled input to be controlled'].join('\n'),
-      );
-    });
+    //     return <input {...getInputProps()} value={value} />;
+    //   }
+    //   const { setProps } = render(<NumberInput />);
+    //   expect(() => {
+    //     setProps({ value: 5 });
+    //   }).to.toErrorDev(
+    //     ['Warning: A component is changing an uncontrolled input to be controlled'].join('\n'),
+    //   );
+    // });
 
     it('should warn when switching from controlled to uncontrolled', () => {
       const handleChange = spy();

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
@@ -277,15 +277,16 @@ describe('useNumberInput', () => {
       function NumberInput({ value }: { value?: number }) {
         const { getInputProps } = useNumberInput({
           onChange: handleChange,
+          value,
         });
 
-        return <input {...getInputProps()} value={value} />;
+        return <input {...getInputProps()} />;
       }
       const { setProps } = render(<NumberInput />);
       expect(() => {
         setProps({ value: 5 });
       }).to.toErrorDev(
-        ['Warning: A component is changing an uncontrolled input to be controlled'].join('\n'),
+        'MUI: A component is changing the uncontrolled value state of NumberInput to be controlled',
       );
     });
   });

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
@@ -270,4 +270,40 @@ describe('useNumberInput', () => {
       expect(handleChange.args[0][1]).to.equal(undefined);
     });
   });
+
+  describe('warnings', () => {
+    it('should warn when switching from uncontrolled to controlled', async () => {
+      const handleChange = spy();
+      function NumberInput({ value }: { value?: number }) {
+        const { getInputProps } = useNumberInput({
+          onChange: handleChange,
+        });
+
+        return <input {...getInputProps()} value={value} />;
+      }
+      const { setProps } = render(<NumberInput />);
+      expect(() => {
+        setProps({ value: 5 });
+      }).to.toErrorDev(
+        ['Warning: A component is changing an uncontrolled input to be controlled'].join('\n'),
+      );
+    });
+
+    it('should warn when switching from controlled to uncontrolled', async () => {
+      const handleChange = spy();
+      function NumberInput({ value }: { value?: number }) {
+        const { getInputProps } = useNumberInput({
+          onChange: handleChange,
+        });
+
+        return <input {...getInputProps()} value={value} />;
+      }
+      const { setProps } = render(<NumberInput value={5} />);
+      expect(() => {
+        setProps({ value: undefined });
+      }).to.toErrorDev(
+        ['Warning: A component is changing a controlled input to be uncontrolled'].join('\n'),
+      );
+    });
+  });
 });

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.test.tsx
@@ -272,7 +272,7 @@ describe('useNumberInput', () => {
   });
 
   describe('warnings', () => {
-    it('should warn when switching from uncontrolled to controlled', async () => {
+    it('should warn when switching from uncontrolled to controlled', () => {
       const handleChange = spy();
       function NumberInput({ value }: { value?: number }) {
         const { getInputProps } = useNumberInput({
@@ -289,7 +289,7 @@ describe('useNumberInput', () => {
       );
     });
 
-    it('should warn when switching from controlled to uncontrolled', async () => {
+    it('should warn when switching from controlled to uncontrolled', () => {
       const handleChange = spy();
       function NumberInput({ value }: { value?: number }) {
         const { getInputProps } = useNumberInput({

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput.ts
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput.ts
@@ -1,7 +1,11 @@
 'use client';
 import * as React from 'react';
 import MuiError from '@mui/utils/macros/MuiError.macro';
-import { unstable_useForkRef as useForkRef, unstable_useId as useId } from '@mui/utils';
+import {
+  unstable_useForkRef as useForkRef,
+  unstable_useId as useId,
+  unstable_useControlled as useControlled,
+} from '@mui/utils';
 import { FormControlState, useFormControlContext } from '../FormControl';
 import {
   UseNumberInputParameters,
@@ -81,7 +85,12 @@ export function useNumberInput(parameters: UseNumberInputParameters): UseNumberI
   const [focused, setFocused] = React.useState(false);
 
   // the "final" value
-  const [value, setValue] = React.useState(valueProp ?? defaultValueProp);
+  const [value, setValue] = useControlled({
+    controlled: valueProp,
+    default: defaultValueProp,
+    name: 'NumberInput',
+  });
+
   // the (potentially) dirty or invalid input value
   const [dirtyValue, setDirtyValue] = React.useState<string | undefined>(
     value ? String(value) : undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/38513

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
