### PR TITLE
[docs] Polish Slider demos

### DIFF
--- a/docs/data/material/components/transitions/SimpleCollapse.js
+++ b/docs/data/material/components/transitions/SimpleCollapse.js
@@ -6,18 +6,18 @@ import Collapse from '@mui/material/Collapse';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
           fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleCollapse.tsx
+++ b/docs/data/material/components/transitions/SimpleCollapse.tsx
@@ -4,21 +4,20 @@ import Switch from '@mui/material/Switch';
 import Paper from '@mui/material/Paper';
 import Collapse from '@mui/material/Collapse';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { Theme } from '@mui/material/styles';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
-          fill: (theme: Theme) => theme.palette.common.white,
+          fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleFade.js
+++ b/docs/data/material/components/transitions/SimpleFade.js
@@ -6,18 +6,18 @@ import Fade from '@mui/material/Fade';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
           fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleFade.tsx
+++ b/docs/data/material/components/transitions/SimpleFade.tsx
@@ -4,21 +4,20 @@ import Switch from '@mui/material/Switch';
 import Paper from '@mui/material/Paper';
 import Fade from '@mui/material/Fade';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { Theme } from '@mui/material/styles';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
-          fill: (theme: Theme) => theme.palette.common.white,
+          fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleGrow.js
+++ b/docs/data/material/components/transitions/SimpleGrow.js
@@ -6,18 +6,18 @@ import Grow from '@mui/material/Grow';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
           fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleGrow.tsx
+++ b/docs/data/material/components/transitions/SimpleGrow.tsx
@@ -4,21 +4,20 @@ import Switch from '@mui/material/Switch';
 import Paper from '@mui/material/Paper';
 import Grow from '@mui/material/Grow';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { Theme } from '@mui/material/styles';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
-          fill: (theme: Theme) => theme.palette.common.white,
+          fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleSlide.js
+++ b/docs/data/material/components/transitions/SimpleSlide.js
@@ -6,18 +6,18 @@ import Slide from '@mui/material/Slide';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
           fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 
@@ -29,16 +29,21 @@ export default function SimpleSlide() {
   };
 
   return (
-    <Box sx={{ height: 180 }}>
-      <Box sx={{ width: `calc(100px + 16px)`, position: 'relative', zIndex: 1 }}>
-        <FormControlLabel
-          control={<Switch checked={checked} onChange={handleChange} />}
-          label="Show"
-        />
-        <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
-          {icon}
-        </Slide>
-      </Box>
+    <Box
+      sx={{
+        height: 180,
+        width: 130,
+        position: 'relative',
+        zIndex: 1,
+      }}
+    >
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={handleChange} />}
+        label="Show"
+      />
+      <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
+        {icon}
+      </Slide>
     </Box>
   );
 }

--- a/docs/data/material/components/transitions/SimpleSlide.tsx
+++ b/docs/data/material/components/transitions/SimpleSlide.tsx
@@ -4,21 +4,20 @@ import Switch from '@mui/material/Switch';
 import Paper from '@mui/material/Paper';
 import Slide from '@mui/material/Slide';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { Theme } from '@mui/material/styles';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
-          fill: (theme: Theme) => theme.palette.common.white,
+          fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 
@@ -30,16 +29,21 @@ export default function SimpleSlide() {
   };
 
   return (
-    <Box sx={{ height: 180 }}>
-      <Box sx={{ width: `calc(100px + 16px)`, position: 'relative', zIndex: 1 }}>
-        <FormControlLabel
-          control={<Switch checked={checked} onChange={handleChange} />}
-          label="Show"
-        />
-        <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
-          {icon}
-        </Slide>
-      </Box>
+    <Box
+      sx={{
+        height: 180,
+        width: 130,
+        position: 'relative',
+        zIndex: 1,
+      }}
+    >
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={handleChange} />}
+        label="Show"
+      />
+      <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
+        {icon}
+      </Slide>
     </Box>
   );
 }

--- a/docs/data/material/components/transitions/SimpleSlide.tsx.preview
+++ b/docs/data/material/components/transitions/SimpleSlide.tsx.preview
@@ -1,9 +1,7 @@
-<Box sx={{ width: `calc(100px + 16px)`, position: 'relative', zIndex: 1 }}>
-  <FormControlLabel
-    control={<Switch checked={checked} onChange={handleChange} />}
-    label="Show"
-  />
-  <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
-    {icon}
-  </Slide>
-</Box>
+<FormControlLabel
+  control={<Switch checked={checked} onChange={handleChange} />}
+  label="Show"
+/>
+<Slide direction="up" in={checked} mountOnEnter unmountOnExit>
+  {icon}
+</Slide>

--- a/docs/data/material/components/transitions/SimpleZoom.js
+++ b/docs/data/material/components/transitions/SimpleZoom.js
@@ -6,18 +6,18 @@ import Zoom from '@mui/material/Zoom';
 import FormControlLabel from '@mui/material/FormControlLabel';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
           fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SimpleZoom.tsx
