### PR TITLE
[docs] Improve upgrade experience from Material UI v4

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -219,7 +219,11 @@ function AppFrame(props) {
       <AppBar className={appBarClassName}>
         <Typography variant="body2" className={classes.banner} noWrap>
           {t('v5IsOut')}{' '}
-          <Link color="inherit" className={classes.bannerLink} href="https://mui.com">
+          <Link
+            color="inherit"
+            className={classes.bannerLink}
+            href="https://mui.com/material-ui/migration/migration-v4/"
+          >
             {t('v5docsLink')}
           </Link>{' '}
           {t('v5startAdoption')}

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -86,7 +86,7 @@
   "toggleTheme": "Toggle light/dark theme",
   "traffic": "Traffic",
   "v5IsOut": "🎉 Material UI v5 is out! Head to the",
-  "v5docsLink": "documentation",
+  "v5docsLink": "migration guide",
   "v5startAdoption": "to get started.",
   "usage": "Usage",
   "usageButton": "Explore the docs",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -85,7 +85,7 @@
   "toggleRTL": "Toggle right-to-left/left-to-right",
   "toggleTheme": "Toggle light/dark theme",
   "traffic": "Traffic",
-  "v5IsOut": "🎉 v5 is out! Head to the",
+  "v5IsOut": "🎉 Material UI v5 is out! Head to the",
   "v5docsLink": "documentation",
   "v5startAdoption": "to get started.",
   "usage": "Usage",


### PR DESCRIPTION
I have just noticed how broken the migration experience from v4 is.

Open https://v4.mui.com/components/container/ 🙈.

<img width="802" alt="Screenshot 2023-10-19 at 15 59 36" src="https://github.com/mui/material-ui/assets/3165635/df2116e2-1620-44a9-818d-b48c129aaafd">

- We say "migrate to v5, go to mui.com". meaning v5 is called MUI.
- We don't say anything on how to migrate", good luck