### PR TITLE
[Divider][material-next] Copy v5 Divider

### DIFF
--- a/packages/mui-material-next/src/Divider/Divider.d.ts
+++ b/packages/mui-material-next/src/Divider/Divider.d.ts
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { OverridableStringUnion } from '@mui/types';
+import { SxProps } from '@mui/system';
+import { Theme } from '..';
+import { OverridableComponent, OverrideProps } from '../OverridableComponent';
+import { DividerClasses } from './dividerClasses';
+
+export interface DividerPropsVariantOverrides {}
+
+export interface DividerOwnProps {
+  /**
+   * Absolutely position the element.
+   * @default false
+   */
+  absolute?: boolean;
+  /**
+   * The content of the component.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<DividerClasses>;
+  /**
+   * If `true`, a vertical divider will have the correct height when used in flex container.
+   * (By default, a vertical divider will have a calculated height of `0px` if it is the child of a flex container.)
+   * @default false
+   */
+  flexItem?: boolean;
+  /**
+   * If `true`, the divider will have a lighter color.
+   * @default false
+   */
+  light?: boolean;
+  /**
+   * The component orientation.
+   * @default 'horizontal'
+   */
+  orientation?: 'horizontal' | 'vertical';
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The text alignment.
+   * @default 'center'
+   */
+  textAlign?: 'center' | 'right' | 'left';
+  /**
+   * The variant to use.
+   * @default 'fullWidth'
+   */
+  variant?: OverridableStringUnion<'fullWidth' | 'inset' | 'middle', DividerPropsVariantOverrides>;
+}
+
+export interface DividerTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'hr',
+> {
+  props: AdditionalProps & DividerOwnProps;
+  defaultComponent: RootComponent;
+}
+
+/**
+ *
+ * Demos:
+ *
+ * - [Divider](https://mui.com/material-ui/react-divider/)
+ * - [Lists](https://mui.com/material-ui/react-list/)
+ *
+ * API:
+ *
+ * - [Divider API](https://mui.com/material-ui/api/divider/)
+ */
+declare const Divider: OverridableComponent<DividerTypeMap>;
+
+export type DividerProps<
+  RootComponent extends React.ElementType = DividerTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<DividerTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default Divider;

--- a/packages/mui-material-next/src/Divider/Divider.d.ts
+++ b/packages/mui-material-next/src/Divider/Divider.d.ts
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { OverridableStringUnion } from '@mui/types';
+import { OverridableComponent, OverrideProps, OverridableStringUnion } from '@mui/types';
 import { SxProps } from '@mui/system';
 import { Theme } from '..';
-import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { DividerClasses } from './dividerClasses';
 
 export interface DividerPropsVariantOverrides {}

