### PR TITLE
[docs-infra] Simplify footer

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -22,7 +22,6 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import PanToolRoundedIcon from '@mui/icons-material/PanToolRounded';
 import TwitterIcon from '@mui/icons-material/Twitter';
-import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import YouTubeIcon from '@mui/icons-material/YouTube';
 import RssFeedIcon from '@mui/icons-material/RssFeed';
 import ArrowOutwardRoundedIcon from '@mui/icons-material/ArrowOutwardRounded';
@@ -546,15 +545,7 @@ export default function AppLayoutDocsFooter(props) {
             </Typography>
             <Link href={ROUTES.store}>
               <FooterLink>
-                Store <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
-              </FooterLink>
-            </Link>
-            <Typography color="grey.500" fontSize={13}>
-              &bull;
-            </Typography>
-            <Link href={ROUTES.careers}>
-              <FooterLink>
-                Careers <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
+                Templates <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>
             </Link>
           </Stack>
@@ -578,16 +569,6 @@ export default function AppLayoutDocsFooter(props) {
               size="small"
             >
               <TwitterIcon fontSize="small" sx={{ color: 'grey.500' }} />
-            </IconButton>
-            <IconButton
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://www.linkedin.com/company/mui/"
-              aria-label="linkedin"
-              title="LinkedIn"
-              size="small"
-            >
-              <LinkedInIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>
             <IconButton
               target="_blank"

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -535,7 +535,7 @@ export default function AppLayoutDocsFooter(props) {
           spacing={{ xs: 3, sm: 1 }}
         >
           <Stack direction="row" alignItems="center" spacing={1} sx={{ flexGrow: 1 }}>
-            <Link href={ROUTES.blog}>
+            <Link href={ROUTES.blog} target="_blank" rel="noopener noreferrer">
               <FooterLink>
                 Blog <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>
@@ -543,7 +543,7 @@ export default function AppLayoutDocsFooter(props) {
             <Typography color="grey.500" fontSize={13}>
               &bull;
             </Typography>
-            <Link href={ROUTES.store}>
+            <Link href={ROUTES.store} target="_blank" rel="noopener noreferrer">
               <FooterLink>
                 Store <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -545,7 +545,7 @@ export default function AppLayoutDocsFooter(props) {
             </Typography>
             <Link href={ROUTES.store}>
               <FooterLink>
-                Templates <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
+                Store <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>
             </Link>
           </Stack>


### PR DESCRIPTION
A follow-up on #36556. I have two problems with the current footer:

<img width="929" alt="Screenshot 2023-11-02 at 01 40 59" src="https://github.com/mui/material-ui/assets/3165635/f710f429-9089-495e-a98c-ebaf14c6b8a9">

https://mui.com/material-ui/getting-started/design-resources/

1. We don't want candidates who browse the docs to land on the career page so easily. The last time we tried to encourage people who browse the docs to apply to roles, this was the channel with the worst conversion rate. I think it's better for people to actively search the page.
2. I have removed links that are clearly corporate. I think that we should keep the open-source docs focused on its community.
3. We used the icon that signals `target="_blank"` but we didn't add them, fixed. <img width="16" alt="Screenshot 2023-11-02 at 02 05 15" src="https://github.com/mui/material-ui/assets/3165635/3a7b3613-4cd0-4eb0-9aca-5dacb9bd59f0">

Edit: Ah, I forgot I opened an issue #39352

---

In the future, we could specialize these footer links. For example, have a blog area per product, have a template area per product, have a playlist per product on YouTube. Have separate Twitter accounts.