### PR TITLE
[material-next][TextField] Copy v5 TextField's inner components

### DIFF
--- a/packages/mui-material-next/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/mui-material-next/src/FormHelperText/FormHelperText.d.ts
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableComponent, OverrideProps, OverridableStringUnion } from '@mui/types';
+import { Theme } from '../styles';
+import { FormHelperTextClasses } from './formHelperTextClasses';
+
+export interface FormHelperTextPropsVariantOverrides {}
+
+export interface FormHelperTextOwnProps {
+  /**
+   * The content of the component.
+   *
+   * If `' '` is provided, the component reserves one line height for displaying a future message.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<FormHelperTextClasses>;
+  /**
+   * If `true`, the helper text should be displayed in a disabled state.
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, helper text should be displayed in an error state.
+   */
+  error?: boolean;
+  /**
+   * If `true`, the helper text should use filled classes key.
+   */
+  filled?: boolean;
+  /**
+   * If `true`, the helper text should use focused classes key.
+   */
+  focused?: boolean;
+  /**
+   * If `dense`, will adjust vertical spacing. This is normally obtained via context from
+   * FormControl.
+   */
+  margin?: 'dense';
+  /**
+   * If `true`, the helper text should use required classes key.
+   */
+  required?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The variant to use.
+   */
+  variant?: OverridableStringUnion<
+    'standard' | 'outlined' | 'filled',
+    FormHelperTextPropsVariantOverrides
+  >;
+}
+
+export interface FormHelperTextTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'p',
+> {
+  props: AdditionalProps & FormHelperTextOwnProps;
+  defaultComponent: RootComponent;
+}
+/**
+ *
+ * Demos:
+ *
+ * - [Text Field](https://mui.com/material-ui/react-text-field/)
+ *
+ * API:
+ *
+ * - [FormHelperText API](https://mui.com/material-ui/api/form-helper-text/)
+ */
+declare const FormHelperText: OverridableComponent<FormHelperTextTypeMap>;
+
+export type FormHelperTextProps<
+  RootComponent extends React.ElementType = FormHelperTextTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FormHelperTextTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default FormHelperText;

--- a/packages/mui-material-next/src/FormHelperText/FormHelperText.js
+++ b/packages/mui-material-next/src/FormHelperText/FormHelperText.js
@@ -1,0 +1,189 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import formControlState from '../FormControl/formControlState';
+import useFormControl from '../FormControl/useFormControl';
+import styled from '../styles/styled';
+import formHelperTextClasses, { getFormHelperTextUtilityClasses } from './formHelperTextClasses';
+import useThemeProps from '../styles/useThemeProps';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, contained, size, disabled, error, filled, focused, required } = ownerState;
+  const slots = {
+    root: [
+      'root',
+      disabled && 'disabled',
+      error && 'error',
+      size && `size${capitalize(size)}`,
+      contained && 'contained',
+      focused && 'focused',
+      filled && 'filled',
+      required && 'required',
+    ],
+  };
+
+  return composeClasses(slots, getFormHelperTextUtilityClasses, classes);
+};
+
+const FormHelperTextRoot = styled('p', {
+  name: 'MuiFormHelperText',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      ownerState.size && styles[`size${capitalize(ownerState.size)}`],
+      ownerState.contained && styles.contained,
+      ownerState.filled && styles.filled,
+    ];
+  },
+})(({ theme, ownerState }) => ({
+  color: (theme.vars || theme).palette.text.secondary,
+  ...theme.typography.caption,
+  textAlign: 'left',
+  marginTop: 3,
+  marginRight: 0,
+  marginBottom: 0,
+  marginLeft: 0,
+  [`&.${formHelperTextClasses.disabled}`]: {
+    color: (theme.vars || theme).palette.text.disabled,
+  },
+  [`&.${formHelperTextClasses.error}`]: {
+    color: (theme.vars || theme).palette.error.main,
+  },
+  ...(ownerState.size === 'small' && {
+    marginTop: 4,
+  }),
+  ...(ownerState.contained && {
+    marginLeft: 14,
+    marginRight: 14,
+  }),
+}));
+
+const FormHelperText = React.forwardRef(function FormHelperText(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiFormHelperText' });
+  const {
+    children,
+    className,
+    component = 'p',
+    disabled,
+    error,
+    filled,
+    focused,
+    margin,
+    required,
+    variant,
+    ...other
+  } = props;
+
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['variant', 'size', 'disabled', 'error', 'filled', 'focused', 'required'],
+  });
+
+  const ownerState = {
+    ...props,
+    component,
+    contained: fcs.variant === 'filled' || fcs.variant === 'outlined',
+    variant: fcs.variant,
+    size: fcs.size,
+    disabled: fcs.disabled,
+    error: fcs.error,
+    filled: fcs.filled,
+    focused: fcs.focused,
+    required: fcs.required,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <FormHelperTextRoot
+      as={component}
+      ownerState={ownerState}
+      className={clsx(classes.root, className)}
+      ref={ref}
+      {...other}
+    >
+      {children === ' ' ? (
+        // notranslate needed while Google Translate will not fix zero-width space issue
+        <span className="notranslate">&#8203;</span>
+      ) : (
+        children
+      )}
+    </FormHelperTextRoot>
+  );
+});
+
+FormHelperText.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   *
+   * If `' '` is provided, the component reserves one line height for displaying a future message.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, the helper text should be displayed in a disabled state.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, helper text should be displayed in an error state.
+   */
+  error: PropTypes.bool,
+  /**
+   * If `true`, the helper text should use filled classes key.
+   */
+  filled: PropTypes.bool,
+  /**
+   * If `true`, the helper text should use focused classes key.
+   */
+  focused: PropTypes.bool,
+  /**
+   * If `dense`, will adjust vertical spacing. This is normally obtained via context from
+   * FormControl.
+   */
+  margin: PropTypes.oneOf(['dense']),
+  /**
+   * If `true`, the helper text should use required classes key.
+   */
+  required: PropTypes.bool,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['filled', 'outlined', 'standard']),
+    PropTypes.string,
+  ]),
+};
+
+export default FormHelperText;

--- a/packages/mui-material-next/src/FormHelperText/FormHelperText.spec.tsx
+++ b/packages/mui-material-next/src/FormHelperText/FormHelperText.spec.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { expectType } from '@mui/types';
+import FormHelperText, { FormHelperTextProps } from '@mui/material-next/FormHelperText';
+
+const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> =
+  function CustomComponent() {
+    return <div />;
+  };
+
+const props1: FormHelperTextProps<'div'> = {
+  component: 'div',
+  onChange: (event) => {
+    expectType<React.FormEvent<HTMLDivElement>, typeof event>(event);
+  },
+};
+
+const props2: FormHelperTextProps = {
+  onChange: (event) => {
+    expectType<React.FormEvent<HTMLParagraphElement>, typeof event>(event);
+  },
+};
+
+const props3: FormHelperTextProps<typeof CustomComponent> = {
+  component: CustomComponent,
+  stringProp: '2',
+  numberProp: 2,
+};
+
+const props4: FormHelperTextProps<typeof CustomComponent> = {
+  component: CustomComponent,
+  stringProp: '2',
+  numberProp: 2,
+  // @ts-expect-error CustomComponent does not accept incorrectProp
+  incorrectProp: 3,
+};
+
+// @ts-expect-error missing props
+const props5: FormHelperTextProps<typeof CustomComponent> = {
+  component: CustomComponent,
+};
+
+const TestComponent = () => {
+  return (
+    <React.Fragment>
+      <FormHelperText />
+      <FormHelperText component={'a'} href="/test" />
+
+      <FormHelperText component={CustomComponent} stringProp="s" numberProp={1} />
+      {
+        // @ts-expect-error missing props
+        <FormHelperText component={CustomComponent} />
+      }
+      <FormHelperText
+        component="span"
+        onChange={(event) => {
+          expectType<React.FormEvent<HTMLSpanElement>, typeof event>(event);
+        }}
+      />
+    </React.Fragment>
+  );
+};

