### PR TITLE
[website] Fix modal not being closed with the escape key on the Base UI page

### DIFF
--- a/docs/src/components/productBaseUI/BaseUIThemesDemo.tsx
+++ b/docs/src/components/productBaseUI/BaseUIThemesDemo.tsx
@@ -614,7 +614,7 @@ const Dialog = styled(AnimatedElement)({
     transform: 'translateY(0)',
     opacity: 1,
     boxShadow: 'var(--Panel-shadow)',
-    transition: 'opacity 0.3s ease, transform 0.2s ease-out',
+    transition: 'opacity 0.3s ease, transform 0.3s ease-out',
   },
 });
 

--- a/docs/src/components/productBaseUI/BaseUIThemesDemo.tsx
+++ b/docs/src/components/productBaseUI/BaseUIThemesDemo.tsx
@@ -609,12 +609,12 @@ const Dialog = styled(AnimatedElement)({
   width: 'auto',
   transform: 'translateY(8px)',
   opacity: 0,
-  transition: 'all 0.2s ease-out',
+  transition: 'opacity 0.2s ease-out, transform 0.2s ease-out',
   '&[data-open="true"]': {
     transform: 'translateY(0)',
     opacity: 1,
     boxShadow: 'var(--Panel-shadow)',
-    transition: 'all 0.3s ease',
+    transition: 'opacity 0.3s ease, transform 0.2s ease-out',
   },
 });
 

--- a/docs/src/components/productBaseUI/BaseUIThemesDemo.tsx
+++ b/docs/src/components/productBaseUI/BaseUIThemesDemo.tsx
@@ -614,7 +614,7 @@ const Dialog = styled(AnimatedElement)({
     transform: 'translateY(0)',
     opacity: 1,
     boxShadow: 'var(--Panel-shadow)',
-    transition: 'opacity 0.3s ease, transform 0.3s ease-out',
+    transition: 'opacity 0.3s ease, transform 0.3s ease',
   },
 });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #38468

I'm uncertain why the transition property `all` had an impact on this.

When using `transition: all`, the document's activeElement is the "View Modal" button when opened. However, with specific transition properties applied, as in this PR, the document's activeElement becomes the Modal when opened allowing the Escape key to close the modal.

While I'm unsure about the reason, it seems to work. I would like to understand why using `transition: all` didn't maintain focus on the modal for allowing closure with the Escape key, or if there's another reason behind it.

Before: https://mui.com/base-ui/
After: https://deploy-preview-39880--material-ui.netlify.app/base-ui/

----

Edit: Also see https://github.com/mui/material-ui/pull/38255#issuecomment-1662945897.