### PR TITLE
Use correct loading indicator component in code example

### DIFF
--- a/docs/data/joy/components/button/ButtonLoadingIndicator.js
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import Stack from '@mui/joy/Stack';
-import SendIcon from '@mui/icons-material/Send';
+import CircularProgress from '@mui/joy/CircularProgress';
 import Button from '@mui/joy/Button';
 
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading endDecorator={<SendIcon />} variant="solid">
+      <Button loading endDecorator={<CircularProgress />} variant="solid">
         Send
       </Button>
       <Button loading loadingIndicator="Loading…" variant="outlined">


### PR DESCRIPTION
Use Joys `<CircularProgress />` instead of Material UIs `<SendIcon />` in the loading indicator code example.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
