### PR TITLE
[lab] Update peer dep of @mui/material

### DIFF
--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
-    "@mui/material": "^5.0.0",
+    "@mui/material": ">=5.10.11",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #39379

lab now uses `@mui/material/generateUtilityClass` which is only available in material after `5.10.10`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
