### PR TITLE
[docs][joy-ui] Add scrollable tabs example

### DIFF
--- a/docs/data/joy/components/tabs/TabsBottomNavExample.js
+++ b/docs/data/joy/components/tabs/TabsBottomNavExample.js
@@ -4,7 +4,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
-import HomeOutlined from '@mui/icons-material/HomeOutlined';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
 import Search from '@mui/icons-material/Search';
 import Person from '@mui/icons-material/Person';
@@ -17,8 +17,7 @@ export default function TabsBottomNavExample() {
       sx={{
         flexGrow: 1,
         m: -3,
-        p: 3,
-        py: 5,
+        p: 4,
         borderTopLeftRadius: '12px',
         borderTopRightRadius: '12px',
         bgcolor: `${colors[index]}.500`,
@@ -31,30 +30,36 @@ export default function TabsBottomNavExample() {
         onChange={(event, value) => setIndex(value)}
         sx={(theme) => ({
           p: 1,
-          borderRadius: '24px',
+          borderRadius: 16,
           maxWidth: 400,
           mx: 'auto',
           boxShadow: theme.shadow.sm,
           '--joy-shadowChannel': theme.vars.palette[colors[index]].darkChannel,
           [`& .${tabClasses.root}`]: {
-            whiteSpace: 'nowrap',
+            py: 1,
+            flex: 1,
             transition: '0.3s',
             fontWeight: 'md',
-            flex: 1,
+            fontSize: 'md',
             [`&:not(.${tabClasses.selected}):not(:hover)`]: {
-              opacity: 0.72,
+              opacity: 0.7,
             },
           },
         })}
       >
-        <TabList variant="plain" disableUnderline sx={{ borderRadius: 'xl', p: 0 }}>
+        <TabList
+          variant="plain"
+          size="sm"
+          disableUnderline
+          sx={{ borderRadius: 'lg', p: 0 }}
+        >
           <Tab
             disableIndicator
             orientation="vertical"
             {...(index === 0 && { color: colors[0] })}
           >
             <ListItemDecorator>
-              <HomeOutlined />
+              <HomeRoundedIcon />
             </ListItemDecorator>
             Home
           </Tab>

--- a/docs/data/joy/components/tabs/TabsBottomNavExample.js
+++ b/docs/data/joy/components/tabs/TabsBottomNavExample.js
@@ -4,7 +4,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
-import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
+import HomeOutlined from '@mui/icons-material/HomeOutlined';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
 import Search from '@mui/icons-material/Search';
 import Person from '@mui/icons-material/Person';
@@ -17,7 +17,8 @@ export default function TabsBottomNavExample() {
       sx={{
         flexGrow: 1,
         m: -3,
-        p: 4,
+        p: 3,
+        py: 5,
         borderTopLeftRadius: '12px',
         borderTopRightRadius: '12px',
         bgcolor: `${colors[index]}.500`,
@@ -30,37 +31,30 @@ export default function TabsBottomNavExample() {
         onChange={(event, value) => setIndex(value)}
         sx={(theme) => ({
           p: 1,
-          borderRadius: 16,
+          borderRadius: '24px',
           maxWidth: 400,
           mx: 'auto',
           boxShadow: theme.shadow.sm,
           '--joy-shadowChannel': theme.vars.palette[colors[index]].darkChannel,
           [`& .${tabClasses.root}`]: {
-            paddingY: 1,
-            flex: 1,
             whiteSpace: 'nowrap',
             transition: '0.3s',
-            fontSize: 'md',
             fontWeight: 'md',
+            flex: 1,
             [`&:not(.${tabClasses.selected}):not(:hover)`]: {
               opacity: 0.72,
             },
           },
         })}
       >
-        <TabList
-          variant="plain"
-          size="small"
-          disableUnderline
-          sx={{ borderRadius: 'lg', p: 0 }}
-        >
+        <TabList variant="plain" disableUnderline sx={{ borderRadius: 'xl', p: 0 }}>
           <Tab
             disableIndicator
             orientation="vertical"
             {...(index === 0 && { color: colors[0] })}
           >
             <ListItemDecorator>
-              <HomeRoundedIcon />
+              <HomeOutlined />
             </ListItemDecorator>
             Home
           </Tab>
@@ -85,7 +79,6 @@ export default function TabsBottomNavExample() {
             Search
           </Tab>
           <Tab
-            size="small"
             disableIndicator
             orientation="vertical"
             {...(index === 3 && { color: colors[3] })}

--- a/docs/data/joy/components/tabs/TabsBottomNavExample.js
+++ b/docs/data/joy/components/tabs/TabsBottomNavExample.js
@@ -4,7 +4,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
-import HomeOutlined from '@mui/icons-material/HomeOutlined';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
 import Search from '@mui/icons-material/Search';
 import Person from '@mui/icons-material/Person';
@@ -17,8 +17,7 @@ export default function TabsBottomNavExample() {
       sx={{
         flexGrow: 1,
         m: -3,
-        p: 3,
-        py: 5,
+        p: 4,
         borderTopLeftRadius: '12px',
         borderTopRightRadius: '12px',
         bgcolor: `${colors[index]}.500`,
@@ -31,30 +30,37 @@ export default function TabsBottomNavExample() {
         onChange={(event, value) => setIndex(value)}
         sx={(theme) => ({
           p: 1,
-          borderRadius: '24px',
+          borderRadius: 16,
           maxWidth: 400,
           mx: 'auto',
           boxShadow: theme.shadow.sm,
           '--joy-shadowChannel': theme.vars.palette[colors[index]].darkChannel,
           [`& .${tabClasses.root}`]: {
+            paddingY: 1,
+            flex: 1,
             whiteSpace: 'nowrap',
             transition: '0.3s',
+            fontSize: 'md',
             fontWeight: 'md',
-            flex: 1,
             [`&:not(.${tabClasses.selected}):not(:hover)`]: {
               opacity: 0.72,
             },
           },
         })}
       >
-        <TabList variant="plain" disableUnderline sx={{ borderRadius: 'xl', p: 0 }}>
+        <TabList
+          variant="plain"
+          size="small"
+          disableUnderline
+          sx={{ borderRadius: 'lg', p: 0 }}
+        >
           <Tab
             disableIndicator
             orientation="vertical"
             {...(index === 0 && { color: colors[0] })}
           >
             <ListItemDecorator>
-              <HomeOutlined />
+              <HomeRoundedIcon />
             </ListItemDecorator>
             Home
           </Tab>
@@ -79,6 +85,7 @@ export default function TabsBottomNavExample() {
             Search
           </Tab>
           <Tab
+            size="small"
             disableIndicator
             orientation="vertical"
             {...(index === 3 && { color: colors[3] })}

--- a/docs/data/joy/components/tabs/TabsBottomNavExample.tsx
+++ b/docs/data/joy/components/tabs/TabsBottomNavExample.tsx
@@ -4,7 +4,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
-import HomeOutlined from '@mui/icons-material/HomeOutlined';
+import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import FavoriteBorder from '@mui/icons-material/FavoriteBorder';
 import Search from '@mui/icons-material/Search';
 import Person from '@mui/icons-material/Person';
@@ -17,8 +17,7 @@ export default function TabsBottomNavExample() {
       sx={{
         flexGrow: 1,
         m: -3,
-        p: 3,
-        py: 5,
+        p: 4,
         borderTopLeftRadius: '12px',
         borderTopRightRadius: '12px',
         bgcolor: `${colors[index]}.500`,
@@ -31,30 +30,36 @@ export default function TabsBottomNavExample() {
         onChange={(event, value) => setIndex(value as number)}
         sx={(theme) => ({
           p: 1,
-          borderRadius: '24px',
+          borderRadius: 16,
           maxWidth: 400,
           mx: 'auto',
           boxShadow: theme.shadow.sm,
           '--joy-shadowChannel': theme.vars.palette[colors[index]].darkChannel,
           [`& .${tabClasses.root}`]: {
-            whiteSpace: 'nowrap',
+            py: 1,
+            flex: 1,
             transition: '0.3s',
             fontWeight: 'md',
-            flex: 1,
+            fontSize: 'md',
             [`&:not(.${tabClasses.selected}):not(:hover)`]: {
-              opacity: 0.72,
+              opacity: 0.7,
             },
           },
         })}
       >
-        <TabList variant="plain" disableUnderline sx={{ borderRadius: 'xl', p: 0 }}>
+        <TabList
+          variant="plain"
+          size="sm"
+          disableUnderline
+          sx={{ borderRadius: 'lg', p: 0 }}
+        >
           <Tab
             disableIndicator
             orientation="vertical"
             {...(index === 0 && { color: colors[0] })}
           >
             <ListItemDecorator>
-              <HomeOutlined />
+              <HomeRoundedIcon />
             </ListItemDecorator>
             Home
           </Tab>

--- a/docs/data/joy/components/tabs/TabsPageExample.js
+++ b/docs/data/joy/components/tabs/TabsPageExample.js
@@ -5,9 +5,6 @@ import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
 import TabPanel from '@mui/joy/TabPanel';
-import Typography from '@mui/joy/Typography';
-import Input from '@mui/joy/Input';
-import SearchRounded from '@mui/icons-material/SearchRounded';
 
 export default function TabsPageExample() {
   const [index, setIndex] = React.useState(0);
@@ -15,9 +12,8 @@ export default function TabsPageExample() {
     <Box
       sx={{
         flexGrow: 1,
-        m: -3,
+        m: -2,
         overflowX: 'hidden',
-        borderRadius: 'md',
       }}
     >
       <Tabs
@@ -27,7 +23,7 @@ export default function TabsPageExample() {
       >
         <TabList
           sx={{
-            pt: 2,
+            pt: 1,
             justifyContent: 'center',
             [`&& .${tabClasses.root}`]: {
               flex: 'initial',
@@ -38,9 +34,9 @@ export default function TabsPageExample() {
               [`&.${tabClasses.selected}`]: {
                 color: 'primary.plainColor',
                 '&::after': {
-                  height: '3px',
-                  borderTopLeftRadius: '3px',
-                  borderTopRightRadius: '3px',
+                  height: 2,
+                  borderTopLeftRadius: 3,
+                  borderTopRightRadius: 3,
                   bgcolor: 'primary.500',
                 },
               },
@@ -64,10 +60,19 @@ export default function TabsPageExample() {
               variant="soft"
               color={index === 1 ? 'primary' : 'neutral'}
             >
-              24
+              20
             </Chip>
           </Tab>
-          <Tab indicatorInset>Search library</Tab>
+          <Tab indicatorInset>
+            Products{' '}
+            <Chip
+              size="sm"
+              variant="soft"
+              color={index === 2 ? 'primary' : 'neutral'}
+            >
+              8
+            </Chip>
+          </Tab>
         </TabList>
         <Box
           sx={(theme) => ({
@@ -77,33 +82,9 @@ export default function TabsPageExample() {
             clipPath: 'inset(0 -100vmax)',
           })}
         >
-          <TabPanel value={0}>
-            <Typography
-              level="h2"
-              component="div"
-              fontSize="lg"
-              textColor="text.primary"
-            >
-              Deals panel
-            </Typography>
-          </TabPanel>
-          <TabPanel value={1}>
-            <Typography
-              level="h2"
-              component="div"
-              fontSize="lg"
-              textColor="text.primary"
-            >
-              Library panel
-            </Typography>
-          </TabPanel>
-          <TabPanel value={2}>
-            <Input
-              autoFocus
-              placeholder="Type in third panel..."
-              startDecorator={<SearchRounded />}
-            />
-          </TabPanel>
+          <TabPanel value={0}>Deals</TabPanel>
+          <TabPanel value={1}>Library</TabPanel>
+          <TabPanel value={2}>Products</TabPanel>
         </Box>
       </Tabs>
     </Box>

--- a/docs/data/joy/components/tabs/TabsPageExample.js
+++ b/docs/data/joy/components/tabs/TabsPageExample.js
@@ -5,6 +5,9 @@ import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
 import TabPanel from '@mui/joy/TabPanel';
+import Typography from '@mui/joy/Typography';
+import Input from '@mui/joy/Input';
+import SearchRounded from '@mui/icons-material/SearchRounded';
 
 export default function TabsPageExample() {
   const [index, setIndex] = React.useState(0);
@@ -12,8 +15,9 @@ export default function TabsPageExample() {
     <Box
       sx={{
         flexGrow: 1,
-        m: -2,
+        m: -3,
         overflowX: 'hidden',
+        borderRadius: 'md',
       }}
     >
       <Tabs
@@ -23,7 +27,7 @@ export default function TabsPageExample() {
       >
         <TabList
           sx={{
-            pt: 1,
+            pt: 2,
             justifyContent: 'center',
             [`&& .${tabClasses.root}`]: {
               flex: 'initial',
@@ -34,9 +38,10 @@ export default function TabsPageExample() {
               [`&.${tabClasses.selected}`]: {
                 color: 'primary.plainColor',
                 '&::after': {
-                  height: 2,
-                  borderTopLeftRadius: 3,
-                  borderTopRightRadius: 3,
+                  height: '3px',
+                  borderTopLeftRadius: '3px',
+                  borderTopRightRadius: '3px',
+                  bgcolor: 'primary.500',
                 },
               },
             },
@@ -59,23 +64,47 @@ export default function TabsPageExample() {
               variant="soft"
               color={index === 1 ? 'primary' : 'neutral'}
             >
-              20
+              24
             </Chip>
           </Tab>
-          <Tab indicatorInset>
-            Products{' '}
-            <Chip
-              size="sm"
-              variant="soft"
-              color={index === 2 ? 'primary' : 'neutral'}
-            >
-              8
-            </Chip>
-          </Tab>
+          <Tab indicatorInset>Search library</Tab>
         </TabList>
-        <TabPanel value={0}>Deals</TabPanel>
-        <TabPanel value={1}>Library</TabPanel>
-        <TabPanel value={2}>Products</TabPanel>
+        <Box
+          sx={(theme) => ({
+            '--bg': theme.vars.palette.background.surface,
+            background: 'var(--bg)',
+            boxShadow: '0 0 0 100vmax var(--bg)',
+            clipPath: 'inset(0 -100vmax)',
+          })}
+        >
+          <TabPanel value={0}>
+            <Typography
+              level="h2"
+              component="div"
+              fontSize="lg"
+              textColor="text.primary"
+            >
+              Deals panel
+            </Typography>
+          </TabPanel>
+          <TabPanel value={1}>
+            <Typography
+              level="h2"
+              component="div"
+              fontSize="lg"
+              textColor="text.primary"
+            >
+              Library panel
+            </Typography>
+          </TabPanel>
+          <TabPanel value={2}>
+            <Input
+              autoFocus
+              placeholder="Type in third panel..."
+              startDecorator={<SearchRounded />}
+            />
+          </TabPanel>
+        </Box>
       </Tabs>
     </Box>
   );

--- a/docs/data/joy/components/tabs/TabsPageExample.js
+++ b/docs/data/joy/components/tabs/TabsPageExample.js
@@ -5,9 +5,6 @@ import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
 import TabPanel from '@mui/joy/TabPanel';
-import Typography from '@mui/joy/Typography';
-import Input from '@mui/joy/Input';
-import SearchRounded from '@mui/icons-material/SearchRounded';
 
 export default function TabsPageExample() {
   const [index, setIndex] = React.useState(0);
@@ -15,9 +12,8 @@ export default function TabsPageExample() {
     <Box
       sx={{
         flexGrow: 1,
-        m: -3,
+        m: -2,
         overflowX: 'hidden',
-        borderRadius: 'md',
       }}
     >
       <Tabs
@@ -27,7 +23,7 @@ export default function TabsPageExample() {
       >
         <TabList
           sx={{
-            pt: 2,
+            pt: 1,
             justifyContent: 'center',
             [`&& .${tabClasses.root}`]: {
               flex: 'initial',
@@ -38,10 +34,9 @@ export default function TabsPageExample() {
               [`&.${tabClasses.selected}`]: {
                 color: 'primary.plainColor',
                 '&::after': {
-                  height: '3px',
-                  borderTopLeftRadius: '3px',
-                  borderTopRightRadius: '3px',
-                  bgcolor: 'primary.500',
+                  height: 2,
+                  borderTopLeftRadius: 3,
+                  borderTopRightRadius: 3,
                 },
               },
             },
@@ -64,47 +59,23 @@ export default function TabsPageExample() {
               variant="soft"
               color={index === 1 ? 'primary' : 'neutral'}
             >
-              24
+              20
             </Chip>
           </Tab>
-          <Tab indicatorInset>Search library</Tab>
+          <Tab indicatorInset>
+            Products{' '}
+            <Chip
+              size="sm"
+              variant="soft"
+              color={index === 2 ? 'primary' : 'neutral'}
+            >
+              8
+            </Chip>
+          </Tab>
         </TabList>
-        <Box
-          sx={(theme) => ({
-            '--bg': theme.vars.palette.background.surface,
-            background: 'var(--bg)',
-            boxShadow: '0 0 0 100vmax var(--bg)',
-            clipPath: 'inset(0 -100vmax)',
-          })}
-        >
-          <TabPanel value={0}>
-            <Typography
-              level="h2"
-              component="div"
-              fontSize="lg"
-              textColor="text.primary"
-            >
-              Deals panel
-            </Typography>
-          </TabPanel>
-          <TabPanel value={1}>
-            <Typography
-              level="h2"
-              component="div"
-              fontSize="lg"
-              textColor="text.primary"
-            >
-              Library panel
-            </Typography>
-          </TabPanel>
-          <TabPanel value={2}>
-            <Input
-              autoFocus
-              placeholder="Type in third panel..."
-              startDecorator={<SearchRounded />}
-            />
-          </TabPanel>
-        </Box>
+        <TabPanel value={0}>Deals</TabPanel>
+        <TabPanel value={1}>Library</TabPanel>
+        <TabPanel value={2}>Products</TabPanel>
       </Tabs>
     </Box>
   );

--- a/docs/data/joy/components/tabs/TabsPageExample.tsx
+++ b/docs/data/joy/components/tabs/TabsPageExample.tsx
@@ -5,9 +5,6 @@ import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab, { tabClasses } from '@mui/joy/Tab';
 import TabPanel from '@mui/joy/TabPanel';
-import Typography from '@mui/joy/Typography';
-import Input from '@mui/joy/Input';
-import SearchRounded from '@mui/icons-material/SearchRounded';
 
 export default function TabsPageExample() {
   const [index, setIndex] = React.useState(0);
@@ -15,9 +12,8 @@ export default function TabsPageExample() {
     <Box
       sx={{
         flexGrow: 1,
-        m: -3,
+        m: -2,
         overflowX: 'hidden',
-        borderRadius: 'md',
       }}
     >
       <Tabs
@@ -27,7 +23,7 @@ export default function TabsPageExample() {
       >
         <TabList
           sx={{
-            pt: 2,
+            pt: 1,
             justifyContent: 'center',
             [`&& .${tabClasses.root}`]: {
               flex: 'initial',
@@ -38,9 +34,9 @@ export default function TabsPageExample() {
               [`&.${tabClasses.selected}`]: {
                 color: 'primary.plainColor',
                 '&::after': {
-                  height: '3px',
-                  borderTopLeftRadius: '3px',
-                  borderTopRightRadius: '3px',
+                  height: 2,
+                  borderTopLeftRadius: 3,
+                  borderTopRightRadius: 3,
                   bgcolor: 'primary.500',
                 },
               },
@@ -64,10 +60,19 @@ export default function TabsPageExample() {
               variant="soft"
               color={index === 1 ? 'primary' : 'neutral'}
             >
-              24
+              20
             </Chip>
           </Tab>
-          <Tab indicatorInset>Search library</Tab>
+          <Tab indicatorInset>
+            Products{' '}
+            <Chip
+              size="sm"
+              variant="soft"
+              color={index === 2 ? 'primary' : 'neutral'}
+            >
+              8
+            </Chip>
+          </Tab>
         </TabList>
         <Box
           sx={(theme) => ({
@@ -77,33 +82,9 @@ export default function TabsPageExample() {
             clipPath: 'inset(0 -100vmax)',
           })}
         >
-          <TabPanel value={0}>
-            <Typography
-              level="h2"
-              component="div"
-              fontSize="lg"
-              textColor="text.primary"
-            >
-              Deals panel
-            </Typography>
-          </TabPanel>
-          <TabPanel value={1}>
-            <Typography
-              level="h2"
-              component="div"
-              fontSize="lg"
-              textColor="text.primary"
-            >
-              Library panel
-            </Typography>
-          </TabPanel>
-          <TabPanel value={2}>
-            <Input
-              autoFocus
-              placeholder="Type in third panel..."
-              startDecorator={<SearchRounded />}
-            />
-          </TabPanel>
+          <TabPanel value={0}>Deals</TabPanel>
+          <TabPanel value={1}>Library</TabPanel>
+          <TabPanel value={2}>Products</TabPanel>
         </Box>
       </Tabs>
     </Box>

--- a/docs/data/joy/components/tabs/TabsScrollable.js
+++ b/docs/data/joy/components/tabs/TabsScrollable.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import Card from '@mui/joy/Card';
+import Tabs from '@mui/joy/Tabs';
+import TabList from '@mui/joy/TabList';
+import Tab from '@mui/joy/Tab';
+
+export default function TabsScrollable() {
+  return (
+    <Card sx={{ width: 400, maxWidth: '100%' }}>
+      <Tabs aria-label="Scrollable tabs" defaultValue={0}>
+        <TabList
+          sx={{
+            overflow: 'auto',
+            scrollSnapType: 'x mandatory',
+            '&::-webkit-scrollbar': { display: 'none' },
+          }}
+        >
+          {[...Array(20)].map((_, index) => (
+            <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
+              Tab #{index + 1}
+            </Tab>
+          ))}
+        </TabList>
+      </Tabs>
+    </Card>
+  );
+}

--- a/docs/data/joy/components/tabs/TabsScrollable.js
+++ b/docs/data/joy/components/tabs/TabsScrollable.js
@@ -1,27 +1,24 @@
 import * as React from 'react';
-import Card from '@mui/joy/Card';
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab from '@mui/joy/Tab';
 
 export default function TabsScrollable() {
   return (
-    <Card sx={{ width: 400, maxWidth: '100%' }}>
-      <Tabs aria-label="Scrollable tabs" defaultValue={0}>
-        <TabList
-          sx={{
-            overflow: 'auto',
-            scrollSnapType: 'x mandatory',
-            '&::-webkit-scrollbar': { display: 'none' },
-          }}
-        >
-          {[...Array(20)].map((_, index) => (
-            <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
-              Tab #{index + 1}
-            </Tab>
-          ))}
-        </TabList>
-      </Tabs>
-    </Card>
+    <Tabs aria-label="Scrollable tabs" defaultValue={0} sx={{ width: 400 }}>
+      <TabList
+        sx={{
+          overflow: 'auto',
+          scrollSnapType: 'x mandatory',
+          '&::-webkit-scrollbar': { display: 'none' },
+        }}
+      >
+        {[...Array(20)].map((_, index) => (
+          <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
+            Tab #{index + 1}
+          </Tab>
+        ))}
+      </TabList>
+    </Tabs>
   );
 }

--- a/docs/data/joy/components/tabs/TabsScrollable.tsx
+++ b/docs/data/joy/components/tabs/TabsScrollable.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import Card from '@mui/joy/Card';
+import Tabs from '@mui/joy/Tabs';
+import TabList from '@mui/joy/TabList';
+import Tab from '@mui/joy/Tab';
+
+export default function TabsScrollable() {
+  return (
+    <Card sx={{ width: 400, maxWidth: '100%' }}>
+      <Tabs aria-label="Scrollable tabs" defaultValue={0}>
+        <TabList
+          sx={{
+            overflow: 'auto',
+            scrollSnapType: 'x mandatory',
+            '&::-webkit-scrollbar': { display: 'none' },
+          }}
+        >
+          {[...Array(20)].map((_, index) => (
+            <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
+              Tab #{index + 1}
+            </Tab>
+          ))}
+        </TabList>
+      </Tabs>
+    </Card>
+  );
+}

--- a/docs/data/joy/components/tabs/TabsScrollable.tsx
+++ b/docs/data/joy/components/tabs/TabsScrollable.tsx
@@ -1,27 +1,24 @@
 import * as React from 'react';
-import Card from '@mui/joy/Card';
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab from '@mui/joy/Tab';
 
 export default function TabsScrollable() {
   return (
-    <Card sx={{ width: 400, maxWidth: '100%' }}>
-      <Tabs aria-label="Scrollable tabs" defaultValue={0}>
-        <TabList
-          sx={{
-            overflow: 'auto',
-            scrollSnapType: 'x mandatory',
-            '&::-webkit-scrollbar': { display: 'none' },
-          }}
-        >
-          {[...Array(20)].map((_, index) => (
-            <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
-              Tab #{index + 1}
-            </Tab>
-          ))}
-        </TabList>
-      </Tabs>
-    </Card>
+    <Tabs aria-label="Scrollable tabs" defaultValue={0} sx={{ width: 400 }}>
+      <TabList
+        sx={{
+          overflow: 'auto',
+          scrollSnapType: 'x mandatory',
+          '&::-webkit-scrollbar': { display: 'none' },
+        }}
+      >
+        {[...Array(20)].map((_, index) => (
+          <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
+            Tab #{index + 1}
+          </Tab>
+        ))}
+      </TabList>
+    </Tabs>
   );
 }

--- a/docs/data/joy/components/tabs/TabsScrollable.tsx.preview
+++ b/docs/data/joy/components/tabs/TabsScrollable.tsx.preview
@@ -1,0 +1,15 @@
+<Tabs aria-label="Scrollable tabs" defaultValue={0} sx={{ width: 400 }}>
+  <TabList
+    sx={{
+      overflow: 'auto',
+      scrollSnapType: 'x mandatory',
+      '&::-webkit-scrollbar': { display: 'none' },
+    }}
+  >
+    {[...Array(20)].map((_, index) => (
+      <Tab key={index} sx={{ flex: 'none', scrollSnapAlign: 'start' }}>
+        Tab #{index + 1}
+      </Tab>
+    ))}
+  </TabList>
+</Tabs>

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -159,6 +159,14 @@ You can use those to customize the component on both the `sx` prop and the theme
 
 ## Common examples
 
+### Scrollable tabs
+
+To make the tabs scrollable, use the `sx` prop on the `TabList` component and set `overflow: auto` to the `TabList`.
+
+In this example, the scrollbar is hidden by setting display `none` to `::-webkit-scrollbar` and is snapped to the edge by setting [CSS scroll snap](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_snap) properties.
+
+{{"demo": "TabsScrollable.js"}}
+
 ### Segmented controls
 
 To mimic the iOS segmented controls, add the border-radius to the `sx` prop of the TabList and set the selected Tab's background to `background.surface`.

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -24,41 +24,34 @@ Joy UI provides four tabs-related components:
 
 {{"demo": "TabsUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
-## Component
-
-After [installation](/joy-ui/getting-started/installation/), you can start building with this component using the following basic elements:
+## Basics
 
 ```jsx
 import Tabs from '@mui/joy/Tabs';
 import TabList from '@mui/joy/TabList';
 import Tab from '@mui/joy/Tab';
-
-export default function MyApp() {
-  return (
-    <Tabs defaultValue={1}>
-      <TabList>
-        <Tab value={1}>Tab A</Tab>
-        <Tab value={2}>Tab B</Tab>
-        <Tab value={3}>Tab C</Tab>
-      </TabList>
-    </Tabs>
-  );
-}
 ```
 
-### Basic usage
+The Joy UI set of Tabs components follows the [WAI ARIA design pattern guidelines](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
 
-The tabs structure follows [WAI ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
-To target the initially selected tab, specify the `value` prop to the `TabPanel` and use `Tabs`'s `defaultValue`.
+Use the `value` prop on the Tab Panel and the `defaultValue` prop on the Tabs component to target the selected tab.
 
 {{"demo": "TabsBasic.js"}}
 
+### Disabled tab
+
+Use the `disabled` prop to disable interaction and focus.
+
+{{"demo": "TabDisabled.js"}}
+
+## Customization
+
 ### Variants
 
-Both `TabList` and `Tab` accept [global variant](/joy-ui/main-features/global-variants/) values, so you can mix and match to get the desired result.
+The Tab List and Tab components accept the global `variant` prop values.
 
 :::info
-A selected `Tab` does not apply `:hover` and `:active` global variant styles.
+The selected Tab won't apply the `:hover` and `:active` styles defined globally.
 :::
 
 {{"demo": "TabsVariants.js"}}
@@ -67,87 +60,64 @@ A selected `Tab` does not apply `:hover` and `:active` global variant styles.
 To learn how to add more variants to the component, check out [Themed components—Extend variants](/joy-ui/customization/themed-components/#extend-variants).
 :::
 
-### Disabled tab
-
-To disable a tab, use the `disabled` prop on the `Tab` component.
-
-{{"demo": "TabDisabled.js"}}
-
 ### Vertical
 
-To set the tabs orientation to vertical, use the `orientation="vertical"` on the `Tabs` component.
-Keyboard navigation (e.g. arrow keys) will adapt automatically to the used orientation.
+Use the `orientation="vertical"` prop on the Tabs component to make it vertical.
+Keyboard navigation using arrow keys adapts automatically.
 
 {{"demo": "TabsVertical.js"}}
 
-### Placement
+### Indicator placement
 
-To change the placement, you should provide the value of `top`, `bottom`, `left` or `right`.
-
-This prop can be applied on the TabList component to change the `underlinePlacement` as in the example:
+Use the `underlinePlacement` prop on the Tab List component to change the Tabs' underline border placement.
 
 {{"demo": "TabsUnderlinePlacement.js"}}
 
-Or, it can be applied on the Tab component to change the `indicatorPlacement`:
+Control the selected Tab indicator independently using the `indicatorPlacement` prop.
 
 {{"demo": "TabsIndicatorPlacement.js"}}
 
-The flex direction of the Tabs component will need to be changed based on each placement.
+Depending on the underline and selected indicator placement, you may need to change the Tabs component flex-direction.
 
 {{"demo": "TabsFlexPlacement.js"}}
 
 ### Sticky
 
-For long content, you can use the `sticky="top"` prop on the TabList component to keep the tabs visible while scrolling.
-
-To stick the TabList at the bottom, use `sticky="bottom"` and render the TabList at the end of the Tabs component.
+In a long content scenario, use the `sticky="top"` prop on the Tab List component to keep the tabs visible while scrolling.
 
 {{"demo": "TabsSticky.js"}}
 
+To stick the Tab List component at the bottom, use the `sticky="bottom"` prop instead and put it below the Tabs component.
+
 ### Tab flex
 
-Use the `tabFlex` prop on the TabList component to make the Tab elements fill the available space as shown in the example below.
+Use the `tabFlex` prop on the Tab List component to make the Tab elements fill the available space as shown in the example below.
 
-The first demo, `tabFlex={1}`, the Tab elements will fill the available space equally.
+In the first demo, the Tab elements fill the available space using `tabFlex={1}`.
 
-The second demo, `tabFlex="auto`, the Tab elements will fill the available space equally, but the width of each Tab element will be based on the content.
+In the second demo, the Tab elements fill the available space equally using `tabFlex="auto"`, but the width of each one of them is based on the content.
 
 {{"demo": "TabsFlex.js"}}
 
-:::success
-The value of the `tabFlex` can be any valid [CSS flex](https://developer.mozilla.org/en-US/docs/Web/CSS/flex) value.
+:::info
+The value of the `tabFlex` prop can be any [valid CSS flex value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex).
 :::
 
 ### Icon
 
-Since `TabList` uses the same style as the [`List`](/joy-ui/react-list/) component, you can use the icon directly as a child or use `ListItemDecorator` with a text.
+Since the Tab List component uses the same style as the [List](/joy-ui/react-list/) component, you can use the icon directly as a child or use List Item Decorator with a text.
 
 {{"demo": "TabsIcon.js"}}
 
 {{"demo": "TabsIconWithText.js"}}
 
-### Accessibility
+### Scrollable tabs
 
-For ensuring proper accessibility, it's recommended by [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#wai-aria-roles-states-and-properties-22) to associate a label to the Tabs component.
-To do that, there are two options:
+Add the `overflow: auto` property to the Tab List component to make the tabs scrollable.
 
-#### Option one
+Polish it further by making the scrollbar hidden with `'&::-webkit-scrollbar': { display: 'none' }` and snapping the scroll to the edge of the Tab List component with [CSS scroll snap properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_snap).
 
-Render a text element with an `id` and provide `aria-labelledby="$is"`to the Tabs component.
-
-```js
-<Typography id="tabs-accessibility-label">Meaningful label</Typography>
-<Tabs aria-labelledby="tabs-accessibility-label">...</Tabs>
-```
-
-#### Option two
-
-When not displaying a text element on the screen, use `aria-label` directly on the Tabs component.
-Screen readers will then properly announce the label.
-
-```js
-<Tabs aria-label="Meaningful label">...</Tabs>
-```
+{{"demo": "TabsScrollable.js"}}
 
 ## CSS variables playground
 
@@ -159,40 +129,58 @@ You can use those to customize the component on both the `sx` prop and the theme
 
 ## Common examples
 
-### Scrollable tabs
-
-To make the tabs scrollable, use the `sx` prop on the `TabList` component and set `overflow: auto` to the `TabList`.
-
-In this example, the scrollbar is hidden by setting display `none` to `::-webkit-scrollbar` and is snapped to the edge by setting [CSS scroll snap](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_snap) properties.
-
-{{"demo": "TabsScrollable.js"}}
-
 ### Segmented controls
 
-To mimic the iOS segmented controls, add the border-radius to the `sx` prop of the TabList and set the selected Tab's background to `background.surface`.
+To mimic the iOS segmented controls, add a border-radius to the Tab List component and set the selected Tab background to `background.surface`.
 
 {{"demo": "TabsSegmentedControls.js"}}
 
 ### Browser tabs
 
-In this example, the Tab's variant is set to `outlined` and the indicator is moved to the top via `indicatorPlacement="top"`. The borders of the Tab are set to `transparent` based on the selected state.
+In this example, the Tab's variant prop is set to `outlined` and the indicator is moved to the top via `indicatorPlacement="top"`.
+The borders are then set to `transparent` based on the selected state.
 
 {{"demo": "TabsBrowserExample.js"}}
 
 ### Pricing tabs
 
-This example removes the background of the selected Tab by targeting `[aria-selected="true"]` on the `sx` prop.
+This example removes the background of the selected Tab by targeting the `aria-selected="true"` attribute.
 
 {{"demo": "TabsPricingExample.js"}}
 
 ### With counter chips
 
-To render tab items at the center of the TabList, use `justifyContent: 'center'` on the `sx` prop of the TabList and set `flex: initial` to each of the Tab to override the default `flex-grow`.
+To make each Tab component centralized in the Tab List, add the `flex: initial` property to override the default `flex-grow` behavior.
+Then, on the list, add `justifyContent: center`.
 
 {{"demo": "TabsPageExample.js"}}
 
 ### Mobile bottom navigation
 
-In this example, each Tab's is applied with one of the theme's color palette when it is selected.
+In this example, each Tab is painted with a color from the theme when it is selected.
 
 {{"demo": "TabsBottomNavExample.js"}}
+
+## Accessibility
+
+To ensure proper accessibility, [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#wai-aria-roles-states-and-properties-22) recommends to associate a label to the Tabs component.
+There are two options to do that:
+
+### Using the id attribute
+
+Add a text element close to the tabs with the `id` attribute.
+Then, on the Tabs component, add the `aria-labelledby` attribute.
+Make sure to use meaningful labels for both.
+
+```js
+<Typography id="tabs-accessibility-label">Meaningful label</Typography>
+<Tabs aria-labelledby="tabs-accessibility-label">...</Tabs>
+```
+
+### Using aria-label
+
+If a text element does not accompany your Tabs component, use the `aria-label` attribute directly to make it readable by screen readers.
+
+```js
+<Tabs aria-label="Meaningful label">...</Tabs>
+```

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -83,19 +83,17 @@ Depending on the underline and selected indicator placement, you may need to cha
 
 ### Sticky
 
-In a long content scenario, use the `sticky="top"` prop on the Tab List component to keep the tabs visible while scrolling.
+Use the `sticky` prop to place the Tab List component at the top or bottom in a long content scenario.
 
 {{"demo": "TabsSticky.js"}}
-
-To stick the Tab List component at the bottom, use the `sticky="bottom"` prop instead and put it below the Tabs component.
 
 ### Tab flex
 
 Use the `tabFlex` prop on the Tab List component to make the Tab elements fill the available space as shown in the example below.
 
-In the first demo, the Tab elements fill the available space using `tabFlex={1}`.
+- In the first demo, the Tab elements fill the available space using `tabFlex={1}`.
 
-In the second demo, the Tab elements fill the available space equally using `tabFlex="auto"`, but the width of each one of them is based on the content.
+- In the second demo, the Tab elements fill the available space equally using `tabFlex="auto"`, but the width of each one of them is based on the content.
 
 {{"demo": "TabsFlex.js"}}
 

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -146,7 +146,7 @@ This example removes the background of the selected Tab by targeting the `aria-s
 
 {{"demo": "TabsPricingExample.js"}}
 
-### With counter chips
+### Centralized tabs
 
 To make each Tab component centralized in the Tab List, add the `flex: initial` property to override the default `flex-grow` behavior.
 Then, on the list, add `justifyContent: center`.

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -48,28 +48,28 @@ Use the `disabled` prop to disable interaction and focus.
 
 ### Variants
 
-The Tab List and Tab components accept the global `variant` prop values.
+The `<TabList />` and `<Tab />` components accept the global `variant` prop values.
 
 :::info
-The selected Tab won't apply the `:hover` and `:active` styles defined globally.
+When a Tab is selected, it _won't_ apply globally defined `:hover` and `:active` styles.
 :::
 
 {{"demo": "TabsVariants.js"}}
 
-:::info
+:::warning
 To learn how to add more variants to the component, check out [Themed components—Extend variants](/joy-ui/customization/themed-components/#extend-variants).
 :::
 
 ### Vertical
 
-Use the `orientation="vertical"` prop on the Tabs component to make it vertical.
+Use the `orientation="vertical"` prop on the `<Tabs />` component to make it vertical.
 Keyboard navigation using arrow keys adapts automatically.
 
 {{"demo": "TabsVertical.js"}}
 
 ### Indicator placement
 
-Use the `underlinePlacement` prop on the Tab List component to change the Tabs' underline border placement.
+Use the `underlinePlacement` prop on the Tab List component to change the placement of the underline border on the Tabs.
 
 {{"demo": "TabsUnderlinePlacement.js"}}
 
@@ -77,23 +77,23 @@ Control the selected Tab indicator independently using the `indicatorPlacement` 
 
 {{"demo": "TabsIndicatorPlacement.js"}}
 
-Depending on the underline and selected indicator placement, you may need to change the Tabs component flex-direction.
+Depending on the placement of the underline and the selected indicator, you may need to change the flex direction of the Tabs component.
 
 {{"demo": "TabsFlexPlacement.js"}}
 
 ### Sticky
 
-Use the `sticky` prop to place the Tab List component at the top or bottom in a long content scenario.
+Use the `sticky` prop to anchor the Tab List component at the top or bottom.
+This is ideal for use cases that involve longer content.
 
 {{"demo": "TabsSticky.js"}}
 
 ### Tab flex
 
-Use the `tabFlex` prop on the Tab List component to make the Tab elements fill the available space as shown in the example below.
+Use the `tabFlex` prop on the Tab List component to make the Tab elements fill the available space, as shown in the example below.
 
 - In the first demo, the Tab elements fill the available space using `tabFlex={1}`.
-
-- In the second demo, the Tab elements fill the available space equally using `tabFlex="auto"`, but the width of each one of them is based on the content.
+- In the second demo, the Tab elements fill the available space equally using `tabFlex="auto"`, but the width of each respective element is based on its content.
 
 {{"demo": "TabsFlex.js"}}
 
@@ -103,7 +103,7 @@ The value of the `tabFlex` prop can be any [valid CSS flex value](https://develo
 
 ### Icon
 
-Since the Tab List component uses the same style as the [List](/joy-ui/react-list/) component, you can use the icon directly as a child or use List Item Decorator with a text.
+Since the Tab List component uses the same style as the [List](/joy-ui/react-list/) component, you can use the icon directly as a child, or use List Item Decorator with text.
 
 {{"demo": "TabsIcon.js"}}
 
@@ -113,7 +113,7 @@ Since the Tab List component uses the same style as the [List](/joy-ui/react-lis
 
 Add the `overflow: auto` property to the Tab List component to make the tabs scrollable.
 
-Polish it further by making the scrollbar hidden with `'&::-webkit-scrollbar': { display: 'none' }` and snapping the scroll to the edge of the Tab List component with [CSS scroll snap properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_snap).
+Polish it further by hiding the scrollbar with `'&::-webkit-scrollbar': { display: 'none' }`, and snapping the scroll to the edge of the Tab List component with [CSS scroll snap properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_snap).
 
 {{"demo": "TabsScrollable.js"}}
 
@@ -129,7 +129,7 @@ You can use those to customize the component on both the `sx` prop and the theme
 
 ### Segmented controls
 
-To mimic the iOS segmented controls, add a border-radius to the Tab List component and set the selected Tab background to `background.surface`.
+To mimic the segmented controls of iOS, add a border-radius to the Tab List component and set the selected Tab background to `background.surface`.
 
 {{"demo": "TabsSegmentedControls.js"}}
 
@@ -146,28 +146,28 @@ This example removes the background of the selected Tab by targeting the `aria-s
 
 {{"demo": "TabsPricingExample.js"}}
 
-### Centralized tabs
+### Centered tabs
 
-To make each Tab component centralized in the Tab List, add the `flex: initial` property to override the default `flex-grow` behavior.
+To center the Tab components in the Tab List, add the `flex: initial` property to override the default `flex-grow` behavior.
 Then, on the list, add `justifyContent: center`.
 
 {{"demo": "TabsPageExample.js"}}
 
 ### Mobile bottom navigation
 
-In this example, each Tab is painted with a color from the theme when it is selected.
+In this example, each Tab is painted with a color from the theme when selected.
 
 {{"demo": "TabsBottomNavExample.js"}}
 
 ## Accessibility
 
-To ensure proper accessibility, [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#wai-aria-roles-states-and-properties-22) recommends to associate a label to the Tabs component.
-There are two options to do that:
+To ensure proper accessibility, the [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/#wai-aria-roles-states-and-properties-22) recommends associating a label with the Tabs component.
+There are two options to accomplish this:
 
 ### Using the id attribute
 
 Add a text element close to the tabs with the `id` attribute.
-Then, on the Tabs component, add the `aria-labelledby` attribute.
+Then add the `aria-labelledby` attribute to the Tabs component.
 Make sure to use meaningful labels for both.
 
 ```js


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #34974

A CSS-only approach until we have the JS version from Base UI.

👉  **https://deploy-preview-39260--material-ui.netlify.app/joy-ui/react-tabs/#scrollable-tabs**


