### PR TITLE
[docs][material-ui] Improve Dialog demos

### DIFF
--- a/docs/data/material/components/dialogs/AlertDialog.js
+++ b/docs/data/material/components/dialogs/AlertDialog.js
@@ -18,7 +18,7 @@ export default function AlertDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open alert dialog
       </Button>
@@ -44,6 +44,6 @@ export default function AlertDialog() {
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/AlertDialog.tsx
+++ b/docs/data/material/components/dialogs/AlertDialog.tsx
@@ -18,7 +18,7 @@ export default function AlertDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open alert dialog
       </Button>
@@ -44,6 +44,6 @@ export default function AlertDialog() {
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/AlertDialogSlide.js
+++ b/docs/data/material/components/dialogs/AlertDialogSlide.js
@@ -23,7 +23,7 @@ export default function AlertDialogSlide() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Slide in alert dialog
       </Button>
@@ -46,6 +46,6 @@ export default function AlertDialogSlide() {
           <Button onClick={handleClose}>Agree</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/AlertDialogSlide.tsx
+++ b/docs/data/material/components/dialogs/AlertDialogSlide.tsx
@@ -29,7 +29,7 @@ export default function AlertDialogSlide() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Slide in alert dialog
       </Button>
@@ -52,6 +52,6 @@ export default function AlertDialogSlide() {
           <Button onClick={handleClose}>Agree</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/ConfirmationDialog.js
+++ b/docs/data/material/components/dialogs/ConfirmationDialog.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -121,11 +121,10 @@ export default function ConfirmationDialog() {
   return (
     <Box sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
       <List component="div" role="group">
-        <ListItem button divider disabled>
+        <ListItemButton divider disabled>
           <ListItemText primary="Interruptions" />
-        </ListItem>
-        <ListItem
-          button
+        </ListItemButton>
+        <ListItemButton
           divider
           aria-haspopup="true"
           aria-controls="ringtone-menu"
@@ -133,10 +132,10 @@ export default function ConfirmationDialog() {
           onClick={handleClickListItem}
         >
           <ListItemText primary="Phone ringtone" secondary={value} />
-        </ListItem>
-        <ListItem button divider disabled>
+        </ListItemButton>
+        <ListItemButton divider disabled>
           <ListItemText primary="Default notification ringtone" secondary="Tethys" />
-        </ListItem>
+        </ListItemButton>
         <ConfirmationDialogRaw
           id="ringtone-menu"
           keepMounted

--- a/docs/data/material/components/dialogs/ConfirmationDialog.tsx
+++ b/docs/data/material/components/dialogs/ConfirmationDialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -122,11 +122,10 @@ export default function ConfirmationDialog() {
   return (
     <Box sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
       <List component="div" role="group">
-        <ListItem button divider disabled>
+        <ListItemButton divider disabled>
           <ListItemText primary="Interruptions" />
-        </ListItem>
-        <ListItem
-          button
+        </ListItemButton>
+        <ListItemButton
           divider
           aria-haspopup="true"
           aria-controls="ringtone-menu"
@@ -134,10 +133,10 @@ export default function ConfirmationDialog() {
           onClick={handleClickListItem}
         >
           <ListItemText primary="Phone ringtone" secondary={value} />
-        </ListItem>
-        <ListItem button divider disabled>
+        </ListItemButton>
+        <ListItemButton divider disabled>
           <ListItemText primary="Default notification ringtone" secondary="Tethys" />
-        </ListItem>
+        </ListItemButton>
         <ConfirmationDialogRaw
           id="ringtone-menu"
           keepMounted

--- a/docs/data/material/components/dialogs/CustomizedDialogs.js
+++ b/docs/data/material/components/dialogs/CustomizedDialogs.js
@@ -29,7 +29,7 @@ export default function CustomizedDialogs() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open dialog
       </Button>
@@ -75,6 +75,6 @@ export default function CustomizedDialogs() {
           </Button>
         </DialogActions>
       </BootstrapDialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/CustomizedDialogs.tsx
+++ b/docs/data/material/components/dialogs/CustomizedDialogs.tsx
@@ -29,7 +29,7 @@ export default function CustomizedDialogs() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open dialog
       </Button>
@@ -75,6 +75,6 @@ export default function CustomizedDialogs() {
           </Button>
         </DialogActions>
       </BootstrapDialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/DraggableDialog.js
+++ b/docs/data/material/components/dialogs/DraggableDialog.js
@@ -31,7 +31,7 @@ export default function DraggableDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open draggable dialog
       </Button>
@@ -57,6 +57,6 @@ export default function DraggableDialog() {
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/DraggableDialog.tsx
+++ b/docs/data/material/components/dialogs/DraggableDialog.tsx
@@ -31,7 +31,7 @@ export default function DraggableDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open draggable dialog
       </Button>
@@ -57,6 +57,6 @@ export default function DraggableDialog() {
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/FormDialog.js
+++ b/docs/data/material/components/dialogs/FormDialog.js
@@ -19,7 +19,7 @@ export default function FormDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
@@ -45,6 +45,6 @@ export default function FormDialog() {
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/FormDialog.tsx
+++ b/docs/data/material/components/dialogs/FormDialog.tsx
@@ -19,7 +19,7 @@ export default function FormDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open form dialog
       </Button>
@@ -45,6 +45,6 @@ export default function FormDialog() {
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/FullScreenDialog.js
+++ b/docs/data/material/components/dialogs/FullScreenDialog.js
@@ -28,7 +28,7 @@ export default function FullScreenDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open full-screen dialog
       </Button>
@@ -69,6 +69,6 @@ export default function FullScreenDialog() {
           </ListItem>
         </List>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/FullScreenDialog.tsx
+++ b/docs/data/material/components/dialogs/FullScreenDialog.tsx
@@ -34,7 +34,7 @@ export default function FullScreenDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open full-screen dialog
       </Button>
@@ -75,6 +75,6 @@ export default function FullScreenDialog() {
           </ListItem>
         </List>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/ResponsiveDialog.js
+++ b/docs/data/material/components/dialogs/ResponsiveDialog.js
@@ -22,7 +22,7 @@ export default function ResponsiveDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open responsive dialog
       </Button>
@@ -50,6 +50,6 @@ export default function ResponsiveDialog() {
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/ResponsiveDialog.tsx
+++ b/docs/data/material/components/dialogs/ResponsiveDialog.tsx
@@ -22,7 +22,7 @@ export default function ResponsiveDialog() {
   };
 
   return (
-    <div>
+    <React.Fragment>
       <Button variant="outlined" onClick={handleClickOpen}>
         Open responsive dialog
       </Button>
@@ -50,6 +50,6 @@ export default function ResponsiveDialog() {
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/ScrollDialog.js
+++ b/docs/data/material/components/dialogs/ScrollDialog.js
@@ -30,7 +30,7 @@ export default function ScrollDialog() {
   }, [open]);
 
   return (
-    <div>
+    <React.Fragment>
       <Button onClick={handleClickOpen('paper')}>scroll=paper</Button>
       <Button onClick={handleClickOpen('body')}>scroll=body</Button>
       <Dialog
@@ -62,6 +62,6 @@ Praesent commodo cursus magna, vel scelerisque nisl consectetur et.`,
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }

--- a/docs/data/material/components/dialogs/ScrollDialog.tsx
+++ b/docs/data/material/components/dialogs/ScrollDialog.tsx
@@ -30,7 +30,7 @@ export default function ScrollDialog() {
   }, [open]);
 
   return (
-    <div>
+    <React.Fragment>
       <Button onClick={handleClickOpen('paper')}>scroll=paper</Button>
       <Button onClick={handleClickOpen('body')}>scroll=body</Button>
       <Dialog
@@ -62,6 +62,6 @@ Praesent commodo cursus magna, vel scelerisque nisl consectetur et.`,
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- Replace unnecessary divs with `React.Fragment`
- Replace deprecated ListItem `button` with `ListItemButton` component in [Confirmation Dialogs](https://mui.com/material-ui/react-dialog/#confirmation-dialogs) demo.

Preview - https://deploy-preview-39642--material-ui.netlify.app/material-ui/react-dialog/