### PR TITLE
[joy-ui][docs] Spread other object in creating-themed-components.md

### DIFF
--- a/docs/data/joy/customization/creating-themed-components/StatFullTemplate.js
+++ b/docs/data/joy/customization/creating-themed-components/StatFullTemplate.js
@@ -39,7 +39,7 @@ const Stat = React.forwardRef(function Stat(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'JoyStat' });
   const { value, unit, variant, ...other } = props;
 
-  const ownerState = { ...props, variant };
+  const ownerState = { ...other, variant };
 
   return (
     <StatRoot ref={ref} ownerState={ownerState} {...other}>

--- a/docs/data/joy/customization/creating-themed-components/creating-themed-components.md
+++ b/docs/data/joy/customization/creating-themed-components/creating-themed-components.md
@@ -147,7 +147,7 @@ Add a `variant` prop to the `Stat` component and use it to style the `root` slot
   const Stat = React.forwardRef(function Stat(props, ref) {
 +   const { value, unit, variant, ...other } = props;
 +
-+   const ownerState = { ...props, variant };
++   const ownerState = { ...other, variant };
 
     return (
 -      <StatRoot ref={ref} {...other}>
@@ -268,7 +268,7 @@ const Stat = React.forwardRef<HTMLDivElement, StatProps>(function Stat(inProps, 
   const props = useThemeProps({ props: inProps, name: 'JoyStat' });
   const { value, unit, variant, ...other } = props;
 
-  const ownerState = { ...props, variant };
+  const ownerState = { ...other, variant };
 
   return (
     <StatRoot ref={ref} ownerState={ownerState} {...other}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The published documentation spreads `props` object and adds variant to create an `ownerState`. I think it is not intended because `props` already has variant.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
