### PR TITLE
[base-ui][useMenu] Align external props handling for useMenu/MenuButton/MenuItem

### DIFF
--- a/docs/pages/base-ui/api/use-menu-button.json
+++ b/docs/pages/base-ui/api/use-menu-button.json
@@ -16,8 +16,8 @@
     "active": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "getRootProps": {
       "type": {
-        "name": "(otherHandlers?: EventHandlers) =&gt; UseMenuButtonRootSlotProps",
-        "description": "(otherHandlers?: EventHandlers) =&gt; UseMenuButtonRootSlotProps"
+        "name": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseMenuButtonRootSlotProps&lt;ExternalProps&gt;",
+        "description": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseMenuButtonRootSlotProps&lt;ExternalProps&gt;"
       },
       "required": true
     },

--- a/docs/pages/base-ui/api/use-menu-item.json
+++ b/docs/pages/base-ui/api/use-menu-item.json
@@ -19,8 +19,8 @@
     "focusVisible": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "getRootProps": {
       "type": {
-        "name": "&lt;TOther extends EventHandlers = {}&gt;(otherHandlers?: TOther) =&gt; UseMenuItemRootSlotProps&lt;TOther&gt;",
-        "description": "&lt;TOther extends EventHandlers = {}&gt;(otherHandlers?: TOther) =&gt; UseMenuItemRootSlotProps&lt;TOther&gt;"
+        "name": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseMenuItemRootSlotProps&lt;ExternalProps&gt;",
+        "description": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseMenuItemRootSlotProps&lt;ExternalProps&gt;"
       },
       "required": true
     },

--- a/docs/pages/base-ui/api/use-menu.json
+++ b/docs/pages/base-ui/api/use-menu.json
@@ -25,8 +25,8 @@
     },
     "getListboxProps": {
       "type": {
-        "name": "&lt;TOther extends EventHandlers&gt;(otherHandlers?: TOther) =&gt; UseMenuListboxSlotProps",
-        "description": "&lt;TOther extends EventHandlers&gt;(otherHandlers?: TOther) =&gt; UseMenuListboxSlotProps"
+        "name": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseMenuListboxSlotProps",
+        "description": "&lt;ExternalProps extends Record&lt;string, unknown&gt; = {}&gt;(externalProps?: ExternalProps) =&gt; UseMenuListboxSlotProps"
       },
       "required": true
     },

