### PR TITLE
[joy-ui][typography] Update docs after lineHeight changes

### DIFF
--- a/docs/data/joy/components/typography/TypographyTitleBody.js
+++ b/docs/data/joy/components/typography/TypographyTitleBody.js
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import Stack from '@mui/joy/Stack';
 import Typography from '@mui/joy/Typography';
 import Card from '@mui/joy/Card';
-import SvgIcon from '@mui/joy/SvgIcon';
+import Stack from '@mui/joy/Stack';
 
 export default function TypographyTitleBody() {
   return (
@@ -13,142 +12,101 @@ export default function TypographyTitleBody() {
       }}
     >
       <Card>
-        <Stack direction="row" spacing={1.5}>
-          <SvgIcon size="lg">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-              />
-            </svg>
-          </SvgIcon>
-          <div>
-            <Typography level="title-lg">
-              Title of the component{' '}
-              <Typography
-                level="title-lg"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>title-lg</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-md">
-              This is the description of the component that contain some information
-              of it.{' '}
-              <Typography
-                level="body-md"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-md</i>
-              </Typography>
-            </Typography>
-          </div>
-        </Stack>
+        <Typography level="title-lg">
+          Title of the component{' '}
+          <Typography
+            level="title-lg"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            title-lg
+          </Typography>
+        </Typography>
+        <Typography level="body-md">
+          This is the description of the component that contain some information of
+          it.{' '}
+          <Typography
+            level="body-md"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-md
+          </Typography>
+        </Typography>
       </Card>
       <Card>
-        <Stack direction="row" spacing={1.5}>
-          <SvgIcon>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-              />
-            </svg>
-          </SvgIcon>
-          <div>
-            <Typography level="title-md">
-              Title of the component{' '}
-              <Typography
-                level="title-md"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>title-md</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-md">
-              This is the description of the component that contain some information
-              of it.{' '}
-              <Typography
-                level="body-md"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-md</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-sm">
-              Metadata, e.g. a date.{' '}
-              <Typography
-                level="body-sm"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-sm</i>
-              </Typography>
-            </Typography>
-          </div>
-        </Stack>
+        <Typography level="title-md">
+          Title of the component{' '}
+          <Typography
+            level="title-md"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            title-md
+          </Typography>
+        </Typography>
+        <Typography level="body-md">
+          This is the description of the component that contain some information of
+          it.{' '}
+          <Typography
+            level="body-md"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-md
+          </Typography>
+        </Typography>
+        <Typography level="body-sm">
+          Metadata, e.g. a date.{' '}
+          <Typography
+            level="body-sm"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-sm
+          </Typography>
+        </Typography>
       </Card>
       <Card>
-        <Stack direction="row" spacing={1.5}>
-          <SvgIcon size="sm">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-              />
-            </svg>
-          </SvgIcon>
-          <div>
-            <Typography level="title-sm">
-              Title of the component{' '}
-              <Typography
-                level="title-sm"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>title-sm</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-sm">
-              This is the description of the component that contain some information
-              of it.{' '}
-              <Typography
-                level="body-sm"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-sm</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-xs">
-              Metadata, e.g. a date.{' '}
-              <Typography
-                level="body-xs"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-xs</i>
-              </Typography>
-            </Typography>
-          </div>
-        </Stack>
+        <Typography level="title-sm">
+          Title of the component{' '}
+          <Typography
+            level="title-sm"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            title-sm
+          </Typography>
+        </Typography>
+        <Typography level="body-sm">
+          This is the description of the component that contain some information of
+          it.{' '}
+          <Typography
+            level="body-sm"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-sm
+          </Typography>
+        </Typography>
+        <Typography level="body-xs">
+          Metadata, e.g. a date.{' '}
+          <Typography
+            level="body-xs"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-xs
+          </Typography>
+        </Typography>
       </Card>
     </Stack>
   );

