### PR TITLE
[docs][base-ui] Improve Select's country select demo

### DIFF
--- a/docs/data/base/components/select/UnstyledSelectCustomRenderValue.js
+++ b/docs/data/base/components/select/UnstyledSelectCustomRenderValue.js
@@ -8,7 +8,16 @@ import { styled } from '@mui/system';
 
 export default function UnstyledSelectCustomRenderValue() {
   return (
-    <CustomSelect renderValue={renderValue} placeholder="Select an option…">
+    <CustomSelect
+      defaultValue={10}
+      renderValue={(option) => {
+        if (option == null || option.value === null) {
+          return 'Select an option…';
+        }
+        return `${option.label} (${option.value})`;
+      }}
+    >
+      <StyledOption value={null}>None</StyledOption>
       <StyledOption value={10}>Ten</StyledOption>
       <StyledOption value={20}>Twenty</StyledOption>
       <StyledOption value={30}>Thirty</StyledOption>
@@ -39,18 +48,6 @@ CustomSelect.propTypes = {
     root: PropTypes.elementType,
   }),
 };
-
-function renderValue(option) {
-  if (option == null) {
-    return null;
-  }
-
-  return (
-    <span>
-      {option.label} ({option.value})
-    </span>
-  );
-}
 
 const blue = {
   100: '#DAECFF',

--- a/docs/data/base/components/select/UnstyledSelectCustomRenderValue.tsx
+++ b/docs/data/base/components/select/UnstyledSelectCustomRenderValue.tsx
@@ -7,7 +7,16 @@ import { styled } from '@mui/system';
 
 export default function UnstyledSelectCustomRenderValue() {
   return (
-    <CustomSelect renderValue={renderValue} placeholder="Select an option…">
+    <CustomSelect
+      defaultValue={10}
+      renderValue={(option: SelectOption<number> | null) => {
+        if (option == null || option.value === null) {
+          return 'Select an option…';
+        }
+        return `${option.label} (${option.value})`;
+      }}
+    >
+      <StyledOption value={null}>None</StyledOption>
       <StyledOption value={10}>Ten</StyledOption>
       <StyledOption value={20}>Twenty</StyledOption>
       <StyledOption value={30}>Thirty</StyledOption>
@@ -24,18 +33,6 @@ function CustomSelect(props: SelectProps<number, false>) {
   };
 
   return <Select {...props} slots={slots} />;
-}
-
-function renderValue(option: SelectOption<number> | null) {
-  if (option == null) {
-    return null;
-  }
-
-  return (
-    <span>
-      {option.label} ({option.value})
-    </span>
-  );
 }
 
 const blue = {

--- a/docs/data/base/components/select/UnstyledSelectCustomRenderValue.tsx.preview
+++ b/docs/data/base/components/select/UnstyledSelectCustomRenderValue.tsx.preview
@@ -1,4 +1,13 @@
-<CustomSelect renderValue={renderValue} placeholder="Select an option…">
+<CustomSelect
+  defaultValue={10}
+  renderValue={(option: SelectOption<number> | null) => {
+    if (option == null || option.value === null) {
+      return 'Select an option…';
+    }
+    return `${option.label} (${option.value})`;
+  }}
+>
+  <StyledOption value={null}>None</StyledOption>
   <StyledOption value={10}>Ten</StyledOption>
   <StyledOption value={20}>Twenty</StyledOption>
   <StyledOption value={30}>Thirty</StyledOption>

--- a/docs/data/base/components/select/UnstyledSelectRichOptions.js
+++ b/docs/data/base/components/select/UnstyledSelectRichOptions.js
@@ -3,21 +3,22 @@ import PropTypes from 'prop-types';
 import { Select, selectClasses } from '@mui/base/Select';
 import { Option, optionClasses } from '@mui/base/Option';
 import { styled } from '@mui/system';
-import { Popper } from '@mui/base';
+import { Popper } from '@mui/base/Popper';
 
 export default function UnstyledSelectRichOptions() {
   return (
     <CustomSelect placeholder="Select country…">
-      {countries.map((c) => (
-        <StyledOption key={c.code} value={c.code} label={c.label}>
+      {countries.map((country) => (
+        <StyledOption key={country.code} value={country.code} label={country.label}>
           <img
             loading="lazy"
-            width="20"
-            srcSet={`https://flagcdn.com/w40/${c.code.toLowerCase()}.png 2x`}
-            src={`https://flagcdn.com/w20/${c.code.toLowerCase()}.png`}
-            alt={`Flag of ${c.label}`}
+            width={20}
+            height={14}
+            srcSet={`https://flagcdn.com/w40/${country.code.toLowerCase()}.png 2x`}
+            src={`https://flagcdn.com/w20/${country.code.toLowerCase()}.png`}
+            alt={`Flag of ${country.label}`}
           />
-          {c.label} ({c.code}) +{c.phone}
+          {country.label} ({country.code}) +{country.phone}
         </StyledOption>
       ))}
     </CustomSelect>

--- a/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
+++ b/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
@@ -2,21 +2,22 @@ import * as React from 'react';
 import { Select, SelectProps, selectClasses } from '@mui/base/Select';
 import { Option, optionClasses } from '@mui/base/Option';
 import { styled } from '@mui/system';
-import { Popper } from '@mui/base';
+import { Popper } from '@mui/base/Popper';
 
 export default function UnstyledSelectRichOptions() {
   return (
     <CustomSelect placeholder="Select country…">
-      {countries.map((c) => (
-        <StyledOption key={c.code} value={c.code} label={c.label}>
+      {countries.map((country) => (
+        <StyledOption key={country.code} value={country.code} label={country.label}>
           <img
             loading="lazy"
-            width="20"
-            srcSet={`https://flagcdn.com/w40/${c.code.toLowerCase()}.png 2x`}
-            src={`https://flagcdn.com/w20/${c.code.toLowerCase()}.png`}
-            alt={`Flag of ${c.label}`}
+            width={20}
+            height={14}
+            srcSet={`https://flagcdn.com/w40/${country.code.toLowerCase()}.png 2x`}
+            src={`https://flagcdn.com/w20/${country.code.toLowerCase()}.png`}
+            alt={`Flag of ${country.label}`}
           />
-          {c.label} ({c.code}) +{c.phone}
+          {country.label} ({country.code}) +{country.phone}
         </StyledOption>
       ))}
     </CustomSelect>

--- a/docs/data/base/components/select/UnstyledSelectRichOptions.tsx.preview
+++ b/docs/data/base/components/select/UnstyledSelectRichOptions.tsx.preview
@@ -1,14 +1,15 @@
 <CustomSelect placeholder="Select country…">
-  {countries.map((c) => (
-    <StyledOption key={c.code} value={c.code} label={c.label}>
+  {countries.map((country) => (
+    <StyledOption key={country.code} value={country.code} label={country.label}>
       <img
         loading="lazy"
-        width="20"
-        srcSet={`https://flagcdn.com/w40/${c.code.toLowerCase()}.png 2x`}
-        src={`https://flagcdn.com/w20/${c.code.toLowerCase()}.png`}
-        alt={`Flag of ${c.label}`}
+        width={20}
+        height={14}
+        srcSet={`https://flagcdn.com/w40/${country.code.toLowerCase()}.png 2x`}
+        src={`https://flagcdn.com/w20/${country.code.toLowerCase()}.png`}
+        alt={`Flag of ${country.label}`}
       />
-      {c.label} ({c.code}) +{c.phone}
+      {country.label} ({country.code}) +{country.phone}
     </StyledOption>
   ))}
 </CustomSelect>

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -219,7 +219,7 @@ For the sake of simplicity, demos and code snippets primarily feature components
 You can customize the appearance of the selected value display by providing a function to the `renderValue` prop.
 The element returned by this function will be rendered inside the Select's button.
 
-{{"demo": "UnstyledSelectCustomRenderValue.js", "defaultCodeOpen": false}}
+{{"demo": "UnstyledSelectCustomRenderValue.js"}}
 
 ### Option appearance
 

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -226,4 +226,4 @@ The element returned by this function will be rendered inside the Select's butto
 Options don't have to be plain strings.
 You can include custom elements to be rendered inside the listbox.
 
-{{"demo": "UnstyledSelectRichOptions.js", "defaultCodeOpen": false}}
+{{"demo": "UnstyledSelectRichOptions.js"}}


### PR DESCRIPTION
A quick iteration on #38796 to polish the demo. This feels much clearer for me when reading.

Before: https://master--material-ui.netlify.app/base-ui/react-select/#selected-value-appearance
Preview: https://deploy-preview-38983--material-ui.netlify.app/base-ui/react-select/#selected-value-appearance

---

A side note, I have tried to make this

```diff
diff --git a/docs/data/base/components/select/UnstyledSelectRichOptions.tsx b/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
index 1144795569..b5d901cbc0 100644
--- a/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
+++ b/docs/data/base/components/select/UnstyledSelectRichOptions.tsx
@@ -7,6 +7,7 @@ import { Popper } from '@mui/base/Popper';
 export default function UnstyledSelectRichOptions() {
   return (
     <CustomSelect placeholder="Select country…">
+      <StyledOption value={undefined} label="">None</StyledOption>
       {countries.map((country) => (
         <StyledOption key={country.code} value={country.code} label={country.label}>
           <img
```

work to reproduce https://mui.com/material-ui/react-select/#filled-and-standard-variants but it didn't show the placeholder. Should we expect it to?

https://github.com/mui/material-ui/assets/3165635/4df4c411-b36a-4e55-9f77-47cef128dda6
