### PR TITLE
[joy-ui][Input] Add debounce input demo

### DIFF
--- a/docs/data/joy/components/input/DebouncedInput.js
+++ b/docs/data/joy/components/input/DebouncedInput.js
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Input from '@mui/joy/Input';
+import Typography from '@mui/joy/Typography';
+import Box from '@mui/joy/Box';
 
 function DebounceInput(props) {
   const { handleDebounce, debounceTimeout, ...rest } = props;
@@ -26,14 +28,18 @@ DebounceInput.propTypes = {
 };
 
 export default function DebouncedInput() {
-  const handleDebounce = () => {
-    alert('This function is called after 1 second of typing');
+  const [debouncedValue, setDebouncedValue] = React.useState('');
+  const handleDebounce = (value) => {
+    setDebouncedValue(value);
   };
   return (
-    <DebounceInput
-      placeholder="Type in here…"
-      debounceTimeout={1000}
-      handleDebounce={handleDebounce}
-    />
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <DebounceInput
+        placeholder="Type in here…"
+        debounceTimeout={1000}
+        handleDebounce={handleDebounce}
+      />
+      <Typography>Debounced input: {debouncedValue}</Typography>
+    </Box>
   );
 }

--- a/docs/data/joy/components/input/DebouncedInput.js
+++ b/docs/data/joy/components/input/DebouncedInput.js
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Input from '@mui/joy/Input';
+
+function DebounceInput(props) {
+  const { handleDebounce, debounceTimeout, ...rest } = props;
+
+  const timerRef = React.useRef();
+
+  const handleChange = (event) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = window.setTimeout(() => {
+      handleDebounce(event.target.value);
+    }, debounceTimeout);
+  };
+
+  return <Input {...rest} onChange={handleChange} />;
+}
+
+DebounceInput.propTypes = {
+  debounceTimeout: PropTypes.number.isRequired,
+  handleDebounce: PropTypes.func.isRequired,
+};
+
+export default function DebouncedInput() {
+  const handleDebounce = () => {
+    alert('This function is called after 1 second of typing');
+  };
+  return (
+    <DebounceInput
+      placeholder="Type in here…"
+      debounceTimeout={1000}
+      handleDebounce={handleDebounce}
+    />
+  );
+}

--- a/docs/data/joy/components/input/DebouncedInput.tsx
+++ b/docs/data/joy/components/input/DebouncedInput.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import Input, { InputProps } from '@mui/joy/Input';
+
+type DebounceProps = {
+  handleDebounce: (value: string) => void;
+  debounceTimeout: number;
+};
+
+function DebounceInput(props: InputProps & DebounceProps) {
+  const { handleDebounce, debounceTimeout, ...rest } = props;
+
+  const timerRef = React.useRef<number>();
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = window.setTimeout(() => {
+      handleDebounce(event.target.value);
+    }, debounceTimeout);
+  };
+
+  return <Input {...rest} onChange={handleChange} />;
+}
+
+export default function DebouncedInput() {
+  const handleDebounce = () => {
+    alert('This function is called after 1 second of typing');
+  };
+  return (
+    <DebounceInput
+      placeholder="Type in here…"
+      debounceTimeout={1000}
+      handleDebounce={handleDebounce}
+    />
+  );
+}

--- a/docs/data/joy/components/input/DebouncedInput.tsx
+++ b/docs/data/joy/components/input/DebouncedInput.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import Input, { InputProps } from '@mui/joy/Input';
+import Typography from '@mui/joy/Typography';
+import Box from '@mui/joy/Box';
 
 type DebounceProps = {
   handleDebounce: (value: string) => void;
@@ -25,14 +27,18 @@ function DebounceInput(props: InputProps & DebounceProps) {
 }
 
 export default function DebouncedInput() {
-  const handleDebounce = () => {
-    alert('This function is called after 1 second of typing');
+  const [debouncedValue, setDebouncedValue] = React.useState('');
+  const handleDebounce = (value: string) => {
+    setDebouncedValue(value);
   };
   return (
-    <DebounceInput
-      placeholder="Type in here…"
-      debounceTimeout={1000}
-      handleDebounce={handleDebounce}
-    />
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <DebounceInput
+        placeholder="Type in here…"
+        debounceTimeout={1000}
+        handleDebounce={handleDebounce}
+      />
+      <Typography>Debounced input: {debouncedValue}</Typography>
+    </Box>
   );
 }

--- a/docs/data/joy/components/input/DebouncedInput.tsx.preview
+++ b/docs/data/joy/components/input/DebouncedInput.tsx.preview
@@ -3,3 +3,4 @@
   debounceTimeout={1000}
   handleDebounce={handleDebounce}
 />
+<Typography>Debounced input: {debouncedValue}</Typography>

--- a/docs/data/joy/components/input/DebouncedInput.tsx.preview
+++ b/docs/data/joy/components/input/DebouncedInput.tsx.preview
@@ -1,0 +1,5 @@
+<DebounceInput
+  placeholder="Type in here…"
+  debounceTimeout={1000}
+  handleDebounce={handleDebounce}
+/>

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -166,6 +166,10 @@ To create a floating label input, a custom component (combination of `<input>` a
 
 {{"demo": "PasswordMeterInput.js"}}
 
+### Debounced Input
+
+{{"demo": "DebouncedInput.js"}}
+
 ### Third-party formatting
 
 The Input component can be integrated with third-party formatting libraries for more complex use cases.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

preview: https://deploy-preview-39300--material-ui.netlify.app/joy-ui/react-input/#debounced-input

https://www.npmjs.com/package/react-debounce-input has 224k weekly downloads, so i think debounce is pouplar enough use-case that can go be a demo.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
