### PR TITLE
[docs-infra] Display markdown lists correctly in docs for props description

### DIFF
--- a/docs/src/modules/components/PropertiesTable.js
+++ b/docs/src/modules/components/PropertiesTable.js
@@ -117,6 +117,25 @@ export const getPropsToC = ({
   ],
 });
 
+function PropDescription({ description }) {
+  const isUlPresent = description.includes('<ul>');
+
+  const ComponentToRender = isUlPresent ? 'div' : 'p';
+
+  return (
+    <ComponentToRender
+      className="prop-list-description" // This className is used by Algolia
+      dangerouslySetInnerHTML={{
+        __html: description,
+      }}
+    />
+  );
+}
+
+PropDescription.propTypes = {
+  description: PropTypes.string.isRequired,
+};
+
 export default function PropertiesTable(props) {
   const {
     properties,
@@ -150,12 +169,7 @@ export default function PropertiesTable(props) {
               type="props"
             >
               {propDescription?.description && (
-                <p
-                  className="prop-list-description" // This className is used by Algolia
-                  dangerouslySetInnerHTML={{
-                    __html: propDescription?.description,
-                  }}
-                />
+                <PropDescription description={propDescription?.description} />
               )}
               {propDescription?.requiresRef && (
                 <Alert
@@ -181,7 +195,6 @@ export default function PropertiesTable(props) {
                   />
                 </Alert>
               )}
-
               {Object.keys(additionalPropsInfoText)
                 .filter((key) => propData.additionalInfo?.[key])
                 .map((key) => (

--- a/docs/src/pages/production-error/ErrorDecoder.js
+++ b/docs/src/pages/production-error/ErrorDecoder.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
-import { renderInline as renderInlineMarkdown } from '@mui/markdown';
+import { renderMarkdown } from '@mui/markdown';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 
 const ErrorMessageSection = styled('div')({
@@ -86,7 +86,7 @@ export default function ErrorDecoder() {
       return div.innerHTML;
     });
 
-    return renderInlineMarkdown(readableMessage);
+    return renderMarkdown(readableMessage);
   }, [args, code, data.errorCodes]);
 
   if (data.state === 'loading') {

--- a/docs/translations/api-docs-base/slider/slider.json
+++ b/docs/translations/api-docs-base/slider/slider.json
@@ -65,7 +65,7 @@
     },
     "tabIndex": { "description": "Tab index attribute of the hidden <code>input</code> element." },
     "track": {
-      "description": "The track presentation:<br>- <code>normal</code> the track will render a bar representing the slider value. - <code>inverted</code> the track will render a bar representing the remaining slider value. - <code>false</code> the track will render without a bar."
+      "description": "<p>The track presentation:</p>\n<ul>\n<li><code>normal</code> the track will render a bar representing the slider value.</li>\n<li><code>inverted</code> the track will render a bar representing the remaining slider value.</li>\n<li><code>false</code> the track will render without a bar.</li>\n</ul>\n"
     },
     "value": {
       "description": "The value of the slider. For ranged sliders, provide an array with two values."

--- a/docs/translations/api-docs-joy/chip-delete/chip-delete.json
+++ b/docs/translations/api-docs-joy/chip-delete/chip-delete.json
@@ -12,7 +12,7 @@
       "description": "If <code>true</code>, the component is disabled. If <code>undefined</code>, the value inherits from the parent chip via a React context."
     },
     "onDelete": {
-      "description": "Callback fired when the component is not disabled and either: - <code>Backspace</code>, <code>Enter</code> or <code>Delete</code> is pressed. - The component is clicked."
+      "description": "<p>Callback fired when the component is not disabled and either:</p>\n<ul>\n<li><code>Backspace</code>, <code>Enter</code> or <code>Delete</code> is pressed.</li>\n<li>The component is clicked.</li>\n</ul>\n"
     },
     "slotProps": { "description": "The props used for each slot inside." },
     "slots": { "description": "The components used for each slot inside." },

--- a/docs/translations/api-docs-joy/slider/slider.json
+++ b/docs/translations/api-docs-joy/slider/slider.json
@@ -73,13 +73,13 @@
     },
     "tabIndex": { "description": "Tab index attribute of the hidden <code>input</code> element." },
     "track": {
-      "description": "The track presentation:<br>- <code>normal</code> the track will render a bar representing the slider value. - <code>inverted</code> the track will render a bar representing the remaining slider value. - <code>false</code> the track will render without a bar."
+      "description": "<p>The track presentation:</p>\n<ul>\n<li><code>normal</code> the track will render a bar representing the slider value.</li>\n<li><code>inverted</code> the track will render a bar representing the remaining slider value.</li>\n<li><code>false</code> the track will render without a bar.</li>\n</ul>\n"
     },
     "value": {
       "description": "The value of the slider. For ranged sliders, provide an array with two values."
     },
     "valueLabelDisplay": {
-      "description": "Controls when the value label is displayed:<br>- <code>auto</code> the value label will display when the thumb is hovered or focused. - <code>on</code> will display persistently. - <code>off</code> will never display."
+      "description": "<p>Controls when the value label is displayed:</p>\n<ul>\n<li><code>auto</code> the value label will display when the thumb is hovered or focused.</li>\n<li><code>on</code> will display persistently.</li>\n<li><code>off</code> will never display.</li>\n</ul>\n"
     },
     "valueLabelFormat": {
       "description": "The format function the value label&#39;s value.<br>When a function is provided, it should have the following signature:<br>- {number} value The value label&#39;s value to format - {number} index The value label&#39;s index to format"

--- a/docs/translations/api-docs/autocomplete/autocomplete.json
+++ b/docs/translations/api-docs/autocomplete/autocomplete.json
@@ -11,7 +11,7 @@
       "description": "If <code>true</code>, the selected option becomes the value of the input when the Autocomplete loses focus unless the user chooses a different option or changes the character string in the input.<br>When using <code>freeSolo</code> mode, the typed value will be the input value if the Autocomplete loses focus without highlighting an option."
     },
     "blurOnSelect": {
-      "description": "Control if the input should be blurred when an option is selected:<br>- <code>false</code> the input is not blurred. - <code>true</code> the input is always blurred. - <code>touch</code> the input is blurred after a touch event. - <code>mouse</code> the input is blurred after a mouse event."
+      "description": "<p>Control if the input should be blurred when an option is selected:</p>\n<ul>\n<li><code>false</code> the input is not blurred.</li>\n<li><code>true</code> the input is always blurred.</li>\n<li><code>touch</code> the input is blurred after a touch event.</li>\n<li><code>mouse</code> the input is blurred after a mouse event.</li>\n</ul>\n"
     },
     "ChipProps": {
       "description": "Props applied to the <a href=\"/material-ui/api/chip/\"><code>Chip</code></a> element."

--- a/docs/translations/api-docs/slider/slider.json
+++ b/docs/translations/api-docs/slider/slider.json
@@ -76,13 +76,13 @@
     },
     "tabIndex": { "description": "Tab index attribute of the hidden <code>input</code> element." },
     "track": {
-      "description": "The track presentation:<br>- <code>normal</code> the track will render a bar representing the slider value. - <code>inverted</code> the track will render a bar representing the remaining slider value. - <code>false</code> the track will render without a bar."
+      "description": "<p>The track presentation:</p>\n<ul>\n<li><code>normal</code> the track will render a bar representing the slider value.</li>\n<li><code>inverted</code> the track will render a bar representing the remaining slider value.</li>\n<li><code>false</code> the track will render without a bar.</li>\n</ul>\n"
     },
     "value": {
       "description": "The value of the slider. For ranged sliders, provide an array with two values."
     },
     "valueLabelDisplay": {
-      "description": "Controls when the value label is displayed:<br>- <code>auto</code> the value label will display when the thumb is hovered or focused. - <code>on</code> will display persistently. - <code>off</code> will never display."
+      "description": "<p>Controls when the value label is displayed:</p>\n<ul>\n<li><code>auto</code> the value label will display when the thumb is hovered or focused.</li>\n<li><code>on</code> will display persistently.</li>\n<li><code>off</code> will never display.</li>\n</ul>\n"
     },
     "valueLabelFormat": {
       "description": "The format function the value label&#39;s value.<br>When a function is provided, it should have the following signature:<br>- {number} value The value label&#39;s value to format - {number} index The value label&#39;s index to format"

--- a/docs/translations/api-docs/tabs/tabs.json
+++ b/docs/translations/api-docs/tabs/tabs.json
@@ -30,7 +30,7 @@
     "orientation": { "description": "The component orientation (layout flow direction)." },
     "ScrollButtonComponent": { "description": "The component used to render the scroll buttons." },
     "scrollButtons": {
-      "description": "Determine behavior of scroll buttons when tabs are set to scroll:<br>- <code>auto</code> will only present them when not all the items are visible. - <code>true</code> will always present them. - <code>false</code> will never present them.<br>By default the scroll buttons are hidden on mobile. This behavior can be disabled with <code>allowScrollButtonsMobile</code>."
+      "description": "<p>Determine behavior of scroll buttons when tabs are set to scroll:</p>\n<ul>\n<li><code>auto</code> will only present them when not all the items are visible.</li>\n<li><code>true</code> will always present them.</li>\n<li><code>false</code> will never present them.</li>\n</ul>\n<p>By default the scroll buttons are hidden on mobile.\nThis behavior can be disabled with <code>allowScrollButtonsMobile</code>.</p>\n"
     },
     "selectionFollowsFocus": {
       "description": "If <code>true</code> the selected tab changes on focus. Otherwise it only changes on activation."
@@ -51,7 +51,7 @@
       "description": "The value of the currently selected <code>Tab</code>. If you don&#39;t want any selected <code>Tab</code>, you can set this prop to <code>false</code>."
     },
     "variant": {
-      "description": "Determines additional display behavior of the tabs:<br> - <code>scrollable</code> will invoke scrolling properties and allow for horizontally  scrolling (or swiping) of the tab bar.  -<code>fullWidth</code> will make the tabs grow to use all the available space,  which should be used for small views, like on mobile.  - <code>standard</code> will render the default state."
+      "description": "<p>Determines additional display behavior of the tabs:</p>\n<ul>\n<li><code>scrollable</code> will invoke scrolling properties and allow for horizontally\n scrolling (or swiping) of the tab bar.</li>\n<li><code>fullWidth</code> will make the tabs grow to use all the available space,\n which should be used for small views, like on mobile.</li>\n<li><code>standard</code> will render the default state.</li>\n</ul>\n"
     },
     "visibleScrollbar": {
       "description": "If <code>true</code>, the scrollbar is visible. It can be useful when displaying a long vertical list of tabs."

--- a/docs/translations/api-docs/use-autocomplete/use-autocomplete.json
+++ b/docs/translations/api-docs/use-autocomplete/use-autocomplete.json
@@ -2,19 +2,19 @@
   "hookDescription": "",
   "parametersDescriptions": {
     "autoComplete": {
-      "description": "If <code>true</code>, the portion of the selected suggestion that has not been typed by the user,\nknown as the completion string, appears inline after the input cursor in the textbox.\nThe inline completion string is visually highlighted and has a selected state."
+      "description": "If <code>true</code>, the portion of the selected suggestion that has not been typed by the user, known as the completion string, appears inline after the input cursor in the textbox. The inline completion string is visually highlighted and has a selected state."
     },
     "autoHighlight": {
       "description": "If <code>true</code>, the first option is automatically highlighted."
     },
     "autoSelect": {
-      "description": "If <code>true</code>, the selected option becomes the value of the input\nwhen the Autocomplete loses focus unless the user chooses\na different option or changes the character string in the input.\n\nWhen using <code>freeSolo</code> mode, the typed value will be the input value\nif the Autocomplete loses focus without highlighting an option."
+      "description": "If <code>true</code>, the selected option becomes the value of the input when the Autocomplete loses focus unless the user chooses a different option or changes the character string in the input.<br>When using <code>freeSolo</code> mode, the typed value will be the input value if the Autocomplete loses focus without highlighting an option."
     },
     "blurOnSelect": {
-      "description": "Control if the input should be blurred when an option is selected:\n\n- <code>false</code> the input is not blurred.\n- <code>true</code> the input is always blurred.\n- <code>touch</code> the input is blurred after a touch event.\n- <code>mouse</code> the input is blurred after a mouse event."
+      "description": "<p>Control if the input should be blurred when an option is selected:</p>\n<ul>\n<li><code>false</code> the input is not blurred.</li>\n<li><code>true</code> the input is always blurred.</li>\n<li><code>touch</code> the input is blurred after a touch event.</li>\n<li><code>mouse</code> the input is blurred after a mouse event.</li>\n</ul>\n"
     },
     "clearOnBlur": {
-      "description": "If <code>true</code>, the input&#39;s text is cleared on blur if no value is selected.\n\nSet to <code>true</code> if you want to help the user enter a new value.\nSet to <code>false</code> if you want to help the user resume their search."
+      "description": "If <code>true</code>, the input&#39;s text is cleared on blur if no value is selected.<br>Set to <code>true</code> if you want to help the user enter a new value. Set to <code>false</code> if you want to help the user resume their search."
     },
     "clearOnEscape": {
       "description": "If <code>true</code>, clear all values when the user presses escape and the popup is closed."
@@ -49,35 +49,35 @@
       "description": "Used to determine the disabled state for a given option."
     },
     "getOptionLabel": {
-      "description": "Used to determine the string value for a given option.\nIt&#39;s used to fill the input (and the list box options if <code>renderOption</code> is not provided).\n\nIf used in free solo mode, it must accept both the type of the options and a string."
+      "description": "Used to determine the string value for a given option. It&#39;s used to fill the input (and the list box options if <code>renderOption</code> is not provided).<br>If used in free solo mode, it must accept both the type of the options and a string."
     },
     "groupBy": {
-      "description": "If provided, the options will be grouped under the returned string.\nThe groupBy value is also used as the text for group headings when <code>renderGroup</code> is not provided."
+      "description": "If provided, the options will be grouped under the returned string. The groupBy value is also used as the text for group headings when <code>renderGroup</code> is not provided."
     },
     "handleHomeEndKeys": {
-      "description": "If <code>true</code>, the component handles the &quot;Home&quot; and &quot;End&quot; keys when the popup is open.\nIt should move focus to the first option and last option, respectively."
+      "description": "If <code>true</code>, the component handles the &quot;Home&quot; and &quot;End&quot; keys when the popup is open. It should move focus to the first option and last option, respectively."
     },
     "id": {
-      "description": "This prop is used to help implement the accessibility logic.\nIf you don&#39;t provide an id it will fall back to a randomly generated one."
+      "description": "This prop is used to help implement the accessibility logic. If you don&#39;t provide an id it will fall back to a randomly generated one."
     },
     "includeInputInList": {
       "description": "If <code>true</code>, the highlight can move to the input."
     },
     "inputValue": { "description": "The input value." },
     "isOptionEqualToValue": {
-      "description": "Used to determine if the option represents the given value.\nUses strict equality by default.\n⚠️ Both arguments need to be handled, an option can only match with one value."
+      "description": "Used to determine if the option represents the given value. Uses strict equality by default. ⚠️ Both arguments need to be handled, an option can only match with one value."
     },
     "multiple": {
       "description": "If <code>true</code>, <code>value</code> must be an array and the menu will support multiple selections."
     },
     "onChange": { "description": "Callback fired when the value changes." },
     "onClose": {
-      "description": "Callback fired when the popup requests to be closed.\nUse in controlled mode (see open)."
+      "description": "Callback fired when the popup requests to be closed. Use in controlled mode (see open)."
     },
     "onHighlightChange": { "description": "Callback fired when the highlight option changes." },
     "onInputChange": { "description": "Callback fired when the input value changes." },
     "onOpen": {
-      "description": "Callback fired when the popup requests to be opened.\nUse in controlled mode (see open)."
+      "description": "Callback fired when the popup requests to be opened. Use in controlled mode (see open)."
     },
     "open": { "description": "If <code>true</code>, the component is shown." },
     "openOnFocus": { "description": "If <code>true</code>, the popup will open on input focus." },
@@ -86,10 +86,10 @@
       "description": "If <code>true</code>, the component becomes readonly. It is also supported for multiple tags where the tag cannot be deleted."
     },
     "selectOnFocus": {
-      "description": "If <code>true</code>, the input&#39;s text is selected on focus.\nIt helps the user clear the selected value."
+      "description": "If <code>true</code>, the input&#39;s text is selected on focus. It helps the user clear the selected value."
     },
     "value": {
-      "description": "The value of the autocomplete.\n\nThe value must have reference equality with the option in order to be selected.\nYou can customize the equality behavior with the <code>isOptionEqualToValue</code> prop."
+      "description": "The value of the autocomplete.<br>The value must have reference equality with the option in order to be selected. You can customize the equality behavior with the <code>isOptionEqualToValue</code> prop."
     }
   },
   "returnValueDescriptions": {

--- a/docs/translations/api-docs/use-dropdown/use-dropdown.json
+++ b/docs/translations/api-docs/use-dropdown/use-dropdown.json
@@ -6,7 +6,7 @@
       "description": "Callback fired when the component requests to be opened or closed."
     },
     "open": {
-      "description": "Allows to control whether the dropdown is open.\nThis is a controlled counterpart of <code>defaultOpen</code>."
+      "description": "Allows to control whether the dropdown is open. This is a controlled counterpart of <code>defaultOpen</code>."
     }
   },
   "returnValueDescriptions": {

--- a/docs/translations/api-docs/use-input/use-input.json
+++ b/docs/translations/api-docs/use-input/use-input.json
@@ -5,13 +5,13 @@
       "description": "The default value. Use when the component is not controlled."
     },
     "disabled": {
-      "description": "If <code>true</code>, the component is disabled.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
+      "description": "If <code>true</code>, the component is disabled. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     },
     "error": {
-      "description": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
+      "description": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     },
     "required": {
-      "description": "If <code>true</code>, the <code>input</code> element is required.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
+      "description": "If <code>true</code>, the <code>input</code> element is required. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     }
   },
   "returnValueDescriptions": {

--- a/docs/translations/api-docs/use-menu/use-menu.json
+++ b/docs/translations/api-docs/use-menu/use-menu.json
@@ -8,7 +8,7 @@
   "returnValueDescriptions": {
     "contextValue": { "description": "The value to be passed into the MenuProvider." },
     "dispatch": {
-      "description": "Action dispatcher for the menu component.\nAllows to programmatically control the menu."
+      "description": "Action dispatcher for the menu component. Allows to programmatically control the menu."
     },
     "getListboxProps": { "description": "Resolver for the listbox slot&#39;s props." },
     "highlightedValue": { "description": "The highlighted option in the menu listbox." },

--- a/docs/translations/api-docs/use-modal/use-modal.json
+++ b/docs/translations/api-docs/use-modal/use-modal.json
@@ -6,14 +6,14 @@
       "description": "When set to true the Modal waits until a nested Transition is completed before closing."
     },
     "container": {
-      "description": "An HTML element or function that returns one.\nThe <code>container</code> will have the portal children appended to it.\n\nBy default, it uses the body of the top-level document object,\nso it&#39;s simply <code>document.body</code> most of the time."
+      "description": "An HTML element or function that returns one. The <code>container</code> will have the portal children appended to it.<br>By default, it uses the body of the top-level document object, so it&#39;s simply <code>document.body</code> most of the time."
     },
     "disableEscapeKeyDown": {
       "description": "If <code>true</code>, hitting escape will not fire the <code>onClose</code> callback."
     },
     "disableScrollLock": { "description": "Disable the scroll lock behavior." },
     "onClose": {
-      "description": "Callback fired when the component requests to be closed.\nThe <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>."
+      "description": "Callback fired when the component requests to be closed. The <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>."
     },
     "onTransitionEnter": { "description": "A function called when a transition enters." },
     "onTransitionExited": { "description": "A function called when a transition has exited." },

--- a/docs/translations/api-docs/use-number-input/use-number-input.json
+++ b/docs/translations/api-docs/use-number-input/use-number-input.json
@@ -5,29 +5,29 @@
       "description": "The default value. Use when the component is not controlled."
     },
     "disabled": {
-      "description": "If <code>true</code>, the component is disabled.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
+      "description": "If <code>true</code>, the component is disabled. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     },
     "error": {
-      "description": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
+      "description": "If <code>true</code>, the <code>input</code> will indicate an error by setting the <code>aria-invalid</code> attribute. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     },
     "inputId": { "description": "The <code>id</code> attribute of the input element." },
     "inputRef": { "description": "The ref of the input element." },
     "max": { "description": "The maximum value." },
     "min": { "description": "The minimum value." },
     "onChange": {
-      "description": "Callback fired after the value is clamped and changes - when the <code>input</code> is blurred or when\nthe stepper buttons are triggered.\nCalled with <code>undefined</code> when the value is unset."
+      "description": "Callback fired after the value is clamped and changes - when the <code>input</code> is blurred or when the stepper buttons are triggered. Called with <code>undefined</code> when the value is unset."
     },
     "onInputChange": {
-      "description": "Callback fired when the <code>input</code> value changes after each keypress, before clamping is applied.\nNote that <code>event.target.value</code> may contain values that fall outside of <code>min</code> and <code>max</code> or\nare otherwise &quot;invalid&quot;."
+      "description": "Callback fired when the <code>input</code> value changes after each keypress, before clamping is applied. Note that <code>event.target.value</code> may contain values that fall outside of <code>min</code> and <code>max</code> or are otherwise &quot;invalid&quot;."
     },
     "readOnly": {
-      "description": "If <code>true</code>, the <code>input</code> element becomes read-only. The stepper buttons remain active,\nwith the addition that they are now keyboard focusable."
+      "description": "If <code>true</code>, the <code>input</code> element becomes read-only. The stepper buttons remain active, with the addition that they are now keyboard focusable."
     },
     "required": {
-      "description": "If <code>true</code>, the <code>input</code> element is required.\nThe prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
+      "description": "If <code>true</code>, the <code>input</code> element is required. The prop defaults to the value (<code>false</code>) inherited from the parent FormControl component."
     },
     "shiftMultiplier": {
-      "description": "Multiplier applied to <code>step</code> if the shift key is held while incrementing\nor decrementing the value. Defaults to <code>10</code>."
+      "description": "Multiplier applied to <code>step</code> if the shift key is held while incrementing or decrementing the value. Defaults to <code>10</code>."
     },
     "step": { "description": "The amount that the value changes on each increment or decrement." },
     "value": { "description": "The current value. Use when the component is controlled." }
@@ -53,10 +53,10 @@
       "description": "The dirty <code>value</code> of the <code>input</code> element when it is in focus."
     },
     "isDecrementDisabled": {
-      "description": "If <code>true</code>, the decrement button will be disabled.\ne.g. when the <code>value</code> is already at <code>min</code>"
+      "description": "If <code>true</code>, the decrement button will be disabled. e.g. when the <code>value</code> is already at <code>min</code>"
     },
     "isIncrementDisabled": {
-      "description": "If <code>true</code>, the increment button will be disabled.\ne.g. when the <code>value</code> is already at <code>max</code>"
+      "description": "If <code>true</code>, the increment button will be disabled. e.g. when the <code>value</code> is already at <code>max</code>"
     },
     "required": {
       "description": "If <code>true</code>, the <code>input</code> will indicate that it&#39;s required."

--- a/docs/translations/api-docs/use-select/use-select.json
+++ b/docs/translations/api-docs/use-select/use-select.json
@@ -2,7 +2,7 @@
   "hookDescription": "",
   "parametersDescriptions": {
     "areOptionsEqual": {
-      "description": "A function used to determine if two options&#39; values are equal.\nBy default, reference equality is used.\n\nThere is a performance impact when using the <code>areOptionsEqual</code> prop (proportional to the number of options).\nTherefore, it&#39;s recommented to use the default reference equality comparison whenever possible."
+      "description": "A function used to determine if two options&#39; values are equal. By default, reference equality is used.<br>There is a performance impact when using the <code>areOptionsEqual</code> prop (proportional to the number of options). Therefore, it&#39;s recommented to use the default reference equality comparison whenever possible."
     },
     "buttonRef": { "description": "The ref of the trigger button element." },
     "defaultOpen": { "description": "If <code>true</code>, the select will be open by default." },
@@ -11,33 +11,33 @@
     },
     "disabled": { "description": "If <code>true</code>, the select is disabled." },
     "getOptionAsString": {
-      "description": "A function used to convert the option label to a string.\nThis is useful when labels are elements and need to be converted to plain text\nto enable keyboard navigation with character keys."
+      "description": "A function used to convert the option label to a string. This is useful when labels are elements and need to be converted to plain text to enable keyboard navigation with character keys."
     },
     "getSerializedValue": {
-      "description": "A function to convert the currently selected value to a string.\nUsed to set a value of a hidden input associated with the select,\nso that the selected value can be posted with a form."
+      "description": "A function to convert the currently selected value to a string. Used to set a value of a hidden input associated with the select, so that the selected value can be posted with a form."
     },
     "listboxId": { "description": "The <code>id</code> attribute of the listbox element." },
     "listboxRef": { "description": "The ref of the listbox element." },
     "multiple": {
-      "description": "If <code>true</code>, the end user can select multiple values.\nThis affects the type of the <code>value</code>, <code>defaultValue</code>, and <code>onChange</code> props."
+      "description": "If <code>true</code>, the end user can select multiple values. This affects the type of the <code>value</code>, <code>defaultValue</code>, and <code>onChange</code> props."
     },
     "name": {
-      "description": "The <code>name</code> attribute of the hidden input element.\nThis is useful when the select is embedded in a form and you want to access the selected value in the form data."
+      "description": "The <code>name</code> attribute of the hidden input element. This is useful when the select is embedded in a form and you want to access the selected value in the form data."
     },
     "onChange": { "description": "Callback fired when an option is selected." },
     "onHighlightChange": { "description": "Callback fired when an option is highlighted." },
     "onOpenChange": { "description": "Callback fired when the listbox is opened or closed." },
     "open": {
-      "description": "Controls the open state of the select&#39;s listbox.\nThis is the controlled equivalent of the <code>defaultOpen</code> prop."
+      "description": "Controls the open state of the select&#39;s listbox. This is the controlled equivalent of the <code>defaultOpen</code> prop."
     },
     "options": {
-      "description": "An alternative way to specify the options.\nIf this parameter is set, options defined as JSX children are ignored."
+      "description": "An alternative way to specify the options. If this parameter is set, options defined as JSX children are ignored."
     },
     "required": {
-      "description": "If <code>true</code>, the select embedded in a form must have a selected value.\nOtherwise, the form submission will fail."
+      "description": "If <code>true</code>, the select embedded in a form must have a selected value. Otherwise, the form submission will fail."
     },
     "value": {
-      "description": "The selected value.\nSet to <code>null</code> to deselect all options."
+      "description": "The selected value. Set to <code>null</code> to deselect all options."
     }
   },
   "returnValueDescriptions": {
@@ -53,7 +53,7 @@
     },
     "disabled": { "description": "If <code>true</code>, the select is disabled." },
     "dispatch": {
-      "description": "Action dispatcher for the select component.\nAllows to programmatically control the select."
+      "description": "Action dispatcher for the select component. Allows to programmatically control the select."
     },
     "getButtonProps": { "description": "Resolver for the button slot&#39;s props." },
     "getHiddenInputProps": { "description": "Resolver for the hidden input slot&#39;s props." },

--- a/docs/translations/api-docs/use-slider/use-slider.json
+++ b/docs/translations/api-docs/use-slider/use-slider.json
@@ -15,13 +15,13 @@
       "description": "If <code>true</code> the Slider will be rendered right-to-left (with the lowest value on the right-hand side)."
     },
     "marks": {
-      "description": "Marks indicate predetermined values to which the user can move the slider.\nIf <code>true</code> the marks are spaced according the value of the <code>step</code> prop.\nIf an array, it should contain objects with <code>value</code> and an optional <code>label</code> keys."
+      "description": "Marks indicate predetermined values to which the user can move the slider. If <code>true</code> the marks are spaced according the value of the <code>step</code> prop. If an array, it should contain objects with <code>value</code> and an optional <code>label</code> keys."
     },
     "max": {
-      "description": "The maximum allowed value of the slider.\nShould not be equal to min."
+      "description": "The maximum allowed value of the slider. Should not be equal to min."
     },
     "min": {
-      "description": "The minimum allowed value of the slider.\nShould not be equal to max."
+      "description": "The minimum allowed value of the slider. Should not be equal to max."
     },
     "name": { "description": "Name attribute of the hidden <code>input</code> element." },
     "onChange": {
@@ -34,11 +34,11 @@
     "rootRef": { "description": "The ref attached to the root of the Slider." },
     "scale": { "description": "A transformation function, to change the scale of the slider." },
     "step": {
-      "description": "The granularity with which the slider can step through values. (A &quot;discrete&quot; slider.)\nThe <code>min</code> prop serves as the origin for the valid values.\nWe recommend (max - min) to be evenly divisible by the step.\n\nWhen step is <code>null</code>, the thumb can only be slid onto marks provided with the <code>marks</code> prop."
+      "description": "The granularity with which the slider can step through values. (A &quot;discrete&quot; slider.) The <code>min</code> prop serves as the origin for the valid values. We recommend (max - min) to be evenly divisible by the step.<br>When step is <code>null</code>, the thumb can only be slid onto marks provided with the <code>marks</code> prop."
     },
     "tabIndex": { "description": "Tab index attribute of the hidden <code>input</code> element." },
     "value": {
-      "description": "The value of the slider.\nFor ranged sliders, provide an array with two values."
+      "description": "The value of the slider. For ranged sliders, provide an array with two values."
     }
   },
   "returnValueDescriptions": {

--- a/docs/translations/api-docs/use-snackbar/use-snackbar.json
+++ b/docs/translations/api-docs/use-snackbar/use-snackbar.json
@@ -2,17 +2,17 @@
   "hookDescription": "The basic building block for creating custom snackbar.",
   "parametersDescriptions": {
     "autoHideDuration": {
-      "description": "The number of milliseconds to wait before automatically calling the\n<code>onClose</code> function. <code>onClose</code> should then set the state of the <code>open</code>\nprop to hide the Snackbar. This behavior is disabled by default with\nthe <code>null</code> value."
+      "description": "The number of milliseconds to wait before automatically calling the <code>onClose</code> function. <code>onClose</code> should then set the state of the <code>open</code> prop to hide the Snackbar. This behavior is disabled by default with the <code>null</code> value."
     },
     "disableWindowBlurListener": {
       "description": "If <code>true</code>, the <code>autoHideDuration</code> timer will expire even if the window is not focused."
     },
     "onClose": {
-      "description": "Callback fired when the component requests to be closed.\nTypically <code>onClose</code> is used to set state in the parent component,\nwhich is used to control the <code>Snackbar</code> <code>open</code> prop.\nThe <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>,\nfor example ignoring <code>clickaway</code>."
+      "description": "Callback fired when the component requests to be closed. Typically <code>onClose</code> is used to set state in the parent component, which is used to control the <code>Snackbar</code> <code>open</code> prop. The <code>reason</code> parameter can optionally be used to control the response to <code>onClose</code>, for example ignoring <code>clickaway</code>."
     },
     "open": { "description": "If <code>true</code>, the component is shown." },
     "resumeHideDuration": {
-      "description": "The number of milliseconds to wait before dismissing after user interaction.\nIf <code>autoHideDuration</code> prop isn&#39;t specified, it does nothing.\nIf <code>autoHideDuration</code> prop is specified but <code>resumeHideDuration</code> isn&#39;t,\nwe default to <code>autoHideDuration / 2</code> ms."
+      "description": "The number of milliseconds to wait before dismissing after user interaction. If <code>autoHideDuration</code> prop isn&#39;t specified, it does nothing. If <code>autoHideDuration</code> prop is specified but <code>resumeHideDuration</code> isn&#39;t, we default to <code>autoHideDuration / 2</code> ms."
     }
   },
   "returnValueDescriptions": {

--- a/docs/translations/api-docs/use-tab/use-tab.json
+++ b/docs/translations/api-docs/use-tab/use-tab.json
@@ -3,13 +3,13 @@
   "parametersDescriptions": {
     "disabled": { "description": "If <code>true</code>, the tab will be disabled." },
     "id": {
-      "description": "The id of the tab.\nIf not provided, it will be automatically generated."
+      "description": "The id of the tab. If not provided, it will be automatically generated."
     },
     "onChange": { "description": "If <code>true</code>, the tab will be disabled." },
     "onClick": { "description": "Callback fired when the tab is clicked." },
     "rootRef": { "description": "Ref to the root slot&#39;s DOM element." },
     "value": {
-      "description": "The value of the tab.\nIt&#39;s used to associate the tab with a tab panel(s) with the same value.\nIf the value is not provided, it falls back to the position index."
+      "description": "The value of the tab. It&#39;s used to associate the tab with a tab panel(s) with the same value. If the value is not provided, it falls back to the position index."
     }
   },
   "returnValueDescriptions": {
@@ -17,7 +17,7 @@
       "description": "If <code>true</code>, the tab is active (as in <code>:active</code> pseudo-class; in other words, pressed)."
     },
     "focusVisible": {
-      "description": "If <code>true</code>, the tab has visible focus.\nThis is a workaround for browsers that do not support this feature natively."
+      "description": "If <code>true</code>, the tab has visible focus. This is a workaround for browsers that do not support this feature natively."
     },
     "getRootProps": { "description": "Resolver for the root slot&#39;s props." },
     "highlighted": { "description": "If <code>true</code>, the tab is highlighted." },
@@ -25,10 +25,10 @@
     "rootRef": { "description": "Ref to the root slot&#39;s DOM element." },
     "selected": { "description": "If <code>true</code>, the tab is selected." },
     "setFocusVisible": {
-      "description": "Sets the focus-visible state of the tab.\nThis is a workaround for browsers that do not support this feature natively."
+      "description": "Sets the focus-visible state of the tab. This is a workaround for browsers that do not support this feature natively."
     },
     "totalTabsCount": {
-      "description": "Total number of tabs in the nearest parent TabsList.\nThis can be used to determine if the tab is the last one to style it accordingly."
+      "description": "Total number of tabs in the nearest parent TabsList. This can be used to determine if the tab is the last one to style it accordingly."
     }
   }
 }

--- a/docs/translations/api-docs/use-tabs-list/use-tabs-list.json
+++ b/docs/translations/api-docs/use-tabs-list/use-tabs-list.json
@@ -6,7 +6,7 @@
       "description": "The value to be passed to the TabListProvider above all the tabs."
     },
     "dispatch": {
-      "description": "Action dispatcher for the tabs list component.\nAllows to programmatically control the tabs list."
+      "description": "Action dispatcher for the tabs list component. Allows to programmatically control the tabs list."
     },
     "getRootProps": { "description": "Resolver for the root slot&#39;s props." },
     "highlightedValue": { "description": "The value of the currently highlighted tab." },

--- a/docs/translations/api-docs/use-tabs/use-tabs.json
+++ b/docs/translations/api-docs/use-tabs/use-tabs.json
@@ -8,10 +8,10 @@
     "onChange": { "description": "Callback invoked when new value is being set." },
     "orientation": { "description": "The component orientation (layout flow direction)." },
     "selectionFollowsFocus": {
-      "description": "If <code>true</code> the selected tab changes on focus. Otherwise it only\nchanges on activation."
+      "description": "If <code>true</code> the selected tab changes on focus. Otherwise it only changes on activation."
     },
     "value": {
-      "description": "The value of the currently selected <code>Tab</code>.\nIf you don&#39;t want any selected <code>Tab</code>, you can set this prop to <code>false</code>."
+      "description": "The value of the currently selected <code>Tab</code>. If you don&#39;t want any selected <code>Tab</code>, you can set this prop to <code>false</code>."
     }
   },
   "returnValueDescriptions": {

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -10,7 +10,7 @@ import remarkVisit from 'unist-util-visit';
 import { Link } from 'mdast';
 import { defaultHandlers, parse as docgenParse, ReactDocgenApi } from 'react-docgen';
 import { unstable_generateUtilityClass as generateUtilityClass } from '@mui/utils';
-import { renderInline as renderMarkdownInline } from '@mui/markdown';
+import { renderMarkdown } from '@mui/markdown';
 import { LANGUAGES } from 'docs/config';
 import { ComponentInfo, writePrettifiedFile } from '../buildApiUtils';
 import muiDefaultPropsHandler from '../utils/defaultPropsHandler';
@@ -333,19 +333,19 @@ function extractClassConditions(descriptions: any) {
 
       if (conditions && conditions[6]) {
         classConditions[className] = {
-          description: renderMarkdownInline(
+          description: renderMarkdown(
             description.replace(stylesRegex, '$1{{nodeName}}$5{{conditions}}.'),
           ),
-          nodeName: renderMarkdownInline(conditions[3]),
-          conditions: renderMarkdownInline(conditions[6].replace(/`(.*?)`/g, '<code>$1</code>')),
+          nodeName: renderMarkdown(conditions[3]),
+          conditions: renderMarkdown(conditions[6].replace(/`(.*?)`/g, '<code>$1</code>')),
         };
       } else if (conditions && conditions[3] && conditions[3] !== 'the root element') {
         classConditions[className] = {
-          description: renderMarkdownInline(description.replace(stylesRegex, '$1{{nodeName}}$5.')),
-          nodeName: renderMarkdownInline(conditions[3]),
+          description: renderMarkdown(description.replace(stylesRegex, '$1{{nodeName}}$5.')),
+          nodeName: renderMarkdown(conditions[3]),
         };
       } else {
-        classConditions[className] = { description: renderMarkdownInline(description) };
+        classConditions[className] = { description: renderMarkdown(description) };
       }
     }
   });
@@ -517,13 +517,13 @@ const attachTranslations = (reactApi: ReactApi) => {
 
       const typeDescriptions: { [t: string]: string } = {};
       (signatureArgs || []).concat(signatureReturn || []).forEach(({ name, description }) => {
-        typeDescriptions[name] = renderMarkdownInline(description);
+        typeDescriptions[name] = renderMarkdown(description);
       });
 
       translations.propDescriptions[propName] = {
-        description: renderMarkdownInline(jsDocText),
+        description: renderMarkdown(jsDocText),
         requiresRef: requiresRef || undefined,
-        deprecated: renderMarkdownInline(deprecated) || undefined,
+        deprecated: renderMarkdown(deprecated) || undefined,
         typeDescriptions: Object.keys(typeDescriptions).length > 0 ? typeDescriptions : undefined,
       };
     }
@@ -631,8 +631,7 @@ const attachPropsTable = (reactApi: ReactApi) => {
           // undefined values are not serialized => saving some bytes
           required: requiredProp || undefined,
           deprecated: !!deprecation || undefined,
-          deprecationInfo:
-            renderMarkdownInline(deprecation?.groups?.info || '').trim() || undefined,
+          deprecationInfo: renderMarkdown(deprecation?.groups?.info || '').trim() || undefined,
           signature,
           additionalInfo:
             Object.keys(additionalPropsInfo).length === 0 ? undefined : additionalPropsInfo,

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -8,7 +8,7 @@ import traverse from '@babel/traverse';
 import { defaultHandlers, parse as docgenParse, ReactDocgenApi } from 'react-docgen';
 import kebabCase from 'lodash/kebabCase';
 import upperFirst from 'lodash/upperFirst';
-import { renderInline as renderMarkdownInline } from '@mui/markdown';
+import { renderMarkdown } from '@mui/markdown';
 import { LANGUAGES } from 'docs/config';
 import { toGitHubPath, computeApiDescription } from './ComponentApiBuilder';
 import {
@@ -328,8 +328,7 @@ const attachTable = (
           // undefined values are not serialized => saving some bytes
           required: requiredProp || undefined,
           deprecated: !!deprecation || undefined,
-          deprecationInfo:
-            renderMarkdownInline(deprecation?.groups?.info || '').trim() || undefined,
+          deprecationInfo: renderMarkdown(deprecation?.groups?.info || '').trim() || undefined,
         },
       };
     })
@@ -351,7 +350,7 @@ const attachTable = (
 };
 
 const generateTranslationDescription = (description: string) => {
-  return renderMarkdownInline(description.replace(/\n@default.*$/, ''));
+  return renderMarkdown(description.replace(/\n@default.*$/, ''));
 };
 
 const attachTranslations = (reactApi: ReactApi) => {
@@ -369,7 +368,7 @@ const attachTranslations = (reactApi: ReactApi) => {
       const deprecation = (description || '').match(/@deprecated(\s+(?<info>.*))?/);
       if (deprecation !== null) {
         translations.parametersDescriptions[propName].deprecated =
-          renderMarkdownInline(deprecation?.groups?.info || '').trim() || undefined;
+          renderMarkdown(deprecation?.groups?.info || '').trim() || undefined;
       }
     }
   });
@@ -382,7 +381,7 @@ const attachTranslations = (reactApi: ReactApi) => {
       const deprecation = (description || '').match(/@deprecated(\s+(?<info>.*))?/);
       if (deprecation !== null) {
         translations.parametersDescriptions[propName].deprecated =
-          renderMarkdownInline(deprecation?.groups?.info || '').trim() || undefined;
+          renderMarkdown(deprecation?.groups?.info || '').trim() || undefined;
       }
     }
   });

