### PR TITLE
[joy-ui][GlobalStyles] Ensure compatibility with RSC

### DIFF
--- a/packages/api-docs-builder/buildApi.ts
+++ b/packages/api-docs-builder/buildApi.ts
@@ -182,8 +182,9 @@ async function run(argv: yargs.ArgumentsCamelCase<CommandOptions>) {
             (component.filename.includes('mui-joy') &&
               // Box's demo isn't ready
               // Container's demo isn't ready
+              // GlobalStyles's demo isn't ready
               // Grid has problem with react-docgen
-              component.filename.match(/(Box|Container|ColorInversion|Grid)/)) ||
+              component.filename.match(/(Box|Container|ColorInversion|Grid|GlobalStyles)/)) ||
             (component.filename.includes('mui-system') && component.filename.match(/GlobalStyles/))
           ) {
             return false;

--- a/packages/mui-joy/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/mui-joy/src/GlobalStyles/GlobalStyles.tsx
@@ -1,0 +1,12 @@
+'use client';
+import * as React from 'react';
+import { GlobalStyles as SystemGlobalStyles, GlobalStylesProps } from '@mui/system';
+import defaultTheme from '../styles/defaultTheme';
+import THEME_ID from '../styles/identifier';
+import { Theme } from '../styles/types';
+
+function GlobalStyles(props: GlobalStylesProps<Theme>) {
+  return <SystemGlobalStyles {...props} defaultTheme={defaultTheme} themeId={THEME_ID} />;
+}
+
+export default GlobalStyles;

--- a/packages/mui-joy/src/GlobalStyles/index.tsx
+++ b/packages/mui-joy/src/GlobalStyles/index.tsx
@@ -1,11 +1,1 @@
-import * as React from 'react';
-import { GlobalStyles as SystemGlobalStyles, GlobalStylesProps } from '@mui/system';
-import defaultTheme from '../styles/defaultTheme';
-import THEME_ID from '../styles/identifier';
-import { Theme } from '../styles/types';
-
-function GlobalStyles(props: GlobalStylesProps<Theme>) {
-  return <SystemGlobalStyles {...props} defaultTheme={defaultTheme} themeId={THEME_ID} />;
-}
-
-export default GlobalStyles;
+export { default } from './GlobalStyles';


### PR DESCRIPTION
<!-- Thank you for your contribution! ❤️ -->

Closes #38494 

### What I Did

In this pull request, I made the following changes:

1. Created a new file, `GlobalStyles.tsx`, in the `packages/mui-joy/src/GlobalStyles` folder.
2. Modified the `packages/mui-joy/src/GlobalStyles/index.tsx` file to export the `GlobalStyles`.
3. Ran the script `yarn rsc:build` to insert the `use client` directive into the `GlobalStyles.tsx` file.

I followed the guidance provided by @siriwatknp in the following comment: https://github.com/mui/material-ui/issues/38494#issuecomment-1714903097.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).