### PR TITLE
[base-ui][useSnackbar] Align externalProps handling

### DIFF
--- a/docs/pages/base-ui/api/use-snackbar.json
+++ b/docs/pages/base-ui/api/use-snackbar.json
@@ -20,8 +20,8 @@
   "returnValue": {
     "getRootProps": {
       "type": {
-        "name": "&lt;TOther extends Record&lt;string, ((event: any) =&gt; void) | undefined&gt; = {}&gt;(externalProps?: TOther) =&gt; UseSnackbarRootSlotProps&lt;TOther&gt;",
-        "description": "&lt;TOther extends Record&lt;string, ((event: any) =&gt; void) | undefined&gt; = {}&gt;(externalProps?: TOther) =&gt; UseSnackbarRootSlotProps&lt;TOther&gt;"
+        "name": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseSnackbarRootSlotProps&lt;ExternalProps&gt;",
+        "description": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseSnackbarRootSlotProps&lt;ExternalProps&gt;"
       },
       "required": true
     },

--- a/packages/mui-base/src/useSnackbar/useSnackbar.test.tsx
+++ b/packages/mui-base/src/useSnackbar/useSnackbar.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { fireEvent, createRenderer } from 'test/utils';
+import { useSnackbar, UseSnackbarParameters } from '@mui/base/useSnackbar';
+
+describe('useSnackbar', () => {
+  const { render } = createRenderer();
+
+  const invokeUseSnackbar = (props: UseSnackbarParameters) => {
+    const ref = React.createRef<ReturnType<typeof useSnackbar>>();
+    function TestComponent() {
+      const snackbarDefinition = useSnackbar(props);
+      React.useImperativeHandle(ref, () => snackbarDefinition, [snackbarDefinition]);
+      return null;
+    }
+
+    render(<TestComponent />);
+
+    return ref.current!;
+  };
+
+  describe('getRootProps', () => {
+    it('returns props for the root slot', () => {
+      const props: UseSnackbarParameters = {};
+
+      const { getRootProps } = invokeUseSnackbar(props);
+
+      const rootProps = getRootProps();
+
+      expect(rootProps.role).to.equal('presentation');
+    });
+
+    it('forwards external props including event handlers', () => {
+      const handleClickSpy = spy();
+
+      function Snackbar() {
+        const { getRootProps } = useSnackbar();
+
+        return <div {...getRootProps({ onClick: handleClickSpy, random: 'arbitraryValue' })} />;
+      }
+      const { getByRole } = render(<Snackbar />);
+
+      const snackbar = getByRole('presentation');
+
+      expect(snackbar).to.have.attribute('random', 'arbitraryValue');
+
+      fireEvent.click(snackbar);
+
+      expect(handleClickSpy.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/mui-base/src/useSnackbar/useSnackbar.ts
+++ b/packages/mui-base/src/useSnackbar/useSnackbar.ts
@@ -20,7 +20,7 @@ import { EventHandlers } from '../utils/types';
  *
  * - [useSnackbar API](https://mui.com/base-ui/react-snackbar/hooks-api/#use-snackbar)
  */
-export function useSnackbar(parameters: UseSnackbarParameters): UseSnackbarReturnValue {
+export function useSnackbar(parameters: UseSnackbarParameters = {}): UseSnackbarReturnValue {
   const {
     autoHideDuration = null,
     disableWindowBlurListener = false,

--- a/packages/mui-base/src/useSnackbar/useSnackbar.ts
+++ b/packages/mui-base/src/useSnackbar/useSnackbar.ts
@@ -145,21 +145,19 @@ export function useSnackbar(parameters: UseSnackbarParameters): UseSnackbarRetur
     return undefined;
   }, [disableWindowBlurListener, handleResume, open]);
 
-  const getRootProps: UseSnackbarReturnValue['getRootProps'] = <
-    TOther extends Parameters<UseSnackbarReturnValue['getRootProps']>[0],
-  >(
-    otherHandlers: TOther = {} as TOther,
+  const getRootProps = <ExternalProps extends Record<string, any> = {}>(
+    externalProps: ExternalProps = {} as ExternalProps,
   ) => {
-    const propsEventHandlers = extractEventHandlers(parameters) as Partial<UseSnackbarParameters>;
     const externalEventHandlers = {
-      ...propsEventHandlers,
-      ...otherHandlers,
+      ...extractEventHandlers(parameters),
+      ...extractEventHandlers(externalProps),
     };
 
     return {
       // ClickAwayListener adds an `onClick` prop which results in the alert not being announced.
       // See https://github.com/mui/material-ui/issues/29080
       role: 'presentation',
+      ...externalProps,
       ...externalEventHandlers,
       onBlur: createHandleBlur(externalEventHandlers),
       onFocus: createHandleFocus(externalEventHandlers),

--- a/packages/mui-base/src/useSnackbar/useSnackbar.ts
+++ b/packages/mui-base/src/useSnackbar/useSnackbar.ts
@@ -7,6 +7,7 @@ import {
   UseSnackbarReturnValue,
 } from './useSnackbar.types';
 import { extractEventHandlers } from '../utils/extractEventHandlers';
+import { EventHandlers } from '../utils/types';
 
 /**
  * The basic building block for creating custom snackbar.
@@ -99,32 +100,28 @@ export function useSnackbar(parameters: UseSnackbarParameters): UseSnackbarRetur
   }, [autoHideDuration, resumeHideDuration, setAutoHideTimer]);
 
   const createHandleBlur =
-    (otherHandlers: Record<string, React.EventHandler<any> | undefined>) =>
-    (event: React.FocusEvent<HTMLDivElement, Element>) => {
+    (otherHandlers: EventHandlers) => (event: React.FocusEvent<HTMLDivElement, Element>) => {
       const onBlurCallback = otherHandlers.onBlur;
       onBlurCallback?.(event);
       handleResume();
     };
 
   const createHandleFocus =
-    (otherHandlers: Record<string, React.EventHandler<any> | undefined>) =>
-    (event: React.FocusEvent<HTMLDivElement, Element>) => {
+    (otherHandlers: EventHandlers) => (event: React.FocusEvent<HTMLDivElement, Element>) => {
       const onFocusCallback = otherHandlers.onFocus;
       onFocusCallback?.(event);
       handlePause();
     };
 
   const createMouseEnter =
-    (otherHandlers: Record<string, React.EventHandler<any> | undefined>) =>
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    (otherHandlers: EventHandlers) => (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       const onMouseEnterCallback = otherHandlers.onMouseEnter;
       onMouseEnterCallback?.(event);
       handlePause();
     };
 
   const createMouseLeave =
-    (otherHandlers: Record<string, React.EventHandler<any> | undefined>) =>
-    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    (otherHandlers: EventHandlers) => (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       const onMouseLeaveCallback = otherHandlers.onMouseLeave;
       onMouseLeaveCallback?.(event);
       handleResume();
@@ -145,7 +142,7 @@ export function useSnackbar(parameters: UseSnackbarParameters): UseSnackbarRetur
     return undefined;
   }, [disableWindowBlurListener, handleResume, open]);
 
-  const getRootProps = <ExternalProps extends Record<string, any> = {}>(
+  const getRootProps = <ExternalProps extends Record<string, unknown> = {}>(
     externalProps: ExternalProps = {} as ExternalProps,
   ) => {
     const externalEventHandlers = {

--- a/packages/mui-base/src/useSnackbar/useSnackbar.types.ts
+++ b/packages/mui-base/src/useSnackbar/useSnackbar.types.ts
@@ -56,7 +56,7 @@ export interface UseSnackbarReturnValue {
    * @param externalProps props for the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <ExternalProps extends Record<string, ((event: any) => void) | undefined> = {}>(
+  getRootProps: <ExternalProps extends Record<string, unknown> = {}>(
     externalProps?: ExternalProps,
   ) => UseSnackbarRootSlotProps<ExternalProps>;
   /**

--- a/packages/mui-base/src/useSnackbar/useSnackbar.types.ts
+++ b/packages/mui-base/src/useSnackbar/useSnackbar.types.ts
@@ -38,7 +38,8 @@ export interface UseSnackbarParameters {
   resumeHideDuration?: number;
 }
 
-export type UseSnackbarRootSlotProps<TOther = {}> = TOther & UseSnackbarRootSlotOwnProps;
+export type UseSnackbarRootSlotProps<ExternalProps = {}> = ExternalProps &
+  UseSnackbarRootSlotOwnProps;
 
 export interface UseSnackbarRootSlotOwnProps {
   onBlur: React.FocusEventHandler;
@@ -55,9 +56,9 @@ export interface UseSnackbarReturnValue {
    * @param externalProps props for the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <TOther extends Record<string, ((event: any) => void) | undefined> = {}>(
-    externalProps?: TOther,
-  ) => UseSnackbarRootSlotProps<TOther>;
+  getRootProps: <ExternalProps extends Record<string, ((event: any) => void) | undefined> = {}>(
+    externalProps?: ExternalProps,
+  ) => UseSnackbarRootSlotProps<ExternalProps>;
   /**
    * Callback fired when a "click away" event is detected.
    */


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/38186

This PR aligns the typing and handling of external props and event handlers

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
