### PR TITLE
[docs][joy-ui] Fix color inversion demos

### DIFF
--- a/docs/data/joy/main-features/color-inversion/ColorInversionAnyParentStyled.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionAnyParentStyled.js
@@ -6,17 +6,19 @@ import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Typography from '@mui/joy/Typography';
 
-const StyledBox = styled(Box)(({ theme }) => ({
-  padding: 32,
-  display: 'grid',
-  gridTemplateColumns: '1fr 1fr',
-  alignItems: 'center',
-  rowGap: 16,
-  columnGap: 64,
-  borderRadius: 8,
-  background: `linear-gradient(45deg, ${theme.vars.palette.neutral[800]}, ${theme.vars.palette.neutral[600]})`,
-  ...applySolidInversion('neutral'),
-}));
+const StyledBox = styled(Box)(
+  ({ theme }) => ({
+    padding: 32,
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    alignItems: 'center',
+    rowGap: 16,
+    columnGap: 64,
+    borderRadius: 8,
+    background: `linear-gradient(45deg, ${theme.vars.palette.neutral[800]}, ${theme.vars.palette.neutral[600]})`,
+  }),
+  applySolidInversion('neutral'),
+);
 
 function Stat({ description, value }) {
   return (

--- a/docs/data/joy/main-features/color-inversion/ColorInversionAnyParentStyled.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionAnyParentStyled.tsx
@@ -5,17 +5,19 @@ import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
 import Typography from '@mui/joy/Typography';
 
-const StyledBox = styled(Box)(({ theme }) => ({
-  padding: 32,
-  display: 'grid',
-  gridTemplateColumns: '1fr 1fr',
-  alignItems: 'center',
-  rowGap: 16,
-  columnGap: 64,
-  borderRadius: 8,
-  background: `linear-gradient(45deg, ${theme.vars.palette.neutral[800]}, ${theme.vars.palette.neutral[600]})`,
-  ...applySolidInversion('neutral'),
-}));
+const StyledBox = styled(Box)(
+  ({ theme }) => ({
+    padding: 32,
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    alignItems: 'center',
+    rowGap: 16,
+    columnGap: 64,
+    borderRadius: 8,
+    background: `linear-gradient(45deg, ${theme.vars.palette.neutral[800]}, ${theme.vars.palette.neutral[600]})`,
+  }),
+  applySolidInversion('neutral'),
+);
 
 function Stat({
   description,

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
@@ -48,7 +48,6 @@ export default function ColorInversionHeader() {
           const nextColor = colors.indexOf(color);
           setColor(colors[nextColor + 1] ?? colors[0]);
         }}
-        sx={{ borderRadius: '50%' }}
       >
         <ColorLensRoundedIcon fontSize="small" />
       </IconButton>
@@ -104,7 +103,7 @@ export default function ColorInversionHeader() {
       <Box sx={{ display: 'flex', flexShrink: 0, gap: 2 }}>
         <Button
           startDecorator={<AddIcon />}
-          sx={{ borderRadius: '50%', display: { xs: 'none', md: 'inline-flex' } }}
+          sx={{ display: { xs: 'none', md: 'inline-flex' } }}
         >
           New invoice
         </Button>
@@ -123,7 +122,6 @@ export default function ColorInversionHeader() {
             </Typography>
           }
           sx={{
-            '--Input-radius': '50%',
             '--Input-paddingInline': '12px',
             width: 160,
             display: { xs: 'none', lg: 'flex' },

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -53,7 +53,6 @@ export default function ColorInversionHeader() {
           const nextColor = colors.indexOf(color);
           setColor(colors[nextColor + 1] ?? colors[0]);
         }}
-        sx={{ borderRadius: '50%' }}
       >
         <ColorLensRoundedIcon fontSize="small" />
       </IconButton>
@@ -109,7 +108,7 @@ export default function ColorInversionHeader() {
       <Box sx={{ display: 'flex', flexShrink: 0, gap: 2 }}>
         <Button
           startDecorator={<AddIcon />}
-          sx={{ borderRadius: '50%', display: { xs: 'none', md: 'inline-flex' } }}
+          sx={{ display: { xs: 'none', md: 'inline-flex' } }}
         >
           New invoice
         </Button>
@@ -128,7 +127,6 @@ export default function ColorInversionHeader() {
             </Typography>
           }
           sx={{
-            '--Input-radius': '50%',
             '--Input-paddingInline': '12px',
             width: 160,
             display: { xs: 'none', lg: 'flex' },

--- a/docs/data/joy/main-features/color-inversion/color-inversion.md
+++ b/docs/data/joy/main-features/color-inversion/color-inversion.md
@@ -87,9 +87,17 @@ The examples below show how to use these utilities with both the `sx` prop and t
 
 #### With the sx prop
 
+```jsx
+<Box sx={[{ ...baseStyles }, applySolidInversion('neutral')]}>...</Box>
+```
+
 {{"demo": "ColorInversionAnyParent.js"}}
 
 #### With the styled API
+
+```jsx
+const Parent = styled('div')([{ ...baseStyles }, applySolidInversion('neutral')]);
+```
 
 {{"demo": "ColorInversionAnyParentStyled.js"}}
 

--- a/packages/mui-joy/src/colorInversion/colorInversionUtils.spec.tsx
+++ b/packages/mui-joy/src/colorInversion/colorInversionUtils.spec.tsx
@@ -21,6 +21,20 @@ import Box from '@mui/joy/Box';
 /**
  * styled API type check
  */
+const StyledBox = styled(Box)(
+  ({ theme }) => ({
+    padding: 32,
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    alignItems: 'center',
+    rowGap: 16,
+    columnGap: 64,
+    borderRadius: 8,
+    background: `linear-gradient(45deg, ${theme.vars.palette.neutral[800]}, ${theme.vars.palette.neutral[600]})`,
+  }),
+  applySolidInversion('neutral'),
+);
+
 styled('div')(({ theme }) => ({}), applySoftInversion('primary'), applySolidInversion('primary'));
 
 styled('div')(

--- a/packages/mui-joy/src/colorInversion/colorInversionUtils.ts
+++ b/packages/mui-joy/src/colorInversion/colorInversionUtils.ts
@@ -127,14 +127,24 @@ export const skipInvertedColors = (theme: ThemeFragment) => {
   };
 };
 
+// @internal
+// to support the same usage between `sx` prop and `styled` function, need to resolve the `theme`.
+//  sx: (theme) => ...
+//  styled: ({ theme }) => ...
+function isStyledThemeProp(
+  props: ThemeFragment | { theme?: ThemeFragment },
+): props is { theme: ThemeFragment } {
+  return (props as { theme?: ThemeFragment }).theme !== undefined;
+}
+
 /**
  *
  * @param color a supported theme color palette
  * @returns (theme: ThemeFragment) => Record<DefaultColorPalette, CSSObject>
  */
 export const applySolidInversion =
-  (color: ColorPaletteProp) => (themeProp: ThemeFragment & { theme?: ThemeFragment }) => {
-    const { theme = themeProp } = themeProp;
+  (color: ColorPaletteProp) => (themeProp: ThemeFragment | { theme?: ThemeFragment }) => {
+    const theme = isStyledThemeProp(themeProp) ? themeProp.theme : (themeProp as ThemeFragment);
     const getCssVarDefault = createGetCssVar(theme.cssVarPrefix);
     const prefixVar = createPrefixVar(theme.cssVarPrefix);
     const getCssVar = (cssVar: string) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR fixes some regressions caused by my previous PR on the same page/demos — https://github.com/mui/material-ui/pull/39306 🫠

| Before | After |
|--------|--------|
| <img width="848" alt="Screen Shot 2023-10-11 at 17 00 41" src="https://github.com/mui/material-ui/assets/67129314/43f9ac07-cf66-4ac5-95e7-6519da948e33"> | <img width="848" alt="Screen Shot 2023-10-11 at 17 00 50" src="https://github.com/mui/material-ui/assets/67129314/7b474c22-f97c-4f64-b40e-7b4feff05045"> | 

👉 **https://deploy-preview-39403--material-ui.netlify.app/joy-ui/main-features/color-inversion/**