### PR TITLE
[website] Fix Pricing page row hover

### DIFF
--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -957,17 +957,13 @@ function renderMasterRow(key: string, gridSx: object, plans: Array<any>) {
         (theme) => ({
           '&:hover > div': {
             bgcolor: alpha(theme.palette.grey[50], 0.4),
-            '@media (hover: none)': {
-              bgcolor: 'initial',
-            },
           },
-        }),
-        (theme) =>
-          theme.applyDarkStyles({
+          ...theme.applyDarkStyles({
             '&:hover > div': {
               bgcolor: alpha(theme.palette.primaryDark[900], 0.5),
             },
           }),
+        }),
       ]}
     >
       {rowHeaders[key]}

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -924,7 +924,7 @@ function StickyHead({
         (theme) =>
           theme.applyDarkStyles({
             boxShadow: `inset 0px -1px 1px ${(theme.vars || theme).palette.primaryDark[700]}`,
-            backgroundColor: alpha(theme.palette.primaryDark[900], 0.72),
+            backgroundColor: alpha(theme.palette.primaryDark[900], 0.7),
           }),
       ]}
     >
@@ -964,8 +964,8 @@ function renderMasterRow(key: string, gridSx: object, plans: Array<any>) {
         }),
         (theme) =>
           theme.applyDarkStyles({
-            '&:hover': {
-              bgcolor: alpha(theme.palette.primaryDark[900], 0.3),
+            '&:hover > div': {
+              bgcolor: alpha(theme.palette.primaryDark[900], 0.5),
             },
           }),
       ]}


### PR DESCRIPTION
This PR fixes the row hover on dark mode, which was displaying a much lighter color than it should!

<img width="400" alt="Screenshot 2023-09-24 at 20 20 50" src="https://github.com/mui/material-ui/assets/3165635/792ba4b0-a774-442f-825d-46e64a2cb54d">


**https://deploy-preview-39097--material-ui.netlify.app/pricing/**