### PR TITLE
[Modal][material] Fix console warning when onTransitionEnter , onTransitionExit provided

### DIFF
--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -91,6 +91,8 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     keepMounted = false,
     onBackdropClick,
     onClose,
+    onTransitionEnter,
+    onTransitionExited,
     open,
     slotProps,
     slots,
@@ -154,10 +156,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     elementType: RootSlot,
     externalSlotProps: rootSlotProps,
     externalForwardedProps: other,
-    getSlotProps: (otherHandlers) => {
-      const { onTransitionEnter, onTransitionExited, ...restOfHandlers } = otherHandlers;
-      return getRootProps(restOfHandlers);
-    },
+    getSlotProps: getRootProps,
     additionalProps: {
       ref,
       as: component,

--- a/packages/mui-material/src/Modal/Modal.js
+++ b/packages/mui-material/src/Modal/Modal.js
@@ -154,7 +154,10 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     elementType: RootSlot,
     externalSlotProps: rootSlotProps,
     externalForwardedProps: other,
-    getSlotProps: getRootProps,
+    getSlotProps: (otherHandlers) => {
+      const { onTransitionEnter, onTransitionExited, ...restOfHandlers } = otherHandlers;
+      return getRootProps(restOfHandlers);
+    },
     additionalProps: {
       ref,
       as: component,

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -872,7 +872,7 @@ describe('<Modal />', () => {
     });
   });
 
-  it.only('should not warn when onTransitionEnter and onTransitionExited are provided', () => {
+  it('should not warn when onTransitionEnter and onTransitionExited are provided', () => {
     expect(() => {
       render(
         <Modal open onTransitionEnter={() => {}} onTransitionExited={() => {}}>

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -871,4 +871,14 @@ describe('<Modal />', () => {
       expect(getByTestId('backdrop')).to.have.class('custom-backdrop');
     });
   });
+
+  it.only('should not warn when onTransitionEnter and onTransitionExited are provided', () => {
+    expect(() => {
+      render(
+        <Modal open onTransitionEnter={() => {}} onTransitionExited={() => {}}>
+          <div />
+        </Modal>,
+      );
+    }).not.toErrorDev();
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes: https://github.com/mui/material-ui/issues/38843

before: https://codesandbox.io/s/mui-swipabledrawer-example-new-7pnch2

after: https://codesandbox.io/s/affectionate-hooks-vwlqrk

`Base` `Modal`  extracted `onTransitionEntered`, `onTransitionExited` [here](https://github.com/mui/material-ui/blob/master/packages/mui-base/src/Modal/Modal.tsx#L67)  from `props` before passing to useSlotProps [here](https://github.com/mui/material-ui/blob/master/packages/mui-base/src/Modal/Modal.tsx#L128). That's why same error didn't occured in `BaseUI` `Modal`. This PR follows same implemetation as `BaseUI`  `Modal` to fix the warning

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