--- a/packages/mui-material-next/src/FormHelperText/FormHelperText.test.js
+++ b/packages/mui-material-next/src/FormHelperText/FormHelperText.test.js
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import FormHelperText, { formHelperTextClasses as classes } from '@mui/material/FormHelperText';
+import FormControl from '@mui/material/FormControl';
+
+describe('<FormHelperText />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<FormHelperText />, () => ({
+    classes,
+    inheritComponent: 'p',
+    render,
+    refInstanceof: window.HTMLParagraphElement,
+    testComponentPropWith: 'div',
+    muiName: 'MuiFormHelperText',
+    testVariantProps: { size: 'small' },
+    skip: ['componentsProp'],
+  }));
+
+  describe('prop: error', () => {
+    it('should have an error class', () => {
+      const { container } = render(<FormHelperText error />);
+      expect(container.firstChild).to.have.class(classes.error);
+    });
+  });
+
+  describe('with FormControl', () => {
+    ['error', 'disabled'].forEach((visualState) => {
+      describe(visualState, () => {
+        function FormHelperTextInFormControl(props) {
+          return (
+            <FormControl {...{ [visualState]: true }}>
+              <FormHelperText {...props}>Foo</FormHelperText>
+            </FormControl>
+          );
+        }
+
+        it(`should have the ${visualState} class`, () => {
+          const { getByText } = render(
+            <FormHelperTextInFormControl>Foo</FormHelperTextInFormControl>,
+          );
+
+          expect(getByText(/Foo/)).to.have.class(classes[visualState]);
+        });
+
+        it('should be overridden by props', () => {
+          const { getByText, setProps } = render(
+            <FormHelperTextInFormControl {...{ [visualState]: false }}>
+              Foo
+            </FormHelperTextInFormControl>,
+          );
+
+          expect(getByText(/Foo/)).not.to.have.class(classes[visualState]);
+
+          setProps({ [visualState]: true });
+          expect(getByText(/Foo/)).to.have.class(classes[visualState]);
+        });
+      });
+    });
+
+    describe('size', () => {
+      describe('small margin FormControl', () => {
+        it('should have the small class', () => {
+          const { getByText } = render(
+            <FormControl size="small">
+              <FormHelperText>Foo</FormHelperText>
+            </FormControl>,
+          );
+
+          expect(getByText(/Foo/)).to.have.class(classes.sizeSmall);
+        });
+      });
+
+      it('should be overridden by props', () => {
+        function FormHelperTextInFormControl(props) {
+          return (
+            <FormControl size="medium">
+              <FormHelperText {...props}>Foo</FormHelperText>
+            </FormControl>
+          );
+        }
+
+        const { getByText, setProps } = render(
+          <FormHelperTextInFormControl>Foo</FormHelperTextInFormControl>,
+        );
+
+        expect(getByText(/Foo/)).not.to.have.class(classes.sizeSmall);
+        setProps({ size: 'small' });
+        expect(getByText(/Foo/)).to.have.class(classes.sizeSmall);
+      });
+    });
+  });
+});

--- a/packages/mui-material-next/src/FormHelperText/formHelperTextClasses.ts
+++ b/packages/mui-material-next/src/FormHelperText/formHelperTextClasses.ts
@@ -1,0 +1,43 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface FormHelperTextClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** State class applied to the root element if `error={true}`. */
+  error: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the root element if `variant="filled"` or `variant="outlined"`. */
+  contained: string;
+  /** State class applied to the root element if `focused={true}`. */
+  focused: string;
+  /** State class applied to the root element if `filled={true}`. */
+  filled: string;
+  /** State class applied to the root element if `required={true}`. */
+  required: string;
+}
+
+export type FormHelperTextClassKey = keyof FormHelperTextClasses;
+
+export function getFormHelperTextUtilityClasses(slot: string): string {
+  return generateUtilityClass('MuiFormHelperText', slot);
+}
+
+const formHelperTextClasses: FormHelperTextClasses = generateUtilityClasses('MuiFormHelperText', [
+  'root',
+  'error',
+  'disabled',
+  'sizeSmall',
+  'sizeMedium',
+  'contained',
+  'focused',
+  'filled',
+  'required',
+]);
+
+export default formHelperTextClasses;

--- a/packages/mui-material-next/src/FormHelperText/index.d.ts
+++ b/packages/mui-material-next/src/FormHelperText/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './FormHelperText';
+export * from './FormHelperText';
+
+export { default as formHelperTextClasses } from './formHelperTextClasses';
+export * from './formHelperTextClasses';

--- a/packages/mui-material-next/src/FormHelperText/index.js
+++ b/packages/mui-material-next/src/FormHelperText/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './FormHelperText';
+
+export { default as formHelperTextClasses } from './formHelperTextClasses';
+export * from './formHelperTextClasses';

--- a/packages/mui-material-next/src/FormLabel/FormLabel.d.ts
+++ b/packages/mui-material-next/src/FormLabel/FormLabel.d.ts
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import {
+  OverridableStringUnion,
+  OverridableComponent,
+  OverrideProps,
+  OverridableTypeMap,
+} from '@mui/types';
+import { Theme } from '../styles';
+import { FormLabelClasses } from './formLabelClasses';
+
+export interface FormLabelPropsColorOverrides {}
+
+/**
+ * This type is kept for compatibility. Use `FormLabelOwnProps` instead.
+ */
+export type FormLabelBaseProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export interface FormLabelOwnProps {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<FormLabelClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   */
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+    FormLabelPropsColorOverrides
+  >;
+  /**
+   * If `true`, the label should be displayed in a disabled state.
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the label is displayed in an error state.
+   */
+  error?: boolean;
+  /**
+   * If `true`, the label should use filled classes key.
+   */
+  filled?: boolean;
+  /**
+   * If `true`, the input of this label is focused (used by `FormGroup` components).
+   */
+  focused?: boolean;
+  /**
+   * If `true`, the label will indicate that the `input` is required.
+   */
+  required?: boolean;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+}
+
+export interface FormLabelTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'label',
+> {
+  props: AdditionalProps & FormLabelBaseProps & FormLabelOwnProps;
+  defaultComponent: RootComponent;
+}
+
+/**
+ *
+ * Demos:
+ *
+ * - [Checkbox](https://mui.com/material-ui/react-checkbox/)
+ * - [Radio Group](https://mui.com/material-ui/react-radio-button/)
+ * - [Switch](https://mui.com/material-ui/react-switch/)
+ *
+ * API:
+ *
+ * - [FormLabel API](https://mui.com/material-ui/api/form-label/)
+ */
+declare const FormLabel: OverridableComponent<FormLabelTypeMap>;
+
+export interface ExtendFormLabelTypeMap<TypeMap extends OverridableTypeMap> {
+  props: TypeMap['props'] & Pick<FormLabelOwnProps, 'filled' | 'color'>;
+  defaultComponent: TypeMap['defaultComponent'];
+}
+
+export type FormLabelProps<
+  RootComponent extends React.ElementType = FormLabelTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<FormLabelTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default FormLabel;

