### PR TITLE
[website] Change roadmap link destination

### DIFF
--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -95,7 +95,7 @@ export default function AppFooter(props: AppFooterProps) {
             <Link href={ROUTES.store}>Store</Link>
             <Link href={ROUTES.blog}>Blog</Link>
             <Link href={ROUTES.showcase}>Showcase</Link>
-            <Link href={ROUTES.xRoadmap}>Roadmap</Link>
+            <Link href={ROUTES.coreRoadmap}>Roadmap</Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             <Typography fontWeight="bold" variant="body2" sx={{ mb: 0.5 }}>

--- a/docs/src/route.ts
+++ b/docs/src/route.ts
@@ -26,6 +26,7 @@ const ROUTES = {
   communityHelp: '/material-ui/getting-started/support/#community-help-free',
   blog: '/blog/',
   showcase: '/material-ui/discover-more/showcase/',
+  coreRoadmap: '/material-ui/discover-more/roadmap/',
   xRoadmap: 'https://github.com/mui/mui-x/projects/1',
   vision: '/material-ui/discover-more/vision/',
   support: '/material-ui/getting-started/support/#professional-support-premium',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Until we have a general place to document company-wide initiatives across all teams & products, linking to the MUI Core roadmap on the website's footer seems a bit more appropriate. I wonder if this page makes more sense than the GitHub project, though... curious to hear from others.
