### PR TITLE
[docs-infra] Fix cut-off sponsors

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -20,7 +20,7 @@ const Nav = styled('nav')(({ theme }) => ({
   height: 'calc(100vh - var(--MuiDocs-header-height))',
   overflowY: 'auto',
   paddingTop: theme.spacing(4),
-  paddingBottom: theme.spacing(4),
+  paddingBottom: theme.spacing(7),
   paddingRight: theme.spacing(4), // We can't use `padding` as stylis-plugin-rtl doesn't swap it
   display: 'none',
   [theme.breakpoints.up('md')]: {

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -126,7 +126,7 @@ export default function DiamondSponsors() {
           href="/material-ui/discover-more/backers/#diamond"
           sx={(theme) => ({
             width: '100%',
-            p: 1.5,
+            p: 1,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',


### PR DESCRIPTION
In the current configuration, it feels like the go-to-top floating button will prevent the audience from comfortably clicking on the 3rd diamond sponsor without clicking on he go-to-top and the other way around. I think this PR goes in the right direction, I made only a small change, maybe it should be bolder.

Before https://master--material-ui.netlify.app/material-ui/react-button/#unstyled
<img width="585" alt="Screenshot 2023-10-23 at 00 50 05" src="https://github.com/mui/material-ui/assets/3165635/034bdf70-5b23-4870-8fe9-8ac59b0cffc7">

After https://deploy-preview-39572--material-ui.netlify.app/material-ui/react-button/#unstyled
<img width="582" alt="Screenshot 2023-10-23 at 00 48 38" src="https://github.com/mui/material-ui/assets/3165635/4c59f94a-7558-4d53-929c-9bc4490606b2">

A bit related to #39332.