### PR TITLE
[base-ui][useList] Accept arbitrary external props and forward to root

### DIFF
--- a/packages/mui-base/src/useList/useList.test.tsx
+++ b/packages/mui-base/src/useList/useList.test.tsx
@@ -88,17 +88,30 @@ describe('useList', () => {
 
   describe('external props', () => {
     it('should pass arbitrary props to the root slot', () => {
+      const handleClick = spy();
+
       function Listbox() {
         const { getRootProps } = useList({
           items: [],
           getItemId: () => undefined,
         });
-        return <div role="listbox" {...getRootProps({ 'data-testid': 'test-listbox' })} />;
+        return (
+          <div
+            role="listbox"
+            {...getRootProps({ 'data-testid': 'test-listbox', onClick: handleClick })}
+          />
+        );
       }
 
       const { getByRole } = render(<Listbox />);
 
-      expect(getByRole('listbox')).to.have.attribute('data-testid', 'test-listbox');
+      const listbox = getByRole('listbox');
+
+      expect(listbox).to.have.attribute('data-testid', 'test-listbox');
+
+      fireEvent.click(listbox);
+
+      expect(handleClick.callCount).to.equal(1);
     });
   });
 });

--- a/packages/mui-base/src/useList/useList.test.tsx
+++ b/packages/mui-base/src/useList/useList.test.tsx
@@ -85,4 +85,20 @@ describe('useList', () => {
       }),
     );
   });
+
+  describe('external props', () => {
+    it('should pass arbitrary props to the root slot', () => {
+      function Listbox() {
+        const { getRootProps } = useList({
+          items: [],
+          getItemId: () => undefined,
+        });
+        return <div role="listbox" {...getRootProps({ 'data-testid': 'test-listbox' })} />;
+      }
+
+      const { getByRole } = render(<Listbox />);
+
+      expect(getByRole('listbox')).to.have.attribute('data-testid', 'test-listbox');
+    });
+  });
 });

--- a/packages/mui-base/src/useList/useList.test.tsx
+++ b/packages/mui-base/src/useList/useList.test.tsx
@@ -106,11 +106,9 @@ describe('useList', () => {
       const { getByRole } = render(<Listbox />);
 
       const listbox = getByRole('listbox');
-
       expect(listbox).to.have.attribute('data-testid', 'test-listbox');
 
       fireEvent.click(listbox);
-
       expect(handleClick.callCount).to.equal(1);
     });
   });

--- a/packages/mui-base/src/useList/useList.ts
+++ b/packages/mui-base/src/useList/useList.ts
@@ -344,10 +344,11 @@ function useList<
         focusManagement === 'activeDescendant' && highlightedValue != null
           ? getItemId!(highlightedValue)
           : undefined,
-      onBlur: createHandleBlur(externalEventHandlers),
-      onKeyDown: createHandleKeyDown(externalEventHandlers),
       tabIndex: focusManagement === 'DOM' ? -1 : 0,
       ref: handleRef,
+      ...externalEventHandlers,
+      onBlur: createHandleBlur(externalEventHandlers),
+      onKeyDown: createHandleKeyDown(externalEventHandlers),
     };
   };
 

--- a/packages/mui-base/src/useList/useList.ts
+++ b/packages/mui-base/src/useList/useList.ts
@@ -20,10 +20,10 @@ import {
   StateComparers,
 } from '../utils/useControllableReducer.types';
 import { areArraysEqual } from '../utils/areArraysEqual';
-import { EventHandlers } from '../utils/types';
 import { useLatest } from '../utils/useLatest';
 import { useTextNavigation } from '../utils/useTextNavigation';
 import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
+import { extractEventHandlers } from '../utils/extractEventHandlers';
 
 const EMPTY_OBJECT = {};
 const NOOP = () => {};
@@ -333,17 +333,18 @@ function useList<
       });
     };
 
-  const getRootProps = <TOther extends EventHandlers = {}>(
-    otherHandlers: TOther = {} as TOther,
-  ): UseListRootSlotProps<TOther> => {
+  const getRootProps = <ExternalProps extends Record<string, any> = {}>(
+    externalProps: ExternalProps = {} as ExternalProps,
+  ): UseListRootSlotProps<ExternalProps> => {
+    const externalEventHandlers = extractEventHandlers(externalProps);
     return {
-      ...otherHandlers,
+      ...externalProps,
       'aria-activedescendant':
         focusManagement === 'activeDescendant' && highlightedValue != null
           ? getItemId!(highlightedValue)
           : undefined,
-      onBlur: createHandleBlur(otherHandlers),
-      onKeyDown: createHandleKeyDown(otherHandlers),
+      onBlur: createHandleBlur(externalEventHandlers),
+      onKeyDown: createHandleKeyDown(externalEventHandlers),
       tabIndex: focusManagement === 'DOM' ? -1 : 0,
       ref: handleRef,
     };

--- a/packages/mui-base/src/useList/useList.ts
+++ b/packages/mui-base/src/useList/useList.ts
@@ -24,6 +24,7 @@ import { useLatest } from '../utils/useLatest';
 import { useTextNavigation } from '../utils/useTextNavigation';
 import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
 import { extractEventHandlers } from '../utils/extractEventHandlers';
+import { EventHandlers } from '../utils/types';
 
 const EMPTY_OBJECT = {};
 const NOOP = () => {};
@@ -276,9 +277,9 @@ function useList<
   }, [highlightedValue, notifyHighlightChanged]);
 
   const createHandleKeyDown =
