### PR TITLE
[IconButton][material-next] Copy IconButton to material-next

### DIFF
--- a/packages/mui-material-next/src/IconButton/IconButton.d.ts
+++ b/packages/mui-material-next/src/IconButton/IconButton.d.ts
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import { Theme } from '@mui/material';
+import { ExtendButtonBase, ExtendButtonBaseTypeMap } from '../ButtonBase/ButtonBase.types';
+import { IconButtonClasses } from './iconButtonClasses';
+
+export interface IconButtonPropsColorOverrides {}
+
+export interface IconButtonPropsSizeOverrides {}
+
+export interface IconButtonOwnProps {
+  /**
+   * The icon to display.
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<IconButtonClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'default'
+   */
+  color?: OverridableStringUnion<
+    'inherit' | 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+    IconButtonPropsColorOverrides
+  >;
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the  keyboard focus ripple is disabled.
+   * @default false
+   */
+  disableFocusRipple?: boolean;
+  /**
+   * If given, uses a negative margin to counteract the padding on one
+   * side (this is often helpful for aligning the left or right
+   * side of the icon with content above or below, without ruining the border
+   * size and shape).
+   * @default false
+   */
+  edge?: 'start' | 'end' | false;
+  /**
+   * The size of the component.
+   * `small` is equivalent to the dense button styling.
+   * @default 'medium'
+   */
+  size?: OverridableStringUnion<'small' | 'medium' | 'large', IconButtonPropsSizeOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+}
+
+export type IconButtonTypeMap<
+  AdditionalProps = {},
+  RootComponent extends React.ElementType = 'button',
+> = ExtendButtonBaseTypeMap<{
+  props: AdditionalProps & IconButtonOwnProps;
+  defaultComponent: RootComponent;
+}>;
+
+/**
+ * Refer to the [Icons](https://mui.com/material-ui/icons/) section of the documentation
+ * regarding the available icon options.
+ *
+ * Demos:
+ *
+ * - [Button](https://mui.com/material-ui/react-button/)
+ *
+ * API:
+ *
+ * - [IconButton API](https://mui.com/material-ui/api/icon-button/)
+ * - inherits [ButtonBase API](https://mui.com/material-ui/api/button-base/)
+ */
+declare const IconButton: ExtendButtonBase<IconButtonTypeMap>;
+
+export type IconButtonProps<
+  RootComponent extends React.ElementType = IconButtonTypeMap['defaultComponent'],
+  AdditionalProps = {},
+> = OverrideProps<IconButtonTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
+  component?: React.ElementType;
+};
+
+export default IconButton;

--- a/packages/mui-material-next/src/IconButton/IconButton.js
+++ b/packages/mui-material-next/src/IconButton/IconButton.js
@@ -5,9 +5,9 @@ import clsx from 'clsx';
 import { chainPropTypes, unstable_capitalize as capitalize } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { alpha } from '@mui/system';
+import ButtonBase from '@mui/material/ButtonBase';
 import styled from '../styles/styled';
 import useThemeProps from '../styles/useThemeProps';
