### PR TITLE
[docs][Drawer] Fix right anchored persistent drawer intercepts click when it is closed

### DIFF
--- a/docs/data/material/components/drawers/PersistentDrawerRight.js
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.js
@@ -37,7 +37,12 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
       }),
       marginRight: 0,
     }),
-    // This is necessary to enable the selection of content. In the DOM, the stacking order is determined by the order of appearance. Following this rule, elements appearing later in the markup will overlay those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures proper interaction with the underlying content.
+    /**
+     * This is necessary to enable the selection of content. In the DOM, the stacking order is determined
+     * by the order of appearance. Following this rule, elements appearing later in the markup will overlay
+     * those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures
+     * proper interaction with the underlying content.
+     */
     position: 'relative',
   }),
 );

--- a/docs/data/material/components/drawers/PersistentDrawerRight.js
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.js
@@ -38,7 +38,7 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
       marginRight: 0,
     }),
     // This is necessary to enable the selection of content. In the DOM, the stacking order is determined by the order of appearance. Following this rule, elements appearing later in the markup will overlay those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures proper interaction with the underlying content.
-    postion: 'relative',
+    position: 'relative',
   }),
 );
 

--- a/docs/data/material/components/drawers/PersistentDrawerRight.js
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.js
@@ -37,6 +37,8 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(
       }),
       marginRight: 0,
     }),
+    // This is necessary to enable the selection of content. In the DOM, the stacking order is determined by the order of appearance. Following this rule, elements appearing later in the markup will overlay those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures proper interaction with the underlying content.
+    postion: 'relative',
   }),
 );
 

--- a/docs/data/material/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.tsx
@@ -39,7 +39,7 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
     marginRight: 0,
   }),
   // This is necessary to enable the selection of content. In the DOM, the stacking order is determined by the order of appearance. Following this rule, elements appearing later in the markup will overlay those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures proper interaction with the underlying content.
-  postion: 'relative',
+  position: 'relative',
 }));
 
 interface AppBarProps extends MuiAppBarProps {

--- a/docs/data/material/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.tsx
@@ -38,6 +38,8 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
     }),
     marginRight: 0,
   }),
+  // This is necessary to enable the selection of content. In the DOM, the stacking order is determined by the order of appearance. Following this rule, elements appearing later in the markup will overlay those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures proper interaction with the underlying content.
+  postion: 'relative',
 }));
 
 interface AppBarProps extends MuiAppBarProps {

--- a/docs/data/material/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/data/material/components/drawers/PersistentDrawerRight.tsx
@@ -38,7 +38,12 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
     }),
     marginRight: 0,
   }),
-  // This is necessary to enable the selection of content. In the DOM, the stacking order is determined by the order of appearance. Following this rule, elements appearing later in the markup will overlay those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures proper interaction with the underlying content.
+  /**
+   * This is necessary to enable the selection of content. In the DOM, the stacking order is determined
+   * by the order of appearance. Following this rule, elements appearing later in the markup will overlay
+   * those that appear earlier. Since the Drawer comes after the Main content, this adjustment ensures
+   * proper interaction with the underlying content.
+   */
   position: 'relative',
 }));
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #29997 

Closes #38760 (PR)

I couldn't push on PR #38760, so I created this one because the author of #38760 has been inactive for a week.

Before: https://mui.com/material-ui/react-drawer/#persistent-drawer
After: https://deploy-preview-39318--material-ui.netlify.app/material-ui/react-drawer/#persistent-drawer