### PR TITLE
[Autocomplete][base-ui] Added ref to getInputProps return value

### DIFF
--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.js
@@ -48,7 +48,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
       >
         <StyledInput
           id={id}
-          ref={setAnchorEl}
           disabled={disabled}
           readOnly={readOnly}
           {...getInputProps()}

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/system/index.tsx
@@ -50,7 +50,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(
       >
         <StyledInput
           id={id}
-          ref={setAnchorEl}
           disabled={disabled}
           readOnly={readOnly}
           {...getInputProps()}

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.js
@@ -56,7 +56,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
       >
         <input
           id={id}
-          ref={setAnchorEl}
           disabled={disabled}
           readOnly={readOnly}
           {...getInputProps()}

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.tsx
@@ -58,7 +58,6 @@ const Autocomplete = React.forwardRef(function Autocomplete(
       >
         <input
           id={id}
-          ref={setAnchorEl}
           disabled={disabled}
           readOnly={readOnly}
           {...getInputProps()}

--- a/docs/pages/base-ui/api/use-autocomplete.json
+++ b/docs/pages/base-ui/api/use-autocomplete.json
@@ -177,8 +177,8 @@
     },
     "getInputProps": {
       "type": {
-        "name": "() =&gt; React.InputHTMLAttributes&lt;HTMLInputElement&gt;",
-        "description": "() =&gt; React.InputHTMLAttributes&lt;HTMLInputElement&gt;"
+        "name": "() =&gt; React.InputHTMLAttributes&lt;HTMLInputElement&gt; &amp; {\n  ref: React.Ref&lt;HTMLInputElement&gt;\n}",
+        "description": "() =&gt; React.InputHTMLAttributes&lt;HTMLInputElement&gt; &amp; {\n  ref: React.Ref&lt;HTMLInputElement&gt;\n}"
       },
       "required": true
     },

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
@@ -369,7 +369,7 @@ export interface UseAutocompleteReturnValue<
    * Resolver for the input element's props.
    * @returns props that should be spread on the input element
    */
-  getInputProps: () => React.InputHTMLAttributes<HTMLInputElement>;
+  getInputProps: () => React.InputHTMLAttributes<HTMLInputElement> & { ref: React.Ref<HTMLInputElement> }
   /**
    * Resolver for the input label element's props.
    * @returns props that should be spread on the input label element

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.d.ts
@@ -369,7 +369,9 @@ export interface UseAutocompleteReturnValue<
    * Resolver for the input element's props.
    * @returns props that should be spread on the input element
    */
-  getInputProps: () => React.InputHTMLAttributes<HTMLInputElement> & { ref: React.Ref<HTMLInputElement> }
+  getInputProps: () => React.InputHTMLAttributes<HTMLInputElement> & {
+    ref: React.Ref<HTMLInputElement>;
+  };
   /**
    * Resolver for the input label element's props.
    * @returns props that should be spread on the input label element


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The type of the UseAutocompleteReturnValue.getInputProps (in packages\mui-base\src\useAutocomplete\useAutocomplete.d.ts) needed to be extended and include the ref: React.Ref<HTMLInputElement> field.

Closes #36552