### PR TITLE
Revert "[Autocomplete] Type multiple values with readonly arrays."

### DIFF
--- a/docs/data/joy/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/joy/components/autocomplete/GitHubLabel.tsx
@@ -32,11 +32,8 @@ const Listbox = React.forwardRef<HTMLUListElement, any>((props, ref) => (
 
 export default function GitHubLabel() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [value, setValue] = React.useState<readonly LabelType[]>([
-    labels[1],
-    labels[11],
-  ]);
-  const [pendingValue, setPendingValue] = React.useState<readonly LabelType[]>([]);
+  const [value, setValue] = React.useState<LabelType[]>([labels[1], labels[11]]);
+  const [pendingValue, setPendingValue] = React.useState<LabelType[]>([]);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setPendingValue(value);

--- a/docs/data/material/components/autocomplete/GitHubLabel.tsx
+++ b/docs/data/material/components/autocomplete/GitHubLabel.tsx
@@ -113,11 +113,8 @@ const Button = styled(ButtonBase)(({ theme }) => ({
 
 export default function GitHubLabel() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [value, setValue] = React.useState<readonly LabelType[]>([
-    labels[1],
-    labels[11],
-  ]);
-  const [pendingValue, setPendingValue] = React.useState<readonly LabelType[]>([]);
+  const [value, setValue] = React.useState<LabelType[]>([labels[1], labels[11]]);
+  const [pendingValue, setPendingValue] = React.useState<LabelType[]>([]);
   const theme = useTheme();
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
@@ -28,7 +28,7 @@ export function createFilterOptions<Value>(
 export type AutocompleteFreeSoloValueMapping<FreeSolo> = FreeSolo extends true ? string : never;
 
 export type AutocompleteValue<Value, Multiple, DisableClearable, FreeSolo> = Multiple extends true
-  ? ReadonlyArray<Value | AutocompleteFreeSoloValueMapping<FreeSolo>>
+  ? Array<Value | AutocompleteFreeSoloValueMapping<FreeSolo>>
   : DisableClearable extends true
   ? NonNullable<Value | AutocompleteFreeSoloValueMapping<FreeSolo>>
   : Value | null | AutocompleteFreeSoloValueMapping<FreeSolo>;

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.spec.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.spec.ts
@@ -73,7 +73,7 @@ function Component() {
     options: ['1', '2', '3'],
     multiple: true,
     onChange(event, value) {
-      expectType<readonly string[], typeof value>(value);
+      expectType<string[], typeof value>(value);
       value;
     },
   });
@@ -83,7 +83,7 @@ function Component() {
     options: ['1', '2', '3', 4, true],
     multiple: true,
     onChange(event, value) {
-      expectType<ReadonlyArray<string | number | boolean>, typeof value>(value);
+      expectType<Array<string | number | boolean>, typeof value>(value);
     },
   });
 
@@ -92,7 +92,7 @@ function Component() {
     options: persons,
     multiple: true,
     onChange(event, value) {
-      expectType<readonly Person[], typeof value>(value);
+      expectType<Person[], typeof value>(value);
       value;
     },
   });
@@ -101,7 +101,7 @@ function Component() {
   useAutocomplete({
     options: persons,
     multiple: true,
-    onChange(event, value: readonly Person[]) {},
+    onChange(event, value: Person[]) {},
   });
 
   // options accepts const and value has correct type
@@ -109,16 +109,6 @@ function Component() {
     options: ['1', '2', '3'] as const,
     onChange(event, value) {
       expectType<'1' | '2' | '3' | null, typeof value>(value);
-    },
-  });
-
-  // values accepts const and value has correct type
-  useAutocomplete({
-    options: ['1', '2', '3'] as const,
-    multiple: true,
-    value: ['1', '3'] as const,
-    onChange(event, value) {
-      expectType<ReadonlyArray<'1' | '2' | '3'>, typeof value>(value);
     },
   });
 
@@ -169,7 +159,7 @@ function Component() {
     options: persons,
     multiple: true,
     onChange(event, value) {
-      expectType<ReadonlyArray<string | Person>, typeof value>(value);
+      expectType<Array<string | Person>, typeof value>(value);
     },
     freeSolo: true,
   });

--- a/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
@@ -45,7 +45,7 @@ function MyAutocomplete<
 <MyAutocomplete
   options={['1', '2', '3']}
   onChange={(event, value) => {
-    expectType<readonly string[], typeof value>(value);
+    expectType<string[], typeof value>(value);
   }}
   renderInput={() => null}
   multiple


### PR DESCRIPTION
Reverts mui/material-ui#38253, see https://github.com/mui/material-ui/issues/38817.

Next actions should be:
- move the current `useAutocomplete` in Material UI
- iterate on the `useAutocomplete` in Base UI - test the changes in Joy UI
- in v6, migrate Material UI's `Autocomplete` to use the Base UI's `useAutocomplete`