### PR TITLE
[docs][base-ui] POC for simpler Tailwind demos

### DIFF
--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.js
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { Switch as BaseSwitch } from '@mui/base/Switch';
 import { useTheme } from '@mui/system';
 
@@ -10,95 +9,42 @@ function useIsDarkMode() {
 }
 
 export default function UnstyledSwitchIntroduction() {
-  const label = { 'aria-label': 'Demo switch' };
-
   // Replace this with your app logic for determining dark modes
   const isDarkMode = useIsDarkMode();
 
   return (
     <div className={isDarkMode ? 'dark' : ''}>
-      <Switch slotProps={{ input: { ...label } }} defaultChecked />
-      <Switch slotProps={{ input: { ...label } }} />
-      <Switch slotProps={{ input: { ...label } }} defaultChecked disabled />
-      <Switch slotProps={{ input: { ...label } }} disabled />
+      <Switch aria-label="Demo switch" defaultChecked />
+      <Switch aria-label="Demo switch" />
+      <Switch aria-label="Demo switch" defaultChecked disabled />
+      <Switch aria-label="Demo switch" disabled />
     </div>
   );
 }
 
-const resolveSlotProps = (fn, args) => (typeof fn === 'function' ? fn(args) : fn);
-
 const Switch = React.forwardRef((props, ref) => {
+  const { 'aria-label': ariaLabel, ...other } = props;
   return (
     <BaseSwitch
       ref={ref}
-      {...props}
+      {...other}
       slotProps={{
-        ...props.slotProps,
-        root: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.root,
-            ownerState,
-          );
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              `relative inline-block w-[38px] h-[24px] m-2.5  ${
-                ownerState.disabled
-                  ? 'cursor-not-allowed opacity-40'
-                  : 'cursor-pointer'
-              }`,
-              resolvedSlotProps?.className,
-            ),
-          };
+        root: {
+          className:
+            'relative inline-block w-[38px] h-[24px] m-2.5 ui-disabled:cursor-not-allowed ui-disabledopacity-40 cursor-pointer',
         },
-        input: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.input,
-            ownerState,
-          );
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              'cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none',
-              resolvedSlotProps?.className,
-            ),
-          };
+        input: {
+          'aria-label': ariaLabel,
+          className:
+            'cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none',
         },
-        track: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.track,
-            ownerState,
-          );
-
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              `absolute block w-full h-full transition rounded-full border border-solid outline-none border-slate-300 dark:border-gray-700 shadow-[inset_0_1_1_rgb(0_0_0_/_0.05)] dark:shadow-[inset_0_1_1_rgb(0_0_0_/_0.5)] focus:shadow-purple-200 dark:focus:shadow-purple-600 
-              ${
-                ownerState.checked
-                  ? 'bg-purple-500 border-none'
-                  : 'bg-slate-100 dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800'
-              } `,
-              resolvedSlotProps?.className,
-            ),
-          };
+        track: {
+          className:
+            'absolute block w-full h-full transition rounded-full border border-solid outline-none border-slate-300 dark:border-gray-700 shadow-[inset_0_1_1_rgb(0_0_0_/_0.05)] dark:shadow-[inset_0_1_1_rgb(0_0_0_/_0.5)] focus:shadow-purple-200 dark:focus:shadow-purple-600 ui-checked:bg-purple-500 ui-checked:border-none bg-slate-100 dark:ui-not-checked:bg-slate-900 hover:ui-not-checked:bg-slate-200 dark:hover:ui-not-checked:bg-slate-800',
         },
