### PR TITLE
[docs-infra] Remove overflow: hidden for demo gradient bg

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -198,7 +198,6 @@ const DemoRootMaterial = styled('div', {
   shouldForwardProp: (prop) => prop !== 'hideToolbar' && prop !== 'bg',
 })(({ theme, hideToolbar, bg }) => ({
   position: 'relative',
-  outline: 0,
   margin: 'auto',
   display: 'flex',
   justifyContent: 'center',
@@ -241,7 +240,7 @@ const DemoRootMaterial = styled('div', {
     padding: theme.spacing(20, 8),
     border: `1px solid`,
     borderColor: (theme.vars || theme).palette.divider,
-    overflow: 'hidden',
+    overflow: 'auto',
     backgroundColor: alpha(theme.palette.primary[50], 0.5),
     backgroundClip: 'padding-box',
     backgroundImage: `radial-gradient(at 51% 52%, ${alpha(
@@ -276,7 +275,6 @@ const DemoRootJoy = joyStyled('div', {
   shouldForwardProp: (prop) => prop !== 'hideToolbar' && prop !== 'bg',
 })(({ theme, hideToolbar, bg }) => ({
   position: 'relative',
-  outline: 0,
   margin: 'auto',
   display: 'flex',
   justifyContent: 'center',


### PR DESCRIPTION
I noticed this from https://github.com/mui/material-ui/issues/39176. Open https://mui.com/base-ui/react-tabs/#introduction, no scrollbar:

<img width="418" alt="Screenshot 2023-09-30 at 00 57 47" src="https://github.com/mui/material-ui/assets/3165635/381efc37-9026-4274-99da-f5e4798a9636">

IMHO, we should almost never use `overflow: hidden` but there are rare valid ones e.g. skeleton animation background. 

Now, in my example, we should also likely fix the demo itself, but here, my goal is to have better behavior when it goes wrong, and make it feel less broken.

Preview: https://deploy-preview-39225--material-ui.netlify.app/base-ui/react-tabs/#introduction

---

Actually, I think that we can broaden the topic on do we even want a `overflow` style? Why is it different based on the demo type?

It's relatively frequent for a demo to break the mobile layout, e.g. https://github.com/mui/mui-x/pull/10455 recently. Today, when this happens, it's quite easy to spot, the whole page is broken. So it's great because it's easy to identify. Now, it's also not so great because it breaks the whole docs experience, it's not isolated to one demo that is broken.

=> Maybe we should have `overflow: auto` everywhere + a warning in the console that flags the demo with a scrollbar? Another problem is that it might break demos that need to overflow their container, e.g. https://mui.com/material-ui/react-autocomplete/#combo-box wouldn't work anymore.