### PR TITLE
AutoComplete | Fix scroll reset near syncHighlight of useAutocomplete 

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -545,6 +545,17 @@ export function useAutocomplete(props) {
         isOptionEqualToValue(optionItem, valueItem),
       );
       if (itemIndex === -1) {
+        if (filterSelectedOptions && filteredOptions.length > 1) {
+          const nextItemToHighlightIndex = Math.min(
+            highlightedIndexRef.current,
+            filteredOptions.length - 1,
+          );
+          setHighlightedIndex({
+            index: nextItemToHighlightIndex,
+            reason: 'adjust-highlight-for-filterSelectionOptions',
+          });
+          return;
+        }
         changeHighlightedIndex({ diff: 'reset' });
       } else {
         setHighlightedIndex({ index: itemIndex });


### PR DESCRIPTION
Fix scroll reset near syncHighlight of useAutocomplete while having multiple, disabledCloseOnSelect and filterSelectedOptions as true

Handles the issues described in #39202

#### Context
- The `syncHighlight` method present in useAutocomplete gets called whenever filteredOptions.length is updated.
- This method will check if `highlightedIndexRef.current` is still valid with the updated option list.
- When it figures out that the previous option label is not the same as the current equivalent one from that index, it will reset the highlighted index.

#### Solution
- Before we reset the highlighted, we can check if `filterSelectedOptions` is sent as `true` and accordingly either stay in the currentIndex or move one index down (when the index is out of bound wrt filtered options)
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
