### PR TITLE
[joy-ui][Select] Fix keyboard navigation in Safari

### DIFF
--- a/packages/mui-joy/src/FormControl/FormControl.test.tsx
+++ b/packages/mui-joy/src/FormControl/FormControl.test.tsx
@@ -219,7 +219,7 @@ describe('<FormControl />', () => {
         </FormControl>,
       );
 
-      expect(getByLabelText('label')).to.have.attribute('disabled');
+      expect(getByLabelText('label')).to.have.attribute('aria-disabled', 'true');
     });
   });
 

--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -106,7 +106,7 @@ describe('Joy <Select />', () => {
   });
 
   it('should pass "name" as part of the event.target for onBlur', () => {
-    const handleBlur = stub().callsFake((event) => event.target.name);
+    const handleBlur = stub().callsFake((event) => event.target.getAttribute('name'));
     const { getByRole } = render(
       <Select
         name="blur-testing"
@@ -305,8 +305,8 @@ describe('Joy <Select />', () => {
     it('associated with a label', () => {
       render(
         <div>
-          <label htmlFor="foo-bar">label</label>
-          <Select id="foo-bar" />
+          <label id="foo-bar">label</label>
+          <Select aria-labelledby="foo-bar" />
         </div>,
       );
       fireEvent.mouseDown(screen.getByLabelText('label'));

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -177,7 +177,7 @@ const SelectRoot = styled('div', {
   ];
 });
 
-// Use a `div` instead of a `button` because tab selection does not work for buttons in Safari.
+// Use a `div` instead of a `button` because tab key navigation does not work for buttons in Safari.
 const SelectButton = styled('div', {
   name: 'JoySelect',
   slot: 'Button',

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -177,7 +177,8 @@ const SelectRoot = styled('div', {
   ];
 });
 
-const SelectButton = styled('button', {
+// Use a `div` instead of a `button` because tab selection does not work for buttons in Safari.
+const SelectButton = styled('div', {
   name: 'JoySelect',
   slot: 'Button',
   overridesResolver: (props, styles) => styles.button,

--- a/packages/mui-joy/src/Select/SelectProps.ts
+++ b/packages/mui-joy/src/Select/SelectProps.ts
@@ -57,7 +57,7 @@ export type SelectSlotsAndSlotProps = CreateSlotsAndSlotProps<
   SelectSlots,
   {
     root: SlotProps<'div', {}, SelectOwnerState<any>>;
-    button: SlotProps<'button', {}, SelectOwnerState<any>>;
+    button: SlotProps<'div', {}, SelectOwnerState<any>>;
     startDecorator: SlotProps<'span', {}, SelectOwnerState<any>>;
     endDecorator: SlotProps<'span', {}, SelectOwnerState<any>>;
     indicator: SlotProps<'span', {}, SelectOwnerState<any>>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #39083

To make keyboard navigation work for the `Select` component in Safari, a `div` element must be used instead of a `button` (as MUI Select does). Safari has only limited tab navigation and a button element cannot be focused out of the box. See https://caniuse.com/?search=tab for more information.