### PR TITLE
[FormControl][material-next] Copy v5 FormControl

### DIFF
--- a/packages/mui-material-next/src/FormControl/FormControl.d.ts
+++ b/packages/mui-material-next/src/FormControl/FormControl.d.ts
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion } from '@mui/types';
+import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { Theme } from '../styles';
+import { FormControlClasses } from './formControlClasses';
+
+export interface FormControlPropsSizeOverrides {}
+export interface FormControlPropsColorOverrides {}
+
+export interface FormControlOwnProps {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<FormControlClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   * @default 'primary'
+   */
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+    FormControlPropsColorOverrides
+  >;
+  /**
+   * If `true`, the label, input and helper text should be displayed in a disabled state.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the label is displayed in an error state.
+   * @default false
+   */
+  error?: boolean;
+  /**
+   * If `true`, the component will take up the full width of its container.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * If `true`, the component is displayed in focused state.
+   */
+  focused?: boolean;
+  /**
+   * If `true`, the label is hidden.
+   * This is used to increase density for a `FilledInput`.
+   * Be sure to add `aria-label` to the `input` element.
+   * @default false
+   */
+  hiddenLabel?: boolean;
+  /**
+   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
+   * @default 'none'
+   */
+  margin?: 'dense' | 'normal' | 'none';
+  /**
+   * If `true`, the label will indicate that the `input` is required.
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * The size of the component.
+   * @default 'medium'
+   */
+  size?: OverridableStringUnion<'small' | 'medium', FormControlPropsSizeOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant?: 'standard' | 'outlined' | 'filled';
+}
+
+export interface FormControlTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & FormControlOwnProps;
+  defaultComponent: RootComponent;
+}
+
+/**
+ * Provides context such as filled/focused/error/required for form inputs.
+ * Relying on the context provides high flexibility and ensures that the state always stays
+ * consistent across the children of the `FormControl`.
+ * This context is used by the following components:
+ *
+ * *   FormLabel
+ * *   FormHelperText
+ * *   Input
+ * *   InputLabel
+ *
+ * You can find one composition example below and more going to [the demos](https://mui.com/material-ui/react-text-field/#components).
+ *
+ * ```jsx
+ * <FormControl>
+ *   <InputLabel htmlFor="my-input">Email address</InputLabel>
+ *   <Input id="my-input" aria-describedby="my-helper-text" />
+ *   <FormHelperText id="my-helper-text">We'll never share your email.</FormHelperText>
+ * </FormControl>
+ * ```
+ *
+ * ⚠️ Only one `InputBase` can be used within a FormControl because it creates visual inconsistencies.
+ * For instance, only one input can be focused at the same time, the state shouldn't be shared.
+ *
+ * Demos:
+ *
+ * - [Checkbox](https://mui.com/material-ui/react-checkbox/)
+ * - [Radio Group](https://mui.com/material-ui/react-radio-button/)
+ * - [Switch](https://mui.com/material-ui/react-switch/)
+ * - [Text Field](https://mui.com/material-ui/react-text-field/)
+ *
+ * API:
+ *
+ * - [FormControl API](https://mui.com/material-ui/api/form-control/)
+ */
+declare const FormControl: OverridableComponent<FormControlTypeMap>;
+
+export type FormControlProps<
+  RootComponent extends React.ElementType = FormControlTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FormControlTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default FormControl;

--- a/packages/mui-material-next/src/FormControl/FormControl.d.ts
+++ b/packages/mui-material-next/src/FormControl/FormControl.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { OverridableStringUnion } from '@mui/types';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { OverridableStringUnion, OverridableComponent, OverrideProps } from '@mui/types';
 import { Theme } from '../styles';
 import { FormControlClasses } from './formControlClasses';
 

