### PR TITLE
fix: added Textarea-ref in docs

### DIFF
--- a/docs/data/joy/components/textarea/textarea.md
+++ b/docs/data/joy/components/textarea/textarea.md
@@ -115,6 +115,20 @@ It's usually more common to see textarea components using decorators at the top 
 
 {{"demo": "TextareaDecorators.js"}}
 
+### Textarea ref
+`useRef` in React is typically used to reference a DOM element or a component. In the case of form inputs like Input or TextArea in Joy UI, you can use useRef to access and interact with the underlying DOM node directly without causing re-renders.
+
+{{"demo": "TextareauseRef.js"}}
+
+Input:
+```js
+<Input slotProps={{ input: { ref } }} />
+```
+Textarea:
+```js
+<Textarea slotProps={{ input: { ref } }} />
+```
+
 ## Accessibility
 
 In order for the textarea to be accessible, **it should be linked to a label**.


### PR DESCRIPTION
Fixes #39187

-> This PR added a Textarea-ref in docs .

-> The addition was made in material-ui/docs/joy/components/textarea/textarea.md 
 
 It's usually more common to see textarea components using decorators at the top
{{"demo": "TextareaDecorators.js"}}
+
### Textarea ref ----- ( added here)
+
 ## Accessibility
 In order for the textarea to be accessible, **it should be linked to a label**.

![changesmade](https://github.com/mui/material-ui/assets/96781102/b365bd7c-a0b0-4de7-949f-89fa63eab3e9)


