### PR TITLE
[joy-ui][Link] Apply `userSelect: none` only when it's a button

### DIFF
--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -130,7 +130,7 @@ const LinkRoot = styled('a', {
               } / 0.6))`,
             },
           }),
-      userSelect: ownerState.component === 'button' && 'none',
+      userSelect: ownerState.component === 'button' ? 'none' : undefined,
       MozAppearance: 'none', // Reset
       WebkitAppearance: 'none', // Reset
       '&::-moz-focus-inner': {

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -130,7 +130,7 @@ const LinkRoot = styled('a', {
               } / 0.6))`,
             },
           }),
-      userSelect: 'none',
+      userSelect: ownerState.component === 'button' && 'none',
       MozAppearance: 'none', // Reset
       WebkitAppearance: 'none', // Reset
       '&::-moz-focus-inner': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Context from Discord:
![image](https://github.com/mui/material-ui/assets/32725014/50264d4b-620a-45c3-8575-135d1111069b)
