### PR TITLE
[core] Simplify docs feedback interaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 /test/regressions/screenshots
 /tmp
 .next
+# created by netlify dev (to perform local debug)
+.netlify
 build
 node_modules
 package-lock.json

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -109,7 +109,7 @@ async function postFeedbackOnSlack(data) {
     currentLocationURL: window.location.href,
     commmentSectionURL: `${window.location.origin}${window.location.pathname}#${commentedSection.hash}`,
     commmentSectionTitle: commentedSection.text,
-    githubRepo: process.env.SOURCE_CODE_REPO ?? 'https://github.com/mui/material-ui',
+    githubRepo: process.env.SOURCE_CODE_REPO,
   };
   if (!comment || comment.length < 10) {
     return 'ignored';

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -109,6 +109,7 @@ async function postFeedbackOnSlack(data) {
     currentLocationURL: window.location.href,
     commmentSectionURL: `${window.location.origin}${window.location.pathname}#${commentedSection.hash}`,
     commmentSectionTitle: commentedSection.text,
+    githubRepo: process.env.SOURCE_CODE_REPO ?? 'https://github.com/mui/material-ui',
   };
   if (!comment || comment.length < 10) {
     return 'ignored';

--- a/netlify/functions/feedback-management.js
+++ b/netlify/functions/feedback-management.js
@@ -54,6 +54,7 @@ const awsLambdaReceiver = new AwsLambdaReceiver({
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   receiver: awsLambdaReceiver,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
 });
 
 // Define slack actions to answer
@@ -185,16 +186,17 @@ exports.handler = async (event, context, callback) => {
       ].join('\n\n');
 
       const githubNewIssueParams = new URLSearchParams({
-        title: encodeURIComponent('[ ] Docs feedback'),
-        body: encodeURIComponent(`Feedback received:
+        title: '[ ] Docs feedback',
+        body: `Feedback received:
 ${comment}
 
 from ${commmentSectionURL}
-`),
+`,
       });
 
       await app.client.chat.postMessage({
         channel: getSlackChannelId(currentLocationURL, { isDesignFeedback }),
+        text: simpleSlackMessage, // Fallback for notification
         blocks: [
           {
             type: 'section',
@@ -203,7 +205,6 @@ from ${commmentSectionURL}
               text: simpleSlackMessage,
             },
           },
-
           {
             type: 'actions',
             elements: [

--- a/netlify/functions/feedback-management.js
+++ b/netlify/functions/feedback-management.js
@@ -51,7 +51,7 @@ app.action('delete_action', async ({ ack, body, client, logger }) => {
       user: { username },
       channel: { id: channelId },
       message,
-      value,
+      actions: [{ value }],
     } = body;
 
     const { comment, currentLocationURL = '', commmentSectionURL = '' } = JSON.parse(value);
@@ -89,7 +89,7 @@ app.action('save_message', async ({ ack, body, client, logger }) => {
       user: { username },
       channel: { id: channelId },
       message,
-      value,
+      actions: [{ value }],
     } = body;
 
     const { comment, currentLocationURL = '', commmentSectionURL = '' } = JSON.parse(value);

--- a/netlify/functions/feedback-management.js
+++ b/netlify/functions/feedback-management.js
@@ -193,12 +193,12 @@ from ${commmentSectionURL}
                 text: {
                   type: 'plain_text',
                   text: 'Save',
-                  value: JSON.stringify({
-                    comment,
-                    currentLocationURL,
-                    commmentSectionURL,
-                  }),
                 },
+                value: JSON.stringify({
+                  comment,
+                  currentLocationURL,
+                  commmentSectionURL,
+                }),
                 action_id: 'save_message',
               },
               {
@@ -206,12 +206,12 @@ from ${commmentSectionURL}
                 text: {
                   type: 'plain_text',
                   text: 'Delete',
-                  value: JSON.stringify({
-                    comment,
-                    currentLocationURL,
-                    commmentSectionURL,
-                  }),
                 },
+                value: JSON.stringify({
+                  comment,
+                  currentLocationURL,
+                  commmentSectionURL,
+                }),
                 style: 'danger',
                 action_id: 'delete_action',
               },

--- a/netlify/functions/feedback-management.js
+++ b/netlify/functions/feedback-management.js
@@ -78,7 +78,6 @@ app.action('delete_action', async ({ ack, body, client, logger }) => {
     const {
       user: { username },
       channel: { id: channelId },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       message,
     } = body;
 
@@ -116,8 +115,6 @@ app.action('save_message', async ({ ack, body, client, logger }) => {
     const {
       user: { username },
       channel: { id: channelId },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      message_ts,
       message,
     } = body;
 
@@ -140,7 +137,7 @@ app.action('save_message', async ({ ack, body, client, logger }) => {
     });
     await client.chat.postMessage({
       channel: channelId,
-      thread_ts: message_ts,
+      thread_ts: message.ts,
       as_user: true,
       text: `Saved in <https://docs.google.com/spreadsheets/d/${spreadSheetsIds.forLater}/>`,
     });

--- a/netlify/functions/feedback-management.js
+++ b/netlify/functions/feedback-management.js
@@ -27,21 +27,6 @@ const getSlackChannelId = (url, specialCases) => {
   return CORE_FEEBACKS_CHANNEL_ID;
 };
 
-const getGitHubRepo = (url, specialCases) => {
-  const { isDesignFeedback } = specialCases;
-
-  if (isDesignFeedback) {
-    return 'material-ui';
-  }
-  if (url.includes('/x/')) {
-    return 'mui-x';
-  }
-  if (url.includes('/toolpad/')) {
-    return 'mui-toolpad';
-  }
-  return 'material-ui';
-};
-
 const spreadSheetsIds = {
   forLater: '1NAUTsIcReVylWPby5K0omXWZpgjd9bjxE8V2J-dwPyc',
 };
@@ -89,7 +74,7 @@ function getQuoteAndLinks(message) {
 app.action('delete_action', async ({ ack, body, client, logger }) => {
   try {
     await ack();
-    console.log(JSON.stringify({ body }));
+
     const {
       user: { username },
       channel: { id: channelId },
@@ -184,6 +169,7 @@ exports.handler = async (event, context, callback) => {
         currentLocationURL,
         commmentSectionURL: inCommmentSectionURL,
         commmentSectionTitle,
+        githubRepo,
       } = data;
 
       const isDesignFeedback = inCommmentSectionURL.includes('#new-docs-api-feedback');
@@ -229,9 +215,7 @@ from ${commmentSectionURL}
                   text: 'Create issue',
                   emoji: true,
                 },
-                url: `https://github.com/mui/${getGitHubRepo(currentLocationURL, {
-                  isDesignFeedback,
-                })}/issues/new?${githubNewIssueParams}`,
+                url: `${githubRepo}/issues/new?${githubNewIssueParams}`,
               },
               {
                 type: 'button',


### PR DESCRIPTION
The goal is to add actions directly into messages, such that with a single click, you can:

- delete useless messages -> will be saved to see later if there is some pattern
- open an issue
- save it in a sheet (if the message is insightful but is not something to fix)