### PR TITLE
[docs] Exclude demos from next.js eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -276,6 +276,7 @@ module.exports = {
     // Next.js plugin
     {
       files: ['docs/**/*'],
+      excludedFiles: ['docs/data/**/*'],
       extends: ['plugin:@next/next/recommended'],
       settings: {
         next: {


### PR DESCRIPTION
The lint rules shouldn't apply to the demos

See https://github.com/mui/mui-x/pull/10619