### PR TITLE
[lab][Masonry] Ability to sort elements from left to right

### DIFF
--- a/docs/data/material/components/masonry/Sequential.js
+++ b/docs/data/material/components/masonry/Sequential.js
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
+import Masonry from '@mui/lab/Masonry';
+
+const heights = [150, 30, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(0.5),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function Sequential() {
+  return (
+    <Box sx={{ width: 500, minHeight: 393 }}>
+      <Masonry
+        columns={4}
+        spacing={2}
+        defaultHeight={450}
+        defaultColumns={4}
+        defaultSpacing={1}
+        sequential
+      >
+        {heights.map((height, index) => (
+          <Item key={index} sx={{ height }}>
+            {index + 1}
+          </Item>
+        ))}
+      </Masonry>
+    </Box>
+  );
+}

--- a/docs/data/material/components/masonry/Sequential.tsx
+++ b/docs/data/material/components/masonry/Sequential.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
+import Masonry from '@mui/lab/Masonry';
+
+const heights = [150, 30, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 30, 50, 80];
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(0.5),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}));
+
+export default function Sequential() {
+  return (
+    <Box sx={{ width: 500, minHeight: 393 }}>
+      <Masonry
+        columns={4}
+        spacing={2}
+        defaultHeight={450}
+        defaultColumns={4}
+        defaultSpacing={1}
+        sequential
+      >
+        {heights.map((height, index) => (
+          <Item key={index} sx={{ height }}>
+            {index + 1}
+          </Item>
+        ))}
+      </Masonry>
+    </Box>
+  );
+}

--- a/docs/data/material/components/masonry/Sequential.tsx.preview
+++ b/docs/data/material/components/masonry/Sequential.tsx.preview
@@ -1,0 +1,14 @@
+<Masonry
+  columns={4}
+  spacing={2}
+  defaultHeight={450}
+  defaultColumns={4}
+  defaultSpacing={1}
+  sequential
+>
+  {heights.map((height, index) => (
+    <Item key={index} sx={{ height }}>
+      {index + 1}
+    </Item>
+  ))}
+</Masonry>

--- a/docs/data/material/components/masonry/masonry.md
+++ b/docs/data/material/components/masonry/masonry.md
@@ -56,6 +56,13 @@ It is important to note that the value provided to the `spacing` prop is multipl
 
 {{"demo": "ResponsiveSpacing.js", "bg": true}}
 
+## Sequential
+
+This example demonstrates the use of the `sequential` to configure the sequential order.
+With `sequential` enabled, items are added in order from left to right rather than adding to the shortest column.
+
+{{"demo": "Sequential.js", "bg": true}}
+
 ## Server-side rendering
 
 This example demonstrates the use of the `defaultHeight`, `defaultColumns` and `defaultSpacing`, which are used to

--- a/docs/pages/material-ui/api/masonry.json
+++ b/docs/pages/material-ui/api/masonry.json
@@ -13,6 +13,7 @@
     "defaultColumns": { "type": { "name": "number" } },
     "defaultHeight": { "type": { "name": "number" } },
     "defaultSpacing": { "type": { "name": "number" } },
