### PR TITLE
[docs][base-ui] Contain stretched multiline inputs to the demo container

### DIFF
--- a/docs/data/base/components/input/InputMultiline.js
+++ b/docs/data/base/components/input/InputMultiline.js
@@ -5,7 +5,11 @@ import { styled } from '@mui/system';
 const CustomInput = React.forwardRef(function CustomInput(props, ref) {
   return (
     <Input
-      slots={{ input: StyledInputElement, textarea: StyledTextareaElement }}
+      slots={{
+        root: StyledRootDiv,
+        input: StyledInputElement,
+        textarea: StyledTextareaElement,
+      }}
       {...props}
       ref={ref}
     />
@@ -38,6 +42,11 @@ const grey = {
   800: '#2D3843',
   900: '#1A2027',
 };
+
+const StyledRootDiv = styled('div')`
+  display: flex;
+  overflow: hidden;
+`;
 
 const StyledInputElement = styled('input')(
   ({ theme }) => `

--- a/docs/data/base/components/input/InputMultiline.tsx
+++ b/docs/data/base/components/input/InputMultiline.tsx
@@ -8,7 +8,7 @@ const CustomInput = React.forwardRef(function CustomInput(
 ) {
   return (
     <Input
-      slots={{ input: StyledInputElement, textarea: StyledTextareaElement }}
+      slots={{ root: StyledRootDiv, input: StyledInputElement, textarea: StyledTextareaElement }}
       {...props}
       ref={ref}
     />
@@ -41,6 +41,11 @@ const grey = {
   800: '#2D3843',
   900: '#1A2027',
 };
+
+const StyledRootDiv = styled('div')`
+  display: flex;
+  overflow: hidden;
+`;
 
 const StyledInputElement = styled('input')(
   ({ theme }) => `

--- a/docs/data/base/components/input/InputMultilineAutosize.js
+++ b/docs/data/base/components/input/InputMultilineAutosize.js
@@ -6,7 +6,11 @@ import { styled } from '@mui/system';
 const CustomInput = React.forwardRef(function CustomInput(props, ref) {
   return (
     <Input
-      slots={{ input: StyledInputElement, textarea: StyledTextareaElement }}
+      slots={{
+        root: StyledRootDiv,
+        input: StyledInputElement,
+        textarea: StyledTextareaElement,
+      }}
       {...props}
       ref={ref}
     />
@@ -39,6 +43,11 @@ const grey = {
   800: '#2D3843',
   900: '#1A2027',
 };
+
+const StyledRootDiv = styled('div')`
+  display: flex;
+  overflow: hidden;
+`;
 
 const StyledInputElement = styled('input')(
   ({ theme }) => `

--- a/docs/data/base/components/input/InputMultilineAutosize.tsx
+++ b/docs/data/base/components/input/InputMultilineAutosize.tsx
@@ -9,7 +9,7 @@ const CustomInput = React.forwardRef(function CustomInput(
 ) {
   return (
     <Input
-      slots={{ input: StyledInputElement, textarea: StyledTextareaElement }}
+      slots={{ root: StyledRootDiv, input: StyledInputElement, textarea: StyledTextareaElement }}
       {...props}
       ref={ref}
     />
@@ -42,6 +42,11 @@ const grey = {
   800: '#2D3843',
   900: '#1A2027',
 };
+
+const StyledRootDiv = styled('div')`
+  display: flex;
+  overflow: hidden;
+`;
 
 const StyledInputElement = styled('input')(
   ({ theme }) => `


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- And it running correctly.

Closes https://github.com/mui/material-ui/issues/39176

https://deploy-preview-39201--material-ui.netlify.app/base-ui/react-textarea-autosize/#introduction

https://github.com/mui/material-ui/assets/105445488/ba33cf74-88d8-480e-83a8-7b059afc7d28