### PR TITLE
[material-next][Switch] Copy `Switch` to material next

### DIFF
--- a/packages/mui-material-next/src/Switch/Switch.d.ts
+++ b/packages/mui-material-next/src/Switch/Switch.d.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion } from '@mui/types';
+import { InternalStandardProps as StandardProps, Theme } from '..';
+import { SwitchBaseProps } from '../internal/SwitchBase';
+import { SwitchClasses } from './switchClasses';
+
+export interface SwitchPropsSizeOverrides {}
+
+export interface SwitchPropsColorOverrides {}
+
+export interface SwitchProps
+  extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon'> {
+  /**
+   * The icon to display when the component is checked.
+   */
+  checkedIcon?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<SwitchClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'primary'
+   */
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning' | 'default',
+    SwitchPropsColorOverrides
+  >;
+  /**
+   * If `true`, the component is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * The icon to display when the component is unchecked.
+   */
+  icon?: React.ReactNode;
+  /**
+   * The size of the component.
+   * `small` is equivalent to the dense switch styling.
+   * @default 'medium'
+   */
+  size?: OverridableStringUnion<'small' | 'medium', SwitchPropsSizeOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * The value of the component. The DOM API casts this to a string.
+   * The browser uses "on" as the default value.
+   */
+  value?: unknown;
+}
+
+/**
+ *
+ * Demos:
+ *
+ * - [Switch](https://mui.com/material-ui/react-switch/)
+ * - [Transfer List](https://mui.com/material-ui/react-transfer-list/)
+ *
+ * API:
+ *
+ * - [Switch API](https://mui.com/material-ui/api/switch/)
+ * - inherits [IconButton API](https://mui.com/material-ui/api/icon-button/)
+ */
+export default function Switch(props: SwitchProps): JSX.Element;

--- a/packages/mui-material-next/src/Switch/Switch.d.ts
+++ b/packages/mui-material-next/src/Switch/Switch.d.ts
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { OverridableStringUnion } from '@mui/types';
-import { InternalStandardProps as StandardProps, Theme } from '..';
-import { SwitchBaseProps } from '../internal/SwitchBase';
+import { InternalStandardProps as StandardProps, Theme } from '@mui/material';
+// eslint-disable-next-line no-restricted-imports
+import type { SwitchBaseProps } from '@mui/material/internal/SwitchBase';
 import { SwitchClasses } from './switchClasses';
 
 export interface SwitchPropsSizeOverrides {}
 
 export interface SwitchPropsColorOverrides {}
 
