### PR TITLE
[Drawer] Add missing `JoyDrawer` in theme components

### DIFF
--- a/packages/mui-joy/src/Drawer/DrawerProps.ts
+++ b/packages/mui-joy/src/Drawer/DrawerProps.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { OverridableStringUnion, OverrideProps } from '@mui/types';
 import { ColorPaletteProp, VariantProp, ApplyColorInversion } from '../styles/types';
-import { ModalOwnProps } from '../Modal';
+import { ModalOwnProps } from '../Modal/ModalProps';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
 export type DrawerSlot = 'root' | 'backdrop' | 'content';

--- a/packages/mui-joy/src/Drawer/DrawerProps.ts
+++ b/packages/mui-joy/src/Drawer/DrawerProps.ts
@@ -4,7 +4,7 @@ import { ColorPaletteProp, VariantProp, ApplyColorInversion } from '../styles/ty
 import { ModalOwnProps } from '../Modal';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
-export type DrawerSlot = 'root' | 'label' | 'action' | 'startDecorator' | 'endDecorator';
+export type DrawerSlot = 'root' | 'backdrop' | 'content';
 
 export interface DrawerSlots {
   /**

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -352,7 +352,7 @@ export interface Components<Theme = unknown> {
   };
   JoyDrawer?: {
     defaultProps?: Partial<DrawerProps>;
-    styleOverrides?: StyleOverrides<DrawerSlot, Dheme, DrawerOwnerState>;
+    styleOverrides?: StyleOverrides<DrawerSlot, DrawerOwnerState, Theme>;
   };
   JoyScopedCssBaseline?: {
     defaultProps?: Partial<ScopedCssBaselineProps>;

--- a/packages/mui-joy/src/styles/components.d.ts
+++ b/packages/mui-joy/src/styles/components.d.ts
@@ -101,6 +101,7 @@ import {
   DialogTitleOwnerState,
   DialogTitleSlot,
 } from '../DialogTitle/DialogTitleProps';
+import { DrawerProps, DrawerOwnerState, DrawerSlot } from '../Drawer/DrawerProps';
 import {
   ScopedCssBaselineProps,
   ScopedCssBaselineOwnerState,
@@ -348,6 +349,10 @@ export interface Components<Theme = unknown> {
   JoyDialogTitle?: {
     defaultProps?: Partial<DialogTitleProps>;
     styleOverrides?: StyleOverrides<DialogTitleSlot, DialogTitleOwnerState, Theme>;
+  };
+  JoyDrawer?: {
+    defaultProps?: Partial<DrawerProps>;
+    styleOverrides?: StyleOverrides<DrawerSlot, Dheme, DrawerOwnerState>;
   };
   JoyScopedCssBaseline?: {
     defaultProps?: Partial<ScopedCssBaselineProps>;

--- a/packages/mui-joy/src/styles/extendTheme.spec.ts
+++ b/packages/mui-joy/src/styles/extendTheme.spec.ts
@@ -638,7 +638,7 @@ extendTheme({
     JoyDrawer: {
       defaultProps: {
         variant: 'plain',
-        color: 'neutral'
+        color: 'neutral',
       },
       styleOverrides: {
         root: ({ ownerState }) => {

--- a/packages/mui-joy/src/styles/extendTheme.spec.ts
+++ b/packages/mui-joy/src/styles/extendTheme.spec.ts
@@ -27,6 +27,7 @@ import { DialogActionsOwnerState } from '@mui/joy/DialogActions';
 import { DialogContentOwnerState } from '@mui/joy/DialogContent';
 import { DialogTitleOwnerState } from '@mui/joy/DialogTitle';
 import { DividerOwnerState } from '@mui/joy/Divider';
+import { DrawerOwnerState } from '@mui/joy/Drawer';
 import { FormControlOwnerState } from '@mui/joy/FormControl';
 import { FormHelperTextOwnerState } from '@mui/joy/FormHelperText';
 import { FormLabelOwnerState } from '@mui/joy/FormLabel';
@@ -630,6 +631,26 @@ extendTheme({
       styleOverrides: {
         root: ({ ownerState }) => {
           expectType<DividerOwnerState & Record<string, unknown>, typeof ownerState>(ownerState);
+          return {};
+        },
+      },
+    },
+    JoyDrawer: {
+      defaultProps: {
+        variant: 'plain',
+        color: 'neutral'
+      },
+      styleOverrides: {
+        root: ({ ownerState }) => {
+          expectType<DrawerOwnerState & Record<string, unknown>, typeof ownerState>(ownerState);
+          return {};
+        },
+        backdrop: ({ ownerState }) => {
+          expectType<DrawerOwnerState & Record<string, unknown>, typeof ownerState>(ownerState);
+          return {};
+        },
+        content: ({ ownerState }) => {
+          expectType<DrawerOwnerState & Record<string, unknown>, typeof ownerState>(ownerState);
           return {};
         },
       },


### PR DESCRIPTION
Fixes #39041

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
