### PR TITLE
[material-next][ProgressIndicator] Copy `CircularProgress` to material next

### DIFF
--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.d.ts
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion } from '@mui/types';
+import { InternalStandardProps as StandardProps, Theme } from '..';
+import { CircularProgressClasses } from './circularProgressClasses';
+
+export interface CircularProgressPropsColorOverrides {}
+
+export interface CircularProgressProps
+  extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<CircularProgressClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'primary'
+   */
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' | 'inherit',
+    CircularProgressPropsColorOverrides
+  >;
+  /**
+   * If `true`, the shrink animation is disabled.
+   * This only works if variant is `indeterminate`.
+   * @default false
+   */
+  disableShrink?: boolean;
+  /**
+   * The size of the component.
+   * If using a number, the pixel unit is assumed.
+   * If using a string, you need to provide the CSS unit, e.g. '3rem'.
+   * @default 40
+   */
+  size?: number | string;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The thickness of the circle.
+   * @default 3.6
+   */
+  thickness?: number;
+  /**
+   * The value of the progress indicator for the determinate variant.
+   * Value between 0 and 100.
+   * @default 0
+   */
+  value?: number;
+  /**
+   * The variant to use.
+   * Use indeterminate when there is no progress value.
+   * @default 'indeterminate'
+   */
+  variant?: 'determinate' | 'indeterminate';
+}
+
+/**
+ * ## ARIA
+ *
+ * If the progress bar is describing the loading progress of a particular region of a page,
+ * you should use `aria-describedby` to point to the progress bar, and set the `aria-busy`
+ * attribute to `true` on that region until it has finished loading.
+ *
+ * Demos:
+ *
+ * - [Progress](https://mui.com/material-ui/react-progress/)
+ *
+ * API:
+ *
+ * - [CircularProgress API](https://mui.com/material-ui/api/circular-progress/)
+ */
+export default function CircularProgress(props: CircularProgressProps): JSX.Element;

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.d.ts
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { OverridableStringUnion } from '@mui/types';
-import { InternalStandardProps as StandardProps, Theme } from '..';
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import { Theme } from '../styles';
 import { CircularProgressClasses } from './circularProgressClasses';
 
 export interface CircularProgressPropsColorOverrides {}
 
-export interface CircularProgressProps
-  extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+export interface CircularProgressOwnProps {
   /**
    * Override or extend the styles applied to the component.
    */
@@ -57,6 +56,19 @@ export interface CircularProgressProps
    */
   variant?: 'determinate' | 'indeterminate';
 }