--- a/packages/mui-material-next/src/Divider/Divider.js
+++ b/packages/mui-material-next/src/Divider/Divider.js
@@ -1,0 +1,294 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { alpha } from '@mui/system';
+import styled from '../styles/styled';
+import useThemeProps from '../styles/useThemeProps';
+import { getDividerUtilityClass } from './dividerClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { absolute, children, classes, flexItem, light, orientation, textAlign, variant } =
+    ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      absolute && 'absolute',
+      variant,
+      light && 'light',
+      orientation === 'vertical' && 'vertical',
+      flexItem && 'flexItem',
+      children && 'withChildren',
+      children && orientation === 'vertical' && 'withChildrenVertical',
+      textAlign === 'right' && orientation !== 'vertical' && 'textAlignRight',
+      textAlign === 'left' && orientation !== 'vertical' && 'textAlignLeft',
+    ],
+    wrapper: ['wrapper', orientation === 'vertical' && 'wrapperVertical'],
+  };
+
+  return composeClasses(slots, getDividerUtilityClass, classes);
+};
+
+const DividerRoot = styled('div', {
+  name: 'MuiDivider',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      ownerState.absolute && styles.absolute,
+      styles[ownerState.variant],
+      ownerState.light && styles.light,
+      ownerState.orientation === 'vertical' && styles.vertical,
+      ownerState.flexItem && styles.flexItem,
+      ownerState.children && styles.withChildren,
+      ownerState.children && ownerState.orientation === 'vertical' && styles.withChildrenVertical,
+      ownerState.textAlign === 'right' &&
+        ownerState.orientation !== 'vertical' &&
+        styles.textAlignRight,
+      ownerState.textAlign === 'left' &&
+        ownerState.orientation !== 'vertical' &&
+        styles.textAlignLeft,
+    ];
+  },
+})(
+  ({ theme, ownerState }) => ({
+    margin: 0, // Reset browser default style.
+    flexShrink: 0,
+    borderWidth: 0,
+    borderStyle: 'solid',
+    borderColor: (theme.vars || theme).palette.divider,
+    borderBottomWidth: 'thin',
+    ...(ownerState.absolute && {
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      width: '100%',
+    }),
+    ...(ownerState.light && {
+      borderColor: theme.vars
+        ? `rgba(${theme.vars.palette.dividerChannel} / 0.08)`
+        : alpha(theme.palette.divider, 0.08),
+    }),
+    ...(ownerState.variant === 'inset' && {
+      marginLeft: 72,
+    }),
+    ...(ownerState.variant === 'middle' &&
+      ownerState.orientation === 'horizontal' && {
+        marginLeft: theme.spacing(2),
+        marginRight: theme.spacing(2),
+      }),
+    ...(ownerState.variant === 'middle' &&
+      ownerState.orientation === 'vertical' && {
+        marginTop: theme.spacing(1),
+        marginBottom: theme.spacing(1),
+      }),
+    ...(ownerState.orientation === 'vertical' && {
+      height: '100%',
+      borderBottomWidth: 0,
+      borderRightWidth: 'thin',
+    }),
+    ...(ownerState.flexItem && {
+      alignSelf: 'stretch',
+      height: 'auto',
+    }),
+  }),
+  ({ ownerState }) => ({
+    ...(ownerState.children && {
+      display: 'flex',
+      whiteSpace: 'nowrap',
+      textAlign: 'center',
+      border: 0,
+      '&::before, &::after': {
+        content: '""',
+        alignSelf: 'center',
+      },
+    }),
+  }),
+  ({ theme, ownerState }) => ({
+    ...(ownerState.children &&
+      ownerState.orientation !== 'vertical' && {
+        '&::before, &::after': {
+          width: '100%',
+          borderTop: `thin solid ${(theme.vars || theme).palette.divider}`,
+        },
+      }),
+  }),
+  ({ theme, ownerState }) => ({
+    ...(ownerState.children &&
+      ownerState.orientation === 'vertical' && {
+        flexDirection: 'column',
+        '&::before, &::after': {
+          height: '100%',
+          borderLeft: `thin solid ${(theme.vars || theme).palette.divider}`,
+        },
+      }),
+  }),
+  ({ ownerState }) => ({
+    ...(ownerState.textAlign === 'right' &&
+      ownerState.orientation !== 'vertical' && {
+        '&::before': {
+          width: '90%',
+        },
+        '&::after': {
+          width: '10%',
+        },
+      }),
+    ...(ownerState.textAlign === 'left' &&
+      ownerState.orientation !== 'vertical' && {
+        '&::before': {
+          width: '10%',
+        },
+        '&::after': {
+          width: '90%',
+        },
+      }),
+  }),
+);
+
+const DividerWrapper = styled('span', {
+  name: 'MuiDivider',
+  slot: 'Wrapper',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [styles.wrapper, ownerState.orientation === 'vertical' && styles.wrapperVertical];
+  },
+})(({ theme, ownerState }) => ({
+  display: 'inline-block',
+  paddingLeft: `calc(${theme.spacing(1)} * 1.2)`,
+  paddingRight: `calc(${theme.spacing(1)} * 1.2)`,
+  ...(ownerState.orientation === 'vertical' && {
+    paddingTop: `calc(${theme.spacing(1)} * 1.2)`,
+    paddingBottom: `calc(${theme.spacing(1)} * 1.2)`,
+  }),
+}));
+
+const Divider = React.forwardRef(function Divider(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiDivider' });
+  const {
+    absolute = false,
+    children,
+    className,
+    component = children ? 'div' : 'hr',
+    flexItem = false,
+    light = false,
+    orientation = 'horizontal',
+    role = component !== 'hr' ? 'separator' : undefined,
+    textAlign = 'center',
+    variant = 'fullWidth',
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    absolute,
+    component,
+    flexItem,
+    light,
+    orientation,
+    role,
+    textAlign,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <DividerRoot
+      as={component}
+      className={clsx(classes.root, className)}
+      role={role}
+      ref={ref}
+      ownerState={ownerState}
+      {...other}
+    >
+      {children ? (
+        <DividerWrapper className={classes.wrapper} ownerState={ownerState}>
+          {children}
+        </DividerWrapper>
+      ) : null}
+    </DividerRoot>
+  );
+});
+
+/**
+ * The following flag is used to ensure that this component isn't tabbable i.e.
+ * does not get highlight/focus inside of MUI List.
+ */
+Divider.muiSkipListHighlight = true;
+
+Divider.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * Absolutely position the element.
+   * @default false
+   */
+  absolute: PropTypes.bool,
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, a vertical divider will have the correct height when used in flex container.
+   * (By default, a vertical divider will have a calculated height of `0px` if it is the child of a flex container.)
+   * @default false
+   */
+  flexItem: PropTypes.bool,
+  /**
+   * If `true`, the divider will have a lighter color.
+   * @default false
+   */
+  light: PropTypes.bool,
+  /**
+   * The component orientation.
+   * @default 'horizontal'
+   */
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
+   * @ignore
+   */
+  role: PropTypes /* @typescript-to-proptypes-ignore */.string,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The text alignment.
+   * @default 'center'
+   */
+  textAlign: PropTypes.oneOf(['center', 'left', 'right']),
+  /**
+   * The variant to use.
+   * @default 'fullWidth'
+   */
+  variant: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['fullWidth', 'inset', 'middle']),
+    PropTypes.string,
+  ]),
+};
+
+export default Divider;

