### PR TITLE
[base-ui][useSelect] Support browser autofill

### DIFF
--- a/docs/pages/base-ui/api/select.json
+++ b/docs/pages/base-ui/api/select.json
@@ -1,6 +1,7 @@
 {
   "props": {
     "areOptionsEqual": { "type": { "name": "func" } },
+    "autoComplete": { "type": { "name": "string" } },
     "autoFocus": { "type": { "name": "bool" }, "default": "false" },
     "defaultListboxOpen": { "type": { "name": "bool" }, "default": "false" },
     "defaultValue": { "type": { "name": "any" } },

--- a/docs/pages/base-ui/api/use-select.json
+++ b/docs/pages/base-ui/api/use-select.json
@@ -89,8 +89,8 @@
     "disabled": { "type": { "name": "boolean", "description": "boolean" }, "required": true },
     "dispatch": {
       "type": {
-        "name": "(action: ListAction&lt;Value&gt; | SelectAction) =&gt; void",
-        "description": "(action: ListAction&lt;Value&gt; | SelectAction) =&gt; void"
+        "name": "(action: ListAction&lt;Value&gt; | SelectAction&lt;Value&gt;) =&gt; void",
+        "description": "(action: ListAction&lt;Value&gt; | SelectAction&lt;Value&gt;) =&gt; void"
       },
       "required": true
     },

--- a/docs/translations/api-docs-base/select/select.json
+++ b/docs/translations/api-docs-base/select/select.json
@@ -4,6 +4,9 @@
     "areOptionsEqual": {
       "description": "A function used to determine if two options&#39; values are equal. By default, reference equality is used.<br>There is a performance impact when using the <code>areOptionsEqual</code> prop (proportional to the number of options). Therefore, it&#39;s recommented to use the default reference equality comparison whenever possible."
     },
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
     "autoFocus": {
       "description": "If <code>true</code>, the select element is focused during the first mount"
     },

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -1261,4 +1261,58 @@ describe('<Select />', () => {
     expect(renderOption3Spy.callCount).to.equal(0);
     expect(renderOption4Spy.callCount).to.equal(0);
   });
+
+  describe('browser autofill', () => {
+    it('sets value and calls external onChange when browser autofills', () => {
+      const onChangeHandler = spy();
+      const { container } = render(
+        <Select onChange={onChangeHandler} defaultValue="germany" autoComplete="country">
+          <Option value="france">France</Option>
+          <Option value="germany">Germany</Option>
+          <Option value="china">China</Option>
+        </Select>,
+      );
+
+      const hiddenInput = container.querySelector('[autocomplete="country"]');
+
+      expect(hiddenInput).not.to.eq(null);
+      expect(hiddenInput).to.have.value('germany');
+
+      fireEvent.change(hiddenInput!, {
+        target: {
+          value: 'france',
+        },
+      });
+
+      expect(onChangeHandler.calledOnce).to.equal(true);
+      expect(onChangeHandler.firstCall.args[1]).to.equal('france');
+      expect(hiddenInput).to.have.value('france');
+    });
+
+    it('clears value and calls external onChange when browser clears autofill', () => {
+      const onChangeHandler = spy();
+      const { container } = render(
+        <Select onChange={onChangeHandler} defaultValue="germany" autoComplete="country">
+          <Option value="france">France</Option>
+          <Option value="germany">Germany</Option>
+          <Option value="china">China</Option>
+        </Select>,
+      );
+
+      const hiddenInput = container.querySelector('[autocomplete="country"]');
+
+      expect(hiddenInput).not.to.eq(null);
+      expect(hiddenInput).to.have.value('germany');
+
+      fireEvent.change(hiddenInput!, {
+        target: {
+          value: '',
+        },
+      });
+
+      expect(onChangeHandler.calledOnce).to.equal(true);
+      expect(onChangeHandler.firstCall.args[1]).to.equal(null);
+      expect(hiddenInput).to.have.value('');
+    });
+  });
 });

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -1289,6 +1289,31 @@ describe('<Select />', () => {
       expect(hiddenInput).to.have.value('france');
     });
 
