### PR TITLE
[CssBaseline] use Joy `GlobalStyles`

### DIFF
--- a/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
+++ b/packages/mui-joy/src/CssBaseline/CssBaseline.tsx
@@ -1,10 +1,10 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { GlobalStyles } from '@mui/system';
+import GlobalStyles from '../GlobalStyles';
+import defaultTheme from '../styles/defaultTheme';
 import { Theme, DefaultColorScheme, ColorSystem } from '../styles/types';
 import { Components } from '../styles/components';
-import defaultTheme from '../styles/defaultTheme';
 import { CssBaselineProps } from './CssBaselineProps';
 
 /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

From https://github.com/mui/material-ui/pull/36829/files/af3d831e7130d34b5ab81b4b2821a387067c87a3#r1343238470.

This fix will make theme scoping work with CssBaseline.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
