### PR TITLE
[docs-infra] Adjust the website & docs footer

### DIFF
--- a/docs/src/components/footer/EmailSubscribe.tsx
+++ b/docs/src/components/footer/EmailSubscribe.tsx
@@ -93,9 +93,9 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
     <Form onSubmit={handleSubmit} sx={sx}>
       <FormLabel
         htmlFor="email-subscribe"
-        sx={{ typography: 'caption', color: 'text.secondary', fontWeight: 500 }}
+        sx={{ typography: 'caption', color: 'text.secondary', fontWeight: 'medium' }}
       >
-        Enter your email:
+        Your email
       </FormLabel>
       <Box
         sx={{

--- a/docs/src/icons/SvgMuiLogotype.tsx
+++ b/docs/src/icons/SvgMuiLogotype.tsx
@@ -10,10 +10,10 @@ export default function SvgMuiLogomark(props: RootSvgProps) {
       sx={[
         (theme) => ({
           flexShrink: 0,
-          color: '#0B0D0E',
-          [theme.getColorSchemeSelector('dark')]: {
-            color: '#fff',
-          },
+          color: 'common.black',
+          ...theme.applyDarkStyles({
+            color: '#FFF',
+          }),
         }),
         ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
       ]}

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -50,7 +50,10 @@ export default function AppFooter(props: AppFooterProps) {
         }}
       >
         <div>
-          <Typography variant="body2" fontWeight="bold">
+          <Link href="/" aria-label="Go to homepage" sx={{ mb: 2 }}>
+            <SvgMuiLogotype height={28} width={91} />
+          </Link>
+          <Typography variant="body2" fontWeight="bold" gutterBottom>
             Keep up to date
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
@@ -141,31 +144,16 @@ export default function AppFooter(props: AppFooterProps) {
         </Box>
       </Box>
       <Divider />
-      <Box
-        sx={{
-          my: 4,
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          alignItems: { sm: 'center' },
-          justifyContent: { sm: 'space-between' },
-          gap: { xs: 2, sm: 1 },
-        }}
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        alignItems="center"
+        justifyContent={{ sm: 'space-between' }}
+        gap={{ xs: 2, sm: 1 }}
+        sx={{ my: 4 }}
       >
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: { xs: 'column', sm: 'row' },
-            alignItems: { xs: 'start', sm: 'center' },
-            gap: 1.5,
-          }}
-        >
-          <Link href="/" aria-label="Go to homepage">
-            <SvgMuiLogotype height={28} width={91} />
-          </Link>
-          <Typography color="text.tertiary" variant="caption" fontWeight={400}>
-            Copyright © {new Date().getFullYear()} Material UI SAS, trading as MUI.
-          </Typography>
-        </Box>
+        <Typography color="text.tertiary" variant="caption" fontWeight={400}>
+          Copyright © {new Date().getFullYear()} Material UI SAS, trading as MUI.
+        </Typography>
         <Stack spacing={1} direction="row" flexWrap="wrap" useFlexGap>
           <IconButton
             target="_blank"
@@ -240,7 +228,7 @@ export default function AppFooter(props: AppFooterProps) {
             </IconButton>
           ) : null}
         </Stack>
-      </Box>
+      </Stack>
     </Container>
   );
 }

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -31,6 +31,7 @@ import ROUTES from 'docs/src/route';
 import Link from 'docs/src/modules/components/Link';
 import PageContext from 'docs/src/modules/components/PageContext';
 import EditPage from 'docs/src/modules/components/EditPage';
+import SvgMuiLogotype from 'docs/src/icons/SvgMuiLogotype';
 import { useUserLanguage, useTranslate } from 'docs/src/modules/utils/i18n';
 import { getCookie, pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 
@@ -540,13 +541,19 @@ export default function AppLayoutDocsFooter(props) {
           alignItems="center"
           spacing={{ xs: 3, sm: 1 }}
         >
-          <Stack direction="row" alignItems="center" spacing={1} sx={{ flexGrow: 1 }}>
+          <Stack direction="row" alignItems="center" spacing={1.2} sx={{ flexGrow: 1 }}>
+            <Link href="/" aria-label="Go to homepage" sx={{ mb: 2 }}>
+              <SvgMuiLogotype height={24} width={72} />
+            </Link>
+            <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
+              &bull;
+            </Typography>
             <Link href={ROUTES.blog} target="_blank" rel="noopener noreferrer">
               <FooterLink>
                 Blog <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>
             </Link>
-            <Typography color="grey.500" fontSize={13}>
+            <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
               &bull;
             </Typography>
             <Link href={ROUTES.store} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/39789

This PR repositions the company's logo on the website footer and includes it on the documentation footer.

- Website: https://deploy-preview-39810--material-ui.netlify.app/
- Docs: https://deploy-preview-39810--material-ui.netlify.app/joy-ui/getting-started/