### PR TITLE
[docs-infra] Prevent docs crash

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -222,8 +222,13 @@ async function submitFeedback(page, rating, comment, language, commentedSection)
 function getCurrentRating(pathname) {
   let userFeedback;
   if (typeof window !== 'undefined') {
-    userFeedback = getCookie('feedback');
-    userFeedback = userFeedback && JSON.parse(userFeedback);
+    try {
+      userFeedback = getCookie('feedback');
+      userFeedback = userFeedback && JSON.parse(userFeedback);
+    } catch {
+      // For unknown reason the `userFeedback` can be uncomplet, leading the JSON.parse to crash the entire docs
+      return undefined;
+    }
   }
   return userFeedback && userFeedback[pathname] && userFeedback[pathname].rating;
 }


### PR DESCRIPTION
I just got the docs crashing. After some navigation in the source code of the page, it appears it's the `feedback` cookies that have incorrect JSON format.

![image](https://github.com/mui/material-ui/assets/45398769/52fb0e45-8fbd-406c-95b8-b6164a0f2060)

This token is used to save user feedback on pages. Since it's not super important, I just added a try/catch.



