### PR TITLE
[joy-ui][docs] Fix menu in color inversion header demo

### DIFF
--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
@@ -3,11 +3,13 @@ import * as React from 'react';
 import Badge from '@mui/joy/Badge';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
+import Dropdown from '@mui/joy/Dropdown';
 import Input from '@mui/joy/Input';
 import IconButton from '@mui/joy/IconButton';
 import ListDivider from '@mui/joy/ListDivider';
 import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Menu from '@mui/joy/Menu';
+import MenuButton from '@mui/joy/MenuButton';
 import MenuItem from '@mui/joy/MenuItem';
 import Typography from '@mui/joy/Typography';
 import Sheet from '@mui/joy/Sheet';
@@ -19,7 +21,6 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ColorLensRoundedIcon from '@mui/icons-material/ColorLensRounded';
 
 export default function ColorInversionHeader() {
-  const [anchorEl, setAnchorEl] = React.useState(null);
   const [color, setColor] = React.useState('primary');
   return (
     <Sheet
@@ -52,57 +53,52 @@ export default function ColorInversionHeader() {
         <ColorLensRoundedIcon fontSize="small" />
       </IconButton>
       <Box sx={{ flex: 1, display: 'flex', gap: 1, px: 2 }}>
-        <Chip
-          variant="outlined"
-          onClick={(event) => {
-            if (anchorEl) {
-              setAnchorEl(null);
-            } else {
-              setAnchorEl(event.currentTarget);
-            }
-          }}
-          endDecorator={<KeyboardArrowDownIcon />}
-        >
-          Main
-        </Chip>
-        <Menu
-          variant="outlined"
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={() => setAnchorEl(null)}
-          placement="bottom-start"
-          disablePortal
-          size="sm"
-          sx={{
-            '--ListItemDecorator-size': '24px',
-            '--ListItem-minHeight': '40px',
-            '--ListDivider-gap': '4px',
-            minWidth: 200,
-          }}
-        >
-          <MenuItem onClick={() => setAnchorEl(null)}>
-            <ListItemDecorator>
-              <BubbleChartIcon />
-            </ListItemDecorator>
-            Products
-          </MenuItem>
-          <ListDivider />
-          <MenuItem onClick={() => setAnchorEl(null)}>Pricing</MenuItem>
-          <MenuItem onClick={() => setAnchorEl(null)}>
-            Case studies{' '}
-            <Chip
-              variant="outlined"
-              size="sm"
-              sx={{
-                ml: 'auto',
-                bgcolor: (theme) =>
-                  `rgba(${theme.vars.palette.primary.mainChannel} / 0.1)`,
-              }}
-            >
-              Beta
-            </Chip>
-          </MenuItem>
-        </Menu>
+        <Dropdown>
+          <MenuButton
+            sx={{
+              borderRadius: '1.5rem',
+            }}
+            variant="outlined"
+            endDecorator={<KeyboardArrowDownIcon />}
+          >
+            Main
+          </MenuButton>
+          <Menu
+            variant="outlined"
+            placement="bottom-start"
+            disablePortal
+            size="sm"
+            sx={{
+              '--ListItemDecorator-size': '24px',
+              '--ListItem-minHeight': '40px',
+              '--ListDivider-gap': '4px',
+              minWidth: 200,
+            }}
+          >
+            <MenuItem>
+              <ListItemDecorator>
+                <BubbleChartIcon />
+              </ListItemDecorator>
+              Products
+            </MenuItem>
+            <ListDivider />
+            <MenuItem>Pricing</MenuItem>
+            <MenuItem>
+              Case studies{' '}
+              <Chip
+                variant="outlined"
+                size="sm"
+                sx={{
+                  ml: 'auto',
+                  bgcolor: (theme) =>
+                    `rgba(${theme.vars.palette.primary.mainChannel} / 0.1)`,
+                }}
+              >
+                Beta
+              </Chip>
+            </MenuItem>
+          </Menu>
+        </Dropdown>
       </Box>
       <Box sx={{ display: 'flex', flexShrink: 0, gap: 2 }}>
         <Button

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
@@ -56,7 +56,7 @@ export default function ColorInversionHeader() {
         <Dropdown>
           <MenuButton
             sx={{
-              borderRadius: '1.5rem',
+              '--Button-radius': '1.5rem',
             }}
             variant="outlined"
             endDecorator={<KeyboardArrowDownIcon />}

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
@@ -55,7 +55,11 @@ export default function ColorInversionHeader() {
         <Chip
           variant="outlined"
           onClick={(event) => {
-            setAnchorEl(event.currentTarget);
+            if (anchorEl) {
+              setAnchorEl(null);
+            } else {
+              setAnchorEl(event.currentTarget);
+            }
           }}
           endDecorator={<KeyboardArrowDownIcon />}
         >

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -60,7 +60,11 @@ export default function ColorInversionHeader() {
         <Chip
           variant="outlined"
           onClick={(event) => {
-            setAnchorEl(event.currentTarget);
+            if (anchorEl) {
+              setAnchorEl(null);
+            } else {
+              setAnchorEl(event.currentTarget);
+            }
           }}
           endDecorator={<KeyboardArrowDownIcon />}
         >

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -3,11 +3,13 @@ import { ColorPaletteProp } from '@mui/joy/styles';
 import Badge from '@mui/joy/Badge';
 import Box from '@mui/joy/Box';
 import Button from '@mui/joy/Button';
+import Dropdown from '@mui/joy/Dropdown';
 import Input from '@mui/joy/Input';
 import IconButton from '@mui/joy/IconButton';
 import ListDivider from '@mui/joy/ListDivider';
 import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Menu from '@mui/joy/Menu';
+import MenuButton from '@mui/joy/MenuButton';
 import MenuItem from '@mui/joy/MenuItem';
 import Typography from '@mui/joy/Typography';
 import Sheet from '@mui/joy/Sheet';
@@ -18,8 +20,8 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ColorLensRoundedIcon from '@mui/icons-material/ColorLensRounded';
 
+
 export default function ColorInversionHeader() {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const [color, setColor] = React.useState<ColorPaletteProp>('primary');
   return (
     <Sheet
@@ -57,57 +59,52 @@ export default function ColorInversionHeader() {
         <ColorLensRoundedIcon fontSize="small" />
       </IconButton>
       <Box sx={{ flex: 1, display: 'flex', gap: 1, px: 2 }}>
-        <Chip
-          variant="outlined"
-          onClick={(event) => {
-            if (anchorEl) {
-              setAnchorEl(null);
-            } else {
-              setAnchorEl(event.currentTarget);
-            }
-          }}
-          endDecorator={<KeyboardArrowDownIcon />}
-        >
-          Main
-        </Chip>
-        <Menu
-          variant="outlined"
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={() => setAnchorEl(null)}
-          placement="bottom-start"
-          disablePortal
-          size="sm"
-          sx={{
-            '--ListItemDecorator-size': '24px',
-            '--ListItem-minHeight': '40px',
-            '--ListDivider-gap': '4px',
-            minWidth: 200,
-          }}
-        >
-          <MenuItem onClick={() => setAnchorEl(null)}>
-            <ListItemDecorator>
-              <BubbleChartIcon />
-            </ListItemDecorator>
-            Products
-          </MenuItem>
-          <ListDivider />
-          <MenuItem onClick={() => setAnchorEl(null)}>Pricing</MenuItem>
-          <MenuItem onClick={() => setAnchorEl(null)}>
-            Case studies{' '}
-            <Chip
-              variant="outlined"
-              size="sm"
-              sx={{
-                ml: 'auto',
-                bgcolor: (theme) =>
-                  `rgba(${theme.vars.palette.primary.mainChannel} / 0.1)`,
-              }}
-            >
-              Beta
-            </Chip>
-          </MenuItem>
-        </Menu>
+        <Dropdown>
+          <MenuButton
+            sx={{
+              borderRadius: '1.5rem',
+            }}
+            variant="outlined"
+            endDecorator={<KeyboardArrowDownIcon />}
+          >
+            Main
+          </MenuButton>
+          <Menu
+            variant="outlined"
+            placement="bottom-start"
+            disablePortal
+            size="sm"
+            sx={{
+              '--ListItemDecorator-size': '24px',
+              '--ListItem-minHeight': '40px',
+              '--ListDivider-gap': '4px',
+              minWidth: 200,
+            }}
+          >
+            <MenuItem>
+              <ListItemDecorator>
+                <BubbleChartIcon />
+              </ListItemDecorator>
+              Products
+            </MenuItem>
+            <ListDivider />
+            <MenuItem>Pricing</MenuItem>
+            <MenuItem>
+              Case studies{' '}
+              <Chip
+                variant="outlined"
+                size="sm"
+                sx={{
+                  ml: 'auto',
+                  bgcolor: (theme) =>
+                    `rgba(${theme.vars.palette.primary.mainChannel} / 0.1)`,
+                }}
+              >
+                Beta
+              </Chip>
+            </MenuItem>
+          </Menu>
+        </Dropdown>
       </Box>
       <Box sx={{ display: 'flex', flexShrink: 0, gap: 2 }}>
         <Button

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -20,7 +20,6 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ColorLensRoundedIcon from '@mui/icons-material/ColorLensRounded';
 
-
 export default function ColorInversionHeader() {
   const [color, setColor] = React.useState<ColorPaletteProp>('primary');
   return (

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -61,7 +61,7 @@ export default function ColorInversionHeader() {
         <Dropdown>
           <MenuButton
             sx={{
-              borderRadius: '1.5rem',
+              '--Button-radius': '1.5rem',
             }}
             variant="outlined"
             endDecorator={<KeyboardArrowDownIcon />}


### PR DESCRIPTION
- open https://mui.com/joy-ui/main-features/color-inversion/#header
- click on `Main` button
- Again click on `Main`, menu is still open here. It should be closed, This PR fixes that


Preview https://deploy-preview-39785--material-ui.netlify.app/joy-ui/main-features/color-inversion/#header


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
