### PR TITLE
[core] Remove react-dom from @mui/utils peerDependencies

### DIFF
--- a/packages/mui-utils/package.json
+++ b/packages/mui-utils/package.json
@@ -65,8 +65,7 @@
   },
   "peerDependencies": {
     "@types/react": "^17.0.0 || ^18.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
react-dom has been mistakenly added to @mui/utils' peerDependencies, even though it's used only in test and should remain in devDependencies only.

Fixes #38961