### PR TITLE
[base-ui][Option] Option can now have null value

### DIFF
--- a/docs/pages/base-ui/api/option.json
+++ b/docs/pages/base-ui/api/option.json
@@ -1,6 +1,5 @@
 {
   "props": {
-    "value": { "type": { "name": "any" }, "required": true },
     "disabled": { "type": { "name": "bool" }, "default": "false" },
     "label": { "type": { "name": "string" } },
     "slotProps": {
@@ -11,7 +10,8 @@
       "type": { "name": "shape", "description": "{ root?: elementType }" },
       "default": "{}",
       "additionalInfo": { "slotsApi": true }
-    }
+    },
+    "value": { "type": { "name": "any" } }
   },
   "name": "Option",
   "imports": ["import { Option } from '@mui/base/Option';", "import { Option } from '@mui/base';"],

--- a/packages/mui-base/src/Option/Option.tsx
+++ b/packages/mui-base/src/Option/Option.tsx
@@ -146,7 +146,7 @@ Option.propTypes /* remove-proptypes */ = {
   /**
    * The value of the option.
    */
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
 } as any;
 
 export { Option };

--- a/packages/mui-base/src/Option/Option.types.ts
+++ b/packages/mui-base/src/Option/Option.types.ts
@@ -9,7 +9,7 @@ export interface OptionOwnProps<OptionValue> {
   /**
    * The value of the option.
    */
-  value: OptionValue;
+  value: OptionValue | null;
   children?: React.ReactNode;
   /**
    * If `true`, the option will be disabled.


### PR DESCRIPTION
As brought up by @ZeeshanTamboli in issue #39730 there was a warning for using null values. I changed the Option prop types to now allow null values.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
