### PR TITLE
[InputLabel][material-ui] InputLabel supports ownerState.focused for styleOverrides

### DIFF
--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -46,6 +46,7 @@ const InputLabelRoot = styled(FormLabel, {
       ownerState.size === 'small' && styles.sizeSmall,
       ownerState.shrink && styles.shrink,
       !ownerState.disableAnimation && styles.animated,
+      ownerState.focused && styles.focused,
       styles[ownerState.variant],
     ];
   },
@@ -141,7 +142,7 @@ const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
   const fcs = formControlState({
     props,
     muiFormControl,
-    states: ['size', 'variant', 'required'],
+    states: ['size', 'variant', 'required', 'focused'],
   });
 
   const ownerState = {
@@ -152,6 +153,7 @@ const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
     size: fcs.size,
     variant: fcs.variant,
     required: fcs.required,
+    focused: fcs.focused,
   };
 
   const classes = useUtilityClasses(ownerState);

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -121,8 +121,6 @@ describe('<InputLabel />', () => {
       });
 
       it('provides ownerState.focused in styleOverrides', () => {
-        const colorRed = 'rgb(255, 0, 0)';
-
         const theme = createTheme({
           components: {
             MuiInputLabel: {
@@ -130,9 +128,7 @@ describe('<InputLabel />', () => {
                 root: (props) => {
                   return {
                     ...(props.ownerState.focused === true && {
-                      [`&.${classes.focused}`]: {
-                        color: colorRed,
-                      },
+                      fontWeight: '700',
                     }),
                   };
                 },
@@ -144,14 +140,14 @@ describe('<InputLabel />', () => {
         const { getByText } = render(
           <ThemeProvider theme={theme}>
             <FormControl focused>
-              <InputLabel>Red Test Label</InputLabel>
+              <InputLabel>Bold Test Label</InputLabel>
             </FormControl>
           </ThemeProvider>,
         );
 
-        const label = getByText('Red Test Label');
+        const label = getByText('Bold Test Label');
 
-        expect(getComputedStyle(label).color).to.equal(colorRed);
+        expect(getComputedStyle(label).fontWeight).to.equal('700');
       });
     });
   });

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
 import { ClassNames } from '@emotion/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import FormControl from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
 import FormLabel from '@mui/material/FormLabel';
@@ -117,6 +118,40 @@ describe('<InputLabel />', () => {
 
         setProps({ shrink: true });
         expect(getByTestId('root')).to.have.class(classes.shrink);
+      });
+
+      it('provides ownerState.focused in styleOverrides', () => {
+        const colorRed = 'rgb(255, 0, 0)';
+
+        const theme = createTheme({
+          components: {
+            MuiInputLabel: {
+              styleOverrides: {
+                root: (props) => {
+                  return {
+                    ...(props.ownerState.focused === true && {
+                      [`&.${classes.focused}`]: {
+                        color: colorRed,
+                      },
+                    }),
+                  };
+                },
+              },
+            },
+          },
+        });
+
+        const { getByText } = render(
+          <ThemeProvider theme={theme}>
+            <FormControl focused>
+              <InputLabel>Red Test Label</InputLabel>
+            </FormControl>
+          </ThemeProvider>,
+        );
+
+        const label = getByText('Red Test Label');
+
+        expect(getComputedStyle(label).color).to.equal(colorRed);
       });
     });
   });


### PR DESCRIPTION
Resolves https://github.com/mui/material-ui/issues/37069, Resolves https://github.com/mui/material-ui/issues/36550, Resolves https://github.com/mui/material-ui/issues/39427

This PR enables users to more easily customize the `maxWidth` of a `TextField`'s label based on it's focused state to control truncation of the label

![Screenshot 2023-10-16 at 9 25 55 PM](https://github.com/mui/material-ui/assets/4997971/b0f048a8-2323-4196-b9ad-e0d3bfef2504)

The before/after end result look same, but after this fix you are no longer required to manually add a focused state to achieve the customization, and it can be done in the theme

Before: https://codesandbox.io/s/https-github-com-mui-material-ui-issues-39427-vx2gvd?file=/demo.tsx

After: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-39470-y7gr8x

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
