### PR TITLE
[Input][base-ui] Update and port additional tests from material-ui

### DIFF
--- a/packages/mui-base/src/Input/Input.test.tsx
+++ b/packages/mui-base/src/Input/Input.test.tsx
@@ -56,39 +56,86 @@ describe('<Input />', () => {
     });
   });
 
-  it('should call event handlers passed in slotProps', () => {
-    const handleOnKeyDown = spy();
-    const handleOnKeyUp = spy();
-    const { getByRole } = render(
-      <Input
-        autoFocus
-        slotProps={{ input: { onKeyDown: handleOnKeyDown, onKeyUp: handleOnKeyUp } }}
-      />,
-    );
+  describe('event handlers', () => {
+    it('should call event handlers passed in slotProps', () => {
+      const handleChange = spy();
+      const handleFocus = spy();
+      const handleBlur = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
+      const { getByRole } = render(
+        <Input
+          slotProps={{
+            input: {
+              onChange: handleChange,
+              onFocus: handleFocus,
+              onBlur: handleBlur,
+              onKeyDown: handleKeyDown,
+              onKeyUp: handleKeyUp,
+            },
+          }}
+        />,
+      );
 
-    const input = getByRole('textbox');
+      const input = getByRole('textbox');
 
-    fireEvent.keyDown(input, { key: 'a' });
-    fireEvent.keyUp(input, { key: 'a' });
+      act(() => {
+        input.focus();
+      });
+      expect(handleFocus.callCount).to.equal(1);
 
-    expect(handleOnKeyDown.callCount).to.equal(1);
-    expect(handleOnKeyUp.callCount).to.equal(1);
-  });
+      fireEvent.keyDown(input, { key: 'a' });
+      expect(handleKeyDown.callCount).to.equal(1);
 
-  it('should call event handlers passed to component', () => {
-    const handleOnKeyDown = spy();
-    const handleOnKeyUp = spy();
-    const { getByRole } = render(
-      <Input onKeyDown={handleOnKeyDown} onKeyUp={handleOnKeyUp} autoFocus />,
-    );
+      fireEvent.change(input, { target: { value: 'a' } });
+      expect(handleChange.callCount).to.equal(1);
 
-    const input = getByRole('textbox');
+      fireEvent.keyUp(input, { key: 'a' });
+      expect(handleKeyUp.callCount).to.equal(1);
 
-    fireEvent.keyDown(input, { key: 'a' });
-    fireEvent.keyUp(input, { key: 'a' });
+      act(() => {
+        input.blur();
+      });
+      expect(handleBlur.callCount).to.equal(1);
+    });
 
-    expect(handleOnKeyDown.callCount).to.equal(1);
-    expect(handleOnKeyUp.callCount).to.equal(1);
+    it('should call event handlers passed to component', () => {
+      const handleChange = spy();
+      const handleFocus = spy();
+      const handleBlur = spy();
+      const handleKeyDown = spy();
+      const handleKeyUp = spy();
+      const { getByRole } = render(
+        <Input
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyUp={handleKeyUp}
+          onKeyDown={handleKeyDown}
+        />,
+      );
+
+      const input = getByRole('textbox');
+
+      act(() => {
+        input.focus();
+      });
+      expect(handleFocus.callCount).to.equal(1);
+
+      fireEvent.keyDown(input, { key: 'a' });
+      expect(handleKeyDown.callCount).to.equal(1);
+
+      fireEvent.change(input, { target: { value: 'a' } });
+      expect(handleChange.callCount).to.equal(1);
+
+      fireEvent.keyUp(input, { key: 'a' });
+      expect(handleKeyUp.callCount).to.equal(1);
+
+      act(() => {
+        input.blur();
+      });
+      expect(handleBlur.callCount).to.equal(1);
+    });
   });
 
   describe('prop: multiline', () => {

--- a/packages/mui-base/src/Input/Input.test.tsx
+++ b/packages/mui-base/src/Input/Input.test.tsx
@@ -5,6 +5,7 @@ import {
   describeConformanceUnstyled,
   fireEvent,
   screen,
+  act,
 } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
@@ -103,6 +104,25 @@ describe('<Input />', () => {
       );
 
       render(<Input multiline minRows={5} maxRows={10} slots={{ textarea: CustomTextarea }} />);
+    });
+
+    it('should forward the value to the textarea', () => {
+      render(<Input multiline maxRows={4} value="Hello" />);
+
+      const textarea = screen.getByRole('textbox', { hidden: false });
+      expect(textarea).to.have.value('Hello');
+    });
+
+    it('should preserve state when changing rows', () => {
+      const { setProps } = render(<Input multiline />);
+      const textarea = screen.getByRole('textbox', { hidden: false });
+      act(() => {
+        textarea.focus();
+      });
+
+      setProps({ rows: 4 });
+
+      expect(textarea).toHaveFocus();
     });
   });
 });

