### PR TITLE
[docs] fixed layouts/HeroContainer to fit renderRightWrapper componenent inside screen

### DIFF
--- a/docs/src/layouts/HeroContainer.tsx
+++ b/docs/src/layouts/HeroContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Box, { BoxProps } from '@mui/material/Box';
 import Container from '@mui/material/Container';
-import {Grid,useMediaQuery} from '@mui/material';
+import { Grid, useMediaQuery } from '@mui/material';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
 import { alpha, useTheme } from '@mui/material/styles';
 
@@ -24,7 +24,7 @@ export default function HeroContainer(props: HeroContainerProps) {
     rightSx,
   } = props;
   const frame = React.useRef<HTMLDivElement>(null);
-  const globalTheme = useTheme()
+  const globalTheme = useTheme();
   const isMdUp = useMediaQuery(globalTheme.breakpoints.up('md'));
 
   useEnhancedEffect(() => {
@@ -147,7 +147,7 @@ export default function HeroContainer(props: HeroContainerProps) {
         }}
       >
         <Grid container alignItems="center" wrap="nowrap" sx={{ height: '100%', mx: 'auto' }}>
-          <Grid item sx={{ m: isMdUp? '':'auto' }}>
+          <Grid item sx={{ m: isMdUp ? '' : 'auto' }}>
             {left}
           </Grid>
           <Grid

--- a/docs/src/layouts/HeroContainer.tsx
+++ b/docs/src/layouts/HeroContainer.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import Box, { BoxProps } from '@mui/material/Box';
 import Container from '@mui/material/Container';
-import Grid from '@mui/material/Grid';
+import {Grid,useMediaQuery} from '@mui/material';
 import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/utils';
-import { alpha } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 
 interface HeroContainerProps {
   disableMobileHidden?: boolean;
@@ -24,6 +24,8 @@ export default function HeroContainer(props: HeroContainerProps) {
     rightSx,
   } = props;
   const frame = React.useRef<HTMLDivElement>(null);
+  const globalTheme = useTheme()
+  const isMdUp = useMediaQuery(globalTheme.breakpoints.up('md'));
 
   useEnhancedEffect(() => {
     let obs: undefined | MutationObserver;
@@ -145,7 +147,7 @@ export default function HeroContainer(props: HeroContainerProps) {
         }}
       >
         <Grid container alignItems="center" wrap="nowrap" sx={{ height: '100%', mx: 'auto' }}>
-          <Grid item md={7} lg={6} sx={{ m: 'auto' }}>
+          <Grid item sx={{ m: isMdUp? '':'auto' }}>
             {left}
           </Grid>
           <Grid


### PR DESCRIPTION
**Fixed in the mui homepage**: Right component (**renderRightWrapper**) doesn't fit properly inside desktop screens. 

Before:
![Screenshot (12)](https://github.com/mui/material-ui/assets/70434968/821cd04a-9d1d-433a-92fd-c9b168ba9fb8)

After: 
![Screenshot (13)](https://github.com/mui/material-ui/assets/70434968/9bdb538c-d93f-4de0-b20b-55e2cba5787b)
