### PR TITLE
[docs][joy-ui] Refine the structure of already revised Joy UI Component docs

### DIFF
--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -70,6 +70,12 @@ Play around combining different colors with different variants.
 
 {{"demo": "ButtonColors.js"}}
 
+### Decorators
+
+Use the `startDecorator` and `endDecorator` props to append actions and icons to either side of the Button:
+
+{{"demo": "ButtonIcons.js"}}
+
 ### Disabled
 
 Use the `disabled` prop to disable interaction and focus:
@@ -83,12 +89,6 @@ The Button is [disabled](#disabled) as long as it's loading.
 See [Loading indicator](#loading-indicator) and [Loading position](#loading-position) for customization options.
 
 {{"demo": "ButtonLoading.js"}}
-
-### Decorators
-
-Use the `startDecorator` and `endDecorator` props to append actions and icons to either side of the Button:
-
-{{"demo": "ButtonIcons.js"}}
 
 ### Loading indicator
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -42,20 +42,6 @@ Use the Icon Button component for a square button to house an icon with no text 
 
 {{"demo": "IconButtons.js"}}
 
-### Disabled
-
-Use the `disabled` prop to disable interaction and focus:
-
-{{"demo": "ButtonDisabled.js"}}
-
-### Loading
-
-Add the `loading` prop to show the Button's loading state.
-The Button is [disabled](#disabled) as long as it's loading.
-See [Loading indicator](#loading-indicator) and [Loading position](#loading-position) for customization options.
-
-{{"demo": "ButtonLoading.js"}}
-
 ### Variants
 
 The Button component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid` (default), `soft`, `outlined`, and `plain`.
@@ -83,6 +69,20 @@ Every palette included in the theme is available via the `color` prop.
 Play around combining different colors with different variants.
 
 {{"demo": "ButtonColors.js"}}
+
+### Disabled
+
+Use the `disabled` prop to disable interaction and focus:
+
+{{"demo": "ButtonDisabled.js"}}
+
+### Loading
+
+Add the `loading` prop to show the Button's loading state.
+The Button is [disabled](#disabled) as long as it's loading.
+See [Loading indicator](#loading-indicator) and [Loading position](#loading-position) for customization options.
+
+{{"demo": "ButtonLoading.js"}}
 
 ### Decorators
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -18,6 +18,8 @@ unstyled: /base-ui/react-button/
 Buttons communicate actions that users can take.
 The Joy UI Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
 
+Joy UI also provides an Icon Button component for buttons with no text content.
+
 {{"demo": "ButtonUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
 ## Basics
@@ -32,6 +34,14 @@ The demo below shows the three basic states available to the Button: default, di
 
 {{"demo": "BasicButtons.js"}}
 
+```jsx
+import IconButton from '@mui/joy/IconButton';
+```
+
+Use the Icon Button component for a square button to house an icon with no text content.
+
+{{"demo": "IconButtons.js"}}
+
 ### Disabled
 
 Use the `disabled` prop to disable interaction and focus:
@@ -45,8 +55,6 @@ The Button is [disabled](#disabled) as long as it's loading.
 See [Loading indicator](#loading-indicator) and [Loading position](#loading-position) for customization options.
 
 {{"demo": "ButtonLoading.js"}}
-
-## Customization
 
 ### Variants
 
@@ -100,6 +108,8 @@ It supports three values:
 
 {{"demo": "ButtonLoadingPosition.js"}}
 
+## Customization
+
 ### Link Button
 
 Buttons let users take actions, but if that action is to navigate to a new page, then an anchor tag is generally preferable over a button tag.
@@ -113,16 +123,6 @@ If you need the style of a button with the functionality of a link, then you can
 To create a file upload button, turn the button into a label using `component="label"` and then create a visually-hidden input with type `file`.
 
 {{"demo": "InputFileUpload.js"}}
-
-## Icon Button
-
-```jsx
-import IconButton from '@mui/joy/IconButton';
-```
-
-Use the Icon Button component for a square button to house an icon with no text content.
-
-{{"demo": "IconButtons.js"}}
 
 ## CSS variables playground
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -39,8 +39,6 @@ Use the `label` prop to provide text, and add `defaultChecked` when the input sh
 
 {{"demo": "BasicCheckbox.js"}}
 
-## Customization
-
 ### Variants
 
 The Checkbox component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid`, `soft`, `outlined`, and `plain`. By default, when unchecked, the Checkbox is set to `outlined`;
@@ -95,13 +93,6 @@ Try clicking on the Checkbox labels in the demo below to see how this works:
 
 {{"demo": "IconlessCheckbox.js"}}
 
-### Focus outline
-
-By default, the focus outline wraps both the Checkbox input and its label.
-To set the focus outline so that it only wraps the input, target the `checkboxClasses.checkbox` class and add `position: 'relative'`, as shown in the demo below:
-
-{{"demo": "FocusCheckbox.js"}}
-
 ### Clickable container
 
 Use the `overlay` prop to shift the focus outline from the Checkbox to its container, making the entire container clickable to toggle the state of the Checkbox.
@@ -129,6 +120,15 @@ It has no accessibility or UX implications.
 
 {{"demo": "IndeterminateCheckbox.js"}}
 
+## Customization
+
+### Focus outline
+
+By default, the focus outline wraps both the Checkbox input and its label.
+To set the focus outline so that it only wraps the input, target the `checkboxClasses.checkbox` class and add `position: 'relative'`, as shown in the demo below:
+
+{{"demo": "FocusCheckbox.js"}}
+
 ### Helper text
 
 ```jsx
@@ -136,7 +136,7 @@ import FormControl from '@mui/joy/FormControl';
 import FormHelperText from '@mui/joy/FormHelperText';
 ```
 
-Use the Form Control and Form Helper Text components add a description to the Checkbox.
+Use the Form Control and Form Helper Text components to add a description to the Checkbox.
 The Checkbox will be linked to the helper text via the `aria-describedby` attribute.
 
 {{"demo": "HelperTextCheckbox.js"}}

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -168,7 +168,7 @@ To create a floating label input, a custom component (combination of `<input>` a
 
 {{"demo": "DebouncedInput.js"}}
 
-### Third-party formatting
+## Third-party integrations
 
 The Input component can be integrated with third-party formatting libraries for more complex use cases.
 
@@ -177,13 +177,13 @@ Then use that adapter as a value to the `slotProps.input.component` property of 
 
 The demos below illustrate how to do this with two popular libraries.
 
-#### React imask
+### React imask
 
 [react-imask](https://github.com/uNmAnNeR/imaskjs/tree/master/packages/react-imask) provides the `IMaskInput` component for complex formatting options.
 
 {{"demo": "InputReactImask.js"}}
 
-#### React number format
+### React number format
 
 [react-number-format](https://github.com/s-yadav/react-number-format) provides the `NumericFormat` component for enforcing text formatting that follows a specific number or string pattern.
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -27,8 +27,6 @@ The Input component provides a customizable input field that can be used to coll
 
 {{"demo": "BasicInput.js"}}
 
-## Customization
-
 ### Variants
 
 The Input component supports Joy UI's four [global variants](/joy-ui/main-features/global-variants/): `solid` (default), `soft`, `outlined`, and `plain`.
@@ -56,11 +54,34 @@ Every palette included in the theme is available via the `color` prop.
 
 {{"demo": "InputColors.js"}}
 
+### Decorators
+
+Use the `startDecorator` and `endDecorator` props to add supporting icons or elements to the input.
+
+{{"demo": "InputDecorators.js"}}
+
 ### Form submission
 
 You can add standard form attributes such as `required` and `disabled` to the Input component:
 
 {{"demo": "InputFormProps.js"}}
+
+### Validation
+
+Use the `error` prop on Input or Form Control to toggle the error state:
+
+{{"demo": "InputValidation.js"}}
+
+:::info
+Using the `color` prop with `danger` as the value gives you the same result:
+
+```js
+<Input color="danger" />
+```
+
+:::
+
+## Customization
 
 ### Focused ring
 
@@ -100,31 +121,15 @@ The focus ring still appear on focus even though you set `--Input-focused: 0`.
 
 ### Label and helper text
 
-Group Input with the Form label and Form helper text in a Form control component to create a text field.
-
-{{"demo": "InputField.js"}}
-
-### Validation
-
-Use the `error` prop on Input or Form Control to toggle the error state:
-
-{{"demo": "InputValidation.js"}}
-
-:::info
-Using the `color` prop with `danger` as the value gives you the same result:
-
-```js
-<Input color="danger" />
+```jsx
+import FormControl from '@mui/joy/FormControl';
+import FormLabel from '@mui/joy/FormLabel';
+import FormHelperText from '@mui/joy/FormHelperText';
 ```
 
-:::
+Group an Input with the Form Label and Form Helper Text in a Form Control component to create a more sophisticated text input for a form.
 
-### Decorators
-
-The `startDecorator` and `endDecorator` props can be used to add supporting icons or elements to the input.
-With inputs, decorators are typically located at the top and/or bottom of the input field.
-
-{{"demo": "InputDecorators.js"}}
+{{"demo": "InputField.js"}}
 
 ### Inner HTML input
 
@@ -132,13 +137,6 @@ If you need to pass props to the inner HTML `<input>`, use `slotProps={{ input: 
 These props may include HTML attributes such as `ref`, `min`, `max`, and `autocomplete`.
 
 {{"demo": "InputSlotProps.js"}}
-
-## CSS variables playground
-
-Play around with the CSS variables available to the Input component to see how the design changes.
-You can use these to customize the component with both the `sx` prop and the theme.
-
-{{"demo": "InputVariables.js", "hideToolbar": true, "bg": "gradient"}}
 
 ## Common examples
 
@@ -190,6 +188,13 @@ The demos below illustrate how to do this with two popular libraries.
 [react-number-format](https://github.com/s-yadav/react-number-format) provides the `NumericFormat` component for enforcing text formatting that follows a specific number or string pattern.
 
 {{"demo": "InputReactNumberFormat.js"}}
+
+## CSS variables playground
+
+Play around with the CSS variables available to the Input component to see how the design changes.
+You can use these to customize the component with both the `sx` prop and the theme.
+
+{{"demo": "InputVariables.js", "hideToolbar": true, "bg": "gradient"}}
 
 ## Accessibility
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -156,7 +156,7 @@ To create a floating label input, a custom component (combination of `<input>` a
 
 {{"demo": "UnderlineInput.js"}}
 
-### Newsletter Subscription
+### Newsletter subscription
 
 {{"demo": "InputSubscription.js"}}
 

--- a/docs/data/joy/components/radio-button/radio-button.md
+++ b/docs/data/joy/components/radio-button/radio-button.md
@@ -14,20 +14,19 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/radio/
 
 ## Introduction
 
-Radio buttons let users make a mutually exclusive choice (e.g., this or that).
+Radio buttons let users make a mutually exclusive choice ("this _or_ that").
 Only one selection is allowed from the available set of options.
 
 Radio buttons should have the most commonly used option selected by default.
 
 {{"demo": "RadioUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
-:::success
-When should you use radio buttons rather than checkboxes, switches, or selects?
+:::info
+When should you use Radio buttons rather than Checkboxes, Switches, or Selects?
 
-- Use checkboxes to give the user **multiple binary choices**—radio buttons are preferable when you need to restrict user selection to one mutually exclusive option from a series.
-- Use a switch to provide the user with **a single binary choice**—radio buttons are preferable when you need to give the user multiple binary choices.
-- Consider using a select if it's not important for the user to be able to see all options.
-- If available options can be collapsed, consider using a Select component to conserve space.
+- Use Checkboxes to give the user **multiple binary choices**—Radio buttons are preferable when you need to restrict user selection to one mutually exclusive option from a series.
+- Use a Switch to provide the user with **a single binary choice**—Radio buttons are preferable when you need to give the user multiple binary choices.
+- Consider using a Select if it's not important for the user to be able to see all options and you want to conserve space.
   :::
 
 ## Basics
@@ -39,8 +38,6 @@ import Radio from '@mui/joy/Radio';
 The Joy UI Radio button behaves similar to the native HTML <input type="radio">, so it accepts props like `checked`, `value` and `onChange`.
 
 {{"demo": "RadioButtons.js"}}
-
-## Customization
 
 ### Variants
 
@@ -79,36 +76,6 @@ For more complex layouts, compose a Radio button with Form Control, Form Label, 
 
 {{"demo": "RadioButtonControl.js"}}
 
-### Position
-
-To swap the positions of a Radio and its label, use the CSS property `flex-direction: row-reverse`.
-
-{{"demo": "RadioPositionEnd.js"}}
-
-## Usage with Radio Group
-
-```jsx
-import RadioGroup from '@mui/joy/RadioGroup';
-```
-
-The Radio Group component is the ideal wrapper for multiple Radio components as it provides a tailored API for grouping and better keyboard navigation accessibility.
-
-{{"demo": "RadioButtonsGroup.js"}}
-
-### Controlled
-
-Use the `value` and `onChange` props to control the actions performed by the Radio buttons.
-For example, the Radio buttons in the demo below update the state to reflect the selected option:
-
-{{"demo": "ControlledRadioButtonsGroup.js"}}
-
-### Focus outline
-
-By default, the focus outline wraps both the Radio button and its label.
-If you need to focus to omit the label, target the `radioClasses.radio` class and add `position: 'relative'`.
-
-{{"demo": "RadioFocus.js"}}
-
 ### Overlay
 
 To make the Radio button's container clickable, use the `overlay` prop.
@@ -134,6 +101,45 @@ Use the `disableIcon` prop to remove the Radio button's icon.
 In this case, you'll need to use CSS properties like border and background color to communicate the state of the Radio button, as shown in the demo below:
 
 {{"demo": "IconlessRadio.js"}}
+
+### Controlled
+
+Use the `value` and `onChange` props to control the actions performed by the Radio buttons.
+For example, the Radio buttons in the demo below update the state to reflect the selected option:
+
+{{"demo": "ControlledRadioButtonsGroup.js"}}
+
+:::info
+
+- A component is **controlled** when it's managed by its parent using props.
+- A component is **uncontrolled** when it's managed by its own local state.
+  Learn more about controlled and uncontrolled components in the [React documentation](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+  :::
+
+## Customization
+
+### Position
+
+To swap the positions of a Radio and its label, use the CSS property `flex-direction: row-reverse`.
+
+{{"demo": "RadioPositionEnd.js"}}
+
+### Focus outline
+
+By default, the focus outline wraps both the Radio button and its label.
+If you need to focus to omit the label, target the `radioClasses.radio` class and add `position: 'relative'`.
+
+{{"demo": "RadioFocus.js"}}
+
+### Use with Radio Group
+
+```jsx
+import RadioGroup from '@mui/joy/RadioGroup';
+```
+
+The Radio Group component is the ideal wrapper for multiple Radio components as it provides a tailored API for grouping and better keyboard navigation accessibility.
+
+{{"demo": "RadioButtonsGroup.js"}}
 
 ## Common examples
 


### PR DESCRIPTION
Related to #39702 

Updating all of the Joy UI pages that have already gone through one round of editing, to apply the updated format—this is mostly about moving more content to the "Basics" sections, with minimal edits to the content itself (except where I find little typos and things along the way).

There are quite a few of these to cover and I'd like to knock 'em all out in this PR, so I'll mark this as ready to review once I've gotten through them all.