### PR TITLE
[system] Fix changed types between 5.14.0 and 5.14.1

### DIFF
--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -112,6 +112,11 @@ export interface FilteringStyledOptions<Props, ForwardedProps extends keyof Prop
   target?: string;
 }
 
+export type OverriddableForwardProps<
+  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+  RootComponent extends React.ElementType = React.ElementType,
+> = React.ComponentProps<C> & { component: RootComponent };
+
 /**
  * @typeparam ComponentProps  Props which will be included when withComponent is called
  * @typeparam SpecificComponentProps  Props which will *not* be included when withComponent is called
@@ -185,11 +190,21 @@ export interface CreateMUIStyled<
 
   <
     C extends React.JSXElementConstructor<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
+    RootComponent extends React.ElementType = React.ElementType,
+    ForwardedProps extends keyof OverriddableForwardProps<
+      C,
+      RootComponent
+    > = keyof OverriddableForwardProps<C, RootComponent>,
   >(
     component: C,
-    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
-  ): CreateStyledComponent<Pick<PropsOf<C>, ForwardedProps> & MUIStyledCommonProps, {}, {}, Theme>;
+    options: FilteringStyledOptions<OverriddableForwardProps<C, RootComponent>, ForwardedProps> &
+      MuiStyledOptions,
+  ): CreateStyledComponent<
+    Pick<PropsOf<C> & { component?: RootComponent }, ForwardedProps> & MUIStyledCommonProps,
+    {},
+    {},
+    Theme
+  >;
 
   <C extends React.JSXElementConstructor<React.ComponentProps<C>>>(
     component: C,


### PR DESCRIPTION
## Description

Update the styled component typing to include component prop typing.

closes https://github.com/mui/material-ui/issues/38626

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