--- a/packages/mui-material-next/src/Divider/Divider.test.js
+++ b/packages/mui-material-next/src/Divider/Divider.test.js
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { describeConformance, createRenderer } from 'test/utils';
+import Divider, { dividerClasses as classes } from '@mui/material/Divider';
+
+describe('<Divider />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Divider />, () => ({
+    classes,
+    inheritComponent: 'hr',
+    render,
+    muiName: 'MuiDivider',
+    refInstanceof: window.HTMLHRElement,
+    testComponentPropWith: 'div',
+    testVariantProps: { orientation: 'vertical', flexItem: true, textAlign: 'left' },
+    skip: ['componentsProp'],
+  }));
+
+  it('should set the absolute class', () => {
+    const { container } = render(<Divider absolute />);
+    expect(container.firstChild).to.have.class(classes.absolute);
+  });
+
+  it('should set the light class', () => {
+    const { container } = render(<Divider light />);
+    expect(container.firstChild).to.have.class(classes.light);
+  });
+
+  it('should set the flexItem class', () => {
+    const { container } = render(<Divider flexItem />);
+    expect(container.firstChild).to.have.class(classes.flexItem);
+  });
+
+  describe('prop: children', () => {
+    it('should render with the children', () => {
+      const text = 'test content';
+      const { container } = render(<Divider>{text}</Divider>);
+      expect(container.querySelectorAll('span').length).to.equal(1);
+      expect(container.querySelectorAll('span')[0].textContent).to.equal(text);
+    });
+
+    it('should set the default text class', () => {
+      const { container } = render(<Divider>content</Divider>);
+      expect(container.firstChild).to.have.class(classes.withChildren);
+    });
+
+    describe('prop: orientation', () => {
+      it('should set the textVertical class', () => {
+        const { container } = render(<Divider orientation="vertical">content</Divider>);
+        expect(container.querySelectorAll(`.${classes.withChildrenVertical}`).length).to.equal(1);
+        expect(container.querySelectorAll(`.${classes.wrapperVertical}`).length).to.equal(1);
+      });
+    });
+
+    describe('prop: textAlign', () => {
+      it('should set the textAlignRight class', () => {
+        const { container } = render(<Divider textAlign="right">content</Divider>);
+        expect(container.querySelectorAll(`.${classes.textAlignRight}`).length).to.equal(1);
+      });
+
+      it('should set the textAlignLeft class', () => {
+        const { container } = render(<Divider textAlign="left">content</Divider>);
+        expect(container.querySelectorAll(`.${classes.textAlignLeft}`).length).to.equal(1);
+      });
+
+      it('should not set the textAlignRight class if orientation="vertical"', () => {
+        const { container } = render(
+          <Divider textAlign="right" orientation="vertical">
+            content
+          </Divider>,
+        );
+        expect(container.querySelectorAll(`.${classes.textAlignRight}`).length).to.equal(0);
+      });
+
+      it('should not set the textAlignLeft class if orientation="vertical"', () => {
+        const { container } = render(
+          <Divider textAlign="left" orientation="vertical">
+            content
+          </Divider>,
+        );
+        expect(container.querySelectorAll(`.${classes.textAlignLeft}`).length).to.equal(0);
+      });
+    });
+  });
+
+  describe('prop: variant', () => {
+    it('should default to variant="fullWidth"', () => {
+      const { container } = render(<Divider />);
+      expect(container.firstChild).not.to.have.class(classes.inset);
+      expect(container.firstChild).not.to.have.class(classes.middle);
+    });
+
+    describe('prop: variant="fullWidth" ', () => {
+      it('should render with the root and default class', () => {
+        const { container } = render(<Divider />);
+        expect(container.firstChild).to.have.class(classes.root);
+      });
+    });
+
+    describe('prop: variant="inset" ', () => {
+      it('should set the inset class', () => {
+        const { container } = render(<Divider variant="inset" />);
+        expect(container.firstChild).to.have.class(classes.inset);
+      });
+    });
+
+    describe('prop: variant="middle" with default orientation (horizontal)', () => {
+      it('should set the middle class', () => {
+        const { container } = render(<Divider variant="middle" />);
+        expect(container.firstChild).to.have.class(classes.middle);
+        expect(container.firstChild).toHaveComputedStyle({
+          marginLeft: '16px',
+          marginRight: '16px',
+        });
+      });
+    });
+
+    describe('prop: variant="middle" with orientation="vertical"', () => {
+      it('should set the middle class with marginTop & marginBottom styles', () => {
+        const { container } = render(<Divider variant="middle" orientation="vertical" />);
+        expect(container.firstChild).toHaveComputedStyle({
+          marginTop: '8px',
+          marginBottom: '8px',
+        });
+      });
+    });
+  });
+
+  describe('role', () => {
+    it('avoids adding implicit aria semantics', () => {
+      const { container } = render(<Divider />);
+      expect(container.firstChild).not.to.have.attribute('role');
+    });
+
+    it('adds a proper role if none is specified', () => {
+      const { container } = render(<Divider component="div" />);
+      expect(container.firstChild).to.have.attribute('role', 'separator');
+    });
+
+    it('overrides the computed role with the provided one', () => {
+      // presentation is the only valid aria role
+      const { container } = render(<Divider role="presentation" />);
+      expect(container.firstChild).to.have.attribute('role', 'presentation');
+    });
+  });
+});

