### PR TITLE
[docs][joy-ui] Simplify the button's loading indicator demo

### DIFF
--- a/docs/data/joy/components/button/ButtonIcons.js
+++ b/docs/data/joy/components/button/ButtonIcons.js
@@ -3,17 +3,13 @@ import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Add from '@mui/icons-material/Add';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
-import ThumbUp from '@mui/icons-material/ThumbUp';
 
 export default function ButtonIcons() {
   return (
     <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
       <Button startDecorator={<Add />}>Add to cart</Button>
-      <Button aria-label="Like" variant="outlined" color="neutral">
-        <ThumbUp />
-      </Button>
-      <Button variant="soft" endDecorator={<KeyboardArrowRight />} color="success">
-        Checkout
+      <Button endDecorator={<KeyboardArrowRight />} color="success">
+        Go to checkout
       </Button>
     </Box>
   );

--- a/docs/data/joy/components/button/ButtonIcons.tsx
+++ b/docs/data/joy/components/button/ButtonIcons.tsx
@@ -3,17 +3,13 @@ import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Add from '@mui/icons-material/Add';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
-import ThumbUp from '@mui/icons-material/ThumbUp';
 
 export default function ButtonIcons() {
   return (
     <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
       <Button startDecorator={<Add />}>Add to cart</Button>
-      <Button aria-label="Like" variant="outlined" color="neutral">
-        <ThumbUp />
-      </Button>
-      <Button variant="soft" endDecorator={<KeyboardArrowRight />} color="success">
-        Checkout
+      <Button endDecorator={<KeyboardArrowRight />} color="success">
+        Go to checkout
       </Button>
     </Box>
   );

--- a/docs/data/joy/components/button/ButtonIcons.tsx.preview
+++ b/docs/data/joy/components/button/ButtonIcons.tsx.preview
@@ -1,7 +1,4 @@
 <Button startDecorator={<Add />}>Add to cart</Button>
-<Button aria-label="Like" variant="outlined" color="neutral">
-  <ThumbUp />
-</Button>
-<Button variant="soft" endDecorator={<KeyboardArrowRight />} color="success">
-  Checkout
+<Button endDecorator={<KeyboardArrowRight />} color="success">
+  Go to checkout
 </Button>

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.js
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.js
@@ -5,11 +5,11 @@ import Button from '@mui/joy/Button';
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading variant="solid">
-        Send
+      <Button loading variant="outlined">
+        Default
       </Button>
       <Button loading loadingIndicator="Loading…" variant="outlined">
-        Fetch data
+        Custom
       </Button>
     </Stack>
   );

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.js
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.js
@@ -5,10 +5,8 @@ import Button from '@mui/joy/Button';
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading variant="outlined">
-        Default
-      </Button>
-      <Button loading loadingIndicator="Loading…" variant="outlined">
+      <Button loading>Default</Button>
+      <Button loading loadingIndicator="Loading…">
         Custom
       </Button>
     </Stack>

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.js
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import Stack from '@mui/joy/Stack';
-import SendIcon from '@mui/icons-material/Send';
 import Button from '@mui/joy/Button';
 
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading endDecorator={<SendIcon />} variant="solid">
+      <Button loading variant="solid">
         Send
       </Button>
       <Button loading loadingIndicator="Loading…" variant="outlined">

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
@@ -5,11 +5,11 @@ import Button from '@mui/joy/Button';
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading variant="solid">
-        Send
+      <Button loading variant="outlined">
+        Default
       </Button>
       <Button loading loadingIndicator="Loading…" variant="outlined">
-        Fetch data
+        Custom
       </Button>
     </Stack>
   );

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
@@ -5,10 +5,8 @@ import Button from '@mui/joy/Button';
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading variant="outlined">
-        Default
-      </Button>
-      <Button loading loadingIndicator="Loading…" variant="outlined">
+      <Button loading>Default</Button>
+      <Button loading loadingIndicator="Loading…">
         Custom
       </Button>
     </Stack>

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import Stack from '@mui/joy/Stack';
-import SendIcon from '@mui/icons-material/Send';
 import Button from '@mui/joy/Button';
 
 export default function ButtonLoadingIndicator() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading endDecorator={<SendIcon />} variant="solid">
