### PR TITLE
[website] Developer Advocate / DevEx Engineer role

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -146,6 +146,16 @@ const openRolesData = [
       },
     ],
   },
+  {
+    title: 'Developer Experience',
+    roles: [
+      {
+        title: 'Developer Advocate / DevEx Engineer',
+        description: 'You will delight our users and make them excited about the product roadmap.',
+        url: '/careers/developer-advocate/',
+      },
+    ],
+  },
 ];
 
 const nextRolesData = [

--- a/docs/pages/careers/developer-advocate.js
+++ b/docs/pages/careers/developer-advocate.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
+import * as pageProps from 'docs/pages/careers/developer-advocate.md?@mui/markdown';
+
+export default function Page() {
+  return <TopLayoutCareers {...pageProps} />;
+}

--- a/docs/pages/careers/developer-advocate.md
+++ b/docs/pages/careers/developer-advocate.md
@@ -4,7 +4,7 @@
 
 ## Details of the Role
 
-- **Location**: Remote (strong requirement for UTC-6 to UTC+2).
+- **Location**: Remote (strong preference for UTC-6 to UTC+2).
 - **Type of work**: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501#494af1f358794028beb4b7697b5d3102)).
 - We're a **remote** company, we prefer asynchronous communication over meetings.
 
@@ -28,19 +28,19 @@ For additional details about the MUI team and culture, you can check our [career
 
 In our [last developer survey](https://mui.com/blog/2021-developer-survey-results/#what-else-can-we-do-to-improve-mui-for-you), we learned that we have a long way to go in helping developers to be successful with our technology.
 We have underinvested in this area for too long.
-Your missing will be to lead the developer experience effort at MUI.
+Your mission will be to lead the developer experience effort at MUI.
 We are looking for someone who can contribute to the following outcomes:
 
-- Create excitement in the React community about the product roadmap.
+- Get the React community excited about our product's roadmap
 - Improve the overall developer experience, resulting in better NPS & CSAT scores, through learning content, documentation improvements, integration with other frameworks, etc.
-- Amplify the needs of the community so the product direction aims at what people need the most.
+- Focus on the community's needs ensuring the product direction is covering them.
 
 Both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 
 ## About the role
 
-We are looking for an experienced React developer to join us as a Developer Advocate to help the developers build slick UI at a speed they never experienced before, with the MUI's open-source projects.
+We are looking for an experienced React engineer to join us as a Developer Advocate to help developers build slick UI at a speed they have never experienced with MUI's open-source projects.
 
 ### Why this is interesting
 
@@ -55,7 +55,7 @@ Depending on the day, you'll:
   - Follow GitHub issues to understand where developers face frustration and develop strategies to overcome these. This could be suggesting or implementing documentation updates, or proposing or contributing code changes that solve the core issue.
   - Give feedback to product management, to influence the product roadmaps based on developers' needs.
 - **Docs**.
-  - Rework the pages of the documentation that are confusing, base on feedback.
+  - Rewrite confusing documentation pages, ensuring the writing is clear and the structure is intuitive to follow.
 - **Content**.
   - Create inspiring sample applications, documentation, and tutorials.
   - Write code where required to support how-to content, blog posts, and presentations.
@@ -67,7 +67,7 @@ Depending on the day, you'll:
   - Create & produce events (podcasts, roundtables, hackathons).
   - Manage the sponsorships of events, newsletters, etc.
   - Help other team members grow at engaging with the community. For instance by encouraging and providing critical feedback on the blog posts they create, or by keeping track of the health of community contributions.
-  - Create relationships with fellow ecosystem influencers and open-source leaders. Nurture ongoing connections with user group members to build personal relationships and deeply understand their needs, usage, journeys, and barriers to adoption.
+  - Nurture relationships with influencers and members from the React and open-source communities, fostering a connection that allows for a clear understanding of their needs, journeys, and issues.
 
 For the right candidate:
 
@@ -95,7 +95,7 @@ For the right candidate:
 - You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
 - Hands-on developer who is a skilled React engineer.
 - You are passionate about UI development.
-- You have a taste for great design UI/UX.
+- You have a taste for great product design.
 
 ### What would be nice if you had, but isn't required
 

--- a/docs/pages/careers/developer-advocate.md
+++ b/docs/pages/careers/developer-advocate.md
@@ -1,10 +1,10 @@
-# Developer Advocate
+# Developer Advocate / DevEx Engineer
 
-<p class="description">You will build a thriving and connected developer community around our suite of products.</p>
+<p class="description">You will delight our users and make them excited about the product roadmap.</p>
 
 ## Details of the Role
 
-- **Location**: Remote (strong requirement for UTC-8 to UTC+2).
+- **Location**: Remote (strong requirement for UTC-6 to UTC+2).
 - **Type of work**: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501#494af1f358794028beb4b7697b5d3102)).
 - We're a **remote** company, we prefer asynchronous communication over meetings.
 
@@ -28,19 +28,19 @@ For additional details about the MUI team and culture, you can check our [career
 
 In our [last developer survey](https://mui.com/blog/2021-developer-survey-results/#what-else-can-we-do-to-improve-mui-for-you), we learned that we have a long way to go in helping developers to be successful with our technology.
 We have underinvested in this area for too long.
-Your mission will be to be the voice of the developers of the community inside the company.
-We are looking for someone that can contribute to the following outcomes:
+Your missing will be to lead the developer experience effort at MUI.
+We are looking for someone who can contribute to the following outcomes:
 
-- Create momentum in the React community and drive adoption of the library.
-- Improve the overall developer experience, resulting in better NPS & CSAT scores, e.g., through educational content.
-- Amplify the need of the community so the product direction aims at what people need the most.
+- Create excitement in the React community about the product roadmap.
+- Improve the overall developer experience, resulting in better NPS & CSAT scores, through learning content, documentation improvements, integration with other frameworks, etc.
+- Amplify the needs of the community so the product direction aims at what people need the most.
 
 Both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 
 ## About the role
 
-We are looking for a experienced developer to join us as a Developer Advocate to help the developers get familiar with and use MUI most effectively.
+We are looking for an experienced React developer to join us as a Developer Advocate to help the developers build slick UI at a speed they never experienced before, with the MUI's open-source projects.
 
 ### Why this is interesting
 
@@ -50,28 +50,29 @@ Our products empower React developers to build awesome applications faster – w
 
 Depending on the day, you'll:
 
+- **Product**.
+  - Fix simple small annoyances in the product.
+  - Follow GitHub issues to understand where developers face frustration and develop strategies to overcome these. This could be suggesting or implementing documentation updates, or proposing or contributing code changes that solve the core issue.
+  - Give feedback to product management, to influence the product roadmaps based on developers' needs.
+- **Docs**.
+  - Rework the pages of the documentation that are confusing, base on feedback.
 - **Content**.
+  - Create inspiring sample applications, documentation, and tutorials.
+  - Write code where required to support how-to content, blog posts, and presentations.
   - Produce high-quality technical "how-to" content (blogs, webinars, demos, talks) addressing common user needs, latest technology advances, and emerging best practices. Videos might go to [our YouTube channel](https://www.youtube.com/@MUI_hq).
   - Distribute content and leverage pieces to broaden awareness of the MUI brand, via existing connections.
-  - Rework the pages of the documentation that are confusing, base on feedback.
 - **Community**.
   - Built our developer-focused community.
   - Deliver presentations at meetups, conferences, and other ecosystem events.
   - Create & produce events (podcasts, roundtables, hackathons).
   - Manage the sponsorships of events, newsletters, etc.
   - Help other team members grow at engaging with the community. For instance by encouraging and providing critical feedback on the blog posts they create, or by keeping track of the health of community contributions.
-- **Relationship-building**.
-  - Create relationships with fellow ecosystem influencers and open-source leaders.
-  - Nurture ongoing connections with user group members to build personal relationships and deeply understand their needs, usage, journeys, and barriers to adoption.
-- **Technical**.
-  - Write code where required to support how-to content, blog posts, and presentations.
-  - Create inspiring sample applications, documentation, and tutorials.
-  - Give feedback to product management, to influence the product roadmaps based on developers' needs.
-  - Follow GitHub issues to understand where developers face frustration and develop strategies to overcome these. This could be suggesting or implementing documentation updates, or proposing or contributing code changes that solve the core issue.
+  - Create relationships with fellow ecosystem influencers and open-source leaders. Nurture ongoing connections with user group members to build personal relationships and deeply understand their needs, usage, journeys, and barriers to adoption.
 
 For the right candidate:
 
-- Working with the Leadership to construct and execute on a hiring plan to grow the Developer Experience team.
+- Lead the Developer Experience team.
+- Working with the Leadership to construct and execute on a hiring plan to grow the team.
 
 ### Here are a few initiatives you might work on
 
@@ -82,25 +83,26 @@ For the right candidate:
 - Revamp the blog post infrastructure to empower the rest of the team to create more content.
 - Start a monthly newsletter to engage with the community.
 - Organize a MUIConf (once we go >50 people)
-- Think about creative ways to promote Base UI, Joy UI, MUI X, MUI X Pro, and new products.
+- Think about creative ways to promote Base UI, Joy UI, Material UI, MUI X, and new open-source projects.
 
 ## About you
 
 ### Skills you should have
 
-- You are fluent in English (both written and spoken). You'll be the face of MUI in the world, and make everyone in the company proud of the Developer Experience team.
+- You are fluent in English (both written and spoken). You'll be a face of MUI in the world, and make everyone in the company proud of the Developer Experience team.
 - You are a highly empathic person.
 - You are passionate about helping other developers solve problems and have an educational mindset.
 - You have some formal or informal experience in teaching: training, tutoring, mentoring, etc.
-- Hands-on developer who is comfortable with full-stack development.
+- Hands-on developer who is a skilled React engineer.
 - You are passionate about UI development.
+- You have a taste for great design UI/UX.
 
 ### What would be nice if you had, but isn't required
 
-- Experience in building community across some of the following channels: Twitter, YouTube, Twitch, Discord, blogs, meetups, public speaking & events
 - Experience working with open-source and/or with the open-source community.
-- Experience working with/editing video.
+- Experience in building community across some of the following channels: Twitter, YouTube, Twitch, Discord, blogs, meetups, public speaking & events
 - Experience using MUI.
+- Experience working with/editing video.
 
 ## Benefits & Compensation
 

--- a/docs/pages/careers/developer-experience-engineer.md
+++ b/docs/pages/careers/developer-experience-engineer.md
@@ -34,7 +34,7 @@ Developer Experience matters, [a lot](https://future.com/the-case-for-developer-
 We are looking for somebody to build the best developer experience ever created around a component library, earning the love of developers everywhere.
 This is about focusing on the outcome: success, that developers can have a wonderful workflow with our product.
 
-We are looking for someone that can contribute to the following outcomes:
+We are looking for someone who can contribute to the following outcomes:
 
 - Amplify the need of the community so the product direction aims at what people need the most.
 - Improve the overall developer experience, resulting in better NPS & CSAT scores.


### PR DESCRIPTION
Since DevEx owns with Product the more users flywheel, asking for reviews from the folks who the person is the most likely to work closely with. 

Preview: https://deploy-preview-39141--material-ui.netlify.app/careers/developer-advocate/

The role: https://www.notion.so/mui-org/Developer-Advocate-634b2a699266480abf8663c045768902