--- a/packages/mui-material-next/src/FormLabel/FormLabel.js
+++ b/packages/mui-material-next/src/FormLabel/FormLabel.js
@@ -1,0 +1,182 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import formControlState from '../FormControl/formControlState';
+import useFormControl from '../FormControl/useFormControl';
+import useThemeProps from '../styles/useThemeProps';
+import styled from '../styles/styled';
+import formLabelClasses, { getFormLabelUtilityClasses } from './formLabelClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, color, focused, disabled, error, filled, required } = ownerState;
+  const slots = {
+    root: [
+      'root',
+      `color${capitalize(color)}`,
+      disabled && 'disabled',
+      error && 'error',
+      filled && 'filled',
+      focused && 'focused',
+      required && 'required',
+    ],
+    asterisk: ['asterisk', error && 'error'],
+  };
+
+  return composeClasses(slots, getFormLabelUtilityClasses, classes);
+};
+
+export const FormLabelRoot = styled('label', {
+  name: 'MuiFormLabel',
+  slot: 'Root',
+  overridesResolver: ({ ownerState }, styles) => {
+    return {
+      ...styles.root,
+      ...(ownerState.color === 'secondary' && styles.colorSecondary),
+      ...(ownerState.filled && styles.filled),
+    };
+  },
+})(({ theme, ownerState }) => ({
+  color: (theme.vars || theme).palette.text.secondary,
+  ...theme.typography.body1,
+  lineHeight: '1.4375em',
+  padding: 0,
+  position: 'relative',
+  [`&.${formLabelClasses.focused}`]: {
+    color: (theme.vars || theme).palette[ownerState.color].main,
+  },
+  [`&.${formLabelClasses.disabled}`]: {
+    color: (theme.vars || theme).palette.text.disabled,
+  },
+  [`&.${formLabelClasses.error}`]: {
+    color: (theme.vars || theme).palette.error.main,
+  },
+}));
+
+const AsteriskComponent = styled('span', {
+  name: 'MuiFormLabel',
+  slot: 'Asterisk',
+  overridesResolver: (props, styles) => styles.asterisk,
+})(({ theme }) => ({
+  [`&.${formLabelClasses.error}`]: {
+    color: (theme.vars || theme).palette.error.main,
+  },
+}));
+
+const FormLabel = React.forwardRef(function FormLabel(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiFormLabel' });
+  const {
+    children,
+    className,
+    color,
+    component = 'label',
+    disabled,
+    error,
+    filled,
+    focused,
+    required,
+    ...other
+  } = props;
+
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['color', 'required', 'focused', 'disabled', 'error', 'filled'],
+  });
+
+  const ownerState = {
+    ...props,
+    color: fcs.color || 'primary',
+    component,
+    disabled: fcs.disabled,
+    error: fcs.error,
+    filled: fcs.filled,
+    focused: fcs.focused,
+    required: fcs.required,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <FormLabelRoot
+      as={component}
+      ownerState={ownerState}
+      className={clsx(classes.root, className)}
+      ref={ref}
+      {...other}
+    >
+      {children}
+      {fcs.required && (
+        <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>
+          &thinsp;{'*'}
+        </AsteriskComponent>
+      )}
+    </FormLabelRoot>
+  );
+});
+
+FormLabel.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['error', 'info', 'primary', 'secondary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, the label should be displayed in a disabled state.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the label is displayed in an error state.
+   */
+  error: PropTypes.bool,
+  /**
+   * If `true`, the label should use filled classes key.
+   */
+  filled: PropTypes.bool,
+  /**
+   * If `true`, the input of this label is focused (used by `FormGroup` components).
+   */
+  focused: PropTypes.bool,
+  /**
+   * If `true`, the label will indicate that the `input` is required.
+   */
+  required: PropTypes.bool,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+};
+
+export default FormLabel;

--- a/packages/mui-material-next/src/FormLabel/FormLabel.test.js
+++ b/packages/mui-material-next/src/FormLabel/FormLabel.test.js
@@ -6,7 +6,11 @@ import FormLabel, { formLabelClasses as classes } from '@mui/material-next/FormL
 import FormControl, { useFormControl } from '@mui/material-next/FormControl';
 // TODO v6: re-export from material-next
 import { hexToRgb } from '@mui/system';
-import defaultTheme from '../styles/defaultTheme';
+// TODO v6: remove after implementing Material You styles
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+// TODO v6: remove after implementing Material You styles
+const MaterialV5DefaultTheme = createTheme();
 
 describe('<FormLabel />', () => {
   const { render } = createRenderer();
@@ -163,21 +167,25 @@ describe('<FormLabel />', () => {
 
     it('should have the focused class and style', () => {
       const { container, getByTestId } = render(
-        <FormLabel data-testid="FormLabel" color="secondary" focused />,
+        <ThemeProvider theme={MaterialV5DefaultTheme}>
+          <FormLabel data-testid="FormLabel" color="secondary" focused />
+        </ThemeProvider>,
       );
       expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.focused);
       expect(getByTestId('FormLabel')).toHaveComputedStyle({
-        color: hexToRgb(defaultTheme.palette.secondary.main),
+        color: hexToRgb(MaterialV5DefaultTheme.palette.secondary.main),
       });
     });
 
     it('should have the error class and style, even when focused', () => {
       const { container, getByTestId } = render(
-        <FormLabel data-testid="FormLabel" color="secondary" focused error />,
+        <ThemeProvider theme={MaterialV5DefaultTheme}>
+          <FormLabel data-testid="FormLabel" color="secondary" focused error />
+        </ThemeProvider>,
       );
       expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.error);
       expect(getByTestId('FormLabel')).toHaveComputedStyle({
-        color: hexToRgb(defaultTheme.palette.error.main),
+        color: hexToRgb(MaterialV5DefaultTheme.palette.error.main),
       });
     });
   });

