### PR TITLE
[material-ui][Select] Remove unnecessary picking of `onChange` type from SelectInputProps

### DIFF
--- a/packages/mui-material-next/src/Select/Select.d.ts
+++ b/packages/mui-material-next/src/Select/Select.d.ts
@@ -15,8 +15,7 @@ export { SelectChangeEvent };
 
 export interface SelectProps<Value = unknown>
   extends StandardProps<InputProps, 'value' | 'onChange'>,
-    Omit<OutlinedInputProps, 'value' | 'onChange'>,
-    Pick<SelectInputProps<Value>, 'onChange'> {
+    Omit<OutlinedInputProps, 'value' | 'onChange'> {
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.

--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -11,8 +11,7 @@ export { SelectChangeEvent };
 
 export interface SelectProps<Value = unknown>
   extends StandardProps<InputProps, 'value' | 'onChange'>,
-    Omit<OutlinedInputProps, 'value' | 'onChange'>,
-    Pick<SelectInputProps<Value>, 'onChange'> {
+    Omit<OutlinedInputProps, 'value' | 'onChange'> {
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The `onChange` type is being picked unnecessarily when there is a direct definition of the `onChange` type in `SelectProps`, which already utilizes the `SelectInputProps` type.

It was added in #11041 but was missed to remove it in #20298.
