### PR TITLE
[core] Speed up the CI by removing the second build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
           # Don't need playwright in this job
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - run: yarn release:build
-      # double run to check if cleanup works
-      - run: yarn release:build
       - run: yarn release:changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed the second build of all the libraries as it's time-consuming (over 6 minutes). While testing if the build is idempotent is valuable, it feels that removing it could be a compromise between completeness and speed. It's not an area that often changes.