### PR TITLE
[docs] Fix use of quote in markdown

### DIFF
--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -70,7 +70,9 @@ In general, you can expect the following release cycle:
 
 You can follow the [milestones](https://github.com/mui/material-ui/milestones) for a more detailed overview.
 
-> ⚠️ **Disclaimer**: We operate in a dynamic environment, and things are subject to change. The information provided is intended to outline the general framework direction, for informational purposes only. We may decide to add or remove new items at any time, depending on our capability to deliver while meeting our quality standards. The development, releases, and timing of any features or functionality remains at the sole discretion of MUI. The roadmap does not represent a commitment, obligation, or promise to deliver at any time.
+:::warning
+**Disclaimer**: We operate in a dynamic environment, and things are subject to change. The information provided is intended to outline the general framework direction, for informational purposes only. We may decide to add or remove new items at any time, depending on our capability to deliver while meeting our quality standards. The development, releases, and timing of any features or functionality remain at the sole discretion of MUI. The roadmap does not represent a commitment, obligation, or promise to deliver at any time.
+:::
 
 ## Supported versions
 


### PR DESCRIPTION
Before https://mui.com/versions/#release-schedule

<img src="https://github.com/mui/material-ui/assets/3165635/5e7f4586-b924-4f1f-bbec-d3f66eb8095c" width="496" />

After https://deploy-preview-39953--material-ui.netlify.app/versions/#release-schedule

<img src="https://github.com/mui/material-ui/assets/3165635/e6a92f61-dcd2-45b1-ab29-b77fd8d626b3" width="552" />
