### PR TITLE
[docs] Show design links on Joy UI

### DIFF
--- a/docs/data/joy/components/alert/alert.md
+++ b/docs/data/joy/components/alert/alert.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 
 <p class="description">Alerts display brief messages for the user without interrupting their use of the app.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/autocomplete/autocomplete.md
+++ b/docs/data/joy/components/autocomplete/autocomplete.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
 
 <p class="description">The autocomplete is a text input enhanced by a panel of suggested options when users start typing.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/avatar/avatar.md
+++ b/docs/data/joy/components/avatar/avatar.md
@@ -9,7 +9,7 @@ githubLabel: 'component: avatar'
 
 <p class="description">An avatar is a graphical representation of a user's identity.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/badge/badge.md
+++ b/docs/data/joy/components/badge/badge.md
@@ -10,7 +10,7 @@ unstyled: /base-ui/react-badge/
 
 <p class="description">The Badge component generates a small label that is attached to its child element.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/breadcrumbs/breadcrumbs.md
+++ b/docs/data/joy/components/breadcrumbs/breadcrumbs.md
@@ -9,7 +9,7 @@ githubLabel: 'component: breadcrumbs'
 
 <p class="description">A breadcrumb trail is a navigational tool that helps users keep track of their location within an app.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -26,7 +26,7 @@ The Joy UI Button component replaces the native HTML `<button>` element and offe
 import Button from '@mui/joy/Button';
 ```
 
-The Joy UI Button behaves similarly to the native HTML `<button>`, so it wraps around the text that will be displayed on its surface.
+The Joy UI Button behaves similarly to the native HTML `<button>`, so it wraps around the text displayed on its surface.
 
 The demo below shows the three basic states available to the Button: default, disabled, and loading.
 

--- a/docs/data/joy/components/button/button.md
+++ b/docs/data/joy/components/button/button.md
@@ -11,12 +11,12 @@ unstyled: /base-ui/react-button/
 
 <p class="description">Buttons let users take actions and make choices with a single tap.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 
 Buttons communicate actions that users can take.
-The Joy UI Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.
+The Joy UI Button component replaces the native HTML `<button>` element and offers expanded options for styling and accessibility.
 
 {{"demo": "ButtonUsage.js", "hideToolbar": true, "bg": "gradient"}}
 
@@ -26,7 +26,7 @@ The Joy UI Button component replaces the native HTML `<button>` element, and off
 import Button from '@mui/joy/Button';
 ```
 
-The Joy UI Button behaves similar to the native HTML `<button>`, so it wraps around the text that will be displayed on its surface.
+The Joy UI Button behaves similarly to the native HTML `<button>`, so it wraps around the text that will be displayed on its surface.
 
 The demo below shows the three basic states available to the Button: default, disabled, and loading.
 

--- a/docs/data/joy/components/checkbox/checkbox.md
+++ b/docs/data/joy/components/checkbox/checkbox.md
@@ -10,14 +10,14 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 
 <p class="description">Checkboxes give users binary choices when presented with multiple options in a series.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 
 Checkboxes provide users with a graphical representation of a binary choice (yes or no, on or off).
 They are most commonly presented in a series, giving the user multiple choices to make.
 
-The Joy UI Checkbox component replaces the native HTML `<input type="checkbox">` element, and offers expanded options for styling and accessibility.
+The Joy UI Checkbox component replaces the native HTML `<input type="checkbox">` element and offers expanded options for styling and accessibility.
 
 {{"demo": "CheckboxUsage.js", "hideToolbar": true, "bg": "gradient"}}
 

--- a/docs/data/joy/components/chip/chip.md
+++ b/docs/data/joy/components/chip/chip.md
@@ -9,7 +9,7 @@ githubLabel: 'component: chip'
 
 <p class="description">Chip generates a compact element that can represent an input, attribute, or action.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/circular-progress/circular-progress.md
+++ b/docs/data/joy/components/circular-progress/circular-progress.md
@@ -9,7 +9,7 @@ githubLabel: 'component: CircularProgress'
 
 <p class="description">The Circular Progress component showcases the duration of a process or an indefinite wait period.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/divider/divider.md
