### PR TITLE
[docs-infra] Prevent horizontal scroll in the TOC

### DIFF
--- a/docs/pages/experiments/docs/markdown.md
+++ b/docs/pages/experiments/docs/markdown.md
@@ -40,3 +40,11 @@ https://spec.commonmark.org/0.30/#links
 Make sure to include the `class="key"` declaration in each individual `kbd` element.
 
 That's because when referring to two keys that should be pressed together－for example, <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd>－the `kbd` elements are wrapped by a parent `kbd`, and we don't add styles to just the tag.
+
+## This item is here to test a long table of contents instance
+
+### And here is another one right below it to see how it feels like one level down
+
+### Wordwithoutspaceasitwouldhappenwithapropdeclaration
+
+Table of contents word wrap test.

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -29,9 +29,7 @@ const Nav = styled('nav')(({ theme }) => ({
 }));
 
 const NavLabel = styled(Typography)(({ theme }) => ({
-  marginTop: theme.spacing(2),
-  marginBottom: theme.spacing(1),
-  paddingLeft: theme.spacing(1.4),
+  padding: theme.spacing(1, 0, 1, 1.4),
   fontSize: theme.typography.pxToRem(11),
   fontWeight: theme.typography.fontWeightBold,
   textTransform: 'uppercase',
@@ -67,12 +65,13 @@ const NavItem = styled(Link, {
 
   return [
     {
+      display: 'block',
       fontSize: theme.typography.pxToRem(13),
-      padding: theme.spacing(0, 1, 0, secondary ? 2.5 : '10px'),
-      margin: theme.spacing(0.5, 0, 1, 0),
+      fontWeight: theme.typography.fontWeightMedium,
+      overflowWrap: 'break-word',
+      padding: theme.spacing('6px', 0, '6px', secondary ? 3 : '12px'),
       borderLeft: `1px solid transparent`,
       boxSizing: 'border-box',
-      fontWeight: 500,
       '&:hover': {
         borderLeftColor: (theme.vars || theme).palette.grey[400],
         color: (theme.vars || theme).palette.grey[600],
@@ -86,7 +85,7 @@ const NavItem = styled(Link, {
     },
     theme.applyDarkStyles({
       '&:hover': {
-        borderLeftColor: (theme.vars || theme).palette.grey[600],
+        borderLeftColor: (theme.vars || theme).palette.grey[500],
         color: (theme.vars || theme).palette.grey[200],
       },
       ...(!active && {
@@ -334,7 +333,7 @@ export default function AppTableOfContents(props) {
       </NoSsr>
       {toc.length > 0 ? (
         <React.Fragment>
-          <NavLabel gutterBottom>{t('tableOfContents')}</NavLabel>
+          <NavLabel>{t('tableOfContents')}</NavLabel>
           <NavList component="ul">
             {toc.map((item) => (
               <li key={item.text}>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -65,13 +65,14 @@ const NavItem = styled(Link, {
 
   return [
     {
+      boxSizing: 'border-box',
+      padding: theme.spacing('6px', 0, '6px', secondary ? 3 : '12px'),
+      borderLeft: `1px solid transparent`,
       display: 'block',
       fontSize: theme.typography.pxToRem(13),
       fontWeight: theme.typography.fontWeightMedium,
-      overflowWrap: 'break-word',
-      padding: theme.spacing('6px', 0, '6px', secondary ? 3 : '12px'),
-      borderLeft: `1px solid transparent`,
-      boxSizing: 'border-box',
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
       '&:hover': {
         borderLeftColor: (theme.vars || theme).palette.grey[400],
         color: (theme.vars || theme).palette.grey[600],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR is primarily for adding `textOverflow: 'ellipsis'` to the table of content items, preventing them from overflowing in case there's a big label without spaces. It's been recently surfaced by a non-related PR (https://github.com/mui/material-ui/pull/39412). Also took advantage of the opportunity for some stylistic polish! 😊 

👉 **https://deploy-preview-39417--material-ui.netlify.app/experiments/docs/data-grid-premium/#css**
👉 **https://deploy-preview-39417--material-ui.netlify.app/experiments/docs/markdown/#wordwithoutspaceasitwouldhappenwithapropdeclaration**