-export interface SwitchProps
-  extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon'> {
+type NewType = SwitchBaseProps;
+
+export interface SwitchProps extends StandardProps<NewType, 'checkedIcon' | 'color' | 'icon'> {
   /**
    * The icon to display when the component is checked.
    */

--- a/packages/mui-material-next/src/Switch/Switch.d.ts
+++ b/packages/mui-material-next/src/Switch/Switch.d.ts
@@ -10,9 +10,8 @@ export interface SwitchPropsSizeOverrides {}
 
 export interface SwitchPropsColorOverrides {}
 
-type NewType = SwitchBaseProps;
-
-export interface SwitchProps extends StandardProps<NewType, 'checkedIcon' | 'color' | 'icon'> {
+export interface SwitchProps
+  extends StandardProps<SwitchBaseProps, 'checkedIcon' | 'color' | 'icon'> {
   /**
    * The icon to display when the component is checked.
    */

--- a/packages/mui-material-next/src/Switch/Switch.js
+++ b/packages/mui-material-next/src/Switch/Switch.js
@@ -1,0 +1,343 @@
+'use client';
+// @inheritedComponent IconButton
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { refType } from '@mui/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { alpha, darken, lighten } from '@mui/system';
+import capitalize from '../utils/capitalize';
+import SwitchBase from '../internal/SwitchBase';
+import useThemeProps from '../styles/useThemeProps';
+import styled from '../styles/styled';
+import switchClasses, { getSwitchUtilityClass } from './switchClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, edge, size, color, checked, disabled } = ownerState;
+
+  const slots = {
+    root: ['root', edge && `edge${capitalize(edge)}`, `size${capitalize(size)}`],
+    switchBase: [
+      'switchBase',
+      `color${capitalize(color)}`,
+      checked && 'checked',
+      disabled && 'disabled',
+    ],
+    thumb: ['thumb'],
+    track: ['track'],
+    input: ['input'],
+  };
+
+  const composedClasses = composeClasses(slots, getSwitchUtilityClass, classes);
+
+  return {
+    ...classes, // forward the disabled and checked classes to the SwitchBase
+    ...composedClasses,
+  };
+};
+
+const SwitchRoot = styled('span', {
+  name: 'MuiSwitch',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      ownerState.edge && styles[`edge${capitalize(ownerState.edge)}`],
+      styles[`size${capitalize(ownerState.size)}`],
+    ];
+  },
+})(({ ownerState }) => ({
+  display: 'inline-flex',
+  width: 34 + 12 * 2,
+  height: 14 + 12 * 2,
+  overflow: 'hidden',
+  padding: 12,
+  boxSizing: 'border-box',
+  position: 'relative',
+  flexShrink: 0,
+  zIndex: 0, // Reset the stacking context.
+  verticalAlign: 'middle', // For correct alignment with the text.
+  '@media print': {
+    colorAdjust: 'exact',
+  },
+  ...(ownerState.edge === 'start' && {
+    marginLeft: -8,
+  }),
+  ...(ownerState.edge === 'end' && {
+    marginRight: -8,
+  }),
+  ...(ownerState.size === 'small' && {
+    width: 40,
+    height: 24,
+    padding: 7,
+    [`& .${switchClasses.thumb}`]: {
+      width: 16,
+      height: 16,
+    },
+    [`& .${switchClasses.switchBase}`]: {
+      padding: 4,
+      [`&.${switchClasses.checked}`]: {
+        transform: 'translateX(16px)',
+      },
+    },
+  }),
+}));
+
+const SwitchSwitchBase = styled(SwitchBase, {
+  name: 'MuiSwitch',
+  slot: 'SwitchBase',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.switchBase,
+      { [`& .${switchClasses.input}`]: styles.input },
+      ownerState.color !== 'default' && styles[`color${capitalize(ownerState.color)}`],
+    ];
+  },
+})(
+  ({ theme }) => ({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    zIndex: 1, // Render above the focus ripple.
+    color: theme.vars
+      ? theme.vars.palette.Switch.defaultColor
+      : `${theme.palette.mode === 'light' ? theme.palette.common.white : theme.palette.grey[300]}`,
+    transition: theme.transitions.create(['left', 'transform'], {
+      duration: theme.transitions.duration.shortest,
+    }),
+    [`&.${switchClasses.checked}`]: {
+      transform: 'translateX(20px)',
+    },
+    [`&.${switchClasses.disabled}`]: {
+      color: theme.vars
+        ? theme.vars.palette.Switch.defaultDisabledColor
+        : `${theme.palette.mode === 'light' ? theme.palette.grey[100] : theme.palette.grey[600]}`,
+    },
+    [`&.${switchClasses.checked} + .${switchClasses.track}`]: {
+      opacity: 0.5,
+    },
+    [`&.${switchClasses.disabled} + .${switchClasses.track}`]: {
+      opacity: theme.vars
+        ? theme.vars.opacity.switchTrackDisabled
+        : `${theme.palette.mode === 'light' ? 0.12 : 0.2}`,
+    },
+    [`& .${switchClasses.input}`]: {
+      left: '-100%',
+      width: '300%',
+    },
+  }),
+  ({ theme, ownerState }) => ({
+    '&:hover': {
+      backgroundColor: theme.vars
+        ? `rgba(${theme.vars.palette.action.activeChannel} / ${theme.vars.palette.action.hoverOpacity})`
+        : alpha(theme.palette.action.active, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+    ...(ownerState.color !== 'default' && {
+      [`&.${switchClasses.checked}`]: {
+        color: (theme.vars || theme).palette[ownerState.color].main,
+        '&:hover': {
+          backgroundColor: theme.vars
+            ? `rgba(${theme.vars.palette[ownerState.color].mainChannel} / ${
+                theme.vars.palette.action.hoverOpacity
+              })`
+            : alpha(theme.palette[ownerState.color].main, theme.palette.action.hoverOpacity),
+          '@media (hover: none)': {
+            backgroundColor: 'transparent',
+          },
+        },
+        [`&.${switchClasses.disabled}`]: {
+          color: theme.vars
+            ? theme.vars.palette.Switch[`${ownerState.color}DisabledColor`]
+            : `${
+                theme.palette.mode === 'light'
+                  ? lighten(theme.palette[ownerState.color].main, 0.62)
+                  : darken(theme.palette[ownerState.color].main, 0.55)
+              }`,
+        },
+      },
+      [`&.${switchClasses.checked} + .${switchClasses.track}`]: {
+        backgroundColor: (theme.vars || theme).palette[ownerState.color].main,
+      },
+    }),
+  }),
+);
+
+const SwitchTrack = styled('span', {
+  name: 'MuiSwitch',
+  slot: 'Track',
+  overridesResolver: (props, styles) => styles.track,
+})(({ theme }) => ({
+  height: '100%',
+  width: '100%',
+  borderRadius: 14 / 2,
+  zIndex: -1,
+  transition: theme.transitions.create(['opacity', 'background-color'], {
+    duration: theme.transitions.duration.shortest,
+  }),
+  backgroundColor: theme.vars
+    ? theme.vars.palette.common.onBackground
+    : `${theme.palette.mode === 'light' ? theme.palette.common.black : theme.palette.common.white}`,
+  opacity: theme.vars
+    ? theme.vars.opacity.switchTrack
+    : `${theme.palette.mode === 'light' ? 0.38 : 0.3}`,
+}));
+
+const SwitchThumb = styled('span', {
+  name: 'MuiSwitch',
+  slot: 'Thumb',
+  overridesResolver: (props, styles) => styles.thumb,
+})(({ theme }) => ({
+  boxShadow: (theme.vars || theme).shadows[1],
+  backgroundColor: 'currentColor',
+  width: 20,
+  height: 20,
+  borderRadius: '50%',
+}));
+
+const Switch = React.forwardRef(function Switch(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSwitch' });
+  const { className, color = 'primary', edge = false, size = 'medium', sx, ...other } = props;
+
+  const ownerState = {
+    ...props,
+    color,
+    edge,
+    size,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+  const icon = <SwitchThumb className={classes.thumb} ownerState={ownerState} />;
+
+  return (
+    <SwitchRoot className={clsx(classes.root, className)} sx={sx} ownerState={ownerState}>
+      <SwitchSwitchBase
+        type="checkbox"
+        icon={icon}
+        checkedIcon={icon}
+        ref={ref}
+        ownerState={ownerState}
+        {...other}
+        classes={{
+          ...classes,
+          root: classes.switchBase,
+        }}
+      />
+      <SwitchTrack className={classes.track} ownerState={ownerState} />
+    </SwitchRoot>
+  );
+});
+
+Switch.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * If `true`, the component is checked.
+   */
+  checked: PropTypes.bool,
+  /**
+   * The icon to display when the component is checked.
+   */
+  checkedIcon: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'primary'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['default', 'primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The default checked state. Use when the component is not controlled.
+   */
+  defaultChecked: PropTypes.bool,
+  /**
+   * If `true`, the component is disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the ripple effect is disabled.
+   * @default false
+   */
+  disableRipple: PropTypes.bool,
+  /**
+   * If given, uses a negative margin to counteract the padding on one
+   * side (this is often helpful for aligning the left or right
+   * side of the icon with content above or below, without ruining the border
+   * size and shape).
+   * @default false
+   */
+  edge: PropTypes.oneOf(['end', 'start', false]),
+  /**
+   * The icon to display when the component is unchecked.
+   */
+  icon: PropTypes.node,
+  /**
+   * The id of the `input` element.
+   */
+  id: PropTypes.string,
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: refType,
+  /**
+   * Callback fired when the state is changed.
+   *
+   * @param {React.ChangeEvent<HTMLInputElement>} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   * You can pull out the new checked state by accessing `event.target.checked` (boolean).
+   */
+  onChange: PropTypes.func,
+  /**
+   * If `true`, the `input` element is required.
+   * @default false
+   */
+  required: PropTypes.bool,
+  /**
+   * The size of the component.
+   * `small` is equivalent to the dense switch styling.
+   * @default 'medium'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * The value of the component. The DOM API casts this to a string.
+   * The browser uses "on" as the default value.
+   */
+  value: PropTypes.any,
+};
+
+export default Switch;

--- a/packages/mui-material-next/src/Switch/Switch.js
+++ b/packages/mui-material-next/src/Switch/Switch.js
@@ -3,11 +3,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { refType } from '@mui/utils';
+import { refType, unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { alpha, darken, lighten } from '@mui/system';
-import capitalize from '../utils/capitalize';
-import SwitchBase from '../internal/SwitchBase';
+import SwitchBase from '@mui/material/internal/SwitchBase';
 import useThemeProps from '../styles/useThemeProps';
 import styled from '../styles/styled';
 import switchClasses, { getSwitchUtilityClass } from './switchClasses';

--- a/packages/mui-material-next/src/Switch/Switch.test.js
+++ b/packages/mui-material-next/src/Switch/Switch.test.js
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import Switch, { switchClasses as classes } from '@mui/material/Switch';
+import FormControl from '@mui/material/FormControl';
+
+describe('<Switch />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<Switch />, () => ({
+    classes,
+    render,
+    muiName: 'MuiSwitch',
+    testDeepOverrides: [
+      { slotName: 'track', slotClassName: classes.track },
+      { slotName: 'input', slotClassName: classes.input },
+    ],
+    refInstanceof: window.HTMLSpanElement,
+    skip: ['componentProp', 'componentsProp', 'propsSpread', 'themeDefaultProps', 'themeVariants'],
+  }));
+
+  describe('styleSheet', () => {
+    it('should have the classes required for SwitchBase', () => {
+      expect(classes).to.include.all.keys(['root', 'checked', 'disabled']);
+    });
+  });
+
+  specify('should render an .thumb element inside the .switchBase element', () => {
+    const { container } = render(
+      <Switch classes={{ thumb: 'thumb', switchBase: 'switch-base' }} />,
+    );
+
+    expect(container.querySelector('.switch-base .thumb')).not.to.equal(null);
+  });
+
+  it('should render the track as the 2nd child', () => {
+    const {
+      container: { firstChild: root },
+    } = render(<Switch />);
+
+    expect(root.childNodes[1]).to.have.property('tagName', 'SPAN');
+    expect(root.childNodes[1]).to.have.class(classes.track);
+  });
+
+  it('renders a `role="checkbox"` with the Unchecked state by default', () => {
+    const { getByRole } = render(<Switch />);
+
+    expect(getByRole('checkbox')).to.have.property('checked', false);
+  });
+
+  it('renders a checkbox with the Checked state when checked', () => {
+    const { getByRole } = render(<Switch defaultChecked />);
+
+    expect(getByRole('checkbox')).to.have.property('checked', true);
+  });
+
+  specify('the switch can be disabled', () => {
+    const { getByRole } = render(<Switch disabled />);
+
+    expect(getByRole('checkbox')).to.have.property('disabled', true);
+  });
+
+  specify('the switch can be readonly', () => {
+    const { getByRole } = render(<Switch readOnly />);
+
+    expect(getByRole('checkbox')).to.have.property('readOnly', true);
+  });
+
+  specify('renders a custom icon when provided', () => {
+    const { getByTestId } = render(<Switch icon={<span data-testid="icon" />} />);
+
+    expect(getByTestId('icon')).toBeVisible();
+  });
+
+  specify('renders a custom checked icon when provided', () => {
+    const { getByTestId } = render(
+      <Switch defaultChecked checkedIcon={<span data-testid="icon" />} />,
+    );
+
+    expect(getByTestId('icon')).toBeVisible();
+  });
+
+  specify('the Checked state changes after change events', () => {
+    const { getByRole } = render(<Switch defaultChecked />);
+
+    // how a user would trigger it
+    act(() => {
+      getByRole('checkbox').click();
+      fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+    });
+
+    expect(getByRole('checkbox')).to.have.property('checked', false);
+  });
+
+  it('should not show warnings when custom `type` is provided', () => {
+    expect(() => render(<Switch type="submit" />)).not.toErrorDev();
+  });
+
+  describe('with FormControl', () => {
+    describe('enabled', () => {
+      it('should not have the disabled class', () => {
+        const { getByRole } = render(
+          <FormControl>
+            <Switch />
+          </FormControl>,
+        );
+
+        expect(getByRole('checkbox')).not.to.have.attribute('disabled');
+      });
+
+      it('should be overridden by props', () => {
+        const { getByRole } = render(
+          <FormControl>
+            <Switch disabled />
+          </FormControl>,
+        );
+
+        expect(getByRole('checkbox')).to.have.attribute('disabled');
+      });
+    });
+
+    describe('disabled', () => {
+      it('should have the disabled class', () => {
+        const { getByRole } = render(
+          <FormControl disabled>
+            <Switch />
+          </FormControl>,
+        );
+
+        expect(getByRole('checkbox')).to.have.attribute('disabled');
+      });
+
+      it('should be overridden by props', () => {
+        const { getByRole } = render(
+          <FormControl disabled>
+            <Switch disabled={false} />
+          </FormControl>,
+        );
+
+        expect(getByRole('checkbox')).not.to.have.attribute('disabled');
+      });
+    });
+  });
+});

