### PR TITLE
[zero][vite] Modify plugin to transform node_modules 

### DIFF
--- a/apps/local-library/index.d.ts
+++ b/apps/local-library/index.d.ts
@@ -1,0 +1,6 @@
+export const bounceAnim: string;
+export const Button: React.ComponentType<
+  JSX.IntrinsicElements['button'] & {
+    isRed?: boolean;
+  }
+>;

--- a/apps/local-library/index.js
+++ b/apps/local-library/index.js
@@ -1,0 +1,31 @@
+import { keyframes, styled } from '@mui/zero-runtime';
+
+export const bounceAnim = keyframes({
+  'from, 20%, 53%, 80%, to': {
+    transform: 'translate3d(0,0,0)',
+  },
+  '40%, 43%': {
+    transform: 'translate3d(0, -30px, 0)',
+  },
+  '70%': {
+    transform: 'translate3d(0, -15px, 0)',
+  },
+  '90%': {
+    transform: 'translate3d(0,-4px,0)',
+  },
+});
+
+export const Button = styled('button', {
+  name: 'MuiButton',
+  slot: 'Root',
+})(
+  ({ theme }) => ({
+    fontFamily: 'sans-serif',
+    backgroundColor: theme.palette.primary.main,
+  }),
+  {
+    fontFamily: 'sans-serif',
+    color: (props) => (props.isRed ? 'primary.main' : 'secondary.main'),
+    '--css-variable': (props) => (props.isRed ? 'palette.primary.main' : 'palette.secondary.main'),
+  },
+);

--- a/apps/local-library/package.json
+++ b/apps/local-library/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "local-ui-lib",
+  "version": "0.0.0",
+  "dependencies": {
+    "zero-runtime": "*"
+  }
+}

--- a/apps/zero-runtime-vite-app/package.json
+++ b/apps/zero-runtime-vite-app/package.json
@@ -26,6 +26,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^22.1.0",
+    "local-library": "file:../local-library",
     "vite": "4.4.11",
     "vitest": "^0.34.6"
   },

--- a/apps/zero-runtime-vite-app/src/App.tsx
+++ b/apps/zero-runtime-vite-app/src/App.tsx
@@ -1,51 +1,7 @@
 import * as React from 'react';
-import { styled, keyframes } from '@mui/zero-runtime';
+import { styled } from '@mui/zero-runtime';
+import { Button, bounceAnim } from 'local-library';
 import Slider from './Slider/ZeroSlider';
