### PR TITLE
[material-ui][utils] Fix getUtilityClass behavior when undefined

### DIFF
--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -1,6 +1,6 @@
 export default function composeClasses<ClassKey extends string>(
   slots: Record<ClassKey, ReadonlyArray<string | false | undefined | null>>,
-  getUtilityClass: (slot: string) => string,
+  getUtilityClass: (slot: string) => string | undefined,
   classes: Record<string, string> | undefined = undefined,
 ): Record<ClassKey, string> {
   const output: Record<ClassKey, string> = {} as any;
@@ -12,7 +12,7 @@ export default function composeClasses<ClassKey extends string>(
       output[slot] = slots[slot]
         .reduce((acc, key) => {
           if (key) {
-            const utilityClass = getUtilityClass(key);
+            const utilityClass = getUtilityClass?.(key) ?? '';
             if (utilityClass !== '') {
               acc.push(utilityClass);
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This resolves the issue #39937 