### PR TITLE
[docs][styled-engine-sc] Specify the support version of styled-components

### DIFF
--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -302,6 +302,10 @@ Following this approach reduces the bundle size, and removes the need to configu
 After the style engine is configured properly, you can use the [`styled()`](/system/styled/) utility
 from `@mui/material/styles` and have direct access to the theme.
 
+:::warning
+Currently, `@mui/styled-engine-sc` only supports version 5 of `styled-components`. To stay updated on the progress of version 6 support, please refer to [#38431](https://github.com/mui/material-ui/issues/38431).
+:::
+
 {{"demo": "StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-interoperability-w9z9d)

--- a/docs/data/material/guides/interoperability/interoperability.md
+++ b/docs/data/material/guides/interoperability/interoperability.md
@@ -303,7 +303,7 @@ After the style engine is configured properly, you can use the [`styled()`](/sys
 from `@mui/material/styles` and have direct access to the theme.
 
 :::warning
-Currently, `@mui/styled-engine-sc` only supports version 5 of `styled-components`. To stay updated on the progress of version 6 support, please refer to [#38431](https://github.com/mui/material-ui/issues/38431).
+Currently, `@mui/styled-engine-sc` only supports version 5 of `styled-components`. To stay updated on the progress of version 6 support, please refer to [issue #38431 on GitHub](https://github.com/mui/material-ui/issues/38431).
 :::
 
 {{"demo": "StyledComponents.js", "hideToolbar": true}}

--- a/docs/data/material/guides/styled-components/styled-components.md
+++ b/docs/data/material/guides/styled-components/styled-components.md
@@ -26,6 +26,10 @@ These two packages implement the same interface, making them interchangeable.
 By default, `@mui/material` has `@mui/styled-engine` as a dependency.
 To use styled-components, you need to configure your bundler to replace it with `@mui/styled-engine-sc`.
 
+:::warning
+Currently, `@mui/styled-engine-sc` only supports version 5 of `styled-components`. To stay updated on the progress of version 6 support, please refer to [#38431](https://github.com/mui/material-ui/issues/38431).
+:::
+
 ### With yarn
 
 If you're using yarn, you can configure it using a package resolution:

--- a/docs/data/material/guides/styled-components/styled-components.md
+++ b/docs/data/material/guides/styled-components/styled-components.md
@@ -27,7 +27,7 @@ By default, `@mui/material` has `@mui/styled-engine` as a dependency.
 To use styled-components, you need to configure your bundler to replace it with `@mui/styled-engine-sc`.
 
 :::warning
-Currently, `@mui/styled-engine-sc` only supports version 5 of `styled-components`. To stay updated on the progress of version 6 support, please refer to [#38431](https://github.com/mui/material-ui/issues/38431).
+Currently, `@mui/styled-engine-sc` only supports version 5 of `styled-components`. To stay updated on the progress of version 6 support, please refer to [issue #38431 on GitHub](https://github.com/mui/material-ui/issues/38431).
 :::
 
 ### With yarn

--- a/examples/material-ui-cra-styled-components-ts/package.json
+++ b/examples/material-ui-cra-styled-components-ts/package.json
@@ -12,7 +12,7 @@
     "react": "latest",
     "react-dom": "latest",
     "react-scripts": "latest",
-    "styled-components": "latest"
+    "styled-components": "^5.0.0"
   },
   "scripts": {
     "tsc": "./node_modules/.bin/tsc",
@@ -38,7 +38,7 @@
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",
-    "@types/styled-components": "latest",
+    "@types/styled-components": "^5.0.0",
     "craco-alias": "^3.0.1",
     "typescript": "latest"
   }

--- a/examples/material-ui-cra-styled-components/package.json
+++ b/examples/material-ui-cra-styled-components/package.json
@@ -12,7 +12,7 @@
     "react": "latest",
     "react-dom": "latest",
     "react-scripts": "latest",
-    "styled-components": "latest"
+    "styled-components": "^5.0.0"
   },
   "scripts": {
     "start": "craco start",


### PR DESCRIPTION
Related to https://github.com/mui/material-ui/issues/38431

----

Note: I noticed that the examples using cra + styled-components show this warning:

```
react-dom.development.js:86 Warning: ReactDOM.render is no longer supported in React 18.
Use createRoot instead. Until you switch to the new API, your app will behave as if it's running
React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```

We need to revisit this and see what needs to be updated. 