### PR TITLE
[useInput][base-ui] Fix inputRef in useInput's return value

### DIFF
--- a/docs/pages/base-ui/api/use-input.json
+++ b/docs/pages/base-ui/api/use-input.json
@@ -60,8 +60,8 @@
     },
     "inputRef": {
       "type": {
-        "name": "React.RefCallback&lt;HTMLInputElement | HTMLTextAreaElement&gt; | null",
-        "description": "React.RefCallback&lt;HTMLInputElement | HTMLTextAreaElement&gt; | null"
+        "name": "React.RefObject&lt;HTMLInputElement | HTMLTextAreaElement&gt; | null",
+        "description": "React.RefObject&lt;HTMLInputElement | HTMLTextAreaElement&gt; | null"
       },
       "required": true
     },

--- a/packages/mui-base/src/useInput/useInput.test.tsx
+++ b/packages/mui-base/src/useInput/useInput.test.tsx
@@ -7,6 +7,14 @@ import { UseInputParameters } from './useInput.types';
 
 describe('useInput', () => {
   const { render } = createRenderer();
+  it('returns an inputRef to the underlying input', () => {
+    const { getInputProps, inputRef } = useInput();
+
+    const { getByRole } = render(<input {...getInputProps()} />);
+
+    expect(inputRef.current).to.deep.equal(getByRole('textbox'));
+  });
+
   describe('params: inputRef', () => {
     it('should be able to attach input ref passed through params', () => {
       const inputRef = React.createRef<HTMLInputElement>();

--- a/packages/mui-base/src/useInput/useInput.test.tsx
+++ b/packages/mui-base/src/useInput/useInput.test.tsx
@@ -8,7 +8,9 @@ import { UseInputParameters } from './useInput.types';
 describe('useInput', () => {
   const { render } = createRenderer();
   it('returns an inputRef to the underlying input', () => {
-    let returnedInputRef;
+    let returnedInputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement> | null = {
+      current: null,
+    };
 
     function Input() {
       const { getInputProps, inputRef } = useInput();
@@ -18,7 +20,7 @@ describe('useInput', () => {
 
     const { getByRole } = render(<Input />);
 
-    expect(returnedInputRef.current).to.deep.equal(getByRole('textbox'));
+    expect(returnedInputRef?.current).to.deep.equal(getByRole('textbox'));
   });
 
   describe('params: inputRef', () => {

--- a/packages/mui-base/src/useInput/useInput.test.tsx
+++ b/packages/mui-base/src/useInput/useInput.test.tsx
@@ -8,11 +8,17 @@ import { UseInputParameters } from './useInput.types';
 describe('useInput', () => {
   const { render } = createRenderer();
   it('returns an inputRef to the underlying input', () => {
-    const { getInputProps, inputRef } = useInput();
+    let returnedInputRef;
 
-    const { getByRole } = render(<input {...getInputProps()} />);
+    function Input() {
+      const { getInputProps, inputRef } = useInput();
+      returnedInputRef = inputRef;
+      return <input {...getInputProps()} />;
+    }
 
-    expect(inputRef.current).to.deep.equal(getByRole('textbox'));
+    const { getByRole } = render(<Input />);
+
+    expect(returnedInputRef.current).to.deep.equal(getByRole('textbox'));
   });
 
   describe('params: inputRef', () => {

--- a/packages/mui-base/src/useInput/useInput.ts
+++ b/packages/mui-base/src/useInput/useInput.ts
@@ -216,7 +216,7 @@ export function useInput(parameters: UseInputParameters = {}): UseInputReturnVal
     formControlContext,
     getInputProps,
     getRootProps,
-    inputRef: handleInputRef,
+    inputRef,
     required,
     value,
   };

--- a/packages/mui-base/src/useInput/useInput.types.ts
+++ b/packages/mui-base/src/useInput/useInput.types.ts
@@ -90,7 +90,7 @@ export interface UseInputReturnValue {
   getRootProps: <ExternalProps extends Record<string, any> = {}>(
     externalProps?: ExternalProps,
   ) => UseInputRootSlotProps<ExternalProps>;
-  inputRef: React.RefCallback<HTMLInputElement | HTMLTextAreaElement> | null;
+  inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement> | null;
   /**
    * If `true`, the `input` will indicate that it's required.
    */


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/39599

Before: https://codesandbox.io/s/use-input-returned-inputref-kjyyn8?file=/src/App.tsx

After: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-39600-xsf368?file=/src/App.tsx

Basically we should be able to use `inputRef` from the return value normally:

```jsx
function CustomInput() {
  const { getInputProps, inputRef } = useInput();
  return (
    <div>
      <input {...getInputProps()} />
      <Button
        onClick={() => {
          if (inputRef && inputRef.current) {
            inputRef.current.focus();
          } else {
            console.warn('nope');
            console.warn(inputRef);
          }
        }}
      >
        Button
      </Button>
    </div>
  );
}
```

Background: v6 `InputBase` is relying on this `inputRef` to set the initial filled state for SSR [here](https://github.com/mui/material-ui/blob/master/packages/mui-material-next/src/InputBase/InputBase.tsx#L527-L532)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