--- a/docs/data/joy/components/typography/TypographyTitleBody.js
+++ b/docs/data/joy/components/typography/TypographyTitleBody.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Stack from '@mui/joy/Stack';
 import Typography from '@mui/joy/Typography';
+import Card from '@mui/joy/Card';
 import SvgIcon from '@mui/joy/SvgIcon';
 
 export default function TypographyTitleBody() {
@@ -9,152 +10,146 @@ export default function TypographyTitleBody() {
       spacing={2}
       sx={{
         maxWidth: '60ch',
-        '& *:not(path, i)': { outline: '1px solid rgb(255 53 53 / 40%)' },
       }}
     >
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="lg">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-lg">
-            <i>title-lg</i>: Title of the component
-          </Typography>
-          <Typography level="body-lg">
-            <i>body-lg</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="lg">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-lg">
-            <i>title-lg</i>: Title of the component
-          </Typography>
-          <Typography level="body-md">
-            <i>body-md</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="lg">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-lg">
-            <i>title-lg</i>: Title of the component
-          </Typography>
-          <Typography level="body-md">
-            <i>body-md</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-          <Typography level="body-sm">
-            <i>body-sm</i>: Metadata, e.g. a date.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-md">
-            <i>title-md</i>: Title of the component
-          </Typography>
-          <Typography level="body-md">
-            <i>body-md</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-          <Typography level="body-sm">
-            <i>body-sm</i>: Metadata, e.g. a date.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="sm">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-sm">
-            <i>title-sm</i>: Title of the component
-          </Typography>
-          <Typography level="body-sm">
-            <i>body-sm</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-          <Typography level="body-xs">
-            <i>body-xs</i>: Metadata, e.g. a date.
-          </Typography>
-        </div>
-      </Stack>
+      <Card>
+        <Stack direction="row" spacing={1.5}>
+          <SvgIcon size="lg">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+              />
+            </svg>
+          </SvgIcon>
+          <div>
+            <Typography level="title-lg">
+              Title of the component{' '}
+              <Typography
+                level="title-lg"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // title-lg
+              </Typography>
+            </Typography>
+            <Typography level="body-md">
+              This is the description of the component that contain some information
+              of it. Title of the component{' '}
+              <Typography
+                level="body-md"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-md
+              </Typography>
+            </Typography>
+          </div>
+        </Stack>
+      </Card>
+      <Card>
+        <Stack direction="row" spacing={1.5}>
+          <SvgIcon>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+              />
+            </svg>
+          </SvgIcon>
+          <div>
+            <Typography level="title-md">
+              Title of the component{' '}
+              <Typography
+                level="title-md"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // title-md
+              </Typography>
+            </Typography>
+            <Typography level="body-md">
+              This is the description of the component that contain some information
+              of it.{' '}
+              <Typography
+                level="body-md"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-md
+              </Typography>
+            </Typography>
+            <Typography level="body-sm">
+              Metadata, e.g. a date.{' '}
+              <Typography
+                level="body-sm"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-sm
+              </Typography>
+            </Typography>
+          </div>
+        </Stack>
+      </Card>
+      <Card>
+        <Stack direction="row" spacing={1.5}>
+          <SvgIcon size="sm">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+              />
+            </svg>
+          </SvgIcon>
+          <div>
+            <Typography level="title-sm">
+              Title of the component{' '}
+              <Typography
+                level="title-sm"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // title-sm
+              </Typography>
+            </Typography>
+            <Typography level="body-sm">
+              This is the description of the component that contain some information
+              of it.{' '}
+              <Typography
+                level="body-sm"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-sm
+              </Typography>
+            </Typography>
+            <Typography level="body-xs">
+              Metadata, e.g. a date.{' '}
+              <Typography
+                level="body-xs"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-xs
+              </Typography>
+            </Typography>
+          </div>
+        </Stack>
+      </Card>
     </Stack>
   );
 }