+
+export interface CircularProgressTypeMap<
+  AdditionalProps = {},
+  RootComponentType extends React.ElementType = 'span',
+> {
+  props: CircularProgressOwnProps & AdditionalProps;
+  defaultComponent: RootComponentType;
+}
+
+export type CircularProgressProps<
+  RootComponentType extends React.ElementType = CircularProgressTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<CircularProgressTypeMap<AdditionalProps, RootComponentType>, RootComponentType>;
 
 /**
  * ## ARIA

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.js
@@ -1,0 +1,276 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { chainPropTypes } from '@mui/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { keyframes, css } from '@mui/system';
+import capitalize from '../utils/capitalize';
+import useThemeProps from '../styles/useThemeProps';
+import styled from '../styles/styled';
+import { getCircularProgressUtilityClass } from './circularProgressClasses';
+
+const SIZE = 44;
+
+const circularRotateKeyframe = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const circularDashKeyframe = keyframes`
+  0% {
+    stroke-dasharray: 1px, 200px;
+    stroke-dashoffset: 0;
+  }
+
+  50% {
+    stroke-dasharray: 100px, 200px;
+    stroke-dashoffset: -15px;
+  }
+
+  100% {
+    stroke-dasharray: 100px, 200px;
+    stroke-dashoffset: -125px;
+  }
+`;
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, variant, color, disableShrink } = ownerState;
+
+  const slots = {
+    root: ['root', variant, `color${capitalize(color)}`],
+    svg: ['svg'],
+    circle: ['circle', `circle${capitalize(variant)}`, disableShrink && 'circleDisableShrink'],
+  };
+
+  return composeClasses(slots, getCircularProgressUtilityClass, classes);
+};
+
+const CircularProgressRoot = styled('span', {
+  name: 'MuiCircularProgress',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      styles[ownerState.variant],
+      styles[`color${capitalize(ownerState.color)}`],
+    ];
+  },
+})(
+  ({ ownerState, theme }) => ({
+    display: 'inline-block',
+    ...(ownerState.variant === 'determinate' && {
+      transition: theme.transitions.create('transform'),
+    }),
+    ...(ownerState.color !== 'inherit' && {
+      color: (theme.vars || theme).palette[ownerState.color].main,
+    }),
+  }),
+  ({ ownerState }) =>
+    ownerState.variant === 'indeterminate' &&
+    css`
+      animation: ${circularRotateKeyframe} 1.4s linear infinite;
+    `,
+);
+
+const CircularProgressSVG = styled('svg', {
+  name: 'MuiCircularProgress',
+  slot: 'Svg',
+  overridesResolver: (props, styles) => styles.svg,
+})({
+  display: 'block', // Keeps the progress centered
+});
+
+const CircularProgressCircle = styled('circle', {
+  name: 'MuiCircularProgress',
+  slot: 'Circle',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.circle,
+      styles[`circle${capitalize(ownerState.variant)}`],
+      ownerState.disableShrink && styles.circleDisableShrink,
+    ];
+  },
+})(
+  ({ ownerState, theme }) => ({
+    stroke: 'currentColor',
+    // Use butt to follow the specification, by chance, it's already the default CSS value.
+    // strokeLinecap: 'butt',
+    ...(ownerState.variant === 'determinate' && {
+      transition: theme.transitions.create('stroke-dashoffset'),
+    }),
+    ...(ownerState.variant === 'indeterminate' && {
+      // Some default value that looks fine waiting for the animation to kicks in.
+      strokeDasharray: '80px, 200px',
+      strokeDashoffset: 0, // Add the unit to fix a Edge 16 and below bug.
+    }),
+  }),
+  ({ ownerState }) =>
+    ownerState.variant === 'indeterminate' &&
+    !ownerState.disableShrink &&
+    css`
+      animation: ${circularDashKeyframe} 1.4s ease-in-out infinite;
+    `,
+);
+
+/**
+ * ## ARIA
+ *
+ * If the progress bar is describing the loading progress of a particular region of a page,
+ * you should use `aria-describedby` to point to the progress bar, and set the `aria-busy`
+ * attribute to `true` on that region until it has finished loading.
+ */
+const CircularProgress = React.forwardRef(function CircularProgress(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiCircularProgress' });
+  const {
+    className,
+    color = 'primary',
+    disableShrink = false,
+    size = 40,
+    style,
+    thickness = 3.6,
+    value = 0,
+    variant = 'indeterminate',
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    color,
+    disableShrink,
+    size,
+    thickness,
+    value,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  const circleStyle = {};
+  const rootStyle = {};
+  const rootProps = {};
+
+  if (variant === 'determinate') {
+    const circumference = 2 * Math.PI * ((SIZE - thickness) / 2);
+    circleStyle.strokeDasharray = circumference.toFixed(3);
+    rootProps['aria-valuenow'] = Math.round(value);
+    circleStyle.strokeDashoffset = `${(((100 - value) / 100) * circumference).toFixed(3)}px`;
+    rootStyle.transform = 'rotate(-90deg)';
+  }
+
+  return (
+    <CircularProgressRoot
+      className={clsx(classes.root, className)}
+      style={{ width: size, height: size, ...rootStyle, ...style }}
+      ownerState={ownerState}
+      ref={ref}
+      role="progressbar"
+      {...rootProps}
+      {...other}
+    >
+      <CircularProgressSVG
+        className={classes.svg}
+        ownerState={ownerState}
+        viewBox={`${SIZE / 2} ${SIZE / 2} ${SIZE} ${SIZE}`}
+      >
+        <CircularProgressCircle
+          className={classes.circle}
+          style={circleStyle}
+          ownerState={ownerState}
+          cx={SIZE}
+          cy={SIZE}
+          r={(SIZE - thickness) / 2}
+          fill="none"
+          strokeWidth={thickness}
+        />
+      </CircularProgressSVG>
+    </CircularProgressRoot>
+  );
+});
+
+CircularProgress.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'primary'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['inherit', 'primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * If `true`, the shrink animation is disabled.
+   * This only works if variant is `indeterminate`.
+   * @default false
+   */
+  disableShrink: chainPropTypes(PropTypes.bool, (props) => {
+    if (props.disableShrink && props.variant && props.variant !== 'indeterminate') {
+      return new Error(
+        'MUI: You have provided the `disableShrink` prop ' +
+          'with a variant other than `indeterminate`. This will have no effect.',
+      );
+    }
+
+    return null;
+  }),
+  /**
+   * The size of the component.
+   * If using a number, the pixel unit is assumed.
+   * If using a string, you need to provide the CSS unit, e.g. '3rem'.
+   * @default 40
+   */
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  style: PropTypes.object,
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The thickness of the circle.
+   * @default 3.6
+   */
+  thickness: PropTypes.number,
+  /**
+   * The value of the progress indicator for the determinate variant.
+   * Value between 0 and 100.
+   * @default 0
+   */
+  value: PropTypes.number,
+  /**
+   * The variant to use.
+   * Use indeterminate when there is no progress value.
+   * @default 'indeterminate'
+   */
+  variant: PropTypes.oneOf(['determinate', 'indeterminate']),
+};
+
+export default CircularProgress;

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.js
@@ -202,6 +202,10 @@ CircularProgress.propTypes /* remove-proptypes */ = {
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
   /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
    * Override or extend the styles applied to the component.
    */
   classes: PropTypes.object,

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.js
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.js
@@ -2,10 +2,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes } from '@mui/utils';
+import { chainPropTypes, unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { keyframes, css } from '@mui/system';
-import capitalize from '../utils/capitalize';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
 import { getCircularProgressUtilityClass } from './circularProgressClasses';

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.test.js
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.test.js
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import CircularProgress, {
+  circularProgressClasses as classes,
+} from '@mui/material/CircularProgress';
+
+describe('<CircularProgress />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<CircularProgress />, () => ({
+    classes,
+    inheritComponent: 'span',
+    render,
+    muiName: 'MuiCircularProgress',
+    testDeepOverrides: { slotName: 'circle', slotClassName: classes.circle },
+    testVariantProps: { variant: 'determinate' },
+    refInstanceof: window.HTMLSpanElement,
+    skip: ['componentProp', 'componentsProp'],
+  }));
+
+  it('should render with the primary color by default', () => {
+    const { container } = render(<CircularProgress />);
+    const circularProgress = container.firstChild;
+    expect(circularProgress).to.have.class(classes.colorPrimary);
+  });
+
+  it('should render with the primary color', () => {
+    const { container } = render(<CircularProgress color="primary" />);
+    const circularProgress = container.firstChild;
+    expect(circularProgress).to.have.class(classes.colorPrimary);
+  });
+
+  it('should render with the secondary color', () => {
+    const { container } = render(<CircularProgress color="secondary" />);
+    const circularProgress = container.firstChild;
+    expect(circularProgress).to.have.class(classes.colorSecondary);
+  });
+
+  it('should contain an SVG with the svg class, and a circle with the circle class', () => {
+    const { container } = render(<CircularProgress />);
+    const circularProgress = container.firstChild;
+    const svg = circularProgress.firstChild;
+    expect(svg).to.have.tagName('svg');
+    expect(circularProgress).to.have.class(classes.indeterminate);
+    expect(svg.firstChild).to.have.tagName('circle');
+    expect(svg.firstChild).to.have.class(classes.circle, 'should have the circle class');
+  });
+
+  it('should render indeterminate variant by default', () => {
+    const { container } = render(<CircularProgress />);
+    const circularProgress = container.firstChild;
+    expect(circularProgress).to.have.class(classes.root);
+    const svg = circularProgress.firstChild;
+    expect(svg.firstChild).to.have.class(
+      classes.circleIndeterminate,
+      'should have the circleIndeterminate class',
+    );
+  });
+
+  it('should render with a different size', () => {
+    const { container } = render(<CircularProgress size={60} />);
+    const circularProgress = container.firstChild;
+    expect(circularProgress).to.have.class(classes.root);
+    expect(circularProgress.style.width).to.equal('60px', 'should have width correctly set');
+    expect(circularProgress.style.height).to.equal('60px', 'should have height correctly set');
+    const svg = circularProgress.firstChild;
+    expect(svg).to.have.tagName('svg');
+    const circle = svg.firstChild;
+    expect(circle).to.have.tagName('circle');
+    expect(circle).to.have.attribute('cx', '44');
+    expect(circle).to.have.attribute('cy', '44');
+  });
+
+  describe('prop: variant="determinate"', () => {
+    it('should render with determinate classes', () => {
+      const { container } = render(<CircularProgress variant="determinate" />);
+      const circularProgress = container.firstChild;
+      expect(circularProgress).to.have.class(classes.root);
+      const svg = circularProgress.firstChild;
+      expect(svg).to.have.tagName('svg');
+      expect(svg).not.to.have.class(
+        classes.svgIndeterminate,
+        'should not have the svgIndeterminate class',
+      );
+    });
+
+    it('should set strokeDasharray of circle', () => {
+      const { container } = render(<CircularProgress variant="determinate" value={70} />);
+      const circularProgress = container.firstChild;
+      expect(circularProgress).to.have.class(classes.root);
+      const svg = circularProgress.firstChild;
+      const circle = svg.firstChild;
+      expect(circle.style.strokeDasharray).to.match(
+        /126\.920?(px)?/gm,
+        'should have strokeDasharray set',
+      );
+      expect(circle.style.strokeDashoffset).to.equal(
+        '38.076px',
+        'should have strokeDashoffset set',
+      );
+      expect(circularProgress).to.have.attribute('aria-valuenow', '70');
+    });
+  });
+
+  describe('prop: disableShrink ', () => {
+    it('should default to false', () => {
+      const { container } = render(<CircularProgress variant="indeterminate" />);
+      const circularProgress = container.firstChild;
+      expect(circularProgress).to.have.class(classes.root);
+      const svg = circularProgress.firstChild;
+      const circle = svg.firstChild;
+      expect(circle).to.have.tagName('circle');
+      expect(circle).not.to.have.class(classes.circleDisableShrink);
+    });
+
+    it('should render without disableShrink class when set to false', () => {
+      const { container } = render(
+        <CircularProgress variant="indeterminate" disableShrink={false} />,
+      );
+      const circularProgress = container.firstChild;
+      expect(circularProgress).to.have.class(classes.root);
+      const svg = circularProgress.firstChild;
+      const circle = svg.firstChild;
+      expect(circle).to.have.tagName('circle');
+      expect(circle).not.to.have.class(classes.circleDisableShrink);
+    });
+
+    it('should render with disableShrink class when set to true', () => {
+      const { container } = render(<CircularProgress variant="indeterminate" disableShrink />);
+      const circularProgress = container.firstChild;
+      expect(circularProgress).to.have.class(classes.root);
+      const svg = circularProgress.firstChild;
+      const circle = svg.firstChild;
+      expect(circle).to.have.tagName('circle');
+      expect(circle).to.have.class(classes.circleDisableShrink);
+    });
+  });
+});

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.test.js
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createRenderer, describeConformance } from '@mui-internal/test-utils';
 import CircularProgress, {
   circularProgressClasses as classes,
-} from '@mui/material/CircularProgress';
+} from '@mui/material-next/CircularProgress';
 
 describe('<CircularProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/CircularProgress/circularProgressClasses.ts
+++ b/packages/mui-material-next/src/CircularProgress/circularProgressClasses.ts
@@ -1,0 +1,49 @@
+import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
+import generateUtilityClass from '../generateUtilityClass';
+
+export interface CircularProgressClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `variant="determinate"`. */
+  determinate: string;
+  /** Styles applied to the root element if `variant="indeterminate"`. */
+  indeterminate: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the svg element. */
+  svg: string;
+  /** Styles applied to the `circle` svg path. */
+  circle: string;
+  /** Styles applied to the `circle` svg path if `variant="determinate"`. */
+  circleDeterminate: string;
+  /** Styles applied to the `circle` svg path if `variant="indeterminate"`. */
+  circleIndeterminate: string;
+  /** Styles applied to the `circle` svg path if `disableShrink={true}`. */
+  circleDisableShrink: string;
+}
+
+export type CircularProgressClassKey = keyof CircularProgressClasses;
+
+export function getCircularProgressUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiCircularProgress', slot);
+}
+
+const circularProgressClasses: CircularProgressClasses = generateUtilityClasses(
+  'MuiCircularProgress',
+  [
+    'root',
+    'determinate',
+    'indeterminate',
+    'colorPrimary',
+    'colorSecondary',
+    'svg',
+    'circle',
+    'circleDeterminate',
+    'circleIndeterminate',
+    'circleDisableShrink',
+  ],
+);
+
+export default circularProgressClasses;

--- a/packages/mui-material-next/src/CircularProgress/circularProgressClasses.ts
+++ b/packages/mui-material-next/src/CircularProgress/circularProgressClasses.ts
@@ -1,5 +1,7 @@
-import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
-import generateUtilityClass from '../generateUtilityClass';
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
 
 export interface CircularProgressClasses {
   /** Styles applied to the root element. */

--- a/packages/mui-material-next/src/CircularProgress/index.d.ts
+++ b/packages/mui-material-next/src/CircularProgress/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './CircularProgress';
+export * from './CircularProgress';
+
+export { default as circularProgressClasses } from './circularProgressClasses';
+export * from './circularProgressClasses';

--- a/packages/mui-material-next/src/CircularProgress/index.js
+++ b/packages/mui-material-next/src/CircularProgress/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './CircularProgress';
+
+export { default as circularProgressClasses } from './circularProgressClasses';
+export * from './circularProgressClasses';


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**CircularProgress issue:** https://github.com/mui/material-ui/issues/39770
**Material You umbrella issue:** https://github.com/mui/material-ui/issues/29345

## Changes
- Copy `CircularProgress` from `material` v5
- Fix imports
- fix props in d.ts files