### PR TITLE
[core] Fix multiple typos across the repo

### DIFF
--- a/docs/data/base/components/number-input/number-input.md
+++ b/docs/data/base/components/number-input/number-input.md
@@ -160,7 +160,7 @@ The value will be clamped based on `min`, `max` and `step` once the input field 
 
 ### Shift multiplier
 
-Holding down the <kbd class="key">Shift</kbd> key when interacting with the stepper buttons applies a multipler (default 10x) to the value change of each step.
+Holding down the <kbd class="key">Shift</kbd> key when interacting with the stepper buttons applies a multiplier (default 10x) to the value change of each step.
 
 You can customize this behavior with the `shiftMultiplier` prop.
 In the following snippet, if <kbd class="key">Shift</kbd> is held when clicking the increment button, the value will change from 0, to 5, to 10, and on.

--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -134,7 +134,7 @@ The demo below shows how to build the Primer button using Tailwind CSS:
 
 ### Styling with MUI System
 
-[MUI System](/system/getting-started/) is a small set of CSS utilties that provide a styled-components-like API for building out designs that adhere to a theme.
+[MUI System](/system/getting-started/) is a small set of CSS utilities that provide a styled-components-like API for building out designs that adhere to a theme.
 
 MUI System's core utility is a [`styled` function](/system/styled/) that's equivalent to the `styled()` function in emotion and styled-components.
 Interpolations or arguments that are functions called by `styled` receive the `theme` from an upper `ThemeProvider`.

