### PR TITLE
[docs-infra] Adjust the `kbd` tag styles

### DIFF
--- a/docs/data/base/components/number-input/number-input.md
+++ b/docs/data/base/components/number-input/number-input.md
@@ -160,10 +160,10 @@ The value will be clamped based on `min`, `max` and `step` once the input field 
 
 ### Shift multiplier
 
-Holding down the <kbd>Shift</kbd> key when interacting with the stepper buttons applies a multipler (default 10x) to the value change of each step.
+Holding down the <kbd class="key">Shift</kbd> key when interacting with the stepper buttons applies a multipler (default 10x) to the value change of each step.
 
 You can customize this behavior with the `shiftMultiplier` prop.
-In the following snippet, if <kbd>Shift</kbd> is held when clicking the increment button, the value will change from 0, to 5, to 10, and on.
+In the following snippet, if <kbd class="key">Shift</kbd> is held when clicking the increment button, the value will change from 0, to 5, to 10, and on.
 
 ```jsx
 <NumberInput min={0} step={1} shiftMultiplier={5} />

--- a/docs/data/joy/components/drawer/drawer.md
+++ b/docs/data/joy/components/drawer/drawer.md
@@ -21,7 +21,7 @@ Drawers are commonly used as menus for desktop navigation, and as dialogs on mob
 import Drawer from '@mui/joy/Drawer';
 ```
 
-The Drawer will close after the user makes a selection, clicks anywhere outside of it, or presses the <kbd>Esc</kbd> key.
+The Drawer will close after the user makes a selection, clicks anywhere outside of it, or presses the <kbd class="key">Esc</kbd> key.
 
 Use the `open` prop to control the toggling of the Drawer's open and close states, as shown in the demo below:
 

--- a/docs/pages/blog/v6-beta-pickers.md
+++ b/docs/pages/blog/v6-beta-pickers.md
@@ -73,7 +73,7 @@ Moreover, notice in the following example that as we edit the day, the component
 :::info
 **Behavior change alert**
 
-During pre-releases, using <kbd>Arrow Up</kbd> and <kbd>Arrow Down</kbd> to update a date section would essentially update the entire field like you were navigating the calendar.
+During pre-releases, using <kbd class="key">Arrow Up</kbd> and <kbd class="key">Arrow Down</kbd> to update a date section would essentially update the entire field like you were navigating the calendar.
 In the previous example, updating the day value from 28 to 1 would also update the month to March.
 
 On the stable version, released after the original post, each date section is independent.