--- a/packages/mui-material-next/src/FormControl/FormControl.js
+++ b/packages/mui-material-next/src/FormControl/FormControl.js
@@ -1,0 +1,335 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import {
+  unstable_capitalize as capitalize,
+  unstable_isMuiElement as isMuiElement,
+} from '@mui/utils';
+import useThemeProps from '../styles/useThemeProps';
+import styled from '../styles/styled';
+import { isFilled, isAdornedStart } from '../InputBase/utils';
+import FormControlContext from './FormControlContext';
+import { getFormControlUtilityClasses } from './formControlClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, margin, fullWidth } = ownerState;
+  const slots = {
+    root: ['root', margin !== 'none' && `margin${capitalize(margin)}`, fullWidth && 'fullWidth'],
+  };
+
+  return composeClasses(slots, getFormControlUtilityClasses, classes);
+};
+
+const FormControlRoot = styled('div', {
+  name: 'MuiFormControl',
+  slot: 'Root',
+  overridesResolver: ({ ownerState }, styles) => {
+    return {
+      ...styles.root,
+      ...styles[`margin${capitalize(ownerState.margin)}`],
+      ...(ownerState.fullWidth && styles.fullWidth),
+    };
+  },
+})(({ ownerState }) => ({
+  display: 'inline-flex',
+  flexDirection: 'column',
+  position: 'relative',
+  // Reset fieldset default style.
+  minWidth: 0,
+  padding: 0,
+  margin: 0,
+  border: 0,
+  verticalAlign: 'top', // Fix alignment issue on Safari.
+  ...(ownerState.margin === 'normal' && {
+    marginTop: 16,
+    marginBottom: 8,
+  }),
+  ...(ownerState.margin === 'dense' && {
+    marginTop: 8,
+    marginBottom: 4,
+  }),
+  ...(ownerState.fullWidth && {
+    width: '100%',
+  }),
+}));
+
+/**
+ * Provides context such as filled/focused/error/required for form inputs.
+ * Relying on the context provides high flexibility and ensures that the state always stays
+ * consistent across the children of the `FormControl`.
+ * This context is used by the following components:
+ *
+ *  - FormLabel
+ *  - FormHelperText
+ *  - Input
+ *  - InputLabel
+ *
+ * You can find one composition example below and more going to [the demos](/material-ui/react-text-field/#components).
+ *
+ * ```jsx
+ * <FormControl>
+ *   <InputLabel htmlFor="my-input">Email address</InputLabel>
+ *   <Input id="my-input" aria-describedby="my-helper-text" />
+ *   <FormHelperText id="my-helper-text">We'll never share your email.</FormHelperText>
+ * </FormControl>
+ * ```
+ *
+ * ⚠️ Only one `InputBase` can be used within a FormControl because it creates visual inconsistencies.
+ * For instance, only one input can be focused at the same time, the state shouldn't be shared.
+ */
+const FormControl = React.forwardRef(function FormControl(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiFormControl' });
+  const {
+    children,
+    className,
+    color = 'primary',
+    component = 'div',
+    disabled = false,
+    error = false,
+    focused: visuallyFocused,
+    fullWidth = false,
+    hiddenLabel = false,
+    margin = 'none',
+    required = false,
+    size = 'medium',
+    variant = 'outlined',
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    color,
+    component,
+    disabled,
+    error,
+    fullWidth,
+    hiddenLabel,
+    margin,
+    required,
+    size,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  const [adornedStart, setAdornedStart] = React.useState(() => {
+    // We need to iterate through the children and find the Input in order
+    // to fully support server-side rendering.
+    let initialAdornedStart = false;
+
+    if (children) {
+      React.Children.forEach(children, (child) => {
+        if (!isMuiElement(child, ['Input', 'Select'])) {
+          return;
+        }
+
+        const input = isMuiElement(child, ['Select']) ? child.props.input : child;
+
+        if (input && isAdornedStart(input.props)) {
+          initialAdornedStart = true;
+        }
+      });
+    }
+    return initialAdornedStart;
+  });
+
+  const [filled, setFilled] = React.useState(() => {
+    // We need to iterate through the children and find the Input in order
+    // to fully support server-side rendering.
+    let initialFilled = false;
+
+    if (children) {
+      React.Children.forEach(children, (child) => {
+        if (!isMuiElement(child, ['Input', 'Select'])) {
+          return;
+        }
+
+        if (isFilled(child.props, true) || isFilled(child.props.inputProps, true)) {
+          initialFilled = true;
+        }
+      });
+    }
+
+    return initialFilled;
+  });
+
+  const [focusedState, setFocused] = React.useState(false);
+  if (disabled && focusedState) {
+    setFocused(false);
+  }
+
+  const focused = visuallyFocused !== undefined && !disabled ? visuallyFocused : focusedState;
+
+  let registerEffect;
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const registeredInput = React.useRef(false);
+    registerEffect = () => {
+      if (registeredInput.current) {
+        console.error(
+          [
+            'MUI: There are multiple `InputBase` components inside a FormControl.',
+            'This creates visual inconsistencies, only use one `InputBase`.',
+          ].join('\n'),
+        );
+      }
+
+      registeredInput.current = true;
+      return () => {
+        registeredInput.current = false;
+      };
+    };
+  }
+
+  const childContext = React.useMemo(() => {
+    return {
+      adornedStart,
+      setAdornedStart,
+      color,
+      disabled,
+      error,
+      filled,
+      focused,
+      fullWidth,
+      hiddenLabel,
+      size,
+      onBlur: () => {
+        setFocused(false);
+      },
+      onEmpty: () => {
+        setFilled(false);
+      },
+      onFilled: () => {
+        setFilled(true);
+      },
+      onFocus: () => {
+        setFocused(true);
+      },
+      registerEffect,
+      required,
+      variant,
+    };
+  }, [
+    adornedStart,
+    color,
+    disabled,
+    error,
+    filled,
+    focused,
+    fullWidth,
+    hiddenLabel,
+    registerEffect,
+    required,
+    size,
+    variant,
+  ]);
+
+  return (
+    <FormControlContext.Provider value={childContext}>
+      <FormControlRoot
+        as={component}
+        ownerState={ownerState}
+        className={clsx(classes.root, className)}
+        ref={ref}
+        {...other}
+      >
+        {children}
+      </FormControlRoot>
+    </FormControlContext.Provider>
+  );
+});
+
+FormControl.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   * @default 'primary'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, the label, input and helper text should be displayed in a disabled state.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the label is displayed in an error state.
+   * @default false
+   */
+  error: PropTypes.bool,
+  /**
+   * If `true`, the component is displayed in focused state.
+   */
+  focused: PropTypes.bool,
+  /**
+   * If `true`, the component will take up the full width of its container.
+   * @default false
+   */
+  fullWidth: PropTypes.bool,
+  /**
+   * If `true`, the label is hidden.
+   * This is used to increase density for a `FilledInput`.
+   * Be sure to add `aria-label` to the `input` element.
+   * @default false
+   */
+  hiddenLabel: PropTypes.bool,
+  /**
+   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
+   * @default 'none'
+   */
+  margin: PropTypes.oneOf(['dense', 'none', 'normal']),
+  /**
+   * If `true`, the label will indicate that the `input` is required.
+   * @default false
+   */
+  required: PropTypes.bool,
+  /**
+   * The size of the component.
+   * @default 'medium'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
+};
+
+export default FormControl;

--- a/packages/mui-material-next/src/FormControl/FormControl.test.js
+++ b/packages/mui-material-next/src/FormControl/FormControl.test.js
@@ -1,0 +1,374 @@
+/* eslint-disable mocha/no-skipped-tests */
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { describeConformance, act, createRenderer } from 'test/utils';
+import FormControl, { formControlClasses as classes } from '@mui/material-next/FormControl';
+// TODO: replace with material-next/OutlinedInput
+import InputBase from '@mui/material-next/InputBase';
+// TODO: replace with material-next/Select
+import Select from '@mui/material/Select';
+import useFormControl from './useFormControl';
+
+describe('<FormControl />', () => {
+  const { render } = createRenderer();
+
+  function TestComponent(props) {
+    const context = useFormControl();
+    React.useEffect(() => {
+      props.contextCallback(context);
+    });
+    return null;
+  }
+
+  describeConformance(<FormControl />, () => ({
+    classes,
+    inheritComponent: 'div',
+    render,
+    refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: 'fieldset',
+    muiName: 'MuiFormControl',
+    testVariantProps: { margin: 'dense' },
+    skip: ['componentsProp'],
+  }));
+
+  describe('initial state', () => {
+    it('should have no margin', () => {
+      const { container } = render(<FormControl />);
+      const root = container.firstChild;
+
+      expect(root).not.to.have.class(classes.marginNormal);
+      expect(root).not.to.have.class(classes.sizeSmall);
+    });
+
+    it('can have the margin normal class', () => {
+      const { container } = render(<FormControl margin="normal" />);
+      const root = container.firstChild;
+
+      expect(root).to.have.class(classes.marginNormal);
+      expect(root).not.to.have.class(classes.sizeSmall);
+    });
+
+    it('can have the margin dense class', () => {
+      const { container } = render(<FormControl margin="dense" />);
+      const root = container.firstChild;
+
+      expect(root).to.have.class(classes.marginDense);
+      expect(root).not.to.have.class(classes.marginNormal);
+    });
+
+    it('should not be filled initially', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('filled', false);
+    });
+
+    it('should not be focused initially', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('focused', false);
+    });
+  });
+
+  describe('prop: required', () => {
+    it('should not apply it to the DOM', () => {
+      const { container } = render(<FormControl required />);
+      expect(container.firstChild).not.to.have.attribute('required');
+    });
+  });
+
+  // TODO: needs InputBase + FormControl integrated
+  describe.skip('prop: disabled', () => {
+    it('will be unfocused if it gets disabled', () => {
+      const readContext = spy();
+      const { container, setProps } = render(
+        <FormControl>
+          <InputBase />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('focused', false);
+
+      act(() => {
+        container.querySelector('input').focus();
+      });
+      expect(readContext.lastCall.args[0]).to.have.property('focused', true);
+
+      setProps({ disabled: true });
+      expect(readContext.lastCall.args[0]).to.have.property('focused', false);
+    });
+  });
+
+  describe('prop: focused', () => {
+    it('should display input in focused state', () => {
+      const readContext = spy();
+      const { container } = render(
+        <FormControl focused>
+          <InputBase />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+
+      expect(readContext.args[0][0]).to.have.property('focused', true);
+      container.querySelector('input').blur();
+      expect(readContext.args[0][0]).to.have.property('focused', true);
+    });
+
+    it('ignores focused when disabled', () => {
+      const readContext = spy();
+      render(
+        <FormControl focused disabled>
+          <InputBase />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.include({ disabled: true, focused: false });
+    });
+  });
+
+  describe('input', () => {
+    // TODO: needs InputBase + FormControl integrated
+    it.skip('should be filled when a value is set', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <InputBase value="bar" />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('filled', true);
+    });
+
+    // TODO: needs InputBase + FormControl integrated
+    it.skip('should be filled when a value is set through inputProps', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <InputBase inputProps={{ value: 'bar' }} />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('filled', true);
+    });
+
+    // TODO: needs InputBase + FormControl integrated
+    it.skip('should be filled when a defaultValue is set', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <InputBase defaultValue="bar" />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('filled', true);
+    });
+
+    it('should not be adornedStart with an endAdornment', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <InputBase endAdornment={<div />} />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('adornedStart', false);
+    });
+
+    // TODO: needs InputBase + FormControl integrated
+    it.skip('should be adornedStart with a startAdornment', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <InputBase startAdornment={<div />} />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('adornedStart', true);
+    });
+  });
+
+  // TODO: unskip and refactor when integrating material-next/Select
+  describe.skip('select', () => {
+    it('should not be adorned without a startAdornment', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <Select value="" />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0]).to.have.property('adornedStart', false);
+    });
+
+    it('should be adorned with a startAdornment', () => {
+      const readContext = spy();
+      render(
+        <FormControl>
+          <Select value="" input={<InputBase startAdornment={<div />} />} />
+          <TestComponent contextCallback={readContext} />
+        </FormControl>,
+      );
+      expect(readContext.args[0][0].adornedStart, true);
+    });
+  });
+
+  describe('useFormControl', () => {
+    const FormController = React.forwardRef((_, ref) => {
+      const formControl = useFormControl();
+      React.useImperativeHandle(ref, () => formControl, [formControl]);
+      return null;
+    });
+
+    const FormControlled = React.forwardRef(function FormControlled(props, ref) {
+      return (
+        <FormControl {...props}>
+          <FormController ref={ref} />
+        </FormControl>
+      );
+    });
+
+    describe('from props', () => {
+      it('should have the required prop from the instance', () => {
+        const formControlRef = React.createRef();
+        const { setProps } = render(<FormControlled ref={formControlRef} />);
+
+        expect(formControlRef.current).to.have.property('required', false);
+
+        setProps({ required: true });
+        expect(formControlRef.current).to.have.property('required', true);
+      });
+
+      it('should have the error prop from the instance', () => {
+        const formControlRef = React.createRef();
+        const { setProps } = render(<FormControlled ref={formControlRef} />);
+
+        expect(formControlRef.current).to.have.property('error', false);
+
+        setProps({ error: true });
+        expect(formControlRef.current).to.have.property('error', true);
+      });
+
+      it('should have the margin prop from the instance', () => {
+        const formControlRef = React.createRef();
+        const { setProps } = render(<FormControlled ref={formControlRef} />);
+
+        expect(formControlRef.current).to.have.property('size', 'medium');
+
+        setProps({ size: 'small' });
+        expect(formControlRef.current).to.have.property('size', 'small');
+      });
+
+      it('should have the fullWidth prop from the instance', () => {
+        const formControlRef = React.createRef();
+        const { setProps } = render(<FormControlled ref={formControlRef} />);
+
+        expect(formControlRef.current).to.have.property('fullWidth', false);
+
+        setProps({ fullWidth: true });
+        expect(formControlRef.current).to.have.property('fullWidth', true);
+      });
+    });
+
+    describe('callbacks', () => {
+      describe('onFilled', () => {
+        it('should set the filled state', () => {
+          const formControlRef = React.createRef();
+          render(<FormControlled ref={formControlRef} />);
+
+          expect(formControlRef.current).to.have.property('filled', false);
+
+          act(() => {
+            formControlRef.current.onFilled();
+          });
+
+          expect(formControlRef.current).to.have.property('filled', true);
+
+          act(() => {
+            formControlRef.current.onFilled();
+          });
+
+          expect(formControlRef.current).to.have.property('filled', true);
+        });
+      });
+
+      describe('onEmpty', () => {
+        it('should clean the filled state', () => {
+          const formControlRef = React.createRef();
+          render(<FormControlled ref={formControlRef} />);
+
+          act(() => {
+            formControlRef.current.onFilled();
+          });
+
+          expect(formControlRef.current).to.have.property('filled', true);
+
+          act(() => {
+            formControlRef.current.onEmpty();
+          });
+
+          expect(formControlRef.current).to.have.property('filled', false);
+
+          act(() => {
+            formControlRef.current.onEmpty();
+          });
+
+          expect(formControlRef.current).to.have.property('filled', false);
+        });
+      });
+
+      describe('handleFocus', () => {
+        it('should set the focused state', () => {
+          const formControlRef = React.createRef();
+          render(<FormControlled ref={formControlRef} />);
+          expect(formControlRef.current).to.have.property('focused', false);
+
+          act(() => {
+            formControlRef.current.onFocus();
+          });
+
+          expect(formControlRef.current).to.have.property('focused', true);
+
+          act(() => {
+            formControlRef.current.onFocus();
+          });
+
+          expect(formControlRef.current).to.have.property('focused', true);
+        });
+      });
+
+      describe('handleBlur', () => {
+        it('should clear the focused state', () => {
+          const formControlRef = React.createRef();
+          render(<FormControlled ref={formControlRef} />);
+          expect(formControlRef.current).to.have.property('focused', false);
+
+          act(() => {
+            formControlRef.current.onFocus();
+          });
+
+          expect(formControlRef.current).to.have.property('focused', true);
+
+          act(() => {
+            formControlRef.current.onBlur();
+          });
+
+          expect(formControlRef.current).to.have.property('focused', false);
+
+          act(() => {
+            formControlRef.current.onBlur();
+          });
+
+          expect(formControlRef.current).to.have.property('focused', false);
+        });
+      });
+    });
+  });
+});

