### PR TITLE
[docs][material-ui] Add comment about code to be removed from Drawer demo

### DIFF
--- a/docs/data/material/components/drawers/ResponsiveDrawer.js
+++ b/docs/data/material/components/drawers/ResponsiveDrawer.js
@@ -59,6 +59,7 @@ function ResponsiveDrawer(props) {
     </div>
   );
 
+  // Remove this const when copying and pasting into your project.
   const container = window !== undefined ? () => window().document.body : undefined;
 
   return (
@@ -158,7 +159,7 @@ function ResponsiveDrawer(props) {
 ResponsiveDrawer.propTypes = {
   /**
    * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
+   * Remove this when copying and pasting into your project.
    */
   window: PropTypes.func,
 };

--- a/docs/data/material/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/data/material/components/drawers/ResponsiveDrawer.tsx
@@ -21,7 +21,7 @@ const drawerWidth = 240;
 interface Props {
   /**
    * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
+   * Remove this when copying and pasting into your project.
    */
   window?: () => Window;
 }
@@ -66,6 +66,7 @@ export default function ResponsiveDrawer(props: Props) {
     </div>
   );
 
+  // Remove this const when copying and pasting into your project.
   const container = window !== undefined ? () => window().document.body : undefined;
 
   return (


### PR DESCRIPTION
Closes #39667 by adding a comment next to the line that should be removed when copying and pasting the "Responsive Drawer" demo into an app. I also changed the "you won't need" comment to be more explicit that it should be removed.