--- a/docs/pages/experiments/docs/markdown.md
+++ b/docs/pages/experiments/docs/markdown.md
@@ -34,3 +34,9 @@ https://spec.commonmark.org/0.30/#loose
 https://spec.commonmark.org/0.30/#links
 
 - Link [with a title](#link 'Stay on the same page').
+
+## kbd tag
+
+**In isolation:** <kbd class="key">caps lock</kbd>
+
+**In context:** The following demo shows how the `focusableWhenDisabled` prop works—use the <kbd>Tab</kbd> key to navigate within this document to see that only the second Button accepts the focus:

--- a/docs/pages/experiments/docs/markdown.md
+++ b/docs/pages/experiments/docs/markdown.md
@@ -37,5 +37,6 @@ https://spec.commonmark.org/0.30/#links
 
 ## kbd tag
 
-Make sure to include the `class="key"` in each individual `kbd` element.
-That's because when referring to two keys that should be pressed together－for example, <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd>－all the individual `kbd` elements should be wrapped by a parent `kbd`, and we don't add styles to just the tag.
+Make sure to include the `class="key"` declaration in each individual `kbd` element.
+
+That's because when referring to two keys that should be pressed together－for example, <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd>－the `kbd` elements are wrapped by a parent `kbd`, and we don't add styles to just the tag.

--- a/docs/pages/experiments/docs/markdown.md
+++ b/docs/pages/experiments/docs/markdown.md
@@ -37,6 +37,5 @@ https://spec.commonmark.org/0.30/#links
 
 ## kbd tag
 
-**In isolation:** <kbd class="key">caps lock</kbd>
-
-**In context:** The following demo shows how the `focusableWhenDisabled` prop works—use the <kbd>Tab</kbd> key to navigate within this document to see that only the second Button accepts the focus:
+Make sure to include the `class="key"` in each individual `kbd` element.
+That's because when referring to two keys that should be pressed together－for example, <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd>－all the individual `kbd` elements should be wrapped by a parent `kbd`, and we don't add styles to just the tag.

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -416,19 +416,20 @@ const Root = styled('div')(
       flexShrink: 0,
       backgroundColor: `var(--muidocs-palette-divider, ${lightTheme.palette.divider})`,
     },
-    '& kbd.key': {
-      padding: '5px',
+    '& kbd': {
+      padding: 6,
       display: 'inline-block',
       whiteSpace: 'nowrap',
       margin: '0 1px',
-      font: '11px Consolas,Liberation Mono,Menlo,monospace',
-      lineHeight: '10px',
+      fontFamily: lightTheme.typography.fontFamilyCode,
+      fontSize: lightTheme.typography.pxToRem(11),
       color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
+      lineHeight: '10px',
       verticalAlign: 'middle',
-      backgroundColor: `var(--muidocs-palette-grey-50, ${lightTheme.palette.grey[50]})`,
+      borderRadius: 6,
       border: `1px solid var(--muidocs-palette-grey-300, ${lightTheme.palette.grey[300]})`,
-      borderRadius: 5,
-      boxShadow: `inset 0 -1px 0 var(--muidocs-palette-grey-300, ${lightTheme.palette.grey[300]})`,
+      backgroundColor: `var(--muidocs-palette-grey-50, ${lightTheme.palette.grey[50]})`,
+      boxShadow: `inset 0 -2px 0 var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
     },
     '& details': {
       marginBottom: theme.spacing(1.5),
@@ -680,11 +681,11 @@ const Root = styled('div')(
       '& a code': {
         color: `var(--muidocs-palette-primary-light, ${darkTheme.palette.primary.light})`,
       },
-      '& kbd.key': {
+      '& kbd': {
         color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
-        backgroundColor: `var(--muidocs-palette-primaryDark-900, ${darkTheme.palette.primaryDark[900]})`,
-        border: `1px solid var(--muidocs-palette-primaryDark-500, ${darkTheme.palette.primaryDark[500]})`,
-        boxShadow: `inset 0 -1px 0 var(--muidocs-palette-primaryDark-700, ${darkTheme.palette.primaryDark[700]})`,
+        backgroundColor: `var(--muidocs-palette-primaryDark-800, ${darkTheme.palette.primaryDark[800]})`,
+        border: `1px solid var(--muidocs-palette-primaryDark-600, ${darkTheme.palette.primaryDark[600]})`,
+        boxShadow: `inset 0 -2px 0 var(--muidocs-palette-primaryDark-700, ${darkTheme.palette.primaryDark[700]})`,
       },
     },
   }),

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -416,7 +416,7 @@ const Root = styled('div')(
       flexShrink: 0,
       backgroundColor: `var(--muidocs-palette-divider, ${lightTheme.palette.divider})`,
     },
-    '& kbd': {
+    '& kbd.key': {
       padding: 6,
       display: 'inline-block',
       whiteSpace: 'nowrap',
@@ -681,7 +681,7 @@ const Root = styled('div')(
       '& a code': {
         color: `var(--muidocs-palette-primary-light, ${darkTheme.palette.primary.light})`,
       },
-      '& kbd': {
+      '& kbd.key': {
         color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
         backgroundColor: `var(--muidocs-palette-primaryDark-800, ${darkTheme.palette.primaryDark[800]})`,
         border: `1px solid var(--muidocs-palette-primaryDark-600, ${darkTheme.palette.primaryDark[600]})`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds some styling tweaks to the `<kbd>` tag and adds instructions about using the specific `key` class for them. Initially, this PR changed the Markdown Element file targeting to get the whole tag, but I learned through Alex (down below) that the class existed for when we want to wrap individual tags with a parent `kbd` to indicate that they should be pressed together. 

👉 **https://deploy-preview-39397--material-ui.netlify.app/experiments/docs/markdown/#kbd-tag**