### PR TITLE
[core] Replace a `useCallback` by `useRef` in useEventCallback

### DIFF
--- a/packages/mui-utils/src/useEventCallback/useEventCallback.ts
+++ b/packages/mui-utils/src/useEventCallback/useEventCallback.ts
@@ -19,13 +19,11 @@ function useEventCallback<Args extends unknown[], Return>(
   useEnhancedEffect(() => {
     ref.current = fn;
   });
-  return React.useCallback(
-    (...args: Args) =>
-      // @ts-expect-error hide `this`
-      // tslint:disable-next-line:ban-comma-operator
-      (0, ref.current!)(...args),
-    [],
-  );
+  return React.useRef((...args: Args) =>
+    // @ts-expect-error hide `this`
+    // tslint:disable-next-line:ban-comma-operator
+    (0, ref.current!)(...args),
+  ).current;
 }
 
 export default useEventCallback;


### PR DESCRIPTION
Minor touchup, `useRef` is leaner than `useCallback`.