--- a/packages/mui-material-next/src/FormControl/FormControlContext.ts
+++ b/packages/mui-material-next/src/FormControl/FormControlContext.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import type { FormControlProps } from './FormControl';
+
+type ContextFromPropsKey =
+  | 'color'
+  | 'disabled'
+  | 'error'
+  | 'fullWidth'
+  | 'hiddenLabel'
+  | 'margin'
+  | 'onBlur'
+  | 'onFocus'
+  | 'required'
+  | 'size'
+  | 'variant';
+
+export interface FormControlState extends Pick<FormControlProps, ContextFromPropsKey> {
+  adornedStart: boolean;
+  filled: boolean;
+  focused: boolean;
+  onEmpty: () => void;
+  onFilled: () => void;
+  registerEffect: () => void;
+  setAdornedStart: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+/**
+ * @ignore - internal component.
+ */
+const FormControlContext = React.createContext<FormControlState | undefined>(undefined);
+
+if (process.env.NODE_ENV !== 'production') {
+  FormControlContext.displayName = 'FormControlContext';
+}
+
+export default FormControlContext;

--- a/packages/mui-material-next/src/FormControl/formControlClasses.ts
+++ b/packages/mui-material-next/src/FormControl/formControlClasses.ts
@@ -1,0 +1,32 @@
+import {
+  unstable_generateUtilityClass as generateUtilityClass,
+  unstable_generateUtilityClasses as generateUtilityClasses,
+} from '@mui/utils';
+
+export interface FormControlClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `margin="normal"`. */
+  marginNormal: string;
+  /** Styles applied to the root element if `margin="dense"`. */
+  marginDense: string;
+  /** Styles applied to the root element if `fullWidth={true}`. */
+  fullWidth: string;
+}
+
+export type FormControlClassKey = keyof FormControlClasses;
+
+export function getFormControlUtilityClasses(slot: string): string {
+  return generateUtilityClass('MuiFormControl', slot);
+}
+
+const formControlClasses: FormControlClasses = generateUtilityClasses('MuiFormControl', [
+  'root',
+  'marginNone',
+  'marginNormal',
+  'marginDense',
+  'fullWidth',
+  'disabled',
+]);
+
+export default formControlClasses;

