### PR TITLE
[material-ui][Rating] Fix the hover highlighting for spaced icons

### DIFF
--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -367,14 +367,16 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
     }
 
     const rootNode = rootRef.current;
-    const { right, left } = rootNode.getBoundingClientRect();
-    const { width } = rootNode.firstChild.getBoundingClientRect();
+    const { right, left, width: containerWidth } = rootNode.getBoundingClientRect();
+
+    const itemWidth = containerWidth / max;
+
     let percent;
 
     if (theme.direction === 'rtl') {
-      percent = (right - event.clientX) / (width * max);
+      percent = (right - event.clientX) / (itemWidth * max);
     } else {
-      percent = (event.clientX - left) / (width * max);
+      percent = (event.clientX - left) / (itemWidth * max);
     }
 
     let newHover = roundValueToPrecision(max * percent + precision / 2, precision);

--- a/packages/mui-material/src/Rating/Rating.js
+++ b/packages/mui-material/src/Rating/Rating.js
@@ -369,14 +369,12 @@ const Rating = React.forwardRef(function Rating(inProps, ref) {
     const rootNode = rootRef.current;
     const { right, left, width: containerWidth } = rootNode.getBoundingClientRect();
 
-    const itemWidth = containerWidth / max;
-
     let percent;
 
     if (theme.direction === 'rtl') {
-      percent = (right - event.clientX) / (itemWidth * max);
+      percent = (right - event.clientX) / containerWidth;
     } else {
-      percent = (event.clientX - left) / (itemWidth * max);
+      percent = (event.clientX - left) / containerWidth;
     }
 
     let newHover = roundValueToPrecision(max * percent + precision / 2, precision);

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -58,6 +58,52 @@ describe('<Rating />', () => {
     expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(2);
   });
 
+  it('should handle mouse hover correctly for icons with spacing', () => {
+    const { container } = render(
+      <Rating
+        sx={{
+          '.MuiRating-decimal': { marginRight: 2 },
+        }}
+        precision={0.5}
+      />,
+    );
+    stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
+      left: 0,
+      right: 200,
+      width: 200,
+    }));
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 19,
+    });
+    // half star highlighted
+    expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(1);
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 21,
+    });
+    // one full star highlighted
+    expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(2);
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 39,
+    });
+    // Still one star remains highlighted as the total item width (40px) has not been reached yet, considering 24px for the icon width and 16px for margin-right.
+    expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(2);
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 41,
+    });
+    // one and half star highlighted
+    expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(3);
+
+    fireEvent.mouseMove(container.firstChild, {
+      clientX: 60,
+    });
+    // two full stars highlighted
+    expect(container.querySelectorAll(`.${classes.iconHover}`).length).to.equal(4);
+  });
+
   it('should clear the rating', () => {
     const handleChange = spy();
     const { container } = render(<Rating name="rating-test" onChange={handleChange} value={2} />);

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -62,7 +62,7 @@ describe('<Rating />', () => {
     const { container } = render(
       <Rating
         sx={{
-          '.MuiRating-decimal': { marginRight: 2 },
+          [`.${classes.decimal}`]: { marginRight: 2 },
         }}
         precision={0.5}
       />,

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -46,9 +46,7 @@ describe('<Rating />', () => {
     stub(container.firstChild, 'getBoundingClientRect').callsFake(() => ({
       left: 0,
       right: 100,
-    }));
-    stub(container.firstChild.firstChild, 'getBoundingClientRect').callsFake(() => ({
-      width: 20,
+      width: 100,
     }));
     fireEvent.mouseMove(container.firstChild, {
       clientX: 19,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #26380

The hover calculation in the mousemove event only considered the icon width, leading to incorrect hover highlighting when there is spacing between icons. Proper hover calculation is achieved when we consider the container's width regardless of spacing or no spacing.

Before: https://codesandbox.io/s/clever-keldysh-k4wshp?file=/src/App.tsx

After: https://codesandbox.io/s/material-ui-cra-ts-forked-2qjdhh