### PR TITLE
[joy-ui][ModalDialog] Remove redundant code

### DIFF
--- a/packages/mui-joy/src/CardOverflow/CardOverflow.tsx
+++ b/packages/mui-joy/src/CardOverflow/CardOverflow.tsx
@@ -39,7 +39,6 @@ const CardOverflowRoot = styled('div', {
   ownerState: CardOverflowOwnerState & {
     'data-first-child'?: string;
     'data-last-child'?: string;
-    'data-parent'?: 'Card-horizontal' | 'Card-vertical';
   };
 }>(({ theme, ownerState }) => {
   const childRadius = 'calc(var(--CardOverflow-radius) - var(--variant-borderWidth, 0px))';

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.tsx
@@ -201,14 +201,6 @@ const ModalDialog = React.forwardRef(function ModalDialog(inProps, ref) {
               extraProps.orientation =
                 'orientation' in child.props ? child.props.orientation : dividerOrientation;
             }
-            if (isMuiElement(child, ['CardOverflow'])) {
-              if (orientation === 'horizontal') {
-                extraProps['data-parent'] = 'Card-horizontal';
-              }
-              if (orientation === 'vertical') {
-                extraProps['data-parent'] = 'Card-vertical';
-              }
-            }
             if (index === 0) {
               extraProps['data-first-child'] = '';
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Adding `data-*` props to `CardOverFlow` is removed in this PR as styling is handled by `css` (https://github.com/mui/material-ui/pull/39101/files#diff-ba48a66cb44c70614c0374277ba1300dd6bdccb7d4a87ccad4e7f92d9930dce8) but removing in `ModalDialog` component is missed

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