--- a/packages/mui-base/src/useMenu/useMenu.test.js
+++ b/packages/mui-base/src/useMenu/useMenu.test.js
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { createRenderer, screen, fireEvent } from 'test/utils';
+import { MenuItem } from '../MenuItem';
+import { useMenu } from './useMenu';
+
+describe('useMenu', () => {
+  const { render } = createRenderer();
+  describe('getListboxProps', () => {
+    it('returns props for root slot', () => {
+      function TestMenu() {
+        const listboxRef = React.createRef();
+        const { getListboxProps } = useMenu({ listboxRef });
+        return <div {...getListboxProps()} />;
+      }
+
+      function Test() {
+        return (
+          <TestMenu>
+            <MenuItem />
+          </TestMenu>
+        );
+      }
+
+      const { getByRole } = render(<Test />);
+
+      const menu = getByRole('menu');
+      expect(menu).not.to.equal(null);
+    });
+
+    it('forwards external props including event handlers', () => {
+      const handleClick = spy();
+
+      function TestMenu() {
+        const listboxRef = React.createRef();
+        const { getListboxProps } = useMenu({ listboxRef });
+        return (
+          <div {...getListboxProps({ 'data-testid': 'test-listbox', onClick: handleClick })} />
+        );
+      }
+
+      function Test() {
+        return (
+          <TestMenu>
+            <MenuItem />
+          </TestMenu>
+        );
+      }
+
+      render(<Test />);
+
+      const listbox = screen.getByTestId('test-listbox');
+      expect(listbox).not.to.equal(null);
+
+      fireEvent.click(listbox);
+      expect(handleClick.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/mui-base/src/useMenu/useMenu.ts
+++ b/packages/mui-base/src/useMenu/useMenu.ts
@@ -11,10 +11,11 @@ import { DropdownContext, DropdownContextValue } from '../useDropdown/DropdownCo
 import { useList } from '../useList';
 import { MenuItemMetadata } from '../useMenuItem';
 import { DropdownActionTypes } from '../useDropdown';
-import { EventHandlers } from '../utils';
+import { EventHandlers } from '../utils/types';
 import { useCompoundParent } from '../utils/useCompound';
 import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
 import { combineHooksSlotProps } from '../utils/combineHooksSlotProps';
+import { extractEventHandlers } from '../utils/extractEventHandlers';
 
 const FALLBACK_MENU_CONTEXT: DropdownContextValue = {
   dispatch: () => {},
@@ -154,12 +155,15 @@ export function useMenu(parameters: UseMenuParameters = {}): UseMenuReturnValue 
     onKeyDown: createHandleKeyDown(otherHandlers),
   });
 
-  const getListboxProps = <TOther extends EventHandlers>(
-    otherHandlers: TOther = {} as TOther,
+  const getListboxProps = <ExternalProps extends Record<string, unknown>>(
+    externalProps: ExternalProps = {} as ExternalProps,
   ): UseMenuListboxSlotProps => {
     const getCombinedRootProps = combineHooksSlotProps(getOwnListboxHandlers, getListRootProps);
+    const externalEventHandlers = extractEventHandlers(externalProps);
     return {
-      ...getCombinedRootProps(otherHandlers),
+      ...externalProps,
+      ...externalEventHandlers,
+      ...getCombinedRootProps(externalEventHandlers),
       id: listboxId,
       role: 'menu',
     };

--- a/packages/mui-base/src/useMenu/useMenu.types.ts
+++ b/packages/mui-base/src/useMenu/useMenu.types.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ListAction, ListState, UseListRootSlotProps } from '../useList';
 import { MenuItemMetadata } from '../useMenuItem';
-import { EventHandlers } from '../utils/types';
 import { MenuProviderValue } from './MenuProvider';
 
 export interface UseMenuParameters {
@@ -31,11 +30,11 @@ export interface UseMenuReturnValue {
   dispatch: (action: ListAction<string>) => void;
   /**
    * Resolver for the listbox slot's props.
-   * @param otherHandlers event handlers for the listbox component
+   * @param externalProps additional props for the listbox component
    * @returns props that should be spread on the listbox component
    */
-  getListboxProps: <TOther extends EventHandlers>(
-    otherHandlers?: TOther,
+  getListboxProps: <ExternalProps extends Record<string, unknown> = {}>(
+    externalProps?: ExternalProps,
   ) => UseMenuListboxSlotProps;
   /**
    * The highlighted option in the menu listbox.
@@ -64,8 +63,8 @@ interface UseMenuListboxSlotEventHandlers {
   onKeyDown: React.KeyboardEventHandler;
 }
 
-export type UseMenuListboxSlotProps<TOther = {}> = UseListRootSlotProps<
-  Omit<TOther, keyof UseMenuListboxSlotEventHandlers> & UseMenuListboxSlotEventHandlers
+export type UseMenuListboxSlotProps<ExternalProps = {}> = UseListRootSlotProps<
+  Omit<ExternalProps, keyof UseMenuListboxSlotEventHandlers> & UseMenuListboxSlotEventHandlers
 > & {
   ref: React.RefCallback<Element> | null;
   role: React.AriaRole;

--- a/packages/mui-base/src/useMenuButton/useMenuButton.test.tsx
+++ b/packages/mui-base/src/useMenuButton/useMenuButton.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { createRenderer, screen, fireEvent } from 'test/utils';
+import { DropdownContext, DropdownContextValue } from '@mui/base/useDropdown';
+import { useMenuButton } from './useMenuButton';
+
+const testContext: DropdownContextValue = {
+  dispatch: () => {},
+  popupId: 'menu-popup',
+  registerPopup: () => {},
+  registerTrigger: () => {},
+  state: { open: true },
+  triggerElement: null,
+};
+
+describe('useMenuButton', () => {
+  const { render } = createRenderer();
+  describe('getRootProps', () => {
+    it('returns props for root slot', () => {
+      function TestMenuButton() {
+        const { getRootProps } = useMenuButton();
+        return <div {...getRootProps()} />;
+      }
+
+      function Test() {
+        return (
+          <DropdownContext.Provider value={testContext}>
+            <TestMenuButton />
+          </DropdownContext.Provider>
+        );
+      }
+
+      const { getByRole } = render(<Test />);
+
+      const button = getByRole('button');
+      expect(button).not.to.equal(null);
+    });
+
+    it('forwards external props including event handlers', () => {
+      const handleClick = spy();
+
+      function TestMenuButton() {
+        const { getRootProps } = useMenuButton();
+        return (
+          <div {...getRootProps({ 'data-testid': 'test-menu-button', onClick: handleClick })} />
+        );
+      }
+
+      function Test() {
+        return (
+          <DropdownContext.Provider value={testContext}>
+            <TestMenuButton />
+          </DropdownContext.Provider>
+        );
+      }
+
+      render(<Test />);
+
+      const button = screen.getByTestId('test-menu-button');
+      expect(button).not.to.equal(null);
+
+      fireEvent.click(button);
+      expect(handleClick.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/mui-base/src/useMenuButton/useMenuButton.ts
+++ b/packages/mui-base/src/useMenuButton/useMenuButton.ts
@@ -8,6 +8,7 @@ import { useButton } from '../useButton/useButton';
 import { EventHandlers } from '../utils/types';
 import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
 import { combineHooksSlotProps } from '../utils/combineHooksSlotProps';
+import { extractEventHandlers } from '../utils';
 
 /**
  *
@@ -75,14 +76,19 @@ export function useMenuButton(parameters: UseMenuButtonParameters = {}): UseMenu
     onKeyDown: createHandleKeyDown(otherHandlers),
   });
 
-  const getRootProps = (otherHandlers: EventHandlers = {}) => {
+  const getRootProps = <ExternalProps extends Record<string, unknown> = {}>(
+    externalProps: ExternalProps = {} as ExternalProps,
+  ) => {
+    const externalEventHandlers = extractEventHandlers(externalProps);
     const getCombinedProps = combineHooksSlotProps(getButtonRootProps, getOwnRootProps);
 
     return {
-      ...getCombinedProps(otherHandlers),
       'aria-haspopup': 'menu' as const,
       'aria-expanded': state.open,
       'aria-controls': popupId,
+      ...externalProps,
+      ...externalEventHandlers,
+      ...getCombinedProps(externalEventHandlers),
       ref: handleRef,
     };
   };

--- a/packages/mui-base/src/useMenuButton/useMenuButton.types.ts
+++ b/packages/mui-base/src/useMenuButton/useMenuButton.types.ts
@@ -1,5 +1,3 @@
-import { EventHandlers } from '../utils';
-
 export interface UseMenuButtonParameters {
   /**
    * If `true`, the component is disabled.
@@ -17,7 +15,9 @@ export interface UseMenuButtonParameters {
   rootRef?: React.Ref<HTMLElement>;
 }
 
-interface UseMenuButtonRootSlotProps {
+type UseMenuButtonRootSlotProps<ExternalProps = {}> = ExternalProps & UseMenuButtonRootSlotOwnProps;
+
+interface UseMenuButtonRootSlotOwnProps {
   'aria-haspopup': 'menu';
   'aria-expanded': boolean;
   'aria-controls': string;
@@ -38,8 +38,12 @@ export interface UseMenuButtonReturnValue {
   active: boolean;
   /**
    * Resolver for the root slot's props.
+   * @param externalProps props for the root slot
+   * @returns props that should be spread on the root slot
    */
-  getRootProps: (otherHandlers?: EventHandlers) => UseMenuButtonRootSlotProps;
+  getRootProps: <ExternalProps extends Record<string, unknown> = {}>(
+    externalProps?: ExternalProps,
+  ) => UseMenuButtonRootSlotProps<ExternalProps>;
   /*
    * If `true`, the menu is open.
    */

--- a/packages/mui-base/src/useMenuItem/useMenuItem.test.tsx
+++ b/packages/mui-base/src/useMenuItem/useMenuItem.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { createRenderer, screen, fireEvent } from 'test/utils';
+import { Menu } from '../Menu';
+import { useMenuItem } from './useMenuItem';
+
+describe('useMenuItem', () => {
+  const { render } = createRenderer();
+  describe('getRootProps', () => {
+    it('returns props for root slot', () => {
+      function TestMenuItem() {
+        const rootRef = React.createRef<HTMLElement>();
+        const { getRootProps } = useMenuItem({ rootRef });
+        return <div {...getRootProps()} />;
+      }
+
+      function Test() {
+        return (
+          <Menu>
+            <TestMenuItem />
+          </Menu>
+        );
+      }
+
+      const { getByRole } = render(<Test />);
+
+      const menuItem = getByRole('menuitem');
+      expect(menuItem).not.to.equal(null);
+    });
+
+    it('forwards external props including event handlers', () => {
+      const handleClick = spy();
+
+      function TestMenuItem() {
+        const rootRef = React.createRef<HTMLElement>();
+        const { getRootProps } = useMenuItem({ rootRef, id: 'test-menu-item-1' });
+        return <div {...getRootProps({ 'data-testid': 'test-menu-item', onClick: handleClick })} />;
+      }
+
+      function Test() {
+        return (
+          <Menu>
+            <TestMenuItem />
+          </Menu>
+        );
+      }
+
+      render(<Test />);
+
+      const menuItem = screen.getByTestId('test-menu-item');
+      expect(menuItem).not.to.equal(null);
+
+      fireEvent.click(menuItem);
+      expect(handleClick.callCount).to.equal(1);
+    });
+  });
+});

--- a/packages/mui-base/src/useMenuItem/useMenuItem.ts
+++ b/packages/mui-base/src/useMenuItem/useMenuItem.ts
@@ -15,6 +15,7 @@ import { combineHooksSlotProps } from '../utils/combineHooksSlotProps';
 import { useCompoundItem } from '../utils/useCompoundItem';
 import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
 import { EventHandlers } from '../utils/types';
+import { extractEventHandlers } from '../utils/extractEventHandlers';
 
 function idGenerator(existingKeys: Set<string>) {
   return `menu-item-${existingKeys.size}`;
@@ -88,20 +89,25 @@ export function useMenuItem(params: UseMenuItemParameters): UseMenuItemReturnVal
       });
     };
 
-  const getOwnHandlers = <TOther extends EventHandlers>(otherHandlers: TOther = {} as TOther) => ({
+  const getOwnHandlers = <ExternalProps extends EventHandlers>(
+    otherHandlers: ExternalProps = {} as ExternalProps,
+  ) => ({
     ...otherHandlers,
     onClick: createHandleClick(otherHandlers),
   });
 
-  function getRootProps<TOther extends EventHandlers = {}>(
-    otherHandlers: TOther = {} as TOther,
-  ): UseMenuItemRootSlotProps<TOther> {
+  function getRootProps<ExternalProps extends Record<string, unknown> = {}>(
+    externalProps: ExternalProps = {} as ExternalProps,
+  ): UseMenuItemRootSlotProps<ExternalProps> {
+    const externalEventHandlers = extractEventHandlers(externalProps);
     const getCombinedRootProps = combineHooksSlotProps(
       getOwnHandlers,
       combineHooksSlotProps(getButtonProps, getListRootProps),
     );
     return {
-      ...getCombinedRootProps(otherHandlers),
+      ...externalProps,
+      ...externalEventHandlers,
+      ...getCombinedRootProps(externalEventHandlers),
       ref: handleRef,
       role: 'menuitem',
     };

--- a/packages/mui-base/src/useMenuItem/useMenuItem.types.ts
+++ b/packages/mui-base/src/useMenuItem/useMenuItem.types.ts
@@ -1,4 +1,3 @@
-import { EventHandlers } from '../utils/types';
 import { UseButtonRootSlotProps } from '../useButton';
 import { MuiCancellableEventHandler } from '../utils/MuiCancellableEvent';
 
@@ -14,9 +13,9 @@ export interface MenuItemMetadata {
   ref: React.RefObject<HTMLElement>;
 }
 
-export type UseMenuItemRootSlotProps<TOther = {}> = TOther &
+export type UseMenuItemRootSlotProps<ExternalProps = {}> = ExternalProps &
   UseMenuItemRootSlotOwnProps &
-  UseButtonRootSlotProps<TOther> & {
+  UseButtonRootSlotProps<ExternalProps> & {
     onClick: MuiCancellableEventHandler<React.MouseEvent>;
   };
 
@@ -31,12 +30,12 @@ export interface UseMenuItemParameters {
 export interface UseMenuItemReturnValue {
   /**
    * Resolver for the root slot's props.
-   * @param otherHandlers event handlers for the root slot
+   * @param externalProps event handlers for the root slot
    * @returns props that should be spread on the root slot
    */
-  getRootProps: <TOther extends EventHandlers = {}>(
-    otherHandlers?: TOther,
-  ) => UseMenuItemRootSlotProps<TOther>;
+  getRootProps: <ExternalProps extends Record<string, unknown> = {}>(
+    externalProps?: ExternalProps,
+  ) => UseMenuItemRootSlotProps<ExternalProps>;
   /**
    * If `true`, the component is disabled.
    */


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/38186

This PR aligns the typing/handling of external props for `useMenu`, `useMenuButton` and `useMenuItem`, and adds some simple tests

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
