### PR TITLE
[core] Remove package declaration from same package dependencies

### DIFF
--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -50,7 +50,6 @@
     "prop-types": "^15.8.1"
   },
   "devDependencies": {
-    "@mui/base": "5.0.0-beta.14",
     "@mui/material": "^5.14.8",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -44,7 +44,6 @@
     "react": "^18.2.0"
   },
   "devDependencies": {
-    "@mui/styled-engine-sc": "^5.14.8",
     "@types/chai": "^4.3.5",
     "@types/react": "^18.2.21",
     "@types/styled-components": "^5.1.26",

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/styled-engine": "^5.14.8",
     "@types/chai": "^4.3.5",
     "@types/react": "^18.2.21",
     "chai": "^4.3.7",

--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -59,7 +59,6 @@
   "devDependencies": {
     "@mui/joy": "5.0.0-beta.5",
     "@mui/material": "^5.14.8",
-    "@mui/styles": "^5.14.7",
     "@types/chai": "^4.3.5",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",

--- a/packages/mui-system/package.json
+++ b/packages/mui-system/package.json
@@ -55,7 +55,6 @@
     "@mui/joy": "5.0.0-beta.5",
     "@mui/material": "^5.14.8",
     "@mui/material-next": "6.0.0-alpha.100",
-    "@mui/system": "^5.14.8",
     "@types/chai": "^4.3.5",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^18.2.21",

--- a/packages/mui-types/package.json
+++ b/packages/mui-types/package.json
@@ -38,7 +38,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mui/types": "^7.2.4",
     "@types/react": "^18.2.21"
   },
   "peerDependencies": {


### PR DESCRIPTION
In https://github.com/mui/material-ui/pull/38859, dependencies were explicitly added to packages. Some declared themselves as a dependency. `lerna` does not update these versions, causing mismatches. For example from the [v5.14.9 release PR](https://github.com/mui/material-ui/pull/38920), after update `@mui/base` ended up with ["version": "5.0.0-beta.15"](https://github.com/mui/material-ui/blob/7d4e5e7ee71e20b1fddad78e6a77406855ea5b7b/packages/mui-base/package.json#L3) and ["@mui/base": "5.0.0-beta.14"](https://github.com/mui/material-ui/blob/7d4e5e7ee71e20b1fddad78e6a77406855ea5b7b/packages/mui-base/package.json#L53) as a dependency.
