### PR TITLE
[docs-infra] Catch duplicated trailing splashes in links

### DIFF
--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,4 +1,4 @@
 Broken links found by `yarn docs:link-check` that exist:
 
 - https://mui.com/blog/material-ui-v4-is-out/#premium-themes-store-✨
-- https://mui.com/size-snapshot
+- https://mui.com/size-snapshot/

--- a/docs/pages/blog/first-look-at-joy.md
+++ b/docs/pages/blog/first-look-at-joy.md
@@ -22,7 +22,7 @@ Material UI is MUI's React implementation of Google's Material Design.
 
 Over time Material UI has established itself as the go-to library for quickly breathing life into products, mostly thanks to its design, customizability, and documentation.
 However, the components do come by default with the 2018 Google look and feel that is no longer as popular as it once was.
-And as we've confirmed with [our latest developer survey](/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library/), design quality is one of the most important elements that developers consider when choosing a UI library.
+And as we've confirmed with [our latest developer survey](/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), design quality is one of the most important elements that developers consider when choosing a UI library.
 
 ## Why not just build a new Material UI theme?
 

--- a/docs/scripts/reportBrokenLinks.js
+++ b/docs/scripts/reportBrokenLinks.js
@@ -6,7 +6,7 @@ const { marked } = require('marked');
 const { LANGUAGES_IGNORE_PAGES } = require('../config');
 
 // Use renderer to extract all links into a markdown document
-const getPageLinks = (markdown) => {
+function getPageLinks(markdown) {
   const hrefs = [];
 
   const renderer = new marked.Renderer();
@@ -17,10 +17,10 @@ const getPageLinks = (markdown) => {
   };
   marked(markdown, { mangle: false, headerIds: false, renderer });
   return hrefs;
-};
+}
 
 // List all .js files in a folder
