### PR TITLE
[docs-infra] Fix crawler on API pages

### DIFF
--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -69,11 +69,26 @@ export function useApiPageOption(
   storageKey: string,
 ): [ApiDisplayOptions, (newOption: ApiDisplayOptions) => void] {
   const [option, setOption] = React.useState(getOption(storageKey));
+  const [needsScroll, setNeedsScroll] = React.useState(false);
 
   useEnhancedEffect(() => {
     neverHydrated = false;
-    setOption(getOption(storageKey));
+    const newOption = getOption(storageKey);
+    setOption(newOption);
+    setNeedsScroll(newOption !== DEFAULT_LAYOUT);
   }, [storageKey]);
+
+  React.useEffect(() => {
+    setNeedsScroll(false);
+    if (needsScroll) {
+      return () => {
+        const id = document?.location.hash.slice(1);
+        const element = document.getElementById(id);
+        element?.scrollIntoView();
+      };
+    }
+    return () => {};
+  }, [needsScroll]);
 
   const updateOption = React.useCallback(
     (newOption: ApiDisplayOptions) => {

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -20,8 +20,8 @@ export const API_LAYOUT_STORAGE_KEYS = {
 } as const;
 
 const getRandomOption = () => {
-  if (/Algolia Crawler/.test(navigator.userAgent)) {
-    // When algolia crawls the page, it should not have to expand items
+  if (/Algolia Crawler/.test(navigator.userAgent) || /Googlebot/.test(navigator.userAgent)) {
+    // When crawlers visit the page, they should not have to expand items
     return 'expended';
   }
   // A default layout is saved in localstorage at first render to make sure all section start with the same layout.

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -20,6 +20,10 @@ export const API_LAYOUT_STORAGE_KEYS = {
 } as const;
 
 const getRandomOption = () => {
+  if (/Algolia Crawler/.test(navigator.userAgent)) {
+    // When algolia crawls the page, it should not have to expand items
+    return 'expended';
+  }
   // A default layout is saved in localstorage at first render to make sure all section start with the same layout.
   const savedDefaultOption = localStorage.getItem(
     API_LAYOUT_STORAGE_KEYS.default,

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -22,7 +22,7 @@ export const API_LAYOUT_STORAGE_KEYS = {
 } as const;
 
 const getRandomOption = () => {
-  if (/Algolia Crawler/.test(navigator.userAgent) || /Googlebot/.test(navigator.userAgent)) {
+  if (/bot|googlebot|crawler|spider|robot|crawling/i.test(navigator.userAgent)) {
     // When crawlers visit the page, they should not have to expand items
     return DEFAULT_LAYOUT;
   }

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -46,7 +46,7 @@ const getRandomOption = () => {
 
 let neverHydrated = true;
 
-const getOption = (storageKey: string) => () => {
+const getOption = (storageKey: string) => {
   if (neverHydrated) {
     return DEFAULT_LAYOUT;
   }
@@ -71,11 +71,9 @@ export function useApiPageOption(
   const [option, setOption] = React.useState(getOption(storageKey));
 
   useEnhancedEffect(() => {
-    if (neverHydrated) {
-      document.getElementById(document.location.hash)?.scrollIntoView();
-    }
     neverHydrated = false;
-  }, []);
+    setOption(getOption(storageKey));
+  }, [storageKey]);
 
   const updateOption = React.useCallback(
     (newOption: ApiDisplayOptions) => {

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -69,11 +69,10 @@ export function useApiPageOption(
   storageKey: string,
 ): [ApiDisplayOptions, (newOption: ApiDisplayOptions) => void] {
   const [option, setOption] = React.useState(getOption(storageKey));
+
   useEnhancedEffect(() => {
     if (neverHydrated) {
-      if (document?.location.hash) {
-        document.getElementById(document?.location.hash)?.scrollIntoView();
-      }
+      document.getElementById(document.location.hash)?.scrollIntoView();
     }
     neverHydrated = false;
   }, []);


### PR DESCRIPTION
Due to the new API page #38265, the API layout is randomly chosen the first time a user connects. This choice is saved in the localStorage. But crawlers like Algolia don't keep that information, so at each crawl, they could face either the table, collapse, or expanded layout.

To write a craw for only one layout, we need to enforce this layout when Algolia is visiting. This modification enforces the expanded layout for Algolia and Google bots

Fix https://groups.google.com/a/mui.com/g/docs-infra/c/cr9i8LDORjE

Preview https://deploy-preview-39490--material-ui.netlify.app/material-ui/api/autocomplete/#Autocomplete-prop-autoHighlight