### PR TITLE
[core] Move eslint to peer dependencies of eslint-plugin-material-ui

### DIFF
--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -9,7 +9,8 @@
   },
   "devDependencies": {
     "@types/eslint": "^8.44.2",
-    "@typescript-eslint/parser": "^6.6.0"
+    "@typescript-eslint/parser": "^6.6.0",
+    "eslint": "^8.47.0"
   },
   "peerDependencies": {
     "eslint": "^8.47.0"

--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -9,7 +9,9 @@
   },
   "devDependencies": {
     "@types/eslint": "^8.44.2",
-    "@typescript-eslint/parser": "^6.6.0",
+    "@typescript-eslint/parser": "^6.6.0"
+  },
+  "peerDependencies": {
     "eslint": "^8.47.0"
   },
   "scripts": {


### PR DESCRIPTION
eslint-plugin-material-ui should use the existing eslint, not bundle it on its own (as noted in https://github.com/mui/material-ui/pull/38859#discussion_r1325512165).