+      <Button loading variant="solid">
         Send
       </Button>
       <Button loading loadingIndicator="Loading…" variant="outlined">

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
@@ -1,6 +1,6 @@
-<Button loading variant="solid">
-  Send
+<Button loading variant="outlined">
+  Default
 </Button>
 <Button loading loadingIndicator="Loading…" variant="outlined">
-  Fetch data
+  Custom
 </Button>

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
@@ -1,4 +1,4 @@
-<Button loading endDecorator={<SendIcon />} variant="solid">
+<Button loading variant="solid">
   Send
 </Button>
 <Button loading loadingIndicator="Loading…" variant="outlined">

--- a/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingIndicator.tsx.preview
@@ -1,6 +1,4 @@
-<Button loading variant="outlined">
-  Default
-</Button>
-<Button loading loadingIndicator="Loading…" variant="outlined">
+<Button loading>Default</Button>
+<Button loading loadingIndicator="Loading…">
   Custom
 </Button>

--- a/docs/data/joy/components/button/ButtonLoadingPosition.js
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.js
@@ -7,15 +7,15 @@ export default function ButtonLoadingPosition() {
   return (
     <Stack spacing={2} direction="row">
       <Button loading loadingPosition="start" variant="outlined">
-        Fetch data
+        Start
       </Button>
       <Button
         loading
         loadingPosition="end"
         endDecorator={<SendIcon />}
-        variant="solid"
+        variant="outlined"
       >
-        Send
+        End
       </Button>
     </Stack>
   );

--- a/docs/data/joy/components/button/ButtonLoadingPosition.js
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.js
@@ -6,15 +6,10 @@ import Button from '@mui/joy/Button';
 export default function ButtonLoadingPosition() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading loadingPosition="start" variant="outlined">
+      <Button loading loadingPosition="start">
         Start
       </Button>
-      <Button
-        loading
-        loadingPosition="end"
-        endDecorator={<SendIcon />}
-        variant="outlined"
-      >
+      <Button loading loadingPosition="end" endDecorator={<SendIcon />}>
         End
       </Button>
     </Stack>

--- a/docs/data/joy/components/button/ButtonLoadingPosition.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.tsx
@@ -7,15 +7,15 @@ export default function ButtonLoadingPosition() {
   return (
     <Stack spacing={2} direction="row">
       <Button loading loadingPosition="start" variant="outlined">
-        Fetch data
+        Start
       </Button>
       <Button
         loading
         loadingPosition="end"
         endDecorator={<SendIcon />}
-        variant="solid"
+        variant="outlined"
       >
-        Send
+        End
       </Button>
     </Stack>
   );

--- a/docs/data/joy/components/button/ButtonLoadingPosition.tsx
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.tsx
@@ -6,15 +6,10 @@ import Button from '@mui/joy/Button';
 export default function ButtonLoadingPosition() {
   return (
     <Stack spacing={2} direction="row">
-      <Button loading loadingPosition="start" variant="outlined">
+      <Button loading loadingPosition="start">
         Start
       </Button>
-      <Button
-        loading
-        loadingPosition="end"
-        endDecorator={<SendIcon />}
-        variant="outlined"
-      >
+      <Button loading loadingPosition="end" endDecorator={<SendIcon />}>
         End
       </Button>
     </Stack>

--- a/docs/data/joy/components/button/ButtonLoadingPosition.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.tsx.preview
@@ -1,11 +1,6 @@
-<Button loading loadingPosition="start" variant="outlined">
+<Button loading loadingPosition="start">
   Start
 </Button>
-<Button
-  loading
-  loadingPosition="end"
-  endDecorator={<SendIcon />}
-  variant="outlined"
->
+<Button loading loadingPosition="end" endDecorator={<SendIcon />}>
   End
 </Button>

--- a/docs/data/joy/components/button/ButtonLoadingPosition.tsx.preview
+++ b/docs/data/joy/components/button/ButtonLoadingPosition.tsx.preview
@@ -1,11 +1,11 @@
 <Button loading loadingPosition="start" variant="outlined">
-  Fetch data
+  Start
 </Button>
 <Button
   loading
   loadingPosition="end"
   endDecorator={<SendIcon />}
-  variant="solid"
+  variant="outlined"
 >
-  Send
+  End
 </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Following a recent docs-feedback entry, this PR removes an unnecessary icon import from the Joy UI Button loading indicator demo.

**https://deploy-preview-39082--material-ui.netlify.app/joy-ui/react-button/#loading-indicator**