+    it('does not set value when browser autofills invalid value', () => {
+      const onChangeHandler = spy();
+      const { container } = render(
+        <Select onChange={onChangeHandler} defaultValue="germany" autoComplete="country">
+          <Option value="france">France</Option>
+          <Option value="germany">Germany</Option>
+          <Option value="china">China</Option>
+        </Select>,
+      );
+
+      const hiddenInput = container.querySelector('[autocomplete="country"]');
+
+      expect(hiddenInput).not.to.eq(null);
+      expect(hiddenInput).to.have.value('germany');
+
+      fireEvent.change(hiddenInput!, {
+        target: {
+          value: 'portugal',
+        },
+      });
+
+      expect(onChangeHandler.called).to.equal(false);
+      expect(hiddenInput).to.have.value('germany');
+    });
+
     it('clears value and calls external onChange when browser clears autofill', () => {
       const onChangeHandler = spy();
       const { container } = render(

--- a/packages/mui-base/src/Select/Select.tsx
+++ b/packages/mui-base/src/Select/Select.tsx
@@ -71,6 +71,7 @@ const Select = React.forwardRef(function Select<
 ) {
   const {
     areOptionsEqual,
+    autoComplete,
     autoFocus,
     children,
     defaultValue,
@@ -225,7 +226,7 @@ const Select = React.forwardRef(function Select<
         </PopperComponent>
       )}
 
-      <input {...getHiddenInputProps()} />
+      <input {...getHiddenInputProps()} autoComplete={autoComplete} />
     </React.Fragment>
   );
 }) as SelectType;

--- a/packages/mui-base/src/Select/Select.tsx
+++ b/packages/mui-base/src/Select/Select.tsx
@@ -245,6 +245,12 @@ Select.propTypes /* remove-proptypes */ = {
    */
   areOptionsEqual: PropTypes.func,
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
    * If `true`, the select element is focused during the first mount
    * @default false
    */

--- a/packages/mui-base/src/Select/Select.types.ts
+++ b/packages/mui-base/src/Select/Select.types.ts
@@ -19,6 +19,12 @@ export interface SelectOwnProps<OptionValue extends {}, Multiple extends boolean
    */
   areOptionsEqual?: (a: OptionValue, b: OptionValue) => boolean;
   /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete?: string;
+  /**
    * If `true`, the select element is focused during the first mount
    * @default false
    */

--- a/packages/mui-base/src/useList/listActions.types.ts
+++ b/packages/mui-base/src/useList/listActions.types.ts
@@ -56,7 +56,7 @@ interface ResetHighlightAction {
   event: React.SyntheticEvent | null;
 }
 
-interface ClearSelection {
+interface ClearSelectionAction {
   type: typeof ListActionTypes.clearSelection;
 }
 
@@ -72,4 +72,4 @@ export type ListAction<ItemValue> =
   | KeyDownAction
   | ResetHighlightAction
   | TextNavigationAction
-  | ClearSelection;
+  | ClearSelectionAction;

--- a/packages/mui-base/src/useList/listActions.types.ts
+++ b/packages/mui-base/src/useList/listActions.types.ts
@@ -7,6 +7,7 @@ export const ListActionTypes = {
   keyDown: 'list:keyDown',
   resetHighlight: 'list:resetHighlight',
   textNavigation: 'list:textNavigation',
+  clearSelection: 'list:clearSelection',
 } as const;
 
 interface ItemClickAction<ItemValue> {
@@ -55,6 +56,10 @@ interface ResetHighlightAction {
   event: React.SyntheticEvent | null;
 }
 
+interface ClearSelection {
+  type: typeof ListActionTypes.clearSelection;
+}
+
 /**
  * A union of all standard actions that can be dispatched to the list reducer.
  */
@@ -66,4 +71,5 @@ export type ListAction<ItemValue> =
   | ItemsChangeAction<ItemValue>
   | KeyDownAction
   | ResetHighlightAction
-  | TextNavigationAction;
+  | TextNavigationAction
+  | ClearSelection;

--- a/packages/mui-base/src/useList/listReducer.test.ts
+++ b/packages/mui-base/src/useList/listReducer.test.ts
@@ -1142,4 +1142,32 @@ describe('listReducer', () => {
       expect(result.highlightedValue).to.equal('two');
     });
   });
+
+  describe('action: clearSelection', () => {
+    it('clears the selection', () => {
+      const state: ListState<string> = {
+        highlightedValue: null,
+        selectedValues: ['one', 'two'],
+      };
+
+      const action: ListReducerAction<string> = {
+        type: ListActionTypes.clearSelection,
+        context: {
+          items: ['one', 'two', 'three'],
+          disableListWrap: false,
+          disabledItemsFocusable: false,
+          focusManagement: 'DOM',
+          isItemDisabled: () => false,
+          itemComparer: (o, v) => o === v,
+          getItemAsString: (option) => option,
+          orientation: 'vertical',
+          pageSize: 5,
+          selectionMode: 'none',
+        },
+      };
+
+      const result = listReducer(state, action);
+      expect(result.selectedValues).to.deep.equal([]);
+    });
+  });
 });

