### PR TITLE
[docs-infra] Render footer in SSR

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { styled } from '@mui/material/styles';
 import { exactProp } from '@mui/utils';
 import GlobalStyles from '@mui/material/GlobalStyles';
-import NoSsr from '@mui/material/NoSsr';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
 import Head from 'docs/src/modules/components/Head';
 import AppFrame from 'docs/src/modules/components/AppFrame';
@@ -150,9 +149,7 @@ export default function AppLayoutDocs(props) {
           */}
           <StyledAppContainer disableAd={disableAd} hasTabs={hasTabs} disableToc={disableToc}>
             {children}
-            <NoSsr>
-              <AppLayoutDocsFooter tableOfContents={toc} location={location} />
-            </NoSsr>
+            <AppLayoutDocsFooter tableOfContents={toc} location={location} />
           </StyledAppContainer>
           {disableToc ? null : <AppTableOfContents toc={toc} />}
         </Main>

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -421,81 +421,84 @@ export default function AppLayoutDocsFooter(props) {
             </Tooltip>
           </Stack>
         </Stack>
-        <Collapse
-          in={commentOpen}
-          unmountOnExit
-          onEntered={handleEntered}
-          timeout={{ enter: 0, exit: theme.transitions.duration.standard }}
-        >
-          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-          <form
-            aria-labelledby="feedback-message"
-            onReset={handleCancelComment}
-            onSubmit={handleSubmitComment}
-            onKeyDown={handleKeyDownForm}
+        {/* Wrapper div to fix Collapse close animation */}
+        <div>
+          <Collapse
+            in={commentOpen}
+            unmountOnExit
+            onEntered={handleEntered}
+            timeout={{ enter: 0, exit: theme.transitions.duration.standard }}
           >
-            <div>
-              {commentedSection.text ? (
-                <Typography
-                  variant="body2"
-                  id="feedback-description"
-                  color="text.secondary"
-                  dangerouslySetInnerHTML={{
-                    __html: t('feedbackSectionSpecific').replace(
-                      '{{sectionName}}',
-                      `"${commentedSection.text}"`,
-                    ),
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+            <form
+              aria-labelledby="feedback-message"
+              onReset={handleCancelComment}
+              onSubmit={handleSubmitComment}
+              onKeyDown={handleKeyDownForm}
+            >
+              <div>
+                {commentedSection.text ? (
+                  <Typography
+                    variant="body2"
+                    id="feedback-description"
+                    color="text.secondary"
+                    dangerouslySetInnerHTML={{
+                      __html: t('feedbackSectionSpecific').replace(
+                        '{{sectionName}}',
+                        `"${commentedSection.text}"`,
+                      ),
+                    }}
+                  />
+                ) : (
+                  <Typography variant="body2" id="feedback-description" color="text.secondary">
+                    {rating === 1 ? t('feedbackMessageUp') : t('feedbackMessageDown')}
+                  </Typography>
+                )}
+                <TextField
+                  multiline
+                  margin="dense"
+                  name="comment"
+                  fullWidth
+                  rows={4}
+                  value={comment}
+                  onChange={handleChangeTextfield}
+                  inputProps={{
+                    'aria-label': t('feedbackCommentLabel'),
+                    'aria-describedby': 'feedback-description',
+                    ref: inputRef,
                   }}
                 />
-              ) : (
-                <Typography variant="body2" id="feedback-description" color="text.secondary">
-                  {rating === 1 ? t('feedbackMessageUp') : t('feedbackMessageDown')}
-                </Typography>
-              )}
-              <TextField
-                multiline
-                margin="dense"
-                name="comment"
-                fullWidth
-                rows={4}
-                value={comment}
-                onChange={handleChangeTextfield}
-                inputProps={{
-                  'aria-label': t('feedbackCommentLabel'),
-                  'aria-describedby': 'feedback-description',
-                  ref: inputRef,
-                }}
-              />
-              {rating !== 1 && (
-                <Alert
-                  severity="warning"
-                  color="warning"
-                  icon={<PanToolRoundedIcon fontSize="small" />}
-                  sx={{ my: 1.5 }}
-                >
-                  <Typography id="feedback-description" color="text.secondary">
-                    {t('feedbackMessageToGitHub.usecases')}{' '}
-                    <Link
-                      href={`${process.env.SOURCE_CODE_REPO}/issues/new?template=${process.env.GITHUB_TEMPLATE_DOCS_FEEDBACK}&page-url=${window.location.href}`}
-                      target="_blank"
-                    >
-                      {t('feedbackMessageToGitHub.callToAction.link')}
-                    </Link>{' '}
-                    {t('feedbackMessageToGitHub.reasonWhy')}
-                  </Typography>
-                </Alert>
-              )}
-              <DialogActions>
-                <Button type="reset" size="small">
-                  {t('cancel')}
-                </Button>
-                <Button type="submit" variant="contained" size="small">
-                  {t('submit')}
-                </Button>
-              </DialogActions>
-            </div>
-          </form>
-        </Collapse>
+                {rating !== 1 && typeof window !== 'undefined' && (
+                  <Alert
+                    severity="warning"
+                    color="warning"
+                    icon={<PanToolRoundedIcon fontSize="small" />}
+                    sx={{ my: 1.5 }}
+                  >
+                    <Typography id="feedback-description" color="text.secondary">
+                      {t('feedbackMessageToGitHub.usecases')}{' '}
+                      <Link
+                        href={`${process.env.SOURCE_CODE_REPO}/issues/new?template=${process.env.GITHUB_TEMPLATE_DOCS_FEEDBACK}&page-url=${window.location.href}`}
+                        target="_blank"
+                      >
+                        {t('feedbackMessageToGitHub.callToAction.link')}
+                      </Link>{' '}
+                      {t('feedbackMessageToGitHub.reasonWhy')}
+                    </Typography>
+                  </Alert>
+                )}
+                <DialogActions>
+                  <Button type="reset" size="small">
+                    {t('cancel')}
+                  </Button>
+                  <Button type="submit" variant="contained" size="small">
+                    {t('submit')}
+                  </Button>
+                </DialogActions>
+              </div>
+            </form>
+          </Collapse>
+        </div>
         <Divider />
         {hidePagePagination ? null : (
           <Stack direction="row" justifyContent="space-between" sx={{ my: 2 }}>


### PR DESCRIPTION
I have noticed this while I was looking at https://github.com/mui/material-ui/pull/39704.

- Fix layout shift in https://mui.com/material-ui/getting-started/design-resources/ when loading the page. Overall, it feels like it makes more sense to SSR the footer. In the future, we might be able to make it a Server component. The alternative fix would be to simply force the scrollbar to reserve space.
- Fix the animation by adding a `<div>`. Before

https://github.com/mui/material-ui/assets/3165635/812f8b8e-4f7f-4126-bd10-edf203971d6a

Preview: https://deploy-preview-39710--material-ui.netlify.app/material-ui/getting-started/design-resources/