### PR TITLE
[docs-infra] Fix Code Sandbox download issue

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -67,7 +67,7 @@ describe('CodeSandbox', () => {
   </body>
 </html>`,
       },
-      'Demo.js': {
+      'src/Demo.js': {
         content: `import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
@@ -83,7 +83,7 @@ export default function BasicButtons() {
 }
 `,
       },
-      'index.js': {
+      'src/index.js': {
         content: `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';
@@ -157,7 +157,7 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
   </body>
 </html>`,
       },
-      'Demo.tsx': {
+      'src/Demo.tsx': {
         content: `import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
@@ -173,7 +173,7 @@ export default function BasicButtons() {
 }
 `,
       },
-      'index.tsx': {
+      'src/index.tsx': {
         content: `import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { StyledEngineProvider } from '@mui/material/styles';

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -83,7 +83,7 @@ const createReactApp = (demoData: DemoData) => {
      * @description should start with `/`, e.g. `/Demo.tsx`. If the extension is not provided,
      * it will be appended based on the code variant.
      */
-    openSandbox: (initialFile: string = `/Demo.${ext}`) =>
+    openSandbox: (initialFile: string = `/src/Demo.${ext}`) =>
       openSandbox({ files, codeVariant: demoData.codeVariant, initialFile }),
   };
 };

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -41,10 +41,10 @@ const createReactApp = (demoData: DemoData) => {
     'public/index.html': {
       content: CRA.getHtml(demoData),
     },
-    [`index.${ext}`]: {
+    [`src/index.${ext}`]: {
       content: CRA.getRootIndex(demoData),
     },
-    [`Demo.${ext}`]: {
+    [`src/Demo.${ext}`]: {
       content: demoData.raw,
     },
     ...(demoData.codeVariant === 'TS' && {


### PR DESCRIPTION
Preview: https://deploy-preview-39317--material-ui.netlify.app/material-ui/react-alert/#basic-alerts
Closes https://github.com/mui/material-ui/issues/38860

| Before | After |
|--------|--------|
| ![image](https://github.com/mui/material-ui/assets/67954450/602cb309-96b4-40ba-b567-9cebe0eb375a) | ![image](https://github.com/mui/material-ui/assets/67954450/46b69132-beb4-4b7b-91a5-3f003dfe86b6) | 

Also, I think the issue has also fixed the problem where you navigate to the docker tab and convert to a cloud sandbox.
![image](https://github.com/mui/material-ui/assets/67954450/b8fffaa2-65e9-4bd5-afb2-cfceb0fdc397)
 

Thank you so much @Janpot, your suggestion was very helpful and was enough to solve the problem