### PR TITLE
[material-next][Snackbar] copy Snackbar Content files to material-next package

### DIFF
--- a/packages/mui-material-next/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/mui-material-next/src/SnackbarContent/SnackbarContent.d.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { InternalStandardProps as StandardProps, PaperProps, Theme } from '@mui/material';
+import { SnackbarContentClasses } from './snackbarContentClasses';
+
+export interface SnackbarContentProps extends StandardProps<PaperProps, 'children'> {
+  /**
+   * The action to display. It renders after the message, at the end of the snackbar.
+   */
+  action?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<SnackbarContentClasses>;
+  /**
+   * The message to display.
+   */
+  message?: React.ReactNode;
+  /**
+   * The ARIA role attribute of the element.
+   * @default 'alert'
+   */
+  role?: PaperProps['role'];
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ *
+ * Demos:
+ *
+ * - [Snackbar](https://mui.com/material-ui/react-snackbar/)
+ *
+ * API:
+ *
+ * - [SnackbarContent API](https://mui.com/material-ui/api/snackbar-content/)
+ * - inherits [Paper API](https://mui.com/material-ui/api/paper/)
+ */
+export default function SnackbarContent(props: SnackbarContentProps): JSX.Element;

--- a/packages/mui-material-next/src/SnackbarContent/SnackbarContent.js
+++ b/packages/mui-material-next/src/SnackbarContent/SnackbarContent.js
@@ -1,0 +1,135 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { emphasize } from '@mui/system';
+import styled from '@mui/material/styles/styled';
+import useThemeProps from '@mui/material/styles/useThemeProps';
+import Paper from '@mui/material/Paper';
+import { getSnackbarContentUtilityClass } from './snackbarContentClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes } = ownerState;
+
+  const slots = {
+    root: ['root'],
+    action: ['action'],
+    message: ['message'],
+  };
+
+  return composeClasses(slots, getSnackbarContentUtilityClass, classes);
+};
+
+const SnackbarContentRoot = styled(Paper, {
+  name: 'MuiSnackbarContent',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => {
+  const emphasis = theme.palette.mode === 'light' ? 0.8 : 0.98;
+  const backgroundColor = emphasize(theme.palette.background.default, emphasis);
+
+  return {
+    ...theme.typography.body2,
+    color: theme.vars
+      ? theme.vars.palette.SnackbarContent.color
+      : theme.palette.getContrastText(backgroundColor),
+    backgroundColor: theme.vars ? theme.vars.palette.SnackbarContent.bg : backgroundColor,
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    padding: '6px 16px',
+    borderRadius: (theme.vars || theme).shape.borderRadius,
+    flexGrow: 1,
+    [theme.breakpoints.up('sm')]: {
+      flexGrow: 'initial',
+      minWidth: 288,
+    },
+  };
+});
+
+const SnackbarContentMessage = styled('div', {
+  name: 'MuiSnackbarContent',
+  slot: 'Message',
+  overridesResolver: (props, styles) => styles.message,
+})({
+  padding: '8px 0',
+});
+
+const SnackbarContentAction = styled('div', {
+  name: 'MuiSnackbarContent',
+  slot: 'Action',
+  overridesResolver: (props, styles) => styles.action,
+})({
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: 'auto',
+  paddingLeft: 16,
+  marginRight: -8,
+});
+
+const SnackbarContent = React.forwardRef(function SnackbarContent(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSnackbarContent' });
+  const { action, className, message, role = 'alert', ...other } = props;
+  const ownerState = props;
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <SnackbarContentRoot
+      role={role}
+      square
+      elevation={6}
+      className={clsx(classes.root, className)}
+      ownerState={ownerState}
+      ref={ref}
+      {...other}
+    >
+      <SnackbarContentMessage className={classes.message} ownerState={ownerState}>
+        {message}
+      </SnackbarContentMessage>
+      {action ? (
+        <SnackbarContentAction className={classes.action} ownerState={ownerState}>
+          {action}
+        </SnackbarContentAction>
+      ) : null}
+    </SnackbarContentRoot>
+  );
+});
+
+SnackbarContent.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The action to display. It renders after the message, at the end of the snackbar.
+   */
+  action: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The message to display.
+   */
+  message: PropTypes.node,
+  /**
+   * The ARIA role attribute of the element.
+   * @default 'alert'
+   */
+  role: PropTypes /* @typescript-to-proptypes-ignore */.string,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+};
+
+export default SnackbarContent;

--- a/packages/mui-material-next/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material-next/src/SnackbarContent/SnackbarContent.test.js
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import Paper from '@mui/material/Paper';
+import SnackbarContent, {
+  snackbarContentClasses as classes,
+} from '@mui/material-next/SnackbarContent';
+
+describe('<SnackbarContent />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<SnackbarContent message="conform?" />, () => ({
+    classes,
+    inheritComponent: Paper,
+    render,
+    muiName: 'MuiSnackbarContent',
+    refInstanceof: window.HTMLDivElement,
+    skip: ['componentProp', 'componentsProp', 'themeVariants'],
+  }));
+
+  describe('prop: action', () => {
+    it('should render the action', () => {
+      const action = <span>action</span>;
+      const { container } = render(
+        <SnackbarContent message="message" data-testid="action" action={action} />,
+      );
+      expect(container.querySelector(`.${classes.action}`)).to.have.class(classes.action);
+      expect(container.querySelector(`.${classes.action}`)).to.contain('span');
+    });
+
+    it('should render an array of elements', () => {
+      const action0 = <span key={0}>action0</span>;
+      const action1 = <span key={1}>action1</span>;
+      const { getByText } = render(
+        <SnackbarContent message="message" action={[action0, action1]} />,
+      );
+      expect(getByText('action0')).not.to.equal(null);
+      expect(getByText('action1')).not.to.equal(null);
+    });
+  });
+
+  describe('prop: message', () => {
+    it('should render the message', () => {
+      const message = 'message prop text';
+      const { getByRole } = render(<SnackbarContent message={<span>{message}</span>} />);
+      expect(getByRole('alert')).to.have.text(message);
+    });
+  });
+
+  describe('prop: role', () => {
+    it('renders the default role', () => {
+      const { getByRole } = render(<SnackbarContent message="alert message" />);
+      expect(getByRole('alert')).to.have.text('alert message');
+    });
+
+    it('can override the role', () => {
+      const { queryByRole } = render(
+        <SnackbarContent message="alertdialog message" role="alertdialog" />,
+      );
+      expect(queryByRole('alertdialog')).to.have.text('alertdialog message');
+    });
+  });
+});

