### PR TITLE
[examples][material-ui] Remove hardcoded `color="black"` from Next.js App Router layout

### DIFF
--- a/examples/material-ui-nextjs-ts/src/app/layout.tsx
+++ b/examples/material-ui-nextjs-ts/src/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AppBar position="fixed" sx={{ zIndex: 2000 }}>
             <Toolbar sx={{ backgroundColor: 'background.paper' }}>
               <DashboardIcon sx={{ color: '#444', mr: 2, transform: 'translateY(-2px)' }} />
-              <Typography variant="h6" noWrap component="div">
+              <Typography variant="h6" noWrap color="text.primary">
                 Next.js App Router
               </Typography>
             </Toolbar>

--- a/examples/material-ui-nextjs-ts/src/app/layout.tsx
+++ b/examples/material-ui-nextjs-ts/src/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AppBar position="fixed" sx={{ zIndex: 2000 }}>
             <Toolbar sx={{ backgroundColor: 'background.paper' }}>
               <DashboardIcon sx={{ color: '#444', mr: 2, transform: 'translateY(-2px)' }} />
-              <Typography variant="h6" noWrap component="div" color="black">
+              <Typography variant="h6" noWrap component="div">
                 Next.js App Router
               </Typography>
             </Toolbar>

--- a/examples/material-ui-nextjs-ts/src/app/layout.tsx
+++ b/examples/material-ui-nextjs-ts/src/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <AppBar position="fixed" sx={{ zIndex: 2000 }}>
             <Toolbar sx={{ backgroundColor: 'background.paper' }}>
               <DashboardIcon sx={{ color: '#444', mr: 2, transform: 'translateY(-2px)' }} />
-              <Typography variant="h6" noWrap color="text.primary">
+              <Typography variant="h6" color="text.primary">
                 Next.js App Router
               </Typography>
             </Toolbar>


### PR DESCRIPTION
Closes #39473 by removing `color="black"` from the Typography component at the top of `layout.tsx` so the colors will render correctly in light and dark modes.