### PR TITLE
[mui-system][style] bug fix for style value check color in nullable object

### DIFF
--- a/packages/mui-material/src/Typography/Typography.test.js
+++ b/packages/mui-material/src/Typography/Typography.test.js
@@ -115,7 +115,7 @@ describe('<Typography />', () => {
   describe('prop: color', () => {
     it('should check for invalid color value', () => {
       const msg =
-        'MUI: The value found in theme for prop: "background" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".';
+        'MUI: The value found in theme for prop: "background" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, e.g., "background.paper" instead of "background".';
       expect(() => {
         render(
           <Typography variant="h6" color="background">

--- a/packages/mui-system/src/palette.test.js
+++ b/packages/mui-system/src/palette.test.js
@@ -16,7 +16,7 @@ describe('palette', () => {
         backgroundColor: 'grey',
       });
     }).toWarnDev(
-      'MUI: The value found in theme for prop: "grey" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".',
+      'MUI: The value found in theme for prop: "grey" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, e.g., "background.paper" instead of "background".',
     );
 
     expect(output).to.deep.equal({

--- a/packages/mui-system/src/style.js
+++ b/packages/mui-system/src/style.js
@@ -35,10 +35,10 @@ export function getStyleValue(themeMapping, transform, propValueFinal, userValue
     value = getPath(themeMapping, propValueFinal) || userValue;
   }
 
-  if (typeof value === 'object') {
-    if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production') {
+    if (value && typeof value === 'object' && isColor(Object.values(value)[0])) {
       console.warn(
-        `MUI: The value found in theme for prop: "${propValueFinal}" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".`,
+        `MUI: The value found in theme for prop: "${propValueFinal}" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, e.g., "background.paper" instead of "background".`,
       );
     }
   }
@@ -98,6 +98,20 @@ function style(options) {
   fn.filterProps = [prop];
 
   return fn;
+}
+
+function isColor(str) {
+  // Regular expressions to match different color patterns
+  const colorPatterns = [
+    /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, // Hex color
+    /^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/, // RGB color
+    /^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*0?(\.\d+)?\s*\)$/, // RGBA color
+    /^(red|green|blue|yellow|orange|purple|pink|white|black|gray|grey|transparent)$/, // CSS color keyword
+    /^\$[a-zA-Z_][a-zA-Z0-9_]*$/, // SCSS variable reference
+    /^var\(--[^)]+\)$/, // CSS variable reference (e.g., var(--main-color))
+  ];
+
+  return colorPatterns.some((pattern) => pattern.test(str));
 }
 
 export default style;

--- a/packages/mui-system/src/style.test.js
+++ b/packages/mui-system/src/style.test.js
@@ -259,7 +259,7 @@ describe('style', () => {
     });
   });
   describe('getStyleValue', () => {
-    it('should warn on acceptable object', () => {
+    it('should not warn on acceptable object', () => {
       const round = (value) => Math.round(value * 1e5) / 1e5;
       let output;
 
@@ -277,9 +277,7 @@ describe('style', () => {
           null,
           'body1',
         );
-      }).toWarnDev(
-        'MUI: The value found in theme for prop: "body1" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".',
-      );
+      }).not.toWarnDev();
 
       expect(output).to.deep.equal({
         fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
@@ -290,7 +288,7 @@ describe('style', () => {
       });
     });
 
-    it('should warn on unacceptable object', () => {
+    it('should warn on objects that directly contain colors', () => {
       const theme = {
         palette: {
           grey: { 100: '#f5f5f5' },
@@ -308,7 +306,7 @@ describe('style', () => {
       expect(() => {
         output = getStyleValue(theme.palette, paletteTransform, 'grey');
       }).toWarnDev(
-        'MUI: The value found in theme for prop: "grey" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".',
+        'MUI: The value found in theme for prop: "grey" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, e.g., "background.paper" instead of "background".',
       );
 
       expect(output).to.be.equal('grey');

--- a/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
+++ b/packages/mui-system/src/styleFunctionSx/styleFunctionSx.test.js
@@ -100,10 +100,7 @@ describe('styleFunctionSx', () => {
           theme,
           sx: { typography: ['body2', 'body1'] },
         });
-      }).toWarnDev([
-        'MUI: The value found in theme for prop: "body2" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".',
-        'MUI: The value found in theme for prop: "body1" is an [Object] instead of string or number. Check if you forgot to add the correct dotted notation, eg, "background.paper" instead of "background".',
-      ]);
+      }).not.toWarnDev();
 
       expect(result).to.deep.equal({
         '@media (min-width:0px)': {


### PR DESCRIPTION
**Description**
In PR #39071, we added checks to `getStyleValue` to throw a warning in development mode to double check if the prop value resolved from `themeMapping` was intentionally object. This was to ensure that setting object values to css such as `color` does not fail silently. But, the warning was also thrown on setting object values when necessary such as typography to `body1` which quickly led to spam a lot of warnings.

**Changes Made:**

- Added a function to check if a given string is a colour in any of the standard color styles (hex, rgb, rgba, var, scss).
- Updated the `getStyleValue` function to check if the resolved value is non-null object and only throw warning if the object immediately contains color values.
- Updated all tests from the previous PR to better fit the new `getStyleValue`.

**Testing:**

I have updated all relevant tests from the original PR, `style.test.js`, `palette.test.js`, `styleFunctionsSx.test.js` and `Typography.test.js` file to ensure that the changes work as expected. The tests include checking that the warning is only thrown on objects which immediately contain colours.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes #39399