### PR TITLE
[docs][system] Clean up `@mui/styles` docs and discourage users from installing it

### DIFF
--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -2,11 +2,16 @@
 
 <p class="description">This section covers more advanced usage of @mui/styles.</p>
 
-> ⚠️ `@mui/styles` is the _**legacy**_ styling solution for Material UI.
-> It depends on [JSS](https://cssinjs.org/) as a styling solution, which is not used in the `@mui/material` anymore, deprecated in v5.
-> If you don't want to have both Emotion & JSS in your bundle, please refer to the [`@mui/system`](/system/getting-started/) documentation which is the recommended alternative.
+:::error
+`@mui/styles` was deprecated in v5, which was released in late 2021.
+It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in `@mui/material`.
 
-> ⚠️ `@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18.
+`@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.
+
+This documentation remains here for those working on legacy projects, but we **strongly discourage** you from using `@mui/styles` when creating a new app with Material UI—you _will_ face unresolvable dependency issues.
+
+Please use [`@mui/system`](/system/getting-started/) instead.
+:::
 
 ## Theming
 

--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -17,7 +17,9 @@ Please use [`@mui/system`](/system/getting-started/) instead.
 
 Add a `ThemeProvider` to the top level of your app to pass a theme down the React component tree. Then, you can access the theme object in style functions.
 
-> This example creates a theme object for custom-built components. If you intend to use some of Material UI's components you need to provide a richer theme structure using the `createTheme()` method. Head to the [theming section](/material-ui/customization/theming/) to learn how to build your custom Material UI theme.
+:::info
+This example creates a theme object for custom-built components. If you intend to use some of Material UI's components you need to provide a richer theme structure using the `createTheme()` method. Head to the [theming section](/material-ui/customization/theming/) to learn how to build your custom Material UI theme.
+:::
 
 ```jsx
 import { ThemeProvider } from '@mui/styles';
@@ -232,9 +234,10 @@ Note that this doesn't support selectors, or nested rules.
 
 ## CSS injection order
 
-> It's **really important** to understand how the CSS specificity is calculated by the browser,
-> as it's one of the key elements to know when overriding styles.
-> You are encouraged to read this MDN paragraph: [How is specificity calculated?](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#How_is_specificity_calculated)
+:::warning
+It's **really important** to understand how the CSS specificity is calculated by the browser, as it's one of the key elements to know when overriding styles.
+Read this section from the MDN docs for more information: [How is specificity calculated?](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#How_is_specificity_calculated)
+:::
 
 By default, the style tags are injected **last** in the `<head>` element of the page.
 They gain more specificity than any other style tags on your page e.g. CSS modules, styled components.

--- a/docs/data/styles/advanced/advanced.md
+++ b/docs/data/styles/advanced/advanced.md
@@ -3,7 +3,7 @@
 <p class="description">This section covers more advanced usage of @mui/styles.</p>
 
 :::error
-`@mui/styles` was deprecated in v5, which was released in late 2021.
+`@mui/styles` was deprecated with the release of MUI Core v5 in late 2021.
 It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in `@mui/material`.
 
 `@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.

--- a/docs/data/styles/api/api.md
+++ b/docs/data/styles/api/api.md
@@ -7,7 +7,7 @@ title: Styles API
 <p class="description">The API reference for @mui/styles.</p>
 
 :::error
-`@mui/styles` was deprecated in v5, which was released in late 2021.
+`@mui/styles` was deprecated with the release of MUI Core v5 in late 2021.
 It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in `@mui/material`.
 
 `@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.

--- a/docs/data/styles/api/api.md
+++ b/docs/data/styles/api/api.md
@@ -4,13 +4,18 @@ title: Styles API
 
 # API (LEGACY)
 
-<p class="description">The API reference of @mui/styles.</p>
+<p class="description">The API reference for @mui/styles.</p>
 
-> ⚠️ `@mui/styles` is the _**legacy**_ styling solution for Material UI.
-> It depends on [JSS](https://cssinjs.org/) as a styling solution, which is not used in the `@mui/material` anymore, deprecated in v5.
-> If you don't want to have both Emotion & JSS in your bundle, please refer to the [`@mui/system`](/system/getting-started/) documentation which is the recommended alternative.
+:::error
+`@mui/styles` was deprecated in v5, which was released in late 2021.
+It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in `@mui/material`.
 
-> ⚠️ `@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18.
+`@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.
+
+This documentation remains here for those working on legacy projects, but we **strongly discourage** you from using `@mui/styles` when creating a new app with Material UI—you _will_ face unresolvable dependency issues.
+
+Please use [`@mui/system`](/system/getting-started/) instead.
+:::
 
 ## `createGenerateClassName([options]) => class name generator`
 

--- a/docs/data/styles/basics/basics.md
+++ b/docs/data/styles/basics/basics.md
@@ -1,12 +1,17 @@
 # @mui/styles (LEGACY)
 
-<p class="description">The legacy styling solution for Material UI.</p>
+<p class="description">The legacy styling solution for Material UI, now deprecated and not recommended for use.</p>
 
-> ⚠️ `@mui/styles` is the _**legacy**_ styling solution for Material UI.
-> It depends on [JSS](https://cssinjs.org/) as a styling solution, which is not used in the `@mui/material` anymore, deprecated in v5.
-> If you don't want to have both Emotion & JSS in your bundle, please refer to the [`@mui/system`](/system/getting-started/) documentation which is the recommended alternative.
+:::error
+`@mui/styles` was deprecated in v5, which was released in late 2021.
+It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in `@mui/material`.
 
-> ⚠️ `@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18.
+`@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.
+
+This documentation remains here for those working on legacy projects, but we **strongly discourage** you from using `@mui/styles` when creating a new app with Material UI—you _will_ face unresolvable dependency issues.
+
+Please use [`@mui/system`](/system/getting-started/) instead.
+:::
 
 Material UI aims to provide a strong foundation for building dynamic UIs.
 For the sake of simplicity, **we expose the styling solution used in Material UI components** as the `@mui/styles` package.

--- a/docs/data/styles/basics/basics.md
+++ b/docs/data/styles/basics/basics.md
@@ -3,7 +3,7 @@
 <p class="description">The legacy styling solution for Material UI, now deprecated and not recommended for use.</p>
 
 :::error
-`@mui/styles` was deprecated in v5, which was released in late 2021.
+`@mui/styles` was deprecated with the release of MUI Core v5 in late 2021.
 It depended on [JSS](https://cssinjs.org/) as a styling solution, which is no longer used in `@mui/material`.
 
 `@mui/styles` is not compatible with [React.StrictMode](https://react.dev/reference/react/StrictMode) or React 18, and it will not be updated.

--- a/docs/data/styles/basics/basics.md
+++ b/docs/data/styles/basics/basics.md
@@ -13,27 +13,6 @@ This documentation remains here for those working on legacy projects, but we **s
 Please use [`@mui/system`](/system/getting-started/) instead.
 :::
 
-Material UI aims to provide a strong foundation for building dynamic UIs.
-For the sake of simplicity, **we expose the styling solution used in Material UI components** as the `@mui/styles` package.
-You can use it, but you don't have to, since Material UI is also [interoperable with](/material-ui/guides/interoperability/) all the other major styling solutions.
-
-## Why use Material UI's styling solution?
-
-In previous versions, Material UI has used [Less](https://lesscss.org/), and then a custom inline-style solution to write the component styles, but these approaches proved to be limited.
-[A _CSS-in-JS_ solution](https://github.com/oliviertassinari/a-journey-toward-better-style) overcomes many of those limitations,
-and **unlocks many great features** (theme nesting, dynamic styles, self-support, etc.).
-
-Material UI's styling solution is inspired by many other styling libraries such as [styled-components](https://styled-components.com/) and [Emotion](https://emotion.sh/).
-
-- 💅 You can expect [the same advantages](https://styled-components.com/docs/basics#motivation) as styled-components.
-
-<!-- #default-branch-switch -->
-
-- 🚀 It's [blazing fast](https://github.com/mui/material-ui/tree/master/benchmark/server#material-uistyles).
-- 🧩 It's extensible via a [plugin](https://github.com/cssinjs/jss/blob/master/docs/plugins.md) API.
-- ⚡️ It uses [JSS](https://github.com/cssinjs/jss) at its core – a [high performance](https://github.com/cssinjs/jss/blob/master/docs/performance.md) JavaScript to CSS compiler which works at runtime and server-side.
-- 📦 Less than [15 kB gzipped](https://bundlephobia.com/package/@mui/styles); and no bundle size increase if used alongside Material UI.
-
 ## Installation
 
 To install and save in your `package.json` dependencies, run:


### PR DESCRIPTION
Related to #39643 

We don't maintain `@mui/styles` anymore so we shouldn't invest much effort into these legacy docs, but I noticed some weird styles being applied to the blockquotes on these pages and figured they should be replaced with a much scarier `:::error` callout to discourage users from installing it. I routinely see newer developers on Stack Overflow getting stuck when trying to use `@mui/styles` with the latest version of Material UI—presumably because they're following some outdated third-party content—so maybe this will help minimize those issues.

I also cut all the intro text in the "Basics" page that referred to it as "Material UI's styling solution" and listed all of the reasons why it's such a great choice. 😅

Before:

<img width="870" alt="Screenshot 2023-10-28 at 11 02 34 AM" src="https://github.com/mui/material-ui/assets/71297412/b6b215be-014d-4138-aed7-d392dd604b63">


After:

<img width="883" alt="Screenshot 2023-10-28 at 11 02 08 AM" src="https://github.com/mui/material-ui/assets/71297412/e60ee439-2050-4c24-81d0-c869e7298f0f">
