### PR TITLE
[joy-ui] Add `CssVarsProvider` to quickstart demo

### DIFF
--- a/docs/data/joy/getting-started/usage/ButtonUsage.js
+++ b/docs/data/joy/getting-started/usage/ButtonUsage.js
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import Button from '@mui/joy/Button';
+import { CssVarsProvider } from '@mui/joy/styles';
 
 export default function ButtonUsage() {
-  return <Button variant="solid">Hello world</Button>;
+  return (
+    <CssVarsProvider>
+      <Button variant="solid">Hello world</Button>{' '}
+    </CssVarsProvider>
+  );
 }

--- a/docs/data/joy/getting-started/usage/ButtonUsage.tsx
+++ b/docs/data/joy/getting-started/usage/ButtonUsage.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import Button from '@mui/joy/Button';
+import { CssVarsProvider } from '@mui/joy/styles';
 
 export default function ButtonUsage() {
-  return <Button variant="solid">Hello world</Button>;
+  return (
+    <CssVarsProvider>
+      <Button variant="solid">Hello world</Button>{' '}
+    </CssVarsProvider>
+  );
 }

--- a/docs/data/joy/getting-started/usage/ButtonUsage.tsx.preview
+++ b/docs/data/joy/getting-started/usage/ButtonUsage.tsx.preview
@@ -1,1 +1,3 @@
-<Button variant="solid">Hello world</Button>
+<CssVarsProvider>
+  <Button variant="solid">Hello world</Button>{' '}
+</CssVarsProvider>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes https://mui-org.slack.com/archives/C050VE13HDL/p1698001033114239

preview: https://deploy-preview-39573--material-ui.netlify.app/joy-ui/getting-started/usage/#quickstart

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
