### PR TITLE
[utils] use ownerWindow to calculate scrollbar size

### DIFF
--- a/packages/mui-utils/src/getScrollbarSize.ts
+++ b/packages/mui-utils/src/getScrollbarSize.ts
@@ -1,7 +1,9 @@
+import ownerWindow from './ownerWindow';
+
 // A change of the browser zoom change the scrollbar size.
 // Credit https://github.com/twbs/bootstrap/blob/488fd8afc535ca3a6ad4dc581f5e89217b6a36ac/js/src/util/scrollbar.js#L14-L18
 export default function getScrollbarSize(doc: Document): number {
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/innerWidth#usage_notes
   const documentWidth = doc.documentElement.clientWidth;
-  return Math.abs(window.innerWidth - documentWidth);
+  return Math.abs(ownerWindow(doc).innerWidth - documentWidth);
 }


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/39523

If the `doc` is inside an iframe, `getScrollbarSize` uses the wrong `window` object to get `innerWidth`.

The fixed implementation matches [`isOverflowing`](https://github.com/mui/material-ui/blob/v5.14.12/packages/mui-base/src/unstable_useModal/ModalManager.ts#L16).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