-    (other: Record<string, React.EventHandler<any>>) =>
+    (externalHandlers: EventHandlers) =>
     (event: React.KeyboardEvent<HTMLElement> & MuiCancellableEvent) => {
-      other.onKeyDown?.(event);
+      externalHandlers.onKeyDown?.(event);
 
       if (event.defaultMuiPrevented) {
         return;
@@ -314,9 +315,9 @@ function useList<
     };
 
   const createHandleBlur =
-    (other: Record<string, React.EventHandler<any>>) =>
+    (externalHandlers: EventHandlers) =>
     (event: React.FocusEvent<HTMLElement> & MuiCancellableEvent) => {
-      other.onBlur?.(event);
+      externalHandlers.onBlur?.(event);
 
       if (event.defaultMuiPrevented) {
         return;

--- a/packages/mui-base/src/useList/useList.types.ts
+++ b/packages/mui-base/src/useList/useList.types.ts
@@ -6,7 +6,6 @@ import {
   ControllableReducerAction,
   StateChangeCallback,
 } from '../utils/useControllableReducer.types';
-import { EventHandlers } from '../utils';
 import type { ListContextValue } from './ListContext';
 import { MuiCancellableEventHandler } from '../utils/MuiCancellableEvent';
 
@@ -106,6 +105,7 @@ export interface UseListParameters<
   /**
    * The focus management strategy used by the list.
    * Controls the attributes used to set focus on the list items.
+   * @default 'activeDescendant'
    */
   focusManagement?: FocusManagementType;
   /**
@@ -248,7 +248,7 @@ interface UseListRootSlotOwnProps {
   ref: React.RefCallback<Element> | null;
 }
 
-export type UseListRootSlotProps<TOther = {}> = TOther & UseListRootSlotOwnProps;
+export type UseListRootSlotProps<ExternalProps = {}> = ExternalProps & UseListRootSlotOwnProps;
 
 export interface UseListReturnValue<
   ItemValue,
@@ -257,9 +257,14 @@ export interface UseListReturnValue<
 > {
   contextValue: ListContextValue<ItemValue>;
   dispatch: (action: CustomAction | ListAction<ItemValue>) => void;
-  getRootProps: <TOther extends EventHandlers = {}>(
-    otherHandlers?: TOther,
-  ) => UseListRootSlotProps<TOther>;
+  /**
+   * Resolver for the root slot's props.
+   * @param externalProps additional props for the root slot
+   * @returns props that should be spread on the root slot
+   */
+  getRootProps: <ExternalProps extends Record<string, any> = {}>(
+    externalProps?: ExternalProps,
+  ) => UseListRootSlotProps<ExternalProps>;
   rootRef: React.RefCallback<Element> | null;
   state: State;
 }

--- a/packages/mui-base/src/useList/useList.types.ts
+++ b/packages/mui-base/src/useList/useList.types.ts
@@ -262,7 +262,7 @@ export interface UseListReturnValue<
    * @param externalProps additional props for the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <ExternalProps extends Record<string, any> = {}>(
+  getRootProps: <ExternalProps extends Record<string, unknown> = {}>(
     externalProps?: ExternalProps,
   ) => UseListRootSlotProps<ExternalProps>;
   rootRef: React.RefCallback<Element> | null;

--- a/packages/mui-base/src/useList/useListItem.ts
+++ b/packages/mui-base/src/useList/useListItem.ts
@@ -4,8 +4,9 @@ import {
   unstable_useForkRef as useForkRef,
   unstable_useEnhancedEffect as useEnhancedEffect,
 } from '@mui/utils';
-import { EventHandlers } from '../utils/types';
 import { useForcedRerendering } from '../utils/useForcedRerendering';
+import { extractEventHandlers } from '../utils/extractEventHandlers';
+import { EventHandlers } from '../utils/types';
 import { UseListItemParameters, UseListItemReturnValue } from './useListItem.types';
 import { ListActionTypes } from './listActions.types';
 import { ListContext } from './ListContext';
@@ -65,8 +66,8 @@ export function useListItem<ItemValue>(
   }, [registerSelectionChangeHandler, rerender, selected, item]);
 
   const createHandleClick = React.useCallback(
-    (other: Record<string, React.EventHandler<any>>) => (event: React.MouseEvent) => {
-      other.onClick?.(event);
+    (externalHandlers: EventHandlers) => (event: React.MouseEvent) => {
+      externalHandlers.onClick?.(event);
       if (event.defaultPrevented) {
         return;
       }
@@ -81,8 +82,8 @@ export function useListItem<ItemValue>(
   );
 
   const createHandlePointerOver = React.useCallback(
-    (other: Record<string, React.EventHandler<any>>) => (event: React.PointerEvent) => {
-      other.onMouseOver?.(event);
+    (externalHandlers: EventHandlers) => (event: React.PointerEvent) => {
+      externalHandlers.onMouseOver?.(event);
       if (event.defaultPrevented) {
         return;
       }
@@ -101,12 +102,14 @@ export function useListItem<ItemValue>(
     tabIndex = highlighted ? 0 : -1;
   }
 
-  const getRootProps = <TOther extends EventHandlers = {}>(
-    otherHandlers: TOther = {} as TOther,
+  const getRootProps = <ExternalProps extends Record<string, any>>(
+    externalProps: ExternalProps = {} as ExternalProps,
   ) => ({
-    ...otherHandlers,
-    onClick: createHandleClick(otherHandlers),
-    onPointerOver: handlePointerOverEvents ? createHandlePointerOver(otherHandlers) : undefined,
+    ...externalProps,
+    onClick: createHandleClick(extractEventHandlers(externalProps)),
+    onPointerOver: handlePointerOverEvents
+      ? createHandlePointerOver(extractEventHandlers(externalProps))
+      : undefined,
     ref: handleRef,
     tabIndex,
   });

--- a/packages/mui-base/src/useList/useListItem.ts
+++ b/packages/mui-base/src/useList/useListItem.ts
@@ -104,15 +104,18 @@ export function useListItem<ItemValue>(
 
   const getRootProps = <ExternalProps extends Record<string, any>>(
     externalProps: ExternalProps = {} as ExternalProps,
-  ) => ({
-    ...externalProps,
-    onClick: createHandleClick(extractEventHandlers(externalProps)),
-    onPointerOver: handlePointerOverEvents
-      ? createHandlePointerOver(extractEventHandlers(externalProps))
-      : undefined,
-    ref: handleRef,
-    tabIndex,
-  });
+  ) => {
+    const externalEventHandlers = extractEventHandlers(externalProps);
+    return {
+      ...externalProps,
+      onClick: createHandleClick(externalEventHandlers),
+      onPointerOver: handlePointerOverEvents
+        ? createHandlePointerOver(externalEventHandlers)
+        : undefined,
+      ref: handleRef,
+      tabIndex,
+    };
+  };
 
   return {
     getRootProps,

--- a/packages/mui-base/src/useList/useListItem.types.ts
+++ b/packages/mui-base/src/useList/useListItem.types.ts
@@ -1,5 +1,3 @@
-import { EventHandlers } from '../utils';
-
 export interface UseListItemParameters<ItemValue> {
   /**
    * If `true`, the list item will dispatch the `itemHover` action on pointer over.
@@ -27,17 +25,18 @@ interface UseListItemRootSlotOwnProps {
   tabIndex?: number;
 }
 
-export type UseListItemRootSlotProps<TOther = {}> = TOther & UseListItemRootSlotOwnProps;
+export type UseListItemRootSlotProps<ExternalProps = {}> = ExternalProps &
+  UseListItemRootSlotOwnProps;
 
 export interface UseListItemReturnValue {
   /**
    * Resolver for the root slot's props.
-   * @param otherHandlers event handlers for the root slot
+   * @param externalProps additional props to be forwarded to the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <TOther extends EventHandlers = {}>(
-    otherHandlers?: TOther,
-  ) => UseListItemRootSlotProps<TOther>;
+  getRootProps: <ExternalProps extends Record<string, any> = {}>(
+    externalProps?: ExternalProps,
+  ) => UseListItemRootSlotProps<ExternalProps>;
   /**
    * If `true`, the current item is highlighted.
    */

--- a/packages/mui-base/src/useList/useListItem.types.ts
+++ b/packages/mui-base/src/useList/useListItem.types.ts
@@ -34,7 +34,7 @@ export interface UseListItemReturnValue {
    * @param externalProps additional props to be forwarded to the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <ExternalProps extends Record<string, any> = {}>(
+  getRootProps: <ExternalProps extends Record<string, unknown> = {}>(
     externalProps?: ExternalProps,
   ) => UseListItemRootSlotProps<ExternalProps>;
   /**


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/38186

`getRootProps` of `useList` and `useListItem` already forwards external props, this PR just aligns the naming

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