--- a/packages/mui-base/src/Input/Input.test.tsx
+++ b/packages/mui-base/src/Input/Input.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { Input, inputClasses } from '@mui/base/Input';
+import { Input, inputClasses, InputOwnerState } from '@mui/base/Input';
 
 describe('<Input />', () => {
   const mount = createMount();
@@ -50,7 +50,7 @@ describe('<Input />', () => {
     });
 
     it('should be able to access the native textarea of a multiline input', () => {
-      const inputRef = React.createRef();
+      const inputRef = React.createRef<HTMLInputElement>();
       const { container } = render(<Input multiline slotProps={{ input: { ref: inputRef } }} />);
       expect(inputRef.current).to.equal(container.querySelector('textarea'));
     });
@@ -150,6 +150,7 @@ describe('<Input />', () => {
       const CustomInput = React.forwardRef(function CustomInput(
         props: {
           onChange: (...args: string[]) => void;
+          ownerState: InputOwnerState;
         },
         ref: React.ForwardedRef<HTMLInputElement>,
       ) {

--- a/packages/mui-base/src/useInput/useInput.test.tsx
+++ b/packages/mui-base/src/useInput/useInput.test.tsx
@@ -24,6 +24,18 @@ describe('useInput', () => {
   });
 
   describe('prop: disabled', () => {
+    it('should render a disabled <input />', () => {
+      function Input(props: { disabled: boolean }) {
+        const { getInputProps } = useInput({
+          disabled: props.disabled,
+        });
+        return <input {...getInputProps()} />;
+      }
+      const { getByRole } = render(<Input disabled />);
+      const input = getByRole('textbox');
+      expect(input).to.have.attribute('disabled');
+    });
+
     it('should reset the focused state if getting disabled', () => {
       const handleBlur = spy();
       const handleFocus = spy();

--- a/packages/mui-material-next/src/InputBase/InputBase.test.tsx
+++ b/packages/mui-material-next/src/InputBase/InputBase.test.tsx
@@ -613,13 +613,14 @@ describe('<InputBase />', () => {
   });
 
   describe('prop: slots and slotProps', () => {
-    // e.g. integration of react-select with InputBase
-    // https://github.com/mui/material-ui/issues/18130
-    // react-select has a custom onChange that is essentially "(string, string) => void"
     it('should call slotProps.input.onChange callback with all params sent from custom inputComponent', () => {
       const INPUT_VALUE = 'material';
       const OUTPUT_VALUE = 'test';
-
+      /**
+       * This component simulates the integration of react-select with Input
+       * react-select has a custom onChange that is essentially "(string, string) => void"
+       * https://github.com/mui/material-ui/issues/18130
+       */
       const MyInputBase = React.forwardRef(function MyInputBase(
         props: {
           onChange: (...args: string[]) => void;


### PR DESCRIPTION
Part of: https://github.com/mui/material-ui/pull/38392
Follow up to: https://github.com/mui/material-ui/pull/38392#discussion_r1291341517

This PR ports relevant tests from `material-next/InputBase` to Base's `Input.test`/`useInput.test`, as lot of functionality that was in the v5 InputBase has been migrated to Base UI.



- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
