### PR TITLE
[InputBase][material-next] InputBase slotProps accepts sx type

### DIFF
--- a/packages/mui-material-next/src/InputBase/InputBase.spec.tsx
+++ b/packages/mui-material-next/src/InputBase/InputBase.spec.tsx
@@ -7,3 +7,19 @@ import InputBase from '@mui/material-next/InputBase';
     expectType<React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, typeof event>(event);
   }}
 />;
+
+// Tests presence of `sx` prop on input and root slot
+<InputBase
+  slotProps={{
+    input: {
+      sx: {
+        background: 'white',
+      },
+    },
+    root: {
+      sx: {
+        background: 'black',
+      },
+    },
+  }}
+/>;

--- a/packages/mui-material-next/src/InputBase/InputBase.types.ts
+++ b/packages/mui-material-next/src/InputBase/InputBase.types.ts
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { SlotComponentProps } from '@mui/base';
 import { FormControlContextValue } from '@mui/material-next/FormControl/FormControlContext';
 import { UseInputRootSlotProps } from '@mui/base/useInput';
-import { SxProps } from '@mui/system';
 import { OverridableStringUnion, OverrideProps, Simplify } from '@mui/types';
-import { Theme } from '../styles';
+import { SxProps } from '../styles';
 import { InputBaseClasses } from './inputBaseClasses';
 
 export interface InputBasePropsSizeOverrides {}
@@ -137,8 +136,12 @@ export type InputBaseOwnProps = {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', InputBaseRootSlotPropsOverrides, InputBaseOwnerState>;
-    input?: SlotComponentProps<'input', InputBaseInputSlotPropsOverrides, InputBaseOwnerState>;
+    root?: SlotComponentProps<'div', InputBaseRootSlotPropsOverrides, InputBaseOwnerState> & {
+      sx?: SxProps;
+    };
+    input?: SlotComponentProps<'input', InputBaseInputSlotPropsOverrides, InputBaseOwnerState> & {
+      sx?: SxProps;
+    };
   };
   /**
    * The components used for each slot inside the InputBase.
@@ -153,7 +156,7 @@ export type InputBaseOwnProps = {
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
-  sx?: SxProps<Theme>;
+  sx?: SxProps;
   /**
    * The value of the `input` element, required for a controlled component.
    */


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/38372

This PR ports the fix in https://github.com/mui/material-ui/pull/39569 to `material-next`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