--- a/packages/mui-material-next/src/FormLabel/FormLabel.test.js
+++ b/packages/mui-material-next/src/FormLabel/FormLabel.test.js
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { expect } from 'chai';
+import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import FormLabel, { formLabelClasses as classes } from '@mui/material-next/FormLabel';
+import FormControl, { useFormControl } from '@mui/material-next/FormControl';
+// TODO v6: re-export from material-next
+import { hexToRgb } from '@mui/system';
+import defaultTheme from '../styles/defaultTheme';
+
+describe('<FormLabel />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<FormLabel />, () => ({
+    classes,
+    inheritComponent: 'label',
+    render,
+    refInstanceof: window.HTMLLabelElement,
+    testComponentPropWith: 'div',
+    muiName: 'MuiFormLabel',
+    testVariantProps: { color: 'secondary' },
+    skip: ['componentsProp'],
+  }));
+
+  describe('prop: required', () => {
+    it('should visually show an asterisk but not include it in the a11y tree', () => {
+      const { container } = render(<FormLabel required>name</FormLabel>);
+
+      expect(container.querySelector('label')).to.have.text('name\u2009*');
+      expect(container.querySelectorAll(`.${classes.asterisk}`)).to.have.lengthOf(1);
+      expect(container.querySelectorAll(`.${classes.asterisk}`)[0]).toBeAriaHidden();
+    });
+
+    it('should not show an asterisk by default', () => {
+      const { container } = render(<FormLabel>name</FormLabel>);
+
+      expect(container.querySelector('label')).to.have.text('name');
+      expect(container.querySelectorAll(`.${classes.asterisk}`)).to.have.lengthOf(0);
+    });
+  });
+
+  describe('prop: error', () => {
+    it('should have an error class', () => {
+      const { container } = render(<FormLabel required error />);
+
+      expect(container.querySelectorAll(`.${classes.asterisk}`)).to.have.lengthOf(1);
+      expect(container.querySelector(`.${classes.asterisk}`)).to.have.class(classes.error);
+      expect(container.querySelectorAll(`.${classes.asterisk}`)[0]).toBeAriaHidden();
+      expect(container.firstChild).to.have.class(classes.error);
+    });
+  });
+
+  describe('with FormControl', () => {
+    describe('error', () => {
+      function Wrapper(props) {
+        return <FormControl error {...props} />;
+      }
+
+      it(`should have the error class`, () => {
+        const { container } = render(<FormLabel />, {
+          wrapper: Wrapper,
+        });
+
+        expect(container.querySelector('label')).to.have.class(classes.error);
+      });
+
+      it('should be overridden by props', () => {
+        const { container, setProps } = render(
+          <FormLabel data-testid="FormLabel" error={false} />,
+          {
+            wrapper: Wrapper,
+          },
+        );
+
+        expect(container.querySelector('label')).not.to.have.class(classes.error);
+
+        setProps({ error: true });
+        expect(container.querySelector('label')).to.have.class(classes.error);
+      });
+    });
+
+    describe('focused', () => {
+      const FormController = React.forwardRef((_, ref) => {
+        const formControl = useFormControl();
+        React.useImperativeHandle(ref, () => formControl, [formControl]);
+        return null;
+      });
+
+      it(`should have the focused class`, () => {
+        const formControlRef = React.createRef();
+        const { container } = render(
+          <FormControl error>
+            <FormLabel data-testid="FormLabel" />
+            <FormController ref={formControlRef} />
+          </FormControl>,
+        );
+
+        expect(container.querySelector('label')).not.to.have.class(classes.focused);
+
+        act(() => {
+          formControlRef.current.onFocus();
+        });
+        expect(container.querySelector('label')).to.have.class(classes.focused);
+      });
+
+      it('should be overridden by props', () => {
+        const formControlRef = React.createRef();
+        function Wrapper({ children }) {
+          return (
+            <FormControl error>
+              {children}
+              <FormController ref={formControlRef} />
+            </FormControl>
+          );
+        }
+        Wrapper.propTypes = { children: PropTypes.node };
+        const { container, setProps } = render(<FormLabel data-testid="FormLabel" />, {
+          wrapper: Wrapper,
+        });
+        act(() => {
+          formControlRef.current.onFocus();
+        });
+
+        expect(container.querySelector('label')).to.have.class(classes.focused);
+
+        setProps({ focused: false });
+        expect(container.querySelector('label')).not.to.have.class(classes.focused);
+
+        setProps({ focused: true });
+        expect(container.querySelector('label')).to.have.class(classes.focused);
+      });
+    });
+
+    describe('required', () => {
+      it('should show an asterisk', () => {
+        const { container } = render(
+          <FormControl required>
+            <FormLabel>name</FormLabel>
+          </FormControl>,
+        );
+
+        expect(container).to.have.text('name\u2009*');
+      });
+
+      it('should be overridden by props', () => {
+        const { container, setProps } = render(<FormLabel required={false}>name</FormLabel>, {
+          wrapper: (props) => <FormControl required {...props} />,
+        });
+
+        expect(container).to.have.text('name');
+
+        setProps({ required: true });
+        expect(container).to.have.text('name\u2009*');
+      });
+    });
+  });
+
+  describe('prop: color', () => {
+    it('should have color secondary class', () => {
+      const { container } = render(<FormLabel color="secondary" />);
+      expect(container.firstChild).to.have.class(classes.colorSecondary);
+    });
+
+    it('should have the focused class and style', () => {
+      const { container, getByTestId } = render(
+        <FormLabel data-testid="FormLabel" color="secondary" focused />,
+      );
+      expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.focused);
+      expect(getByTestId('FormLabel')).toHaveComputedStyle({
+        color: hexToRgb(defaultTheme.palette.secondary.main),
+      });
+    });
+
+    it('should have the error class and style, even when focused', () => {
+      const { container, getByTestId } = render(
+        <FormLabel data-testid="FormLabel" color="secondary" focused error />,
+      );
+      expect(container.querySelector(`.${classes.colorSecondary}`)).to.have.class(classes.error);
+      expect(getByTestId('FormLabel')).toHaveComputedStyle({
+        color: hexToRgb(defaultTheme.palette.error.main),
+      });
+    });
+  });
+});

--- a/packages/mui-material-next/src/FormLabel/formLabelClasses.ts
+++ b/packages/mui-material-next/src/FormLabel/formLabelClasses.ts
@@ -1,0 +1,42 @@
+import {
+  unstable_generateUtilityClass as generateUtilityClass,
+  unstable_generateUtilityClasses as generateUtilityClasses,
+} from '@mui/utils';
+
+export interface FormLabelClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if the color is secondary. */
+  colorSecondary: string;
+  /** State class applied to the root element if `focused={true}`. */
+  focused: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** State class applied to the root element if `error={true}`. */
+  error: string;
+  /** State class applied to the root element if `filled={true}`. */
+  filled: string;
+  /** State class applied to the root element if `required={true}`. */
+  required: string;
+  /** Styles applied to the asterisk element. */
+  asterisk: string;
+}
+
+export type FormLabelClassKey = keyof FormLabelClasses;
+
+export function getFormLabelUtilityClasses(slot: string): string {
+  return generateUtilityClass('MuiFormLabel', slot);
+}
+
+const formLabelClasses: FormLabelClasses = generateUtilityClasses('MuiFormLabel', [
+  'root',
+  'colorSecondary',
+  'focused',
+  'disabled',
+  'error',
+  'filled',
+  'required',
+  'asterisk',
+]);
+
+export default formLabelClasses;

--- a/packages/mui-material-next/src/FormLabel/index.d.ts
+++ b/packages/mui-material-next/src/FormLabel/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './FormLabel';
+export * from './FormLabel';
+
+export { default as formLabelClasses } from './formLabelClasses';
+export * from './formLabelClasses';

--- a/packages/mui-material-next/src/FormLabel/index.js
+++ b/packages/mui-material-next/src/FormLabel/index.js
@@ -1,0 +1,6 @@
+'use client';
+export { default } from './FormLabel';
+export * from './FormLabel';
+
+export { default as formLabelClasses } from './formLabelClasses';
+export * from './formLabelClasses';

--- a/packages/mui-material-next/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/mui-material-next/src/InputAdornment/InputAdornment.d.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableComponent, OverrideProps } from '@mui/types';
+import { Theme } from '..';
+import { InputAdornmentClasses } from './inputAdornmentClasses';
+
+export interface InputAdornmentOwnProps {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<InputAdornmentClasses>;
+  /**
+   * The content of the component, normally an `IconButton` or string.
+   */
+  children?: React.ReactNode;
+  /**
+   * Disable pointer events on the root.
+   * This allows for the content of the adornment to focus the `input` on click.
+   * @default false
+   */
+  disablePointerEvents?: boolean;
+  /**
+   * If children is a string then disable wrapping in a Typography component.
+   * @default false
+   */
+  disableTypography?: boolean;
+  /**
+   * The position this adornment should appear relative to the `Input`.
+   */
+  position: 'start' | 'end';
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The variant to use.
+   * Note: If you are using the `TextField` component or the `FormControl` component
+   * you do not have to set this manually.
+   */
+  variant?: 'standard' | 'outlined' | 'filled';
+}
+
+export interface InputAdornmentTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'div',
+> {
+  props: AdditionalProps & InputAdornmentOwnProps;
+  defaultComponent: RootComponent;
+}
+/**
+ *
+ * Demos:
+ *
+ * - [Text Field](https://mui.com/material-ui/react-text-field/)
+ *
+ * API:
+ *
+ * - [InputAdornment API](https://mui.com/material-ui/api/input-adornment/)
+ */
+declare const InputAdornment: OverridableComponent<InputAdornmentTypeMap>;
+
+export type InputAdornmentProps<
+  RootComponent extends React.ElementType = InputAdornmentTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<InputAdornmentTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default InputAdornment;