--- a/packages/mui-base/src/useList/listReducer.test.ts
+++ b/packages/mui-base/src/useList/listReducer.test.ts
@@ -63,6 +63,35 @@ describe('listReducer', () => {
       expect(result.selectedValues).to.deep.equal(['two']);
     });
 
+    it('does not select a disabled item', () => {
+      const state: ListState<string> = {
+        highlightedValue: null,
+        selectedValues: [],
+      };
+
+      const action: ListReducerAction<string> = {
+        type: ListActionTypes.itemClick,
+        event: {} as any, // not relevant
+        context: {
+          items: ['one', 'two', 'three'],
+          disableListWrap: false,
+          disabledItemsFocusable: false,
+          focusManagement: 'activeDescendant',
+          isItemDisabled: (item) => item === 'two',
+          itemComparer: (o, v) => o === v,
+          getItemAsString: (option) => option,
+          orientation: 'vertical',
+          pageSize: 5,
+          selectionMode: 'single',
+        },
+        item: 'two',
+      };
+
+      const result = listReducer(state, action);
+      expect(result.highlightedValue).to.equal(null);
+      expect(result.selectedValues).to.deep.equal([]);
+    });
+
     it('replaces the selectedValues with the clicked value if selectionMode = "single"', () => {
       const state: ListState<string> = {
         highlightedValue: 'a',

--- a/packages/mui-base/src/useList/listReducer.ts
+++ b/packages/mui-base/src/useList/listReducer.ts
@@ -431,6 +431,17 @@ function handleResetHighlight<ItemValue, State extends ListState<ItemValue>>(
   };
 }
 
+function handleClearSelection<ItemValue, State extends ListState<ItemValue>>(
+  state: State,
+  context: ListActionContext<ItemValue>,
+) {
+  return {
+    ...state,
+    selectedValues: [],
+    highlightedValue: moveHighlight(null, 'reset', context),
+  };
+}
+
 export function listReducer<ItemValue, State extends ListState<ItemValue>>(
   state: State,
   action: ListReducerAction<ItemValue> & { context: ListActionContext<ItemValue> },
@@ -450,6 +461,8 @@ export function listReducer<ItemValue, State extends ListState<ItemValue>>(
       return handleItemsChange(action.items, action.previousItems, state, context);
     case ListActionTypes.resetHighlight:
       return handleResetHighlight(state, context);
+    case ListActionTypes.clearSelection:
+      return handleClearSelection(state, context);
     default:
       return state;
   }

--- a/packages/mui-base/src/useList/listReducer.ts
+++ b/packages/mui-base/src/useList/listReducer.ts
@@ -200,7 +200,15 @@ export function toggleSelection<ItemValue>(
   return [...selectedValues, item];
 }
 
-function handleItemSelection<ItemValue, State extends ListState<ItemValue>>(
+/**
+ * Handles item selection in a list.
+ *
+ * @param item - The item to be selected.
+ * @param state - The current state of the list.
+ * @param context - The context of the list action.
+ * @returns The new state of the list after the item has been selected, or the original state if the item is disabled.
+ */
+export function handleItemSelection<ItemValue, State extends ListState<ItemValue>>(
   item: ItemValue,
   state: State,
   context: ListActionContext<ItemValue>,

--- a/packages/mui-base/src/useSelect/selectReducer.test.ts
+++ b/packages/mui-base/src/useSelect/selectReducer.test.ts
@@ -26,7 +26,7 @@ describe('selectReducer', () => {
         open: false,
       };
 
-      const action: ActionWithContext<SelectAction, ListActionContext<unknown>> = {
+      const action: ActionWithContext<SelectAction<string>, ListActionContext<unknown>> = {
         type: SelectActionTypes.buttonClick,
         event: {} as any, // not relevant
         context: irrelevantConfig,
@@ -43,7 +43,7 @@ describe('selectReducer', () => {
         open: true,
       };
 
-      const action: ActionWithContext<SelectAction, ListActionContext<unknown>> = {
+      const action: ActionWithContext<SelectAction<string>, ListActionContext<unknown>> = {
         type: SelectActionTypes.buttonClick,
         event: {} as any, // not relevant
         context: {
@@ -62,7 +62,7 @@ describe('selectReducer', () => {
         open: false,
       };
 
-      const action: ActionWithContext<SelectAction, ListActionContext<string>> = {
+      const action: ActionWithContext<SelectAction<string>, ListActionContext<string>> = {
         type: SelectActionTypes.buttonClick,
         event: {} as any, // not relevant
         context: {
@@ -82,7 +82,7 @@ describe('selectReducer', () => {
         open: false,
       };
 
-      const action: ActionWithContext<SelectAction, ListActionContext<string>> = {
+      const action: ActionWithContext<SelectAction<string>, ListActionContext<string>> = {
         type: SelectActionTypes.buttonClick,
         event: {} as any, // not relevant
         context: {
@@ -93,6 +93,30 @@ describe('selectReducer', () => {
 
       const result = selectReducer(state, action);
       expect(result.highlightedValue).to.equal('1');
+    });
+  });
+
+  describe('action: browserAutoFill', () => {
+    it('selects the item and highlights it', () => {
+      const state: SelectInternalState<string> = {
+        highlightedValue: null,
+        selectedValues: [],
+        open: false,
+      };
+
+      const action: ActionWithContext<SelectAction<string>, ListActionContext<string>> = {
+        type: SelectActionTypes.browserAutoFill,
+        event: {} as any, // not relevant
+        item: '1',
+        context: {
+          ...irrelevantConfig,
+          items: ['1', '2', '3'],
+        },
+      };
+
+      const result = selectReducer(state, action);
+      expect(result.highlightedValue).to.equal('1');
+      expect(result.selectedValues).to.deep.equal(['1']);
     });
   });
 });

--- a/packages/mui-base/src/useSelect/selectReducer.ts
+++ b/packages/mui-base/src/useSelect/selectReducer.ts
@@ -4,13 +4,17 @@ import {
   moveHighlight,
   listReducer,
   ListActionTypes,
+  handleItemSelection,
 } from '../useList';
 import { ActionWithContext } from '../utils/useControllableReducer.types';
 import { SelectAction, SelectActionTypes, SelectInternalState } from './useSelect.types';
 
 export function selectReducer<OptionValue>(
   state: SelectInternalState<OptionValue>,
-  action: ActionWithContext<ListAction<OptionValue> | SelectAction, ListActionContext<OptionValue>>,
+  action: ActionWithContext<
+    ListAction<OptionValue> | SelectAction<OptionValue>,
+    ListActionContext<OptionValue>
+  >,
 ) {
   const { open } = state;
   const {
@@ -26,6 +30,14 @@ export function selectReducer<OptionValue>(
       open: !open,
       highlightedValue: !open ? itemToHighlight : null,
     };
+  }
+
+  if (action.type === SelectActionTypes.browserAutoFill) {
+    return handleItemSelection<OptionValue, SelectInternalState<OptionValue>>(
+      action.item,
+      state,
+      action.context,
+    );
   }
 
   const newState: SelectInternalState<OptionValue> = listReducer(

--- a/packages/mui-base/src/useSelect/useSelect.test.tsx
+++ b/packages/mui-base/src/useSelect/useSelect.test.tsx
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { act, renderHook } from '@testing-library/react';
 import { useSelect } from './useSelect';
+import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
 
 describe('useSelect', () => {
   describe('param: options', () => {
@@ -188,6 +189,37 @@ describe('useSelect', () => {
           act(() => {
             // @ts-ignore We only need the target value for this test
             hiddenInputOnChange({ target: { value: '' } });
+          });
+
+          const { value: updatedValue } = result.current;
+
+          expect(updatedValue).to.equal(null);
+        });
+
+        it('should be preventable', () => {
+          const options = [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ];
+
+          const onHiddenInputChange = (
+            event: React.ChangeEvent<HTMLInputElement> & MuiCancellableEvent,
+          ) => {
+            event.defaultMuiPrevented = true;
+          };
+
+          const { result } = renderHook(() => useSelect({ options }));
+
+          const { value: initialValue, getHiddenInputProps } = result.current;
+          const { onChange: hiddenInputOnChange } = getHiddenInputProps({
+            onChange: onHiddenInputChange,
+          });
+
+          expect(initialValue).to.equal(null);
+
+          act(() => {
+            // @ts-ignore We only need the target value for this test
+            hiddenInputOnChange({ target: { value: 'a' } });
           });
 
           const { value: updatedValue } = result.current;

--- a/packages/mui-base/src/useSelect/useSelect.test.tsx
+++ b/packages/mui-base/src/useSelect/useSelect.test.tsx
@@ -125,27 +125,75 @@ describe('useSelect', () => {
         expect(externalOnChangeSpy.calledWith({ target: { value: 'foo' } })).to.equal(true);
       });
 
-      it('sets reducer value when called', () => {
-        const options = [
-          { value: 'a', label: 'A' },
-          { value: 'b', label: 'B' },
-        ];
+      describe('browser autofill', () => {
+        it('sets reducer value when called with valid option', () => {
+          const options = [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ];
 
-        const { result } = renderHook(() => useSelect({ options }));
+          const { result } = renderHook(() => useSelect({ options }));
 
-        const { value: initialValue, getHiddenInputProps } = result.current;
-        const { onChange: hiddenInputOnChange } = getHiddenInputProps();
+          const { value: initialValue, getHiddenInputProps } = result.current;
+          const { onChange: hiddenInputOnChange } = getHiddenInputProps();
 
-        expect(initialValue).to.equal(null);
+          expect(initialValue).to.equal(null);
 
-        act(() => {
-          // @ts-ignore We only need the target value for this test
-          hiddenInputOnChange({ target: { value: 'a' } });
+          act(() => {
+            // @ts-ignore We only need the target value for this test
+            hiddenInputOnChange({ target: { value: 'a' } });
+          });
+
+          const { value: updatedValue } = result.current;
+
+          expect(updatedValue).to.equal('a');
         });
 
-        const { value: updatedValue } = result.current;
+        it('does not set reducer value when called with invalid option', () => {
+          const options = [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ];
 
-        expect(updatedValue).to.equal('a');
+          const { result } = renderHook(() => useSelect({ options }));
+
+          const { value: initialValue, getHiddenInputProps } = result.current;
+          const { onChange: hiddenInputOnChange } = getHiddenInputProps();
+
+          expect(initialValue).to.equal(null);
+
+          act(() => {
+            // @ts-ignore We only need the target value for this test
+            hiddenInputOnChange({ target: { value: 'c' } });
+          });
+
+          const { value: updatedValue } = result.current;
+
+          expect(updatedValue).to.equal(null);
+        });
+
+        it('clears reducer value when called with empty string', () => {
+          const options = [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B' },
+          ];
+
+          const { result } = renderHook(() => useSelect({ options, defaultValue: 'a' }));
+
+          const { value: initialValue, getHiddenInputProps } = result.current;
+          const { onChange: hiddenInputOnChange } = getHiddenInputProps();
+
+          expect(initialValue).to.equal('a');
+
+          act(() => {
+            // @ts-ignore We only need the target value for this test
+            hiddenInputOnChange({ target: { value: '' } });
+          });
+
+          const { value: updatedValue } = result.current;
+
+          expect(updatedValue).to.equal(null);
+        });
       });
     });
   });

--- a/packages/mui-base/src/useSelect/useSelect.test.tsx
+++ b/packages/mui-base/src/useSelect/useSelect.test.tsx
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useSelect } from './useSelect';
-import { MuiCancellableEvent } from '../utils/MuiCancellableEvent';
 
 describe('useSelect', () => {
   describe('param: options', () => {
@@ -124,108 +123,6 @@ describe('useSelect', () => {
         hiddenInputOnChange({ target: { value: 'foo' } });
         expect(externalOnChangeSpy.calledOnce).to.equal(true);
         expect(externalOnChangeSpy.calledWith({ target: { value: 'foo' } })).to.equal(true);
-      });
-
-      describe('browser autofill', () => {
-        it('sets reducer value when called with valid option', () => {
-          const options = [
-            { value: 'a', label: 'A' },
-            { value: 'b', label: 'B' },
-          ];
-
-          const { result } = renderHook(() => useSelect({ options }));
-
-          const { value: initialValue, getHiddenInputProps } = result.current;
-          const { onChange: hiddenInputOnChange } = getHiddenInputProps();
-
-          expect(initialValue).to.equal(null);
-
-          act(() => {
-            // @ts-ignore We only need the target value for this test
-            hiddenInputOnChange({ target: { value: 'a' } });
-          });
-
-          const { value: updatedValue } = result.current;
-
-          expect(updatedValue).to.equal('a');
-        });
-
-        it('does not set reducer value when called with invalid option', () => {
-          const options = [
-            { value: 'a', label: 'A' },
-            { value: 'b', label: 'B' },
-          ];
-
-          const { result } = renderHook(() => useSelect({ options }));
-
-          const { value: initialValue, getHiddenInputProps } = result.current;
-          const { onChange: hiddenInputOnChange } = getHiddenInputProps();
-
-          expect(initialValue).to.equal(null);
-
-          act(() => {
-            // @ts-ignore We only need the target value for this test
-            hiddenInputOnChange({ target: { value: 'c' } });
-          });
-
-          const { value: updatedValue } = result.current;
-
-          expect(updatedValue).to.equal(null);
-        });
-
-        it('clears reducer value when called with empty string', () => {
-          const options = [
-            { value: 'a', label: 'A' },
-            { value: 'b', label: 'B' },
-          ];
-
-          const { result } = renderHook(() => useSelect({ options, defaultValue: 'a' }));
-
-          const { value: initialValue, getHiddenInputProps } = result.current;
-          const { onChange: hiddenInputOnChange } = getHiddenInputProps();
-
-          expect(initialValue).to.equal('a');
-
-          act(() => {
-            // @ts-ignore We only need the target value for this test
-            hiddenInputOnChange({ target: { value: '' } });
-          });
-
-          const { value: updatedValue } = result.current;
-
-          expect(updatedValue).to.equal(null);
-        });
-
-        it('should be preventable', () => {
-          const options = [
-            { value: 'a', label: 'A' },
-            { value: 'b', label: 'B' },
-          ];
-
-          const onHiddenInputChange = (
-            event: React.ChangeEvent<HTMLInputElement> & MuiCancellableEvent,
-          ) => {
-            event.defaultMuiPrevented = true;
-          };
-
-          const { result } = renderHook(() => useSelect({ options }));
-
-          const { value: initialValue, getHiddenInputProps } = result.current;
-          const { onChange: hiddenInputOnChange } = getHiddenInputProps({
-            onChange: onHiddenInputChange,
-          });
-
-          expect(initialValue).to.equal(null);
-
-          act(() => {
-            // @ts-ignore We only need the target value for this test
-            hiddenInputOnChange({ target: { value: 'a' } });
-          });
-
-          const { value: updatedValue } = result.current;
-
-          expect(updatedValue).to.equal(null);
-        });
       });
     });
   });

--- a/packages/mui-base/src/useSelect/useSelect.ts
+++ b/packages/mui-base/src/useSelect/useSelect.ts
@@ -415,22 +415,18 @@ function useSelect<OptionValue, Multiple extends boolean = false>(
         return;
       }
 
+      const option = options.get(event.target.value as OptionValue);
+
       // support autofill
-      if (options.has(event.target.value as OptionValue)) {
-        const option = options.get(event.target.value as OptionValue);
-
-        if (option === undefined) {
-          return;
-        }
-
+      if (event.target.value === '') {
+        dispatch({
+          type: ListActionTypes.clearSelection,
+        });
+      } else if (option !== undefined) {
         dispatch({
           type: SelectActionTypes.browserAutoFill,
           item: option.value,
           event,
-        });
-      } else if (event.target.value === '') {
-        dispatch({
-          type: ListActionTypes.clearSelection,
         });
       }
     };

--- a/packages/mui-base/src/useSelect/useSelect.ts
+++ b/packages/mui-base/src/useSelect/useSelect.ts
@@ -407,8 +407,13 @@ function useSelect<OptionValue, Multiple extends boolean = false>(
   }
 
   const createHandleHiddenInputChange =
-    (externalEventHandlers?: EventHandlers) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    (externalEventHandlers?: EventHandlers) =>
+    (event: React.ChangeEvent<HTMLInputElement> & MuiCancellableEvent) => {
       externalEventHandlers?.onChange?.(event);
+
+      if (event.defaultMuiPrevented) {
+        return;
+      }
 
       // support autofill
       if (options.has(event.target.value as OptionValue)) {

--- a/packages/mui-base/src/useSelect/useSelect.ts
+++ b/packages/mui-base/src/useSelect/useSelect.ts
@@ -18,7 +18,7 @@ import {
   UseSelectParameters,
   UseSelectReturnValue,
 } from './useSelect.types';
-import { useList, UseListParameters } from '../useList';
+import { ListActionTypes, useList, UseListParameters } from '../useList';
 import { EventHandlers } from '../utils/types';
 import { defaultOptionStringifier } from './defaultOptionStringifier';
 import { SelectProviderValue } from './SelectProvider';
@@ -418,13 +418,15 @@ function useSelect<OptionValue, Multiple extends boolean = false>(
           return;
         }
 
-        const action: SelectAction<OptionValue> = {
+        dispatch({
           type: SelectActionTypes.browserAutoFill,
           item: option.value,
           event,
-        };
-
-        dispatch(action);
+        });
+      } else if (event.target.value === '') {
+        dispatch({
+          type: ListActionTypes.clearSelection,
+        });
       }
     };
 

--- a/packages/mui-base/src/useSelect/useSelect.types.ts
+++ b/packages/mui-base/src/useSelect/useSelect.types.ts
@@ -139,8 +139,13 @@ export type UseSelectButtonSlotProps<TOther = {}> = UseListRootSlotProps<
     ref: React.RefCallback<Element> | null;
   };
 
-export type UseSelectHiddenInputSlotProps<TOther = {}> =
-  React.InputHTMLAttributes<HTMLInputElement> & TOther;
+interface UseSelectHiddenInputSlotEventHandlers {
+  onChange: MuiCancellableEventHandler<React.ChangeEvent<HTMLInputElement>>;
+}
+
+export type UseSelectHiddenInputSlotProps<TOther = {}> = UseSelectHiddenInputSlotEventHandlers &
+  React.InputHTMLAttributes<HTMLInputElement> &
+  TOther;
 
 interface UseSelectListboxSlotEventHandlers {
   onMouseDown: React.MouseEventHandler;
@@ -178,7 +183,7 @@ export interface UseSelectReturnValue<Value, Multiple> {
    * Action dispatcher for the select component.
    * Allows to programmatically control the select.
    */
-  dispatch: (action: ListAction<Value> | SelectAction) => void;
+  dispatch: (action: ListAction<Value> | SelectAction<Value>) => void;
   /**
    * Resolver for the button slot's props.
    * @param externalProps event handlers for the button slot
@@ -238,6 +243,7 @@ export interface UseSelectReturnValue<Value, Multiple> {
 
 export const SelectActionTypes = {
   buttonClick: 'buttonClick',
+  browserAutoFill: 'browserAutoFill',
 } as const;
 
 export interface ButtonClickAction {
@@ -245,7 +251,13 @@ export interface ButtonClickAction {
   event: React.MouseEvent;
 }
 
-export type SelectAction = ButtonClickAction;
+export interface BrowserAutofillAction<OptionValue> {
+  type: typeof SelectActionTypes.browserAutoFill;
+  item: OptionValue;
+  event: React.ChangeEvent;
+}
+
+export type SelectAction<OptionValue> = ButtonClickAction | BrowserAutofillAction<OptionValue>;
 
 export interface SelectInternalState<OptionValue> extends ListState<OptionValue> {
   open: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/37646

Support browser autofill in the useSelect hook and Select component.

### Changes:
- Add `onChange` handler to `getHiddenInputProps` which
    - dispatches a (new) browser autofill action if the value is found in the options
    - dispatches a (new) clear selection action if the value is an empty string
- Add `autoComplete` prop to Select component and forward to the hidden input
- Added tests for all the changes. 

### Manual testing

I tested with

- 1Password on Chrome
- Chrome native autofill (including clear autofill, avoiding [#31426](https://github.com/mui/material-ui/issues/31426) by clearing when the onChange handler is called with an empty string as value)
- Safari native autofill

I couldn't get Firefox autofill to work on my computer, so I didn't test with that one. Apparently, the feature is blocked by region.

### Demo

Before changes: https://codesandbox.io/s/base-ui-select-autofill-demo-benchmark-rz7qff?file=/src/Demo.tsx
After changes: https://codesandbox.io/s/base-ui-select-autofill-demo-nj6ylw?file=/src/Demo.tsx

https://github.com/mui/material-ui/assets/16889233/4a3dc798-72e5-4b4c-8771-72aedbd4702b

