### PR TITLE
[base-ui][Autocomplete] Standardize box shadow on demos

### DIFF
--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.js
@@ -194,8 +194,8 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};
-        box-shadow: 0px 4px 6px ${
-          isDarkMode ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'
+        box-shadow: 0px 2px 4px ${
+          isDarkMode ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
         };
         display: flex;
         gap: 5px;

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/css/index.tsx
@@ -168,8 +168,8 @@ function Styles() {
         background: ${isDarkMode ? grey[900] : '#fff'};
         border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
         color: ${isDarkMode ? grey[300] : grey[900]};
-        box-shadow: 0px 4px 6px ${
-          isDarkMode ? 'rgba(0,0,0, 0.50)' : 'rgba(0,0,0, 0.05)'
+        box-shadow: 0px 2px 4px ${
+          isDarkMode ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
         };
         display: flex;
         gap: 5px;

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.js
@@ -47,7 +47,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
         {...getRootProps(other)}
         ref={rootRef}
         className={clsx(
-          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0',
+          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0 shadow-[0_2px_4px_rgb(0_0_0/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0/_0.5)]',
           !focused &&
             'shadow-[0_2px_2px_transparent] shadow-gray-50 dark:shadow-gray-900',
           focused &&

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.js
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.js
@@ -47,7 +47,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
         {...getRootProps(other)}
         ref={rootRef}
         className={clsx(
-          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0 shadow-[0_2px_4px_rgb(0_0_0/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0/_0.5)]',
+          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0 shadow-[0_2px_4px_rgb(0_0_0_/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0_/_0.5)]',
           !focused &&
             'shadow-[0_2px_2px_transparent] shadow-gray-50 dark:shadow-gray-900',
           focused &&

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.tsx
@@ -49,7 +49,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(
         {...getRootProps(other)}
         ref={rootRef}
         className={clsx(
-          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0',
+          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0 shadow-[0_2px_4px_rgb(0_0_0/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0/_0.5)]',
           !focused &&
             'shadow-[0_2px_2px_transparent] shadow-gray-50 dark:shadow-gray-900',
           focused &&

--- a/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/autocomplete/AutocompleteIntroduction/tailwind/index.tsx
@@ -49,7 +49,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(
         {...getRootProps(other)}
         ref={rootRef}
         className={clsx(
-          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0 shadow-[0_2px_4px_rgb(0_0_0/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0/_0.5)]',
+          'flex gap-[5px] pr-[5px] overflow-hidden w-80 rounded-lg bg-white dark:bg-gray-800 border border-solid border-gray-200 dark:border-gray-700 hover:border-violet-400 dark:hover:border-violet-400 focus-visible:outline-0 shadow-[0_2px_4px_rgb(0_0_0_/_0.05)] dark:shadow-[0_2px_4px_rgb(0_0_0_/_0.5)]',
           !focused &&
             'shadow-[0_2px_2px_transparent] shadow-gray-50 dark:shadow-gray-900',
           focused &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow-up to https://github.com/mui/material-ui/pull/38820

Standardize the box-shadow on all Base UI `Autocomplete` demos.

👉  https://deploy-preview-39519--material-ui.netlify.app/base-ui/react-autocomplete/