### PR TITLE
[docs-infra] Open demo crash in the right repository

### DIFF
--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -9,7 +9,7 @@ import Button from '@mui/material/Button';
  * with node 8 + IE11 support i.e. not using URL (URLSearchParams.set replaced with Map.set)
  */
 function newGitHubIssueUrl(options) {
-  const url = `https://github.com/${options.user}/${options.repo}/issues/new`;
+  const url = `${process.env.SOURCE_CODE_REPO}/issues/new`;
 
   const query = Object.keys(options)
     .map((type) => {
@@ -38,23 +38,23 @@ export default class DemoErrorBoundary extends React.Component {
       const title = `[docs] Demo ${name} crashes`;
       const searchQuery = encodeURIComponent(`is:issue ${title}`);
       const issueLink = newGitHubIssueUrl({
-        user: 'mui',
-        repo: 'material-ui',
         title,
         body: `
 <!-- Please make sure you have fulfilled the following items before submitting -->
 <!-- Checked checkbox should look like this: [x] -->
-- [ ] I have [searched for similar issues](https://github.com/mui/material-ui/issues?q=${searchQuery}) in this repository and believe that this is not a duplicate.
+- [ ] I have [searched for similar issues](${
+          process.env.SOURCE_CODE_REPO
+        }/issues?q=${searchQuery}) in this repository and believe that this is not a duplicate.
 
-## Steps to Reproduce
+## Steps to reproduce
 1. Visit ${window.location.href}
 2. ??
 3. demo *${name}* crashes
 
-## Your Environment
+## Your environment
 | Tech         | Version |
 |--------------|---------|
-| MUI  | v${process.env.LIB_VERSION}  |
+| Version  | v${process.env.LIB_VERSION}  |
 | Netlify deploy | ${process.env.NETLIFY_DEPLOY_URL} |
 | Browser      | ${
           typeof window !== 'undefined' && window.navigator

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -71,15 +71,16 @@ export default class DemoErrorBoundary extends React.Component {
             This demo had a runtime error!
           </Typography>
           <Typography>
-            We would appreciate it if you{' '}
+            {'We would appreciate it if you '}
             <Link href={issueLink} rel="noreferrer" target="_blank">
               report this error
-            </Link>{' '}
-            directly in our issue tracker. You will be provided with a prefilled description that
-            includes valuable information about this error.
+            </Link>
+            {
+              ' directly in our issue tracker with the steps you took to trigger it. The "report this error" link prefills the issue description with valuable information.'
+            }
           </Typography>
           <pre style={{ whiteSpace: 'pre-wrap' }}>{error.toString()}</pre>
-          <Button color="secondary" onClick={onResetDemoClick} variant="text">
+          <Button onClick={onResetDemoClick} variant="text">
             {t('resetDemo')}
           </Button>
         </div>

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -75,9 +75,8 @@ export default class DemoErrorBoundary extends React.Component {
             <Link href={issueLink} rel="noreferrer" target="_blank">
               report this error
             </Link>
-            {
-              ' directly in our issue tracker with the steps you took to trigger it. The "report this error" link prefills the issue description with valuable information.'
-            }
+            {` directly in our issue tracker with the steps you took to trigger it.
+The "report this error" link prefills the issue description with valuable information.`}
           </Typography>
           <pre style={{ whiteSpace: 'pre-wrap' }}>{error.toString()}</pre>
           <Button onClick={onResetDemoClick} variant="text">


### PR DESCRIPTION
I have seen enough of it https://github.com/mui/mui-x/issues?q=is%3Aissue+demo+crashes+is%3Aclosed+

<img width="550" alt="Screenshot 2023-09-16 at 17 12 18" src="https://github.com/mui/material-ui/assets/3165635/9a67125e-6982-4966-9606-d5c593bdf0bc">

<img width="474" alt="Screenshot 2023-09-16 at 17 12 40" src="https://github.com/mui/material-ui/assets/3165635/44360816-9a92-445f-a7a1-60194c4905a8">

<img width="518" alt="Screenshot 2023-09-16 at 17 13 19" src="https://github.com/mui/material-ui/assets/3165635/acb962c2-bbc3-4aab-b499-ea0dbb3f9117">

<img width="517" alt="Screenshot 2023-09-16 at 17 13 04" src="https://github.com/mui/material-ui/assets/3165635/6c06c284-fd12-40aa-aafb-14530fae293b">

<img width="534" alt="Screenshot 2023-09-16 at 17 15 25" src="https://github.com/mui/material-ui/assets/3165635/9c0712a3-8796-4fb3-8f1a-26e3f0d4581f">

<img width="568" alt="Screenshot 2023-09-16 at 17 12 33" src="https://github.com/mui/material-ui/assets/3165635/fd045ddc-51ff-4a5c-9a49-cf62b48e814d">

I'm stepping in 😁, transferring issues takes time, so let's have developers open the issue in the right repository instead.

I changed a bit the UI as well, it looks like this:

<img width="609" alt="Screenshot 2023-09-16 at 17 31 07" src="https://github.com/mui/material-ui/assets/3165635/e1d328e7-f862-4ebd-945a-751ef186afe5">
