### PR TITLE
[docs][base-ui] Improve focus trap demo

### DIFF
--- a/docs/data/base/components/focus-trap/BasicFocusTrap.js
+++ b/docs/data/base/components/focus-trap/BasicFocusTrap.js
@@ -6,7 +6,14 @@ export default function BasicFocusTrap() {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/BasicFocusTrap.tsx
+++ b/docs/data/base/components/focus-trap/BasicFocusTrap.tsx
@@ -6,7 +6,14 @@ export default function BasicFocusTrap() {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/DisableEnforceFocus.js
+++ b/docs/data/base/components/focus-trap/DisableEnforceFocus.js
@@ -6,7 +6,14 @@ export default function DisableEnforceFocus() {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/DisableEnforceFocus.tsx
+++ b/docs/data/base/components/focus-trap/DisableEnforceFocus.tsx
@@ -6,7 +6,14 @@ export default function DisableEnforceFocus() {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/LazyFocusTrap.js
+++ b/docs/data/base/components/focus-trap/LazyFocusTrap.js
@@ -6,7 +6,14 @@ export default function LazyFocusTrap() {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/LazyFocusTrap.tsx
+++ b/docs/data/base/components/focus-trap/LazyFocusTrap.tsx
@@ -6,7 +6,14 @@ export default function LazyFocusTrap() {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/PortalFocusTrap.js
+++ b/docs/data/base/components/focus-trap/PortalFocusTrap.js
@@ -8,7 +8,14 @@ export default function PortalFocusTrap() {
   const [container, setContainer] = React.useState(null);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>

--- a/docs/data/base/components/focus-trap/PortalFocusTrap.tsx
+++ b/docs/data/base/components/focus-trap/PortalFocusTrap.tsx
@@ -8,7 +8,14 @@ export default function PortalFocusTrap() {
   const [container, setContainer] = React.useState<HTMLElement | null>(null);
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'column',
+        '& [tabindex]:focus': { outline: '1px solid green' },
+      }}
+    >
       <button type="button" onClick={() => setOpen(true)}>
         Open
       </button>


### PR DESCRIPTION
Something that I noticed during the review of #38878. It was hard to spot that the focus moved to the container.

https://github.com/mui/material-ui/assets/3165635/c3061ef0-e64f-4460-ae7f-96ed58c710d6

https://deploy-preview-38985--material-ui.netlify.app/base-ui/react-focus-trap/