### PR TITLE
[Autocomplete][material-ui] Fix React key warning in Next.js

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -552,7 +552,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
   );
 
   const renderGroup = renderGroupProp || defaultRenderGroup;
-  const defaultRenderOption = (props2, option) => <li {...props2}>{getOptionLabel(option)}</li>;
+  const defaultRenderOption = (props2, option) => {
+    const { key, ...otherProps } = props2;
+    return (
+      <li key={key} {...otherProps}>
+        {getOptionLabel(option)}
+      </li>
+    );
+  };
   const renderOption = renderOptionProp || defaultRenderOption;
 
   const renderListOption = (option, index) => {


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/39474

Demo: https://codesandbox.io/p/sandbox/https-github-com-mui-material-ui-pull-39795-fwdm7f?file=%2Fsrc%2Fapp%2Fpage.tsx%3A1%2C1

There should no console errors when opening the listbox with grouped options

Next.js doesn't like it when a `key` prop is part of an object being spread, here's the related issue in their repo: https://github.com/vercel/next.js/issues/55642

BTW I'm not sure why this doesn't repro when the options are ungrouped, as in both cases they both use `defaultRenderOption`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
