### PR TITLE
[base-ui][Slider] Fix the `track="inverted"` style issues

### DIFF
--- a/packages/mui-base/src/Slider/Slider.test.tsx
+++ b/packages/mui-base/src/Slider/Slider.test.tsx
@@ -40,6 +40,13 @@ describe('<Slider />', () => {
   const mount = createMount();
   const { render } = createRenderer();
 
+  it('should apply the correct classes when track="inverted"', () => {
+    render(<Slider track="inverted" value={50} />);
+
+    const slider = screen.getByRole('slider');
+    expect(slider).to.have.class('trackInverted');
+  });
+
   describeConformanceUnstyled(<Slider value={0} />, () => ({
     classes,
     inheritComponent: 'span',

--- a/packages/mui-base/src/Slider/Slider.tsx
+++ b/packages/mui-base/src/Slider/Slider.tsx
@@ -155,6 +155,13 @@ const Slider = React.forwardRef(function Slider<RootComponentType extends React.
     ownerState,
     className: classes.rail,
   });
+  let adjustedTrackOffset = trackOffset;
+  let adjustedTrackLeap = trackLeap;
+
+  if (track === 'inverted') {
+    adjustedTrackLeap = 100 - trackOffset - trackLeap;
+    adjustedTrackOffset = 100 - adjustedTrackLeap;
+  }
 
   const Track = slots.track ?? 'span';
   const trackProps = useSlotProps({
@@ -162,8 +169,8 @@ const Slider = React.forwardRef(function Slider<RootComponentType extends React.
     externalSlotProps: slotProps.track,
     additionalProps: {
       style: {
-        ...axisProps[axis].offset(trackOffset),
-        ...axisProps[axis].leap(trackLeap),
+        ...axisProps[axis].offset(adjustedTrackOffset),
+        ...axisProps[axis].leap(adjustedTrackLeap),
       },
     },
     ownerState,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes  #38925

A new PR with all the requirements for the issue [Slider][base-ui] track="inverted" does not work. 
