### PR TITLE
[docs–infra] Fix callout container width

### DIFF
--- a/docs/data/joy/integrations/next-js-app-router/next-js-app-router.md
+++ b/docs/data/joy/integrations/next-js-app-router/next-js-app-router.md
@@ -140,7 +140,6 @@ export default function Page() {
     <Sheet>
       {/* Next.js won't render this button without 'use-client' */}
       <Button
-        variant="outlined"
         onClick={() => {
           console.log('handle click');
         }}

--- a/docs/data/material/guides/next-js-app-router/next-js-app-router.md
+++ b/docs/data/material/guides/next-js-app-router/next-js-app-router.md
@@ -212,7 +212,6 @@ export default function Page() {
     <Container>
       {/* Next.js won't render this button without 'use-client' */}
       <Button
-        variant="text"
         onClick={() => {
           console.log('handle click');
         }}

--- a/docs/pages/experiments/docs/callouts.md
+++ b/docs/pages/experiments/docs/callouts.md
@@ -129,9 +129,7 @@ import * as React from 'react';
 import Stack from '@mui/material/Stack';
 
 export default function BasicAlerts() {
-  return (
-    <Stack sx={{ width: '100%' }} spacing={2} />
-  );
+  return <Stack sx={{ width: '100%' }} spacing={2} />;
 }
 ```
 

--- a/docs/pages/experiments/docs/callouts.md
+++ b/docs/pages/experiments/docs/callouts.md
@@ -118,3 +118,21 @@ It says, "You will fail if you don't heed this dire warning."
 - a [link](#link).
 :::
 ```
+
+## With code
+
+:::info
+This is a callout.
+
+```jsx
+import * as React from 'react';
+import Stack from '@mui/material/Stack';
+
+export default function BasicAlerts() {
+  return (
+    <Stack sx={{ width: '100%' }} spacing={2} />
+  );
+}
+```
+
+:::

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -282,6 +282,7 @@ const Root = styled('div')(
       }px)`,
       '& .MuiCallout-content': {
         minWidth: 0, // Allows content to shrink. Useful when callout contains code block
+        flexGrow: 1,
         display: 'flex',
         flexDirection: 'column',
         gap: 6,


### PR DESCRIPTION
## Before

<img width="804" alt="Screenshot 2023-09-10 at 01 18 27" src="https://github.com/mui/material-ui/assets/3165635/64a9313c-23da-4ecf-bb13-9d6c3b959a38">

https://master--material-ui.netlify.app/material-ui/guides/next-js-app-router/#props-serialization

## After

<img width="790" alt="Screenshot 2023-09-10 at 01 18 11" src="https://github.com/mui/material-ui/assets/3165635/e7691dca-e0df-4027-9cec-33aa59ac3602">

https://deploy-preview-38880--material-ui.netlify.app/material-ui/guides/next-js-app-router/#props-serialization