+++ b/docs/data/joy/components/divider/divider.md
@@ -9,7 +9,7 @@ githubLabel: 'component: divider'
 
 <p class="description">A divider is a thin line that groups content in lists and layouts.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/input/input.md
+++ b/docs/data/joy/components/input/input.md
@@ -9,7 +9,7 @@ unstyled: /base-ui/react-input/
 
 <p class="description">The Input component facilitates the entry of text data from the user.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/linear-progress/linear-progress.md
+++ b/docs/data/joy/components/linear-progress/linear-progress.md
@@ -9,7 +9,7 @@ githubLabel: 'component: LinearProgress'
 
 <p class="description">Linear Progress indicators, commonly known as loaders, express an unspecified wait time or display the length of a process.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/link/link.md
+++ b/docs/data/joy/components/link/link.md
@@ -10,11 +10,11 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/link/
 
 <p class="description">The Link component lets you customize anchor tags with theme colors and typography styles.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 
-The Joy UI Link component replaces the native HTML `<a>` element, and accepts the same props as the [Typography](/joy-ui/react-typography/) component, as well as MUI System props.
+The Joy UI Link component replaces the native HTML `<a>` element and accepts the same props as the [Typography](/joy-ui/react-typography/) component, as well as MUI System props.
 
 {{"demo": "LinkUsage.js", "hideToolbar": true, "bg": "gradient"}}
 

--- a/docs/data/joy/components/modal/modal.md
+++ b/docs/data/joy/components/modal/modal.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 <p class="description">The modal component provides a solid foundation for creating dialogs, popovers, lightboxes, or whatever else.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/radio-button/radio-button.md
+++ b/docs/data/joy/components/radio-button/radio-button.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/radio/
 
 <p class="description">Radio buttons enable the user to select one option from a set.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/select/select.md
+++ b/docs/data/joy/components/select/select.md
@@ -9,9 +9,9 @@ unstyled: /base-ui/react-select/
 
 # Select
 
-<p class="description">Select components are used for collecting user provided information from a list of options.</p>
+<p class="description">Select components are used for collecting user-provided information from a list of options.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/sheet/sheet.md
+++ b/docs/data/joy/components/sheet/sheet.md
@@ -8,7 +8,7 @@ components: Sheet
 
 <p class="description">Sheet is a generic container that supports Joy UI's global variants.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/slider/slider.md
+++ b/docs/data/joy/components/slider/slider.md
@@ -10,7 +10,7 @@ unstyled: /base-ui/react-slider/
 
 <p class="description">Slider generates a background element that can be used for various purposes.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/snackbar/snackbar.md
+++ b/docs/data/joy/components/snackbar/snackbar.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 
 <p class="description">The Snackbar, also commonly referred to as Toast, component informs users that an action has been or will be performed by the app.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/stack/stack.md
+++ b/docs/data/joy/components/stack/stack.md
@@ -9,7 +9,7 @@ githubLabel: 'component: Stack'
 
 <p class="description">Stack is a container component for arranging elements vertically or horizontally.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/switch/switch.md
+++ b/docs/data/joy/components/switch/switch.md
@@ -10,7 +10,7 @@ unstyled: /base-ui/react-switch/
 
 <p class="description">Switches toggle the state of a single setting on or off.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/table/table.md
+++ b/docs/data/joy/components/table/table.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/table/
 
 <p class="description">Tables display sets of data organized in rows and columns.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/tabs/tabs.md
+++ b/docs/data/joy/components/tabs/tabs.md
@@ -11,7 +11,7 @@ unstyled: /base-ui/react-tabs/
 
 <p class="description">Tabs make it easy to explore and switch between different views.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/joy/components/tooltip/tooltip.md
+++ b/docs/data/joy/components/tooltip/tooltip.md
@@ -10,7 +10,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 
 <p class="description">Tooltips display informative text when users hover over, focus on, or tap an element.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Introduction
 

--- a/docs/data/material/components/stack/stack.md
+++ b/docs/data/material/components/stack/stack.md
@@ -17,7 +17,7 @@ The Stack component manages the layout of its immediate children along the verti
 Stack is ideal for one-dimensional layouts, while Grid is preferable when you need both vertical _and_ horizontal arrangement.
 :::
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Basics
 

