### PR TITLE
[docs] Clearer npm package homepages

### DIFF
--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/base-ui/getting-started/",
+  "homepage": "https://mui.com/base-ui/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-joy/package.json
+++ b/packages/mui-joy/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/",
+  "homepage": "https://mui.com/joy-ui/getting-started/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-material-next/package.json
+++ b/packages/mui-material-next/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/material-ui/getting-started/",
+  "homepage": "https://mui.com/material-ui/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/material-ui/getting-started/",
+  "homepage": "https://mui.com/material-ui/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-private-theming/package.json
+++ b/packages/mui-private-theming/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/",
+  "homepage": "https://github.com/mui/material-ui/tree/master/packages/mui-private-theming",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://mui.com/system/getting-started/",
+  "homepage": "https://mui.com/system/styled/",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"

--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/mui/material-ui/issues"
   },
-  "homepage": "https://github.com/mui/material-ui/tree/master/packages/mui-utils",
+  "homepage": "private package",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/mui"


### PR DESCRIPTION
When looking at https://www.npmjs.com/package/next, https://www.npmjs.com/package/react, the homepage points you to the homepage of each project so I think we could do the same.

e.g. https://www.npmjs.com/package/@mui/joy, so strange:

<img width="143" alt="Screenshot 2023-09-08 at 03 03 54" src="https://github.com/mui/material-ui/assets/3165635/b5a0ffbe-2a7a-41ab-acf4-715ec6d4df35">

I noticed this from https://github.com/ericdiviney/react-handbook/pull/89.