### PR TITLE
[website] Create the `InfoCard` component

### DIFF
--- a/docs/src/components/action/InfoCard.tsx
+++ b/docs/src/components/action/InfoCard.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Link from 'docs/src/modules/components/Link';
+
+interface InfoCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  link?: string;
+  linkable?: boolean;
+}
+
+export default function InfoCard({ icon, title, description, link, linkable }: InfoCardProps) {
+  return (
+    <Paper
+      component={linkable ? Link : 'div'}
+      href={link}
+      noLinkStyle={linkable}
+      variant="outlined"
+      sx={(theme) => ({
+        p: 3.5,
+        height: '100%',
+        background: `${(theme.vars || theme).palette.gradients.linearSubtle}`,
+        ...theme.applyDarkStyles({
+          bgcolor: 'primaryDark.900',
+          background: `${(theme.vars || theme).palette.gradients.linearSubtle}`,
+          borderColor: 'primaryDark.700',
+        }),
+      })}
+    >
+      <Box
+        sx={(theme) => ({
+          width: 40,
+          height: 40,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderRadius: 1,
+          border: '1px solid',
+          borderColor: 'primary.200',
+          bgcolor: 'primary.50',
+          boxShadow:
+            '0px 1px 6px 0px rgba(194, 224, 255, 1), 0px 2px 30px 0px rgba(234, 237, 241, 0.3) inset',
+          ...theme.applyDarkStyles({
+            borderColor: 'primary.400',
+            bgcolor: 'primary.900',
+            boxShadow:
+              '0px 1px 6px 0px rgba(0, 89, 178, 1), 0px 2px 30px 0px rgba(0, 0, 0, 0.25) inset',
+          }),
+        })}
+      >
+        {icon}
+      </Box>
+      <Typography
+        fontWeight="bold"
+        component="h3"
+        color="text.primary"
+        variant="body2"
+        mt={2}
+        mb={0.5}
+      >
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {description}
+      </Typography>
+    </Paper>
+  );
+}

--- a/docs/src/components/action/InfoCard.tsx
+++ b/docs/src/components/action/InfoCard.tsx
@@ -9,15 +9,14 @@ interface InfoCardProps {
   title: string;
   description: string;
   link?: string;
-  linkable?: boolean;
 }
 