--- a/packages/api-docs-builder/utils/generatePropDescription.ts
+++ b/packages/api-docs-builder/utils/generatePropDescription.ts
@@ -93,11 +93,7 @@ export default function generatePropDescription(
     }
   }
 
-  // Two new lines result in a newline in the table.
-  // All other new lines must be eliminated to prevent markdown mayhem.
-  const jsDocText = escapeCell(annotation.description)
-    .replace(/(\r?\n){2}/g, '<br>')
-    .replace(/\r?\n/g, ' ');
+  const jsDocText = escapeCell(annotation.description);
 
   // Split up the parsed tags into 'arguments' and 'returns' parsed objects. If there's no
   // 'returns' parsed object (i.e., one with title being 'returns'), make one of type 'void'.

--- a/packages/markdown/index.d.ts
+++ b/packages/markdown/index.d.ts
@@ -16,4 +16,4 @@ export function getHeaders(markdown: string): Record<string, string | string[]>;
 
 export function getTitle(markdown: string): string;
 
-export function renderInline(markdown: string): string;
+export function renderMarkdown(markdown: string): string;

--- a/packages/markdown/index.js
+++ b/packages/markdown/index.js
@@ -1,3 +1,3 @@
-const { createRender, getHeaders, getTitle, renderInline } = require('./parseMarkdown');
+const { createRender, getHeaders, getTitle, renderMarkdown } = require('./parseMarkdown');
 