--- a/packages/mui-material-next/src/FormControl/formControlState.js
+++ b/packages/mui-material-next/src/FormControl/formControlState.js
@@ -1,0 +1,13 @@
+export default function formControlState({ props, states, muiFormControl }) {
+  return states.reduce((acc, state) => {
+    acc[state] = props[state];
+
+    if (muiFormControl) {
+      if (typeof props[state] === 'undefined') {
+        acc[state] = muiFormControl[state];
+      }
+    }
+
+    return acc;
+  }, {});
+}

--- a/packages/mui-material-next/src/FormControl/index.d.ts
+++ b/packages/mui-material-next/src/FormControl/index.d.ts
@@ -1,0 +1,9 @@
+export { default } from './FormControl';
+export * from './FormControl';
+
+export { default as useFormControl } from './useFormControl';
+
+export { FormControlState } from './FormControlContext';
+
+export { default as formControlClasses } from './formControlClasses';
+export * from './formControlClasses';

--- a/packages/mui-material-next/src/FormControl/index.js
+++ b/packages/mui-material-next/src/FormControl/index.js
@@ -1,0 +1,6 @@
+'use client';
+export { default } from './FormControl';
+export { default as useFormControl } from './useFormControl';
+
+export { default as formControlClasses } from './formControlClasses';
+export * from './formControlClasses';

--- a/packages/mui-material-next/src/FormControl/useFormControl.ts
+++ b/packages/mui-material-next/src/FormControl/useFormControl.ts
@@ -1,0 +1,7 @@
+'use client';
+import * as React from 'react';
+import FormControlContext, { FormControlState } from './FormControlContext';
+
+export default function useFormControl(): FormControlState | undefined {
+  return React.useContext(FormControlContext);
+}

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -12,6 +12,9 @@ export * from './ButtonBase';
 export { default as Chip } from './Chip';
 export * from './Chip';
 
+export { default as FormControl } from './FormControl';
+export * from './FormControl';
+
 export { default as InputBase } from './InputBase';
 export * from './InputBase';
 


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/38411, https://github.com/mui/material-ui/issues/29345

This PR copies `FormControl` from `mui-material` to `mui-material-next` with minimal modification (e.g. import paths, just enough to pass CI) so it's easier to see the diffs in [the PR](https://github.com/mui/material-ui/pull/39032) containing the actual code changes

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
