### PR TITLE
[joy-ui][Progress] Revamp Linear and Circular progress variants

### DIFF
--- a/docs/data/joy/components/alert/AlertInvertedColors.js
+++ b/docs/data/joy/components/alert/AlertInvertedColors.js
@@ -55,14 +55,14 @@ export default function AlertInvertedColors() {
           </Typography>
         </div>
         <LinearProgress
-          variant="soft"
+          variant="solid"
+          color="success"
           value={40}
           sx={(theme) => ({
             position: 'absolute',
             bottom: 0,
             left: 0,
             right: 0,
-            color: `rgb(${theme.vars.palette.success.lightChannel} / 0.72)`,
             '--LinearProgress-radius': '0px',
           })}
         />
@@ -72,7 +72,7 @@ export default function AlertInvertedColors() {
         color="danger"
         invertedColors
         startDecorator={
-          <CircularProgress size="lg">
+          <CircularProgress size="lg" color="danger">
             <Warning />
           </CircularProgress>
         }

--- a/docs/data/joy/components/alert/AlertInvertedColors.js
+++ b/docs/data/joy/components/alert/AlertInvertedColors.js
@@ -58,13 +58,13 @@ export default function AlertInvertedColors() {
           variant="solid"
           color="success"
           value={40}
-          sx={(theme) => ({
+          sx={{
             position: 'absolute',
             bottom: 0,
             left: 0,
             right: 0,
-            '--LinearProgress-radius': '0px',
-          })}
+            borderRadius: 0,
+          }}
         />
       </Alert>
       <Alert

--- a/docs/data/joy/components/alert/AlertInvertedColors.tsx
+++ b/docs/data/joy/components/alert/AlertInvertedColors.tsx
@@ -55,14 +55,14 @@ export default function AlertInvertedColors() {
           </Typography>
         </div>
         <LinearProgress
-          variant="soft"
+          variant="solid"
+          color="success"
           value={40}
           sx={(theme) => ({
             position: 'absolute',
             bottom: 0,
             left: 0,
             right: 0,
-            color: `rgb(${theme.vars.palette.success.lightChannel} / 0.72)`,
             '--LinearProgress-radius': '0px',
           })}
         />
@@ -72,7 +72,7 @@ export default function AlertInvertedColors() {
         color="danger"
         invertedColors
         startDecorator={
-          <CircularProgress size="lg">
+          <CircularProgress size="lg" color="danger">
             <Warning />
           </CircularProgress>
         }

--- a/docs/data/joy/components/alert/AlertInvertedColors.tsx
+++ b/docs/data/joy/components/alert/AlertInvertedColors.tsx
@@ -58,13 +58,13 @@ export default function AlertInvertedColors() {
           variant="solid"
           color="success"
           value={40}
-          sx={(theme) => ({
+          sx={{
             position: 'absolute',
             bottom: 0,
             left: 0,
             right: 0,
-            '--LinearProgress-radius': '0px',
-          })}
+            borderRadius: 0,
+          }}
         />
       </Alert>
       <Alert

--- a/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
+++ b/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
@@ -129,12 +129,13 @@ const CircularProgressRoot = styled('span', {
       },
     }),
     ...(ownerState.variant === 'soft' && {
-      '--CircularProgress-trackColor': 'var(--joy-palette-neutral-softBg)',
-      '--CircularProgress-progressColor': `var(--joy-palette-${ownerState.color}-solidBg)`,
+      '--CircularProgress-trackColor': theme.variants.soft.neutral.backgroundColor,
+      '--CircularProgress-progressColor': theme.variants.solid?.[ownerState.color!].backgroundColor,
     }),
     ...(ownerState.variant === 'solid' && {
-      '--CircularProgress-trackColor': `var(--joy-palette-${ownerState.color}-softHoverBg)`,
-      '--CircularProgress-progressColor': `var(--joy-palette-${ownerState.color}-solidBg)`,
+      '--CircularProgress-trackColor':
+        theme.variants.softHover?.[ownerState.color!].backgroundColor,
+      '--CircularProgress-progressColor': theme.variants.solid?.[ownerState.color!].backgroundColor,
     }),
   };
 });

--- a/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
+++ b/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
@@ -128,6 +128,14 @@ const CircularProgressRoot = styled('span', {
         ...rest,
       },
     }),
+    ...(ownerState.variant === 'soft' && {
+      '--CircularProgress-trackColor': 'var(--joy-palette-neutral-softBg)',
+      '--CircularProgress-progressColor': 'var(--joy-palette-primary-solidBg)',
+    }),
+    ...(ownerState.variant === 'solid' && {
+      '--CircularProgress-trackColor': 'var(--joy-palette-primary-softBg)',
+      '--CircularProgress-progressColor': 'var(--joy-palette-primary-solidBg)',
+    }),
   };
 });
 

