### PR TITLE
[material][styled-engine-sc] Fix ownerstate being propagated to DOM node

### DIFF
--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -1,9 +1,9 @@
 'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from '../styles/styled';
+import styled, { rootShouldForwardProp } from '../styles/styled';
 
-const NotchedOutlineRoot = styled('fieldset')({
+const NotchedOutlineRoot = styled('fieldset', { shouldForwardProp: rootShouldForwardProp })({
   textAlign: 'left',
   position: 'absolute',
   bottom: 0,
@@ -20,47 +20,49 @@ const NotchedOutlineRoot = styled('fieldset')({
   minWidth: '0%',
 });
 
-const NotchedOutlineLegend = styled('legend')(({ ownerState, theme }) => ({
-  float: 'unset', // Fix conflict with bootstrap
-  width: 'auto', // Fix conflict with bootstrap
-  overflow: 'hidden', // Fix Horizontal scroll when label too long
-  ...(!ownerState.withLabel && {
-    padding: 0,
-    lineHeight: '11px', // sync with `height` in `legend` styles
-    transition: theme.transitions.create('width', {
-      duration: 150,
-      easing: theme.transitions.easing.easeOut,
-    }),
-  }),
-  ...(ownerState.withLabel && {
-    display: 'block', // Fix conflict with normalize.css and sanitize.css
-    padding: 0,
-    height: 11, // sync with `lineHeight` in `legend` styles
-    fontSize: '0.75em',
-    visibility: 'hidden',
-    maxWidth: 0.01,
-    transition: theme.transitions.create('max-width', {
-      duration: 50,
-      easing: theme.transitions.easing.easeOut,
-    }),
-    whiteSpace: 'nowrap',
-    '& > span': {
-      paddingLeft: 5,
-      paddingRight: 5,
-      display: 'inline-block',
-      opacity: 0,
-      visibility: 'visible',
-    },
-    ...(ownerState.notched && {
-      maxWidth: '100%',
-      transition: theme.transitions.create('max-width', {
-        duration: 100,
+const NotchedOutlineLegend = styled('legend', { shouldForwardProp: rootShouldForwardProp })(
+  ({ ownerState, theme }) => ({
+    float: 'unset', // Fix conflict with bootstrap
+    width: 'auto', // Fix conflict with bootstrap
+    overflow: 'hidden', // Fix Horizontal scroll when label too long
+    ...(!ownerState.withLabel && {
+      padding: 0,
+      lineHeight: '11px', // sync with `height` in `legend` styles
+      transition: theme.transitions.create('width', {
+        duration: 150,
         easing: theme.transitions.easing.easeOut,
-        delay: 50,
+      }),
+    }),
+    ...(ownerState.withLabel && {
+      display: 'block', // Fix conflict with normalize.css and sanitize.css
+      padding: 0,
+      height: 11, // sync with `lineHeight` in `legend` styles
+      fontSize: '0.75em',
+      visibility: 'hidden',
+      maxWidth: 0.01,
+      transition: theme.transitions.create('max-width', {
+        duration: 50,
+        easing: theme.transitions.easing.easeOut,
+      }),
+      whiteSpace: 'nowrap',
+      '& > span': {
+        paddingLeft: 5,
+        paddingRight: 5,
+        display: 'inline-block',
+        opacity: 0,
+        visibility: 'visible',
+      },
+      ...(ownerState.notched && {
+        maxWidth: '100%',
+        transition: theme.transitions.create('max-width', {
+          duration: 100,
+          easing: theme.transitions.easing.easeOut,
+          delay: 50,
+        }),
       }),
     }),
   }),
-}));
+);
 
 /**
  * @ignore - internal component.

--- a/packages/mui-material/src/Radio/RadioButtonIcon.js
+++ b/packages/mui-material/src/Radio/RadioButtonIcon.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
-import styled from '../styles/styled';
+import styled, { rootShouldForwardProp } from '../styles/styled';
 
 const RadioButtonIconRoot = styled('span', { shouldForwardProp: rootShouldForwardProp })({
   position: 'relative',

--- a/packages/mui-material/src/Radio/RadioButtonIcon.js
+++ b/packages/mui-material/src/Radio/RadioButtonIcon.js
@@ -5,7 +5,7 @@ import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import styled from '../styles/styled';
 
-const RadioButtonIconRoot = styled('span')({
+const RadioButtonIconRoot = styled('span', { shouldForwardProp: rootShouldForwardProp })({
   position: 'relative',
   display: 'flex',
 });

--- a/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import styled from '../styles/styled';
+import styled, { rootShouldForwardProp } from '../styles/styled';
 import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
 

--- a/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeArea.js
@@ -6,29 +6,31 @@ import styled from '../styles/styled';
 import capitalize from '../utils/capitalize';
 import { isHorizontal } from '../Drawer/Drawer';
 
-const SwipeAreaRoot = styled('div')(({ theme, ownerState }) => ({
-  position: 'fixed',
-  top: 0,
-  left: 0,
-  bottom: 0,
-  zIndex: theme.zIndex.drawer - 1,
-  ...(ownerState.anchor === 'left' && {
-    right: 'auto',
-  }),
-  ...(ownerState.anchor === 'right' && {
-    left: 'auto',
-    right: 0,
-  }),
-  ...(ownerState.anchor === 'top' && {
-    bottom: 'auto',
-    right: 0,
-  }),
-  ...(ownerState.anchor === 'bottom' && {
-    top: 'auto',
+const SwipeAreaRoot = styled('div', { shouldForwardProp: rootShouldForwardProp })(
+  ({ theme, ownerState }) => ({
+    position: 'fixed',
+    top: 0,
+    left: 0,
     bottom: 0,
-    right: 0,
+    zIndex: theme.zIndex.drawer - 1,
+    ...(ownerState.anchor === 'left' && {
+      right: 'auto',
+    }),
+    ...(ownerState.anchor === 'right' && {
+      left: 'auto',
+      right: 0,
+    }),
+    ...(ownerState.anchor === 'top' && {
+      bottom: 'auto',
+      right: 0,
+    }),
+    ...(ownerState.anchor === 'bottom' && {
+      top: 'auto',
+      bottom: 0,
+      right: 0,
+    }),
   }),
-}));
+);
 
 /**
  * @ignore - internal component.

--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -33,7 +33,7 @@ const SwitchBaseRoot = styled(ButtonBase)(({ ownerState }) => ({
   }),
 }));
 
-const SwitchBaseInput = styled('input')({
+const SwitchBaseInput = styled('input', { shouldForwardProp: rootShouldForwardProp })({
   cursor: 'inherit',
   position: 'absolute',
   opacity: 0,

--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { refType } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import capitalize from '../utils/capitalize';
-import styled from '../styles/styled';
+import styled, { rootShouldForwardProp } from '../styles/styled';
 import useControlled from '../utils/useControlled';
 import useFormControl from '../FormControl/useFormControl';
 import ButtonBase from '../ButtonBase';


### PR DESCRIPTION
This PR fixes https://github.com/mui/material-ui/issues/38431#issuecomment-1766076798. Starting from v6 styled-components no longer blocks the invalid props used on components created with the styled() util. In 4 of the Material UI components we are using a tag without specifying a slot name for it primitive tag without specifying slot name for it. For all of these components, all props propagated are ending up on the DOM element. This PR adds explicitly a `shouldForwardProp` on these places. @siriwatknp we will need to apply the same on Joy UI in cases where we don't have specified slot on the styled component. 

Previous (search for ownerstate in the DOM inspector): https://codesandbox.io/s/styled-components-forked-pxgs8h?file=/src/demo.js
Now (if it wants to load): https://codesandbox.io/s/styled-components-forked-tjtlgp?file=/src/demo.js