### PR TITLE
[docs][material-ui] Include link to bundler how-to for Styled Components users

### DIFF
--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -43,6 +43,8 @@ pnpm add @mui/material @mui/styled-engine-sc styled-components
 
 </codeblock>
 
+Next, follow the [styled-components how-to guide](https://mui.com/material-ui/guides/styled-components/) to properly configure your bundler to support `@mui/styled-engine-sc`.
+
 :::error
 As of late 2021, [styled-components](https://github.com/styled-components/styled-components) is **not compatible** with server-rendered Material UI projects.
 This is because `babel-plugin-styled-components` isn't able to work with the `styled()` utility inside `@mui` packages.

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -43,7 +43,7 @@ pnpm add @mui/material @mui/styled-engine-sc styled-components
 
 </codeblock>
 
-Next, follow the [styled-components how-to guide](https://mui.com/material-ui/guides/styled-components/) to properly configure your bundler to support `@mui/styled-engine-sc`.
+Next, follow the [styled-components how-to guide](/material-ui/guides/styled-components/) to properly configure your bundler to support `@mui/styled-engine-sc`.
 
 :::error
 As of late 2021, [styled-components](https://github.com/styled-components/styled-components) is **not compatible** with server-rendered Material UI projects.


### PR DESCRIPTION
I was unable to compile until I followed this article's recommendations, but as far as I can see, it's only linked to in the description at https://www.npmjs.com/package/@mui/styled-engine-sc

👉 **https://deploy-preview-39620--material-ui.netlify.app/material-ui/getting-started/installation/**

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
