### PR TITLE
[core] Remove duplicate export

### DIFF
--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -5,6 +5,7 @@ import * as colors from './colors';
 export { colors };
 export * from './styles';
 
+// TODO remove, import directly from Base UI or create one folder per module
 export * from './utils';
 
 export { default as Accordion } from './Accordion';
@@ -408,8 +409,6 @@ export { default as useAutocomplete } from './useAutocomplete';
 
 export { default as GlobalStyles } from './GlobalStyles';
 export * from './GlobalStyles';
-
-export { StyledEngineProvider } from './styles';
 
 export { unstable_composeClasses } from '@mui/base/composeClasses';
 


### PR DESCRIPTION
I noticed this in https://github.com/vercel/next.js/issues/55663#issuecomment-1740148971. We already export `export * from './styles';`.