--- a/docs/data/joy/components/skeleton/skeleton.md
+++ b/docs/data/joy/components/skeleton/skeleton.md
@@ -25,7 +25,7 @@ import Skeleton from '@mui/joy/Skeleton';
 There are two methods of using the Skeleton component:
 
 1. **Masking a component**: see the [Avatar](#avatar), [Image](#image) and [Typography](#inline-with-typography) examples. The Skeleton component will inherit their dimension which makes for a more predictable UI while also preventing layout shift when the loading is done.
-2. **Setting a custom width and height**: see the [Geometry](#geometry) and [Text block](#text-block) examples. Use this for full control of the Skeleton size, ignoring its parent dimensions entirely. Be aware that this option _can_ generate layout shift if the actual component the Skeleton is mimicing has a different size.
+2. **Setting a custom width and height**: see the [Geometry](#geometry) and [Text block](#text-block) examples. Use this for full control of the Skeleton size, ignoring its parent dimensions entirely. Be aware that this option _can_ generate layout shift if the actual component the Skeleton is mimicking has a different size.
 
 ## Customization
 

--- a/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
+++ b/docs/data/system/experimental-api/css-theme-variables/css-theme-variables.md
@@ -39,7 +39,7 @@ The comparison described in the table above may not be applicable to large and c
 
 ## Usage
 
-The CSS variables API usage is exposed as a higher order function called `unstable_createCssVarsProvider` which can be called to create a theme provider and other utitlities to share the theme config throughout your app. This is a very low-level function and has a lot of moving parts. If you are already using [Material UI](https://mui.com/material-ui/experimental-api/css-theme-variables/overview/) or [Joy UI](https://mui.com/joy-ui/customization/using-css-variables/), they already expose their own `CssVarsProvider` component that you can use directly without needing to configure your theme. Now that's out of the way, we can continue with how this util can be used.
+The CSS variables API usage is exposed as a higher order function called `unstable_createCssVarsProvider` which can be called to create a theme provider and other utilities to share the theme config throughout your app. This is a very low-level function and has a lot of moving parts. If you are already using [Material UI](https://mui.com/material-ui/experimental-api/css-theme-variables/overview/) or [Joy UI](https://mui.com/joy-ui/customization/using-css-variables/), they already expose their own `CssVarsProvider` component that you can use directly without needing to configure your theme. Now that's out of the way, we can continue with how this util can be used.
 
 We'll first define a minimal theme palette for light and dark modes.
 
@@ -200,7 +200,7 @@ See the complete usage of `createVssVarsProvider` in [Material UI](https://githu
 - `defaultMode?`: Design system default mode (`light` by default)
 - `disableTransitionOnChange?`: Disable CSS transitions when switching between modes or color schemes (`false` by default)
 - `themeId?`: The design system's unique id for getting the corresponded theme when there are multiple design systems.
-- `theme`: Design system default theme. It's structure, besides the minimium requirements by `createCssVarsProvider`, is upto the design system to implement.
+- `theme`: Design system default theme. It's structure, besides the minimum requirements by `createCssVarsProvider`, is upto the design system to implement.
 - `resolveTheme(theme: Theme) => Theme`: A function to be called after the CSS variables are attached. The result of this function will be the final theme pass to `ThemeProvider`.
 
 `createCssVarsProvider` returns 3 items.

--- a/docs/pages/blog/2021-developer-survey-results.md
+++ b/docs/pages/blog/2021-developer-survey-results.md
@@ -507,7 +507,7 @@ The majority of respondents don't use any paid libraries, but those who do are m
   MUI mainly develops open-source software, and we deeply value the OSS ethos of freely sharing what we build so that others can use it and improve upon it.
   - The price of our Pro plan positions it as a product intended for use by teams at professional organizations.
     That said, many who left feedback on the price are individuals, so there might be an opportunity to expand our offerings for those not backed by their company.
-- **More features & feature fixes:** Collapsable rows, column resizing, and features for ERP apps were some of the features requested.
+- **More features & feature fixes:** Collapsible rows, column resizing, and features for ERP apps were some of the features requested.
   And regarding features to fix, the most common requests were pagination with REST APIs, backend filtering, and cell editor.
 - **Improvements to the documentation:** The data grid docs could certainly use a major overhaul—we're working on it.
 - **Improvements to the look and feel:** Data grid builders want more default design options beyond Material.

--- a/docs/pages/blog/2023-mui-values.md
+++ b/docs/pages/blog/2023-mui-values.md
@@ -1,6 +1,6 @@
 ---
 title: Evolving MUI's core values and behaviors
-description: After significant growth, we united as a team to rediscover the values that underpin our shared sucess.
+description: After significant growth, we united as a team to rediscover the values that underpin our shared success.
 date: 2023-09-26T00:00:00.000Z
 authors: ['mikailaread']
 card: true

--- a/docs/pages/blog/first-look-at-joy.md
+++ b/docs/pages/blog/first-look-at-joy.md
@@ -93,7 +93,7 @@ You're still able to override the style completely via the usual CSS overrides, 
 Joy UI provides an effective way to prevent UI flicker when users refresh or re-enter a page with dark mode enabled.
 The out-of-the-box CSS variables support allows every color scheme to be rendered at build time, inserting the selected color scheme and mode before the browser renders the DOM.
 
-What's more, it provides a function called `getInitColorSchemeScript()` that enables you to have perfect functioning dark mode in various React framworks, such as Next.js, Gatsby, and Remix.
+What's more, it provides a function called `getInitColorSchemeScript()` that enables you to have perfect functioning dark mode in various React frameworks, such as Next.js, Gatsby, and Remix.
 
 ```js
 // A Next.js example

--- a/docs/pages/blog/mui-core-v5-migration-update.md
+++ b/docs/pages/blog/mui-core-v5-migration-update.md
@@ -87,6 +87,6 @@ You can check out the progress on this effort [in this GitHub issue](https://git
 ## Upgrade now
 
 What are you waiting for?
-Jump into the [newly revised migration documention](/material-ui/migration/migration-v4/) and get started today.
+Jump into the [newly revised migration documentation](/material-ui/migration/migration-v4/) and get started today.
 
 Let us know if you have any questions along the way!

--- a/docs/pages/careers/senior-designer.md
+++ b/docs/pages/careers/senior-designer.md
@@ -106,7 +106,7 @@ So, if you're this designer, either already able to code or growing in this dire
 
 ## Benefits & Compensation
 
-We are ready to pay competitive, top market rates, for a person that can cleary exceed the role's expectations.
+We are ready to pay competitive, top market rates, for a person that can clearly exceed the role's expectations.
 Therefore, we consider profile and location.
 You can find the other perks & benefits on the [careers](https://mui.com/careers/#perks-and-benefits) page.
 


### PR DESCRIPTION
Multiple typos on multiple files located inside /docs directory has been fixed.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
