### PR TITLE
[material-ui][Box] Fix system properties has incorrect `Theme` interface when applied directly

### DIFF
--- a/packages/mui-material/src/Box/Box.spec.tsx
+++ b/packages/mui-material/src/Box/Box.spec.tsx
@@ -32,3 +32,10 @@ expectType<typeof Box, typeof CustomBox>(CustomBox);
 
 // @ts-expect-error System's Box has different type than Material UI's Box
 expectType<typeof SystemBox, typeof CustomBox>(CustomBox);
+
+function ColorTest() {
+  <Box
+    color={(theme) => theme.vars.palette.common.black}
+    sx={(theme) => ({ backgroundColor: theme.vars.palette.background.default })}
+  />;
+}

--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -182,7 +182,7 @@ export type SystemProps<Theme extends object = {}> = {
     | ((theme: Theme) => ResponsiveStyleValue<AllSystemCSSProperties[K]>);
 };
 
-export interface BoxOwnProps<Theme extends object = SystemTheme> extends SystemProps<SystemTheme> {
+export interface BoxOwnProps<Theme extends object = SystemTheme> extends SystemProps<Theme> {
   children?: React.ReactNode;
   /**
    * The component used for the root node.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/39402