+++ b/docs/data/material/components/transitions/SimpleZoom.tsx
@@ -4,21 +4,20 @@ import Switch from '@mui/material/Switch';
 import Paper from '@mui/material/Paper';
 import Zoom from '@mui/material/Zoom';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { Theme } from '@mui/material/styles';
 
 const icon = (
-  <Paper sx={{ m: 1 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+  <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
-          fill: (theme: Theme) => theme.palette.common.white,
+          fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 

--- a/docs/data/material/components/transitions/SlideFromContainer.js
+++ b/docs/data/material/components/transitions/SlideFromContainer.js
@@ -32,21 +32,19 @@ export default function SlideFromContainer() {
   return (
     <Box
       sx={{
-        height: 200,
-        display: 'flex',
-        borderRadius: 1,
+        width: 240,
+        borderRadius: 2,
         border: '1px solid',
         borderColor: 'divider',
         backgroundColor: 'background.default',
-        overflow: 'hidden',
       }}
     >
-      <Box sx={{ width: 240, padding: 2 }} ref={containerRef}>
+      <Box sx={{ p: 2, height: 200, overflow: 'hidden' }} ref={containerRef}>
         <FormControlLabel
           control={<Switch checked={checked} onChange={handleChange} />}
           label="Show from target"
         />
-        <Slide direction="up" in={checked} container={containerRef.current}>
+        <Slide in={checked} container={containerRef.current}>
           {icon}
         </Slide>
       </Box>

--- a/docs/data/material/components/transitions/SlideFromContainer.js
+++ b/docs/data/material/components/transitions/SlideFromContainer.js
@@ -7,17 +7,17 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 
 const icon = (
   <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
           fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 
@@ -32,18 +32,16 @@ export default function SlideFromContainer() {
   return (
     <Box
       sx={{
-        height: 180,
-        width: 240,
+        height: 200,
         display: 'flex',
-        padding: 2,
         borderRadius: 1,
-        bgcolor: (theme) =>
-          theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
+        border: '1px solid',
+        borderColor: 'divider',
+        backgroundColor: 'background.default',
         overflow: 'hidden',
       }}
-      ref={containerRef}
     >
-      <Box sx={{ width: 200 }}>
+      <Box sx={{ width: 240, padding: 2 }} ref={containerRef}>
         <FormControlLabel
           control={<Switch checked={checked} onChange={handleChange} />}
           label="Show from target"

--- a/docs/data/material/components/transitions/SlideFromContainer.tsx
+++ b/docs/data/material/components/transitions/SlideFromContainer.tsx
@@ -32,21 +32,19 @@ export default function SlideFromContainer() {
   return (
     <Box
       sx={{
-        height: 200,
-        display: 'flex',
-        borderRadius: 1,
+        width: 240,
+        borderRadius: 2,
         border: '1px solid',
         borderColor: 'divider',
         backgroundColor: 'background.default',
-        overflow: 'hidden',
       }}
     >
-      <Box sx={{ width: 240, padding: 2 }} ref={containerRef}>
+      <Box sx={{ p: 2, height: 200, overflow: 'hidden' }} ref={containerRef}>
         <FormControlLabel
           control={<Switch checked={checked} onChange={handleChange} />}
           label="Show from target"
         />
-        <Slide direction="up" in={checked} container={containerRef.current}>
+        <Slide in={checked} container={containerRef.current}>
           {icon}
         </Slide>
       </Box>

--- a/docs/data/material/components/transitions/SlideFromContainer.tsx
+++ b/docs/data/material/components/transitions/SlideFromContainer.tsx
@@ -4,27 +4,26 @@ import Switch from '@mui/material/Switch';
 import Paper from '@mui/material/Paper';
 import Slide from '@mui/material/Slide';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { Theme } from '@mui/material/styles';
 
 const icon = (
   <Paper sx={{ m: 1, width: 100, height: 100 }} elevation={4}>
-    <Box component="svg" sx={{ width: 100, height: 100 }}>
+    <svg>
       <Box
         component="polygon"
+        points="0,100 50,00, 100,100"
         sx={{
-          fill: (theme: Theme) => theme.palette.common.white,
+          fill: (theme) => theme.palette.common.white,
           stroke: (theme) => theme.palette.divider,
           strokeWidth: 1,
         }}
-        points="0,100 50,00, 100,100"
       />
-    </Box>
+    </svg>
   </Paper>
 );
 
 export default function SlideFromContainer() {
   const [checked, setChecked] = React.useState(false);
-  const containerRef = React.useRef(null);
+  const containerRef = React.useRef<HTMLElement>(null);
 
   const handleChange = () => {
     setChecked((prev) => !prev);
@@ -33,18 +32,16 @@ export default function SlideFromContainer() {
   return (
     <Box
       sx={{
-        height: 180,
-        width: 240,
+        height: 200,
         display: 'flex',
-        padding: 2,
         borderRadius: 1,
-        bgcolor: (theme) =>
-          theme.palette.mode === 'light' ? 'grey.100' : 'grey.900',
+        border: '1px solid',
+        borderColor: 'divider',
+        backgroundColor: 'background.default',
         overflow: 'hidden',
       }}
-      ref={containerRef}
     >
-      <Box sx={{ width: 200 }}>
+      <Box sx={{ width: 240, padding: 2 }} ref={containerRef}>
         <FormControlLabel
           control={<Switch checked={checked} onChange={handleChange} />}
           label="Show from target"

--- a/docs/data/material/components/transitions/SlideFromContainer.tsx.preview
+++ b/docs/data/material/components/transitions/SlideFromContainer.tsx.preview
@@ -1,9 +1,9 @@
-<Box sx={{ width: 240, padding: 2 }} ref={containerRef}>
+<Box sx={{ p: 2, height: 200, overflow: 'hidden' }} ref={containerRef}>
   <FormControlLabel
     control={<Switch checked={checked} onChange={handleChange} />}
     label="Show from target"
   />
-  <Slide direction="up" in={checked} container={containerRef.current}>
+  <Slide in={checked} container={containerRef.current}>
     {icon}
   </Slide>
 </Box>

--- a/docs/data/material/components/transitions/SlideFromContainer.tsx.preview
+++ b/docs/data/material/components/transitions/SlideFromContainer.tsx.preview
@@ -1,4 +1,4 @@
-<Box sx={{ width: 200 }}>
+<Box sx={{ width: 240, padding: 2 }} ref={containerRef}>
   <FormControlLabel
     control={<Switch checked={checked} onChange={handleChange} />}
     label="Show from target"

--- a/docs/data/material/components/transitions/TransitionGroupExample.js
+++ b/docs/data/material/components/transitions/TransitionGroupExample.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
@@ -63,17 +62,13 @@ export default function TransitionGroupExample() {
   return (
     <div>
       {addFruitButton}
-      <Box sx={{ mt: 1 }}>
-        <List>
-          <TransitionGroup>
-            {fruitsInBasket.map((item) => (
-              <Collapse key={item}>
-                {renderItem({ item, handleRemoveFruit })}
-              </Collapse>
-            ))}
-          </TransitionGroup>
-        </List>
-      </Box>
+      <List sx={{ mt: 1 }}>
+        <TransitionGroup>
+          {fruitsInBasket.map((item) => (
+            <Collapse key={item}>{renderItem({ item, handleRemoveFruit })}</Collapse>
+          ))}
+        </TransitionGroup>
+      </List>
     </div>
   );
 }

--- a/docs/data/material/components/transitions/TransitionGroupExample.tsx
+++ b/docs/data/material/components/transitions/TransitionGroupExample.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
@@ -68,17 +67,13 @@ export default function TransitionGroupExample() {
   return (
     <div>
       {addFruitButton}
-      <Box sx={{ mt: 1 }}>
-        <List>
-          <TransitionGroup>
-            {fruitsInBasket.map((item) => (
-              <Collapse key={item}>
-                {renderItem({ item, handleRemoveFruit })}
-              </Collapse>
-            ))}
-          </TransitionGroup>
-        </List>
-      </Box>
+      <List sx={{ mt: 1 }}>
+        <TransitionGroup>
+          {fruitsInBasket.map((item) => (
+            <Collapse key={item}>{renderItem({ item, handleRemoveFruit })}</Collapse>
+          ))}
+        </TransitionGroup>
+      </List>
     </div>
   );
 }

--- a/docs/data/material/components/transitions/TransitionGroupExample.tsx.preview
+++ b/docs/data/material/components/transitions/TransitionGroupExample.tsx.preview
@@ -1,12 +1,8 @@
 {addFruitButton}
-<Box sx={{ mt: 1 }}>
-  <List>
-    <TransitionGroup>
-      {fruitsInBasket.map((item) => (
-        <Collapse key={item}>
-          {renderItem({ item, handleRemoveFruit })}
-        </Collapse>
-      ))}
-    </TransitionGroup>
-  </List>
-</Box>
+<List sx={{ mt: 1 }}>
+  <TransitionGroup>
+    {fruitsInBasket.map((item) => (
+      <Collapse key={item}>{renderItem({ item, handleRemoveFruit })}</Collapse>
+    ))}
+  </TransitionGroup>
+</List>

--- a/docs/data/material/components/transitions/transitions.md
+++ b/docs/data/material/components/transitions/transitions.md
@@ -54,7 +54,7 @@ Similarly, the `unmountOnExit` prop removes the component from the DOM after it 
 The Slide component also accepts `container` prop, which is a reference to a DOM node.
 If this prop is set, the Slide component will slide from the edge of that DOM node.
 
-{{"demo": "SlideFromContainer.js"}}
+{{"demo": "SlideFromContainer.js", "bg": true}}
 
 ## Zoom
 


### PR DESCRIPTION
Seeing the change to the online preview in #38646: https://github.com/mui/material-ui/pull/38646/files#diff-abc20b07c6893afa34e4fc5d939e3ab2cae95855b4585748bee4bf3822e0cd6b 

<img width="637" alt="Screenshot 2023-09-02 at 22 58 05" src="https://github.com/mui/material-ui/assets/3165635/54bccf63-4d7e-4f47-842b-f89d5ef26efc">

triggered me to have a quick look at improving the demos in the page.

---

Preview: https://deploy-preview-38759--material-ui.netlify.app/material-ui/transitions/#slide