### PR TITLE
[docs-infra] Fix mobile display in CodeSandbox

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -48,6 +48,7 @@ describe('CodeSandbox', () => {
 <html lang="en">
   <head>
     <title>BasicButtons Material Demo</title>
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <!-- Fonts to support Material Design -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -137,6 +138,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
 <html lang="en">
   <head>
     <title>BasicButtons Material Demo</title>
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <!-- Fonts to support Material Design -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -15,6 +15,7 @@ export const getHtml = ({
 <html lang="${language}">
   <head>
     <title>${title}</title>
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <!-- Fonts to support Material Design -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/src/modules/sandbox/StackBlitz.test.js
+++ b/docs/src/modules/sandbox/StackBlitz.test.js
@@ -35,6 +35,7 @@ describe('StackBlitz', () => {
 <html lang="en">
   <head>
     <title>BasicButtons Material Demo</title>
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <!-- Fonts to support Material Design -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -110,6 +111,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
 <html lang="en">
   <head>
     <title>BasicButtons Material Demo</title>
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <!-- Fonts to support Material Design -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
I noticed in #38684. It's annoying for the codesandbox demo created to be broken on mobile.

Reproduction https://mui.com/material-ui/react-alert/#basic-alerts

https://github.com/mui/material-ui/assets/3165635/b074906a-fc83-42ce-a5f4-ee51d0cf94b3