--- a/packages/mui-material-next/src/InputAdornment/InputAdornment.js
+++ b/packages/mui-material-next/src/InputAdornment/InputAdornment.js
@@ -1,0 +1,196 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import {
+  unstable_composeClasses as composeClasses,
+  unstable_capitalize as capitalize,
+} from '@mui/base/composeClasses';
+import Typography from '@mui/material/Typography';
+import FormControlContext from '../FormControl/FormControlContext';
+import useFormControl from '../FormControl/useFormControl';
+import styled from '../styles/styled';
+import inputAdornmentClasses, { getInputAdornmentUtilityClass } from './inputAdornmentClasses';
+import useThemeProps from '../styles/useThemeProps';
+
+const overridesResolver = (props, styles) => {
+  const { ownerState } = props;
+
+  return [
+    styles.root,
+    styles[`position${capitalize(ownerState.position)}`],
+    ownerState.disablePointerEvents === true && styles.disablePointerEvents,
+    styles[ownerState.variant],
+  ];
+};
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, disablePointerEvents, hiddenLabel, position, size, variant } = ownerState;
+  const slots = {
+    root: [
+      'root',
+      disablePointerEvents && 'disablePointerEvents',
+      position && `position${capitalize(position)}`,
+      variant,
+      hiddenLabel && 'hiddenLabel',
+      size && `size${capitalize(size)}`,
+    ],
+  };
+
+  return composeClasses(slots, getInputAdornmentUtilityClass, classes);
+};
+
+const InputAdornmentRoot = styled('div', {
+  name: 'MuiInputAdornment',
+  slot: 'Root',
+  overridesResolver,
+})(({ theme, ownerState }) => ({
+  display: 'flex',
+  height: '0.01em', // Fix IE11 flexbox alignment. To remove at some point.
+  maxHeight: '2em',
+  alignItems: 'center',
+  whiteSpace: 'nowrap',
+  color: (theme.vars || theme).palette.action.active,
+  ...(ownerState.variant === 'filled' && {
+    // Styles applied to the root element if `variant="filled"`.
+    [`&.${inputAdornmentClasses.positionStart}&:not(.${inputAdornmentClasses.hiddenLabel})`]: {
+      marginTop: 16,
+    },
+  }),
+  ...(ownerState.position === 'start' && {
+    // Styles applied to the root element if `position="start"`.
+    marginRight: 8,
+  }),
+  ...(ownerState.position === 'end' && {
+    // Styles applied to the root element if `position="end"`.
+    marginLeft: 8,
+  }),
+  ...(ownerState.disablePointerEvents === true && {
+    // Styles applied to the root element if `disablePointerEvents={true}`.
+    pointerEvents: 'none',
+  }),
+}));
+
+const InputAdornment = React.forwardRef(function InputAdornment(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiInputAdornment' });
+  const {
+    children,
+    className,
+    component = 'div',
+    disablePointerEvents = false,
+    disableTypography = false,
+    position,
+    variant: variantProp,
+    ...other
+  } = props;
+
+  const muiFormControl = useFormControl() || {};
+
+  let variant = variantProp;
+
+  if (variantProp && muiFormControl.variant) {
+    if (process.env.NODE_ENV !== 'production') {
+      if (variantProp === muiFormControl.variant) {
+        console.error(
+          'MUI: The `InputAdornment` variant infers the variant prop ' +
+            'you do not have to provide one.',
+        );
+      }
+    }
+  }
+
+  if (muiFormControl && !variant) {
+    variant = muiFormControl.variant;
+  }
+
+  const ownerState = {
+    ...props,
+    hiddenLabel: muiFormControl.hiddenLabel,
+    size: muiFormControl.size,
+    disablePointerEvents,
+    position,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <FormControlContext.Provider value={null}>
+      <InputAdornmentRoot
+        as={component}
+        ownerState={ownerState}
+        className={clsx(classes.root, className)}
+        ref={ref}
+        {...other}
+      >
+        {typeof children === 'string' && !disableTypography ? (
+          <Typography color="text.secondary">{children}</Typography>
+        ) : (
+          <React.Fragment>
+            {/* To have the correct vertical alignment baseline */}
+            {position === 'start' ? (
+              /* notranslate needed while Google Translate will not fix zero-width space issue */
+              <span className="notranslate">&#8203;</span>
+            ) : null}
+            {children}
+          </React.Fragment>
+        )}
+      </InputAdornmentRoot>
+    </FormControlContext.Provider>
+  );
+});
+
+InputAdornment.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component, normally an `IconButton` or string.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * Disable pointer events on the root.
+   * This allows for the content of the adornment to focus the `input` on click.
+   * @default false
+   */
+  disablePointerEvents: PropTypes.bool,
+  /**
+   * If children is a string then disable wrapping in a Typography component.
+   * @default false
+   */
+  disableTypography: PropTypes.bool,
+  /**
+   * The position this adornment should appear relative to the `Input`.
+   */
+  position: PropTypes.oneOf(['end', 'start']).isRequired,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The variant to use.
+   * Note: If you are using the `TextField` component or the `FormControl` component
+   * you do not have to set this manually.
+   */
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
+};
+
+export default InputAdornment;

--- a/packages/mui-material-next/src/InputAdornment/InputAdornment.test.js
+++ b/packages/mui-material-next/src/InputAdornment/InputAdornment.test.js
@@ -1,0 +1,220 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import {
+  createRenderer,
+  describeConformance,
+  strictModeDoubleLoggingSuppressed,
+} from '@mui-internal/test-utils';
+import { typographyClasses } from '@mui/material/Typography';
+import InputAdornment, { inputAdornmentClasses as classes } from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import Input from '@mui/material/Input';
+
+describe('<InputAdornment />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<InputAdornment position="start">foo</InputAdornment>, () => ({
+    classes,
+    inheritComponent: 'div',
+    render,
+    muiName: 'MuiInputAdornment',
+    testVariantProps: { color: 'primary' },
+    refInstanceof: window.HTMLDivElement,
+    skip: ['componentsProp'],
+    testComponentPropWith: 'span',
+  }));
+
+  it('should wrap text children in a Typography', () => {
+    const { container } = render(<InputAdornment position="start">foo</InputAdornment>);
+    const typography = container.querySelector(`.${typographyClasses.root}`);
+
+    expect(typography).not.to.equal(null);
+    expect(typography).to.have.text('foo');
+  });
+
+  it('should have the root and start class when position is start', () => {
+    const { container } = render(<InputAdornment position="start">foo</InputAdornment>);
+    const adornment = container.firstChild;
+
+    expect(adornment).to.have.class(classes.root);
+    expect(adornment).to.have.class(classes.positionStart);
+  });
+
+  it('should have the root and end class when position is end', () => {
+    const { container } = render(<InputAdornment position="end">foo</InputAdornment>);
+    const adornment = container.firstChild;
+
+    expect(adornment).to.have.class(classes.root);
+    expect(adornment).to.have.class(classes.positionEnd);
+  });
+
+  describe('prop: variant', () => {
+    it("should inherit the TextField's variant", () => {
+      const { getByTestId } = render(
+        <TextField
+          fullWidth
+          placeholder="Search"
+          label="Search"
+          variant="filled"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment data-testid="InputAdornment" position="start">
+                foo
+              </InputAdornment>
+            ),
+          }}
+        />,
+      );
+      const adornment = getByTestId('InputAdornment');
+
+      expect(adornment).to.have.class(classes.root);
+      expect(adornment).to.have.class(classes.positionStart);
+      expect(adornment).to.have.class(classes.filled);
+    });
+
+    it("should inherit the FormControl's variant", () => {
+      const { getByTestId } = render(
+        <FormControl variant="filled">
+          <InputAdornment data-testid="InputAdornment" position="start">
+            foo
+          </InputAdornment>
+        </FormControl>,
+      );
+      const adornment = getByTestId('InputAdornment');
+
+      expect(adornment).to.have.class(classes.root);
+      expect(adornment).to.have.class(classes.positionStart);
+      expect(adornment).to.have.class(classes.filled);
+    });
+
+    it('should override the inherited variant', () => {
+      const { getByTestId } = render(
+        <TextField
+          fullWidth
+          placeholder="Search"
+          label="Search"
+          variant="filled"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment data-testid="InputAdornment" variant="standard" position="start">
+                foo
+              </InputAdornment>
+            ),
+          }}
+        />,
+      );
+      const adornment = getByTestId('InputAdornment');
+
+      expect(adornment).to.have.class(classes.root);
+      expect(adornment).to.have.class(classes.positionStart);
+      expect(adornment).not.to.have.class(classes.filled);
+    });
+
+    it('should have the filled root and class when variant is filled', () => {
+      const { container } = render(
+        <InputAdornment variant="filled" position="start">
+          foo
+        </InputAdornment>,
+      );
+      const adornment = container.firstChild;
+
+      expect(adornment).to.have.class(classes.root);
+      expect(adornment).to.have.class(classes.positionStart);
+      expect(adornment).to.have.class(classes.filled);
+    });
+
+    it('should warn if the variant supplied is equal to the variant inferred', () => {
+      expect(() => {
+        render(
+          <FormControl variant="filled">
+            <Input
+              startAdornment={
+                <InputAdornment variant="filled" position="start">
+                  foo
+                </InputAdornment>
+              }
+            />
+          </FormControl>,
+        );
+      }).toErrorDev([
+        'MUI: The `InputAdornment` variant infers the variant ' +
+          'prop you do not have to provide one.',
+        !strictModeDoubleLoggingSuppressed &&
+          'MUI: The `InputAdornment` variant infers the variant ' +
+            'prop you do not have to provide one.',
+      ]);
+    });
+  });
+
+  it('should have the disabled pointer events class when disabledPointerEvents true', () => {
+    const { container } = render(
+      <InputAdornment disablePointerEvents position="start">
+        foo
+      </InputAdornment>,
+    );
+    const adornment = container.firstChild;
+
+    expect(adornment).to.have.class(classes.disablePointerEvents);
+  });
+
+  it('should not wrap text children in a Typography when disableTypography true', () => {
+    const { container } = render(
+      <InputAdornment disableTypography position="start">
+        foo
+      </InputAdornment>,
+    );
+
+    expect(container.querySelector(`.${typographyClasses.root}`)).to.equal(null);
+  });
+
+  it('should render children', () => {
+    const { container } = render(
+      <InputAdornment position="end">
+        <div>foo</div>
+      </InputAdornment>,
+    );
+    const adornment = container.firstChild;
+
+    expect(adornment.firstChild).to.have.property('nodeName', 'DIV');
+  });
+
+  describe('prop: position', () => {
+    it('should render span for vertical baseline alignment', () => {
+      const { container } = render(
+        <InputAdornment position="start">
+          <div>foo</div>
+        </InputAdornment>,
+      );
+      const adornment = container.firstChild;
+
+      expect(adornment.firstChild).to.have.tagName('span');
+      expect(adornment.firstChild).to.have.class('notranslate');
+      expect(adornment.childNodes[1]).to.have.tagName('div');
+    });
+  });
+
+  it('applies a size small class inside <FormControl size="small" />', () => {
+    const { getByTestId } = render(
+      <FormControl size="small">
+        <InputAdornment position="start" data-testid="root">
+          $
+        </InputAdornment>
+      </FormControl>,
+    );
+
+    expect(getByTestId('root')).to.have.class(classes.sizeSmall);
+  });
+
+  it('applies a hiddenLabel class inside <FormControl hiddenLabel />', () => {
+    const { getByTestId } = render(
+      <FormControl hiddenLabel>
+        <InputAdornment position="start" data-testid="root">
+          $
+        </InputAdornment>
+      </FormControl>,
+    );
+
+    expect(getByTestId('root')).to.have.class(classes.hiddenLabel);
+  });
+});

