### PR TITLE
[docs-infra] Refine the API page design

### DIFF
--- a/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
@@ -37,6 +37,9 @@ const StyledApiItem = styled(ExpendableApiItem)(
         fontSize: theme.typography.pxToRem(12),
       },
     },
+    '& .prop-list-deprecated': {
+      '& code ': { all: 'unset' },
+    },
     '& .prop-list-default-props': {
       ...theme.typography.body2,
       fontWeight: theme.typography.fontWeightSemiBold,
@@ -209,7 +212,7 @@ export default function PropertiesList(props: PropertiesListProps) {
             ))}
             {isDeprecated && (
               <Alert
-                className="MuiApi-collapsible"
+                className="MuiApi-collapsible prop-list-deprecated"
                 severity="warning"
                 icon={<WarningRoundedIcon fontSize="small" />}
                 sx={{
@@ -225,9 +228,7 @@ export default function PropertiesList(props: PropertiesListProps) {
                     {' - '}
                     <span
                       dangerouslySetInnerHTML={{
-                        __html: deprecationInfo
-                          .replace(/<code>/g, '<span>')
-                          .replace(/<\/code>/g, '</span>'),
+                        __html: deprecationInfo,
                       }}
                     />
                   </React.Fragment>
@@ -241,7 +242,7 @@ export default function PropertiesList(props: PropertiesListProps) {
                   <code
                     className="Api-code"
                     dangerouslySetInnerHTML={{
-                      __html: typeName.replace(/<br>&#124;/g, ' |'),
+                      __html: typeName,
                     }}
                   />
                 </p>

--- a/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
+++ b/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
@@ -60,9 +60,7 @@ export default function PropertiesSection(props) {
       const isOptional = !propData.required && showOptionalAbbr;
 
       const isDeprecated = propData.deprecated;
-      const deprecationInfo = propData.deprecationInfo
-        ?.replace(/<code>/g, '<span>')
-        ?.replace(/<\/code>/g, '</span>');
+      const deprecationInfo = propData.deprecationInfo;
 
       const typeName = propData.type?.description || propData.type.name;
       const propDefault = propData.default;

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -66,10 +66,10 @@ const StyledTable = styled('table')(
     '& .MuiPropTable-description-column': {
       width: '40%',
       paddingRight: 8,
-      '& .prop-list-description': {
+      '& .prop-table-description': {
         marginBottom: 0,
       },
-      '& .prop-list-additional-description': {
+      '& .prop-table-additional-description': {
         marginTop: 12,
         marginBottom: 0,
       },
@@ -94,13 +94,13 @@ const StyledTable = styled('table')(
         },
       },
     },
-    '& .prop-list-signature': {
+    '& .prop-table-signature': {
       marginTop: 12,
       marginBottom: 0,
       display: 'flex',
       flexDirection: 'column',
       gap: 16,
-      '& .prop-list-title': {
+      '& .prop-table-title': {
         fontWeight: theme.typography.fontWeightMedium,
       },
     },
@@ -125,8 +125,8 @@ const StyledTable = styled('table')(
         backgroundColor: `var(--muidocs-palette-grey-900, ${darkTheme.palette.grey[900]})`,
         borderColor: `var(--muidocs-palette-divider, ${darkTheme.palette.divider})`,
       },
-      '& .prop-list-signature': {
-        '& .prop-list-title': {
+      '& .prop-table-signature': {
+        '& .prop-table-title': {
           color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
         },
       },
@@ -157,7 +157,7 @@ function PropDescription({ description }: { description: string }) {
 
   return (
     <ComponentToRender
-      className="prop-list-description" // This className is used by Algolia
+      className="prop-table-description" // This className is used by Algolia
       dangerouslySetInnerHTML={{
         __html: description,
       }}
@@ -256,7 +256,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                 )}
                 {additionalInfo.map((key) => (
                   <p
-                    className="prop-list-additional-description"
+                    className="prop-table-additional-description"
                     key={key}
                     dangerouslySetInnerHTML={{
                       __html: t(`api-docs.additional-info.${key}`),
@@ -296,8 +296,8 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                   </Alert>
                 )}
                 {signature && (
-                  <div className="prop-list-signature">
-                    <span className="prop-list-title">{t('api-docs.signature')}:</span>
+                  <div className="prop-table-signature">
+                    <span className="prop-table-title">{t('api-docs.signature')}:</span>
 
                     <code
                       dangerouslySetInnerHTML={{

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -73,7 +73,9 @@ const StyledTable = styled('table')(
         marginTop: 12,
         marginBottom: 0,
       },
-      '& .refAlert': {
+      '& .prop-table-deprecated': {
+        '& code ': { all: 'unset' },
+      },
         padding: '2px 12px',
         marginTop: 12,
         color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
@@ -286,9 +288,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                         {' - '}
                         <span
                           dangerouslySetInnerHTML={{
-                            __html: deprecationInfo
-                              .replace(/<code>/g, '<span>')
-                              .replace(/<\/code>/g, '</span>'),
+                            __html: deprecationInfo,
                           }}
                         />
                       </React.Fragment>

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -76,6 +76,7 @@ const StyledTable = styled('table')(
       '& .prop-table-deprecated': {
         '& code ': { all: 'unset' },
       },
+      '& .prop-table-alert': {
         padding: '2px 12px',
         marginTop: 12,
         color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
@@ -133,7 +134,7 @@ const StyledTable = styled('table')(
         },
       },
       '& .MuiPropTable-description-column': {
-        '& .refAlert': {
+        '& .prop-table-alert': {
           color: `var(--muidocs-palette-warning-50, ${darkTheme.palette.warning[50]})`,
           backgroundColor: alpha(darkTheme.palette.warning[700], 0.15),
           borderColor: alpha(darkTheme.palette.warning[600], 0.3),
@@ -236,7 +237,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                 {description && <PropDescription description={description} />}
                 {requiresRef && (
                   <Alert
-                    className="refAlert"
+                    className="prop-table-alert"
                     severity="warning"
                     icon={<WarningRoundedIcon fontSize="small" />}
                     sx={{
@@ -268,19 +269,9 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                 {isDeprecated && (
                   <Alert
                     severity="warning"
+                    className="prop-table-alert prop-table-deprecated"
                     sx={{ mb: 1, py: 0 }}
-                    iconMapping={{
-                      warning: (
-                        <svg
-                          width="14"
-                          height="12"
-                          viewBox="0 0 14 12"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path d="M1.98012 11.9997H12.0201C13.0468 11.9997 13.6868 10.8864 13.1735 9.99971L8.15345 1.32638C7.64012 0.43971 6.36012 0.43971 5.84679 1.32638L0.826788 9.99971C0.313455 10.8864 0.953455 11.9997 1.98012 11.9997ZM7.00012 7.33304C6.63345 7.33304 6.33345 7.03304 6.33345 6.66638V5.33304C6.33345 4.96638 6.63345 4.66638 7.00012 4.66638C7.36679 4.66638 7.66679 4.96638 7.66679 5.33304V6.66638C7.66679 7.03304 7.36679 7.33304 7.00012 7.33304ZM7.66679 9.99971H6.33345V8.66638H7.66679V9.99971Z" />
-                        </svg>
-                      ),
-                    }}
+                    icon={<WarningRoundedIcon fontSize="small" />}
                   >
                     {t('api-docs.deprecated')}
                     {deprecationInfo && (


### PR DESCRIPTION
Some fixes are from lukas feedback that color were wrong on table layout, and that we supressed the `<code>` in warnings

Some are just classes renaming

Another one is from [slack message](https://mui-org.slack.com/archives/C05HHSFH2QJ/p1697561118893289)

> Oh yeah, this is way better.
>
> One thing I did notice is that long types are all on one line, which make them hard to read. Example here on api/popper is the modifiers prop:
>
> Type:Array<{ data?: object, effect?: func, enabled?: bool, fn?: func, name?: any, options?: object, phase?: 'afterMain' | 'afterRead' | 'afterWrite' | 'beforeMain' | 'beforeRead' | 'beforeWrite' | 'main' | 'read' | 'write', requires?: Array<string>, requiresIfExists?: Array<string> }>
sent from https://mui.com/material-ui/api/popper/ (from section <|New API content design)>

## Before / After

- [popper](https://mui.com/material-ui/api/popper/#Popper-prop-modifiers)
- [modal](https://mui.com/material-ui/api/modal/#props)

![image](https://github.com/mui/material-ui/assets/45398769/bf3e21ee-4d62-4cb2-8600-34d4ed112503)

![image](https://github.com/mui/material-ui/assets/45398769/4b74daee-3680-4ba7-89bc-2b7d4740bb38)


![image](https://github.com/mui/material-ui/assets/45398769/6c211a55-9c4b-4ee6-9c31-3e18bf109f0b)



The next should show no change even if `<span>` got replaced by `<code>`

![image](https://github.com/mui/material-ui/assets/45398769/b16fec09-6ac3-4810-94e6-fe9513107487)
