### PR TITLE
[joy-ui][Radio][Input] Fix inheritance of disabled prop

### DIFF
--- a/packages/mui-joy/src/Input/Input.test.tsx
+++ b/packages/mui-joy/src/Input/Input.test.tsx
@@ -9,7 +9,8 @@ import {
   fireEvent,
 } from '@mui-internal/test-utils';
 import Input, { inputClasses as classes } from '@mui/joy/Input';
-import { ThemeProvider } from '@mui/joy/styles';
+import { ThemeProvider, extendTheme } from '@mui/joy/styles';
+import FormControl from '@mui/joy/FormControl';
 
 describe('Joy <Input />', () => {
   const { render } = createRenderer();
@@ -85,6 +86,28 @@ describe('Joy <Input />', () => {
       expect(handleBlur.callCount).to.equal(1);
       // check if focus not initiated again
       expect(handleFocus.callCount).to.equal(1);
+    });
+
+    it('disabled prop from FormControl should take precedence over disabled prop from theme', () => {
+      const { getByRole } = render(
+        <ThemeProvider
+          theme={extendTheme({
+            components: {
+              JoyInput: {
+                defaultProps: {
+                  disabled: false,
+                },
+              },
+            },
+          })}
+        >
+          <FormControl disabled>
+            <Input />
+          </FormControl>
+        </ThemeProvider>,
+      );
+
+      expect(getByRole('textbox')).to.have.attribute('disabled');
     });
   });
 

--- a/packages/mui-joy/src/Input/Input.tsx
+++ b/packages/mui-joy/src/Input/Input.tsx
@@ -266,7 +266,7 @@ const Input = React.forwardRef(function Input(inProps, ref) {
     slots = {},
     slotProps = {},
     ...other
-  } = useForwardedInput<InputProps>(props, inputClasses);
+  } = useForwardedInput<InputProps>({ ...props, disabledInProp: inProps.disabled }, inputClasses);
 
   if (process.env.NODE_ENV !== 'production') {
     const registerEffect = formControl?.registerEffect;

--- a/packages/mui-joy/src/Input/useForwardedInput.ts
+++ b/packages/mui-joy/src/Input/useForwardedInput.ts
@@ -17,6 +17,7 @@ export default function useForwardedInput<Output>(
     className,
     defaultValue,
     disabled: disabledProp,
+    disabledInProp,
     error: errorProp,
     id,
     name,
@@ -35,7 +36,7 @@ export default function useForwardedInput<Output>(
   } = props;
 
   const { getRootProps, getInputProps, focused, error, disabled } = useInput({
-    disabled: disabledProp ?? formControl?.disabled,
+    disabled: disabledInProp ?? formControl?.disabled ?? disabledProp,
     defaultValue,
     error: errorProp,
     onBlur,

--- a/packages/mui-joy/src/Radio/Radio.test.tsx
+++ b/packages/mui-joy/src/Radio/Radio.test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Radio, { radioClasses as classes } from '@mui/joy/Radio';
-import { ThemeProvider } from '@mui/joy/styles';
+import { ThemeProvider, extendTheme } from '@mui/joy/styles';
+import FormControl from '@mui/joy/FormControl';
 
 describe('<Radio />', () => {
   const { render } = createRenderer();
@@ -69,6 +70,28 @@ describe('<Radio />', () => {
 
   it('the radio can be disabled', () => {
     const { getByRole } = render(<Radio disabled />);
+
+    expect(getByRole('radio')).to.have.property('disabled', true);
+  });
+
+  it('disabled prop from FormControl should take precedence over disabled prop from theme', () => {
+    const { getByRole } = render(
+      <ThemeProvider
+        theme={extendTheme({
+          components: {
+            JoyRadio: {
+              defaultProps: {
+                disabled: false,
+              },
+            },
+          },
+        })}
+      >
+        <FormControl disabled>
+          <Radio value="outlined" label="Outlined" />
+        </FormControl>
+      </ThemeProvider>,
+    );
 
     expect(getByRole('radio')).to.have.property('disabled', true);
   });

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -302,6 +302,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const name = inProps.name || radioGroup?.name || nameProp;
   const disableIcon = inProps.disableIcon || radioGroup?.disableIcon || disableIconProp;
   const overlay = inProps.overlay || radioGroup?.overlay || overlayProp;
+  const isDisabled = inProps.disabled || formControl?.disabled || disabledProp;
 
   const radioChecked =
     typeof checkedProp === 'undefined' && !!value
@@ -310,7 +311,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const useRadioProps = {
     checked: radioChecked,
     defaultChecked,
-    disabled: disabledProp ?? formControl?.disabled,
+    disabled: isDisabled,
     onBlur,
     onChange,
     onFocus,

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -302,7 +302,6 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const name = inProps.name || radioGroup?.name || nameProp;
   const disableIcon = inProps.disableIcon || radioGroup?.disableIcon || disableIconProp;
   const overlay = inProps.overlay || radioGroup?.overlay || overlayProp;
-  const isDisabled = inProps.disabled || formControl?.disabled || disabledProp;
 
   const radioChecked =
     typeof checkedProp === 'undefined' && !!value
@@ -311,7 +310,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const useRadioProps = {
     checked: radioChecked,
     defaultChecked,
-    disabled: isDisabled,
+    disabled: inProps.disabled || formControl?.disabled || disabledProp,
     onBlur,
     onChange,
     onFocus,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Before

https://codesandbox.io/s/vigorous-leaf-l4ynj3?file=/src/index.tsx

### After

https://codesandbox.io/s/elastic-sunset-7fykcs?file=/src/Demo.tsx

In both `Input` and `Radio` `disabled` prop from theme were taking precedence over `disabled` prop from `FormControl`. This PR fixes the issue.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