--- a/packages/mui-material-next/src/InputAdornment/index.d.ts
+++ b/packages/mui-material-next/src/InputAdornment/index.d.ts
@@ -1,0 +1,5 @@
+export * from './InputAdornment';
+export { default } from './InputAdornment';
+
+export { default as inputAdornmentClasses } from './inputAdornmentClasses';
+export * from './inputAdornmentClasses';

--- a/packages/mui-material-next/src/InputAdornment/index.js
+++ b/packages/mui-material-next/src/InputAdornment/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './InputAdornment';
+
+export { default as inputAdornmentClasses } from './inputAdornmentClasses';
+export * from './inputAdornmentClasses';

--- a/packages/mui-material-next/src/InputAdornment/inputAdornmentClasses.ts
+++ b/packages/mui-material-next/src/InputAdornment/inputAdornmentClasses.ts
@@ -1,0 +1,45 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface InputAdornmentClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `variant="filled"`. */
+  filled: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  outlined: string;
+  /** Styles applied to the root element if `variant="standard"`. */
+  standard: string;
+  /** Styles applied to the root element if `position="start"`. */
+  positionStart: string;
+  /** Styles applied to the root element if `position="end"`. */
+  positionEnd: string;
+  /** Styles applied to the root element if `disablePointerEvents={true}`. */
+  disablePointerEvents: string;
+  /** Styles applied if the adornment is used inside <FormControl hiddenLabel />. */
+  hiddenLabel: string;
+  /** Styles applied if the adornment is used inside <FormControl size="small" />. */
+  sizeSmall: string;
+}
+
+export type InputAdornmentClassKey = keyof InputAdornmentClasses;
+
+export function getInputAdornmentUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiInputAdornment', slot);
+}
+
+const inputAdornmentClasses: InputAdornmentClasses = generateUtilityClasses('MuiInputAdornment', [
+  'root',
+  'filled',
+  'standard',
+  'outlined',
+  'positionStart',
+  'positionEnd',
+  'disablePointerEvents',
+  'hiddenLabel',
+  'sizeSmall',
+]);
+
+export default inputAdornmentClasses;

--- a/packages/mui-material-next/src/InputLabel/InputLabel.d.ts
+++ b/packages/mui-material-next/src/InputLabel/InputLabel.d.ts
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion, OverridableComponent, OverrideProps } from '@mui/types';
+import { FormLabelProps, ExtendFormLabelTypeMap } from '../FormLabel';
+import { Theme } from '../styles';
+import { InputLabelClasses } from './inputLabelClasses';
+
+export interface InputLabelPropsSizeOverrides {}
+
+export interface InputLabelOwnProps {
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<InputLabelClasses>;
+  color?: FormLabelProps['color'];
+  /**
+   * If `true`, the transition animation is disabled.
+   * @default false
+   */
+  disableAnimation?: boolean;
+  /**
+   * If `true`, the component is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the label is displayed in an error state.
+   */
+  error?: boolean;
+  /**
+   * If `true`, the `input` of this label is focused.
+   */
+  focused?: boolean;
+  /**
+   * If `dense`, will adjust vertical spacing. This is normally obtained via context from
+   * FormControl.
+   */
+  margin?: 'dense';
+  /**
+   * if `true`, the label will indicate that the `input` is required.
+   */
+  required?: boolean;
+  /**
+   * If `true`, the label is shrunk.
+   */
+  shrink?: boolean;
+  /**
+   * The size of the component.
+   * @default 'normal'
+   */
+  size?: OverridableStringUnion<'small' | 'normal', InputLabelPropsSizeOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The variant to use.
+   */
+  variant?: 'standard' | 'outlined' | 'filled';
+}
+
+export type InputLabelTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'label',
+> = ExtendFormLabelTypeMap<{
+  props: AdditionalProps & InputLabelOwnProps;
+  defaultComponent: RootComponent;
+}>;
+
+/**
+ *
+ * Demos:
+ *
+ * - [Text Field](https://mui.com/material-ui/react-text-field/)
+ *
+ * API:
+ *
+ * - [InputLabel API](https://mui.com/material-ui/api/input-label/)
+ * - inherits [FormLabel API](https://mui.com/material-ui/api/form-label/)
+ */
+declare const InputLabel: OverridableComponent<InputLabelTypeMap>;
+
+export type InputLabelProps<
+  RootComponent extends React.ElementType = InputLabelTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<InputLabelTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default InputLabel;

