### PR TITLE
[material-ui][Checkbox] Asterisk placement aligned correctly

### DIFF
--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -167,10 +167,12 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
       {React.cloneElement(control, controlProps)}
       {required ? (
         <Stack direction="row" alignItems="center">
-          {label}
-          <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>
-            &thinsp;{'*'}
-          </AsteriskComponent>
+          <span>
+            {label}
+            <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>
+              &thinsp;{'*'}
+            </AsteriskComponent>
+          </span>
         </Stack>
       ) : (
         label

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -166,7 +166,7 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
     >
       {React.cloneElement(control, controlProps)}
       {required ? (
-        <Stack direction="row" alignItems="center">
+        <Stack display="block">
           <span>
             {label}
             <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.js
@@ -167,12 +167,10 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(inProps, ref
       {React.cloneElement(control, controlProps)}
       {required ? (
         <Stack display="block">
-          <span>
-            {label}
-            <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>
-              &thinsp;{'*'}
-            </AsteriskComponent>
-          </span>
+          {label}
+          <AsteriskComponent ownerState={ownerState} aria-hidden className={classes.asterisk}>
+            &thinsp;{'*'}
+          </AsteriskComponent>
         </Stack>
       ) : (
         label


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/39626

Demo: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-39721-rdd4kc?file=/src/App.tsx

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
