### PR TITLE
[docs-infra] Fix no-op autoprefixer warning

### DIFF
--- a/docs/postcss.config.js
+++ b/docs/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
   },
 };


### PR DESCRIPTION
Fix https://github.com/mui/material-ui/pull/37319#issuecomment-1599633128

<img width="718" alt="Screenshot 2023-06-20 at 23 58 35" src="https://github.com/mui/material-ui/assets/3165635/f609ce9a-329c-43ce-9fe5-1d0cee3bbf96">

See the code for why it triggers https://github.com/postcss/autoprefixer/blob/026083ccde85fd16607d1056d3fa058480004184/lib/autoprefixer.js#L33

I'm surprised nobody fixed it already, it would have driven me insane to work with this for 3 months 😁