### PR TITLE
[FocusTrap] Fix `disableEnforceFocus` behavior

### DIFF
--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -148,7 +148,9 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
   const nodeToRestore = React.useRef<EventTarget | null>(null);
   const reactFocusEventTarget = React.useRef<EventTarget | null>(null);
   // if disableEnforceFocus is set, we need an internal state for activating/disactivating the trap focus
-  const [controlledOpen, setControlledOpen] = React.useState(!disableEnforceFocus || !disableAutoFocus);
+  const [controlledOpen, setControlledOpen] = React.useState(
+    !disableEnforceFocus || !disableAutoFocus,
+  );
   // This variable is useful when disableAutoFocus is true.
   // It waits for the active element to move into the component to activate.
   const activated = React.useRef(false);

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -228,15 +228,16 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
         return;
       }
 
-      // The disableEnforceFocus is set and the focus is not coming from the sentinel nodes, so do nothing
-      if (disableEnforceFocus && nativeEvent !== false) {
-        return;
-      }
-
       // The focus is already inside
       if (rootElement.contains(doc.activeElement)) {
         return;
       }
+
+      // The disableEnforceFocus is set and the focus is outside of the focus trap, so do nothing
+      if (disableEnforceFocus && nativeEvent !== false) {
+        return;
+      }
+
 
       // if the focus event is not coming from inside the children's react tree, reset the refs
       if (

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -213,7 +213,7 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
   }, [open]);
 
   const contain = React.useCallback(
-    (nativeEvent: FocusEvent | null | false) => {
+    (nativeEvent: FocusEvent | null) => {
       const rootElement = rootRef.current;
       const doc = ownerDocument(rootRef.current);
 
@@ -234,7 +234,11 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
       }
 
       // The disableEnforceFocus is set and the focus is outside of the focus trap (and sentinel nodes)
-      if (disableEnforceFocus && nativeEvent !== false) {
+      if (
+        disableEnforceFocus &&
+        doc.activeElement !== sentinelStart.current &&
+        doc.activeElement !== sentinelEnd.current
+      ) {
         return;
       }
 
@@ -361,8 +365,6 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
       nodeToRestore.current = event.relatedTarget;
     }
     activated.current = true;
-
-    contain(false);
   };
 
   return (

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -233,7 +233,7 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
         return;
       }
 
-      // The disableEnforceFocus is set and the focus is outside of the focus trap, so do nothing
+      // The disableEnforceFocus is set and the focus is outside of the focus trap (and sentinel nodes)
       if (disableEnforceFocus && nativeEvent !== false) {
         return;
       }

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -225,9 +225,9 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
     const focusinHandler = () => {
       if (disableEnforceFocus) {
         if (
-          rootRef.current?.contains(doc.activeElement)
-          || sentinelStart.current?.contains(doc.activeElement)
-          || sentinelEnd.current?.contains(doc.activeElement)
+          rootRef.current?.contains(doc.activeElement) ||
+          sentinelStart.current?.contains(doc.activeElement) ||
+          sentinelEnd.current?.contains(doc.activeElement)
         ) {
           setControlledOpen(true);
         } else {
@@ -367,7 +367,15 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
       doc.removeEventListener('focusin', contain);
       doc.removeEventListener('keydown', loopFocus, true);
     };
-  }, [disableAutoFocus, disableRestoreFocus, isEnabled, open, controlledOpen, getTabbable]);
+  }, [
+    disableAutoFocus,
+    disableEnforceFocus,
+    disableRestoreFocus,
+    isEnabled,
+    open,
+    controlledOpen,
+    getTabbable,
+  ]);
 
   const onFocus = (event: FocusEvent) => {
     if (nodeToRestore.current === null) {

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -238,7 +238,6 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
         return;
       }
 
-
       // if the focus event is not coming from inside the children's react tree, reset the refs
       if (
         (nativeEvent && reactFocusEventTarget.current !== nativeEvent.target) ||

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -148,7 +148,7 @@ function FocusTrap(props: FocusTrapProps): JSX.Element {
   const nodeToRestore = React.useRef<EventTarget | null>(null);
   const reactFocusEventTarget = React.useRef<EventTarget | null>(null);
   // if disableEnforceFocus is set, we need an internal state for activating/disactivating the trap focus
-  const [controlledOpen, setControlledOpen] = React.useState(!disableEnforceFocus);
+  const [controlledOpen, setControlledOpen] = React.useState(!disableEnforceFocus || !disableAutoFocus);
   // This variable is useful when disableAutoFocus is true.
   // It waits for the active element to move into the component to activate.
   const activated = React.useRef(false);

--- a/test/e2e/fixtures/FocusTrap/DisableEnforceFocusFocusTrap.tsx
+++ b/test/e2e/fixtures/FocusTrap/DisableEnforceFocusFocusTrap.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { FocusTrap } from '@mui/base/FocusTrap';
+
+export default function disableEnforceFocusFocusTrap() {
+  return (
+    <React.Fragment>
+      <button data-testid="initial-focus" type="button" autoFocus>
+        initial focus
+      </button>
+      <FocusTrap open disableEnforceFocus>
+        <div data-testid="root">
+          <button data-testid="inside-trap-focus" type="button">
+            inside focusable
+          </button>
+        </div>
+      </FocusTrap>
+    </React.Fragment>
+  );
+}

--- a/test/e2e/fixtures/FocusTrap/DisableEnforceFocusFocusTrap.tsx
+++ b/test/e2e/fixtures/FocusTrap/DisableEnforceFocusFocusTrap.tsx
@@ -7,7 +7,7 @@ export default function disableEnforceFocusFocusTrap() {
       <button data-testid="initial-focus" type="button" autoFocus>
         initial focus
       </button>
-      <FocusTrap open disableEnforceFocus>
+      <FocusTrap open disableEnforceFocus disableAutoFocus>
         <div data-testid="root">
           <button data-testid="inside-trap-focus" type="button">
             inside focusable

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -172,6 +172,26 @@ describe('e2e', () => {
       await page.keyboard.press('Tab');
       await expect(screen.getByText('final tab target')).toHaveFocus();
     });
+
+    it('should not trap focus when clicking outside when disableEnforceFocus is set', async () => {
+      await renderFixture('FocusTrap/DisableEnforceFocusFocusTrap');
+
+      // initial focus is on the button outside of the trap focus
+      await expect(screen.getByTestId('initial-focus')).toHaveFocus();
+
+      // focus the button inside the trap focus
+      await page.keyboard.press('Tab');
+      await expect(screen.getByTestId('inside-trap-focus')).toHaveFocus();
+
+      // the focus is now trapped inside
+      await page.keyboard.press('Tab');
+      await expect(screen.getByTestId('inside-trap-focus')).toHaveFocus();
+
+      const initialFocus = (await screen.getByTestId('initial-focus'))!;
+      await initialFocus.click();
+
+      await expect(screen.getByTestId('initial-focus')).toHaveFocus();
+    });
   });
 
   describe('<Rating />', () => {


### PR DESCRIPTION
Codesandbox with the broken demo from https://github.com/mui/material-ui/pull/38684: https://codesandbox.io/s/condescending-dan-xmxsxw?file=/Demo.tsx

Fixes https://github.com/mui/material-ui/issues/21569

Before: https://mui.com/base-ui/react-focus-trap/#disable-enforced-focus
After: https://deploy-preview-38816--material-ui.netlify.app/base-ui/react-focus-trap/#disable-enforced-focus