### PR TITLE
[material-next][Select] Copy Select files from v5

### DIFF
--- a/packages/mui-material-next/src/Select/Select.d.ts
+++ b/packages/mui-material-next/src/Select/Select.d.ts
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { InternalStandardProps as StandardProps, Theme } from '..';
+import { InputProps } from '../Input';
+import { MenuProps } from '../Menu';
+import { SelectChangeEvent, SelectInputProps } from './SelectInput';
+import { SelectClasses } from './selectClasses';
+import { OutlinedInputProps } from '../OutlinedInput';
+
+export { SelectChangeEvent };
+
+export interface SelectProps<Value = unknown>
+  extends StandardProps<InputProps, 'value' | 'onChange'>,
+    Omit<OutlinedInputProps, 'value' | 'onChange'>,
+    Pick<SelectInputProps<Value>, 'onChange'> {
+  /**
+   * If `true`, the width of the popover will automatically be set according to the items inside the
+   * menu, otherwise it will be at least the width of the select input.
+   * @default false
+   */
+  autoWidth?: boolean;
+  /**
+   * The option elements to populate the select with.
+   * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
+   *
+   * ⚠️The `MenuItem` elements **must** be direct descendants when `native` is false.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   * @default {}
+   */
+  classes?: Partial<SelectClasses>;
+  /**
+   * If `true`, the component is initially open. Use when the component open state is not controlled (i.e. the `open` prop is not defined).
+   * You can only use it when the `native` prop is `false` (default).
+   * @default false
+   */
+  defaultOpen?: boolean;
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue?: Value;
+  /**
+   * If `true`, a value is displayed even if no items are selected.
+   *
+   * In order to display a meaningful value, a function can be passed to the `renderValue` prop which
+   * returns the value to be displayed when no items are selected.
+   *
+   * ⚠️ When using this prop, make sure the label doesn't overlap with the empty displayed value.
+   * The label should either be hidden or forced to a shrunk state.
+   * @default false
+   */
+  displayEmpty?: boolean;
+  /**
+   * The icon that displays the arrow.
+   * @default ArrowDropDownIcon
+   */
+  IconComponent?: React.ElementType;
+  /**
+   * The `id` of the wrapper element or the `select` element when `native`.
+   */
+  id?: string;
+  /**
+   * An `Input` element; does not have to be a material-ui specific `Input`.
+   */
+  input?: React.ReactElement<any, any>;
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   * When `native` is `true`, the attributes are applied on the `select` element.
+   */
+  inputProps?: InputProps['inputProps'];
+  /**
+   * See [OutlinedInput#label](/material-ui/api/outlined-input/#props)
+   */
+  label?: React.ReactNode;
+  /**
+   * The ID of an element that acts as an additional label. The Select will
+   * be labelled by the additional label and the selected value.
+   */
+  labelId?: string;
+  /**
+   * Props applied to the [`Menu`](/material-ui/api/menu/) element.
+   */
+  MenuProps?: Partial<MenuProps>;
+  /**
+   * If `true`, `value` must be an array and the menu will support multiple selections.
+   * @default false
+   */
+  multiple?: boolean;
+  /**
+   * If `true`, the component uses a native `select` element.
+   * @default false
+   */
+  native?: boolean;
+  /**
+   * Callback fired when a menu item is selected.
+   *
+   * @param {SelectChangeEvent<Value>} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (any).
+   * **Warning**: This is a generic event, not a change event, unless the change event is caused by browser autofill.
+   * @param {object} [child] The react element that was selected when `native` is `false` (default).
+   */
+  onChange?: SelectInputProps<Value>['onChange'];
+  /**
+   * Callback fired when the component requests to be closed.
+   * Use it in either controlled (see the `open` prop), or uncontrolled mode (to detect when the Select collapses).
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onClose?: (event: React.SyntheticEvent) => void;
+  /**
+   * Callback fired when the component requests to be opened.
+   * Use it in either controlled (see the `open` prop), or uncontrolled mode (to detect when the Select expands).
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onOpen?: (event: React.SyntheticEvent) => void;
+  /**
+   * If `true`, the component is shown.
+   * You can only use it when the `native` prop is `false` (default).
+   */
+  open?: boolean;
+  /**
+   * Render the selected value.
+   * You can only use it when the `native` prop is `false` (default).
+   *
+   * @param {any} value The `value` provided to the component.
+   * @returns {ReactNode}
+   */
+  renderValue?: (value: Value) => React.ReactNode;
+  /**
+   * Props applied to the clickable div element.
+   */
+  SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The `input` value. Providing an empty string will select no options.
+   * Set to an empty string `''` if you don't want any of the available options to be selected.
+   *
+   * If the value is an object it must have reference equality with the option in order to be selected.
+   * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
+   */
+  value?: Value | '';
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant?: 'standard' | 'outlined' | 'filled';
+}
+
+/**
+ *
+ * Demos:
+ *
+ * - [Select](https://mui.com/material-ui/react-select/)
+ *
+ * API:
+ *
+ * - [Select API](https://mui.com/material-ui/api/select/)
+ * - inherits [OutlinedInput API](https://mui.com/material-ui/api/outlined-input/)
+ */
+declare const Select: (<Value>(props: SelectProps<Value>) => JSX.Element) & {
+  muiName: string;
+};
+
+export default Select;

--- a/packages/mui-material-next/src/Select/Select.d.ts
+++ b/packages/mui-material-next/src/Select/Select.d.ts
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { InternalStandardProps as StandardProps, Theme } from '..';
-import { InputProps } from '../Input';
-import { MenuProps } from '../Menu';
+// TODO v6: replace @mui/material with @mui/material-next when components are available
+import { InternalStandardProps as StandardProps, Theme } from '@mui/material';
+import { InputProps } from '@mui/material/Input';
+import { MenuProps } from '@mui/material/Menu';
+import { OutlinedInputProps } from '@mui/material/OutlinedInput';
 import { SelectChangeEvent, SelectInputProps } from './SelectInput';
 import { SelectClasses } from './selectClasses';
-import { OutlinedInputProps } from '../OutlinedInput';
 
 export { SelectChangeEvent };
 

--- a/packages/mui-material-next/src/Select/Select.d.ts
+++ b/packages/mui-material-next/src/Select/Select.d.ts
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-// TODO v6: replace @mui/material with @mui/material-next when components are available
+// TODO v6: replace material Theme with material-next Theme when Material You design is implemented
 import { InternalStandardProps as StandardProps, Theme } from '@mui/material';
+// TODO v6: replace with material-next Input components props https://github.com/mui/material-ui/pull/39188#discussion_r1339645381
 import { InputProps } from '@mui/material/Input';
+// TODO v6: replace with material-next Menu https://github.com/mui/material-ui/pull/38934
 import { MenuProps } from '@mui/material/Menu';
+// TODO v6: replace with material-next OutlinedInput when available
 import { OutlinedInputProps } from '@mui/material/OutlinedInput';
 import { SelectChangeEvent, SelectInputProps } from './SelectInput';
 import { SelectClasses } from './selectClasses';

--- a/packages/mui-material-next/src/Select/Select.js
+++ b/packages/mui-material-next/src/Select/Select.js
@@ -1,0 +1,285 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { deepmerge } from '@mui/utils';
+import SelectInput from './SelectInput';
+import formControlState from '../FormControl/formControlState';
+import useFormControl from '../FormControl/useFormControl';
+import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
+import Input from '../Input';
+import NativeSelectInput from '../NativeSelect/NativeSelectInput';
+import FilledInput from '../FilledInput';
+import OutlinedInput from '../OutlinedInput';
+import useThemeProps from '../styles/useThemeProps';
+import useForkRef from '../utils/useForkRef';
+import styled, { rootShouldForwardProp } from '../styles/styled';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes } = ownerState;
+
+  return classes;
+};
+
+const styledRootConfig = {
+  name: 'MuiSelect',
+  overridesResolver: (props, styles) => styles.root,
+  shouldForwardProp: (prop) => rootShouldForwardProp(prop) && prop !== 'variant',
+  slot: 'Root',
+};
+
+const StyledInput = styled(Input, styledRootConfig)('');
+
+const StyledOutlinedInput = styled(OutlinedInput, styledRootConfig)('');
+
+const StyledFilledInput = styled(FilledInput, styledRootConfig)('');
+
+const Select = React.forwardRef(function Select(inProps, ref) {
+  const props = useThemeProps({ name: 'MuiSelect', props: inProps });
+  const {
+    autoWidth = false,
+    children,
+    classes: classesProp = {},
+    className,
+    defaultOpen = false,
+    displayEmpty = false,
+    IconComponent = ArrowDropDownIcon,
+    id,
+    input,
+    inputProps,
+    label,
+    labelId,
+    MenuProps,
+    multiple = false,
+    native = false,
+    onClose,
+    onOpen,
+    open,
+    renderValue,
+    SelectDisplayProps,
+    variant: variantProp = 'outlined',
+    ...other
+  } = props;
+
+  const inputComponent = native ? NativeSelectInput : SelectInput;
+
+  const muiFormControl = useFormControl();
+  const fcs = formControlState({
+    props,
+    muiFormControl,
+    states: ['variant', 'error'],
+  });
+
+  const variant = fcs.variant || variantProp;
+
+  const ownerState = { ...props, variant, classes: classesProp };
+  const classes = useUtilityClasses(ownerState);
+  const { root, ...restOfClasses } = classes;
+
+  const InputComponent =
+    input ||
+    {
+      standard: <StyledInput ownerState={ownerState} />,
+      outlined: <StyledOutlinedInput label={label} ownerState={ownerState} />,
+      filled: <StyledFilledInput ownerState={ownerState} />,
+    }[variant];
+
+  const inputComponentRef = useForkRef(ref, InputComponent.ref);
+
+  return (
+    <React.Fragment>
+      {React.cloneElement(InputComponent, {
+        // Most of the logic is implemented in `SelectInput`.
+        // The `Select` component is a simple API wrapper to expose something better to play with.
+        inputComponent,
+        inputProps: {
+          children,
+          error: fcs.error,
+          IconComponent,
+          variant,
+          type: undefined, // We render a select. We can ignore the type provided by the `Input`.
+          multiple,
+          ...(native
+            ? { id }
+            : {
+                autoWidth,
+                defaultOpen,
+                displayEmpty,
+                labelId,
+                MenuProps,
+                onClose,
+                onOpen,
+                open,
+                renderValue,
+                SelectDisplayProps: { id, ...SelectDisplayProps },
+              }),
+          ...inputProps,
+          classes: inputProps ? deepmerge(restOfClasses, inputProps.classes) : restOfClasses,
+          ...(input ? input.props.inputProps : {}),
+        },
+        ...(multiple && native && variant === 'outlined' ? { notched: true } : {}),
+        ref: inputComponentRef,
+        className: clsx(InputComponent.props.className, className, classes.root),
+        // If a custom input is provided via 'input' prop, do not allow 'variant' to be propagated to it's root element. See https://github.com/mui/material-ui/issues/33894.
+        ...(!input && { variant }),
+        ...other,
+      })}
+    </React.Fragment>
+  );
+});
+
+Select.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * If `true`, the width of the popover will automatically be set according to the items inside the
+   * menu, otherwise it will be at least the width of the select input.
+   * @default false
+   */
+  autoWidth: PropTypes.bool,
+  /**
+   * The option elements to populate the select with.
+   * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
+   *
+   * ⚠️The `MenuItem` elements **must** be direct descendants when `native` is false.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   * @default {}
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, the component is initially open. Use when the component open state is not controlled (i.e. the `open` prop is not defined).
+   * You can only use it when the `native` prop is `false` (default).
+   * @default false
+   */
+  defaultOpen: PropTypes.bool,
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue: PropTypes.any,
+  /**
+   * If `true`, a value is displayed even if no items are selected.
+   *
+   * In order to display a meaningful value, a function can be passed to the `renderValue` prop which
+   * returns the value to be displayed when no items are selected.
+   *
+   * ⚠️ When using this prop, make sure the label doesn't overlap with the empty displayed value.
+   * The label should either be hidden or forced to a shrunk state.
+   * @default false
+   */
+  displayEmpty: PropTypes.bool,
+  /**
+   * The icon that displays the arrow.
+   * @default ArrowDropDownIcon
+   */
+  IconComponent: PropTypes.elementType,
+  /**
+   * The `id` of the wrapper element or the `select` element when `native`.
+   */
+  id: PropTypes.string,
+  /**
+   * An `Input` element; does not have to be a material-ui specific `Input`.
+   */
+  input: PropTypes.element,
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   * When `native` is `true`, the attributes are applied on the `select` element.
+   */
+  inputProps: PropTypes.object,
+  /**
+   * See [OutlinedInput#label](/material-ui/api/outlined-input/#props)
+   */
+  label: PropTypes.node,
+  /**
+   * The ID of an element that acts as an additional label. The Select will
+   * be labelled by the additional label and the selected value.
+   */
+  labelId: PropTypes.string,
+  /**
+   * Props applied to the [`Menu`](/material-ui/api/menu/) element.
+   */
+  MenuProps: PropTypes.object,
+  /**
+   * If `true`, `value` must be an array and the menu will support multiple selections.
+   * @default false
+   */
+  multiple: PropTypes.bool,
+  /**
+   * If `true`, the component uses a native `select` element.
+   * @default false
+   */
+  native: PropTypes.bool,
+  /**
+   * Callback fired when a menu item is selected.
+   *
+   * @param {SelectChangeEvent<Value>} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (any).
+   * **Warning**: This is a generic event, not a change event, unless the change event is caused by browser autofill.
+   * @param {object} [child] The react element that was selected when `native` is `false` (default).
+   */
+  onChange: PropTypes.func,
+  /**
+   * Callback fired when the component requests to be closed.
+   * Use it in either controlled (see the `open` prop), or uncontrolled mode (to detect when the Select collapses).
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onClose: PropTypes.func,
+  /**
+   * Callback fired when the component requests to be opened.
+   * Use it in either controlled (see the `open` prop), or uncontrolled mode (to detect when the Select expands).
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onOpen: PropTypes.func,
+  /**
+   * If `true`, the component is shown.
+   * You can only use it when the `native` prop is `false` (default).
+   */
+  open: PropTypes.bool,
+  /**
+   * Render the selected value.
+   * You can only use it when the `native` prop is `false` (default).
+   *
+   * @param {any} value The `value` provided to the component.
+   * @returns {ReactNode}
+   */
+  renderValue: PropTypes.func,
+  /**
+   * Props applied to the clickable div element.
+   */
+  SelectDisplayProps: PropTypes.object,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The `input` value. Providing an empty string will select no options.
+   * Set to an empty string `''` if you don't want any of the available options to be selected.
+   *
+   * If the value is an object it must have reference equality with the option in order to be selected.
+   * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
+   */
+  value: PropTypes.oneOfType([PropTypes.oneOf(['']), PropTypes.any]),
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
+};
+
+Select.muiName = 'Select';
+
+export default Select;

