### PR TITLE
[zero][tag] Fix styled transformation

### DIFF
--- a/packages/zero-tag-processor/src/generateCss.ts
+++ b/packages/zero-tag-processor/src/generateCss.ts
@@ -1,6 +1,6 @@
-import createEmotion from '@emotion/css/create-instance';
 import type { Theme } from '@mui/material/styles';
 import type { PluginCustomOptions } from './utils/cssFnValueToVariable';
+import { css, cache } from './utils/emotion';
 
 type CssGenerationOptions = {
   injectInRoot?: boolean;
@@ -58,9 +58,6 @@ export function generateCss(
   generationOptions: CssGenerationOptions = {},
 ) {
   const { injectInRoot = true, defaultThemeKey = 'theme' } = generationOptions;
-  const { css, cache } = createEmotion({
-    key: 'mui-theme',
-  });
   const { cssVariablesPrefix = 'mui', themeArgs } = options;
   if (!themeArgs) {
     return '';

--- a/packages/zero-tag-processor/src/styled.ts
+++ b/packages/zero-tag-processor/src/styled.ts
@@ -423,8 +423,11 @@ export default class StyledProcessor extends BaseProcessor {
     styleArg: ExpressionValue | null,
     variantsAccumulator?: VariantData[],
   ) {
-    const { themeArgs } = this.options as IOptions;
+    const { themeArgs = {} } = this.options as IOptions;
     const styleObj = typeof styleObjOrFn === 'function' ? styleObjOrFn(themeArgs) : styleObjOrFn;
+    if (!styleObj) {
+      return '';
+    }
     if (styleObj.variants) {
       variantsAccumulator?.push(...styleObj.variants);
       delete styleObj.variants;

--- a/packages/zero-tag-processor/src/sx.ts
+++ b/packages/zero-tag-processor/src/sx.ts
@@ -166,6 +166,6 @@ export default class SxProcessor extends BaseProcessor {
       this.collectedVariables.push(...res);
     }
 
-    return processCssObject(styleObj, themeArgs);
+    return processCssObject(styleObj, themeArgs, false);
   }
 }

--- a/packages/zero-tag-processor/src/utils/processCssObject.ts
+++ b/packages/zero-tag-processor/src/utils/processCssObject.ts
@@ -4,17 +4,20 @@ import styleFunctionSx from '@mui/system/styleFunctionSx';
 import { css, cache } from './emotion';
 import type { PluginCustomOptions } from './cssFnValueToVariable';
 
-export function processCssObject(cssObj: object, themeArgs?: PluginCustomOptions['themeArgs']) {
-  const { theme } = themeArgs ?? {};
+export function processCssObject(
+  cssObj: object,
+  themeArgs?: PluginCustomOptions['themeArgs'],
+  skipSx = true,
+) {
   const processedObj = (
-    theme
-      ? styleFunctionSx({
+    skipSx
+      ? cssObj
+      : styleFunctionSx({
           // Does not support shorthand as of now because
           // it also adds the spacing multiplier
           sx: () => cssObj,
           ...themeArgs,
         })
-      : cssObj
   ) as CSSObject;
   const className = css(processedObj);
   return cache.registered[className];


### PR DESCRIPTION
Now, it'll only transform styles in sx prop. Styled css will be converted directly without any transformation (like `pt` to `paddingTop`).
Also fixes the variable replacement for css property runtime functions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