-export default function InfoCard({ icon, title, description, link, linkable }: InfoCardProps) {
+export default function InfoCard({ icon, title, description, link }: InfoCardProps) {
   return (
     <Paper
-      component={linkable ? Link : 'div'}
+      component={link ? Link : 'div'}
       href={link}
-      noLinkStyle={linkable}
+      noLinkStyle={Boolean(link)}
       variant="outlined"
       sx={(theme) => ({
         p: 3.5,

--- a/docs/src/components/home/ValueProposition.tsx
+++ b/docs/src/components/home/ValueProposition.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import InvertColorsRoundedIcon from '@mui/icons-material/InvertColorsRounded';
@@ -10,6 +8,7 @@ import AccessibilityNewRounded from '@mui/icons-material/AccessibilityNewRounded
 import GradientText from 'docs/src/components/typography/GradientText';
 import Section from 'docs/src/layouts/Section';
 import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
+import InfoCard from 'docs/src/components/action/InfoCard';
 
 const content = [
   {
@@ -53,60 +52,7 @@ function ValueProposition() {
       <Grid container spacing={3}>
         {content.map(({ icon, title, description }) => (
           <Grid key={title} item xs={12} sm={3}>
-            <Paper
-              variant="outlined"
-              sx={(theme) => ({
-                p: 3,
-                height: '100%',
-                position: 'relative',
-                borderRadius: 1,
-                border: '1px solid',
-                borderColor: (theme.vars || theme).palette.grey[100],
-                background: (theme.vars || theme).palette.gradients.linearSubtle,
-                ...theme.applyDarkStyles({
-                  bgcolor: (theme.vars || theme).palette.primaryDark[900],
-                  borderColor: (theme.vars || theme).palette.primaryDark[700],
-                  background: (theme.vars || theme).palette.gradients.linearSubtle,
-                }),
-              })}
-            >
-              <Box
-                sx={(theme) => ({
-                  width: 40,
-                  height: 40,
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  borderRadius: 1,
-                  border: '1px solid',
-                  borderColor: (theme.vars || theme).palette.primary[200],
-                  bgcolor: (theme.vars || theme).palette.primary[50],
-                  boxShadow:
-                    '0px 1px 6px 0px rgba(194, 224, 255, 1), 0px 2px 30px 0px rgba(234, 237, 241, 0.3) inset',
-                  ...theme.applyDarkStyles({
-                    borderColor: (theme.vars || theme).palette.primary[400],
-                    bgcolor: (theme.vars || theme).palette.primary[900],
-                    boxShadow:
-                      '0px 1px 6px 0px rgba(0, 89, 178, 1), 0px 2px 30px 0px rgba(0, 0, 0, 0.25) inset',
-                  }),
-                })}
-              >
-                {icon}
-              </Box>
-              <Typography
-                fontWeight="bold"
-                component="h3"
-                variant="body2"
-                color="text.primary"
-                gutterBottom
-                mt={2}
-              >
-                {title}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {description}
-              </Typography>
-            </Paper>
+            <InfoCard title={title} icon={icon} description={description} />
           </Grid>
         ))}
       </Grid>

--- a/docs/src/components/productBaseUI/BaseUISummary.tsx
+++ b/docs/src/components/productBaseUI/BaseUISummary.tsx
@@ -51,7 +51,7 @@ export default function BaseUISummary() {
         <Grid container spacing={3}>
           {content.map(({ icon, title, description, link }) => (
             <Grid key={title} item xs={12} md={4}>
-              <InfoCard link={link} linkable title={title} icon={icon} description={description} />
+              <InfoCard link={link} title={title} icon={icon} description={description} />
             </Grid>
           ))}
         </Grid>

--- a/docs/src/components/productBaseUI/BaseUISummary.tsx
+++ b/docs/src/components/productBaseUI/BaseUISummary.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import StyleRoundedIcon from '@mui/icons-material/StyleRounded';
@@ -9,7 +8,7 @@ import AccessibilityNewRounded from '@mui/icons-material/AccessibilityNewRounded
 import PhishingRoundedIcon from '@mui/icons-material/PhishingRounded';
 import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
 import GradientText from 'docs/src/components/typography/GradientText';
-import Link from 'docs/src/modules/components/Link';
+import InfoCard from 'docs/src/components/action/InfoCard';
 
 const content = [
   {
@@ -52,59 +51,7 @@ export default function BaseUISummary() {
         <Grid container spacing={3}>
           {content.map(({ icon, title, description, link }) => (
             <Grid key={title} item xs={12} md={4}>
-              <Paper
-                component={Link}
-                href={link}
-                noLinkStyle
-                variant="outlined"
-                sx={(theme) => ({
-                  p: 4,
-                  height: '100%',
-                  background: `${(theme.vars || theme).palette.gradients.linearSubtle}`,
-                  ...theme.applyDarkStyles({
-                    bgcolor: 'primaryDark.900',
-                    background: `${(theme.vars || theme).palette.gradients.linearSubtle}`,
-                    borderColor: 'primaryDark.700',
-                  }),
-                })}
-              >
-                <Box
-                  sx={(theme) => ({
-                    width: 40,
-                    height: 40,
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    borderRadius: 1,
-                    border: '1px solid',
-                    borderColor: 'primary.200',
-                    bgcolor: 'primary.50',
-                    boxShadow:
-                      '0px 1px 6px 0px rgba(194, 224, 255, 1), 0px 2px 30px 0px rgba(234, 237, 241, 0.3) inset',
-                    ...theme.applyDarkStyles({
-                      borderColor: 'primary.400',
-                      bgcolor: 'primary.900',
-                      boxShadow:
-                        '0px 1px 6px 0px rgba(0, 89, 178, 1), 0px 2px 30px 0px rgba(0, 0, 0, 0.25) inset',
-                    }),
-                  })}
-                >
-                  {icon}
-                </Box>
-                <Typography
-                  fontWeight="bold"
-                  component="h3"
-                  color="text.primary"
-                  variant="body2"
-                  mt={2}
-                  mb={0.5}
-                >
-                  {title}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {description}
-                </Typography>
-              </Paper>
+              <InfoCard link={link} linkable title={title} icon={icon} description={description} />
             </Grid>
           ))}
         </Grid>

--- a/docs/src/components/productDesignKit/DesignKitValues.tsx
+++ b/docs/src/components/productDesignKit/DesignKitValues.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import Palette from '@mui/icons-material/Palette';
@@ -8,6 +6,7 @@ import LibraryBooks from '@mui/icons-material/LibraryBooks';
 import CodeRounded from '@mui/icons-material/CodeRounded';
 import GradientText from 'docs/src/components/typography/GradientText';
 import Section from 'docs/src/layouts/Section';
+import InfoCard from 'docs/src/components/action/InfoCard';
 
 const content = [
   {
@@ -43,61 +42,7 @@ function DesignKitValues() {
       <Grid container spacing={3}>
         {content.map(({ icon, title, description }) => (
           <Grid key={title} item xs={12} sm={6} md={4}>
-            <Paper
-              variant="outlined"
-              sx={(theme) => ({
-                p: 3,
-                height: '100%',
-                position: 'relative',
-                borderRadius: '12px',
-                border: '1px solid',
-                borderColor: 'grey.100',
-                background: `${(theme.vars || theme).palette.gradients.linearSubtle}`,
-
-                ...theme.applyDarkStyles({
-                  bgcolor: 'primaryDark.900',
-                  borderColor: 'primaryDark.700',
-                  background: `${(theme.vars || theme).palette.gradients.linearSubtle}`,
-                }),
-              })}
-            >
-              <Box
-                sx={(theme) => ({
-                  width: 40,
-                  height: 40,
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  borderRadius: 1,
-                  border: '1px solid',
-                  borderColor: 'primary.200',
-                  bgcolor: 'primary.50',
-                  boxShadow:
-                    '0px 1px 6px 0px rgba(194, 224, 255, 1), 0px 2px 30px 0px rgba(234, 237, 241, 0.3) inset',
-                  ...theme.applyDarkStyles({
-                    borderColor: 'primary.400',
-                    bgcolor: 'primary.900',
-                    boxShadow:
-                      '0px 1px 6px 0px rgba(0, 89, 178, 1), 0px 2px 30px 0px rgba(0, 0, 0, 0.25) inset',
-                  }),
-                })}
-              >
-                {icon}
-              </Box>
-              <Typography
-                fontWeight="bold"
-                component="h3"
-                color="text.primary"
-                variant="body2"
-                mt={2}
-                mb={0.5}
-              >
-                {title}
-              </Typography>
-              <Typography variant="body2" color="text.secondary" mb={2}>
-                {description}
-              </Typography>
-            </Paper>
+            <InfoCard title={title} icon={icon} description={description} />
           </Grid>
         ))}
       </Grid>

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -1004,13 +1004,13 @@ export function getThemedComponents(): ThemeOptions {
                     (theme.vars || theme).palette.grey[50]
                   }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
                   '&:hover': {
-                    borderColor: (theme.vars || theme).palette.primary[300],
+                    borderColor: (theme.vars || theme).palette.primary[200],
                     boxShadow: `0px 4px 16px ${(theme.vars || theme).palette.grey[200]}`,
                   },
                 },
                 ':is(a&), :is(button&)': {
                   '&:hover': {
-                    borderColor: (theme.vars || theme).palette.primary[300],
+                    borderColor: (theme.vars || theme).palette.primary[200],
                     boxShadow: `0px 4px 16px ${(theme.vars || theme).palette.grey[200]}`,
                   },
                 },
@@ -1027,6 +1027,7 @@ export function getThemedComponents(): ThemeOptions {
                     (theme.vars || theme).palette.primaryDark[900]
                   }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
                   '&:hover': {
+                    borderColor: (theme.vars || theme).palette.primary[700],
                     boxShadow: `0px 4px 24px ${(theme.vars || theme).palette.common.black}`,
                   },
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds a new component to the website's (i.e., marketing pages) set of action components: the `InfoCard`. It's been a while that I'm feeling like there were just too many repeating instances of these same styles... and given I have some upcoming usages of it already lined up in other PRs, it seemed like a good call to finally do this! 😬 

These are the `InfoCard`s: 

<img width="600" alt="Screen Shot 2023-09-15 at 02 05 39" src="https://github.com/mui/material-ui/assets/67129314/266d1f71-5cec-4f10-9814-7d8bb76c77cc">

So far available on: 

- **https://deploy-preview-38987--material-ui.netlify.app/**
- **https://deploy-preview-38987--material-ui.netlify.app/base-ui**
- **https://deploy-preview-38987--material-ui.netlify.app/design-kits**