### PR TITLE
[docs-infra] Improve code syntax highlight

### DIFF
--- a/docs/public/static/styles/prism-okaidia.css
+++ b/docs/public/static/styles/prism-okaidia.css
@@ -147,7 +147,6 @@ pre[class*='language-'] {
 
 .token.property,
 .token.tag,
-.token.constant,
 .token.symbol,
 .token.deleted {
   color: #fc929e;


### PR DESCRIPTION
A bug I noticed in #39180.

Before

<img width="784" alt="Screenshot 2023-09-27 at 00 20 35" src="https://github.com/mui/material-ui/assets/3165635/983ab064-aa26-49fe-9199-203b7cc6518a">

After

<img width="788" alt="Screenshot 2023-09-27 at 00 20 28" src="https://github.com/mui/material-ui/assets/3165635/55a30cd2-283e-466d-9e9c-de73c7234fd4">

The problem starts at https://github.com/PrismJS/prism/blob/59e5a3471377057de1f401ba38337aca27b80e03/components/prism-javascript.js#L114, it considers upper cases separate with space as constant. This feels strange, do we really want different colors between `A` and `a`?

<img width="254" alt="Screenshot 2023-09-27 at 00 26 13" src="https://github.com/mui/material-ui/assets/3165635/7b193c64-983c-48f8-8d98-80e8d8df1e61">

VS Code nor Codemirror do this:

<img width="283" alt="Screenshot 2023-09-27 at 00 26 01" src="https://github.com/mui/material-ui/assets/3165635/0b226519-4c49-4a1b-8f9b-2939d18df2f4">
<img width="355" alt="Screenshot 2023-09-27 at 00 25 45" src="https://github.com/mui/material-ui/assets/3165635/d3be38fb-9d50-47b0-9a21-6281a9d08da4">