--- a/packages/mui-material-next/src/InputLabel/InputLabel.js
+++ b/packages/mui-material-next/src/InputLabel/InputLabel.js
@@ -1,0 +1,249 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+import clsx from 'clsx';
+import formControlState from '../FormControl/formControlState';
+import useFormControl from '../FormControl/useFormControl';
+import FormLabel, { formLabelClasses } from '../FormLabel';
+import useThemeProps from '../styles/useThemeProps';
+import styled, { rootShouldForwardProp } from '../styles/styled';
+import { getInputLabelUtilityClasses } from './inputLabelClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, formControl, size, shrink, disableAnimation, variant, required } = ownerState;
+  const slots = {
+    root: [
+      'root',
+      formControl && 'formControl',
+      !disableAnimation && 'animated',
+      shrink && 'shrink',
+      size && size !== 'normal' && `size${capitalize(size)}`,
+      variant,
+    ],
+    asterisk: [required && 'asterisk'],
+  };
+
+  const composedClasses = composeClasses(slots, getInputLabelUtilityClasses, classes);
+
+  return {
+    ...classes, // forward the focused, disabled, etc. classes to the FormLabel
+    ...composedClasses,
+  };
+};
+
+const InputLabelRoot = styled(FormLabel, {
+  shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes',
+  name: 'MuiInputLabel',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+    return [
+      { [`& .${formLabelClasses.asterisk}`]: styles.asterisk },
+      styles.root,
+      ownerState.formControl && styles.formControl,
+      ownerState.size === 'small' && styles.sizeSmall,
+      ownerState.shrink && styles.shrink,
+      !ownerState.disableAnimation && styles.animated,
+      styles[ownerState.variant],
+    ];
+  },
+})(({ theme, ownerState }) => ({
+  display: 'block',
+  transformOrigin: 'top left',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: '100%',
+  ...(ownerState.formControl && {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    // slight alteration to spec spacing to match visual spec result
+    transform: 'translate(0, 20px) scale(1)',
+  }),
+  ...(ownerState.size === 'small' && {
+    // Compensation for the `Input.inputSizeSmall` style.
+    transform: 'translate(0, 17px) scale(1)',
+  }),
+  ...(ownerState.shrink && {
+    transform: 'translate(0, -1.5px) scale(0.75)',
+    transformOrigin: 'top left',
+    maxWidth: '133%',
+  }),
+  ...(!ownerState.disableAnimation && {
+    transition: theme.transitions.create(['color', 'transform', 'max-width'], {
+      duration: theme.transitions.duration.shorter,
+      easing: theme.transitions.easing.easeOut,
+    }),
+  }),
+  ...(ownerState.variant === 'filled' && {
+    // Chrome's autofill feature gives the input field a yellow background.
+    // Since the input field is behind the label in the HTML tree,
+    // the input field is drawn last and hides the label with an opaque background color.
+    // zIndex: 1 will raise the label above opaque background-colors of input.
+    zIndex: 1,
+    pointerEvents: 'none',
+    transform: 'translate(12px, 16px) scale(1)',
+    maxWidth: 'calc(100% - 24px)',
+    ...(ownerState.size === 'small' && {
+      transform: 'translate(12px, 13px) scale(1)',
+    }),
+    ...(ownerState.shrink && {
+      userSelect: 'none',
+      pointerEvents: 'auto',
+      transform: 'translate(12px, 7px) scale(0.75)',
+      maxWidth: 'calc(133% - 24px)',
+      ...(ownerState.size === 'small' && {
+        transform: 'translate(12px, 4px) scale(0.75)',
+      }),
+    }),
+  }),
+  ...(ownerState.variant === 'outlined' && {
+    // see comment above on filled.zIndex
+    zIndex: 1,
+    pointerEvents: 'none',
+    transform: 'translate(14px, 16px) scale(1)',
+    maxWidth: 'calc(100% - 24px)',
+    ...(ownerState.size === 'small' && {
+      transform: 'translate(14px, 9px) scale(1)',
+    }),
+    ...(ownerState.shrink && {
+      userSelect: 'none',
+      pointerEvents: 'auto',
+      // Theoretically, we should have (8+5)*2/0.75 = 34px
+      // but it feels a better when it bleeds a bit on the left, so 32px.
+      maxWidth: 'calc(133% - 32px)',
+      transform: 'translate(14px, -9px) scale(0.75)',
+    }),
+  }),
+}));
+
+const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
+  const props = useThemeProps({ name: 'MuiInputLabel', props: inProps });
+  const {
+    disableAnimation = false,
+    margin,
+    shrink: shrinkProp,
+    variant,
+    className,
+    ...other
+  } = props;
+
+  const muiFormControl = useFormControl();
+
+  let shrink = shrinkProp;
+  if (typeof shrink === 'undefined' && muiFormControl) {
+    shrink = muiFormControl.filled || muiFormControl.focused || muiFormControl.adornedStart;
+  }
+
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['size', 'variant', 'required'],
+  });
+
+  const ownerState = {
+    ...props,
+    disableAnimation,
+    formControl: muiFormControl,
+    shrink,
+    size: fcs.size,
+    variant: fcs.variant,
+    required: fcs.required,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <InputLabelRoot
+      data-shrink={shrink}
+      ownerState={ownerState}
+      ref={ref}
+      className={clsx(classes.root, className)}
+      {...other}
+      classes={classes}
+    />
+  );
+});
+
+InputLabel.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#adding-new-colors).
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['error', 'info', 'primary', 'secondary', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * If `true`, the transition animation is disabled.
+   * @default false
+   */
+  disableAnimation: PropTypes.bool,
+  /**
+   * If `true`, the component is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the label is displayed in an error state.
+   */
+  error: PropTypes.bool,
+  /**
+   * If `true`, the `input` of this label is focused.
+   */
+  focused: PropTypes.bool,
+  /**
+   * If `dense`, will adjust vertical spacing. This is normally obtained via context from
+   * FormControl.
+   */
+  margin: PropTypes.oneOf(['dense']),
+  /**
+   * if `true`, the label will indicate that the `input` is required.
+   */
+  required: PropTypes.bool,
+  /**
+   * If `true`, the label is shrunk.
+   */
+  shrink: PropTypes.bool,
+  /**
+   * The size of the component.
+   * @default 'normal'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['normal', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
+};
+
+export default InputLabel;

--- a/packages/mui-material-next/src/InputLabel/InputLabel.spec.tsx
+++ b/packages/mui-material-next/src/InputLabel/InputLabel.spec.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { expectType } from '@mui/types';
+import InputLabel from '@mui/material/InputLabel';
+
+const CustomComponent: React.FC<{ prop1: string; prop2: number }> = function CustomComponent() {
+  return <div />;
+};
+
+const InputLabelTest = () => {
+  return (
+    <div>
+      <InputLabel />
+      <InputLabel component="legend" />
+      <InputLabel
+        component="legend"
+        onClick={(event) => {
+          expectType<React.MouseEvent<HTMLLegendElement, MouseEvent>, typeof event>(event);
+        }}
+      />
+
+      {/* @ts-expect-error */}
+      <InputLabel component="a" incorrectAttribute="url" />
+      {/* @ts-expect-error */}
+      <InputLabel component="div" href="url" />
+      <InputLabel component={CustomComponent} prop1="1" prop2={12} />
+      {/* @ts-expect-error */}
+      <InputLabel component={CustomComponent} prop1="1" />
+      {/* @ts-expect-error */}
+      <InputLabel component={CustomComponent} prop1="1" prop2="12" />
+    </div>
+  );
+};

