### PR TITLE
[docs][Drawer] Fix Right-anchored persistent drawer intercepts click when it is closed

### DIFF
--- a/docs/data/material/components/drawers/PersistentDrawerRight.js
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.js
@@ -131,6 +131,7 @@ export default function PersistentDrawerRight() {
         sx={{
           width: drawerWidth,
           flexShrink: 0,
+          zIndex: !open ? -10 : null,
           '& .MuiDrawer-paper': {
             width: drawerWidth,
           },

--- a/docs/data/material/components/drawers/PersistentDrawerRight.js
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.js
@@ -97,7 +97,12 @@ export default function PersistentDrawerRight() {
           </IconButton>
         </Toolbar>
       </AppBar>
-      <Main open={open}>
+      <Main
+        open={open}
+        sx={{
+          position: 'relative',
+        }}
+      >
         <DrawerHeader />
         <Typography paragraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -131,7 +136,6 @@ export default function PersistentDrawerRight() {
         sx={{
           width: drawerWidth,
           flexShrink: 0,
-          zIndex: !open ? -10 : null,
           '& .MuiDrawer-paper': {
             width: drawerWidth,
           },

--- a/docs/data/material/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.tsx
@@ -101,7 +101,12 @@ export default function PersistentDrawerRight() {
           </IconButton>
         </Toolbar>
       </AppBar>
-      <Main open={open}>
+      <Main
+        open={open}
+        sx={{
+          position: 'relative',
+        }}
+      >
         <DrawerHeader />
         <Typography paragraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -135,7 +140,6 @@ export default function PersistentDrawerRight() {
         sx={{
           width: drawerWidth,
           flexShrink: 0,
-          zIndex: !open ? -10 : null,
           '& .MuiDrawer-paper': {
             width: drawerWidth,
           },

--- a/docs/data/material/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.tsx
@@ -135,6 +135,7 @@ export default function PersistentDrawerRight() {
         sx={{
           width: drawerWidth,
           flexShrink: 0,
+          zIndex: !open ? -10 : null,
           '& .MuiDrawer-paper': {
             width: drawerWidth,
           },


### PR DESCRIPTION
I am opening this up to verify the pipeline tests and will finalize the PR once the pipeline is green.

Fixes #29997

Before: https://mui.com/material-ui/react-drawer/#persistent-drawer
After: https://deploy-preview-38760--material-ui.netlify.app/material-ui/react-drawer/#persistent-drawer