### PR TITLE
[docs][joy-ui] Adjust the templates page card design

### DIFF
--- a/docs/data/joy/getting-started/templates/TemplateCollection.js
+++ b/docs/data/joy/getting-started/templates/TemplateCollection.js
@@ -8,7 +8,7 @@ import CardContent from '@mui/joy/CardContent';
 import CardOverflow from '@mui/joy/CardOverflow';
 import Link from '@mui/joy/Link';
 import List from '@mui/joy/List';
-import IconButton from '@mui/joy/IconButton';
+import Button from '@mui/joy/Button';
 import Typography from '@mui/joy/Typography';
 import SvgIcon from '@mui/joy/SvgIcon';
 import Visibility from '@mui/icons-material/Visibility';
@@ -79,16 +79,16 @@ const templates = [
     author: authors.MUI,
   },
   {
+    name: 'email',
+    author: authors.MUI,
+  },
+  {
     name: 'framesx-web-blocks',
     author: authors.MUI,
     design: {
       name: 'Frames X',
       link: 'https://framesxfigma.buninux.com/',
     },
-  },
-  {
-    name: 'email',
-    author: authors.MUI,
   },
 ];
 
@@ -100,7 +100,7 @@ export default function TemplateCollection() {
       sx={{
         px: { xs: 2, sm: 0 },
         flexGrow: 1,
-        gap: 4,
+        gap: 3,
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
       }}
@@ -114,18 +114,8 @@ export default function TemplateCollection() {
             key={template.name}
             sx={(theme) => ({
               bgcolor: 'initial',
-              boxShadow: 'none',
               overflow: 'auto',
-              transition: 'border-color 0.3s, transform 0.2s, box-shadow 0.4s',
-              '&:hover': {
-                '--joy-shadowChannel': 'var(--joy-palette-primary-lightChannel)',
-                boxShadow: theme.shadow.md,
-                borderColor: 'primary.500',
-                transform: 'translateY(-2px)',
-                [theme.getColorSchemeSelector('dark')]: {
-                  '--joy-shadowChannel': 'var(--joy-palette-primary-darkChannel)',
-                },
-              },
+              borderRadius: 12,
             })}
           >
             <CardOverflow>
@@ -141,7 +131,6 @@ export default function TemplateCollection() {
                 <Box
                   sx={(theme) => ({
                     background: `center/cover no-repeat url(/static/screenshots/joy-ui/getting-started/templates/${template.name}.jpg)`,
-                    transition: '0.3s',
                     [theme.getColorSchemeSelector('dark')]: {
                       background: `center/cover no-repeat url(/static/screenshots/joy-ui/getting-started/templates/${template.name}-dark.jpg)`,
                     },
@@ -160,44 +149,142 @@ export default function TemplateCollection() {
                     data-ga-event-category="joy-template"
                     data-ga-event-label={template.name}
                     data-ga-event-action="preview-img"
-                  />
+                    sx={[
+                      (theme) => ({
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexDirection: 'column',
+                        gap: 1,
+                        transition: '0.15s',
+                        position: 'absolute',
+                        width: '100%',
+                        height: '100%',
+                        opacity: 0,
+                        top: 0,
+                        left: 0,
+                        bgcolor: `rgba(${theme.vars.palette.primary.lightChannel} / 0.3)`,
+                        backdropFilter: 'blur(4px)',
+                        '&:hover, &:focus': {
+                          opacity: 1,
+                        },
+                        [theme.getColorSchemeSelector('dark')]: {
+                          bgcolor: `rgba(${theme.vars.palette.primary.darkChannel} / 0.3)`,
+                        },
+                      }),
+                    ]}
+                  >
+                    <Visibility />
+                    <Typography fontWeight="bold" fontFamily="IBM Plex Sans">
+                      View live preview
+                    </Typography>
+                  </Link>
                 </NextLink>
               </AspectRatio>
             </CardOverflow>
-            <CardContent>
-              <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}>
-                <Typography
-                  component="h3"
-                  fontSize="lg"
-                  fontWeight="xl"
-                  slotProps={{ endDecorator: { sx: { ml: 'auto' } } }}
-                  sx={{ mr: 'auto' }}
-                >
-                  {startCase(template.name)}
-                </Typography>
+            <CardContent
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <Typography
+                component="h3"
+                fontFamily="IBM Plex Sans"
+                fontSize="lg"
+                fontWeight="xl"
+              >
+                {startCase(template.name)}
+              </Typography>
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  mb: 2,
+                }}
+              >
+                {template.author && (
+                  <Typography
+                    level="body-sm"
+                    fontWeight="md"
+                    fontFamily="IBM Plex Sans"
+                  >
+                    Built by{' '}
+                    <Link
+                      href={template.author.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <b>{template.author.name}</b>
+                    </Link>
+                  </Typography>
+                )}
+                {template.design && (
+                  <React.Fragment>
+                    <Typography
+                      level="caption"
+                      fontWeight="md"
+                      textColor="text.tertiary"
+                      sx={{ mx: 0.5 }}
+                    >
+                      •
+                    </Typography>
+                    <Typography
+                      level="body-sm"
+                      fontWeight="md"
+                      fontFamily="IBM Plex Sans"
+                    >
+                      Designed by{' '}
+                      <Link
+                        href={template.design.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <b>{template.design.name}</b>
+                      </Link>
+                    </Typography>
+                  </React.Fragment>
+                )}
+              </Box>
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  gap: 1.5,
+                }}
+              >
                 <NextLink
                   href={`/joy-ui/getting-started/templates/${template.name}/`}
                   passHref
                   legacyBehavior
                 >
-                  <IconButton
+                  <Button
                     component="a"
                     variant="outlined"
                     color="neutral"
-                    size="sm"
+                    fullWidth
+                    startDecorator={<Visibility />}
                     aria-label="See live preview"
                     data-ga-event-category="joy-template"
                     data-ga-event-label={template.name}
                     data-ga-event-action="preview"
+                    sx={{ fontFamily: 'IBM Plex Sans' }}
                   >
-                    <Visibility />
-                  </IconButton>
+                    Preview
+                  </Button>
                 </NextLink>
-                <IconButton
+                <Button
                   variant="outlined"
                   color="neutral"
-                  size="sm"
-                  aria-label="Code sandbox playground"
+                  startDecorator={
+                    <SvgIcon viewBox="0 0 1080 1080">
+                      <path d="M755 140.3l0.5-0.3h0.3L512 0 268.3 140h-0.3l0.8 0.4L68.6 256v512L512 1024l443.4-256V256L755 140.3z m-30 506.4v171.2L548 920.1V534.7L883.4 341v215.7l-158.4 90z m-584.4-90.6V340.8L476 534.4v385.7L300 818.5V646.7l-159.4-90.6zM511.7 280l171.1-98.3 166.3 96-336.9 194.5-337-194.6 165.7-95.7L511.7 280z" />
+                    </SvgIcon>
+                  }
+                  fullWidth
+                  aria-label="CodeSandbox playground"
                   data-ga-event-category="joy-template"
                   data-ga-event-label={template.name}
                   data-ga-event-action="codesandbox"
@@ -215,48 +302,8 @@ export default function TemplateCollection() {
                       .openSandbox()
                   }
                 >
-                  <SvgIcon viewBox="0 0 1080 1080">
-                    <path d="M755 140.3l0.5-0.3h0.3L512 0 268.3 140h-0.3l0.8 0.4L68.6 256v512L512 1024l443.4-256V256L755 140.3z m-30 506.4v171.2L548 920.1V534.7L883.4 341v215.7l-158.4 90z m-584.4-90.6V340.8L476 534.4v385.7L300 818.5V646.7l-159.4-90.6zM511.7 280l171.1-98.3 166.3 96-336.9 194.5-337-194.6 165.7-95.7L511.7 280z" />
-                  </SvgIcon>
-                </IconButton>
-              </Box>
-              <Box
-                sx={{
-                  width: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  flexWrap: 'wrap',
-                }}
-              >
-                {template.author && (
-                  <Typography level="body-sm" fontWeight="md">
-                    Built by{' '}
-                    <Link
-                      href={template.author.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <b>{template.author.name}</b>
-                    </Link>
-                  </Typography>
-                )}
-                {template.design && (
-                  <React.Fragment>
-                    <Typography level="caption" fontWeight="md" sx={{ mx: 0.5 }}>
-                      •
-                    </Typography>
-                    <Typography level="body-sm" fontWeight="md">
-                      Designed by{' '}
-                      <Link
-                        href={template.design.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <b>{template.design.name}</b>
-                      </Link>
-                    </Typography>
-                  </React.Fragment>
-                )}
+                  CodeSandbox
+                </Button>
               </Box>
             </CardContent>
           </Card>

--- a/docs/data/joy/getting-started/templates/TemplateCollection.js
+++ b/docs/data/joy/getting-started/templates/TemplateCollection.js
@@ -172,7 +172,11 @@ export default function TemplateCollection() {
                     ]}
                   >
                     <Visibility />
-                    <Typography fontWeight="bold" fontFamily="IBM Plex Sans">
+                    <Typography
+                      fontWeight="bold"
+                      fontFamily="IBM Plex Sans"
+                      textColor="text.primary"
+                    >
                       View live preview
                     </Typography>
                   </Link>

--- a/docs/data/joy/getting-started/templates/TemplateCollection.js
+++ b/docs/data/joy/getting-started/templates/TemplateCollection.js
@@ -112,11 +112,7 @@ export default function TemplateCollection() {
             component="li"
             variant="outlined"
             key={template.name}
-            sx={(theme) => ({
-              bgcolor: 'initial',
-              overflow: 'auto',
-              borderRadius: 12,
-            })}
+            sx={{ bgcolor: 'initial', overflow: 'auto', borderRadius: 12 }}
           >
             <CardOverflow>
               <AspectRatio

--- a/docs/data/joy/getting-started/templates/TemplateCollection.js
+++ b/docs/data/joy/getting-started/templates/TemplateCollection.js
@@ -12,6 +12,7 @@ import Button from '@mui/joy/Button';
 import Typography from '@mui/joy/Typography';
 import SvgIcon from '@mui/joy/SvgIcon';
 import Visibility from '@mui/icons-material/Visibility';
+import CodeRoundedIcon from '@mui/icons-material/CodeRounded';
 import codeSandbox from 'docs/src/modules/sandbox/CodeSandbox';
 import sourceJoyTemplates from 'docs/src/modules/joy/sourceJoyTemplates';
 
@@ -252,7 +253,7 @@ export default function TemplateCollection() {
                 }}
               >
                 <NextLink
-                  href={`/joy-ui/getting-started/templates/${template.name}/`}
+                  href={`https://github.com/mui/material-ui/tree/master/docs/data/joy/getting-started/templates/${template.name}`}
                   passHref
                   legacyBehavior
                 >
@@ -261,14 +262,14 @@ export default function TemplateCollection() {
                     variant="outlined"
                     color="neutral"
                     fullWidth
-                    startDecorator={<Visibility />}
+                    startDecorator={<CodeRoundedIcon />}
                     aria-label="See live preview"
                     data-ga-event-category="joy-template"
                     data-ga-event-label={template.name}
                     data-ga-event-action="preview"
                     sx={{ fontFamily: 'IBM Plex Sans' }}
                   >
-                    Preview
+                    Source code
                   </Button>
                 </NextLink>
                 <Button

--- a/docs/data/joy/getting-started/templates/index.md
+++ b/docs/data/joy/getting-started/templates/index.md
@@ -2,6 +2,6 @@
 
 <p class="description">A selection of free application templates to help you get started building your app with Joy UI.</p>
 
-If while using these examples you make changes or enhancements that could improve the developer experience, or if you would like to contribute with an additional example, please consider creating a [pull request on GitHub](https://github.com/mui/material-ui/pulls).
+If while using these examples you make changes or enhancements that could improve the developer experience, or if you would like to contribute with an additional example, please consider creating a [pull request on GitHub](https://github.com/mui/material-ui/blob/master/CONTRIBUTING.md).
 
 {{"demo": "TemplateCollection.js", "hideToolbar": true, "bg": "inline"}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds some layer of polish to the Templates card design, primarily focusing on adding labels to the buttons to clarify what both of them — the live preview & CodeSanbox — mean, following recent docs-feedback. Additionally, also changed the "open a pull request" link direction to the Contributing guide, as that seems more fitting for folks looking to open one up.

👉 **https://deploy-preview-39369--material-ui.netlify.app/joy-ui/getting-started/templates/**