### PR TITLE
[system][spacing] Allow custom string for spacing prop values

### DIFF
--- a/docs/data/system/spacing/spacing.md
+++ b/docs/data/system/spacing/spacing.md
@@ -61,6 +61,23 @@ const theme = {
 <Box sx={{ m: 2 }} /> // margin: 4px;
 ```
 
+- input: `string` & theme: `function`: the function is called with the prop value.
+
+```jsx
+const spacing = {
+  sm: 2,
+  md: 4,
+  lg: 8,
+}
+
+const theme = {
+  spacing: value => spacing[value],
+}
+
+<Box sx={{ m: 'sm' }} /> // margin: 2px;
+<Box sx={{ m: 'md' }} /> // margin: 4px;
+```
+
 - input: `string`: the prop value is passed as raw CSS value.
 
 ```jsx

--- a/packages/mui-system/src/spacing.js
+++ b/packages/mui-system/src/spacing.js
@@ -162,22 +162,25 @@ export function createUnarySpacing(theme) {
 }
 
 export function getValue(transformer, propValue) {
-  if (typeof propValue === 'string' || propValue == null) {
-    return propValue;
+  if (typeof propValue === 'string') {
+    return transformer(propValue) || propValue;
   }
 
-  const abs = Math.abs(propValue);
-  const transformed = transformer(abs);
+  if (typeof propValue === 'number') {
+    const abs = Math.abs(propValue);
+    const transformed = transformer(abs);
 
-  if (propValue >= 0) {
-    return transformed;
+    if (propValue >= 0) {
+      return transformed;
+    }
+
+    if (typeof transformed === 'number') {
+      return -transformed;
+    }
+
+    return `-${transformed}`;
   }
-
-  if (typeof transformed === 'number') {
-    return -transformed;
-  }
-
-  return `-${transformed}`;
+  return propValue;
 }
 
 export function getStyleFromPropValue(cssProperties, transformer) {

--- a/packages/mui-system/src/spacing.test.js
+++ b/packages/mui-system/src/spacing.test.js
@@ -35,6 +35,14 @@ describe('system spacing', () => {
           p: 2,
         });
         expect(output3).to.deep.equal({ padding: 4 });
+
+        const output4 = spacing({
+          theme: {
+            spacing: (x) => ({ med: 2 }[x]),
+          },
+          p: 'med',
+        });
+        expect(output4).to.deep.equal({ padding: 2 });
       });
     });
 
@@ -219,6 +227,14 @@ describe('system spacing', () => {
           m: 2,
         });
         expect(output3).to.deep.equal({ margin: 4 });
+
+        const output4 = margin({
+          theme: {
+            spacing: (x) => ({ med: 2 }[x]),
+          },
+          m: 'med',
+        });
+        expect(output4).to.deep.equal({ margin: 2 });
       });
     });
 
@@ -403,6 +419,14 @@ describe('system spacing', () => {
           p: 2,
         });
         expect(output3).to.deep.equal({ padding: 4 });
+
+        const output4 = padding({
+          theme: {
+            spacing: (x) => ({ med: 2 }[x]),
+          },
+          p: 'med',
+        });
+        expect(output4).to.deep.equal({ padding: 2 });
       });
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes #37945

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Allows the developer to set an object for mapping custom string values to a spacing unit. 

eg.
```typescript
const spacingMap = {
  xl: '2rem',
  lg: '1.25rem',
  md: '1rem',
  sm: '0.5rem',
  xs: '0.25rem',
};

// Create inverse value for when needed
Object.entries(spacingMap).forEach(([key, value]) => {
  spacingMap[('-' + key)] = '-' + value;
});
```

and custom spacing
```typescript
function spacing(abs: number | string): string | undefined {
  return spacingMap[abs];
}

export const theme = createTheme({
  spacing,
});
```

You could use the Stack component (and other components that use a spacing like prop)
```typescript
<Stack spacing="l" />
```

While implementing I noticed it would be nice to allow an object instead of just a function or array, but as these changes can fix the issue without significant changes (and would be required  for he object option anyway), I opted to not work on it (however I would still think it would be a good addition)