### PR TITLE
[docs] Fix nested CSS warning

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -88,6 +88,7 @@
     "notistack": "3.0.1",
     "nprogress": "^0.2.0",
     "postcss": "^8.4.30",
+    "postcss-import": "^15.1.0",    
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -88,7 +88,7 @@
     "notistack": "3.0.1",
     "nprogress": "^0.2.0",
     "postcss": "^8.4.30",
-    "postcss-import": "^15.1.0",    
+    "postcss-import": "^15.1.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/docs/postcss.config.js
+++ b/docs/postcss.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   plugins: {
+    'postcss-import': {},
+    'tailwindcss/nesting': {},
     tailwindcss: {},
   },
 };

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "nx": "^16.10.0",
     "nyc": "^15.1.0",
     "piscina": "^4.1.0",
+    "postcss-import": "^15.1.0",
     "postcss-styled-syntax": "^0.5.0",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "nx": "^16.10.0",
     "nyc": "^15.1.0",
     "piscina": "^4.1.0",
-    "postcss-import": "^15.1.0",
     "postcss-styled-syntax": "^0.5.0",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3",


### PR DESCRIPTION
Fixes the warning

<img width="1506" alt="Screenshot 2023-11-20 at 09 41 58" src="https://github.com/mui/material-ui/assets/4512430/e2f884d7-ea53-4dcc-8fee-5c9dfcea873c">

Fix regression introduced in #39694