### PR TITLE
[docs-infra] Fix dark theme color

### DIFF
--- a/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
@@ -164,6 +164,7 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
       '& code.Api-code': {
         borderColor: alpha(darkTheme.palette.primary[400], 0.1),
         backgroundColor: alpha(darkTheme.palette.primary[900], 0.4),
+        color: `var(--muidocs-palette-primary-200, ${darkTheme.palette.primary[200]})`,
       },
     },
   }),

--- a/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpendableApiItem.tsx
@@ -164,7 +164,7 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
       '& code.Api-code': {
         borderColor: alpha(darkTheme.palette.primary[400], 0.1),
         backgroundColor: alpha(darkTheme.palette.primary[900], 0.4),
-        color: `var(--muidocs-palette-primary-200, ${darkTheme.palette.primary[200]})`,
+        color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
       },
     },
   }),


### PR DESCRIPTION
Befor/After

![image](https://github.com/mui/material-ui/assets/45398769/80ab2ea2-b64c-4f8c-bd25-5a15f357744a)
![image](https://github.com/mui/material-ui/assets/45398769/c5a1e42d-aa79-4c60-94e6-65adbbd27025)


Also noticed that the default column has some empty ticks that are just due to the content being undefined. It's not the expected behavior, but it looks good :+1: 

![image](https://github.com/mui/material-ui/assets/45398769/e9666fd7-c359-4052-8b3e-f66de8221e47)