+    "sequential": { "type": { "name": "bool" }, "default": "false" },
     "spacing": {
       "type": {
         "name": "union",

--- a/docs/translations/api-docs/masonry/masonry.json
+++ b/docs/translations/api-docs/masonry/masonry.json
@@ -16,6 +16,9 @@
     "defaultSpacing": {
       "description": "The default spacing of the component. Like <code>spacing</code>, it is a factor of the theme&#39;s spacing. This is provided for server-side rendering."
     },
+    "sequential": {
+      "description": "Allows using sequential order rather than adding to shortest column"
+    },
     "spacing": {
       "description": "Defines the space between children. It is a factor of the theme&#39;s spacing."
     },

--- a/packages/mui-lab/src/Masonry/Masonry.d.ts
+++ b/packages/mui-lab/src/Masonry/Masonry.d.ts
@@ -35,6 +35,11 @@ export interface MasonryOwnProps {
    */
   spacing?: ResponsiveStyleValue<number | string>;
   /**
+   * Allows using sequential order rather than adding to shortest column
+   * @default false
+   */
+  sequential?: boolean;
+  /**
    * Allows defining system overrides as well as additional CSS styles.
    */
   sx?: SxProps<Theme>;

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -212,8 +212,8 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  useEnhancedEffect(() => {
-    const handleResize = (masonryChildren) => {
+  const handleResize = React.useCallback(
+    (masonryChildren) => {
       if (!masonryRef.current || !masonryChildren || masonryChildren.length === 0) {
         return;
       }
@@ -287,8 +287,11 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
           setNumberOfLineBreaks(currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0);
         });
       }
-    };
+    },
+    [sequential],
+  );
 
+  useEnhancedEffect(() => {
     // IE and old browsers are not supported
     if (typeof ResizeObserver === 'undefined') {
       return undefined;
@@ -315,7 +318,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
         resizeObserver.disconnect();
       }
     };
-  }, [columns, spacing, children, sequential]);
+  }, [columns, spacing, children, handleResize]);
 
   const handleRef = useForkRef(ref, masonryRef);
 

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -212,83 +212,83 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const handleResize = (masonryChildren) => {
-    if (!masonryRef.current || !masonryChildren || masonryChildren.length === 0) {
-      return;
-    }
-
-    const masonry = masonryRef.current;
-    const masonryFirstChild = masonryRef.current.firstChild;
-    const parentWidth = masonry.clientWidth;
-    const firstChildWidth = masonryFirstChild.clientWidth;
-
-    if (parentWidth === 0 || firstChildWidth === 0) {
-      return;
-    }
-
-    const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild);
-    const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
-    const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
-
-    const currentNumberOfColumns = Math.round(
-      parentWidth / (firstChildWidth + firstChildMarginLeft + firstChildMarginRight),
-    );
-
-    const columnHeights = new Array(currentNumberOfColumns).fill(0);
-    let skip = false;
-    let nextOrder = 1;
-    masonry.childNodes.forEach((child) => {
-      if (child.nodeType !== Node.ELEMENT_NODE || child.dataset.class === 'line-break' || skip) {
-        return;
-      }
-      const childComputedStyle = window.getComputedStyle(child);
-      const childMarginTop = parseToNumber(childComputedStyle.marginTop);
-      const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
-      // if any one of children isn't rendered yet, masonry's height shouldn't be computed yet
-      const childHeight = parseToNumber(childComputedStyle.height)
-        ? Math.ceil(parseToNumber(childComputedStyle.height)) + childMarginTop + childMarginBottom
-        : 0;
-      if (childHeight === 0) {
-        skip = true;
-        return;
-      }
-      // if there is a nested image that isn't rendered yet, masonry's height shouldn't be computed yet
-      for (let i = 0; i < child.childNodes.length; i += 1) {
-        const nestedChild = child.childNodes[i];
-        if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
-          skip = true;
-          break;
-        }
-      }
-      if (!skip) {
-        if (sequential) {
-          columnHeights[nextOrder - 1] += childHeight;
-          child.style.order = nextOrder;
-          nextOrder += 1;
-          if (nextOrder > currentNumberOfColumns) {
-            nextOrder = 1;
-          }
-        } else {
-          // find the current shortest column (where the current item will be placed)
-          const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
-          columnHeights[currentMinColumnIndex] += childHeight;
-          const order = currentMinColumnIndex + 1;
-          child.style.order = order;
-        }
-      }
-    });
-    if (!skip) {
-      // In React 18, state updates in a ResizeObserver's callback are happening after the paint which causes flickering
-      // when doing some visual updates in it. Using flushSync ensures that the dom will be painted after the states updates happen
-      // Related issue - https://github.com/facebook/react/issues/24331
-      ReactDOM.flushSync(() => {
-        setMaxColumnHeight(Math.max(...columnHeights));
-        setNumberOfLineBreaks(currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0);
-      });
-    }
-  };
-
   useEnhancedEffect(() => {
+    const handleResize = (masonryChildren) => {
+      if (!masonryRef.current || !masonryChildren || masonryChildren.length === 0) {
+        return;
+      }
+
+      const masonry = masonryRef.current;
+      const masonryFirstChild = masonryRef.current.firstChild;
+      const parentWidth = masonry.clientWidth;
+      const firstChildWidth = masonryFirstChild.clientWidth;
+
+      if (parentWidth === 0 || firstChildWidth === 0) {
+        return;
+      }
+
+      const firstChildComputedStyle = window.getComputedStyle(masonryFirstChild);
+      const firstChildMarginLeft = parseToNumber(firstChildComputedStyle.marginLeft);
+      const firstChildMarginRight = parseToNumber(firstChildComputedStyle.marginRight);
+
+      const currentNumberOfColumns = Math.round(
+        parentWidth / (firstChildWidth + firstChildMarginLeft + firstChildMarginRight),
+      );
+
+      const columnHeights = new Array(currentNumberOfColumns).fill(0);
+      let skip = false;
+      let nextOrder = 1;
+      masonry.childNodes.forEach((child) => {
+        if (child.nodeType !== Node.ELEMENT_NODE || child.dataset.class === 'line-break' || skip) {
+          return;
+        }
+        const childComputedStyle = window.getComputedStyle(child);
+        const childMarginTop = parseToNumber(childComputedStyle.marginTop);
+        const childMarginBottom = parseToNumber(childComputedStyle.marginBottom);
+        // if any one of children isn't rendered yet, masonry's height shouldn't be computed yet
+        const childHeight = parseToNumber(childComputedStyle.height)
+          ? Math.ceil(parseToNumber(childComputedStyle.height)) + childMarginTop + childMarginBottom
+          : 0;
+        if (childHeight === 0) {
+          skip = true;
+          return;
+        }
+        // if there is a nested image that isn't rendered yet, masonry's height shouldn't be computed yet
+        for (let i = 0; i < child.childNodes.length; i += 1) {
+          const nestedChild = child.childNodes[i];
+          if (nestedChild.tagName === 'IMG' && nestedChild.clientHeight === 0) {
+            skip = true;
+            break;
+          }
+        }
+        if (!skip) {
+          if (sequential) {
+            columnHeights[nextOrder - 1] += childHeight;
+            child.style.order = nextOrder;
+            nextOrder += 1;
+            if (nextOrder > currentNumberOfColumns) {
+              nextOrder = 1;
+            }
+          } else {
+            // find the current shortest column (where the current item will be placed)
+            const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
+            columnHeights[currentMinColumnIndex] += childHeight;
+            const order = currentMinColumnIndex + 1;
+            child.style.order = order;
+          }
+        }
+      });
+      if (!skip) {
+        // In React 18, state updates in a ResizeObserver's callback are happening after the paint which causes flickering
+        // when doing some visual updates in it. Using flushSync ensures that the dom will be painted after the states updates happen
+        // Related issue - https://github.com/facebook/react/issues/24331
+        ReactDOM.flushSync(() => {
+          setMaxColumnHeight(Math.max(...columnHeights));
+          setNumberOfLineBreaks(currentNumberOfColumns > 0 ? currentNumberOfColumns - 1 : 0);
+        });
+      }
+    };
+
     // IE and old browsers are not supported
     if (typeof ResizeObserver === 'undefined') {
       return undefined;
@@ -315,7 +315,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
         resizeObserver.disconnect();
       }
     };
-  }, [columns, spacing, children]);
+  }, [columns, spacing, children, sequential]);
 
   const handleRef = useForkRef(ref, masonryRef);
 

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -181,6 +181,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
     component = 'div',
     columns = 4,
     spacing = 1,