--- a/packages/mui-material-next/src/Switch/Switch.test.js
+++ b/packages/mui-material-next/src/Switch/Switch.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Switch, { switchClasses as classes } from '@mui/material-next/Switch';
-import FormControl from '@mui/material-next/FormControl';
+import FormControl from '@mui/material/FormControl';
 
 describe('<Switch />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Switch/Switch.test.js
+++ b/packages/mui-material-next/src/Switch/Switch.test.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
-import Switch, { switchClasses as classes } from '@mui/material/Switch';
-import FormControl from '@mui/material/FormControl';
+import Switch, { switchClasses as classes } from '@mui/material-next/Switch';
+import FormControl from '@mui/material-next/FormControl';
 
 describe('<Switch />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Switch/index.d.ts
+++ b/packages/mui-material-next/src/Switch/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './Switch';
+export * from './Switch';
+
+export { default as switchClasses } from './switchClasses';
+export * from './switchClasses';

--- a/packages/mui-material-next/src/Switch/index.js
+++ b/packages/mui-material-next/src/Switch/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './Switch';
+
+export { default as switchClasses } from './switchClasses';
+export * from './switchClasses';

--- a/packages/mui-material-next/src/Switch/switchClasses.ts
+++ b/packages/mui-material-next/src/Switch/switchClasses.ts
@@ -1,0 +1,55 @@
+import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
+import generateUtilityClass from '../generateUtilityClass';
+
+export interface SwitchClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `edge="start"`. */
+  edgeStart: string;
+  /** Styles applied to the root element if `edge="end"`. */
+  edgeEnd: string;
+  /** Styles applied to the internal `SwitchBase` component's `root` class. */
+  switchBase: string;
+  /** Styles applied to the internal SwitchBase component's root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the internal SwitchBase component's root element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the root element if `size="medium"`. */
+  sizeMedium: string;
+  /** State class applied to the internal `SwitchBase` component's `checked` class. */
+  checked: string;
+  /** State class applied to the internal SwitchBase component's disabled class. */
+  disabled: string;
+  /** Styles applied to the internal SwitchBase component's input element. */
+  input: string;
+  /** Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop. */
+  thumb: string;
+  /** Styles applied to the track element. */
+  track: string;
+}
+
+export type SwitchClassKey = keyof SwitchClasses;
+
+export function getSwitchUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiSwitch', slot);
+}
+
+const switchClasses: SwitchClasses = generateUtilityClasses('MuiSwitch', [
+  'root',
+  'edgeStart',
+  'edgeEnd',
+  'switchBase',
+  'colorPrimary',
+  'colorSecondary',
+  'sizeSmall',
+  'sizeMedium',
+  'checked',
+  'disabled',
+  'input',
+  'thumb',
+  'track',
+]);
+
+export default switchClasses;

--- a/packages/mui-material-next/src/Switch/switchClasses.ts
+++ b/packages/mui-material-next/src/Switch/switchClasses.ts
@@ -1,5 +1,7 @@
-import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
-import generateUtilityClass from '../generateUtilityClass';
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
 
 export interface SwitchClasses {
   /** Styles applied to the root element. */


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Switch issue:** #39886
**Material You umbrella issue:** #29345

## Changes
- Copy Switch from `material` v5
- Fix imports
## Known Issues
The `Switch` component currently still uses the base component from material-ui. In the next PR, this will be replaced by the `useSwitch` hook.