-import ButtonBase from '../ButtonBase';
 import iconButtonClasses, { getIconButtonUtilityClass } from './iconButtonClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -241,7 +241,7 @@ IconButton.propTypes /* remove-proptypes */ = {
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
-  sx: PropTypes.oneOfType([
+  sx: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
     PropTypes.func,
     PropTypes.object,

--- a/packages/mui-material-next/src/IconButton/IconButton.js
+++ b/packages/mui-material-next/src/IconButton/IconButton.js
@@ -1,0 +1,251 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { chainPropTypes, unstable_capitalize as capitalize } from '@mui/utils';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { alpha } from '@mui/system';
+import styled from '../styles/styled';
+import useThemeProps from '../styles/useThemeProps';
+import ButtonBase from '../ButtonBase';
+import iconButtonClasses, { getIconButtonUtilityClass } from './iconButtonClasses';
+
+const useUtilityClasses = (ownerState) => {
+  const { classes, disabled, color, edge, size } = ownerState;
+
+  const slots = {
+    root: [
+      'root',
+      disabled && 'disabled',
+      color !== 'default' && `color${capitalize(color)}`,
+      edge && `edge${capitalize(edge)}`,
+      `size${capitalize(size)}`,
+    ],
+  };
+
+  return composeClasses(slots, getIconButtonUtilityClass, classes);
+};
+
+const IconButtonRoot = styled(ButtonBase, {
+  name: 'MuiIconButton',
+  slot: 'Root',
+  overridesResolver: (props, styles) => {
+    const { ownerState } = props;
+
+    return [
+      styles.root,
+      ownerState.color !== 'default' && styles[`color${capitalize(ownerState.color)}`],
+      ownerState.edge && styles[`edge${capitalize(ownerState.edge)}`],
+      styles[`size${capitalize(ownerState.size)}`],
+    ];
+  },
+})(
+  ({ theme, ownerState }) => ({
+    textAlign: 'center',
+    flex: '0 0 auto',
+    fontSize: theme.typography.pxToRem(24),
+    padding: 8,
+    borderRadius: '50%',
+    overflow: 'visible', // Explicitly set the default value to solve a bug on IE11.
+    color: (theme.vars || theme).palette.action.active,
+    transition: theme.transitions.create('background-color', {
+      duration: theme.transitions.duration.shortest,
+    }),
+    ...(!ownerState.disableRipple && {
+      '&:hover': {
+        backgroundColor: theme.vars
+          ? `rgba(${theme.vars.palette.action.activeChannel} / ${theme.vars.palette.action.hoverOpacity})`
+          : alpha(theme.palette.action.active, theme.palette.action.hoverOpacity),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: 'transparent',
+        },
+      },
+    }),
+    ...(ownerState.edge === 'start' && {
+      marginLeft: ownerState.size === 'small' ? -3 : -12,
+    }),
+    ...(ownerState.edge === 'end' && {
+      marginRight: ownerState.size === 'small' ? -3 : -12,
+    }),
+  }),
+  ({ theme, ownerState }) => {
+    const palette = (theme.vars || theme).palette?.[ownerState.color];
+    return {
+      ...(ownerState.color === 'inherit' && {
+        color: 'inherit',
+      }),
+      ...(ownerState.color !== 'inherit' &&
+        ownerState.color !== 'default' && {
+          color: palette?.main,
+          ...(!ownerState.disableRipple && {
+            '&:hover': {
+              ...(palette && {
+                backgroundColor: theme.vars
+                  ? `rgba(${palette.mainChannel} / ${theme.vars.palette.action.hoverOpacity})`
+                  : alpha(palette.main, theme.palette.action.hoverOpacity),
+              }),
+              // Reset on touch devices, it doesn't add specificity
+              '@media (hover: none)': {
+                backgroundColor: 'transparent',
+              },
+            },
+          }),
+        }),
+      ...(ownerState.size === 'small' && {
+        padding: 5,
+        fontSize: theme.typography.pxToRem(18),
+      }),
+      ...(ownerState.size === 'large' && {
+        padding: 12,
+        fontSize: theme.typography.pxToRem(28),
+      }),
+      [`&.${iconButtonClasses.disabled}`]: {
+        backgroundColor: 'transparent',
+        color: (theme.vars || theme).palette.action.disabled,
+      },
+    };
+  },
+);
+
+/**
+ * Refer to the [Icons](/material-ui/icons/) section of the documentation
+ * regarding the available icon options.
+ */
+const IconButton = React.forwardRef(function IconButton(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiIconButton' });
+  const {
+    edge = false,
+    children,
+    className,
+    color = 'default',
+    disabled = false,
+    disableFocusRipple = false,
+    size = 'medium',
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    edge,
+    color,
+    disabled,
+    disableFocusRipple,
+    size,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  return (
+    <IconButtonRoot
+      className={clsx(classes.root, className)}
+      centerRipple
+      focusRipple={!disableFocusRipple}
+      disabled={disabled}
+      ref={ref}
+      ownerState={ownerState}
+      {...other}
+    >
+      {children}
+    </IconButtonRoot>
+  );
+});
+
+IconButton.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * The icon to display.
+   */
+  children: chainPropTypes(PropTypes.node, (props) => {
+    const found = React.Children.toArray(props.children).some(
+      (child) => React.isValidElement(child) && child.props.onClick,
+    );
+
+    if (found) {
+      return new Error(
+        [
+          'MUI: You are providing an onClick event listener to a child of a button element.',
+          'Prefer applying it to the IconButton directly.',
+          'This guarantees that the whole <button> will be responsive to click events.',
+        ].join('\n'),
+      );
+    }
+
+    return null;
+  }),
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'default'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf([
+      'inherit',
+      'default',
+      'primary',
+      'secondary',
+      'error',
+      'info',
+      'success',
+      'warning',
+    ]),
+    PropTypes.string,
+  ]),
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the  keyboard focus ripple is disabled.
+   * @default false
+   */
+  disableFocusRipple: PropTypes.bool,
+  /**
+   * If `true`, the ripple effect is disabled.
+   *
+   * ⚠️ Without a ripple there is no styling for :focus-visible by default. Be sure
+   * to highlight the element by applying separate styles with the `.Mui-focusVisible` class.
+   * @default false
+   */
+  disableRipple: PropTypes.bool,
+  /**
+   * If given, uses a negative margin to counteract the padding on one
+   * side (this is often helpful for aligning the left or right
+   * side of the icon with content above or below, without ruining the border
+   * size and shape).
+   * @default false
+   */
+  edge: PropTypes.oneOf(['end', 'start', false]),
+  /**
+   * The size of the component.
+   * `small` is equivalent to the dense button styling.
+   * @default 'medium'
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['small', 'medium', 'large']),
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+};
+
+export default IconButton;

--- a/packages/mui-material-next/src/IconButton/IconButton.test.js
+++ b/packages/mui-material-next/src/IconButton/IconButton.test.js
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import PropTypes from 'prop-types';
+import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { unstable_capitalize as capitalize } from '@mui/utils';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import Icon from '@mui/material/Icon';
+import IconButton, { iconButtonClasses as classes } from '.';
+import ButtonBase from '../ButtonBase';
+
+describe('<IconButton />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(<IconButton>book</IconButton>, () => ({
+    classes,
+    inheritComponent: ButtonBase,
+    render,
+    refInstanceof: window.HTMLButtonElement,
+    muiName: 'MuiIconButton',
+    testVariantProps: { edge: 'end', disabled: true },
+    skip: ['componentProp', 'componentsProp'],
+  }));
+
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('should render Icon children with right classes', () => {
+    const childClassName = 'child-woof';
+    const iconChild = <Icon data-testid="icon" className={childClassName} />;
+    const { getByTestId } = render(<IconButton>{iconChild}</IconButton>);
+
+    expect(getByTestId('icon')).to.have.class(childClassName);
+  });
+
+  it('should have a ripple by default', () => {
+    const { container } = render(
+      <IconButton TouchRippleProps={{ className: 'touch-ripple' }}>book</IconButton>,
+    );
+    expect(container.querySelector('.touch-ripple')).not.to.equal(null);
+  });
+
+  it('can disable the ripple and hover effect', () => {
+    const { container } = render(
+      <IconButton disableRipple TouchRippleProps={{ className: 'touch-ripple' }}>
+        book
+      </IconButton>,
+    );
+    expect(container.querySelector('.touch-ripple')).to.equal(null);
+  });
+
+  describe('prop: size', () => {
+    it('should render the right class', () => {
+      let root;
+      root = render(<IconButton size="small">book</IconButton>).container.firstChild;
+      expect(root).to.have.class(classes.sizeSmall);
+
+      root = render(<IconButton size="medium">book</IconButton>).container.firstChild;
+      expect(root).not.to.have.class(classes.sizeSmall);
+
+      root = render(<IconButton size="large">book</IconButton>).container.firstChild;
+      expect(root).to.have.class(classes.sizeLarge);
+
+      root = render(<IconButton>book</IconButton>).container.firstChild;
+      expect(root).not.to.have.class(classes.sizeSmall);
+      expect(root).not.to.have.class(classes.sizeLarge);
+    });
+  });
+
+  describe('prop: edge', () => {
+    it('edge="start" should render the right class', () => {
+      const { container } = render(<IconButton edge="start">book</IconButton>);
+
+      expect(container.firstChild).to.have.class(classes.edgeStart);
+    });
+    it('edge="end" should render the right class', () => {
+      const { container } = render(<IconButton edge="end">book</IconButton>);
+
+      expect(container.firstChild).to.have.class(classes.edgeEnd);
+    });
+    it('no edge should render the right class', () => {
+      const { container } = render(<IconButton>book</IconButton>);
+
+      expect(container.firstChild).not.to.have.class(classes.edgeStart);
+      expect(container.firstChild).not.to.have.class(classes.edgeEnd);
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('should disable the component', () => {
+      const { getByRole } = render(<IconButton disabled>book</IconButton>);
+      const button = getByRole('button');
+
+      expect(button).to.have.property('disabled', true);
+      expect(button).to.have.class(classes.disabled);
+    });
+  });
+
+  describe('prop: color', () => {
+    ['primary', 'secondary', 'error', 'info', 'success', 'warning'].forEach((color) => {
+      it(`should render the ${color} class`, () => {
+        const { getByRole } = render(<IconButton color={color}>Hello World</IconButton>);
+        const button = getByRole('button');
+        expect(button).to.have.class(classes[`color${capitalize(color)}`]);
+      });
+    });
+  });
+
+  it('should raise a warning about onClick in children because of Firefox', () => {
+    expect(() => {
+      PropTypes.checkPropTypes(
+        IconButton.propTypes,
+        { classes: {}, children: <svg onClick={() => {}} /> },
+        'prop',
+        'MockedName',
+      );
+    }).toErrorDev(['MUI: You are providing an onClick event listener']);
+  });
+
+  it('should not throw error for a custom color', () => {
+    expect(() => (
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiIconButton: {
+              defaultProps: {
+                color: 'custom',
+              },
+            },
+          },
+        })}
+      >
+        <IconButton />
+      </ThemeProvider>
+    )).not.to.throw();
+  });
+});

--- a/packages/mui-material-next/src/IconButton/IconButton.test.js
+++ b/packages/mui-material-next/src/IconButton/IconButton.test.js
@@ -3,10 +3,11 @@ import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { createRenderer, describeConformance } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Icon from '@mui/material/Icon';
-import IconButton, { iconButtonClasses as classes } from '.';
-import ButtonBase from '../ButtonBase';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import ButtonBase from '@mui/material/ButtonBase';
+import { iconButtonClasses as classes } from '@mui/material/IconButton';
+import IconButton from '.';
 
 describe('<IconButton />', () => {
   const { render } = createRenderer();
@@ -21,8 +22,7 @@ describe('<IconButton />', () => {
     skip: ['componentProp', 'componentsProp'],
   }));
 
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('should render Icon children with right classes', () => {
+  it('should render Icon children with right classes', () => {
     const childClassName = 'child-woof';
     const iconChild = <Icon data-testid="icon" className={childClassName} />;
     const { getByTestId } = render(<IconButton>{iconChild}</IconButton>);

--- a/packages/mui-material-next/src/IconButton/iconButtonClasses.ts
+++ b/packages/mui-material-next/src/IconButton/iconButtonClasses.ts
@@ -1,0 +1,60 @@
+import {
+  unstable_generateUtilityClasses as generateUtilityClasses,
+  unstable_generateUtilityClass as generateUtilityClass,
+} from '@mui/utils';
+
+export interface IconButtonClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if `edge="start"`. */
+  edgeStart: string;
+  /** Styles applied to the root element if `edge="end"`. */
+  edgeEnd: string;
+  /** Styles applied to the root element if `color="inherit"`. */
+  colorInherit: string;
+  /** Styles applied to the root element if `color="primary"`. */
+  colorPrimary: string;
+  /** Styles applied to the root element if `color="secondary"`. */
+  colorSecondary: string;
+  /** Styles applied to the root element if `color="error"`. */
+  colorError: string;
+  /** Styles applied to the root element if `color="info"`. */
+  colorInfo: string;
+  /** Styles applied to the root element if `color="success"`. */
+  colorSuccess: string;
+  /** Styles applied to the root element if `color="warning"`. */
+  colorWarning: string;
+  /** State class applied to the root element if `disabled={true}`. */
+  disabled: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the root element if `size="medium"`. */
+  sizeMedium: string;
+  /** Styles applied to the root element if `size="large"`. */
+  sizeLarge: string;
+}
+
+export type IconButtonClassKey = keyof IconButtonClasses;
+
+export function getIconButtonUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiIconButton', slot);
+}
+
+const iconButtonClasses: IconButtonClasses = generateUtilityClasses('MuiIconButton', [
+  'root',
+  'disabled',
+  'colorInherit',
+  'colorPrimary',
+  'colorSecondary',
+  'colorError',
+  'colorInfo',
+  'colorSuccess',
+  'colorWarning',
+  'edgeStart',
+  'edgeEnd',
+  'sizeSmall',
+  'sizeMedium',
+  'sizeLarge',
+]);
+
+export default iconButtonClasses;

--- a/packages/mui-material-next/src/IconButton/index.d.ts
+++ b/packages/mui-material-next/src/IconButton/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './IconButton';
+export * from './IconButton';
+
+export { default as iconButtonClasses } from './iconButtonClasses';
+export * from './iconButtonClasses';

--- a/packages/mui-material-next/src/IconButton/index.js
+++ b/packages/mui-material-next/src/IconButton/index.js
@@ -1,0 +1,5 @@
+'use client';
+export { default } from './IconButton';
+
+export { default as iconButtonClasses } from './iconButtonClasses';
+export * from './iconButtonClasses';


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/39943

This PR copies `IconButton` to `material-next` with minimal changes

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
