### PR TITLE
[zero][system] Add support for keyframes

### DIFF
--- a/apps/zero-runtime-next-app/next.config.js
+++ b/apps/zero-runtime-next-app/next.config.js
@@ -10,9 +10,7 @@ const theme = createTheme({
 // @ts-ignore
 theme.applyDarkStyles = function applyDarkStyles(obj) {
   return {
-    // @TODO - Use custom stylis plugin as in docs/src/createEmotionCache.ts
-    // so that we don't need to use *
-    '* :where([data-mui-color-scheme="dark"]) &': obj,
+    ':where([data-mui-color-scheme="dark"]) &': obj,
   };
 };
 

--- a/apps/zero-runtime-vite-app/src/App.tsx
+++ b/apps/zero-runtime-vite-app/src/App.tsx
@@ -1,12 +1,41 @@
 import * as React from 'react';
-import { styled } from '@mui/zero-runtime';
+import { styled, keyframes } from '@mui/zero-runtime';
 import Slider from './Slider/ZeroSlider';
+
+const bounce = keyframes`
+  from, 20%, 53%, 80%, to {
+    transform: translate3d(0,0,0);
+  }
+  40%, 43% {
+    transform: translate3d(0, -30px, 0);
+  }
+  70% {
+    transform: translate3d(0, -15px, 0);
+  }
+  90% {
+    transform: translate3d(0,-4px,0);
+  }
+`;
+
+const bounceAnim = keyframes({
+  'from, 20%, 53%, 80%, to': {
+    transform: 'translate3d(0,0,0)',
+  },
+  '40%, 43%': {
+    transform: 'translate3d(0, -30px, 0)',
+  },
+  '70%': {
+    transform: 'translate3d(0, -15px, 0)',
+  },
+  '90%': {
+    transform: 'translate3d(0,-4px,0)',
+  },
+});
 
 const Button = styled('button', {
   name: 'MuiButton',
   slot: 'Root',
 })(
-  'color:red',
   ({ theme }: any) => ({
     fontFamily: 'sans-serif',
     backgroundColor: [theme.palette.primary.main, 'text.primary', 'background.paper'],
@@ -30,6 +59,7 @@ const HalfWidth = styled.div({
   maxHeight: 100,
   padding: 20,
   border: '1px solid #ccc',
+  animation: [`${bounce} 1s ease infinite`, `${bounceAnim} 1s ease infinite`],
 });
 
 export default function App({ isRed }: any) {

--- a/apps/zero-runtime-vite-app/vite.config.ts
+++ b/apps/zero-runtime-vite-app/vite.config.ts
@@ -10,9 +10,7 @@ const theme = createTheme();
 // @ts-ignore
 theme.applyDarkStyles = function applyDarkStyles(obj) {
   return {
-    // @TODO - Use custom stylis plugin as in docs/src/createEmotionCache.ts
-    // so that we don't need to use *
-    '* :where([data-mui-color-scheme="dark"]) &': obj,
+    ':where([data-mui-color-scheme="dark"]) &': obj,
   };
 };
 

--- a/packages/zero-next-plugin/src/loaders/transformLoader.ts
+++ b/packages/zero-next-plugin/src/loaders/transformLoader.ts
@@ -10,6 +10,7 @@
 import type { PluginOptions, Preprocessor, Result } from '@linaria/babel-preset';
 import { transform } from '@linaria/babel-preset';
 import path from 'path';
+import { preprocessor as baseProcessor } from '@mui/zero-tag-processor/preprocessor';
 import { transformAsync as babelTransformAsync } from '@babel/core';
 import type { RawLoaderDefinitionFunction } from 'webpack';
 
@@ -55,7 +56,7 @@ const transformLoader: LoaderType = function transformLoader(content, inputSourc
 
   const {
     sourceMap = undefined,
-    preprocessor = undefined,
+    preprocessor = baseProcessor,
     moduleStore,
     ...rest
   } = this.getOptions() || {};

--- a/packages/zero-runtime/package.json
+++ b/packages/zero-runtime/package.json
@@ -62,7 +62,8 @@
     "tags": {
       "styled": "@mui/zero-tag-processor/styled",
       "default": "@mui/zero-tag-processor/styled",
-      "sx": "@mui/zero-tag-processor/sx"
+      "sx": "@mui/zero-tag-processor/sx",
+      "keyframes": "@mui/zero-tag-processor/keyframes"
     }
   }
 }

--- a/packages/zero-runtime/src/index.ts
+++ b/packages/zero-runtime/src/index.ts
@@ -1,5 +1,6 @@
 import styled from './styled';
 import sx from './sx';
+import keyframes from './keyframes';
 
-export { styled, sx };
+export { styled, sx, keyframes };
 export default styled;

--- a/packages/zero-runtime/src/keyframes.d.ts
+++ b/packages/zero-runtime/src/keyframes.d.ts
@@ -1,0 +1,4 @@
+// @TODO - Implement correct style definitions
+type Primitve = string | null | undefined | boolean | number;
+export default function keyframes(arg: Record<string, any>): string;
+export default function keyframes(arg: TemplateStringsArray, ...templateArgs: Primitve[]): string;

--- a/packages/zero-runtime/src/keyframes.js
+++ b/packages/zero-runtime/src/keyframes.js
@@ -1,0 +1,5 @@
+export default function keyframes() {
+  throw new Error(
+    'MUI: You were trying to call "keyframes" function without configuring your bundler. Make sure to install the bundler specific plugin and use it. @mui/zero-vite-plugin for Vite integration or @mui/zero-next-plugin for Next.js integration.',
+  );
+}

--- a/packages/zero-tag-processor/package.json
+++ b/packages/zero-tag-processor/package.json
@@ -48,7 +48,8 @@
     "@linaria/tags": "^4.5.4",
     "@linaria/utils": "^4.5.3",
     "@mui/system": "^5.14.11",
-    "lodash.get": "^4.4.2"
+    "lodash.get": "^4.4.2",
+    "stylis": "^4.2.0"
   },
   "devDependencies": {
     "@mui/material": "^5.14.11",
@@ -58,7 +59,8 @@
     "@types/chai": "^4.3.6",
     "@types/lodash.get": "^4.4.7",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.18.0"
+    "@types/node": "^18.18.0",
+    "@types/stylis": "^4.2.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/zero-tag-processor/src/base-processor.ts
+++ b/packages/zero-tag-processor/src/base-processor.ts
@@ -1,0 +1,44 @@
+import {
+  BaseProcessor as LinariaBaseProcessor,
+  toValidCSSIdentifier,
+  buildSlug,
+} from '@linaria/tags';
+import { slugify, type IVariableContext } from '@linaria/utils';
+
+export default abstract class BaseProcessor extends LinariaBaseProcessor {
+  variableIdx = 0;
+
+  // Implementation taken from Linaria - https://github.com/callstack/linaria/blob/master/packages/react/src/processors/styled.ts#L284
+  protected getCustomVariableId(cssKey: string, source: string, hasUnit: boolean) {
+    const context = this.getVariableContext(cssKey, source, hasUnit);
+    const customSlugFn = this.options.variableNameSlug;
+    if (!customSlugFn) {
+      return toValidCSSIdentifier(`${this.slug}-${context.index}`);
+    }
+
+    return typeof customSlugFn === 'function'
+      ? customSlugFn(context)
+      : buildSlug(customSlugFn, { ...context });
+  }
+
+  // Implementation taken from Linaria - https://github.com/callstack/linaria/blob/master/packages/react/src/processors/styled.ts#L362
+  protected getVariableContext(cssKey: string, source: string, hasUnit: boolean): IVariableContext {
+    const getIndex = () => {
+      // eslint-disable-next-line no-plusplus
+      return this.variableIdx++;
+    };
+
+    return {
+      componentName: this.displayName,
+      componentSlug: this.slug,
+      get index() {
+        return getIndex();
+      },
+      precedingCss: cssKey,
+      processor: this.constructor.name,
+      source: '',
+      unit: '',
+      valueSlug: slugify(`${source}${hasUnit}`),
+    };
+  }
+}

--- a/packages/zero-tag-processor/src/keyframes.ts
+++ b/packages/zero-tag-processor/src/keyframes.ts
@@ -1,0 +1,154 @@
+import type { Expression } from '@babel/types';
+import { validateParams } from '@linaria/tags';
+import type {
+  CallParam,
+  TemplateParam,
+  Params,
+  TailProcessorParams,
+  ValueCache,
+} from '@linaria/tags';
+import type { Replacements, Rules } from '@linaria/utils';
+import { ValueType } from '@linaria/utils';
+import type { CSSInterpolation } from '@emotion/css';
+import BaseProcessor from './base-processor';
+import type { IOptions } from './styled';
+import { cache, keyframes } from './utils/emotion';
+
+type Primitive = string | number | boolean | null | undefined;
+
+export default class KeyframesProcessor extends BaseProcessor {
+  callParam: CallParam | TemplateParam;
+
+  constructor(params: Params, ...args: TailProcessorParams) {
+    super(params, ...args);
+    if (params.length < 2) {
+      throw BaseProcessor.SKIP;
+    }
+    validateParams(
+      params,
+      ['callee', ['call', 'template']],
+      `Invalid use of ${this.tagSource.imported} tag.`,
+    );
+
+    const [, callParams] = params;
+    if (callParams[0] === 'call') {
+      this.dependencies.push(callParams[1]);
+    } else if (callParams[0] === 'template') {
+      callParams[1].forEach((element) => {
+        if ('kind' in element && element.kind !== ValueType.CONST) {
+          this.dependencies.push(element);
+        }
+      });
+    }
+    this.callParam = callParams;
+  }
+
+  build(values: ValueCache) {
+    if (this.artifacts.length > 0) {
+      throw new Error('Tag is already built');
+    }
+
+    const [callType] = this.callParam;
+
+    if (callType === 'template') {
+      this.handleTemplate(this.callParam, values);
+    } else {
+      this.handleCall(this.callParam, values);
+    }
+  }
+
+  private handleTemplate([, callArgs]: TemplateParam, values: ValueCache) {
+    const templateStrs: string[] = [];
+    const templateExpressions: Primitive[] = [];
+    callArgs.forEach((item) => {
+      if ('kind' in item) {
+        switch (item.kind) {
+          case ValueType.FUNCTION:
+            throw item.buildCodeFrameError(
+              'Functions are not allowed to be interpolated in keyframes tag.',
+            );
+          case ValueType.CONST:
+            templateExpressions.push(item.value);
+            break;
+          case ValueType.LAZY: {
+            const evaluatedValue = values.get(item.ex.name);
+            if (typeof evaluatedValue === 'function') {
+              throw item.buildCodeFrameError(
+                'Functions are not allowed to be interpolated in keyframes tag.',
+              );
+            } else {
+              templateExpressions.push(evaluatedValue as Primitive);
+            }
+            break;
+          }
+          default:
+            break;
+        }
+      } else if (item.type === 'TemplateElement') {
+        templateStrs.push(item.value.cooked as string);
+      }
+    });
+    this.generateArtifacts(templateStrs, ...templateExpressions);
+  }
+
+  generateArtifacts(styleObjOrTaggged: CSSInterpolation | string[], ...args: Primitive[]) {
+    const keyframeName = keyframes(styleObjOrTaggged, ...args);
+    const cacheCssText = cache.inserted[keyframeName.replace('animation-', '')] as string;
+    const cssText = cacheCssText.replaceAll(keyframeName, '');
+
+    const rules: Rules = {
+      [this.asSelector]: {
+        className: this.className,
+        cssText,
+        displayName: this.displayName,
+        start: this.location?.start ?? null,
+      },
+    };
+    const sourceMapReplacements: Replacements = [
+      {
+        length: cssText.length,
+        original: {
+          start: {
+            column: this.location?.start.column ?? 0,
+            line: this.location?.start.line ?? 0,
+          },
+          end: {
+            column: this.location?.end.column ?? 0,
+            line: this.location?.end.line ?? 0,
+          },
+        },
+      },
+    ];
+    this.artifacts.push(['css', [rules, sourceMapReplacements]]);
+  }
+
+  private handleCall([, callArg]: CallParam, values: ValueCache) {
+    let styleObj: CSSInterpolation;
+    if (callArg.kind === ValueType.LAZY) {
+      styleObj = values.get(callArg.ex.name) as CSSInterpolation;
+    } else if (callArg.kind === ValueType.FUNCTION) {
+      const { themeArgs } = this.options as IOptions;
+      const value = values.get(callArg.ex.name) as Function;
+      styleObj = value(themeArgs) as CSSInterpolation;
+    }
+    if (styleObj) {
+      this.generateArtifacts(styleObj);
+    }
+  }
+
+  doEvaltimeReplacement() {
+    this.replacer(this.value, false);
+  }
+
+  doRuntimeReplacement() {
+    this.doEvaltimeReplacement();
+  }
+
+  get asSelector() {
+    return this.className;
+  }
+
+  get value(): Expression {
+    return this.astService.stringLiteral(this.className);
+  }
+}

--- a/packages/zero-tag-processor/src/preprocessor.ts
+++ b/packages/zero-tag-processor/src/preprocessor.ts
@@ -1,0 +1,29 @@
+import type { Element } from 'stylis';
+import { serialize, compile, stringify, middleware } from 'stylis';
+
+function globalSelector(element: Element) {
+  switch (element.type) {
+    case 'rule':
+      element.props = (element.props as string[]).map((value: any) => {
+        if (value.match(/(:where|:is)\(/)) {
+          value = value.replace(/\.[^:]+(:where|:is)/, '$1');
+          return value;
+        }
+        return value;
+      });
+      break;
+    default:
+      break;
+  }
+}
+
+const serializer = middleware([globalSelector, stringify]);
+
+const stylis = (css: string) => serialize(compile(css), serializer);
+
+export function preprocessor(selector: string, cssText: string) {
+  if (cssText.startsWith('@keyframes')) {
+    return stylis(cssText.replace('@keyframes', `@keyframes ${selector}`));
+  }
+  return stylis(`${selector}{${cssText}}`);
+}

--- a/packages/zero-tag-processor/src/styled.ts
+++ b/packages/zero-tag-processor/src/styled.ts
@@ -1,4 +1,4 @@
-import { BaseProcessor, buildSlug, toValidCSSIdentifier, validateParams } from '@linaria/tags';
+import { validateParams } from '@linaria/tags';
 import type {
   Expression,
   Params,
@@ -7,14 +7,8 @@ import type {
   IOptions as IBaseOptions,
   WrappedNode,
 } from '@linaria/tags';
-import { ValueType, slugify } from '@linaria/utils';
-import type {
-  IVariableContext,
-  Rules,
-  Replacements,
-  ExpressionValue,
-  LazyValue,
-} from '@linaria/utils';
+import { ValueType } from '@linaria/utils';
+import type { Rules, Replacements, ExpressionValue, LazyValue } from '@linaria/utils';
 import { parseExpression } from '@babel/parser';
 import type { SourceLocation } from '@babel/types';
 import type { Theme } from '@mui/material/styles';
@@ -22,6 +16,7 @@ import type { PluginCustomOptions } from './utils/cssFnValueToVariable';
 import { cssFnValueToVariable } from './utils/cssFnValueToVariable';
 import { processCssObject } from './utils/processCssObject';
 import { valueToLiteral } from './utils/valueToLiteral';
+import BaseProcessor from './base-processor';
 
 type VariantData = {
   props: Record<string, string | number | boolean | null>;
@@ -121,10 +116,14 @@ export default class StyledProcessor extends BaseProcessor {
   constructor(params: Params, ...args: TailProcessorParams) {
     super(params, ...args);
     if (params.length <= 2) {
-      // no need to do any processing if it is an already transformed call.
+      // no need to do any processing if it is an already transformed call or just a reference.
       throw BaseProcessor.SKIP;
     }
-    validateParams(params, ['callee', ['call', 'member'], ['call', 'template']], 'Invalid params');
+    validateParams(
+      params,
+      ['callee', ['call', 'member'], ['call', 'template']],
+      `Invalid use of ${this.tagSource.imported} tag.`,
+    );
     const [call, memberOrCall, styleCall] = params;
     const [callType, componentArg, componentMetaArg] = memberOrCall;
     const [, ...styleArgs] = styleCall;
@@ -170,15 +169,14 @@ export default class StyledProcessor extends BaseProcessor {
     }
   }
 
-  getClassName(key?: string) {
-    const mapKey = key ?? 'base';
-    if (!this.counterMap.has(mapKey)) {
-      this.counterMap.set(mapKey, 0);
+  getClassName(key = 'base') {
+    if (!this.counterMap.has(key)) {
+      this.counterMap.set(key, 0);
     }
-    const currentCount = this.counterMap.get(mapKey) as number;
-    this.counterMap.set(mapKey, currentCount + 1);
+    const currentCount = this.counterMap.get(key) as number;
+    this.counterMap.set(key, currentCount + 1);
 
-    return `${this.className}${mapKey === 'base' ? '' : `-${mapKey}`}${
+    return `${this.className}${key === 'base' ? '' : `-${key}`}${
       currentCount > 0 ? `-${currentCount}` : ''
     }`;
   }
@@ -200,9 +198,9 @@ export default class StyledProcessor extends BaseProcessor {
   }
 
   /**
-   * This is called by linaria after evaluating the code. Here, we get access to
-   * the actual values of the `styled` arguments which we can use to generate our styles.
-   *
+   * This is called by linaria after evaluating the code. Here, we
+   * get access to the actual values of the `styled` arguments
+   * which we can use to generate our styles.
    * Order of processing styles -
    * 1. CSS directly declared in styled call
    * 2. CSS declared in theme object's styledOverrides
@@ -211,7 +209,7 @@ export default class StyledProcessor extends BaseProcessor {
    */
   build(values: ValueCache): void {
     // all the variant definitions are collected here so that we can
-    // variant styles after base styles for more specific targetting.
+    // apply variant styles after base styles for more specific targetting.
     const variantsAccumulator: VariantData[] = [];
     this.styleArgs.forEach((styleArg) => {
       this.processStyle(values, styleArg, variantsAccumulator);
@@ -331,7 +329,10 @@ export default class StyledProcessor extends BaseProcessor {
       );
     }
     this.replacer(
-      t.callExpression(this.callee, [componentName, t.objectExpression(argProperties)]),
+      t.callExpression(t.addNamedImport('styled', '@mui/zero-runtime'), [
+        componentName,
+        t.objectExpression(argProperties),
+      ]),
       true,
     );
   }
@@ -440,40 +441,6 @@ export default class StyledProcessor extends BaseProcessor {
       this.collectedVariables.push(...res);
     }
     return processCssObject(styleObj, themeArgs);
-  }
-
-  // Implementation taken from Linaria - https://github.com/callstack/linaria/blob/master/packages/react/src/processors/styled.ts#L284
-  protected getCustomVariableId(cssKey: string, source: string, hasUnit: boolean) {
-    const context = this.getVariableContext(cssKey, source, hasUnit);
-    const customSlugFn = this.options.variableNameSlug;
-    if (!customSlugFn) {
-      return toValidCSSIdentifier(`${this.slug}-${context.index}`);
-    }
-
-    return typeof customSlugFn === 'function'
-      ? customSlugFn(context)
-      : buildSlug(customSlugFn, context);
-  }
-
-  // Implementation taken from Linaria - https://github.com/callstack/linaria/blob/master/packages/react/src/processors/styled.ts#L362
-  protected getVariableContext(cssKey: string, source: string, hasUnit: boolean): IVariableContext {
-    const getIndex = () => {
-      // eslint-disable-next-line no-plusplus
-      return this.variableIdx++;
-    };
-
-    return {
-      componentName: this.displayName,
-      componentSlug: this.slug,
-      get index() {
-        return getIndex();
-      },
-      precedingCss: cssKey,
-      processor: this.constructor.name,
-      source: '',
-      unit: '',
-      valueSlug: slugify(`${source}${hasUnit}`),
-    };
   }
 
   public override get asSelector(): string {

--- a/packages/zero-tag-processor/src/utils/emotion.ts
+++ b/packages/zero-tag-processor/src/utils/emotion.ts
@@ -1,0 +1,8 @@
+import createEmotion from '@emotion/css/create-instance';
+
+const { keyframes, cache, css } = createEmotion({
+  stylisPlugins: [],
+  key: 'zero',
+});
+
+export { keyframes, cache, css };

--- a/packages/zero-tag-processor/src/utils/processCssObject.ts
+++ b/packages/zero-tag-processor/src/utils/processCssObject.ts
@@ -1,7 +1,7 @@
 import type { CSSObject } from '@emotion/css';
-import { css, cache } from '@emotion/css';
 // @TODO - Ideally, this should be replicated here instead of importing.
 import styleFunctionSx from '@mui/system/styleFunctionSx';
+import { css, cache } from './emotion';
 import type { PluginCustomOptions } from './cssFnValueToVariable';
 
 export function processCssObject(cssObj: object, themeArgs?: PluginCustomOptions['themeArgs']) {

--- a/packages/zero-vite-plugin/src/index.ts
+++ b/packages/zero-vite-plugin/src/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin, PluginOption } from 'vite';
 import { generateCss } from '@mui/zero-tag-processor/generateCss';
+import { preprocessor } from '@mui/zero-tag-processor/preprocessor';
 import { transformAsync } from '@babel/core';
 import baseLinaria from '@linaria/vite';
 
@@ -26,7 +27,10 @@ type LinariaWrapperOptions = Exclude<ZeroVitePluginOptions, 'theme'> & {
 };
 
 const linaria = (options: LinariaWrapperOptions): Plugin => {
-  return baseLinaria(options);
+  return baseLinaria({
+    preprocessor,
+    ...options,
+  });
 };
 
 export function zeroVitePlugin(options: ZeroVitePluginOptions): PluginOption {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,9 +3088,9 @@
     picomatch "^2.2.2"
 
 "@rollup/pluginutils@^5.0.1":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
-  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.4.tgz#74f808f9053d33bafec0cc98e7b835c9667d32ba"
+  integrity sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==
   dependencies:
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
@@ -7625,9 +7625,9 @@ entities@^2.0.0:
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
-  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@~3.0.1:
   version "3.0.1"
@@ -16313,7 +16313,7 @@ stylis@^3.5.4:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
-stylis@^4.3.0:
+stylis@^4.2.0, stylis@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
   integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==


### PR DESCRIPTION
* The functionality is same as in [Emotion](https://emotion.sh/docs/@emotion/css#animation-keyframes).
* This PR also adds custom preprocessor as the default one had issues when using an animation name in the CSS.
* Added custom stylis plugin support as well. This will let us apply dark theme styles without hacky CSS.
