### PR TITLE
[website] Improve the highlighter component colors

### DIFF
--- a/docs/src/components/action/Highlighter.tsx
+++ b/docs/src/components/action/Highlighter.tsx
@@ -45,15 +45,16 @@ export default function Highlighter({
           transitionProperty: 'all',
           transitionDuration: '150ms',
           color: 'primary.300',
+          overflow: 'auto',
           ...((!disableBorder || selected) && {
             borderColor: 'grey.100',
           }),
           ...(selected && {
-            bgcolor: '#FFF',
+            bgcolor: `${alpha(theme.palette.primary[50], 0.5)}`,
             borderColor: 'primary.300',
-            boxShadow: `0px 1px 6px ${
-              (theme.vars || theme).palette.primary[100]
-            }, inset 0px 2px 8px ${(theme.vars || theme).palette.grey[50]}`,
+            boxShadow: `0px 1px 4px ${
+              (theme.vars || theme).palette.primary[200]
+            }, inset 0px 2px 4px ${alpha(theme.palette.primary[100], 0.5)}`,
             color: 'primary.500',
           }),
           ...(!selected && {
@@ -68,10 +69,9 @@ export default function Highlighter({
           ...theme.applyDarkStyles({
             color: 'primary.800',
             ...((!disableBorder || selected) && {
-              borderColor: 'primaryDark.700',
+              borderColor: `${alpha(theme.palette.primaryDark[600], 0.3)}`,
             }),
             ...(!selected && {
-              borderColor: `${alpha(theme.palette.primaryDark[600], 0.3)}`,
               '&:hover, &:focus': {
                 bgcolor: `${alpha(theme.palette.primary[800], 0.1)}`,
                 borderColor: `${alpha(theme.palette.primary[500], 0.3)}`,
@@ -84,9 +84,9 @@ export default function Highlighter({
               bgcolor: `${alpha(theme.palette.primary[800], 0.3)}`,
               borderColor: 'primary.700',
               color: 'primary.300',
-              boxShadow: `0px 1px 6px ${
-                (theme.vars || theme).palette.primary[800]
-              }, inset 0px 2px 8px ${(theme.vars || theme).palette.primaryDark[800]}`,
+              boxShadow: `0px 1px 4px ${
+                (theme.vars || theme).palette.primary[900]
+              }, inset 0px 2px 4px ${(theme.vars || theme).palette.primaryDark[800]}`,
             }),
           }),
           '&.Mui-disabled': {

--- a/docs/src/components/action/Highlighter.tsx
+++ b/docs/src/components/action/Highlighter.tsx
@@ -70,22 +70,23 @@ export default function Highlighter({
             ...((!disableBorder || selected) && {
               borderColor: 'primaryDark.700',
             }),
+            ...(!selected && {
+              borderColor: `${alpha(theme.palette.primaryDark[600], 0.3)}`,
+              '&:hover, &:focus': {
+                bgcolor: `${alpha(theme.palette.primary[800], 0.1)}`,
+                borderColor: `${alpha(theme.palette.primary[500], 0.3)}`,
+                '@media (hover: none)': {
+                  bgcolor: 'transparent',
+                },
+              },
+            }),
             ...(selected && {
-              bgcolor: `${alpha(theme.palette.primary[900], 0.3)}`,
+              bgcolor: `${alpha(theme.palette.primary[800], 0.3)}`,
               borderColor: 'primary.700',
               color: 'primary.300',
               boxShadow: `0px 1px 6px ${
                 (theme.vars || theme).palette.primary[800]
               }, inset 0px 2px 8px ${(theme.vars || theme).palette.primaryDark[800]}`,
-            }),
-            ...(!selected && {
-              '&:hover, &:focus': {
-                bgcolor: 'primaryDark.800',
-                borderColor: 'primaryDark.700',
-                '@media (hover: none)': {
-                  bgcolor: 'transparent',
-                },
-              },
             }),
           }),
           '&.Mui-disabled': {

--- a/docs/src/components/action/More.tsx
+++ b/docs/src/components/action/More.tsx
@@ -51,7 +51,7 @@ export default (function More(props: ButtonBaseProps) {
             },
           },
           ...theme.applyDarkStyles({
-            borderColor: 'primaryDark.600',
+            borderColor: `${alpha(theme.palette.primaryDark[400], 0.3)}`,
             '&:hover, &:focus': {
               bgcolor: alpha(theme.palette.primary[900], 0.4),
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds some slight color tweaks to the Highlighter website component, aiming to improve it, especially in dark mode.

**https://deploy-preview-39087--material-ui.netlify.app/material-ui/**