### PR TITLE
[material-next][InputAdornment] Fix unstable_capitalize import

### DIFF
--- a/packages/mui-material-next/src/InputAdornment/InputAdornment.js
+++ b/packages/mui-material-next/src/InputAdornment/InputAdornment.js
@@ -2,10 +2,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import {
-  unstable_composeClasses as composeClasses,
-  unstable_capitalize as capitalize,
-} from '@mui/base/composeClasses';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import Typography from '@mui/material/Typography';
 import FormControlContext from '../FormControl/FormControlContext';
 import useFormControl from '../FormControl/useFormControl';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/39507

Import `unstable_capitalize` from `@mui/utils` and not `@mui/base/composeClasses`