-        thumb: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.thumb,
-            ownerState,
-          );
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              `block w-4 h-4 top-1 rounded-2xl border border-solid outline-none border-slate-300 dark:border-gray-700 transition shadow-[0_1px_2px_rgb(0_0_0_/_0.1)] dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.25)] ${
-                ownerState.checked
-                  ? 'left-[18px] bg-white border-none shadow-[0_0_0_rgb(0_0_0_/_0.3)]'
-                  : 'left-[4px] bg-white'
-              }  relative transition-all`,
-              resolvedSlotProps?.className,
-            ),
-          };
+        thumb: {
+          className:
+            'block w-4 h-4 top-1 rounded-2xl border border-solid outline-none border-slate-300 dark:border-gray-700 transition shadow-[0_1px_2px_rgb(0_0_0_/_0.1)] dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.25)] ui-checked:left-[18px] ui-checked:bg-white ui-checked:border-none ui-checked:shadow-[0_0_0_rgb(0_0_0_/_0.3)] ui-not-checked:left-[4px] relative transition-all',
         },
       }}
     />
@@ -106,14 +52,5 @@ const Switch = React.forwardRef((props, ref) => {
 });
 
 Switch.propTypes = {
-  /**
-   * The props used for each slot inside the Switch.
-   * @default {}
-   */
-  slotProps: PropTypes.shape({
-    input: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    root: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    thumb: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    track: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-  }),
+  'aria-label': PropTypes.string,
 };

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.js
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.js
@@ -31,7 +31,7 @@ const Switch = React.forwardRef((props, ref) => {
       slotProps={{
         root: {
           className:
-            'relative inline-block w-[38px] h-[24px] m-2.5 ui-disabled:cursor-not-allowed ui-disabledopacity-40 cursor-pointer',
+            'relative inline-block w-[38px] h-[24px] m-2.5 ui-disabled:cursor-not-allowed ui-disabled:opacity-40 cursor-pointer',
         },
         input: {
           'aria-label': ariaLabel,

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import clsx from 'clsx';
-import { Switch as BaseSwitch, SwitchProps } from '@mui/base/Switch';
+import { Switch as BaseSwitch } from '@mui/base/Switch';
 import { useTheme } from '@mui/system';
 
 function useIsDarkMode() {
@@ -9,96 +8,49 @@ function useIsDarkMode() {
 }
 
 export default function UnstyledSwitchIntroduction() {
-  const label = { 'aria-label': 'Demo switch' };
-
   // Replace this with your app logic for determining dark modes
   const isDarkMode = useIsDarkMode();
 
   return (
     <div className={isDarkMode ? 'dark' : ''}>
-      <Switch slotProps={{ input: { ...label } }} defaultChecked />
-      <Switch slotProps={{ input: { ...label } }} />
-      <Switch slotProps={{ input: { ...label } }} defaultChecked disabled />
-      <Switch slotProps={{ input: { ...label } }} disabled />
+      <Switch aria-label="Demo switch" defaultChecked />
+      <Switch aria-label="Demo switch" />
+      <Switch aria-label="Demo switch" defaultChecked disabled />
+      <Switch aria-label="Demo switch" disabled />
     </div>
   );
 }
 
-const resolveSlotProps = (fn: any, args: any) =>
-  typeof fn === 'function' ? fn(args) : fn;
-
+interface SwitchProps {
+  'aria-label'?: string;
+  checked?: boolean;
+  disabled?: boolean;
+  defaultChecked?: boolean;
+  readOnly?: boolean;
+}
 const Switch = React.forwardRef<HTMLSpanElement, SwitchProps>((props, ref) => {
+  const { 'aria-label': ariaLabel, ...other } = props;
   return (
     <BaseSwitch
       ref={ref}
-      {...props}
+      {...other}
       slotProps={{
-        ...props.slotProps,
-        root: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.root,
-            ownerState,
-          );
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              `relative inline-block w-[38px] h-[24px] m-2.5  ${
-                ownerState.disabled
-                  ? 'cursor-not-allowed opacity-40'
-                  : 'cursor-pointer'
-              }`,
-              resolvedSlotProps?.className,
-            ),
-          };
+        root: {
+          className:
+            'relative inline-block w-[38px] h-[24px] m-2.5 ui-disabled:cursor-not-allowed ui-disabledopacity-40 cursor-pointer',
         },
-        input: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.input,
-            ownerState,
-          );
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              'cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none',
-              resolvedSlotProps?.className,
-            ),
-          };
+        input: {
+          'aria-label': ariaLabel,
+          className:
+            'cursor-inherit absolute w-full h-full top-0 left-0 opacity-0 z-10 border-none',
         },
-        track: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.track,
-            ownerState,
-          );
-
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              `absolute block w-full h-full transition rounded-full border border-solid outline-none border-slate-300 dark:border-gray-700 shadow-[inset_0_1_1_rgb(0_0_0_/_0.05)] dark:shadow-[inset_0_1_1_rgb(0_0_0_/_0.5)] focus:shadow-purple-200 dark:focus:shadow-purple-600 
-              ${
-                ownerState.checked
-                  ? 'bg-purple-500 border-none'
-                  : 'bg-slate-100 dark:bg-slate-900 hover:bg-slate-200 dark:hover:bg-slate-800'
-              } `,
-              resolvedSlotProps?.className,
-            ),
-          };
+        track: {
+          className:
+            'absolute block w-full h-full transition rounded-full border border-solid outline-none border-slate-300 dark:border-gray-700 shadow-[inset_0_1_1_rgb(0_0_0_/_0.05)] dark:shadow-[inset_0_1_1_rgb(0_0_0_/_0.5)] focus:shadow-purple-200 dark:focus:shadow-purple-600 ui-checked:bg-purple-500 ui-checked:border-none bg-slate-100 dark:ui-not-checked:bg-slate-900 hover:ui-not-checked:bg-slate-200 dark:hover:ui-not-checked:bg-slate-800',
         },
-        thumb: (ownerState) => {
-          const resolvedSlotProps = resolveSlotProps(
-            props.slotProps?.thumb,
-            ownerState,
-          );
-          return {
-            ...resolvedSlotProps,
-            className: clsx(
-              `block w-4 h-4 top-1 rounded-2xl border border-solid outline-none border-slate-300 dark:border-gray-700 transition shadow-[0_1px_2px_rgb(0_0_0_/_0.1)] dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.25)] ${
-                ownerState.checked
-                  ? 'left-[18px] bg-white border-none shadow-[0_0_0_rgb(0_0_0_/_0.3)]'
-                  : 'left-[4px] bg-white'
-              }  relative transition-all`,
-              resolvedSlotProps?.className,
-            ),
-          };
+        thumb: {
+          className:
+            'block w-4 h-4 top-1 rounded-2xl border border-solid outline-none border-slate-300 dark:border-gray-700 transition shadow-[0_1px_2px_rgb(0_0_0_/_0.1)] dark:shadow-[0_1px_2px_rgb(0_0_0_/_0.25)] ui-checked:left-[18px] ui-checked:bg-white ui-checked:border-none ui-checked:shadow-[0_0_0_rgb(0_0_0_/_0.3)] ui-not-checked:left-[4px] relative transition-all',
         },
       }}
     />

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.tsx
@@ -37,7 +37,7 @@ const Switch = React.forwardRef<HTMLSpanElement, SwitchProps>((props, ref) => {
       slotProps={{
         root: {
           className:
-            'relative inline-block w-[38px] h-[24px] m-2.5 ui-disabled:cursor-not-allowed ui-disabledopacity-40 cursor-pointer',
+            'relative inline-block w-[38px] h-[24px] m-2.5 ui-disabled:cursor-not-allowed ui-disabled:opacity-40 cursor-pointer',
         },
         input: {
           'aria-label': ariaLabel,

--- a/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.tsx.preview
+++ b/docs/data/base/components/switch/UnstyledSwitchIntroduction/tailwind/index.tsx.preview
@@ -1,4 +1,4 @@
-<Switch slotProps={{ input: { ...label } }} defaultChecked />
-<Switch slotProps={{ input: { ...label } }} />
-<Switch slotProps={{ input: { ...label } }} defaultChecked disabled />
-<Switch slotProps={{ input: { ...label } }} disabled />
+<Switch aria-label="Demo switch" defaultChecked />
+<Switch aria-label="Demo switch" />
+<Switch aria-label="Demo switch" defaultChecked disabled />
+<Switch aria-label="Demo switch" disabled />

--- a/docs/src/modules/sandbox/CreateReactApp.ts
+++ b/docs/src/modules/sandbox/CreateReactApp.ts
@@ -76,6 +76,31 @@ export const getHtml = ({
             },
           },
         },
+        plugins: [
+          plugin(({ addVariant }) => {
+            [
+              'active',
+              'checked',
+              'completed',
+              'disabled',
+              'readOnly',
+              'error',
+              'expanded',
+              'focused',
+              'required',
+              'selected',
+            ].forEach((state) => {
+              addVariant(\`ui-\${state}\`, [\`&[class~="Mui-\${state}"]\`]);
+      
+              addVariant(\`ui-not-\${state}\`, [\`&:not([class~="Mui-\${state}"])\`]);
+            });
+      
+            // for focus-visible, use the same selector as headlessui
+            // https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-tailwindcss/src/index.ts#LL35C11-L35C11
+            addVariant('ui-focus-visible, [\`&[class~="Mui-focusVisible"]\`, \`&:focus-visible\`]);
+            addVariant(ui-not-focus-visible, [\`&:not([class~="Mui-focusVisible"])\`]);
+          }),
+        ],
       }
     </script>`
         : ''

--- a/packages/mui-base/src/Switch/Switch.tsx
+++ b/packages/mui-base/src/Switch/Switch.tsx
@@ -28,9 +28,27 @@ const useUtilityClasses = (ownerState: SwitchOwnerState) => {
       focusVisible && 'focusVisible',
       readOnly && 'readOnly',
     ],
-    thumb: ['thumb'],
-    input: ['input'],
-    track: ['track'],
+    thumb: [
+      'thumb',
+      checked && 'checked',
+      disabled && 'disabled',
+      focusVisible && 'focusVisible',
+      readOnly && 'readOnly',
+    ],
+    input: [
+      'input',
+      checked && 'checked',
+      disabled && 'disabled',
+      focusVisible && 'focusVisible',
+      readOnly && 'readOnly',
+    ],
+    track: [
+      'track',
+      checked && 'checked',
+      disabled && 'disabled',
+      focusVisible && 'focusVisible',
+      readOnly && 'readOnly',
+    ],
   };
 
   return composeClasses(slots, useClassNamesOverride(getSwitchUtilityClass));


### PR DESCRIPTION
This PR experiments with having simpler Base UI's demos when it comes to using Tailwind CSS. There are two aspects of the changes we could make:

- Treat the demo components as simplest as possible - we don't need to account for slots, slotProps and other props to be handled in the demo components, we can consider that the component has a simple API surface withprops that make sense in a design system like component.
- Use the tailwind plugin similar to the headless one. For this to work we need to have the state classes applied on all slots (see the Swtich.tsx's changes)

Other thoughts:
- the plugin works currently only with the global state classes, we will need to update it so that it works with class name specific classes 
- on the plugin support, we can go a step further and allow people to use selectors like `ui-switch-track` and add the classes related to the track slot on the class name prop itself. This will simplify the usage of the component, but will create bigger specificity for the slots
- on another thought, so that we don't have to decide on simple demo vs fully featured, we can have both of them, for e.g. on each demo we can link a fully featured component code, that people can copy and paste in their projects - it comes to deciding whether we want to make the demos simple, so that people are not taken off when they see how much code is required, or whether we want to make the fully feature component available immediatelly


Preview demo: https://deploy-preview-39502--material-ui.netlify.app/base-ui/react-switch/

TODO:
- [ ] Fix the sandbox