--- a/packages/mui-material-next/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material-next/src/InputLabel/InputLabel.test.js
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { expect } from 'chai';
+import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { ClassNames } from '@emotion/react';
+import FormControl from '@mui/material/FormControl';
+import Input from '@mui/material/Input';
+import FormLabel from '@mui/material/FormLabel';
+import InputLabel, { inputLabelClasses as classes } from '@mui/material/InputLabel';
+
+describe('<InputLabel />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<InputLabel>Foo</InputLabel>, () => ({
+    classes,
+    inheritComponent: FormLabel,
+    render,
+    refInstanceof: window.HTMLLabelElement,
+    muiName: 'MuiInputLabel',
+    testVariantProps: { size: 'small' },
+    skip: ['componentsProp'],
+  }));
+
+  it('should render a label with text', () => {
+    const { container } = render(<InputLabel>Foo</InputLabel>);
+    expect(container.querySelector('label')).to.have.text('Foo');
+  });
+
+  it('should have the animated class by default', () => {
+    const { container } = render(<InputLabel>Foo</InputLabel>);
+    expect(container.firstChild).to.have.class(classes.animated);
+  });
+
+  it('should not have the animated class when disabled', () => {
+    const { container } = render(<InputLabel disableAnimation>Foo</InputLabel>);
+    expect(container.firstChild).not.to.have.class(classes.animated);
+  });
+
+  it('should forward the asterisk class to AsteriskComponent when required', () => {
+    const { container } = render(
+      <InputLabel classes={{ asterisk: 'my-asterisk' }} required>
+        Foo
+      </InputLabel>,
+    );
+    expect(container.querySelector('.my-asterisk')).to.have.class('MuiFormLabel-asterisk');
+    expect(container.querySelector('.my-asterisk')).to.have.class('MuiInputLabel-asterisk');
+  });
+
+  describe('with FormControl', () => {
+    it('should have the formControl class', () => {
+      const { getByTestId } = render(
+        <FormControl>
+          <InputLabel data-testid="root" />
+        </FormControl>,
+      );
+      expect(getByTestId('root')).to.have.class(classes.formControl);
+    });
+
+    it('should have the small class', () => {
+      const { getByTestId } = render(
+        <FormControl size="small">
+          <InputLabel data-testid="root" />
+        </FormControl>,
+      );
+
+      expect(getByTestId('root')).to.have.class(classes.sizeSmall);
+    });
+
+    describe('filled', () => {
+      it('applies a shrink class that can be controlled by props', () => {
+        function Wrapper({ children }) {
+          return (
+            <FormControl>
+              <Input defaultValue="Dave" />
+              {children}
+            </FormControl>
+          );
+        }
+        Wrapper.propTypes = { children: PropTypes.node };
+        const { getByTestId, setProps } = render(<InputLabel data-testid="root">name</InputLabel>, {
+          wrapper: Wrapper,
+        });
+
+        expect(getByTestId('root')).to.have.class(classes.shrink);
+
+        setProps({ shrink: false });
+        expect(getByTestId('root')).not.to.have.class(classes.shrink);
+
+        setProps({ shrink: true });
+        expect(getByTestId('root')).to.have.class(classes.shrink);
+      });
+    });
+
+    describe('focused', () => {
+      it('applies a shrink class that can be controlled by props', () => {
+        function Wrapper({ children }) {
+          return (
+            <FormControl>
+              <Input />
+              {children}
+            </FormControl>
+          );
+        }
+        Wrapper.propTypes = { children: PropTypes.node };
+
+        const { container, getByTestId, setProps } = render(<InputLabel data-testid="root" />, {
+          wrapper: Wrapper,
+        });
+        act(() => {
+          container.querySelector('input').focus();
+        });
+
+        expect(getByTestId('root')).to.have.class(classes.shrink);
+
+        setProps({ shrink: false });
+        expect(getByTestId('root')).not.to.have.class(classes.shrink);
+
+        setProps({ shrink: true });
+        expect(getByTestId('root')).to.have.class(classes.shrink);
+      });
+    });
+  });
+
+  describe('Emotion compatibility', () => {
+    it('classes.root should overwrite built-in styles.', () => {
+      const text = 'The label';
+
+      const { getByText } = render(
+        <ClassNames>
+          {({ css }) => (
+            <FormControl>
+              <InputLabel classes={{ root: css({ position: 'static' }) }}>{text}</InputLabel>
+            </FormControl>
+          )}
+        </ClassNames>,
+      );
+      const label = getByText(text);
+
+      expect(getComputedStyle(label).position).to.equal('static');
+    });
+
+    it('className should overwrite classes.root and built-in styles.', () => {
+      const text = 'The label';
+
+      const { getByText } = render(
+        <ClassNames>
+          {({ css }) => (
+            <FormControl>
+              <InputLabel
+                color="primary"
+                className={css({ position: 'static' })}
+                classes={{ root: css({ position: 'sticky' }) }}
+              >
+                {text}
+              </InputLabel>
+            </FormControl>
+          )}
+        </ClassNames>,
+      );
+      const label = getByText(text);
+
+      expect(getComputedStyle(label).position).to.equal('static');
+    });
+  });
+});

--- a/packages/mui-material-next/src/InputLabel/index.d.ts
+++ b/packages/mui-material-next/src/InputLabel/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './InputLabel';
+export * from './InputLabel';
+
+export { default as inputLabelClasses } from './inputLabelClasses';
+export * from './inputLabelClasses';

--- a/packages/mui-material-next/src/InputLabel/index.js
+++ b/packages/mui-material-next/src/InputLabel/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './InputLabel';
+
+export { default as inputLabelClasses } from './inputLabelClasses';
+export * from './inputLabelClasses';

--- a/packages/mui-material-next/src/InputLabel/inputLabelClasses.ts
+++ b/packages/mui-material-next/src/InputLabel/inputLabelClasses.ts
@@ -1,0 +1,57 @@
+import {
+  unstable_generateUtilityClass as generateUtilityClass,
+  unstable_generateUtilityClasses as generateUtilityClasses,
+} from '@mui/utils';
+
+export interface InputLabelClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** State class applied to the root element if `focused={true}`. */
+  focused: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** State class applied to the root element if `error={true}`. */
+  error: string;
+  /** State class applied to the root element if `required={true}`. */
+  required: string;
+  /** State class applied to the asterisk element. */
+  asterisk: string;
+  /** Styles applied to the root element if the component is a descendant of `FormControl`. */
+  formControl: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the input element if `shrink={true}`. */
+  shrink: string;
+  /** Styles applied to the input element unless `disableAnimation={true}`. */
+  animated: string;
+  /** Styles applied to the root element if `variant="filled"`. */
+  filled: string;
+  /** Styles applied to the root element if `variant="outlined"`. */
+  outlined: string;
+  /** Styles applied to the root element if `variant="standard"`. */
+  standard: string;
+}
+
+export type InputLabelClassKey = keyof InputLabelClasses;
+
+export function getInputLabelUtilityClasses(slot: string): string {
+  return generateUtilityClass('MuiInputLabel', slot);
+}
+
+const inputLabelClasses: InputLabelClasses = generateUtilityClasses('MuiInputLabel', [
+  'root',
+  'focused',
+  'disabled',
+  'error',
+  'required',
+  'asterisk',
+  'formControl',
+  'sizeSmall',
+  'shrink',
+  'animated',
+  'standard',
+  'filled',
+  'outlined',
+]);
+
+export default inputLabelClasses;

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -18,6 +18,9 @@ export * from './FilledInput';
 export { default as FormControl } from './FormControl';
 export * from './FormControl';
 
+export { default as FormHelperText } from './FormHelperText';
+export * from './FormHelperText';
+
 export { default as FormLabel } from './FormLabel';
 export * from './FormLabel';
 

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -18,6 +18,9 @@ export * from './FilledInput';
 export { default as FormControl } from './FormControl';
 export * from './FormControl';
 
+export { default as FormLabel } from './FormLabel';
+export * from './FormLabel';
+
 export { default as InputBase } from './InputBase';
 export * from './InputBase';
 

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -24,6 +24,9 @@ export * from './FormLabel';
 export { default as InputBase } from './InputBase';
 export * from './InputBase';
 
+export { default as InputLabel } from './InputLabel';
+export * from './InputLabel';
+
 export { default as Input } from './Input';
 
 export { default as Select } from './Select';

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -21,6 +21,9 @@ export * from './FormControl';
 export { default as FormLabel } from './FormLabel';
 export * from './FormLabel';
 
+export { default as InputAdornment } from './InputAdornment';
+export * from './InputAdornment';
+
 export { default as InputBase } from './InputBase';
 export * from './InputBase';
 


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/38374

This PR copies (with minimal changes) the remaining components that are required to compose the `filled` variant of `TextField` and `Select`:

- `FormLabel`
- `InputLabel`
- `InputAdornment`
- `FormHelperText`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
