### PR TITLE
[material-ui][Tooltip] Fix arrow prop name to `hasArrow`

### DIFF
--- a/docs/data/material/components/tooltips/ArrowTooltips.tsx
+++ b/docs/data/material/components/tooltips/ArrowTooltips.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@mui/material/Tooltip';
 
 export default function ArrowTooltips() {
   return (
-    <Tooltip title="Add" arrow>
+    <Tooltip title="Add" hasArrow>
       <Button>Arrow</Button>
     </Tooltip>
   );


### PR DESCRIPTION
As far as I know this prop is `hasArrow` not `arrow` anymore. 

This is just a documentation update so I'm sure it's very low risk to merge.


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
