### PR TITLE
[docs] Fix a11y issues in tables demos

### DIFF
--- a/docs/data/base/components/table-pagination/TableCustomized/css/index.js
+++ b/docs/data/base/components/table-pagination/TableCustomized/css/index.js
@@ -51,7 +51,7 @@ export default function TableCustomized() {
 
             {emptyRows > 0 && (
               <tr style={{ height: 34 * emptyRows }}>
-                <td colSpan={3} />
+                <td colSpan={3} aria-hidden />
               </tr>
             )}
           </tbody>

--- a/docs/data/base/components/table-pagination/TableCustomized/css/index.tsx
+++ b/docs/data/base/components/table-pagination/TableCustomized/css/index.tsx
@@ -56,7 +56,7 @@ export default function TableCustomized() {
 
             {emptyRows > 0 && (
               <tr style={{ height: 34 * emptyRows }}>
-                <td colSpan={3} />
+                <td colSpan={3} aria-hidden />
               </tr>
             )}
           </tbody>

--- a/docs/data/base/components/table-pagination/TableCustomized/system/index.js
+++ b/docs/data/base/components/table-pagination/TableCustomized/system/index.js
@@ -50,7 +50,7 @@ export default function TableCustomized() {
 
           {emptyRows > 0 && (
             <tr style={{ height: 34 * emptyRows }}>
-              <td colSpan={3} />
+              <td colSpan={3} aria-hidden />
             </tr>
           )}
         </tbody>

--- a/docs/data/base/components/table-pagination/TableCustomized/system/index.tsx
+++ b/docs/data/base/components/table-pagination/TableCustomized/system/index.tsx
@@ -55,7 +55,7 @@ export default function TableCustomized() {
 
           {emptyRows > 0 && (
             <tr style={{ height: 34 * emptyRows }}>
-              <td colSpan={3} />
+              <td colSpan={3} aria-hidden />
             </tr>
           )}
         </tbody>

--- a/docs/data/base/components/table-pagination/TableCustomized/tailwind/index.js
+++ b/docs/data/base/components/table-pagination/TableCustomized/tailwind/index.js
@@ -82,6 +82,7 @@ export default function TableCustomized() {
               <td
                 className="border border-solid border-slate-200 dark:border-slate-800 text-left p-1.5"
                 colSpan={3}
+                aria-hidden
               />
             </tr>
           )}

--- a/docs/data/base/components/table-pagination/TableCustomized/tailwind/index.tsx
+++ b/docs/data/base/components/table-pagination/TableCustomized/tailwind/index.tsx
@@ -86,6 +86,7 @@ export default function TableCustomized() {
               <td
                 className="border border-solid border-slate-200 dark:border-slate-800 text-left p-1.5"
                 colSpan={3}
+                aria-hidden
               />
             </tr>
           )}

--- a/docs/data/base/components/table-pagination/TableUnstyled.js
+++ b/docs/data/base/components/table-pagination/TableUnstyled.js
@@ -49,7 +49,7 @@ export default function TableUnstyled() {
           ))}
           {emptyRows > 0 && (
             <tr style={{ height: 41 * emptyRows }}>
-              <td colSpan={3} />
+              <td colSpan={3} aria-hidden />
             </tr>
           )}
         </tbody>

--- a/docs/data/base/components/table-pagination/TableUnstyled.tsx
+++ b/docs/data/base/components/table-pagination/TableUnstyled.tsx
@@ -54,7 +54,7 @@ export default function TableUnstyled() {
           ))}
           {emptyRows > 0 && (
             <tr style={{ height: 41 * emptyRows }}>
-              <td colSpan={3} />
+              <td colSpan={3} aria-hidden />
             </tr>
           )}
         </tbody>

--- a/docs/data/joy/components/table/TableSortAndSelection.js
+++ b/docs/data/joy/components/table/TableSortAndSelection.js
@@ -401,7 +401,7 @@ export default function TableSortAndSelection() {
                 '--TableRow-hoverBackground': 'transparent',
               }}
             >
-              <td colSpan={6} />
+              <td colSpan={6} aria-hidden />
             </tr>
           )}
         </tbody>

--- a/docs/data/joy/components/table/TableSortAndSelection.tsx
+++ b/docs/data/joy/components/table/TableSortAndSelection.tsx
@@ -445,7 +445,7 @@ export default function TableSortAndSelection() {
                 } as React.CSSProperties
               }
             >
-              <td colSpan={6} />
+              <td colSpan={6} aria-hidden />
             </tr>
           )}
         </tbody>


### PR DESCRIPTION
During work on #36287, the dependencies got updated, and ESLint started showing errors in some of the table demos. I couldn't pinpoint which dependency was responsible for this, but it's not super important. The issue was that some of the table cells (used to fill empty space) did not have an accessible label. I fixed it by making them invisible to assistive technologies (as they are just for presentation).
