### PR TITLE
[docs-infra] Fix bug on API prop copy experience

### DIFF
--- a/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
@@ -212,20 +212,11 @@ function ApiItem(props: ApiItemProps) {
       )}
     >
       <div className="MuiApi-item-header">
-        <a
-          className="MuiApi-item-link-visual"
-          href={`#${id}`}
-          onClick={() => {
-            navigator.clipboard.writeText(
-              `${window.location.origin}${window.location.pathname}#${id}`,
-            );
-          }}
-        >
+        <a className="MuiApi-item-link-visual" href={`#${id}`}>
           <svg>
             <use xlinkHref="#anchor-link-icon" />
           </svg>
         </a>
-
         <span
           className="MuiApi-item-title" // This className is used by Algolia
         >


### PR DESCRIPTION
I have noticed this while I was looking at #39704:

1. When I click on prop links in dev mode http://0.0.0.0:3000/material-ui/api/dialog/#Dialog-prop-classes

<img width="167" alt="Screenshot 2023-11-02 at 00 59 45" src="https://github.com/mui/material-ui/assets/3165635/8364a25d-d5c7-4c7d-b6da-29dba45a3bad">

⬇️

<img width="873" alt="Screenshot 2023-11-02 at 00 54 21" src="https://github.com/mui/material-ui/assets/3165635/cbadd77b-01d0-46b1-829e-92922a625d5e">

2. When I click on prop links in production is replaces my clipboard, I didn't ask him to.

The simplest solution seems to remove this behavior. If we really want to keep it, we would need to use `clipboard-copy` instead.