### PR TITLE
[Switch] Simplify source

### DIFF
--- a/packages/mui-base/src/Switch/Switch.tsx
+++ b/packages/mui-base/src/Switch/Switch.tsx
@@ -66,18 +66,7 @@ const Switch = React.forwardRef(function Switch<RootComponentType extends React.
     ...other
   } = props;
 
-  const useSwitchProps = {
-    checked: checkedProp,
-    defaultChecked,
-    disabled: disabledProp,
-    onBlur,
-    onChange,
-    onFocus,
-    onFocusVisible,
-    readOnly: readOnlyProp,
-  };
-
-  const { getInputProps, checked, disabled, focusVisible, readOnly } = useSwitch(useSwitchProps);
+  const { getInputProps, checked, disabled, focusVisible, readOnly } = useSwitch(props);
 
   const ownerState: SwitchOwnerState = {
     ...props,

--- a/packages/mui-joy/src/Switch/Switch.tsx
+++ b/packages/mui-joy/src/Switch/Switch.tsx
@@ -266,7 +266,6 @@ const Switch = React.forwardRef(function Switch(inProps, ref) {
     }, [registerEffect]);
   }
 
-  const disabledProp = inProps.disabled ?? formControl?.disabled ?? disabledExternalProp;
   const size = inProps.size ?? formControl?.size ?? sizeProp;
   const { getColor } = useColorInversion(variant);
   const color = getColor(
@@ -275,14 +274,8 @@ const Switch = React.forwardRef(function Switch(inProps, ref) {
   );
 
   const useSwitchProps = {
-    checked: checkedProp,
-    defaultChecked,
-    disabled: disabledProp,
-    onBlur,
-    onChange,
-    onFocus,
-    onFocusVisible,
-    readOnly: readOnlyProp,
+    disabled: inProps.disabled ?? formControl?.disabled ?? disabledExternalProp,
+    ...props,
   };
 
   const { getInputProps, checked, disabled, focusVisible, readOnly } = useSwitch(useSwitchProps);


### PR DESCRIPTION
Implement https://github.com/mui/material-ui/pull/38570/files#r1299412334. The goal is to simplify the mental model, trying to have hooks feed in from all the props as often as possible.

I had a quick look at two libraries that have a similar hook + component pattern to see how they handle it, out of curiosity:

- Ark https://github.com/chakra-ui/ark/commit/70636c4ef7db420594b54daa3131d0234a9be6d5#diff-df024966829ded72c2597facab74a5fe358eabf030cffd797cb7b7a818ee2efaR26
 - React Aria: https://github.com/adobe/react-spectrum/blob/639548c489d5d4ef3225f62c9a64a474648d183d/packages/react-aria-components/src/NumberField.tsx#L60