--- a/packages/mui-material-next/src/Select/Select.js
+++ b/packages/mui-material-next/src/Select/Select.js
@@ -3,10 +3,12 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { deepmerge, unstable_useForkRef as useForkRef } from '@mui/utils';
-// TODO v6: replace @mui/material with @mui/material-next when components are available
-import Input from '@mui/material/Input';
 import NativeSelectInput from '@mui/material/NativeSelect/NativeSelectInput';
+// TODO v6: Remove Input component after implementing Material You design
+import Input from '@mui/material/Input';
+// TODO v6: replace with material-next FilledInput when available https://github.com/mui/material-ui/issues/39052
 import FilledInput from '@mui/material/FilledInput';
+// TODO v6: replace with material-next OutlinedInput when available
 import OutlinedInput from '@mui/material/OutlinedInput';
 import SelectInput from './SelectInput';
 import formControlState from '../FormControl/formControlState';

--- a/packages/mui-material-next/src/Select/Select.js
+++ b/packages/mui-material-next/src/Select/Select.js
@@ -2,17 +2,17 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { deepmerge } from '@mui/utils';
+import { deepmerge, unstable_useForkRef as useForkRef } from '@mui/utils';
+// TODO v6: replace @mui/material with @mui/material-next when components are available
+import Input from '@mui/material/Input';
+import NativeSelectInput from '@mui/material/NativeSelect/NativeSelectInput';
+import FilledInput from '@mui/material/FilledInput';
+import OutlinedInput from '@mui/material/OutlinedInput';
 import SelectInput from './SelectInput';
 import formControlState from '../FormControl/formControlState';
 import useFormControl from '../FormControl/useFormControl';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
-import Input from '../Input';
-import NativeSelectInput from '../NativeSelect/NativeSelectInput';
-import FilledInput from '../FilledInput';
-import OutlinedInput from '../OutlinedInput';
 import useThemeProps from '../styles/useThemeProps';