+    sequential = false,
     defaultColumns,
     defaultHeight,
     defaultSpacing,
@@ -235,6 +236,7 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
 
     const columnHeights = new Array(currentNumberOfColumns).fill(0);
     let skip = false;
+    let nextOrder = 1;
     masonry.childNodes.forEach((child) => {
       if (child.nodeType !== Node.ELEMENT_NODE || child.dataset.class === 'line-break' || skip) {
         return;
@@ -259,11 +261,20 @@ const Masonry = React.forwardRef(function Masonry(inProps, ref) {
         }
       }
       if (!skip) {
-        // find the current shortest column (where the current item will be placed)
-        const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
-        columnHeights[currentMinColumnIndex] += childHeight;
-        const order = currentMinColumnIndex + 1;
-        child.style.order = order;
+        if (sequential) {
+          columnHeights[nextOrder - 1] += childHeight;
+          child.style.order = nextOrder;
+          nextOrder += 1;
+          if (nextOrder > currentNumberOfColumns) {
+            nextOrder = 1;
+          }
+        } else {
+          // find the current shortest column (where the current item will be placed)
+          const currentMinColumnIndex = columnHeights.indexOf(Math.min(...columnHeights));
+          columnHeights[currentMinColumnIndex] += childHeight;
+          const order = currentMinColumnIndex + 1;
+          child.style.order = order;
+        }
       }
     });
     if (!skip) {
@@ -374,6 +385,11 @@ Masonry.propTypes /* remove-proptypes */ = {
    * The default spacing of the component. Like `spacing`, it is a factor of the theme's spacing. This is provided for server-side rendering.
    */
   defaultSpacing: PropTypes.number,
+  /**
+   * Allows using sequential order rather than adding to shortest column
+   * @default false
+   */
+  sequential: PropTypes.bool,
   /**
    * Defines the space between children. It is a factor of the theme's spacing.
    * @default 1

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -377,13 +377,12 @@ describe('<Masonry />', () => {
         this.skip();
       }
 
-      const spacingProp = 1;
       const firstChildHeight = 20;
       const secondChildHeight = 10;
       const thirdChildHeight = 10;
 
       const { getByTestId } = render(
-        <Masonry columns={2} spacing={spacingProp} sequential data-testid="container">
+        <Masonry columns={2} spacing={0} sequential data-testid="container">
           <div style={{ height: `${firstChildHeight}px` }} />
           <div style={{ height: `${secondChildHeight}px` }} />
           <div style={{ height: `${thirdChildHeight}px` }} />
@@ -391,10 +390,9 @@ describe('<Masonry />', () => {
       );
 
       const masonry = getByTestId('container');
-      const topAndBottomMargin = parseToNumber(defaultTheme.spacing(spacingProp)) * 2;
 
       expect(window.getComputedStyle(masonry).height).to.equal(
-        `${firstChildHeight + thirdChildHeight + topAndBottomMargin}px`,
+        `${firstChildHeight + thirdChildHeight}px`,
       );
     });
   });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -371,29 +371,33 @@ describe('<Masonry />', () => {
   });
 
   describe('prop: sequential', () => {
-    it('should place children in sequential order', function test() {
+    const pause = (timeout) =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, timeout);
+      });
+
+    it('should place children in sequential order', async function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         // only run on browser
         this.skip();
       }
 
-      const firstChildHeight = 20;
-      const secondChildHeight = 10;
-      const thirdChildHeight = 10;
-
       const { getByTestId } = render(
-        <Masonry columns={2} spacing={0} sequential data-testid="container">
-          <div style={{ height: `${firstChildHeight}px` }} />
-          <div style={{ height: `${secondChildHeight}px` }} />
-          <div style={{ height: `${thirdChildHeight}px` }} />
+        <Masonry columns={2} spacing={1} sequential>
+          <div style={{ height: `20px` }} data-testid="child1" />
+          <div style={{ height: `10px` }} data-testid="child2" />
+          <div style={{ height: `10px` }} data-testid="child3" />
         </Masonry>,
       );
-
-      const masonry = getByTestId('container');
-
-      expect(window.getComputedStyle(masonry).height).to.equal(
-        `${firstChildHeight + thirdChildHeight}px`,
-      );
+      await pause(400); // Masonry elements aren't ordered immediately, and so we need the pause to wait for them to be ordered
+      const child1 = getByTestId('child1');
+      const child2 = getByTestId('child2');
+      const child3 = getByTestId('child3');
+      expect(window.getComputedStyle(child1).order).to.equal(`1`);
+      expect(window.getComputedStyle(child2).order).to.equal(`2`);
+      expect(window.getComputedStyle(child3).order).to.equal(`1`);
     });
   });
 });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -376,29 +376,26 @@ describe('<Masonry />', () => {
         // only run on browser
         this.skip();
       }
+
+      const spacingProp = 1;
       const firstChildHeight = 20;
       const secondChildHeight = 10;
       const thirdChildHeight = 10;
 
       const { getByTestId } = render(
-        <Masonry columns={2} sequential>
-          <div style={{ height: `${firstChildHeight}px` }} data-testid="child1" />
-          <div style={{ height: `${secondChildHeight}px` }} data-testid="child2" />
-          <div style={{ height: `${thirdChildHeight}px` }} data-testid="child3" />
+        <Masonry columns={2} spacing={spacingProp} sequential data-testid="container">
+          <div style={{ height: `${firstChildHeight}px` }} />
+          <div style={{ height: `${secondChildHeight}px` }} />
+          <div style={{ height: `${thirdChildHeight}px` }} />
         </Masonry>,
       );
 
-      expect(getByTestId('child1')).toHaveComputedStyle({
-        order: '1',
-      });
+      const masonry = getByTestId('container');
+      const topAndBottomMargin = parseToNumber(defaultTheme.spacing(spacingProp)) * 2;
 
-      expect(getByTestId('child2')).toHaveComputedStyle({
-        order: '2',
-      });
-
-      expect(getByTestId('child3')).toHaveComputedStyle({
-        order: '1',
-      });
+      expect(window.getComputedStyle(masonry).height).to.equal(
+        `${firstChildHeight + thirdChildHeight + topAndBottomMargin}px`,
+      );
     });
   });
 });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -381,23 +381,24 @@ describe('<Masonry />', () => {
       const thirdChildHeight = 10;
 
       const { getByTestId } = render(
-        <Masonry columns={2} data-testid="sequential" sequential>
-          <div style={{ height: `${firstChildHeight}px` }} />
-          <div style={{ height: `${secondChildHeight}px` }} />
-          <div style={{ height: `${thirdChildHeight}px` }} />
+        <Masonry columns={2} sequential>
+          <div style={{ height: `${firstChildHeight}px` }} data-testid="child1" />
+          <div style={{ height: `${secondChildHeight}px` }} data-testid="child2" />
+          <div style={{ height: `${thirdChildHeight}px` }} data-testid="child3" />
         </Masonry>,
       );
-      const masonry = getByTestId('sequential');
 
-      expect(window.getComputedStyle(masonry).height).to.equal(
-        `${firstChildHeight + thirdChildHeight}px`,
-      );
+      expect(getByTestId('child1')).toHaveComputedStyle({
+        order: '1',
+      });
 
-      expect(window.getComputedStyle(masonry.children[0]).style).to.equal(`order: 1;`);
+      expect(getByTestId('child2')).toHaveComputedStyle({
+        order: '2',
+      });
 
-      expect(window.getComputedStyle(masonry.children[1]).style).to.equal(`order: 2;`);
-
-      expect(window.getComputedStyle(masonry.children[2]).style).to.equal(`order: 1;`);
+      expect(getByTestId('child3')).toHaveComputedStyle({
+        order: '1',
+      });
     });
   });
 });

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -369,4 +369,35 @@ describe('<Masonry />', () => {
       });
     });
   });
+
+  describe('prop: sequential', () => {
+    it('should place children in sequential order', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // only run on browser
+        this.skip();
+      }
+      const firstChildHeight = 20;
+      const secondChildHeight = 10;
+      const thirdChildHeight = 10;
+
+      const { getByTestId } = render(
+        <Masonry columns={2} data-testid="sequential" sequential>
+          <div style={{ height: `${firstChildHeight}px` }} />
+          <div style={{ height: `${secondChildHeight}px` }} />
+          <div style={{ height: `${thirdChildHeight}px` }} />
+        </Masonry>,
+      );
+      const masonry = getByTestId('sequential');
+
+      expect(window.getComputedStyle(masonry).height).to.equal(
+        `${firstChildHeight + thirdChildHeight}px`,
+      );
+
+      expect(window.getComputedStyle(masonry.children[0]).style).to.equal(`order: 1;`);
+
+      expect(window.getComputedStyle(masonry.children[1]).style).to.equal(`order: 2;`);
+
+      expect(window.getComputedStyle(masonry.children[2]).style).to.equal(`order: 1;`);
+    });
+  });
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
- [x] Create Tests
- [x] Fix eslint issue


Resolves https://github.com/mui/material-ui/issues/36859. Allows sorting masonry from left to right with the `sequential` prop.
