### PR TITLE
[core] Update Babel types along with source packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     },
     {
       "groupName": "babel",
-      "matchPackagePatterns": "@babel/*"
+      "matchPackagePatterns": ["^@babel/", "^@types/babel"]
     },
     {
       "groupName": "Emotion",


### PR DESCRIPTION
Include `@types/babel*` packages in the Renovate's Babel group to limit the number of dependency PRs.
