### PR TITLE
[docs][joy-ui] Remove redundant `error` prop from input validation demo

### DIFF
--- a/docs/data/joy/components/input/InputValidation.js
+++ b/docs/data/joy/components/input/InputValidation.js
@@ -12,11 +12,7 @@ export default function InputValidation() {
       <Input placeholder="Type in here…" error defaultValue="Oh no, error found!" />
       <FormControl error>
         <FormLabel>Label</FormLabel>
-        <Input
-          placeholder="Type in here…"
-          error
-          defaultValue="Oh no, error found!"
-        />
+        <Input placeholder="Type in here…" defaultValue="Oh no, error found!" />
         <FormHelperText>
           <InfoOutlined />
           Opps! something is wrong.

--- a/docs/data/joy/components/input/InputValidation.tsx
+++ b/docs/data/joy/components/input/InputValidation.tsx
@@ -12,11 +12,7 @@ export default function InputValidation() {
       <Input placeholder="Type in here…" error defaultValue="Oh no, error found!" />
       <FormControl error>
         <FormLabel>Label</FormLabel>
-        <Input
-          placeholder="Type in here…"
-          error
-          defaultValue="Oh no, error found!"
-        />
+        <Input placeholder="Type in here…" defaultValue="Oh no, error found!" />
         <FormHelperText>
           <InfoOutlined />
           Opps! something is wrong.

--- a/docs/data/joy/components/input/InputValidation.tsx.preview
+++ b/docs/data/joy/components/input/InputValidation.tsx.preview
@@ -1,11 +1,7 @@
 <Input placeholder="Type in here…" error defaultValue="Oh no, error found!" />
 <FormControl error>
   <FormLabel>Label</FormLabel>
-  <Input
-    placeholder="Type in here…"
-    error
-    defaultValue="Oh no, error found!"
-  />
+  <Input placeholder="Type in here…" defaultValue="Oh no, error found!" />
   <FormHelperText>
     <InfoOutlined />
     Opps! something is wrong.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

preview: https://deploy-preview-39280--material-ui.netlify.app/joy-ui/react-input/#validation

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
