### PR TITLE
[test][base-ui] Fix import paths in useTab tests

### DIFF
--- a/packages/mui-base/src/useTab/useTab.test.tsx
+++ b/packages/mui-base/src/useTab/useTab.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, screen, fireEvent } from 'test/utils';
+import { createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
 import { Tabs } from '../Tabs';
 import { TabsList } from '../TabsList';
 import { useTab } from './useTab';

--- a/packages/mui-base/src/useTabPanel/useTabPanel.test.js
+++ b/packages/mui-base/src/useTabPanel/useTabPanel.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, screen, fireEvent } from 'test/utils';
+import { createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
 import { Tabs } from '../Tabs';
 import { Tab } from '../Tab';
 import { TabsList } from '../TabsList';

--- a/packages/mui-base/src/useTabsList/useTabsList.test.tsx
+++ b/packages/mui-base/src/useTabsList/useTabsList.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, screen, fireEvent } from 'test/utils';
+import { createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
 import { Tabs } from '../Tabs';
 import { useTabsList } from './useTabsList';
 


### PR DESCRIPTION
I forgot to update to `'@mui-internal/test-utils'` in https://github.com/mui/material-ui/pull/39037 😓 

Fixes CI currently failing on master: https://app.circleci.com/pipelines/github/mui/material-ui/110305/workflows/1def82a9-c4b9-4ac0-aac3-f179632f70ae/jobs/591293

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
