### PR TITLE
[docs] Update Autocomplete demo for React 18

### DIFF
--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -147,7 +147,6 @@ export default function Virtualize() {
       groupBy={(option) => option[0].toUpperCase()}
       renderInput={(params) => <TextField {...params} label="10,000 options" />}
       renderOption={(props, option, state) => [props, option, state.index]}
-      // TODO: Post React 18 update - validate this conversion, look like a hidden bug
       renderGroup={(params) => params}
     />
   );

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -56,9 +56,9 @@ const ListboxComponent = React.forwardRef<
   React.HTMLAttributes<HTMLElement>
 >(function ListboxComponent(props, ref) {
   const { children, ...other } = props;
-  const itemData: React.ReactChild[] = [];
-  (children as React.ReactChild[]).forEach(
-    (item: React.ReactChild & { children?: React.ReactChild[] }) => {
+  const itemData: React.ReactElement[] = [];
+  (children as React.ReactElement[]).forEach(
+    (item: React.ReactElement & { children?: React.ReactElement[] }) => {
       itemData.push(item);
       itemData.push(...(item.children || []));
     },
@@ -71,7 +71,7 @@ const ListboxComponent = React.forwardRef<
   const itemCount = itemData.length;
   const itemSize = smUp ? 36 : 48;
 
-  const getChildSize = (child: React.ReactChild) => {
+  const getChildSize = (child: React.ReactElement) => {
     if (child.hasOwnProperty('group')) {
       return 48;
     }
@@ -149,8 +149,7 @@ export default function Virtualize() {
       renderOption={(props, option, state) =>
         [props, option, state.index] as React.ReactNode
       }
-      // TODO: Post React 18 update - validate this conversion, look like a hidden bug
-      renderGroup={(params) => params as unknown as React.ReactNode}
+      renderGroup={(params) => params as any}
     />
   );
 }

--- a/docs/data/material/components/autocomplete/Virtualize.tsx.preview
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx.preview
@@ -10,6 +10,5 @@
   renderOption={(props, option, state) =>
     [props, option, state.index] as React.ReactNode
   }
-  // TODO: Post React 18 update - validate this conversion, look like a hidden bug
-  renderGroup={(params) => params as unknown as React.ReactNode}
+  renderGroup={(params) => params as any}
 />


### PR DESCRIPTION
ReactChild is deprecated since https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59879

<img width="516" alt="Screenshot 2023-09-26 at 01 24 14" src="https://github.com/mui/material-ui/assets/3165635/9384f574-5b56-4283-bbdb-96ff4979936c">

Solve some of https://mui-org.slack.com/archives/C041SDSF32L/p1695112647646069

Preview: https://deploy-preview-39162--material-ui.netlify.app/material-ui/react-autocomplete/#virtualization