### PR TITLE
[system] Remove getInitColorSchemeScript leading spaces

### DIFF
--- a/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
+++ b/packages/mui-system/src/cssVars/getInitColorSchemeScript.tsx
@@ -57,31 +57,32 @@ export default function getInitColorSchemeScript(options?: GetInitColorSchemeScr
       key="mui-color-scheme-init"
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{
-        __html: `(function() { try {
-        var mode = localStorage.getItem('${modeStorageKey}') || '${defaultMode}';
-        var cssColorScheme = mode;
-        var colorScheme = '';
-        if (mode === 'system') {
-          // handle system mode
-          var mql = window.matchMedia('(prefers-color-scheme: dark)');
-          if (mql.matches) {
-            cssColorScheme = 'dark';
-            colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
-          } else {
-            cssColorScheme = 'light';
-            colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
-          }
-        }
-        if (mode === 'light') {
-          colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
-        }
-        if (mode === 'dark') {
-          colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
-        }
-        if (colorScheme) {
-          ${colorSchemeNode}.setAttribute('${attribute}', colorScheme);
-        }
-      } catch (e) {} })();`,
+        __html: `(function() {
+try {
+  var mode = localStorage.getItem('${modeStorageKey}') || '${defaultMode}';
+  var cssColorScheme = mode;
+  var colorScheme = '';
+  if (mode === 'system') {
+    // handle system mode
+    var mql = window.matchMedia('(prefers-color-scheme: dark)');
+    if (mql.matches) {
+      cssColorScheme = 'dark';
+      colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
+    } else {
+      cssColorScheme = 'light';
+      colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
+    }
+  }
+  if (mode === 'light') {
+    colorScheme = localStorage.getItem('${colorSchemeStorageKey}-light') || '${defaultLightColorScheme}';
+  }
+  if (mode === 'dark') {
+    colorScheme = localStorage.getItem('${colorSchemeStorageKey}-dark') || '${defaultDarkColorScheme}';
+  }
+  if (colorScheme) {
+    ${colorSchemeNode}.setAttribute('${attribute}', colorScheme);
+  }
+} catch (e) {} })();`,
       }}
     />
   );


### PR DESCRIPTION
When you look at the source of the page:

Before: view-source:https://mui.com/
<img width="336" alt="Screenshot 2023-09-04 at 01 53 19" src="https://github.com/mui/material-ui/assets/3165635/0a0badb3-e3ea-4045-92b5-609d2760972e">

After: view-source:https://deploy-preview-38794--material-ui.netlify.app/
<img width="286" alt="Screenshot 2023-09-04 at 01 53 25" src="https://github.com/mui/material-ui/assets/3165635/ca6edb11-8092-4ec0-8ac4-0edbd4aead84">

it's easier to understand. 