### PR TITLE
[joy-ui][docs] Change the design kit link on the Overview page

### DIFF
--- a/docs/src/modules/components/JoyStartingLinksCollection.js
+++ b/docs/src/modules/components/JoyStartingLinksCollection.js
@@ -28,7 +28,7 @@ const content = [
     title: 'Joy UI for Figma',
     description:
       'The Joy UI components, with variables, variants, and states, in your favorite design tool.',
-    link: 'https://mui.com/store/items/figma-react/?utm_source=docs&utm_medium=referral&utm_campaign=installation-figma',
+    link: 'https://www.figma.com/community/file/1293288155415213351/joy-ui-for-figma',
     icon: (
       <img
         src={`/static/branding/design-kits/figma-logo.svg`}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Linking to the Store "MUI for Figma" design kit listing isn't a good landing place for the Joy UI Figma file link on the Overview page. It's not immediately clear how to actually access the Figma file; visitors would need to scroll down until they see — the fairly hidden — Community file link... which is where I think we can link directly. 

👉 **https://deploy-preview-39725--material-ui.netlify.app/joy-ui/getting-started/#start-now**