### PR TITLE
[core] Remove react from styled-engine dependencies

### DIFF
--- a/packages/mui-styled-engine-sc/package.json
+++ b/packages/mui-styled-engine-sc/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.22.15",
     "csstype": "^3.1.2",
-    "prop-types": "^15.8.1",
-    "react": "^18.2.0"
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",
@@ -49,6 +48,7 @@
     "@types/styled-components": "^5.1.26",
     "chai": "^4.3.7",
     "styled-components": "^5.3.1",
+    "react": "^18.2.0",
     "test": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/mui-styled-engine/package.json
+++ b/packages/mui-styled-engine/package.json
@@ -41,8 +41,7 @@
     "@babel/runtime": "^7.22.15",
     "@emotion/cache": "^11.11.0",
     "csstype": "^3.1.2",
-    "prop-types": "^15.8.1",
-    "react": "^18.2.0"
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@emotion/react": "^11.11.1",
@@ -50,6 +49,7 @@
     "@types/chai": "^4.3.5",
     "@types/react": "^18.2.21",
     "chai": "^4.3.7",
+    "react": "^18.2.0",
     "test": "^5.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
React has been added to @mui/styled-engine and @mui/styled-engine-sc dependencies by mistake. It should be a devDependency.