--- a/packages/mui-material-next/src/Divider/Divider.test.js
+++ b/packages/mui-material-next/src/Divider/Divider.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from 'test/utils';
+import { describeConformance, createRenderer } from '@mui-internal/test-utils';
 import Divider, { dividerClasses as classes } from '@mui/material/Divider';
 
 describe('<Divider />', () => {

--- a/packages/mui-material-next/src/Divider/dividerClasses.ts
+++ b/packages/mui-material-next/src/Divider/dividerClasses.ts
@@ -1,0 +1,58 @@
+import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
+import generateUtilityClass from '../generateUtilityClass';
+
+export interface DividerClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `absolute={true}`. */
+  absolute: string;
+  /** Styles applied to the root element if `variant="inset"`. */
+  inset: string;
+  /** Styles applied to the root element if `variant="fullWidth"`. */
+  fullWidth: string;
+  /** Styles applied to the root element if `light={true}`. */
+  light: string;
+  /** Styles applied to the root element if `variant="middle"`. */
+  middle: string;
+  /** Styles applied to the root element if `orientation="vertical"`. */
+  vertical: string;
+  /** Styles applied to the root element if `flexItem={true}`. */
+  flexItem: string;
+  /** Styles applied to the root element if divider have text. */
+  withChildren: string;
+  /** Styles applied to the root element if divider have text and `orientation="vertical"`. */
+  withChildrenVertical: string;
+  /** Styles applied to the root element if `textAlign="right" orientation="horizontal"`. */
+  textAlignRight: string;
+  /** Styles applied to the root element if `textAlign="left" orientation="horizontal"`. */
+  textAlignLeft: string;
+  /** Styles applied to the span children element if `orientation="horizontal"`. */
+  wrapper: string;
+  /** Styles applied to the span children element if `orientation="vertical"`. */
+  wrapperVertical: string;
+}
+
+export type DividerClassKey = keyof DividerClasses;
+
+export function getDividerUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiDivider', slot);
+}
+
+const dividerClasses: DividerClasses = generateUtilityClasses('MuiDivider', [
+  'root',
+  'absolute',
+  'fullWidth',
+  'inset',
+  'middle',
+  'flexItem',
+  'light',
+  'vertical',
+  'withChildren',
+  'withChildrenVertical',
+  'textAlignRight',
+  'textAlignLeft',
+  'wrapper',
+  'wrapperVertical',
+]);
+
+export default dividerClasses;

--- a/packages/mui-material-next/src/Divider/dividerClasses.ts
+++ b/packages/mui-material-next/src/Divider/dividerClasses.ts
@@ -1,5 +1,7 @@
-import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
-import generateUtilityClass from '../generateUtilityClass';
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
 
 export interface DividerClasses {
   /** Styles applied to the root element. */

--- a/packages/mui-material-next/src/Divider/index.d.ts
+++ b/packages/mui-material-next/src/Divider/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './Divider';
+export * from './Divider';
+
+export { default as dividerClasses } from './dividerClasses';
+export * from './dividerClasses';

--- a/packages/mui-material-next/src/Divider/index.js
+++ b/packages/mui-material-next/src/Divider/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './Divider';
+
+export { default as dividerClasses } from './dividerClasses';
+export * from './dividerClasses';


### PR DESCRIPTION
This PR copies the Divider from `material` to `material-next` with minimal changes, so later diffs are easier to review

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
