### PR TITLE
[docs-infra] Fix path bloat client-side

### DIFF
--- a/docs/src/modules/components/RichMarkdownElement.js
+++ b/docs/src/modules/components/RichMarkdownElement.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
@@ -41,7 +40,7 @@ export default function RichMarkdownElement(props) {
     const Component = srcComponents?.[name];
 
     if (Component === undefined) {
-      throw new Error(`No component found at the path ${path.join('docs/src', name)}`);
+      throw new Error(`No component found at the path 'docs/src/${name}`);
     }
 
     const additionalProps = {};


### PR DESCRIPTION
I have noticed this while I was looking at #39704.

Before
<img width="1251" alt="Screenshot 2023-11-02 at 01 09 43" src="https://github.com/mui/material-ui/assets/3165635/00bfdcea-2a98-4c3b-8dcf-6ad2226cf421">

After
<img width="1323" alt="Screenshot 2023-11-02 at 01 10 03" src="https://github.com/mui/material-ui/assets/3165635/547add49-c379-48c3-a57d-23b2b0fcf5d5">

From the network tab, we go from 13.1 to 13.0 MB, so saving ~100KB of JavaScript unzipped on almost all the pages of the docs.