### PR TITLE
[base-ui][select] Standardize box shadow on demos

### DIFF
--- a/docs/data/base/components/select/UnstyledSelectBasic/css/index.js
+++ b/docs/data/base/components/select/UnstyledSelectBasic/css/index.js
@@ -100,7 +100,9 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};
-        box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
+        box-shadow: 0px 2px 4px ${
+          isDarkMode ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
+        };
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 120ms;

--- a/docs/data/base/components/select/UnstyledSelectBasic/css/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectBasic/css/index.tsx
@@ -100,7 +100,9 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};
-        box-shadow: 0px 2px 2px ${isDarkMode ? grey[900] : grey[50]};
+        box-shadow: 0px 2px 4px ${
+          isDarkMode ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
+        };
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 120ms;

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.js
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.js
@@ -100,8 +100,8 @@ function Styles() {
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};
         position: relative;
-        box-shadow: 0px 4px 6px ${
-          isDarkMode ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'
+        box-shadow: 0px 2px 4px ${
+          isDarkMode ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
         };
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/css/index.tsx
@@ -100,8 +100,8 @@ function Styles() {
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};
         position: relative;
-        box-shadow: 0px 4px 6px ${
-          isDarkMode ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'
+        box-shadow: 0px 2px 4px ${
+          isDarkMode ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
         };
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/tailwind/index.js
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/tailwind/index.js
@@ -100,7 +100,7 @@ const Select = React.forwardRef(function CustomSelect(props, ref) {
           return {
             ...resolvedSlotProps,
             className: clsx(
-              `relative text-sm font-sans box-border w-80 px-3 py-2 rounded-lg text-left bg-white dark:bg-slate-800 border border-solid border-slate-300 dark:border-slate-700 text-slate-900 dark:text-slate-300 transition-all hover:bg-slate-50 dark:hover:bg-slate-700 outline-0 shadow-[0_4px_6px_rgb(0_0_0/_0.5)] dark:shadow-indigo-950 ${
+              `relative text-sm font-sans box-border w-80 px-3 py-2 rounded-lg text-left bg-white dark:bg-slate-800 border border-solid border-slate-300 dark:border-slate-700 text-slate-900 dark:text-slate-300 transition-all hover:bg-slate-50 dark:hover:bg-slate-700 outline-0 shadow-[0_2px_4px_rgb(0_0_0/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0/_0.5)] ${
                 ownerState.focusVisible
                   ? 'border-purple-400 shadow-outline-purple'
                   : ''

--- a/docs/data/base/components/select/UnstyledSelectIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectIntroduction/tailwind/index.tsx
@@ -116,7 +116,7 @@ const Select = React.forwardRef(function CustomSelect<
           return {
             ...resolvedSlotProps,
             className: clsx(
-              `relative text-sm font-sans box-border w-80 px-3 py-2 rounded-lg text-left bg-white dark:bg-slate-800 border border-solid border-slate-300 dark:border-slate-700 text-slate-900 dark:text-slate-300 transition-all hover:bg-slate-50 dark:hover:bg-slate-700 outline-0 shadow-[0_4px_6px_rgb(0_0_0/_0.5)] dark:shadow-indigo-950 ${
+              `relative text-sm font-sans box-border w-80 px-3 py-2 rounded-lg text-left bg-white dark:bg-slate-800 border border-solid border-slate-300 dark:border-slate-700 text-slate-900 dark:text-slate-300 transition-all hover:bg-slate-50 dark:hover:bg-slate-700 outline-0 shadow-[0_2px_4px_rgb(0_0_0/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0/_0.5)] ${
                 ownerState.focusVisible
                   ? 'border-purple-400 shadow-outline-purple'
                   : ''


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow-up to #38820 

Standardize the box-shadow on all `Select` demos