### PR TITLE
[material-ui][Autocomplete] Add `defaultMuiPrevented` to onKeyDown type

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -195,6 +195,9 @@ export interface AutocompleteProps<
    * @default 'No options'
    */
   noOptionsText?: React.ReactNode;
+  onKeyDown?: (
+    event: React.KeyboardEvent<HTMLDivElement> & { defaultMuiPrevented?: boolean },
+  ) => void;
   /**
    * Override the default text for the *open popup* icon button.
    *

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -1010,6 +1010,10 @@ Autocomplete.propTypes /* remove-proptypes */ = {
    */
   onInputChange: PropTypes.func,
   /**
+   * @ignore
+   */
+  onKeyDown: PropTypes.func,
+  /**
    * Callback fired when the popup requests to be opened.
    * Use in controlled mode (see open).
    *

--- a/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.spec.tsx
@@ -157,3 +157,17 @@ function CustomListboxRef() {
     />
   );
 }
+
+// Tests presence of defaultMuiPrevented in event
+<Autocomplete
+  renderInput={(params) => <TextField {...params} />}
+  options={['one', 'two', 'three']}
+  onKeyDown={(e) => {
+    expectType<
+      React.KeyboardEvent<HTMLDivElement> & {
+        defaultMuiPrevented?: boolean;
+      },
+      typeof e
+    >(e);
+  }}
+/>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

addresses: https://mui-org.slack.com/archives/C041SDSF32L/p1699372422138089

joy added `defaultMuiPrevented` type to `Autocomplete` `onKeyDown`, but it got missed in `material ui` `Autocomplete`.

https://github.com/mui/material-ui/blob/05652f68c7e9273923b341796ac7605864903f77/packages/mui-joy/src/Autocomplete/AutocompleteProps.ts#L370-L375

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