--- a/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
+++ b/packages/mui-joy/src/CircularProgress/CircularProgress.tsx
@@ -130,11 +130,11 @@ const CircularProgressRoot = styled('span', {
     }),
     ...(ownerState.variant === 'soft' && {
       '--CircularProgress-trackColor': 'var(--joy-palette-neutral-softBg)',
-      '--CircularProgress-progressColor': 'var(--joy-palette-primary-solidBg)',
+      '--CircularProgress-progressColor': `var(--joy-palette-${ownerState.color}-solidBg)`,
     }),
     ...(ownerState.variant === 'solid' && {
-      '--CircularProgress-trackColor': 'var(--joy-palette-primary-softBg)',
-      '--CircularProgress-progressColor': 'var(--joy-palette-primary-solidBg)',
+      '--CircularProgress-trackColor': `var(--joy-palette-${ownerState.color}-softHoverBg)`,
+      '--CircularProgress-progressColor': `var(--joy-palette-${ownerState.color}-solidBg)`,
     }),
   };
 });

--- a/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
+++ b/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
@@ -115,11 +115,11 @@ const LinearProgressRoot = styled('div', {
     },
     ...(ownerState.variant === 'soft' && {
       backgroundColor: 'var(--joy-palette-neutral-softBg)',
-      color: 'var(--joy-palette-primary-solidBg)',
+      color: `var(--joy-palette-${ownerState.color}-solidBg)`,
     }),
     ...(ownerState.variant === 'solid' && {
-      backgroundColor: 'var(--joy-palette-primary-softBg)',
-      color: 'var(--joy-palette-primary-solidBg)',
+      backgroundColor: `var(--joy-palette-${ownerState.color}-softHoverBg)`,
+      color: `var(--joy-palette-${ownerState.color}-solidBg)`,
     }),
   }),
   ({ ownerState }) =>

--- a/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
+++ b/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
@@ -114,12 +114,12 @@ const LinearProgressRoot = styled('div', {
       position: 'absolute', // required to make `left` animation works.
     },
     ...(ownerState.variant === 'soft' && {
-      backgroundColor: 'var(--joy-palette-neutral-softBg)',
-      color: `var(--joy-palette-${ownerState.color}-solidBg)`,
+      backgroundColor: theme.variants.soft.neutral.backgroundColor,
+      color: theme.variants.solid?.[ownerState.color!].backgroundColor,
     }),
     ...(ownerState.variant === 'solid' && {
-      backgroundColor: `var(--joy-palette-${ownerState.color}-softHoverBg)`,
-      color: `var(--joy-palette-${ownerState.color}-solidBg)`,
+      backgroundColor: theme.variants.softHover?.[ownerState.color!].backgroundColor,
+      color: theme.variants.solid?.[ownerState.color!].backgroundColor,
     }),
   }),
   ({ ownerState }) =>

--- a/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
+++ b/packages/mui-joy/src/LinearProgress/LinearProgress.tsx
@@ -113,6 +113,14 @@ const LinearProgressRoot = styled('div', {
       color: 'inherit',
       position: 'absolute', // required to make `left` animation works.
     },
+    ...(ownerState.variant === 'soft' && {
+      backgroundColor: 'var(--joy-palette-neutral-softBg)',
+      color: 'var(--joy-palette-primary-solidBg)',
+    }),
+    ...(ownerState.variant === 'solid' && {
+      backgroundColor: 'var(--joy-palette-primary-softBg)',
+      color: 'var(--joy-palette-primary-solidBg)',
+    }),
   }),
   ({ ownerState }) =>
     ownerState.determinate


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of #39363 

## Linear Progress

| Current | New |
|--------|--------|
| <img width="820" alt="Screenshot 2023-10-17 at 15 33 02" src="https://github.com/mui/material-ui/assets/37222944/193e908c-b31a-4e93-9eda-392b1edc84e1"> | <img width="835" alt="Screenshot 2023-10-17 at 15 32 41" src="https://github.com/mui/material-ui/assets/37222944/9110f319-ec11-4195-a82b-1a9184055e2b"> | 

👉  https://deploy-preview-39492--material-ui.netlify.app/joy-ui/react-linear-progress/

## Circular Progress

| Current | New |
|--------|--------|
| <img width="829" alt="Screenshot 2023-10-17 at 15 34 35" src="https://github.com/mui/material-ui/assets/37222944/74cf2d5d-2716-4dc7-b3d4-3efbde6eabd5"> | <img width="823" alt="Screenshot 2023-10-17 at 15 34 22" src="https://github.com/mui/material-ui/assets/37222944/e789f91b-fdca-49f9-b59a-3f170151d5a1"> | 

👉  https://deploy-preview-39492--material-ui.netlify.app/joy-ui/react-circular-progress/