--- a/packages/mui-material-next/src/SnackbarContent/index.d.ts
+++ b/packages/mui-material-next/src/SnackbarContent/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './SnackbarContent';
+export * from './SnackbarContent';
+
+export { default as snackbarContentClasses } from './snackbarContentClasses';
+export * from './snackbarContentClasses';

--- a/packages/mui-material-next/src/SnackbarContent/index.js
+++ b/packages/mui-material-next/src/SnackbarContent/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './SnackbarContent';
+
+export { default as snackbarContentClasses } from './snackbarContentClasses';
+export * from './snackbarContentClasses';

--- a/packages/mui-material-next/src/SnackbarContent/snackbarContentClasses.ts
+++ b/packages/mui-material-next/src/SnackbarContent/snackbarContentClasses.ts
@@ -1,0 +1,26 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface SnackbarContentClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the message wrapper element. */
+  message: string;
+  /** Styles applied to the action wrapper element if `action` is provided. */
+  action: string;
+}
+
+export type SnackbarContentClassKey = keyof SnackbarContentClasses;
+
+export function getSnackbarContentUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiSnackbarContent', slot);
+}
+
+const snackbarContentClasses: SnackbarContentClasses = generateUtilityClasses(
+  'MuiSnackbarContent',
+  ['root', 'message', 'action'],
+);
+
+export default snackbarContentClasses;

--- a/packages/mui-material-next/src/index.ts
+++ b/packages/mui-material-next/src/index.ts
@@ -47,6 +47,9 @@ export * from './Select';
 export { default as Slider } from './Slider';
 export * from './Slider';
 
+export { default as SnackbarContent } from './SnackbarContent';
+export * from './SnackbarContent';
+
 export { default as Divider } from './Divider';
 export * from './Divider';
 


### PR DESCRIPTION
…erial-next

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

related to: https://github.com/mui/material-ui/issues/39207

In this change, only the Snackbar files were moved to mui-material-next and their imports were adjusted.
I need these changes to be completed in order to proceed with the Snackbar implementation.