### PR TITLE
[material-ui][Stepper] Add props to support customization of step icon in step button

### DIFF
--- a/docs/pages/material-ui/api/step-button.json
+++ b/docs/pages/material-ui/api/step-button.json
@@ -4,6 +4,8 @@
     "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
     "icon": { "type": { "name": "node" } },
     "optional": { "type": { "name": "node" } },
+    "StepIconComponent": { "type": { "name": "elementType" } },
+    "StepIconProps": { "type": { "name": "object" } },
     "sx": {
       "type": {
         "name": "union",

--- a/docs/translations/api-docs/step-button/step-button.json
+++ b/docs/translations/api-docs/step-button/step-button.json
@@ -7,6 +7,12 @@
     "classes": { "description": "Override or extend the styles applied to the component." },
     "icon": { "description": "The icon displayed by the step label." },
     "optional": { "description": "The optional node to display." },
+    "StepIconComponent": {
+      "description": "The component to render in place of the <a href=\"/material-ui/api/step-icon/\"><code>StepIcon</code></a>."
+    },
+    "StepIconProps": {
+      "description": "Props applied to the <a href=\"/material-ui/api/step-icon/\"><code>StepIcon</code></a> element."
+    },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     }

--- a/packages/mui-material/src/StepButton/StepButton.d.ts
+++ b/packages/mui-material/src/StepButton/StepButton.d.ts
@@ -4,6 +4,7 @@ import { ButtonBaseTypeMap, ExtendButtonBase, ExtendButtonBaseTypeMap } from '..
 import { OverrideProps } from '../OverridableComponent';
 import { Theme } from '../styles';
 import { StepButtonClasses } from './stepButtonClasses';
+import { StepIconProps } from '../StepIcon';
 
 /**
  * @deprecated use `StepButtonProps['icon']` instead.
@@ -31,6 +32,14 @@ export interface StepButtonOwnProps {
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx?: SxProps<Theme>;
+  /**
+   * The component to render in place of the [`StepIcon`](/material-ui/api/step-icon/).
+   */
+  StepIconComponent?: React.ElementType;
+  /**
+   * Props applied to the [`StepIcon`](/material-ui/api/step-icon/) element.
+   */
+  StepIconProps?: Partial<StepIconProps>;
 }
 
 export type StepButtonTypeMap<

--- a/packages/mui-material/src/StepButton/StepButton.js
+++ b/packages/mui-material/src/StepButton/StepButton.js
@@ -52,7 +52,7 @@ const StepButtonRoot = styled(ButtonBase, {
 
 const StepButton = React.forwardRef(function StepButton(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiStepButton' });
-  const { children, className, icon, optional, ...other } = props;
+  const { children, className, icon, optional, StepIconProps, StepIconComponent, ...other } = props;
 
   const { disabled, active } = React.useContext(StepContext);
   const { orientation } = React.useContext(StepperContext);
@@ -64,6 +64,8 @@ const StepButton = React.forwardRef(function StepButton(inProps, ref) {
   const childProps = {
     icon,
     optional,
+    StepIconProps,
+    StepIconComponent,
   };
 
   const child = isMuiElement(children, ['StepLabel']) ? (
@@ -113,6 +115,14 @@ StepButton.propTypes /* remove-proptypes */ = {
    * The optional node to display.
    */
   optional: PropTypes.node,
+  /**
+   * The component to render in place of the [`StepIcon`](/material-ui/api/step-icon/).
+   */
+  StepIconComponent: PropTypes.elementType,
+  /**
+   * Props applied to the [`StepIcon`](/material-ui/api/step-icon/) element.
+   */
+  StepIconProps: PropTypes.object,
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/mui-material/src/StepButton/StepButton.test.js
+++ b/packages/mui-material/src/StepButton/StepButton.test.js
@@ -5,6 +5,7 @@ import { createRenderer, describeConformance } from '@mui-internal/test-utils';
 import { fireEvent } from '@testing-library/dom';
 import StepButton, { stepButtonClasses as classes } from '@mui/material/StepButton';
 import Step from '@mui/material/Step';
+import { stepIconClasses as iconClasses } from '@mui/material/StepIcon';
 import StepLabel, { stepLabelClasses } from '@mui/material/StepLabel';
 import ButtonBase from '@mui/material/ButtonBase';
 
@@ -144,5 +145,67 @@ describe('<StepButton />', () => {
     );
 
     expect(getByRole('button')).not.to.equal(null);
+  });
+
+  describe('prop: StepIconComponent', () => {
+    it('should render', () => {
+      function CustomizedIcon() {
+        return <div data-testid="custom-icon" />;
+      }
+      const { container, getByTestId } = render(
+        <Step active completed>
+          <StepButton StepIconComponent={CustomizedIcon}>Step One</StepButton>
+        </Step>,
+      );
+
+      const icon = container.querySelector(`.${stepLabelClasses.iconContainer}`);
+
+      getByTestId('custom-icon');
+      expect(icon).not.to.equal(null);
+      expect(icon).not.to.have.attribute('data-testid').equal('CheckCircleIcon');
+    });
+
+    it('should not render', () => {
+      const { container } = render(
+        <Step active completed>
+          <StepButton>Step One</StepButton>
+        </Step>,
+      );
+
+      const icon = container.querySelector(`.${iconClasses.root}`);
+      expect(icon).to.equal(null);
+    });
+
+    describe('renders <StepIcon> with the className completed', () => {
+      it('renders with completed className when completed', () => {
+        function CustomizedIcon() {
+          return <div data-testid="custom-icon" />;
+        }
+        const { container } = render(
+          <Step completed>
+            <StepButton StepIconComponent={CustomizedIcon}>Step One</StepButton>
+          </Step>,
+        );
+
+        const icon = container.querySelector(`.${stepLabelClasses.iconContainer}`);
+        expect(icon).to.have.class(stepLabelClasses.completed);
+      });
+    });
+
+    describe('renders <StepIcon> with the className active', () => {
+      it('renders with active className when active', () => {
+        function CustomizedIcon() {
+          return <div data-testid="custom-icon" />;
+        }
+        const { container } = render(
+          <Step active>
+            <StepButton StepIconComponent={CustomizedIcon}>Step One</StepButton>
+          </Step>,
+        );
+
+        const icon = container.querySelector(`.${stepLabelClasses.iconContainer}`);
+        expect(icon).to.have.class(stepLabelClasses.active);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

Add  StepIconProps interface so that icon can be modified as on the StepLabel components

Closes https://github.com/mui/material-ui/issues/38863

[Loom video](https://www.loom.com/share/c59312b019694a9d976fb7d6ada37f27)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