-module.exports = { createRender, getHeaders, getTitle, renderInline };
+module.exports = { createRender, getHeaders, getTitle, renderMarkdown };

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -234,7 +234,7 @@ function getCodeblock(content) {
 /**
  * @param {string} markdown
  */
-function renderInline(markdown) {
+function renderMarkdown(markdown) {
   // Check if the markdown contains an inline list. Unordered lists are block elements and cannot be parsed inline.
   if (/[-*+] `([A-Za-z]+)`/g.test(markdown)) {
     return marked.parse(markdown, markedOptions);
@@ -475,5 +475,5 @@ module.exports = {
   getCodeblock,
   getHeaders,
   getTitle,
-  renderInline,
+  renderMarkdown,
 };

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -235,7 +235,7 @@ function getCodeblock(content) {
  * @param {string} markdown
  */
 function renderInline(markdown) {
-  // Parse markdown list. Since unordered lists are block level elements we do not inline parse.
+  // Check if the markdown contains an inline list. Unordered lists are block elements and cannot be parsed inline.
   if (/[-*+] `([A-Za-z]+)`/g.test(markdown)) {
     return marked.parse(markdown, markedOptions);
   }

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -235,7 +235,16 @@ function getCodeblock(content) {
  * @param {string} markdown
  */
 function renderInline(markdown) {
-  return marked.parseInline(markdown, markedOptions);
+  // Parse markdown list. Since unordered lists are block level elements we do not inline parse.
+  if (/[-*+] `([A-Za-z]+)`/g.test(markdown)) {
+    return marked.parse(markdown, markedOptions);
+  }
+  // Two new lines result in a newline in the table.
+  // All other new lines must be eliminated to prevent markdown mayhem.
+  return marked
+    .parseInline(markdown, markedOptions)
+    .replace(/(\r?\n){2}/g, '<br>')
+    .replace(/\r?\n/g, ' ');
 }
 
 // Help rank mui.com on component searches first.

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -1,5 +1,12 @@
 import { expect } from 'chai';
-import { getContents, getDescription, getTitle, getHeaders, getCodeblock } from './parseMarkdown';
+import {
+  getContents,
+  getDescription,
+  getTitle,
+  getHeaders,
+  getCodeblock,
+  renderMarkdown,
+} from './parseMarkdown';
 
 describe('parseMarkdown', () => {
   describe('getTitle', () => {
@@ -232,6 +239,41 @@ authors:
           },
         ],
       });
+    });
+  });
+
+  describe('renderMarkdown', () => {
+    it('should render markdown lists correctly', () => {
+      expect(
+        renderMarkdown(
+          [
+            'The track presentation:',
+            '- `normal` the track will render a bar representing the slider value.',
+            '- `inverted` the track will render a bar representing the remaining slider value.',
+            '- `false` the track will render without a bar.',
+          ].join('\n'),
+        ),
+      ).to.equal(
+        [
+          '<p>The track presentation:</p>',
+          '<ul>',
+          '<li><code>normal</code> the track will render a bar representing the slider value.</li>',
+          '<li><code>inverted</code> the track will render a bar representing the remaining slider value.</li>',
+          '<li><code>false</code> the track will render without a bar.</li>',
+          '</ul>',
+          '',
+        ].join('\n'),
+      );
+    });
+
+    it('should render inline descriptions correctly', () => {
+      expect(
+        renderMarkdown(
+          'Allows to control whether the dropdown is open. This is a controlled counterpart of `defaultOpen`.',
+        ),
+      ).to.equal(
+        'Allows to control whether the dropdown is open. This is a controlled counterpart of <code>defaultOpen</code>.',
+      );
     });
   });
 });

--- a/packages/mui-material/src/Tabs/Tabs.d.ts
+++ b/packages/mui-material/src/Tabs/Tabs.d.ts
@@ -155,7 +155,7 @@ export interface TabsOwnProps {
    *
    *  - `scrollable` will invoke scrolling properties and allow for horizontally
    *  scrolling (or swiping) of the tab bar.
-   *  -`fullWidth` will make the tabs grow to use all the available space,
+   *  - `fullWidth` will make the tabs grow to use all the available space,
    *  which should be used for small views, like on mobile.
    *  - `standard` will render the default state.
    * @default 'standard'

--- a/packages/mui-material/src/Tabs/Tabs.js
+++ b/packages/mui-material/src/Tabs/Tabs.js
@@ -933,7 +933,7 @@ Tabs.propTypes /* remove-proptypes */ = {
    *
    *  - `scrollable` will invoke scrolling properties and allow for horizontally
    *  scrolling (or swiping) of the tab bar.
-   *  -`fullWidth` will make the tabs grow to use all the available space,
+   *  - `fullWidth` will make the tabs grow to use all the available space,
    *  which should be used for small views, like on mobile.
    *  - `standard` will render the default state.
    * @default 'standard'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Previews:**

Before: https://mui.com/base-ui/react-slider/components-api/#Slider-prop-track
After: https://deploy-preview-38973--material-ui.netlify.app/base-ui/react-slider/components-api/#Slider-prop-track

Before: https://mui.com/joy-ui/api/chip-delete/#ChipDelete-prop-onDelete
After: https://deploy-preview-38973--material-ui.netlify.app/joy-ui/api/chip-delete/#ChipDelete-prop-onDelete

Before: https://mui.com/joy-ui/api/slider/#Slider-prop-track
After: https://deploy-preview-38973--material-ui.netlify.app/joy-ui/api/slider/#Slider-prop-track

Before: https://mui.com/joy-ui/api/slider/#Slider-prop-valueLabelDisplay
After: https://deploy-preview-38973--material-ui.netlify.app/joy-ui/api/slider/#Slider-prop-valueLabelDisplay

Before: https://mui.com/material-ui/api/autocomplete/#Autocomplete-prop-blurOnSelect
After: https://deploy-preview-38973--material-ui.netlify.app/material-ui/api/autocomplete/#Autocomplete-prop-blurOnSelect

Before: https://mui.com/material-ui/api/slider/#Slider-prop-track
After: https://deploy-preview-38973--material-ui.netlify.app/material-ui/api/slider/#Slider-prop-track

Before: https://mui.com/material-ui/api/slider/#Slider-prop-valueLabelDisplay
After: https://deploy-preview-38973--material-ui.netlify.app/material-ui/api/slider/#Slider-prop-valueLabelDisplay

Before: https://mui.com/material-ui/api/tabs/#Tabs-prop-scrollButtons
After: https://deploy-preview-38973--material-ui.netlify.app/material-ui/api/tabs/#Tabs-prop-scrollButtons

Before: https://mui.com/material-ui/api/tabs/#Tabs-prop-variant
After: https://deploy-preview-38973--material-ui.netlify.app/material-ui/api/tabs/#Tabs-prop-variant

Before: https://mui.com/base-ui/react-autocomplete/hooks-api/#prop-blurOnSelect
After: https://deploy-preview-38973--material-ui.netlify.app/base-ui/react-autocomplete/hooks-api/#prop-blurOnSelect

Changes in the hook files align with the component files, where we replace two new lines with `<br>` and single new lines with spaces. This consistency is driven by the updated logic to support markdown lists.

Fixes #38316
Closes #38803 (PR)
