### PR TITLE
[TextField][material-ui] Fix padding on small filled multiline TextField

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -137,6 +137,11 @@ const FilledInputRoot = styled(InputBaseRoot, {
         paddingTop: 16,
         paddingBottom: 17,
       }),
+      ...(ownerState.hiddenLabel &&
+        ownerState.size === 'small' && {
+          paddingTop: 8,
+          paddingBottom: 9,
+        }),
     }),
   };
 });
@@ -180,12 +185,6 @@ const FilledInputInput = styled(InputBaseInput, {
     paddingTop: 16,
     paddingBottom: 17,
   }),
-  ...(ownerState.multiline && {
-    paddingTop: 0,
-    paddingBottom: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
-  }),
   ...(ownerState.startAdornment && {
     paddingLeft: 0,
   }),
@@ -197,6 +196,12 @@ const FilledInputInput = styled(InputBaseInput, {
       paddingTop: 8,
       paddingBottom: 9,
     }),
+  ...(ownerState.multiline && {
+    paddingTop: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+    paddingRight: 0,
+  }),
 }));
 
 const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {

--- a/test/regressions/fixtures/TextField/FilledMultilineHiddenLabelTextField.js
+++ b/test/regressions/fixtures/TextField/FilledMultilineHiddenLabelTextField.js
@@ -11,7 +11,16 @@ export default function FilledMultilineHiddenLabelTextField() {
         rows={1}
         hiddenLabel
       />
-      <TextField variant="filled" defaultValue="Default Value" rows={1} hiddenLabel />
+      <TextField variant="filled" defaultValue="Default Value" hiddenLabel />
+      <TextField
+        variant="filled"
+        defaultValue="Multiline Default Value"
+        multiline
+        rows={1}
+        hiddenLabel
+        size="small"
+      />
+      <TextField variant="filled" defaultValue="Default Value" hiddenLabel size="small" />
     </div>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/39610

I've adjusted the padding so that the `small` filled multiline hiddenInput TextField has the same `40px` height and updated a regression test

Before: https://codesandbox.io/s/https-github-com-mui-material-ui-issues-39610-66xjhp?file=/src/App.tsx

![Screenshot 2023-11-06 at 6 21 26 PM](https://github.com/mui/material-ui/assets/4997971/8ed3eb56-c7de-433e-8364-9c4b5ff4f3d4)
The `small` one has larger padding than the `medium` one

After: https://codesandbox.io/s/https-github-com-mui-material-ui-pull-39769-5xpmzh?file=/src/App.tsx

![Screenshot 2023-11-06 at 7 24 07 PM](https://github.com/mui/material-ui/assets/4997971/f334838d-73cb-4c86-b8bb-f09320ac55af)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
