### PR TITLE
[website] Add the LinkedIn profile to the contributors section on the About page

### DIFF
--- a/docs/data/about/teamMembers.json
+++ b/docs/data/about/teamMembers.json
@@ -6,7 +6,8 @@
     "locationCountry": "fr",
     "about": "Exercise addict and lifelong learner",
     "twitter": "olivtassinari",
-    "github": "oliviertassinari"
+    "github": "oliviertassinari",
+    "linkedin":"in/chhawinderpreet-singh-017277228/"
   },
   {
     "name": "Matt Brookes",
@@ -15,7 +16,8 @@
     "locationCountry": "gb",
     "about": "When I'm not 👨🏻‍💻, I'm 🧗🏼‍♂️",
     "twitter": "randomtechdude",
-    "github": "mbrookes"
+    "github": "mbrookes",
+    "linkedin":"in/chhawinderpreet-singh-017277228/"
   },
   {
     "name": "Marija Najdova",
@@ -24,7 +26,8 @@
     "locationCountry": "mk",
     "about": "I do karate 🥋 and read 📚. A lot!",
     "twitter": "marijanajdova",
-    "github": "mnajdova"
+    "github": "mnajdova",
+    "linkedin":"in/chhawinderpreet-singh-017277228/"
   },
   {
     "name": "Danail Hadjiatanasov",

--- a/docs/data/about/teamMembers.json
+++ b/docs/data/about/teamMembers.json
@@ -6,8 +6,7 @@
     "locationCountry": "fr",
     "about": "Exercise addict and lifelong learner",
     "twitter": "olivtassinari",
-    "github": "oliviertassinari",
-    "linkedin":"in/chhawinderpreet-singh-017277228/"
+    "github": "oliviertassinari"
   },
   {
     "name": "Matt Brookes",
@@ -16,8 +15,7 @@
     "locationCountry": "gb",
     "about": "When I'm not 👨🏻‍💻, I'm 🧗🏼‍♂️",
     "twitter": "randomtechdude",
-    "github": "mbrookes",
-    "linkedin":"in/chhawinderpreet-singh-017277228/"
+    "github": "mbrookes"
   },
   {
     "name": "Marija Najdova",
@@ -26,8 +24,7 @@
     "locationCountry": "mk",
     "about": "I do karate 🥋 and read 📚. A lot!",
     "twitter": "marijanajdova",
-    "github": "mnajdova",
-    "linkedin":"in/chhawinderpreet-singh-017277228/"
+    "github": "mnajdova"
   },
   {
     "name": "Danail Hadjiatanasov",

--- a/docs/src/components/about/Team.tsx
+++ b/docs/src/components/about/Team.tsx
@@ -136,7 +136,7 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
         <Box sx={{ mt: -0.5, mr: -0.5, ml: 'auto' }}>
           {props.github && (
             <IconButton
-              aria-label={`${props.name} github`}
+              aria-label={`${props.name} GitHub profile`}
               component="a"
               href={`https://github.com/${props.github}`}
               target="_blank"
@@ -147,7 +147,7 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
           )}
           {props.twitter && (
             <IconButton
-              aria-label={`${props.name} twitter`}
+              aria-label={`${props.name} Twitter profile`}
               component="a"
               href={`https://twitter.com/${props.twitter}`}
               target="_blank"
@@ -156,9 +156,9 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
               <TwitterIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>
           )}
-          {props.linkedin &&(
+          {props.linkedin && (
             <IconButton
-              aria-label={`${props.name} linkedin`}
+              aria-label={`${props.name} LinkedIn profile`}
               component="a"
               href={`https://www.linkedin.com/${props.linkedin}`}
               target="_blank"
@@ -166,9 +166,7 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
             >
               <LinkedInIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>
-          )
-
-          }
+          )}
         </Box>
       </Box>
       <Typography variant="body2" fontWeight="bold" sx={{ mt: 2, mb: 0.5 }}>
@@ -196,7 +194,6 @@ const contributors = [
     locationCountry: 'de',
     src: 'https://avatars.githubusercontent.com/u/12292047',
     twitter: 'sebsilbermann',
-    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Ryan Cogswell',
@@ -205,7 +202,6 @@ const contributors = [
     location: 'Minnesota, United States',
     locationCountry: 'us',
     src: 'https://avatars.githubusercontent.com/u/287804',
-    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Yan Lee',
@@ -214,7 +210,6 @@ const contributors = [
     location: 'China',
     locationCountry: 'cn',
     src: 'https://avatars.githubusercontent.com/u/13300332',
-    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Jairon Alves Lima',
@@ -251,7 +246,6 @@ const emeriti = [
     location: 'Toronto, CA',
     locationCountry: 'ca',
     src: 'https://avatars.githubusercontent.com/u/4420103',
-    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Kevin Ross',

--- a/docs/src/components/about/Team.tsx
+++ b/docs/src/components/about/Team.tsx
@@ -12,6 +12,7 @@ import Tooltip from '@mui/material/Tooltip';
 import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
 import TwitterIcon from '@mui/icons-material/Twitter';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import Link from 'docs/src/modules/components/Link';
 import ROUTES from 'docs/src/route';
 import Section from 'docs/src/layouts/Section';
@@ -43,6 +44,7 @@ interface Profile {
   about?: string;
   github?: string;
   twitter?: string;
+  linkedin?: string;
 }
 
 function Person(props: Profile & { sx?: PaperProps['sx'] }) {
@@ -154,6 +156,19 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
               <TwitterIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>
           )}
+          {props.linkedin &&(
+            <IconButton
+              aria-label={`${props.name} linkedin`}
+              component="a"
+              href={`https://www.linkedin.com/${props.linkedin}`}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <LinkedInIcon fontSize="small" sx={{ color: 'grey.500' }} />
+            </IconButton>
+          )
+
+          }
         </Box>
       </Box>
       <Typography variant="body2" fontWeight="bold" sx={{ mt: 2, mb: 0.5 }}>
@@ -181,6 +196,7 @@ const contributors = [
     locationCountry: 'de',
     src: 'https://avatars.githubusercontent.com/u/12292047',
     twitter: 'sebsilbermann',
+    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Ryan Cogswell',
@@ -189,6 +205,7 @@ const contributors = [
     location: 'Minnesota, United States',
     locationCountry: 'us',
     src: 'https://avatars.githubusercontent.com/u/287804',
+    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Yan Lee',
@@ -197,6 +214,7 @@ const contributors = [
     location: 'China',
     locationCountry: 'cn',
     src: 'https://avatars.githubusercontent.com/u/13300332',
+    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Jairon Alves Lima',
@@ -233,6 +251,7 @@ const emeriti = [
     location: 'Toronto, CA',
     locationCountry: 'ca',
     src: 'https://avatars.githubusercontent.com/u/4420103',
+    linkedin: 'in/chhawinderpreet-singh-017277228/'
   },
   {
     name: 'Kevin Ross',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
this PR adds a linkedin profile button to contributers cards


linkedin button added as shown in below image
![WhatsApp Image 2023-10-15 at 11 10 28_da5c4d52](https://github.com/mui/material-ui/assets/96365487/a3d5bce9-6bff-4de5-96c4-dc60857aa4db)


fixes #39453
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
