### PR TITLE
[joy-ui][Skeleton] Fix semi-transparent scenario when with surface components and color inversion

### DIFF
--- a/packages/mui-joy/src/Skeleton/Skeleton.tsx
+++ b/packages/mui-joy/src/Skeleton/Skeleton.tsx
@@ -131,6 +131,7 @@ const SkeletonRoot = styled('span', {
         '--unstable_pulse-bg': theme.vars.palette.background.level1,
         overflow: 'hidden',
         cursor: 'default',
+        color: 'transparent',
         '& *': {
           visibility: 'hidden',
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #39348 

| Before | After |
|--------|--------|
| ![image](https://github.com/mui/material-ui/assets/104088023/f3c85174-dc24-4030-bf82-0b20963c179b) The Skeleton appears slightly transparent, revealing the text underneath. | ![image](https://github.com/mui/material-ui/assets/104088023/9ca57c30-af5f-4920-8d36-ced013826bdd) Now, the Skeleton is opaque and hides the text underneath. | 