--- a/docs/data/joy/components/typography/TypographyTitleBody.js
+++ b/docs/data/joy/components/typography/TypographyTitleBody.js
@@ -36,7 +36,7 @@ export default function TypographyTitleBody() {
                 level="title-lg"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // title-lg
+                <i>title-lg</i>
               </Typography>
             </Typography>
             <Typography level="body-md">
@@ -46,7 +46,7 @@ export default function TypographyTitleBody() {
                 level="body-md"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-md
+                <i>body-md</i>
               </Typography>
             </Typography>
           </div>
@@ -76,7 +76,7 @@ export default function TypographyTitleBody() {
                 level="title-md"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // title-md
+                <i>title-md</i>
               </Typography>
             </Typography>
             <Typography level="body-md">
@@ -86,7 +86,7 @@ export default function TypographyTitleBody() {
                 level="body-md"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-md
+                <i>body-md</i>
               </Typography>
             </Typography>
             <Typography level="body-sm">
@@ -95,7 +95,7 @@ export default function TypographyTitleBody() {
                 level="body-sm"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-sm
+                <i>body-sm</i>
               </Typography>
             </Typography>
           </div>
@@ -125,7 +125,7 @@ export default function TypographyTitleBody() {
                 level="title-sm"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // title-sm
+                <i>title-sm</i>
               </Typography>
             </Typography>
             <Typography level="body-sm">
@@ -135,7 +135,7 @@ export default function TypographyTitleBody() {
                 level="body-sm"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-sm
+                <i>body-sm</i>
               </Typography>
             </Typography>
             <Typography level="body-xs">
@@ -144,7 +144,7 @@ export default function TypographyTitleBody() {
                 level="body-xs"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-xs
+                <i>body-xs</i>
               </Typography>
             </Typography>
           </div>

--- a/docs/data/joy/components/typography/TypographyTitleBody.js
+++ b/docs/data/joy/components/typography/TypographyTitleBody.js
@@ -41,7 +41,7 @@ export default function TypographyTitleBody() {
             </Typography>
             <Typography level="body-md">
               This is the description of the component that contain some information
-              of it. Title of the component{' '}
+              of it.{' '}
               <Typography
                 level="body-md"
                 textColor="var(--joy-palette-success-plainColor)"

--- a/docs/data/joy/components/typography/TypographyTitleBody.tsx
+++ b/docs/data/joy/components/typography/TypographyTitleBody.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import Stack from '@mui/joy/Stack';
 import Typography from '@mui/joy/Typography';
 import Card from '@mui/joy/Card';
-import SvgIcon from '@mui/joy/SvgIcon';
+import Stack from '@mui/joy/Stack';
 
 export default function TypographyTitleBody() {
   return (
@@ -13,142 +12,101 @@ export default function TypographyTitleBody() {
       }}
     >
       <Card>
-        <Stack direction="row" spacing={1.5}>
-          <SvgIcon size="lg">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-              />
-            </svg>
-          </SvgIcon>
-          <div>
-            <Typography level="title-lg">
-              Title of the component{' '}
-              <Typography
-                level="title-lg"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>title-lg</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-md">
-              This is the description of the component that contain some information
-              of it.{' '}
-              <Typography
-                level="body-md"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-md</i>
-              </Typography>
-            </Typography>
-          </div>
-        </Stack>
+        <Typography level="title-lg">
+          Title of the component{' '}
+          <Typography
+            level="title-lg"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            title-lg
+          </Typography>
+        </Typography>
+        <Typography level="body-md">
+          This is the description of the component that contain some information of
+          it.{' '}
+          <Typography
+            level="body-md"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-md
+          </Typography>
+        </Typography>
       </Card>
       <Card>
-        <Stack direction="row" spacing={1.5}>
-          <SvgIcon>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-              />
-            </svg>
-          </SvgIcon>
-          <div>
-            <Typography level="title-md">
-              Title of the component{' '}
-              <Typography
-                level="title-md"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>title-md</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-md">
-              This is the description of the component that contain some information
-              of it.{' '}
-              <Typography
-                level="body-md"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-md</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-sm">
-              Metadata, e.g. a date.{' '}
-              <Typography
-                level="body-sm"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-sm</i>
-              </Typography>
-            </Typography>
-          </div>
-        </Stack>
+        <Typography level="title-md">
+          Title of the component{' '}
+          <Typography
+            level="title-md"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            title-md
+          </Typography>
+        </Typography>
+        <Typography level="body-md">
+          This is the description of the component that contain some information of
+          it.{' '}
+          <Typography
+            level="body-md"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-md
+          </Typography>
+        </Typography>
+        <Typography level="body-sm">
+          Metadata, e.g. a date.{' '}
+          <Typography
+            level="body-sm"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-sm
+          </Typography>
+        </Typography>
       </Card>
       <Card>
-        <Stack direction="row" spacing={1.5}>
-          <SvgIcon size="sm">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-              />
-            </svg>
-          </SvgIcon>
-          <div>
-            <Typography level="title-sm">
-              Title of the component{' '}
-              <Typography
-                level="title-sm"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>title-sm</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-sm">
-              This is the description of the component that contain some information
-              of it.{' '}
-              <Typography
-                level="body-sm"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-sm</i>
-              </Typography>
-            </Typography>
-            <Typography level="body-xs">
-              Metadata, e.g. a date.{' '}
-              <Typography
-                level="body-xs"
-                textColor="var(--joy-palette-success-plainColor)"
-              >
-                <i>body-xs</i>
-              </Typography>
-            </Typography>
-          </div>
-        </Stack>
+        <Typography level="title-sm">
+          Title of the component{' '}
+          <Typography
+            level="title-sm"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            title-sm
+          </Typography>
+        </Typography>
+        <Typography level="body-sm">
+          This is the description of the component that contain some information of
+          it.{' '}
+          <Typography
+            level="body-sm"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-sm
+          </Typography>
+        </Typography>
+        <Typography level="body-xs">
+          Metadata, e.g. a date.{' '}
+          <Typography
+            level="body-xs"
+            textColor="var(--joy-palette-success-plainColor)"
+            fontFamily="monospace"
+            sx={{ opacity: '50%' }}
+          >
+            body-xs
+          </Typography>
+        </Typography>
       </Card>
     </Stack>
   );

--- a/docs/data/joy/components/typography/TypographyTitleBody.tsx
+++ b/docs/data/joy/components/typography/TypographyTitleBody.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Stack from '@mui/joy/Stack';
 import Typography from '@mui/joy/Typography';
+import Card from '@mui/joy/Card';
 import SvgIcon from '@mui/joy/SvgIcon';
 
 export default function TypographyTitleBody() {
@@ -9,152 +10,146 @@ export default function TypographyTitleBody() {
       spacing={2}
       sx={{
         maxWidth: '60ch',
-        '& *:not(path, i)': { outline: '1px solid rgb(255 53 53 / 40%)' },
       }}
     >
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="lg">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-lg">
-            <i>title-lg</i>: Title of the component
-          </Typography>
-          <Typography level="body-lg">
-            <i>body-lg</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="lg">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-lg">
-            <i>title-lg</i>: Title of the component
-          </Typography>
-          <Typography level="body-md">
-            <i>body-md</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="lg">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-lg">
-            <i>title-lg</i>: Title of the component
-          </Typography>
-          <Typography level="body-md">
-            <i>body-md</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-          <Typography level="body-sm">
-            <i>body-sm</i>: Metadata, e.g. a date.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-md">
-            <i>title-md</i>: Title of the component
-          </Typography>
-          <Typography level="body-md">
-            <i>body-md</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-          <Typography level="body-sm">
-            <i>body-sm</i>: Metadata, e.g. a date.
-          </Typography>
-        </div>
-      </Stack>
-
-      <Stack direction="row" spacing={1.5}>
-        <SvgIcon size="sm">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
-            />
-          </svg>
-        </SvgIcon>
-        <div>
-          <Typography level="title-sm">
-            <i>title-sm</i>: Title of the component
-          </Typography>
-          <Typography level="body-sm">
-            <i>body-sm</i>: This is the description of the component that contain
-            some information of it.
-          </Typography>
-          <Typography level="body-xs">
-            <i>body-xs</i>: Metadata, e.g. a date.
-          </Typography>
-        </div>
-      </Stack>
+      <Card>
+        <Stack direction="row" spacing={1.5}>
+          <SvgIcon size="lg">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+              />
+            </svg>
+          </SvgIcon>
+          <div>
+            <Typography level="title-lg">
+              Title of the component{' '}
+              <Typography
+                level="title-lg"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // title-lg
+              </Typography>
+            </Typography>
+            <Typography level="body-md">
+              This is the description of the component that contain some information
+              of it. Title of the component{' '}
+              <Typography
+                level="body-md"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-md
+              </Typography>
+            </Typography>
+          </div>
+        </Stack>
+      </Card>
+      <Card>
+        <Stack direction="row" spacing={1.5}>
+          <SvgIcon>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+              />
+            </svg>
+          </SvgIcon>
+          <div>
+            <Typography level="title-md">
+              Title of the component{' '}
+              <Typography
+                level="title-md"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // title-md
+              </Typography>
+            </Typography>
+            <Typography level="body-md">
+              This is the description of the component that contain some information
+              of it.{' '}
+              <Typography
+                level="body-md"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-md
+              </Typography>
+            </Typography>
+            <Typography level="body-sm">
+              Metadata, e.g. a date.{' '}
+              <Typography
+                level="body-sm"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-sm
+              </Typography>
+            </Typography>
+          </div>
+        </Stack>
+      </Card>
+      <Card>
+        <Stack direction="row" spacing={1.5}>
+          <SvgIcon size="sm">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+              />
+            </svg>
+          </SvgIcon>
+          <div>
+            <Typography level="title-sm">
+              Title of the component{' '}
+              <Typography
+                level="title-sm"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // title-sm
+              </Typography>
+            </Typography>
+            <Typography level="body-sm">
+              This is the description of the component that contain some information
+              of it.{' '}
+              <Typography
+                level="body-sm"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-sm
+              </Typography>
+            </Typography>
+            <Typography level="body-xs">
+              Metadata, e.g. a date.{' '}
+              <Typography
+                level="body-xs"
+                textColor="var(--joy-palette-success-plainColor)"
+              >
+                // body-xs
+              </Typography>
+            </Typography>
+          </div>
+        </Stack>
+      </Card>
     </Stack>
   );
 }

--- a/docs/data/joy/components/typography/TypographyTitleBody.tsx
+++ b/docs/data/joy/components/typography/TypographyTitleBody.tsx
@@ -36,7 +36,7 @@ export default function TypographyTitleBody() {
                 level="title-lg"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // title-lg
+                <i>title-lg</i>
               </Typography>
             </Typography>
             <Typography level="body-md">
@@ -46,7 +46,7 @@ export default function TypographyTitleBody() {
                 level="body-md"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-md
+                <i>body-md</i>
               </Typography>
             </Typography>
           </div>
@@ -76,7 +76,7 @@ export default function TypographyTitleBody() {
                 level="title-md"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // title-md
+                <i>title-md</i>
               </Typography>
             </Typography>
             <Typography level="body-md">
@@ -86,7 +86,7 @@ export default function TypographyTitleBody() {
                 level="body-md"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-md
+                <i>body-md</i>
               </Typography>
             </Typography>
             <Typography level="body-sm">
@@ -95,7 +95,7 @@ export default function TypographyTitleBody() {
                 level="body-sm"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-sm
+                <i>body-sm</i>
               </Typography>
             </Typography>
           </div>
@@ -125,7 +125,7 @@ export default function TypographyTitleBody() {
                 level="title-sm"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // title-sm
+                <i>title-sm</i>
               </Typography>
             </Typography>
             <Typography level="body-sm">
@@ -135,7 +135,7 @@ export default function TypographyTitleBody() {
                 level="body-sm"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-sm
+                <i>body-sm</i>
               </Typography>
             </Typography>
             <Typography level="body-xs">
@@ -144,7 +144,7 @@ export default function TypographyTitleBody() {
                 level="body-xs"
                 textColor="var(--joy-palette-success-plainColor)"
               >
-                // body-xs
+                <i>body-xs</i>
               </Typography>
             </Typography>
           </div>

--- a/docs/data/joy/components/typography/TypographyTitleBody.tsx
+++ b/docs/data/joy/components/typography/TypographyTitleBody.tsx
@@ -41,7 +41,7 @@ export default function TypographyTitleBody() {
             </Typography>
             <Typography level="body-md">
               This is the description of the component that contain some information
-              of it. Title of the component{' '}
+              of it.{' '}
               <Typography
                 level="body-md"
                 textColor="var(--joy-palette-success-plainColor)"

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -41,8 +41,6 @@ The `title-*` and `body-*` are commonly used in components.
 
 We recommend to combine the title and body with the same or lower size when using them together. For example, `title-lg` and `body-lg` or `title-md` and `body-sm`.
 
-Each level are designed to fit perfectly with the same size of the `SvgIcon` component.
-
 {{"demo": "TypographyTitleBody.js"}}
 
 ### Nested Typography

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -37,9 +37,11 @@ The `h5` and `h6` levels are not provided by default given that they are not com
 
 ### Title and body
 
-The `title-*` and `body-*` are commonly used in components.
+Aside from the heading typographic levels, the Typography component provides `title-*` and `body-*` type levels.
 
-We recommend to combine the title and body with the same or lower size when using them together. For example, `title-lg` and `body-lg` or `title-md` and `body-sm`.
+To ensure a good UI balance and information hierarchy, we recommend combining them using the same size or a lower one.
+
+For example, using `title-lg` with `body-lg` or `title-md` with `body-sm`.
 
 {{"demo": "TypographyTitleBody.js"}}
 

--- a/docs/data/joy/components/typography/typography.md
+++ b/docs/data/joy/components/typography/typography.md
@@ -37,11 +37,9 @@ The `h5` and `h6` levels are not provided by default given that they are not com
 
 ### Title and body
 
-Aside from the heading typographic levels, the Typography component provides `title-*` and `body-*` type levels.
+Aside from the heading typographic levels, the Typography component also provides the `title-*` and `body-*` type levels.
 
-To ensure a good UI balance and information hierarchy, we recommend combining them using the same size or a lower one.
-
-For example, using `title-lg` with `body-lg` or `title-md` with `body-sm`.
+To ensure proper information hierarchy, we recommend combining them using either the same size or a lower one. For example, using `title-lg` with `body-lg` or `title-md` with `body-sm`.
 
 {{"demo": "TypographyTitleBody.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Updated the 'Title and body' demo on the Typography docs page. After changes made on #38462, the lineHeight from Typography no longer fits with SVG icons, so I tweaked the demo to make sense with the current version.

👉 **https://deploy-preview-39366--material-ui.netlify.app/joy-ui/react-typography/#title-and-body**


| Before | After |
|--------|--------|
| <img width="400" alt="Screenshot 2023-10-09 at 16 27 56" src="https://github.com/mui/material-ui/assets/37222944/6827fd46-3b5a-488c-ad58-0238b6e8eea2"> | <img width="400" alt="Screenshot 2023-10-12 at 09 09 19" src="https://github.com/mui/material-ui/assets/37222944/fe739d1e-65cd-4398-b91f-1cba63c31c72"> | 
