### PR TITLE
[core] Bump aws-cli orb to 4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  aws-cli: circleci/aws-cli@4.0
+  aws-cli: circleci/aws-cli@4.1
   aws-s3: circleci/aws-s3@4.0
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,9 +689,9 @@ jobs:
                 value: << pipeline.git.branch >>
           steps:
             - aws-cli/setup:
-                aws_access_key_id: AWS_ACCESS_KEY_ID_ARTIFACTS
-                region: AWS_REGION_ARTIFACTS
-                aws_secret_access_key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
+                aws_access_key_id: $AWS_ACCESS_KEY_ID_ARTIFACTS
+                region: $AWS_REGION_ARTIFACTS
+                aws_secret_access_key: $AWS_SECRET_ACCESS_KEY_ARTIFACTS
             # Upload distributables to S3
             - aws-s3/copy:
                 from: mui-material.tgz
@@ -718,9 +718,9 @@ jobs:
                 value: << pipeline.git.branch >>
           steps:
             - aws-cli/setup:
-                aws_access_key_id: AWS_ACCESS_KEY_ID_ARTIFACTS
-                region: AWS_REGION_ARTIFACTS
-                aws_secret_access_key: AWS_SECRET_ACCESS_KEY_ARTIFACTS
+                aws_access_key_id: $AWS_ACCESS_KEY_ID_ARTIFACTS
+                region: $AWS_REGION_ARTIFACTS
+                aws_secret_access_key: $AWS_SECRET_ACCESS_KEY_ARTIFACTS
             # persist size snapshot on S3
             - aws-s3/copy:
                 arguments: --content-type application/json


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/pull/38776

Deals with the [breaking change](https://github.com/CircleCI-Public/aws-cli-orb/issues/156) in https://github.com/CircleCI-Public/aws-cli-orb/pull/142 (@DiegoAndai Thank you for finding this!)

The parameters have changed from being [`env_var_name`](https://github.com/CircleCI-Public/aws-cli-orb/pull/142/files#diff-ef7a96e661fedfb5b86d2744c2de99e78c53bab5a21687af2bff94b048abe171L54) to `string`. `region` apparently already was a string, but quietly accepted the var name even though as a region it's invalid. changing them to `$VAR_NAME` or `${VAR_NAME}` correctly interpolates them again.