### PR TITLE
[docs-infra] Add refinements to the API content design

### DIFF
--- a/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
@@ -16,6 +16,7 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
   ({ theme }) => ({
     position: 'relative',
     marginBottom: 12,
+    scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
     '& .MuiApi-item-header': {
       minHeight: 26,
       display: 'flex',

--- a/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
@@ -234,7 +234,7 @@ function ApiItem(props: ApiItemProps) {
             onClick={() => setIsExtended((prev) => !prev)}
             className="MuiApi-expend-button"
             size="small"
-            sx={{ p: 0, ml: 'auto' }}
+            sx={{ p: 0, ml: 'auto', borderRadius: '6px' }}
           >
             {isExtended ? (
               <KeyboardArrowUpIcon sx={{ color: 'grey.500' }} />

--- a/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
@@ -237,9 +237,9 @@ function ApiItem(props: ApiItemProps) {
             sx={{ p: 0, ml: 'auto' }}
           >
             {isExtended ? (
-              <KeyboardArrowDownIcon sx={{ color: 'grey.500' }} />
-            ) : (
               <KeyboardArrowUpIcon sx={{ color: 'grey.500' }} />
+            ) : (
+              <KeyboardArrowDownIcon sx={{ color: 'grey.500' }} />
             )}
           </IconButton>
         )}

--- a/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
@@ -68,7 +68,7 @@ export default function ClassesSection(props: ClassesSectionProps) {
 
   return (
     <React.Fragment>
-      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 1 }}>
         <Level id={titleHash} style={{ flexGrow: 1 }}>
           {t(title)}
           <a

--- a/docs/src/modules/components/ApiPage/sections/CssSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/CssSection.tsx
@@ -98,7 +98,7 @@ export default function CSSSection(props: CSSSectionProps) {
 
   return (
     <React.Fragment>
-      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 1 }}>
         <Level id={titleHash} style={{ flexGrow: 1 }}>
           {t(title)}
           <a

--- a/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
+++ b/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
@@ -104,7 +104,7 @@ export default function PropertiesSection(props) {
 
   return (
     <React.Fragment>
-      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 1 }}>
         <Level id={titleHash} style={{ flexGrow: 1 }}>
           {t(title)}
           <a

--- a/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
@@ -50,7 +50,7 @@ export default function SlotsSection(props: SlotsSectionProps) {
 
   return (
     <React.Fragment>
-      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', mb: 1 }}>
         <Level id={titleHash} style={{ flexGrow: 1 }}>
           {t(title)}
           <a

--- a/docs/src/modules/components/ApiPage/table/CSSTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/CSSTable.tsx
@@ -17,6 +17,7 @@ const StyledTable = styled('table')(
       fontSize: theme.typography.pxToRem(14),
     },
     '& tr': {
+      scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
       '&:hover': {
         backgroundColor: alpha(darkTheme.palette.grey[50], 0.5),
       },

--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -20,6 +20,7 @@ const StyledTable = styled('table')(
       fontSize: theme.typography.pxToRem(14),
     },
     '& tr': {
+      scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
       '&:hover': {
         backgroundColor: alpha(darkTheme.palette.grey[50], 0.5),
       },

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -21,6 +21,7 @@ const StyledTable = styled('table')(
       fontSize: theme.typography.pxToRem(14),
     },
     '& tr': {
+      scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
       '&:hover': {
         backgroundColor: alpha(darkTheme.palette.grey[50], 0.5),
       },

--- a/docs/src/modules/components/ApiPage/table/SlotsTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/SlotsTable.tsx
@@ -17,6 +17,7 @@ const StyledTable = styled('table')(
       fontSize: theme.typography.pxToRem(14),
     },
     '& tr': {
+      scrollMarginTop: 'calc(var(--MuiDocs-header-height) + 32px)',
       '&:hover': {
         backgroundColor: alpha(darkTheme.palette.grey[50], 0.5),
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR is a follow-up to the recently merged newer API content design iteration — https://github.com/mui/material-ui/pull/38265. Notable changes are:

- Add a scroll margin-top so clicking on the prop anchors work fine
- Fix icon orientation on the list accordion
- Stray stylistic changes

👉 **https://deploy-preview-39425--material-ui.netlify.app/material-ui/api/button/#Button-prop-classes**