### PR TITLE
[joy-ui][docs] Add `CssBaseline` to integration with Material UI page

### DIFF
--- a/docs/data/joy/integrations/material-ui/material-ui.md
+++ b/docs/data/joy/integrations/material-ui/material-ui.md
@@ -40,7 +40,10 @@ const materialTheme = materialExtendTheme();
 export default function App() {
   return (
     <MaterialCssVarsProvider theme={{ [MATERIAL_THEME_ID]: materialTheme }}>
-      <JoyCssVarsProvider>...Material UI and Joy UI components</JoyCssVarsProvider>
+      <JoyCssVarsProvider>
+        <CssBaseline enableColorScheme />
+        ...Material UI and Joy UI components
+      </JoyCssVarsProvider>
     </MaterialCssVarsProvider>
   );
 }
@@ -97,6 +100,7 @@ If you want to change the `defaultMode`, you have to specify the prop to both of
   theme={{ [MATERIAL_THEME_ID]: materialTheme }}
 >
   <JoyCssVarsProvider defaultMode="system">
+    <CssBaseline enableColorScheme />
     ...Material UI and Joy UI components
   </JoyCssVarsProvider>
 </MaterialCssVarsProvider>

--- a/docs/data/joy/integrations/material-ui/material-ui.md
+++ b/docs/data/joy/integrations/material-ui/material-ui.md
@@ -34,6 +34,7 @@ import {
   THEME_ID as MATERIAL_THEME_ID,
 } from '@mui/material/styles';
 import { CssVarsProvider as JoyCssVarsProvider } from '@mui/joy/styles';
+import CssBaseline from "@mui/material/CssBaseline";
 
 const materialTheme = materialExtendTheme();
 

--- a/docs/data/joy/integrations/material-ui/material-ui.md
+++ b/docs/data/joy/integrations/material-ui/material-ui.md
@@ -34,7 +34,7 @@ import {
   THEME_ID as MATERIAL_THEME_ID,
 } from '@mui/material/styles';
 import { CssVarsProvider as JoyCssVarsProvider } from '@mui/joy/styles';
-import CssBaseline from "@mui/material/CssBaseline";
+import CssBaseline from '@mui/material/CssBaseline';
 
 const materialTheme = materialExtendTheme();
 


### PR DESCRIPTION
Added necessary component that exist on the codesandbox example but not in the docs example.
Without the CssBaseline, colors will not work as expected.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