--- a/docs/data/material/components/transfer-list/transfer-list.md
+++ b/docs/data/material/components/transfer-list/transfer-list.md
@@ -9,7 +9,7 @@ githubLabel: 'component: transfer list'
 
 <p class="description">A Transfer List (or "shuttle") enables the user to move one or more list items between lists.</p>
 
-{{"component": "modules/components/ComponentLinkHeader.js", "design": false}}
+{{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Basic transfer list
 
@@ -19,7 +19,7 @@ For completeness, this example includes buttons for "move all", but not every tr
 
 ## Enhanced transfer list
 
-This example exchanges the "move all" buttons for a "select all / select none" checkbox, and adds a counter.
+This example exchanges the "move all" buttons for a "select all / select none" checkbox and adds a counter.
 
 {{"demo": "SelectAllTransferList.js", "bg": true}}
 

--- a/docs/src/modules/components/ComponentLinkHeader.js
+++ b/docs/src/modules/components/ComponentLinkHeader.js
@@ -140,40 +140,44 @@ export default function ComponentLinkHeader(props) {
               label="Figma"
             />
           </li>
-          <li>
-            <Chip
-              clickable
-              role={undefined}
-              component="a"
-              size="small"
-              variant="outlined"
-              rel="nofollow"
-              href="https://mui.com/store/items/adobe-xd-react/?utm_source=docs&utm_medium=referral&utm_campaign=component-link-header"
-              icon={<AdobeXDIcon />}
-              data-ga-event-category="ComponentLinkHeader"
-              data-ga-event-action="click"
-              data-ga-event-label="Adobe XD"
-              data-ga-event-split="0.1"
-              label="Adobe"
-            />
-          </li>
-          <li>
-            <Chip
-              clickable
-              role={undefined}
-              component="a"
-              size="small"
-              variant="outlined"
-              rel="nofollow"
-              href="https://mui.com/store/items/sketch-react/?utm_source=docs&utm_medium=referral&utm_campaign=component-link-header"
-              icon={<SketchIcon />}
-              data-ga-event-category="ComponentLinkHeader"
-              data-ga-event-action="click"
-              data-ga-event-label="Sketch"
-              data-ga-event-split="0.1"
-              label="Sketch"
-            />
-          </li>
+          {packageName !== '@mui/joy' ? (
+            <li>
+              <Chip
+                clickable
+                role={undefined}
+                component="a"
+                size="small"
+                variant="outlined"
+                rel="nofollow"
+                href="https://mui.com/store/items/adobe-xd-react/?utm_source=docs&utm_medium=referral&utm_campaign=component-link-header"
+                icon={<AdobeXDIcon />}
+                data-ga-event-category="ComponentLinkHeader"
+                data-ga-event-action="click"
+                data-ga-event-label="Adobe XD"
+                data-ga-event-split="0.1"
+                label="Adobe"
+              />
+            </li>
+          ) : null}
+          {packageName !== '@mui/joy' ? (
+            <li>
+              <Chip
+                clickable
+                role={undefined}
+                component="a"
+                size="small"
+                variant="outlined"
+                rel="nofollow"
+                href="https://mui.com/store/items/sketch-react/?utm_source=docs&utm_medium=referral&utm_campaign=component-link-header"
+                icon={<SketchIcon />}
+                data-ga-event-category="ComponentLinkHeader"
+                data-ga-event-action="click"
+                data-ga-event-label="Sketch"
+                data-ga-event-split="0.1"
+                label="Sketch"
+              />
+            </li>
+          ) : null}
         </React.Fragment>
       ) : null}
     </Root>


### PR DESCRIPTION
We have these components covered in Joy UI now: https://www.figma.com/community/file/1293288155415213351

Preview: https://deploy-preview-39955--material-ui.netlify.app/joy-ui/react-alert/.

<img src="https://github.com/mui/material-ui/assets/3165635/623809b7-037e-44fe-9115-3108a1501007" width="461">

---

I have worked a bit on this because Joy UI Figma file downloads are so low, no designers/developers seem to care

<img src="https://github.com/mui/material-ui/assets/3165635/19e783b5-64b6-431e-982a-ef056badffe4" width="235">

https://docs.google.com/spreadsheets/d/1BXZQmzVCzSkzyOedSnRtG_1gInU-_--Z-jSZNYjAE2k/edit#gid=0