### PR TITLE
[lab] update treeview jsdoc comment

### DIFF
--- a/packages/mui-lab/src/TreeView/TreeView.tsx
+++ b/packages/mui-lab/src/TreeView/TreeView.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 };
 
 /**
- * @deprecated The TreeItem component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-tree-view-to-mui-x/.
+ * @deprecated The TreeItem component was moved from `@mui/lab` to `@mui/x-tree-view`. More information about this migration on our blog: https://mui.com/blog/lab-tree-view-to-mui-x/.
  * @ignore - do not document.
  */
 const TreeView = React.forwardRef(function DeprecatedTreeView(


### PR DESCRIPTION
Update the JSDoc comment to point folks to the `@mui/x-tree-view` package instead of `@mui/x-date-pickers`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