-const getJsFilesInFolder = (folderPath) => {
+function getJsFilesInFolder(folderPath) {
   const files = fse.readdirSync(folderPath, { withFileTypes: true });
   return files.reduce((acc, file) => {
     if (file.isDirectory()) {
@@ -32,7 +32,7 @@ const getJsFilesInFolder = (folderPath) => {
     }
     return acc;
   }, []);
-};
+}
 
 // Returns url assuming it's "./docs/pages/x/..." becomes  "mui.com/x/..."
 const jsFilePathToUrl = (jsFilePath) => {
@@ -41,10 +41,10 @@ const jsFilePathToUrl = (jsFilePath) => {
 
   const root = folder.slice(jsFilePath.indexOf('/pages') + '/pages'.length);
   const suffix = path.extname(file);
-  let page = `/${file.slice(0, file.length - suffix.length)}`;
+  let page = `/${file.slice(0, file.length - suffix.length)}/`;
 
-  if (page === '/index') {
-    page = '';
+  if (page === '/index/') {
+    page = '/';
   }
 
   return `${root}${page}`;
@@ -147,7 +147,6 @@ const parseDocFolder = (folderPath, availableLinks = {}, usedLinks = {}) => {
     const { hashes, links } = getLinksAndAnchors(fileName);
 
     links
-      .map((link) => (link[link.length - 1] === '/' ? link.slice(0, link.length - 1) : link))
       .forEach((link) => {
         if (usedLinks[link] === undefined) {
           usedLinks[link] = [fileName];
@@ -157,7 +156,7 @@ const parseDocFolder = (folderPath, availableLinks = {}, usedLinks = {}) => {
       });
 
     hashes.forEach((hash) => {
-      availableLinks[`${url}/#${hash}`] = true;
+      availableLinks[`${url}#${hash}`] = true;
     });
   });
 };

--- a/docs/scripts/reportBrokenLinks.js
+++ b/docs/scripts/reportBrokenLinks.js
@@ -146,14 +146,13 @@ const parseDocFolder = (folderPath, availableLinks = {}, usedLinks = {}) => {
   mdFiles.forEach(({ fileName, url }) => {
     const { hashes, links } = getLinksAndAnchors(fileName);
 
-    links
-      .forEach((link) => {
-        if (usedLinks[link] === undefined) {
-          usedLinks[link] = [fileName];
-        } else {
-          usedLinks[link].push(fileName);
-        }
-      });
+    links.forEach((link) => {
+      if (usedLinks[link] === undefined) {
+        usedLinks[link] = [fileName];
+      } else {
+        usedLinks[link].push(fileName);
+      }
+    });
 
     hashes.forEach((hash) => {
       availableLinks[`${url}#${hash}`] = true;

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -55,6 +55,18 @@ function escape(html, encode) {
 function checkUrlHealth(href, linkText, context) {
   const url = new URL(href, 'https://mui.com/');
 
+  if (/\/{2,}$/.test(url.pathname)) {
+    throw new Error(
+      [
+        'docs-infra: Duplicated trailing slashes. The following link:',
+        `[${linkText}](${href}) in ${context.location} has duplicated trailing slashes, please only add one.`,
+        '',
+        'See https://ahrefs.com/blog/trailing-slash/ for more details.',
+        '',
+      ].join('\n'),
+    );
+  }
+
   // External links to MUI, ignore
   if (url.host !== 'mui.com') {
     return;
@@ -350,7 +362,9 @@ function createRender(context) {
 
       let finalHref = href;
 
-      checkUrlHealth(href, linkText, context);
+      if (process.env.DEPLOY_ENV !== 'production') {
+        checkUrlHealth(href, linkText, context);
+      }
 
       if (userLanguage !== 'en' && href.indexOf('/') === 0 && !options.ignoreLanguagePages(href)) {
         finalHref = `/${userLanguage}${href}`;

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -362,9 +362,7 @@ function createRender(context) {
 
       let finalHref = href;
 
-      if (process.env.DEPLOY_ENV !== 'production') {
-        checkUrlHealth(href, linkText, context);
-      }
+      checkUrlHealth(href, linkText, context);
 
       if (userLanguage !== 'en' && href.indexOf('/') === 0 && !options.ignoreLanguagePages(href)) {
         finalHref = `/${userLanguage}${href}`;

--- a/packages/markdown/prepareMarkdown.test.js
+++ b/packages/markdown/prepareMarkdown.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import prepareMarkdown from './prepareMarkdown';
 
-describe('parseMarkdown', () => {
+describe('prepareMarkdown', () => {
   const defaultParams = {
     fileRelativeContext: 'test/bar',
     options: {
@@ -400,7 +400,9 @@ Use "bash" instead.
   it('should report duplicated trailing splashes', () => {
     const markdown = `
 # Localization
+
 <p class="description">Foo</p>
+
 [foo](/foo/)
 [bar](/bar//#foo)
 `;

--- a/packages/markdown/prepareMarkdown.test.js
+++ b/packages/markdown/prepareMarkdown.test.js
@@ -396,4 +396,20 @@ npm install @mui/material
 Use "bash" instead.
 `);
   });
+
+  it('should report duplicated trailing splashes', () => {
+    const markdown = `
+# Localization
+<p class="description">Foo</p>
+[foo](/foo/)
+[bar](/bar//#foo)
+`;
+
+    expect(() => {
+      prepareMarkdown({
+        ...defaultParams,
+        translations: [{ filename: 'index.md', markdown, userLanguage: 'en' }],
+      });
+    }).to.throw(`docs-infra: Duplicated trailing slashes.`);
+  });
 });


### PR DESCRIPTION
A succession of problems led to me breaking master (a71e6a07b80a230c302e687f6034b29eac3347f0 broke the CI on master). 

1. `yarn docs:link-check` outputted `/joy-ui/integrations/material-ui/` in material-ui/docs/.link-check-errors.txt, it should have been `/joy-ui/integrations/material-ui//`. In #38396 it would have made it clearer that we were introducing double trailing slashes. The root problem IMHO is that when we compare URLs we should compare their final version. So in this PR, I make sure we compare the URL with trailing slashes.
2. In #38396 we shouldn't have been able to get the CI pass with https://github.com/mui/material-ui/pull/38396#discussion_r1312360728. I'm introducing a new error. https://help.ahrefs.com/en/articles/2596665-double-slash-in-url-error-in-site-audit

~A side win, because these URL checks add to the runtime and bundle size, I'm now excluding them from production with `process.env.DEPLOY_ENV !== 'production'`. One step toward making the fastest UI component library documentation 🚀~