-import useForkRef from '../utils/useForkRef';
 import styled, { rootShouldForwardProp } from '../styles/styled';
 
 const useUtilityClasses = (ownerState) => {

--- a/packages/mui-material-next/src/Select/Select.spec.tsx
+++ b/packages/mui-material-next/src/Select/Select.spec.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import { createTheme } from '@mui/material/styles';
+
+function genericValueTest() {
+  function handleChangeWithSameTypeAsSelect(event: SelectChangeEvent<number>) {}
+  <Select<number> onChange={handleChangeWithSameTypeAsSelect} />;
+
+  function handleChangeWithDifferentTypeFromSelect(
+    event: React.ChangeEvent<{ name?: string; value: string }>,
+  ) {}
+  <Select<number>
+    // @ts-expect-error
+    onChange={handleChangeWithDifferentTypeFromSelect}
+  />;
+
+  <Select<string>
+    // @ts-expect-error defaultValue should be a string
+    defaultValue={1}
+    // @ts-expect-error Value should be a string
+    value={10}
+  />;
+
+  <Select
+    onChange={(event) => {
+      function testString(value: string) {}
+      function testNumber(value: number) {}
+
+      testString(event.target.value);
+      // @ts-expect-error
+      testNumber(event.target.value);
+    }}
+    value="1"
+  />;
+
+  <Select onChange={(event) => console.log(event.target.value)} value="1">
+    <MenuItem value="1" />
+    {/* Whoops. The value in onChange won't be a string */}
+    <MenuItem value={2} />
+  </Select>;
+
+  // notched prop should be available (inherited from OutlinedInputProps) and NOT throw typescript error
+  <Select notched />;
+
+  // disabledUnderline prop should be available (inherited from InputProps) and NOT throw typescript error
+  <Select disableUnderline />;
+
+  // Tests presence of `root` class in SelectClasses
+  const theme = createTheme({
+    components: {
+      MuiSelect: {
+        styleOverrides: {
+          root: {
+            borderRadius: '8px',
+          },
+        },
+      },
+    },
+  });
+
+  // tests deep slot prop forwarding up to the modal backdrop
+  <Select
+    MenuProps={{
+      slotProps: {
+        root: {
+          slotProps: {
+            backdrop: {
+              style: {
+                backgroundColor: 'transparent',
+              },
+            },
+          },
+        },
+      },
+    }}
+  />;
+}

--- a/packages/mui-material-next/src/Select/Select.spec.tsx
+++ b/packages/mui-material-next/src/Select/Select.spec.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+// TODO v6: replace @mui/material with @mui/material-next when Menu component is available
 import MenuItem from '@mui/material/MenuItem';
+// TODO v6: replace createTheme with material-next's extendTheme when implementing Material You design
 import { createTheme } from '@mui/material/styles';
+import Select, { SelectChangeEvent } from '@mui/material-next/Select';
 
 function genericValueTest() {
   function handleChangeWithSameTypeAsSelect(event: SelectChangeEvent<number>) {}

--- a/packages/mui-material-next/src/Select/Select.spec.tsx
+++ b/packages/mui-material-next/src/Select/Select.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-// TODO v6: replace @mui/material with @mui/material-next when Menu component is available
+// TODO v6: replace with material-next Menu when available https://github.com/mui/material-ui/pull/38934
 import MenuItem from '@mui/material/MenuItem';
-// TODO v6: replace createTheme with material-next's extendTheme when implementing Material You design
+// TODO v6: replace with material-next's extendTheme when implementing Material You design
 import { createTheme } from '@mui/material/styles';
 import Select, { SelectChangeEvent } from '@mui/material-next/Select';
 

--- a/packages/mui-material-next/src/Select/Select.test.js
+++ b/packages/mui-material-next/src/Select/Select.test.js
@@ -1,0 +1,1709 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy, stub } from 'sinon';
+import {
+  describeConformance,
+  ErrorBoundary,
+  act,
+  createRenderer,
+  fireEvent,
+  screen,
+} from '@mui-internal/test-utils';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import MenuItem, { menuItemClasses } from '@mui/material/MenuItem';
+import ListSubheader from '@mui/material/ListSubheader';
+import InputBase from '@mui/material/InputBase';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import Divider from '@mui/material/Divider';
+import classes from './selectClasses';
+import { nativeSelectClasses } from '../NativeSelect';
+
+describe('<Select />', () => {
+  const { clock, render } = createRenderer({ clock: 'fake' });
+
+  describeConformance(<Select value="" />, () => ({
+    classes,
+    inheritComponent: OutlinedInput,
+    render,
+    refInstanceof: window.HTMLDivElement,
+    muiName: 'MuiSelect',
+    skip: ['componentProp', 'componentsProp', 'themeVariants', 'themeStyleOverrides'],
+  }));
+
+  describe('prop: inputProps', () => {
+    it('should be able to provide a custom classes property', () => {
+      render(
+        <Select
+          inputProps={{
+            classes: { select: 'select' },
+          }}
+          value=""
+        />,
+      );
+      expect(document.querySelector(`.${classes.select}`)).to.have.class('select');
+    });
+  });
+
+  it('should be able to mount the component', () => {
+    const { container } = render(
+      <Select value={10}>
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        <MenuItem value={10}>Ten</MenuItem>
+        <MenuItem value={20}>Twenty</MenuItem>
+        <MenuItem value={30}>Thirty</MenuItem>
+      </Select>,
+    );
+
+    expect(container.querySelector('input')).to.have.property('value', '10');
+  });
+
+  specify('the trigger is in tab order', () => {
+    const { getByRole } = render(
+      <Select value="">
+        <MenuItem value="">None</MenuItem>
+      </Select>,
+    );
+
+    expect(getByRole('combobox')).to.have.property('tabIndex', 0);
+  });
+
+  it('should accept null child', () => {
+    render(
+      <Select open value={10}>
+        {null}
+        <MenuItem value={10}>Ten</MenuItem>
+      </Select>,
+    );
+  });
+
+  ['', 0, false, undefined, NaN].forEach((value) =>
+    it(`should support conditional rendering with "${value}"`, () => {
+      render(
+        <Select open value={2}>
+          {value && <MenuItem value={1}>One</MenuItem>}
+          <MenuItem value={2}>Two</MenuItem>
+        </Select>,
+      );
+    }),
+  );
+
+  it('should have an input with [aria-hidden] by default', () => {
+    const { container } = render(
+      <Select value="10">
+        <MenuItem value="10">Ten</MenuItem>
+      </Select>,
+    );
+
+    expect(container.querySelector('input')).to.have.attribute('aria-hidden', 'true');
+  });
+
+  it('should ignore onBlur when the menu opens', () => {
+    // mousedown calls focus while click opens moving the focus to an item
+    // this means the trigger is blurred immediately
+    const handleBlur = spy();
+    const { getByRole, getAllByRole, queryByRole } = render(
+      <Select
+        onBlur={handleBlur}
+        value=""
+        onMouseDown={(event) => {
+          // simulating certain platforms that focus on mousedown
+          if (event.defaultPrevented === false) {
+            event.currentTarget.focus();
+          }
+        }}
+      >
+        <MenuItem value="">none</MenuItem>
+        <MenuItem value={10}>Ten</MenuItem>
+      </Select>,
+    );
+    const trigger = getByRole('combobox');
+
+    fireEvent.mouseDown(trigger);
+
+    expect(handleBlur.callCount).to.equal(0);
+    expect(getByRole('listbox')).not.to.equal(null);
+
+    act(() => {
+      const options = getAllByRole('option');
+      fireEvent.mouseDown(options[0]);
+      options[0].click();
+    });
+
+    expect(handleBlur.callCount).to.equal(0);
+    expect(queryByRole('listbox', { hidden: false })).to.equal(null);
+  });
+
+  it('options should have a data-value attribute', () => {
+    render(
+      <Select open value={10}>
+        <MenuItem value={10}>Ten</MenuItem>
+        <MenuItem value={20}>Twenty</MenuItem>
+      </Select>,
+    );
+    const options = screen.getAllByRole('option');
+
+    expect(options[0]).to.have.attribute('data-value', '10');
+    expect(options[1]).to.have.attribute('data-value', '20');
+  });
+
+  [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach((key) => {
+    it(`should open menu when pressed ${key} key on select`, () => {
+      render(
+        <Select value="">
+          <MenuItem value="">none</MenuItem>
+        </Select>,
+      );
+      const trigger = screen.getByRole('combobox');
+      act(() => {
+        trigger.focus();
+      });
+
+      fireEvent.keyDown(trigger, { key });
+      expect(screen.getByRole('listbox', { hidden: false })).not.to.equal(null);
+
+      fireEvent.keyUp(screen.getAllByRole('option')[0], { key });
+      expect(screen.getByRole('listbox', { hidden: false })).not.to.equal(null);
+    });
+  });
+
+  it('should pass "name" as part of the event.target for onBlur', () => {
+    const handleBlur = stub().callsFake((event) => event.target.name);
+    const { getByRole } = render(
+      <Select onBlur={handleBlur} name="blur-testing" value="">
+        <MenuItem value="">none</MenuItem>
+      </Select>,
+    );
+    const button = getByRole('combobox');
+    act(() => {
+      button.focus();
+    });
+
+    act(() => {
+      button.blur();
+    });
+
+    expect(handleBlur.callCount).to.equal(1);
+    expect(handleBlur.firstCall.returnValue).to.equal('blur-testing');
+  });
+
+  it('should call onClose when the backdrop is clicked', () => {
+    const handleClose = spy();
+    const { getByTestId } = render(
+      <Select
+        MenuProps={{ BackdropProps: { 'data-testid': 'backdrop' } }}
+        onClose={handleClose}
+        open
+        value=""
+      >
+        <MenuItem value="">none</MenuItem>
+      </Select>,
+    );
+
+    act(() => {
+      getByTestId('backdrop').click();
+    });
+
+    expect(handleClose.callCount).to.equal(1);
+  });
+
+  it('should call onClose when the same option is selected', () => {
+    const handleChange = spy();
+    const handleClose = spy();
+    render(
+      <Select open onChange={handleChange} onClose={handleClose} value="second">
+        <MenuItem value="first" />
+        <MenuItem value="second" />
+      </Select>,
+    );
+
+    screen.getByRole('option', { selected: true }).click();
+
+    expect(handleChange.callCount).to.equal(0);
+    expect(handleClose.callCount).to.equal(1);
+  });
+
+  it('should focus select when its label is clicked', () => {
+    const { getByRole, getByTestId } = render(
+      <React.Fragment>
+        <InputLabel id="my$label" data-testid="label" />
+        <Select value="" labelId="my$label" />
+      </React.Fragment>,
+    );
+
+    fireEvent.click(getByTestId('label'));
+
+    expect(getByRole('combobox')).toHaveFocus();
+  });
+
+  it('should focus list if no selection', () => {
+    const { getByRole } = render(<Select value="" autoFocus />);
+
+    fireEvent.mouseDown(getByRole('combobox'));
+
+    // TODO not matching WAI-ARIA authoring practices. It should focus the first (or selected) item.
+    expect(getByRole('listbox')).toHaveFocus();
+  });
+
+  describe('prop: onChange', () => {
+    it('should get selected element from arguments', () => {
+      const onChangeHandler = spy();
+      const { getAllByRole, getByRole } = render(
+        <Select onChange={onChangeHandler} value="0">
+          <MenuItem value="0" />
+          <MenuItem value="1" />
+          <MenuItem value="2" />
+        </Select>,
+      );
+      fireEvent.mouseDown(getByRole('combobox'));
+      act(() => {
+        getAllByRole('option')[1].click();
+      });
+
+      expect(onChangeHandler.calledOnce).to.equal(true);
+      const selected = onChangeHandler.args[0][1];
+      expect(React.isValidElement(selected)).to.equal(true);
+    });
+
+    it('should call onChange before onClose', () => {
+      const eventLog = [];
+      const onChangeHandler = spy(() => eventLog.push('CHANGE_EVENT'));
+      const onCloseHandler = spy(() => eventLog.push('CLOSE_EVENT'));
+      const { getAllByRole, getByRole } = render(
+        <Select onChange={onChangeHandler} onClose={onCloseHandler} value="0">
+          <MenuItem value="0" />
+          <MenuItem value="1" />
+        </Select>,
+      );
+
+      fireEvent.mouseDown(getByRole('combobox'));
+      act(() => {
+        getAllByRole('option')[1].click();
+      });
+
+      expect(eventLog).to.deep.equal(['CHANGE_EVENT', 'CLOSE_EVENT']);
+    });
+
+    it('should not be called if selected element has the current value (value did not change)', () => {
+      const onChangeHandler = spy();
+      const { getAllByRole, getByRole } = render(
+        <Select onChange={onChangeHandler} value="1">
+          <MenuItem value="0" />
+          <MenuItem value="1" />
+          <MenuItem value="2" />
+        </Select>,
+      );
+      fireEvent.mouseDown(getByRole('combobox'));
+      act(() => {
+        getAllByRole('option')[1].click();
+      });
+
+      expect(onChangeHandler.callCount).to.equal(0);
+    });
+  });
+
+  describe('prop: defaultOpen', () => {
+    it('should be open on mount', () => {
+      const { getByRole } = render(<Select defaultOpen value="" />);
+      expect(getByRole('combobox', { hidden: true })).to.have.attribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('prop: value', () => {
+    it('should select the option based on the number value', () => {
+      render(
+        <Select open value={20}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+      const options = screen.getAllByRole('option');
+
+      expect(options[0]).not.to.have.attribute('aria-selected', 'true');
+      expect(options[1]).to.have.attribute('aria-selected', 'true');
+      expect(options[2]).not.to.have.attribute('aria-selected', 'true');
+    });
+
+    it('should select the option based on the string value', () => {
+      render(
+        <Select open value="20">
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+      const options = screen.getAllByRole('option');
+
+      expect(options[0]).not.to.have.attribute('aria-selected', 'true');
+      expect(options[1]).to.have.attribute('aria-selected', 'true');
+      expect(options[2]).not.to.have.attribute('aria-selected', 'true');
+    });
+
+    it('should select only the option that matches the object', () => {
+      const obj1 = { id: 1 };
+      const obj2 = { id: 2 };
+      render(
+        <Select open value={obj1}>
+          <MenuItem value={obj1}>1</MenuItem>
+          <MenuItem value={obj2}>2</MenuItem>
+        </Select>,
+      );
+      const options = screen.getAllByRole('option');
+
+      expect(options[0]).to.have.attribute('aria-selected', 'true');
+      expect(options[1]).not.to.have.attribute('aria-selected', 'true');
+    });
+
+    it('should be able to use an object', () => {
+      const value = {};
+      const { getByRole } = render(
+        <Select value={value}>
+          <MenuItem value="">
+            <em>None</em>
+          </MenuItem>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={value}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('combobox')).to.have.text('Twenty');
+    });
+
+    describe('warnings', () => {
+      it('warns when the value is not present in any option', () => {
+        expect(() =>
+          render(
+            <Select value={20}>
+              <MenuItem value={10}>Ten</MenuItem>
+              <MenuItem value={30}>Thirty</MenuItem>
+            </Select>,
+          ),
+        ).toWarnDev([
+          'MUI: You have provided an out-of-range value `20` for the select component.',
+          // React 18 Strict Effects run mount effects twice
+          React.version.startsWith('18') &&
+            'MUI: You have provided an out-of-range value `20` for the select component.',
+          'MUI: You have provided an out-of-range value `20` for the select component.',
+        ]);
+      });
+    });
+  });
+
+  it('should not have the selectable option selected when inital value provided is empty string on Select with ListSubHeader item', () => {
+    render(
+      <Select open value="">
+        <ListSubheader>Category 1</ListSubheader>
+        <MenuItem value={10}>Ten</MenuItem>
+        <ListSubheader>Category 2</ListSubheader>
+        <MenuItem value={20}>Twenty</MenuItem>
+        <MenuItem value={30}>Thirty</MenuItem>
+      </Select>,
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options[1]).not.to.have.class(menuItemClasses.selected);
+  });
+
+  describe('SVG icon', () => {
+    it('should not present an SVG icon when native and multiple are specified', () => {
+      const { container } = render(
+        <Select native multiple value={[0, 1]}>
+          <option value={0}>Zero</option>
+          <option value={1}>One</option>
+          <option value={2}>Two</option>
+        </Select>,
+      );
+      expect(container.querySelector('svg')).to.equal(null);
+    });
+
+    it('should present an SVG icon', () => {
+      const { container } = render(
+        <Select native value={1}>
+          <option value={0}>Zero</option>
+          <option value={1}>One</option>
+          <option value={2}>Two</option>
+        </Select>,
+      );
+      expect(container.querySelector('svg')).toBeVisible();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('sets aria-expanded="true" when the listbox is displayed', () => {
+      // since we make the rest of the UI inaccessible when open this doesn't
+      // technically matter. This is only here in case we keep the rest accessible
+      const { getByRole } = render(<Select open value="" />);
+
+      expect(getByRole('combobox', { hidden: true })).to.have.attribute('aria-expanded', 'true');
+    });
+
+    specify('ARIA 1.2: aria-expanded="false" if the listbox isn\'t displayed', () => {
+      const { getByRole } = render(<Select value="" />);
+
+      expect(getByRole('combobox')).to.have.attribute('aria-expanded', 'false');
+    });
+
+    it('sets aria-disabled="true" when component is disabled', () => {
+      const { getByRole } = render(<Select disabled value="" />);
+
+      expect(getByRole('combobox')).to.have.attribute('aria-disabled', 'true');
+    });
+
+    it('sets disabled attribute in input when component is disabled', () => {
+      const { container } = render(<Select disabled value="" />);
+
+      expect(container.querySelector('input')).to.have.property('disabled', true);
+    });
+
+    specify('aria-disabled is not present if component is not disabled', () => {
+      const { getByRole } = render(<Select disabled={false} value="" />);
+
+      expect(getByRole('combobox')).not.to.have.attribute('aria-disabled');
+    });
+
+    it('indicates that activating the button displays a listbox', () => {
+      const { getByRole } = render(<Select value="" />);
+
+      expect(getByRole('combobox')).to.have.attribute('aria-haspopup', 'listbox');
+    });
+
+    it('renders an element with listbox behavior', () => {
+      const { getByRole } = render(<Select open value="" />);
+
+      expect(getByRole('listbox')).toBeVisible();
+    });
+
+    it('indicates that input element has combobox role and aria-controls set to id of listbox', () => {
+      const { getByRole } = render(<Select open value="" />);
+      const listboxId = getByRole('listbox').id;
+
+      expect(getByRole('combobox', { hidden: true })).to.have.attribute('aria-controls', listboxId);
+    });
+
+    specify('the listbox is focusable', () => {
+      const { getByRole } = render(<Select open value="" />);
+
+      act(() => {
+        getByRole('listbox').focus();
+      });
+
+      expect(getByRole('listbox')).toHaveFocus();
+    });
+
+    it('identifies each selectable element containing an option', () => {
+      const { getAllByRole } = render(
+        <Select open value="">
+          <MenuItem value="1">First</MenuItem>
+          <MenuItem value="2">Second</MenuItem>
+        </Select>,
+      );
+
+      const options = getAllByRole('option');
+      expect(options[0]).to.have.text('First');
+      expect(options[1]).to.have.text('Second');
+    });
+
+    it('indicates the selected option', () => {
+      const { getAllByRole } = render(
+        <Select open value="2">
+          <MenuItem value="1">First</MenuItem>
+          <MenuItem value="2">Second</MenuItem>
+        </Select>,
+      );
+
+      expect(getAllByRole('option')[1]).to.have.attribute('aria-selected', 'true');
+    });
+
+    describe('when the first child is a ListSubheader', () => {
+      it('first selectable option is focused to use the arrow', () => {
+        const { getAllByRole } = render(
+          <Select defaultValue="" open>
+            <ListSubheader>Category 1</ListSubheader>
+            <MenuItem value={1}>Option 1</MenuItem>
+            <MenuItem value={2}>Option 2</MenuItem>
+            <ListSubheader>Category 2</ListSubheader>
+            <MenuItem value={3}>Option 3</MenuItem>
+            <MenuItem value={4}>Option 4</MenuItem>
+          </Select>,
+        );
+
+        const options = getAllByRole('option');
+        expect(options[1]).to.have.attribute('tabindex', '0');
+
+        act(() => {
+          fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[4], { key: 'Enter' });
+        });
+
+        expect(options[4]).to.have.attribute('aria-selected', 'true');
+      });
+
+      describe('when also the second child is a ListSubheader', () => {
+        it('first selectable option is focused to use the arrow', () => {
+          const { getAllByRole } = render(
+            <Select defaultValue="" open>
+              <ListSubheader>Empty category</ListSubheader>
+              <ListSubheader>Category 1</ListSubheader>
+              <MenuItem value={1}>Option 1</MenuItem>
+              <MenuItem value={2}>Option 2</MenuItem>
+              <ListSubheader>Category 2</ListSubheader>
+              <MenuItem value={3}>Option 3</MenuItem>
+              <MenuItem value={4}>Option 4</MenuItem>
+            </Select>,
+          );
+
+          const options = getAllByRole('option');
+          expect(options[2]).to.have.attribute('tabindex', '0');
+
+          act(() => {
+            fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+            fireEvent.keyDown(options[3], { key: 'ArrowDown' });
+            fireEvent.keyDown(options[5], { key: 'Enter' });
+          });
+
+          expect(options[5]).to.have.attribute('aria-selected', 'true');
+        });
+      });
+
+      describe('when the second child is null', () => {
+        it('first selectable option is focused to use the arrow', () => {
+          const { getAllByRole } = render(
+            <Select defaultValue="" open>
+              <ListSubheader>Category 1</ListSubheader>
+              {null}
+              <MenuItem value={1}>Option 1</MenuItem>
+              <MenuItem value={2}>Option 2</MenuItem>
+              <ListSubheader>Category 2</ListSubheader>
+              <MenuItem value={3}>Option 3</MenuItem>
+              <MenuItem value={4}>Option 4</MenuItem>
+            </Select>,
+          );
+
+          const options = getAllByRole('option');
+          expect(options[1]).to.have.attribute('tabindex', '0');
+
+          act(() => {
+            fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+            fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+            fireEvent.keyDown(options[4], { key: 'Enter' });
+          });
+
+          expect(options[4]).to.have.attribute('aria-selected', 'true');
+        });
+      });
+
+      ['', 0, false, undefined, NaN].forEach((value) =>
+        describe(`when the second child is conditionally rendering with "${value}"`, () => {
+          it('first selectable option is focused to use the arrow', () => {
+            const { getAllByRole } = render(
+              <Select defaultValue="" open>
+                <ListSubheader>Category 1</ListSubheader>
+                {value && <MenuItem value={1}>One</MenuItem>}
+                <MenuItem value={1}>Option 1</MenuItem>
+                <MenuItem value={2}>Option 2</MenuItem>
+                <ListSubheader>Category 2</ListSubheader>
+                <MenuItem value={3}>Option 3</MenuItem>
+                <MenuItem value={4}>Option 4</MenuItem>
+              </Select>,
+            );
+
+            const options = getAllByRole('option');
+            expect(options[1]).to.have.attribute('tabindex', '0');
+
+            act(() => {
+              fireEvent.keyDown(options[1], { key: 'ArrowDown' });
+              fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+              fireEvent.keyDown(options[4], { key: 'Enter' });
+            });
+
+            expect(options[4]).to.have.attribute('aria-selected', 'true');
+          });
+        }),
+      );
+    });
+
+    describe('when the first child is a ListSubheader wrapped in a custom component', () => {
+      describe('with the `muiSkipListHighlight` static field', () => {
+        function WrappedListSubheader(props) {
+          return <ListSubheader {...props} />;
+        }
+
+        WrappedListSubheader.muiSkipListHighlight = true;
+
+        it('highlights the first selectable option below the header', () => {
+          const { getByText } = render(
+            <Select defaultValue="" open>
+              <WrappedListSubheader>Category 1</WrappedListSubheader>
+              <MenuItem value={1}>Option 1</MenuItem>
+              <MenuItem value={2}>Option 2</MenuItem>
+              <WrappedListSubheader>Category 2</WrappedListSubheader>
+              <MenuItem value={3}>Option 3</MenuItem>
+              <MenuItem value={4}>Option 4</MenuItem>
+            </Select>,
+          );
+
+          const expectedHighlightedOption = getByText('Option 1');
+          expect(expectedHighlightedOption).to.have.attribute('tabindex', '0');
+        });
+      });
+
+      describe('with the `muiSkipListHighlight` prop', () => {
+        function WrappedListSubheader(props) {
+          const { muiSkipListHighlight, ...other } = props;
+          return <ListSubheader {...other} />;
+        }
+
+        it('highlights the first selectable option below the header', () => {
+          const { getByText } = render(
+            <Select defaultValue="" open>
+              <WrappedListSubheader muiSkipListHighlight>Category 1</WrappedListSubheader>
+              <MenuItem value={1}>Option 1</MenuItem>
+              <MenuItem value={2}>Option 2</MenuItem>
+              <WrappedListSubheader muiSkipListHighlight>Category 2</WrappedListSubheader>
+              <MenuItem value={3}>Option 3</MenuItem>
+              <MenuItem value={4}>Option 4</MenuItem>
+            </Select>,
+          );
+
+          const expectedHighlightedOption = getByText('Option 1');
+          expect(expectedHighlightedOption).to.have.attribute('tabindex', '0');
+        });
+      });
+    });
+
+    describe('when the first child is a MenuItem disabled', () => {
+      it('highlights the first selectable option below the header', () => {
+        const { getAllByRole } = render(
+          <Select defaultValue="" open>
+            <MenuItem value="" disabled>
+              <em>None</em>
+            </MenuItem>
+            <ListSubheader>Category 1</ListSubheader>
+            <MenuItem value={1}>Option 1</MenuItem>
+            <MenuItem value={2}>Option 2</MenuItem>
+            <ListSubheader>Category 2</ListSubheader>
+            <MenuItem value={3}>Option 3</MenuItem>
+            <MenuItem value={4}>Option 4</MenuItem>
+          </Select>,
+        );
+
+        const options = getAllByRole('option');
+        expect(options[2]).to.have.attribute('tabindex', '0');
+
+        act(() => {
+          fireEvent.keyDown(options[2], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[3], { key: 'ArrowDown' });
+          fireEvent.keyDown(options[5], { key: 'Enter' });
+        });
+
+        expect(options[5]).to.have.attribute('aria-selected', 'true');
+      });
+    });
+
+    it('it will fallback to its content for the accessible name when it has no name', () => {
+      const { getByRole } = render(<Select value="" />);
+
+      // TODO what is the accessible name actually?
+      expect(getByRole('combobox')).not.to.have.attribute('aria-labelledby');
+    });
+
+    it('is labelled by itself when it has a name', () => {
+      const { getByRole } = render(<Select name="select" value="" />);
+
+      expect(getByRole('combobox')).to.have.attribute(
+        'aria-labelledby',
+        getByRole('combobox').getAttribute('id'),
+      );
+    });
+
+    it('is labelled by itself when it has an id which is preferred over name', () => {
+      const { getAllByRole } = render(
+        <React.Fragment>
+          <span id="select-1-label">Chose first option:</span>
+          <Select id="select-1" labelId="select-1-label" name="select" value="" />
+          <span id="select-2-label">Chose second option:</span>
+          <Select id="select-2" labelId="select-2-label" name="select" value="" />
+        </React.Fragment>,
+      );
+
+      const triggers = getAllByRole('combobox');
+
+      expect(triggers[0]).to.have.attribute(
+        'aria-labelledby',
+        `select-1-label ${triggers[0].getAttribute('id')}`,
+      );
+      expect(triggers[1]).to.have.attribute(
+        'aria-labelledby',
+        `select-2-label ${triggers[1].getAttribute('id')}`,
+      );
+    });
+
+    it('can be labelled by an additional element if its id is provided in `labelId`', () => {
+      const { getByRole } = render(
+        <React.Fragment>
+          <span id="select-label">Choose one:</span>
+          <Select labelId="select-label" name="select" value="" />
+        </React.Fragment>,
+      );
+
+      expect(getByRole('combobox')).to.have.attribute(
+        'aria-labelledby',
+        `select-label ${getByRole('combobox').getAttribute('id')}`,
+      );
+    });
+
+    specify('the list of options is not labelled by default', () => {
+      const { getByRole } = render(<Select open value="" />);
+
+      expect(getByRole('listbox')).not.to.have.attribute('aria-labelledby');
+    });
+
+    specify('the list of options can be labelled by providing `labelId`', () => {
+      const { getByRole } = render(
+        <React.Fragment>
+          <span id="select-label">Choose one:</span>
+          <Select labelId="select-label" open value="" />
+        </React.Fragment>,
+      );
+
+      expect(getByRole('listbox')).to.have.attribute('aria-labelledby', 'select-label');
+    });
+
+    it('should have appropriate accessible description when provided in props', () => {
+      const { getByRole } = render(
+        <React.Fragment>
+          <Select aria-describedby="select-helper-text" value="" />
+          <span id="select-helper-text">Helper text content</span>
+        </React.Fragment>,
+      );
+
+      const target = getByRole('combobox');
+      expect(target).to.have.attribute('aria-describedby', 'select-helper-text');
+      expect(target).toHaveAccessibleDescription('Helper text content');
+    });
+  });
+
+  describe('prop: readOnly', () => {
+    it('should not trigger any event with readOnly', () => {
+      render(
+        <Select readOnly value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+        </Select>,
+      );
+      const trigger = screen.getByRole('combobox');
+      act(() => {
+        trigger.focus();
+      });
+
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+      expect(screen.queryByRole('listbox')).to.equal(null);
+
+      fireEvent.keyUp(trigger, { key: 'ArrowDown' });
+      expect(screen.queryByRole('listbox')).to.equal(null);
+    });
+  });
+
+  describe('prop: MenuProps', () => {
+    it('should apply additional props to the Menu component', () => {
+      const onEntered = spy();
+      const { getByRole } = render(
+        <Select MenuProps={{ TransitionProps: { onEntered }, transitionDuration: 100 }} value="10">
+          <MenuItem value="10">Ten</MenuItem>
+        </Select>,
+      );
+
+      fireEvent.mouseDown(getByRole('combobox'));
+      clock.tick(99);
+
+      expect(onEntered.callCount).to.equal(0);
+
+      clock.tick(1);
+
+      expect(onEntered.callCount).to.equal(1);
+    });
+
+    it('should be able to override PaperProps minWidth', () => {
+      const { getByTestId } = render(
+        <Select
+          MenuProps={{ PaperProps: { 'data-testid': 'paper', style: { minWidth: 12 } } }}
+          open
+          value="10"
+        >
+          <MenuItem value="10">Ten</MenuItem>
+        </Select>,
+      );
+
+      expect(getByTestId('paper').style).to.have.property('minWidth', '12px');
+    });
+
+    // https://github.com/mui/material-ui/issues/38700
+    it('should merge `slotProps.paper` with the default Paper props', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const { getByTestId, getByRole } = render(
+        <Select MenuProps={{ slotProps: { paper: { 'data-testid': 'paper' } } }} open value="10">
+          <MenuItem value="10">Ten</MenuItem>
+        </Select>,
+      );
+
+      const paper = getByTestId('paper');
+      const selectButton = getByRole('combobox', { hidden: true });
+
+      expect(paper.style).to.have.property('minWidth', `${selectButton.clientWidth}px`);
+    });
+
+    // https://github.com/mui/material-ui/issues/38949
+    it('should forward `slotProps` to menu', function test() {
+      const { getByTestId } = render(
+        <Select
+          MenuProps={{
+            slotProps: {
+              root: {
+                slotProps: {
+                  backdrop: { 'data-testid': 'backdrop', style: { backgroundColor: 'red' } },
+                },
+              },
+            },
+          }}
+          open
+          value="10"
+        >
+          <MenuItem value="10">Ten</MenuItem>
+        </Select>,
+      );
+
+      const backdrop = getByTestId('backdrop');
+
+      expect(backdrop.style).to.have.property('backgroundColor', 'red');
+    });
+  });
+
+  describe('prop: SelectDisplayProps', () => {
+    it('should apply additional props to trigger element', () => {
+      const { getByRole } = render(
+        <Select SelectDisplayProps={{ 'data-test': 'SelectDisplay' }} value="10">
+          <MenuItem value="10">Ten</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('combobox')).to.have.attribute('data-test', 'SelectDisplay');
+    });
+  });
+
+  describe('prop: displayEmpty', () => {
+    it('should display the selected item even if its value is empty', () => {
+      const { getByRole } = render(
+        <Select value="" displayEmpty>
+          <MenuItem value="">Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('combobox')).to.have.text('Ten');
+    });
+  });
+
+  describe('prop: renderValue', () => {
+    it('should use the prop to render the value', () => {
+      const renderValue = (x) => `0b${x.toString(2)}`;
+      const { getByRole } = render(
+        <Select renderValue={renderValue} value={4}>
+          <MenuItem value={2}>2</MenuItem>
+          <MenuItem value={4}>4</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('combobox')).to.have.text('0b100');
+    });
+  });
+
+  describe('prop: open (controlled)', () => {
+    it('should not focus on close controlled select', () => {
+      function ControlledWrapper() {
+        const [open, setOpen] = React.useState(false);
+
+        return (
+          <div>
+            <button type="button" id="open-select" onClick={() => setOpen(true)}>
+              Open select
+            </button>
+            <Select
+              MenuProps={{ transitionDuration: 0 }}
+              open={open}
+              onClose={() => setOpen(false)}
+              value=""
+            >
+              <MenuItem onClick={() => setOpen(false)}>close</MenuItem>
+            </Select>
+          </div>
+        );
+      }
+      const { container, getByRole } = render(<ControlledWrapper />);
+      const openSelect = container.querySelector('#open-select');
+      act(() => {
+        openSelect.focus();
+      });
+      fireEvent.click(openSelect);
+
+      const option = getByRole('option');
+      expect(option).toHaveFocus();
+      fireEvent.click(option);
+
+      expect(container.querySelectorAll(classes.focused).length).to.equal(0);
+      expect(openSelect).toHaveFocus();
+    });
+
+    it('should allow to control closing by passing onClose props', () => {
+      function ControlledWrapper() {
+        const [open, setOpen] = React.useState(false);
+
+        return (
+          <Select
+            MenuProps={{ transitionDuration: 0 }}
+            open={open}
+            onClose={() => setOpen(false)}
+            onOpen={() => setOpen(true)}
+            value=""
+          >
+            <MenuItem onClick={() => setOpen(false)}>close</MenuItem>
+          </Select>
+        );
+      }
+      const { getByRole, queryByRole } = render(<ControlledWrapper />);
+
+      fireEvent.mouseDown(getByRole('combobox'));
+      expect(getByRole('listbox')).not.to.equal(null);
+
+      act(() => {
+        getByRole('option').click();
+      });
+      // react-transition-group uses one extra commit for exit to completely remove
+      // it from the DOM. but it's at least immediately inaccessible.
+      // It's desired that this fails one day. The additional tick required to remove
+      // this from the DOM is not a feature
+      expect(getByRole('listbox', { hidden: true })).toBeInaccessible();
+      clock.tick(0);
+
+      expect(queryByRole('listbox', { hidden: true })).to.equal(null);
+    });
+
+    it('should be open when initially true', () => {
+      const { getByRole } = render(
+        <Select open value="">
+          <MenuItem>Hello</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('listbox')).not.to.equal(null);
+    });
+
+    it('open only with the left mouse button click', () => {
+      // Test for https://github.com/mui/material-ui/issues/19250#issuecomment-578620934
+      // Right/middle mouse click shouldn't open the Select
+      const { getByRole, queryByRole } = render(
+        <Select value="">
+          <MenuItem value="">
+            <em>None</em>
+          </MenuItem>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      const trigger = getByRole('combobox');
+
+      // If clicked by the right/middle mouse button, no options list should be opened
+      fireEvent.mouseDown(trigger, { button: 1 });
+      expect(queryByRole('listbox')).to.equal(null);
+
+      fireEvent.mouseDown(trigger, { button: 2 });
+      expect(queryByRole('listbox')).to.equal(null);
+    });
+  });
+
+  describe('prop: autoWidth', () => {
+    it('should take the trigger parent element width into account by default', () => {
+      const { container, getByRole, getByTestId } = render(
+        <Select MenuProps={{ PaperProps: { 'data-testid': 'paper' } }} value="">
+          <MenuItem>Only</MenuItem>
+        </Select>,
+      );
+      const parentEl = container.querySelector('.MuiInputBase-root');
+      const button = getByRole('combobox');
+      stub(parentEl, 'clientWidth').get(() => 14);
+
+      fireEvent.mouseDown(button);
+      expect(getByTestId('paper').style).to.have.property('minWidth', '14px');
+    });
+
+    it('should not take the trigger parent element width into account when autoWidth is true', () => {
+      const { container, getByRole, getByTestId } = render(
+        <Select autoWidth MenuProps={{ PaperProps: { 'data-testid': 'paper' } }} value="">
+          <MenuItem>Only</MenuItem>
+        </Select>,
+      );
+      const parentEl = container.querySelector('.MuiInputBase-root');
+      const button = getByRole('combobox');
+      stub(parentEl, 'clientWidth').get(() => 14);
+
+      fireEvent.mouseDown(button);
+      expect(getByTestId('paper').style).to.have.property('minWidth', '');
+    });
+  });
+
+  describe('prop: multiple', () => {
+    it('should serialize multiple select value', () => {
+      const { container, getAllByRole } = render(
+        <Select multiple open value={[10, 30]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+      const options = getAllByRole('option');
+
+      expect(container.querySelector('input')).to.have.property('value', '10,30');
+      expect(options[0]).to.have.attribute('aria-selected', 'true');
+      expect(options[1]).not.to.have.attribute('aria-selected', 'true');
+      expect(options[2]).to.have.attribute('aria-selected', 'true');
+    });
+
+    it('should have aria-multiselectable=true when multiple is true', () => {
+      const { getByRole } = render(
+        <Select multiple value={[10, 30]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      fireEvent.mouseDown(getByRole('combobox'));
+
+      expect(getByRole('listbox')).to.have.attribute('aria-multiselectable', 'true');
+    });
+
+    it('should serialize multiple select display value', () => {
+      const { getByRole } = render(
+        <Select multiple value={[10, 20, 30]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>
+            <strong>Twenty</strong>
+          </MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      expect(getByRole('combobox')).to.have.text('Ten, Twenty, Thirty');
+    });
+
+    it('should not throw an error if `value` is an empty array', () => {
+      expect(() => {
+        render(<Select multiple value={[]} />);
+      }).not.to.throw();
+    });
+
+    it('should not throw an error if `value` is not an empty array', () => {
+      expect(() => {
+        render(<Select multiple value={['foo']} />);
+      }).not.to.throw();
+    });
+
+    it("selects value based on their stringified equality when they're not objects", () => {
+      const { getAllByRole } = render(
+        <Select multiple open value={['10', '20']}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+      const options = getAllByRole('option');
+
+      expect(options[0]).to.have.attribute('aria-selected', 'true');
+      expect(options[1]).to.have.attribute('aria-selected', 'true');
+      expect(options[2]).not.to.have.attribute('aria-selected', 'true');
+    });
+
+    it("selects values based on strict equality if they're objects", () => {
+      const obj1 = { id: 1 };
+      const obj2 = { id: 2 };
+      const obj3 = { id: 3 };
+      const { getAllByRole } = render(
+        <Select multiple open value={[obj1, obj3]}>
+          <MenuItem value={obj1}>ID: 1</MenuItem>
+          <MenuItem value={obj2}>ID: 2</MenuItem>
+          <MenuItem value={obj3}>ID: 3</MenuItem>
+        </Select>,
+      );
+      const options = getAllByRole('option');
+
+      expect(options[0]).to.have.attribute('aria-selected', 'true');
+      expect(options[1]).not.to.have.attribute('aria-selected', 'true');
+      expect(options[2]).to.have.attribute('aria-selected', 'true');
+    });
+
+    describe('errors', () => {
+      it('should throw if non array', function test() {
+        // TODO is this fixed?
+        if (!/jsdom/.test(window.navigator.userAgent)) {
+          // can't catch render errors in the browser for unknown reason
+          // tried try-catch + error boundary + window onError preventDefault
+          this.skip();
+        }
+
+        const errorRef = React.createRef();
+        expect(() => {
+          render(
+            <ErrorBoundary ref={errorRef}>
+              <Select multiple value="10,20">
+                <MenuItem value="10">Ten</MenuItem>
+                <MenuItem value="20">Twenty</MenuItem>
+                <MenuItem value="30">Thirty</MenuItem>
+              </Select>
+            </ErrorBoundary>,
+          );
+        }).toErrorDev([
+          'MUI: The `value` prop must be an array',
+          // React 18 Strict Effects run mount effects twice
+          React.version.startsWith('18') && 'MUI: The `value` prop must be an array',
+          'The above error occurred in the <ForwardRef(SelectInput)> component',
+        ]);
+        const {
+          current: { errors },
+        } = errorRef;
+        expect(errors).to.have.length(1);
+        expect(errors[0].toString()).to.include('MUI: The `value` prop must be an array');
+      });
+    });
+
+    describe('prop: onChange', () => {
+      it('should call onChange when clicking an item', () => {
+        function ControlledSelectInput(props) {
+          const { onChange } = props;
+          const [values, clickedValue] = React.useReducer((currentValues, valueClicked) => {
+            if (currentValues.indexOf(valueClicked) === -1) {
+              return currentValues.concat(valueClicked);
+            }
+            return currentValues.filter((value) => {
+              return value !== valueClicked;
+            });
+          }, []);
+
+          const handleChange = (event) => {
+            onChange(event);
+            clickedValue(event.target.value);
+          };
+
+          return (
+            <Select multiple name="age" onChange={handleChange} value={values}>
+              <MenuItem value={10}>Ten</MenuItem>
+              <MenuItem value={20}>Ten</MenuItem>
+              <MenuItem value={30}>Ten</MenuItem>
+            </Select>
+          );
+        }
+        const onChange = stub().callsFake((event) => {
+          return {
+            name: event.target.name,
+            value: event.target.value,
+          };
+        });
+        const { getByRole, getAllByRole } = render(<ControlledSelectInput onChange={onChange} />);
+
+        fireEvent.mouseDown(getByRole('combobox'));
+        const options = getAllByRole('option');
+        fireEvent.click(options[2]);
+
+        expect(onChange.callCount).to.equal(1);
+        expect(onChange.firstCall.returnValue).to.deep.equal({ name: 'age', value: [30] });
+
+        act(() => {
+          options[0].click();
+        });
+
+        expect(onChange.callCount).to.equal(2);
+        expect(onChange.secondCall.returnValue).to.deep.equal({ name: 'age', value: [30, 10] });
+      });
+    });
+
+    it('should apply multiple class to `select` slot', () => {
+      const { container } = render(
+        <Select multiple open value={[10, 30]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </Select>,
+      );
+
+      expect(container.querySelector(`.${classes.select}`)).to.have.class(classes.multiple);
+    });
+
+    it('should be able to override `multiple` rule name in `select` slot', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const selectStyle = {
+        marginLeft: '10px',
+        marginTop: '10px',
+      };
+
+      const multipleStyle = {
+        marginTop: '14px',
+      };
+
+      const theme = createTheme({
+        components: {
+          MuiSelect: {
+            styleOverrides: {
+              select: selectStyle,
+              multiple: multipleStyle,
+            },
+          },
+        },
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Select open value={['first']} multiple>
+            <MenuItem value="first" />
+            <MenuItem value="second" />
+          </Select>
+        </ThemeProvider>,
+      );
+
+      const combinedStyle = { ...selectStyle, ...multipleStyle };
+
+      expect(container.getElementsByClassName(classes.select)[0]).to.toHaveComputedStyle(
+        combinedStyle,
+      );
+    });
+  });
+
+  describe('prop: autoFocus', () => {
+    it('should focus select after Select did mount', () => {
+      const { getByRole } = render(<Select value="" autoFocus />);
+
+      expect(getByRole('combobox')).toHaveFocus();
+    });
+  });
+
+  it('should be able to return the input node via a ref object', () => {
+    const ref = React.createRef();
+    const { setProps } = render(<Select inputProps={{ ref }} value="" />);
+
+    expect(ref.current.node).to.have.tagName('input');
+
+    setProps({
+      value: '',
+    });
+    expect(ref.current.node).to.have.tagName('input');
+  });
+
+  describe('prop: inputRef', () => {
+    it('should be able to return the input node via a ref object', () => {
+      const ref = React.createRef();
+      render(<Select inputRef={ref} value="" />);
+
+      expect(ref.current.node).to.have.tagName('input');
+    });
+
+    // TODO: This might be confusing a prop called input!Ref can imperatively
+    // focus a button. This implies <input type="button" /> is still used.
+    it('should be able focus the trigger imperatively', () => {
+      const ref = React.createRef();
+      const { getByRole } = render(<Select inputRef={ref} value="" />);
+
+      act(() => {
+        ref.current.focus();
+      });
+
+      expect(getByRole('combobox')).toHaveFocus();
+    });
+  });
+
+  describe('prop: name', () => {
+    it('should have no id when name is not provided', () => {
+      const { getByRole } = render(<Select value="" />);
+
+      expect(getByRole('combobox')).not.to.have.attribute('id');
+    });
+
+    it('should have select-`name` id when name is provided', () => {
+      const { getByRole } = render(<Select name="foo" value="" />);
+
+      expect(getByRole('combobox')).to.have.attribute('id', 'mui-component-select-foo');
+    });
+  });
+
+  describe('prop: native', () => {
+    it('renders a <select />', () => {
+      const { container } = render(<Select native />);
+
+      expect(container.querySelector('select')).not.to.equal(null);
+    });
+
+    it('can be labelled with a <label />', () => {
+      const { getByRole } = render(
+        <React.Fragment>
+          <label htmlFor="select">A select</label>
+          <Select id="select" native />
+        </React.Fragment>,
+      );
+
+      expect(getByRole('combobox', { name: 'A select' })).to.have.property('tagName', 'SELECT');
+    });
+  });
+
+  it('prevents the default when releasing Space on the children', () => {
+    const keyUpSpy = spy();
+    render(
+      <Select value="one" open>
+        <MenuItem onKeyUp={keyUpSpy} value="one">
+          One
+        </MenuItem>
+      </Select>,
+    );
+
+    fireEvent.keyUp(screen.getAllByRole('option')[0], { key: ' ' });
+
+    expect(keyUpSpy.callCount).to.equal(1);
+    expect(keyUpSpy.firstCall.args[0]).to.have.property('defaultPrevented', true);
+  });
+
+  it('should pass onClick prop to MenuItem', () => {
+    const onClick = spy();
+    const { getAllByRole } = render(
+      <Select open value="30">
+        <MenuItem onClick={onClick} value={30}>
+          Thirty
+        </MenuItem>
+      </Select>,
+    );
+
+    const options = getAllByRole('option');
+    fireEvent.click(options[0]);
+
+    expect(onClick.callCount).to.equal(1);
+  });
+
+  // https://github.com/testing-library/react-testing-library/issues/322
+  // https://twitter.com/devongovett/status/1248306411508916224
+  it('should handle the browser autofill event and simple testing-library API', () => {
+    const onChangeHandler = spy();
+    const { container, getByRole } = render(
+      <Select onChange={onChangeHandler} defaultValue="germany" name="country">
+        <MenuItem value="france">France</MenuItem>
+        <MenuItem value="germany">Germany</MenuItem>
+        <MenuItem value="china">China</MenuItem>
+      </Select>,
+    );
+    fireEvent.change(container.querySelector('input[name="country"]'), {
+      target: {
+        value: 'france',
+      },
+    });
+
+    expect(onChangeHandler.calledOnce).to.equal(true);
+    expect(getByRole('combobox')).to.have.text('France');
+  });
+
+  it('should support native form validation', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // see https://github.com/jsdom/jsdom/issues/123
+      this.skip();
+    }
+
+    const handleSubmit = spy((event) => {
+      // avoid karma reload.
+      event.preventDefault();
+    });
+    function Form(props) {
+      return (
+        <form onSubmit={handleSubmit}>
+          <Select required name="country" {...props}>
+            <MenuItem value="" />
+            <MenuItem value="france">France</MenuItem>
+            <MenuItem value="germany">Germany</MenuItem>
+            <MenuItem value="china">China</MenuItem>
+          </Select>
+          <button type="submit" />
+        </form>
+      );
+    }
+    const { container, setProps } = render(<Form value="" />);
+
+    fireEvent.click(container.querySelector('button[type=submit]'));
+    expect(handleSubmit.callCount).to.equal(0, 'the select is empty it should disallow submit');
+
+    setProps({ value: 'france' });
+    fireEvent.click(container.querySelector('button[type=submit]'));
+    expect(handleSubmit.callCount).to.equal(1);
+  });
+
+  it('should programmatically focus the select', () => {
+    const { getByRole } = render(
+      <Select
+        value={1}
+        inputRef={(input) => {
+          if (input !== null) {
+            input.focus();
+          }
+        }}
+      >
+        <MenuItem value={1}>1</MenuItem>
+        <MenuItem value={2}>2</MenuItem>
+      </Select>,
+    );
+    expect(document.activeElement).to.equal(getByRole('combobox'));
+  });
+
+  it('should not override the event.target on mouse events', () => {
+    const handleChange = spy();
+    const handleClick = spy();
+    render(
+      <div onClick={handleClick}>
+        <Select open onChange={handleChange} value="second">
+          <MenuItem value="first" />
+          <MenuItem value="second" />
+        </Select>
+      </div>,
+    );
+
+    const options = screen.getAllByRole('option');
+    options[0].click();
+
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleClick.callCount).to.equal(1);
+    expect(handleClick.firstCall.args[0]).to.have.property('target', options[0]);
+  });
+
+  it('should only select options', () => {
+    const handleChange = spy();
+    render(
+      <Select open onChange={handleChange} value="second">
+        <MenuItem value="first" />
+        <Divider />
+        <MenuItem value="second" />
+      </Select>,
+    );
+
+    const divider = document.querySelector('hr');
+    divider.click();
+    expect(handleChange.callCount).to.equal(0);
+  });
+
+  it('slots overrides should work', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      this.skip();
+    }
+
+    const rootStyle = {
+      marginTop: '15px',
+    };
+
+    const iconStyle = {
+      marginTop: '13px',
+    };
+
+    const nativeInputStyle = {
+      marginTop: '10px',
+    };
+
+    const selectStyle = {
+      marginLeft: '10px',
+      marginTop: '12px',
+    };
+
+    const multipleStyle = {
+      marginTop: '14px',
+    };
+
+    const theme = createTheme({
+      components: {
+        MuiSelect: {
+          styleOverrides: {
+            root: rootStyle,
+            select: selectStyle,
+            icon: iconStyle,
+            nativeInput: nativeInputStyle,
+            multiple: multipleStyle,
+          },
+        },
+      },
+    });
+
+    const { container, getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <Select open value="first" data-testid="select">
+          <MenuItem value="first" />
+          <MenuItem value="second" />
+        </Select>
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('select')).toHaveComputedStyle(rootStyle);
+    expect(container.getElementsByClassName(classes.icon)[0]).to.toHaveComputedStyle(iconStyle);
+    expect(container.getElementsByClassName(classes.nativeInput)[0]).to.toHaveComputedStyle(
+      nativeInputStyle,
+    );
+    expect(container.getElementsByClassName(classes.select)[0]).to.toHaveComputedStyle(selectStyle);
+  });
+
+  describe('theme styleOverrides:', () => {
+    it('should override with error style when `native select` has `error` state', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const iconStyle = { color: 'rgb(255, 0, 0)' };
+
+      const theme = createTheme({
+        components: {
+          MuiNativeSelect: {
+            styleOverrides: {
+              icon: (props) => ({
+                ...(props.ownerState.error && iconStyle),
+              }),
+            },
+          },
+        },
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Select value="first" error IconComponent="div" native>
+            <option value="first">first</option>
+          </Select>
+        </ThemeProvider>,
+      );
+
+      expect(container.querySelector(`.${nativeSelectClasses.icon}`)).toHaveComputedStyle(
+        iconStyle,
+      );
+    });
+
+    it('should override with error style when `select` has `error` state', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
+      const iconStyle = { color: 'rgb(255, 0, 0)' };
+      const selectStyle = { color: 'rgb(255, 192, 203)' };
+
+      const theme = createTheme({
+        components: {
+          MuiSelect: {
+            styleOverrides: {
+              icon: (props) => ({
+                ...(props.ownerState.error && iconStyle),
+              }),
+              select: (props) => ({
+                ...(props.ownerState.error && selectStyle),
+              }),
+            },
+          },
+        },
+      });
+
+      const { container } = render(
+        <ThemeProvider theme={theme}>
+          <Select value="" error IconComponent="div" />
+        </ThemeProvider>,
+      );
+      expect(container.querySelector(`.${classes.select}`)).toHaveComputedStyle(selectStyle);
+      expect(container.querySelector(`.${classes.icon}`)).toHaveComputedStyle(iconStyle);
+    });
+  });
+
+  ['standard', 'outlined', 'filled'].forEach((variant) => {
+    it(`variant overrides should work for "${variant}" variant`, function test() {
+      const theme = createTheme({
+        components: {
+          MuiSelect: {
+            variants: [
+              {
+                props: {
+                  variant,
+                },
+                style: {
+                  fontWeight: '200',
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const { getByTestId } = render(
+        <ThemeProvider theme={theme}>
+          <Select variant={variant} value="first" data-testid="input">
+            <MenuItem value="first" />
+            <MenuItem value="second" />
+          </Select>
+        </ThemeProvider>,
+      );
+
+      expect(getByTestId('input')).to.toHaveComputedStyle({
+        fontWeight: '200',
+      });
+    });
+  });
+
+  describe('prop: input', () => {
+    it('merges `ref` of `Select` and `input`', () => {
+      const Input = React.forwardRef(function Input(props, ref) {
+        const { inputProps, inputComponent: Component, ...other } = props;
+
+        React.useImperativeHandle(ref, () => {
+          return { refToInput: true };
+        });
+
+        return <Component {...inputProps} {...other} ref={ref} />;
+      });
+      const inputRef = React.createRef();
+      const selectRef = React.createRef();
+      render(
+        <Select input={<Input data-testid="input" ref={inputRef} value="" />} ref={selectRef} />,
+      );
+
+      expect(inputRef).to.deep.equal({ current: { refToInput: true } });
+      expect(selectRef).to.deep.equal({ current: { refToInput: true } });
+    });
+
+    it('should merge the class names', () => {
+      const { getByTestId } = render(
+        <Select
+          className="foo"
+          input={<InputBase data-testid="root" className="bar" />}
+          value=""
+        />,
+      );
+      expect(getByTestId('root')).to.have.class('foo');
+      expect(getByTestId('root')).to.have.class('bar');
+    });
+  });
+
+  it('should not focus select when clicking an arbitrary element with id="undefined"', () => {
+    const { getByRole, getByTestId } = render(
+      <React.Fragment>
+        <div id="undefined" data-testid="test-element" />
+        <Select value="" />
+      </React.Fragment>,
+    );
+
+    fireEvent.click(getByTestId('test-element'));
+
+    expect(getByRole('combobox')).not.toHaveFocus();
+  });
+});

--- a/packages/mui-material-next/src/Select/Select.test.js
+++ b/packages/mui-material-next/src/Select/Select.test.js
@@ -11,14 +11,14 @@ import {
 } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import MenuItem, { menuItemClasses } from '@mui/material/MenuItem';
+// TODO v6: replace @mui/material with @mui/material-next when components are available
 import ListSubheader from '@mui/material/ListSubheader';
-import InputBase from '@mui/material/InputBase';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import InputLabel from '@mui/material/InputLabel';
-import Select from '@mui/material/Select';
+import { nativeSelectClasses } from '@mui/material/NativeSelect';
 import Divider from '@mui/material/Divider';
+import Select from '@mui/material-next/Select';
 import classes from './selectClasses';
-import { nativeSelectClasses } from '../NativeSelect';
 
 describe('<Select />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });
@@ -1685,7 +1685,7 @@ describe('<Select />', () => {
       const { getByTestId } = render(
         <Select
           className="foo"
-          input={<InputBase data-testid="root" className="bar" />}
+          input={<OutlinedInput data-testid="root" className="bar" />}
           value=""
         />,
       );

--- a/packages/mui-material-next/src/Select/Select.test.js
+++ b/packages/mui-material-next/src/Select/Select.test.js
@@ -9,13 +9,18 @@ import {
   fireEvent,
   screen,
 } from '@mui-internal/test-utils';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
-import MenuItem, { menuItemClasses } from '@mui/material/MenuItem';
-// TODO v6: replace @mui/material with @mui/material-next when components are available
-import ListSubheader from '@mui/material/ListSubheader';
-import OutlinedInput from '@mui/material/OutlinedInput';
-import InputLabel from '@mui/material/InputLabel';
 import { nativeSelectClasses } from '@mui/material/NativeSelect';
+// TODO v6: replace with material-next's extendTheme and provider when implementing Material You design
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+// TODO v6: replace with material-next Menu components when available https://github.com/mui/material-ui/pull/38934
+import MenuItem, { menuItemClasses } from '@mui/material/MenuItem';
+// TODO v6: replace with material-next ListSubheader when available
+import ListSubheader from '@mui/material/ListSubheader';
+// TODO v6: replace with material-next OutlinedInput when available
+import OutlinedInput from '@mui/material/OutlinedInput';
+// TODO v6: replace with material-next InputLabel when available
+import InputLabel from '@mui/material/InputLabel';
+// TODO v6: replace with material-next Divider when available
 import Divider from '@mui/material/Divider';
 import Select from '@mui/material-next/Select';
 import classes from './selectClasses';

--- a/packages/mui-material-next/src/Select/SelectInput.d.ts
+++ b/packages/mui-material-next/src/Select/SelectInput.d.ts
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { Theme } from '..';
+import { MenuProps } from '../Menu';
+
+/**
+ * The change can be caused by different kind of events.
+ * The type of event depends on what caused the change.
+ * For example, when the browser auto-fills the `Select` you'll receive a `React.ChangeEvent`.
+ */
+export type SelectChangeEvent<Value = string> =
+  | (Event & { target: { value: Value; name: string } })
+  | React.ChangeEvent<HTMLInputElement>;
+
+export interface SelectInputProps<Value = unknown> {
+  autoFocus?: boolean;
+  autoWidth: boolean;
+  defaultOpen?: boolean;
+  disabled?: boolean;
+  error?: boolean;
+  IconComponent?: React.ElementType;
+  inputRef?: (
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<Value>['value'] },
+  ) => void;
+  MenuProps?: Partial<MenuProps>;
+  multiple: boolean;
+  name?: string;
+  native: boolean;
+  onBlur?: React.FocusEventHandler<any>;
+  onChange?: (event: SelectChangeEvent<Value>, child: React.ReactNode) => void;
+  onClose?: (event: React.SyntheticEvent) => void;
+  onFocus?: React.FocusEventHandler<any>;
+  onOpen?: (event: React.SyntheticEvent) => void;
+  open?: boolean;
+  readOnly?: boolean;
+  renderValue?: (value: SelectInputProps<Value>['value']) => React.ReactNode;
+  SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
+  sx?: SxProps<Theme>;
+  tabIndex?: number;
+  value?: Value;
+  variant?: 'standard' | 'outlined' | 'filled';
+}
+
+declare const SelectInput: React.JSXElementConstructor<SelectInputProps>;
+
+export default SelectInput;

--- a/packages/mui-material-next/src/Select/SelectInput.d.ts
+++ b/packages/mui-material-next/src/Select/SelectInput.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-// TODO v6: replace @mui/material with @mui/material-next when Menu component is available
+// TODO v6: replace with material-next MenuProps when available https://github.com/mui/material-ui/pull/38934
 import { MenuProps } from '@mui/material/Menu';
 import { Theme } from '..';
 

--- a/packages/mui-material-next/src/Select/SelectInput.d.ts
+++ b/packages/mui-material-next/src/Select/SelectInput.d.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
+// TODO v6: replace @mui/material with @mui/material-next when Menu component is available
+import { MenuProps } from '@mui/material/Menu';
 import { Theme } from '..';
-import { MenuProps } from '../Menu';
 
 /**
  * The change can be caused by different kind of events.

--- a/packages/mui-material-next/src/Select/SelectInput.js
+++ b/packages/mui-material-next/src/Select/SelectInput.js
@@ -1,0 +1,723 @@
+'use client';
+import * as React from 'react';
+import { isFragment } from 'react-is';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import MuiError from '@mui/utils/macros/MuiError.macro';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { refType, unstable_useId as useId } from '@mui/utils';
+import ownerDocument from '../utils/ownerDocument';
+import capitalize from '../utils/capitalize';
+import Menu from '../Menu/Menu';
+import {
+  nativeSelectSelectStyles,
+  nativeSelectIconStyles,
+} from '../NativeSelect/NativeSelectInput';
+import { isFilled } from '../InputBase/utils';
+import styled, { slotShouldForwardProp } from '../styles/styled';
+import useForkRef from '../utils/useForkRef';
+import useControlled from '../utils/useControlled';
+import selectClasses, { getSelectUtilityClasses } from './selectClasses';
+
+const SelectSelect = styled('div', {
+  name: 'MuiSelect',
+  slot: 'Select',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+    return [
+      // Win specificity over the input base
+      { [`&.${selectClasses.select}`]: styles.select },
+      { [`&.${selectClasses.select}`]: styles[ownerState.variant] },
+      { [`&.${selectClasses.error}`]: styles.error },
+      { [`&.${selectClasses.multiple}`]: styles.multiple },
+    ];
+  },
+})(nativeSelectSelectStyles, {
+  // Win specificity over the input base
+  [`&.${selectClasses.select}`]: {
+    height: 'auto', // Resets for multiple select with chips
+    minHeight: '1.4375em', // Required for select\text-field height consistency
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+  },
+});
+
+const SelectIcon = styled('svg', {
+  name: 'MuiSelect',
+  slot: 'Icon',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+    return [
+      styles.icon,
+      ownerState.variant && styles[`icon${capitalize(ownerState.variant)}`],
+      ownerState.open && styles.iconOpen,
+    ];
+  },
+})(nativeSelectIconStyles);
+
+const SelectNativeInput = styled('input', {
+  shouldForwardProp: (prop) => slotShouldForwardProp(prop) && prop !== 'classes',
+  name: 'MuiSelect',
+  slot: 'NativeInput',
+  overridesResolver: (props, styles) => styles.nativeInput,
+})({
+  bottom: 0,
+  left: 0,
+  position: 'absolute',
+  opacity: 0,
+  pointerEvents: 'none',
+  width: '100%',
+  boxSizing: 'border-box',
+});
+
+function areEqualValues(a, b) {
+  if (typeof b === 'object' && b !== null) {
+    return a === b;
+  }
+
+  // The value could be a number, the DOM will stringify it anyway.
+  return String(a) === String(b);
+}
+
+function isEmpty(display) {
+  return display == null || (typeof display === 'string' && !display.trim());
+}
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, variant, disabled, multiple, open, error } = ownerState;
+
+  const slots = {
+    select: ['select', variant, disabled && 'disabled', multiple && 'multiple', error && 'error'],
+    icon: ['icon', `icon${capitalize(variant)}`, open && 'iconOpen', disabled && 'disabled'],
+    nativeInput: ['nativeInput'],
+  };
+
+  return composeClasses(slots, getSelectUtilityClasses, classes);
+};
+
+/**
+ * @ignore - internal component.
+ */
+const SelectInput = React.forwardRef(function SelectInput(props, ref) {
+  const {
+    'aria-describedby': ariaDescribedby,
+    'aria-label': ariaLabel,
+    autoFocus,
+    autoWidth,
+    children,
+    className,
+    defaultOpen,
+    defaultValue,
+    disabled,
+    displayEmpty,
+    error = false,
+    IconComponent,
+    inputRef: inputRefProp,
+    labelId,
+    MenuProps = {},
+    multiple,
+    name,
+    onBlur,
+    onChange,
+    onClose,
+    onFocus,
+    onOpen,
+    open: openProp,
+    readOnly,
+    renderValue,
+    SelectDisplayProps = {},
+    tabIndex: tabIndexProp,
+    // catching `type` from Input which makes no sense for SelectInput
+    type,
+    value: valueProp,
+    variant = 'standard',
+    ...other
+  } = props;
+
+  const [value, setValueState] = useControlled({
+    controlled: valueProp,
+    default: defaultValue,
+    name: 'Select',
+  });
+  const [openState, setOpenState] = useControlled({
+    controlled: openProp,
+    default: defaultOpen,
+    name: 'Select',
+  });
+
+  const inputRef = React.useRef(null);
+  const displayRef = React.useRef(null);
+  const [displayNode, setDisplayNode] = React.useState(null);
+  const { current: isOpenControlled } = React.useRef(openProp != null);
+  const [menuMinWidthState, setMenuMinWidthState] = React.useState();
+  const handleRef = useForkRef(ref, inputRefProp);
+
+  const handleDisplayRef = React.useCallback((node) => {
+    displayRef.current = node;
+
+    if (node) {
+      setDisplayNode(node);
+    }
+  }, []);
+
+  const anchorElement = displayNode?.parentNode;
+
+  React.useImperativeHandle(
+    handleRef,
+    () => ({
+      focus: () => {
+        displayRef.current.focus();
+      },
+      node: inputRef.current,
+      value,
+    }),
+    [value],
+  );
+
+  // Resize menu on `defaultOpen` automatic toggle.
+  React.useEffect(() => {
+    if (defaultOpen && openState && displayNode && !isOpenControlled) {
+      setMenuMinWidthState(autoWidth ? null : anchorElement.clientWidth);
+      displayRef.current.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayNode, autoWidth]);
+  // `isOpenControlled` is ignored because the component should never switch between controlled and uncontrolled modes.
+  // `defaultOpen` and `openState` are ignored to avoid unnecessary callbacks.
+  React.useEffect(() => {
+    if (autoFocus) {
+      displayRef.current.focus();
+    }
+  }, [autoFocus]);
+
+  React.useEffect(() => {
+    if (!labelId) {
+      return undefined;
+    }
+    const label = ownerDocument(displayRef.current).getElementById(labelId);
+    if (label) {
+      const handler = () => {
+        if (getSelection().isCollapsed) {
+          displayRef.current.focus();
+        }
+      };
+      label.addEventListener('click', handler);
+      return () => {
+        label.removeEventListener('click', handler);
+      };
+    }
+    return undefined;
+  }, [labelId]);
+
+  const update = (open, event) => {
+    if (open) {
+      if (onOpen) {
+        onOpen(event);
+      }
+    } else if (onClose) {
+      onClose(event);
+    }
+
+    if (!isOpenControlled) {
+      setMenuMinWidthState(autoWidth ? null : anchorElement.clientWidth);
+      setOpenState(open);
+    }
+  };
+
+  const handleMouseDown = (event) => {
+    // Ignore everything but left-click
+    if (event.button !== 0) {
+      return;
+    }
+    // Hijack the default focus behavior.
+    event.preventDefault();
+    displayRef.current.focus();
+
+    update(true, event);
+  };
+
+  const handleClose = (event) => {
+    update(false, event);
+  };
+
+  const childrenArray = React.Children.toArray(children);
+
+  // Support autofill.
+  const handleChange = (event) => {
+    const child = childrenArray.find((childItem) => childItem.props.value === event.target.value);
+
+    if (child === undefined) {
+      return;
+    }
+
+    setValueState(child.props.value);
+
+    if (onChange) {
+      onChange(event, child);
+    }
+  };
+
+  const handleItemClick = (child) => (event) => {
+    let newValue;
+
+    // We use the tabindex attribute to signal the available options.
+    if (!event.currentTarget.hasAttribute('tabindex')) {
+      return;
+    }
+
+    if (multiple) {
+      newValue = Array.isArray(value) ? value.slice() : [];
+      const itemIndex = value.indexOf(child.props.value);
+      if (itemIndex === -1) {
+        newValue.push(child.props.value);
+      } else {
+        newValue.splice(itemIndex, 1);
+      }
+    } else {
+      newValue = child.props.value;
+    }
+
+    if (child.props.onClick) {
+      child.props.onClick(event);
+    }
+
+    if (value !== newValue) {
+      setValueState(newValue);
+
+      if (onChange) {
+        // Redefine target to allow name and value to be read.
+        // This allows seamless integration with the most popular form libraries.
+        // https://github.com/mui/material-ui/issues/13485#issuecomment-676048492
+        // Clone the event to not override `target` of the original event.
+        const nativeEvent = event.nativeEvent || event;
+        const clonedEvent = new nativeEvent.constructor(nativeEvent.type, nativeEvent);
+
+        Object.defineProperty(clonedEvent, 'target', {
+          writable: true,
+          value: { value: newValue, name },
+        });
+        onChange(clonedEvent, child);
+      }
+    }
+
+    if (!multiple) {
+      update(false, event);
+    }
+  };
+
+  const handleKeyDown = (event) => {
+    if (!readOnly) {
+      const validKeys = [
+        ' ',
+        'ArrowUp',
+        'ArrowDown',
+        // The native select doesn't respond to enter on macOS, but it's recommended by
+        // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/
+        'Enter',
+      ];
+
+      if (validKeys.indexOf(event.key) !== -1) {
+        event.preventDefault();
+        update(true, event);
+      }
+    }
+  };
+
+  const open = displayNode !== null && openState;
+
+  const handleBlur = (event) => {
+    // if open event.stopImmediatePropagation
+    if (!open && onBlur) {
+      // Preact support, target is read only property on a native event.
+      Object.defineProperty(event, 'target', { writable: true, value: { value, name } });
+      onBlur(event);
+    }
+  };
+
+  delete other['aria-invalid'];
+
+  let display;
+  let displaySingle;
+  const displayMultiple = [];
+  let computeDisplay = false;
+  let foundMatch = false;
+
+  // No need to display any value if the field is empty.
+  if (isFilled({ value }) || displayEmpty) {
+    if (renderValue) {
+      display = renderValue(value);
+    } else {
+      computeDisplay = true;
+    }
+  }
+
+  const items = childrenArray.map((child) => {
+    if (!React.isValidElement(child)) {
+      return null;
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      if (isFragment(child)) {
+        console.error(
+          [
+            "MUI: The Select component doesn't accept a Fragment as a child.",
+            'Consider providing an array instead.',
+          ].join('\n'),
+        );
+      }
+    }
+
+    let selected;
+
+    if (multiple) {
+      if (!Array.isArray(value)) {
+        throw new MuiError(
+          'MUI: The `value` prop must be an array ' +
+            'when using the `Select` component with `multiple`.',
+        );
+      }
+
+      selected = value.some((v) => areEqualValues(v, child.props.value));
+      if (selected && computeDisplay) {
+        displayMultiple.push(child.props.children);
+      }
+    } else {
+      selected = areEqualValues(value, child.props.value);
+      if (selected && computeDisplay) {
+        displaySingle = child.props.children;
+      }
+    }
+
+    if (selected) {
+      foundMatch = true;
+    }
+
+    return React.cloneElement(child, {
+      'aria-selected': selected ? 'true' : 'false',
+      onClick: handleItemClick(child),
+      onKeyUp: (event) => {
+        if (event.key === ' ') {
+          // otherwise our MenuItems dispatches a click event
+          // it's not behavior of the native <option> and causes
+          // the select to close immediately since we open on space keydown
+          event.preventDefault();
+        }
+
+        if (child.props.onKeyUp) {
+          child.props.onKeyUp(event);
+        }
+      },
+      role: 'option',
+      selected,
+      value: undefined, // The value is most likely not a valid HTML attribute.
+      'data-value': child.props.value, // Instead, we provide it as a data attribute.
+    });
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      if (!foundMatch && !multiple && value !== '') {
+        const values = childrenArray.map((child) => child.props.value);
+        console.warn(
+          [
+            `MUI: You have provided an out-of-range value \`${value}\` for the select ${
+              name ? `(name="${name}") ` : ''
+            }component.`,
+            "Consider providing a value that matches one of the available options or ''.",
+            `The available values are ${
+              values
+                .filter((x) => x != null)
+                .map((x) => `\`${x}\``)
+                .join(', ') || '""'
+            }.`,
+          ].join('\n'),
+        );
+      }
+    }, [foundMatch, childrenArray, multiple, name, value]);
+  }
+
+  if (computeDisplay) {
+    if (multiple) {
+      if (displayMultiple.length === 0) {
+        display = null;
+      } else {
+        display = displayMultiple.reduce((output, child, index) => {
+          output.push(child);
+          if (index < displayMultiple.length - 1) {
+            output.push(', ');
+          }
+          return output;
+        }, []);
+      }
+    } else {
+      display = displaySingle;
+    }
+  }
+
+  // Avoid performing a layout computation in the render method.
+  let menuMinWidth = menuMinWidthState;
+
+  if (!autoWidth && isOpenControlled && displayNode) {
+    menuMinWidth = anchorElement.clientWidth;
+  }
+
+  let tabIndex;
+  if (typeof tabIndexProp !== 'undefined') {
+    tabIndex = tabIndexProp;
+  } else {
+    tabIndex = disabled ? null : 0;
+  }
+
+  const buttonId = SelectDisplayProps.id || (name ? `mui-component-select-${name}` : undefined);
+
+  const ownerState = {
+    ...props,
+    variant,
+    value,
+    open,
+    error,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  const paperProps = {
+    ...MenuProps.PaperProps,
+    ...MenuProps.slotProps?.paper,
+  };
+
+  const listboxId = useId();
+
+  return (
+    <React.Fragment>
+      <SelectSelect
+        ref={handleDisplayRef}
+        tabIndex={tabIndex}
+        role="combobox"
+        aria-controls={listboxId}
+        aria-disabled={disabled ? 'true' : undefined}
+        aria-expanded={open ? 'true' : 'false'}
+        aria-haspopup="listbox"
+        aria-label={ariaLabel}
+        aria-labelledby={[labelId, buttonId].filter(Boolean).join(' ') || undefined}
+        aria-describedby={ariaDescribedby}
+        onKeyDown={handleKeyDown}
+        onMouseDown={disabled || readOnly ? null : handleMouseDown}
+        onBlur={handleBlur}
+        onFocus={onFocus}
+        {...SelectDisplayProps}
+        ownerState={ownerState}
+        className={clsx(SelectDisplayProps.className, classes.select, className)}
+        // The id is required for proper a11y
+        id={buttonId}
+      >
+        {/* So the vertical align positioning algorithm kicks in. */}
+        {isEmpty(display) ? (
+          // notranslate needed while Google Translate will not fix zero-width space issue
+          <span className="notranslate">&#8203;</span>
+        ) : (
+          display
+        )}
+      </SelectSelect>
+      <SelectNativeInput
+        aria-invalid={error}
+        value={Array.isArray(value) ? value.join(',') : value}
+        name={name}
+        ref={inputRef}
+        aria-hidden
+        onChange={handleChange}
+        tabIndex={-1}
+        disabled={disabled}
+        className={classes.nativeInput}
+        autoFocus={autoFocus}
+        ownerState={ownerState}
+        {...other}
+      />
+      <SelectIcon as={IconComponent} className={classes.icon} ownerState={ownerState} />
+      <Menu
+        id={`menu-${name || ''}`}
+        anchorEl={anchorElement}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        {...MenuProps}
+        MenuListProps={{
+          'aria-labelledby': labelId,
+          role: 'listbox',
+          'aria-multiselectable': multiple ? 'true' : undefined,
+          disableListWrap: true,
+          id: listboxId,
+          ...MenuProps.MenuListProps,
+        }}
+        slotProps={{
+          ...MenuProps.slotProps,
+          paper: {
+            ...paperProps,
+            style: {
+              minWidth: menuMinWidth,
+              ...(paperProps != null ? paperProps.style : null),
+            },
+          },
+        }}
+      >
+        {items}
+      </Menu>
+    </React.Fragment>
+  );
+});
+
+SelectInput.propTypes = {
+  /**
+   * @ignore
+   */
+  'aria-describedby': PropTypes.string,
+  /**
+   * @ignore
+   */
+  'aria-label': PropTypes.string,
+  /**
+   * @ignore
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * If `true`, the width of the popover will automatically be set according to the items inside the
+   * menu, otherwise it will be at least the width of the select input.
+   */
+  autoWidth: PropTypes.bool,
+  /**
+   * The option elements to populate the select with.
+   * Can be some `<MenuItem>` elements.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css) below for more details.
+   */
+  classes: PropTypes.object,
+  /**
+   * The CSS class name of the select element.
+   */
+  className: PropTypes.string,
+  /**
+   * If `true`, the component is toggled on mount. Use when the component open state is not controlled.
+   * You can only use it when the `native` prop is `false` (default).
+   */
+  defaultOpen: PropTypes.bool,
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue: PropTypes.any,
+  /**
+   * If `true`, the select is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the selected item is displayed even if its value is empty.
+   */
+  displayEmpty: PropTypes.bool,
+  /**
+   * If `true`, the `select input` will indicate an error.
+   */
+  error: PropTypes.bool,
+  /**
+   * The icon that displays the arrow.
+   */
+  IconComponent: PropTypes.elementType.isRequired,
+  /**
+   * Imperative handle implementing `{ value: T, node: HTMLElement, focus(): void }`
+   * Equivalent to `ref`
+   */
+  inputRef: refType,
+  /**
+   * The ID of an element that acts as an additional label. The Select will
+   * be labelled by the additional label and the selected value.
+   */
+  labelId: PropTypes.string,
+  /**
+   * Props applied to the [`Menu`](/material-ui/api/menu/) element.
+   */
+  MenuProps: PropTypes.object,
+  /**
+   * If `true`, `value` must be an array and the menu will support multiple selections.
+   */
+  multiple: PropTypes.bool,
+  /**
+   * Name attribute of the `select` or hidden `input` element.
+   */
+  name: PropTypes.string,
+  /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
+  /**
+   * Callback fired when a menu item is selected.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (any).
+   * @param {object} [child] The react element that was selected.
+   */
+  onChange: PropTypes.func,
+  /**
+   * Callback fired when the component requests to be closed.
+   * Use in controlled mode (see open).
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onClose: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
+  /**
+   * Callback fired when the component requests to be opened.
+   * Use in controlled mode (see open).
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onOpen: PropTypes.func,
+  /**
+   * If `true`, the component is shown.
+   */
+  open: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * Render the selected value.
+   *
+   * @param {any} value The `value` provided to the component.
+   * @returns {ReactNode}
+   */
+  renderValue: PropTypes.func,
+  /**
+   * Props applied to the clickable div element.
+   */
+  SelectDisplayProps: PropTypes.object,
+  /**
+   * @ignore
+   */
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  type: PropTypes.any,
+  /**
+   * The input value.
+   */
+  value: PropTypes.any,
+  /**
+   * The variant to use.
+   */
+  variant: PropTypes.oneOf(['standard', 'outlined', 'filled']),
+};
+
+export default SelectInput;

--- a/packages/mui-material-next/src/Select/SelectInput.js
+++ b/packages/mui-material-next/src/Select/SelectInput.js
@@ -5,18 +5,23 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import MuiError from '@mui/utils/macros/MuiError.macro';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
-import { refType, unstable_useId as useId } from '@mui/utils';
-import ownerDocument from '../utils/ownerDocument';
-import capitalize from '../utils/capitalize';
-import Menu from '../Menu/Menu';
+import {
+  refType,
+  unstable_useId as useId,
+  unstable_capitalize as capitalize,
+  unstable_ownerDocument as ownerDocument,
+  unstable_useForkRef as useForkRef,
+  unstable_useControlled as useControlled,
+} from '@mui/utils';
+import { shouldForwardProp } from '@mui/system';
+// TODO v6: replace @mui/material with @mui/material-next when components are available
+import Menu from '@mui/material/Menu/Menu';
 import {
   nativeSelectSelectStyles,
   nativeSelectIconStyles,
-} from '../NativeSelect/NativeSelectInput';
+} from '@mui/material/NativeSelect/NativeSelectInput';
 import { isFilled } from '../InputBase/utils';
-import styled, { slotShouldForwardProp } from '../styles/styled';
-import useForkRef from '../utils/useForkRef';
-import useControlled from '../utils/useControlled';
+import styled from '../styles/styled';
 import selectClasses, { getSelectUtilityClasses } from './selectClasses';
 
 const SelectSelect = styled('div', {
@@ -57,7 +62,7 @@ const SelectIcon = styled('svg', {
 })(nativeSelectIconStyles);
 
 const SelectNativeInput = styled('input', {
-  shouldForwardProp: (prop) => slotShouldForwardProp(prop) && prop !== 'classes',
+  shouldForwardProp: (prop) => shouldForwardProp(prop) && prop !== 'classes',
   name: 'MuiSelect',
   slot: 'NativeInput',
   overridesResolver: (props, styles) => styles.nativeInput,

--- a/packages/mui-material-next/src/Select/SelectInput.js
+++ b/packages/mui-material-next/src/Select/SelectInput.js
@@ -14,12 +14,12 @@ import {
   unstable_useControlled as useControlled,
 } from '@mui/utils';
 import { shouldForwardProp } from '@mui/system';
-// TODO v6: replace @mui/material with @mui/material-next when components are available
-import Menu from '@mui/material/Menu/Menu';
 import {
   nativeSelectSelectStyles,
   nativeSelectIconStyles,
 } from '@mui/material/NativeSelect/NativeSelectInput';
+// TODO v6: replace with material-next Menu component when available https://github.com/mui/material-ui/pull/38934
+import Menu from '@mui/material/Menu/Menu';
 import { isFilled } from '../InputBase/utils';
 import styled from '../styles/styled';
 import selectClasses, { getSelectUtilityClasses } from './selectClasses';

--- a/packages/mui-material-next/src/Select/index.d.ts
+++ b/packages/mui-material-next/src/Select/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './Select';
+export * from './Select';
+
+export { default as selectClasses } from './selectClasses';
+export * from './selectClasses';

--- a/packages/mui-material-next/src/Select/index.js
+++ b/packages/mui-material-next/src/Select/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './Select';
+
+export { default as selectClasses } from './selectClasses';
+export * from './selectClasses';

--- a/packages/mui-material-next/src/Select/selectClasses.ts
+++ b/packages/mui-material-next/src/Select/selectClasses.ts
@@ -1,0 +1,59 @@
+import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
+import generateUtilityClass from '../generateUtilityClass';
+
+export interface SelectClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the select component `select` class. */
+  select: string;
+  /** Styles applied to the select component if `multiple={true}`. */
+  multiple: string;
+  /** Styles applied to the select component if `variant="filled"`. */
+  filled: string;
+  /** Styles applied to the select component if `variant="outlined"`. */
+  outlined: string;
+  /** Styles applied to the select component if `variant="standard"`. */
+  standard: string;
+  /** State class applied to the select component `disabled` class. */
+  disabled: string;
+  /** Styles applied to the icon component. */
+  icon: string;
+  /** Styles applied to the icon component if the popup is open. */
+  iconOpen: string;
+  /** Styles applied to the icon component if `variant="filled"`. */
+  iconFilled: string;
+  /** Styles applied to the icon component if `variant="outlined"`. */
+  iconOutlined: string;
+  /** Styles applied to the icon component if `variant="standard"`. */
+  iconStandard: string;
+  /** Styles applied to the underlying native input component. */
+  nativeInput: string;
+  /** State class applied to the root element if `error={true}`. */
+  error: string;
+}
+
+export type SelectClassKey = keyof SelectClasses;
+
+export function getSelectUtilityClasses(slot: string): string {
+  return generateUtilityClass('MuiSelect', slot);
+}
+
+const selectClasses: SelectClasses = generateUtilityClasses('MuiSelect', [
+  'root',
+  'select',
+  'multiple',
+  'filled',
+  'outlined',
+  'standard',
+  'disabled',
+  'focused',
+  'icon',
+  'iconOpen',
+  'iconFilled',
+  'iconOutlined',
+  'iconStandard',
+  'nativeInput',
+  'error',
+]);
+
+export default selectClasses;

--- a/packages/mui-material-next/src/Select/selectClasses.ts
+++ b/packages/mui-material-next/src/Select/selectClasses.ts
@@ -1,5 +1,7 @@
-import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
-import generateUtilityClass from '../generateUtilityClass';
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
 
 export interface SelectClasses {
   /** Styles applied to the root element. */

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -20,6 +20,9 @@ export * from './InputBase';
 
 export { default as Input } from './Input';
 
+export { default as Select } from './Select';
+export * from './Select';
+
 export { default as Slider } from './Slider';
 export * from './Slider';
 

--- a/packages/mui-material-next/src/internal/svg-icons/ArrowDropDown.tsx
+++ b/packages/mui-material-next/src/internal/svg-icons/ArrowDropDown.tsx
@@ -1,0 +1,8 @@
+'use client';
+import * as React from 'react';
+import createSvgIcon from '../../utils/createSvgIcon';
+
+/**
+ * @ignore - internal component.
+ */
+export default createSvgIcon(<path d="M7 10l5 5 5-5z" />, 'ArrowDropDown');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of https://github.com/mui/material-ui/issues/38972, https://github.com/mui/material-ui/issues/29345

This PR copies the files related to the Select component from the `material` package to the `material-next` package with minimal modification (e.g. import paths, just enough to pass CI) so it's easier to see the diffs of the following-up  https://github.com/mui/material-ui/issues/38972 PRs.

There are some imports left from the `material` package that will be updated later:
- Input-related components being worked on https://github.com/mui/material-ui/issues/38374
- Menu-related components being worked on https://github.com/mui/material-ui/pull/38934
- Native Select component, no need to move this one yet