-
-const bounce = keyframes`
-  from, 20%, 53%, 80%, to {
-    transform: translate3d(0,0,0);
-  }
-  40%, 43% {
-    transform: translate3d(0, -30px, 0);
-  }
-  70% {
-    transform: translate3d(0, -15px, 0);
-  }
-  90% {
-    transform: translate3d(0,-4px,0);
-  }
-`;
-
-const bounceAnim = keyframes({
-  'from, 20%, 53%, 80%, to': {
-    transform: 'translate3d(0,0,0)',
-  },
-  '40%, 43%': {
-    transform: 'translate3d(0, -30px, 0)',
-  },
-  '70%': {
-    transform: 'translate3d(0, -15px, 0)',
-  },
-  '90%': {
-    transform: 'translate3d(0,-4px,0)',
-  },
-});
-
-const Button = styled('button', {
-  name: 'MuiButton',
-  slot: 'Root',
-})(
-  ({ theme }: any) => ({
-    fontFamily: 'sans-serif',
-    backgroundColor: [theme.palette.primary.main, 'text.primary', 'background.paper'],
-  }),
-  {
-    fontFamily: 'sans-serif',
-    // p: (props: any) => (props.isRed ? 10 : 20),
-    color: (props: any) => (props.isRed ? 'primary.main' : 'secondary.main'),
-  },
-);
 
 const ShowCaseDiv = styled('div')({
   [`.${Button}`]: {
@@ -59,7 +15,7 @@ const HalfWidth = styled.div({
   maxHeight: 100,
   padding: 20,
   border: '1px solid #ccc',
-  animation: [`${bounce} 1s ease infinite`, `${bounceAnim} 1s ease infinite`],
+  animation: `${bounceAnim} 1s ease infinite`,
 });
 
 export default function App({ isRed }: any) {

--- a/apps/zero-runtime-vite-app/vite.config.ts
+++ b/apps/zero-runtime-vite-app/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     zeroVitePlugin({
       cssVariablesPrefix: 'app',
       theme,
+      transformLibraries: ['local-library'],
     }),
     reactPlugin(),
     splitVendorChunkPlugin(),

--- a/packages/zero-runtime/package.json
+++ b/packages/zero-runtime/package.json
@@ -34,7 +34,7 @@
     "build:types": "node ../../scripts/buildTypes.mjs",
     "prebuild": "rimraf build tsconfig.build.tsbuildinfo",
     "release": "yarn build && npm publish build",
-    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/zero-babel-plugin/**/*.test.{js,ts,tsx}'",
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/zero-runtime/**/*.test.{js,ts,tsx}'",
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{spec,d}.{ts,tsx}\" && tsc -p tsconfig.json",
     "typescript:module-augmentation": "node scripts/testModuleAugmentation.js"
   },

--- a/packages/zero-tag-processor/src/utils/cssFnValueToVariable.ts
+++ b/packages/zero-tag-processor/src/utils/cssFnValueToVariable.ts
@@ -2,8 +2,6 @@ import type { ExpressionValue } from '@linaria/utils';
 import { transformSync, type Node } from '@babel/core';
 import { parseExpression } from '@babel/parser';
 import type { Expression } from '@linaria/tags';
-import type { Theme } from '@mui/material/styles';
-import { unstable_defaultSxConfig as defaultSxConfig } from '@mui/system/styleFunctionSx';
 import * as t from '@babel/types';
 import { isUnitLess } from './isUnitLess';
 import { cssFunctionTransformerPlugin } from './cssFunctionTransformerPlugin';
@@ -38,14 +36,10 @@ function transformThemeKeysInFn(
   filename?: string,
 ) {
   const { themeArgs: { theme } = {} } = options;
-  const userTheme = theme as Theme;
-  const config = userTheme?.unstable_sxConfig ?? defaultSxConfig;
-  const cssPropOptions = config[styleKey];
-  const { themeKey } = cssPropOptions;
 
   // return the function as-is if sxConfig does not contain
   // this css key
-  if (!theme || !config || !cssPropOptions || !themeKey) {
+  if (!theme) {
     return parseExpression(functionString);
   }
 

--- a/packages/zero-tag-processor/src/utils/cssFunctionTransformerPlugin.ts
+++ b/packages/zero-tag-processor/src/utils/cssFunctionTransformerPlugin.ts
@@ -31,13 +31,7 @@ const cssFunctionTransformerPlugin = declare<BabelPluginOptions>((api, pluginOpt
   };
   const config = typedTheme?.unstable_sxConfig ?? defaultSxConfig;
   const cssPropOptions = config[styleKey];
-  const { themeKey } = cssPropOptions;
-  if (!typedTheme || !config || !cssPropOptions || !themeKey) {
-    return {
-      name: '@mui/zero-internal/cssFunctionTransformerPlugin',
-      visitor: {},
-    };
-  }
+  const themeKey = cssPropOptions?.themeKey;
   const finalPrefix = cssVariablesPrefix ? `${cssVariablesPrefix}-` : '';
 
   return {
@@ -82,16 +76,19 @@ const cssFunctionTransformerPlugin = declare<BabelPluginOptions>((api, pluginOpt
         if (themeKey === 'typography' && val === 'inherit') {
           return;
         }
+        const propertyThemeKey = themeKey ?? val.split('.')[0];
         const themeValue =
-          get(typedTheme, `${themeKey}.${val}`) ??
-          (typedTheme.vars ? get(typedTheme.vars, `${themeKey}.${val}`) : undefined);
+          get(typedTheme, `${propertyThemeKey}.${val}`) ??
+          (typedTheme.vars ? get(typedTheme.vars, `${propertyThemeKey}.${val}`) : undefined);
         if (!themeValue) {
           console.warn(
-            `MUI: Value for key: ${val} does not exist in "theme.${themeKey}" or "theme.vars.${themeKey}"`,
+            `MUI: Value for key: ${val} does not exist in "theme.${propertyThemeKey}" or "theme.vars.${propertyThemeKey}"`,
           );
         }
         const themeKeyArr = val.split('.').join('-');
-        path.replaceWith(t.stringLiteral(`var(--${finalPrefix}${themeKey}-${themeKeyArr})`));
+        path.replaceWith(
+          t.stringLiteral(`var(--${finalPrefix}${propertyThemeKey}-${themeKeyArr})`),
+        );
       },
     },
   };

--- a/packages/zero-tag-processor/src/utils/index.ts
+++ b/packages/zero-tag-processor/src/utils/index.ts
@@ -1,0 +1,1 @@
+export type { PluginCustomOptions } from './cssFnValueToVariable';

--- a/packages/zero-vite-plugin/package.json
+++ b/packages/zero-vite-plugin/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.2",
-    "@linaria/vite": "^4.5.4",
+    "@linaria/logger": "^4.5.0",
+    "@linaria/utils": "^4.5.3",
     "@mui/zero-tag-processor": "0.0.1-alpha.0"
   },
   "devDependencies": {

--- a/packages/zero-vite-plugin/src/zero-vite-plugin.ts
+++ b/packages/zero-vite-plugin/src/zero-vite-plugin.ts
@@ -1,0 +1,222 @@
+/**
+ * Extended from -
+ * https://github.com/callstack/linaria/blob/master/packages/vite/src/index.ts
+ * for it be customizable in future
+ */
+
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import type { ModuleNode, Plugin, ResolvedConfig, ViteDevServer, FilterPattern } from 'vite';
+import { optimizeDeps, createFilter } from 'vite';
+
+import { transform, slugify, TransformCacheCollection } from '@linaria/babel-preset';
+import type { PluginOptions, Preprocessor } from '@linaria/babel-preset';
+import { createCustomDebug } from '@linaria/logger';
+import type { IPerfMeterOptions } from '@linaria/utils';
+import { createPerfMeter, getFileIdx, syncResolve } from '@linaria/utils';
+
+export type VitePluginOptions = {
+  debug?: IPerfMeterOptions | false | null | undefined;
+  exclude?: FilterPattern;
+  include?: FilterPattern;
+  preprocessor?: Preprocessor;
+  sourceMap?: boolean;
+  transformLibraries?: string[];
+} & Partial<PluginOptions>;
+
+export default function zeroVitePlugin({
+  debug,
+  include,
+  exclude,
+  sourceMap,
+  preprocessor,
+  transformLibraries = [],
+  ...rest
+}: VitePluginOptions = {}): Plugin {
+  const filter = createFilter(include, exclude);
+  const cssLookup: { [key: string]: string } = {};
+  const cssFileLookup: { [key: string]: string } = {};
+  let config: ResolvedConfig;
+  let devServer: ViteDevServer;
+
+  const { emitter, onDone } = createPerfMeter(debug ?? false);
+
+  // <dependency id, targets>
+  const targets: { dependencies: string[]; id: string }[] = [];
+  const cache = new TransformCacheCollection();
+  return {
+    name: 'vite-plugin-zero-runtime',
+    enforce: 'post',
+    buildEnd() {
+      onDone(process.cwd());
+    },
+    configResolved(resolvedConfig: ResolvedConfig) {
+      config = resolvedConfig;
+    },
+    configureServer(_server) {
+      devServer = _server;
+    },
+    load(url: string) {
+      const [id] = url.split('?', 1);
+      return cssLookup[id];
+    },
+    resolveId(importeeUrl: string) {
+      const [id] = importeeUrl.split('?', 1);
+      if (cssLookup[id]) {
+        return id;
+      }
+      return cssFileLookup[id];
+    },
+    handleHotUpdate(ctx) {
+      // it's module, so just transform it
+      if (ctx.modules.length) {
+        return ctx.modules;
+      }
+
+      // Select affected modules of changed dependency
+      const affected = targets.filter(
+        (x) =>
+          // file is dependency of any target
+          x.dependencies.some((dep) => dep === ctx.file) ||
+          // or changed module is a dependency of any target
+          x.dependencies.some((dep) => ctx.modules.some((m) => m.file === dep)),
+      );
+      const deps = affected.flatMap((target) => target.dependencies);
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const depId of deps) {
+        cache.invalidateForFile(depId);
+      }
+
+      return affected
+        .map((target) => devServer.moduleGraph.getModuleById(target.id))
+        .concat(ctx.modules)
+        .filter((m): m is ModuleNode => !!m);
+    },
+    async transform(code: string, url: string) {
+      const [id] = url.split('?', 1);
+
+      // Main modification start
+      if (id in cssLookup) {
+        return null;
+      }
+      let shouldReturn = url.includes('node_modules');
+
+      if (shouldReturn) {
+        shouldReturn = !transformLibraries.some((libName) => url.includes(libName));
+      }
+
+      if (shouldReturn) {
+        return null;
+      }
+      // Main modification end
+
+      // Do not transform ignored and generated files
+      if (!filter(url)) {
+        return null;
+      }
+
+      const log = createCustomDebug('rollup', getFileIdx(id));
+      log('Vite transform', id);
+
+      const asyncResolve = async (what: string, importer: string, stack: string[]) => {
+        const resolved = await this.resolve(what, importer);
+        if (resolved) {
+          if (resolved.external) {
+            // If module is marked as external, Rollup will not resolve it,
+            // so we need to resolve it ourselves with default resolver
+            const resolvedId = syncResolve(what, importer, stack);
+            log("resolve ✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+            return resolvedId;
+          }
+
+          log("resolve ✅ '%s'@'%s -> %O\n%s", what, importer, resolved);
+          // Vite adds param like `?v=667939b3` to cached modules
+          const resolvedId = resolved.id.split('?', 1)[0];
+
+          if (resolvedId.startsWith('\0')) {
+            // \0 is a special character in Rollup that tells Rollup to not include this in the bundle
+            // https://rollupjs.org/guide/en/#outputexports
+            return null;
+          }
+
+          if (!existsSync(resolvedId)) {
+            await optimizeDeps(config);
+          }
+
+          return resolvedId;
+        }
+
+        log("resolve ❌ '%s'@'%s", what, importer);
+        throw new Error(`Could not resolve ${what}`);
+      };
+
+      const result = await transform(
+        code,
+        {
+          filename: id,
+          preprocessor,
+          pluginOptions: rest,
+        },
+        asyncResolve,
+        {},
+        cache,
+        emitter,
+      );
+
+      let { cssText, dependencies } = result;
+
+      if (!cssText) {
+        return null;
+      }
+      dependencies ??= [];
+
+      const slug = slugify(cssText);
+      const cssFilename = path
+        .normalize(`${id.replace(/\.[jt]sx?$/, '')}_${slug}.css`)
+        .replace(/\\/g, path.posix.sep);
+
+      const cssRelativePath = path
+        .relative(config.root, cssFilename)
+        .replace(/\\/g, path.posix.sep);
+
+      const cssId = `/${cssRelativePath}`;
+
+      if (sourceMap && result.cssSourceMapText) {
+        const map = Buffer.from(result.cssSourceMapText).toString('base64');
+        cssText += `/*# sourceMappingURL=data:application/json;base64,${map}*/`;
+      }
+
+      cssLookup[cssFilename] = cssText;
+      cssFileLookup[cssId] = cssFilename;
+
+      result.code += `\nimport ${JSON.stringify(cssFilename)};\n`;
+      if (devServer?.moduleGraph) {
+        const module = devServer.moduleGraph.getModuleById(cssId);
+
+        if (module) {
+          devServer.moduleGraph.invalidateModule(module);
+          module.lastHMRTimestamp = module.lastInvalidationTimestamp || Date.now();
+        }
+      }
+
+      for (let i = 0, end = dependencies.length; i < end; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        const depModule = await this.resolve(dependencies[i], url, {
+          isEntry: false,
+        });
+        if (depModule) {
+          dependencies[i] = depModule.id;
+        }
+      }
+      const target = targets.find((t) => t.id === id);
+      if (!target) {
+        targets.push({ id, dependencies });
+      } else {
+        target.dependencies = dependencies;
+      }
+      return { code: result.code, map: result.sourceMap };
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,16 +2268,6 @@
     find-up "^5.0.0"
     minimatch "^9.0.3"
 
-"@linaria/vite@^4.5.4":
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/@linaria/vite/-/vite-4.5.4.tgz#bbccbd3de67715a8b6759a578c086c1ab31ec8d2"
-  integrity sha512-YhaLgTAfE7xzRLJwxWjo0Ak/YOJ+kPWuOm3lrkziclsvf1bbTUHlecmvth+2KuJG8HEPReekuyDErnwIQoD6sA==
-  dependencies:
-    "@linaria/babel-preset" "^4.5.4"
-    "@linaria/logger" "^4.5.0"
-    "@linaria/utils" "^4.5.3"
-    "@rollup/pluginutils" "^4.1.0"
-
 "@material-ui/types@^4.0.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-4.1.1.tgz#b65e002d926089970a3271213a3ad7a21b17f02b"
@@ -3087,14 +3077,6 @@
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     magic-string "^0.30.3"
-
-"@rollup/pluginutils@^4.1.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
-  dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
 
 "@rollup/pluginutils@^5.0.1":
   version "5.0.4"
@@ -8200,7 +8182,7 @@ estree-walker@^0.6.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
-estree-walker@^2.0.1, estree-walker@^2.0.2:
+estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
@@ -13726,7 +13708,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This feature allows users to specify a list of packages
that also uses zero runtime and transform the files at
build time. Default behavior is not transform any files
from node_modules.

Also, fix a bug where the transformation did not allow you to write callback functions for css variables.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
