### PR TITLE
[test] Fix flaky screenshot

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -36,6 +36,7 @@ const blacklist = [
   'docs-joy-components-divider/DividerChildPosition.png', // Needs interaction
   'docs-joy-components-linear-progress/LinearProgressCountUp.png', // Flaky due to animation
   'docs-base-guides-working-with-tailwind-css/PlayerFinal.png', // No public components
+  'docs-base-getting-started-quickstart/BaseButtonTailwind.png', // CodeSandbox
   'docs-components-alert/TransitionAlerts.png', // Needs interaction
   'docs-components-app-bar/BackToTop.png', // Needs interaction
   'docs-components-app-bar/ElevateAppBar.png', // Needs interaction


### PR DESCRIPTION
I have noticed this while I was looking at https://github.com/mui/material-ui/pull/39704.

See https://app.argos-ci.com/mui/material-ui/builds/20423/63355721 as an example.

<img width="1413" alt="Screenshot 2023-11-02 at 02 12 58" src="https://github.com/mui/material-ui/assets/3165635/b6b0bfc8-c499-4fd1-96ad-dd2870343f40">

---

I think that we should implement the `NoSnap` suffix demo convention here as MUI X does: https://github.com/mui/mui-x/blob/612fb24d6686565dd1adac613c2d42aadf3047d6/test/regressions/index.js#L19