### PR TITLE
Added support for Bun package manager in installation guide

### DIFF
--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -20,6 +20,10 @@ yarn add @mui/material @emotion/react @emotion/styled
 pnpm add @mui/material @emotion/react @emotion/styled
 ```
 
+```bash bun
+bun add @mui/material @emotion/react @emotion/styled
+```
+
 </codeblock>
 
 ## With styled-components
@@ -39,6 +43,10 @@ yarn add @mui/material @mui/styled-engine-sc styled-components
 
 ```bash pnpm
 pnpm add @mui/material @mui/styled-engine-sc styled-components
+```
+
+```bash bun
+bun add @mui/material @mui/styled-engine-sc styled-components
 ```
 
 </codeblock>
@@ -83,6 +91,10 @@ yarn add @fontsource/roboto
 
 ```bash pnpm
 pnpm add @fontsource/roboto
+```
+
+```bash bun
+bun add @fontsource/roboto
 ```
 
 </codeblock>
@@ -130,6 +142,10 @@ yarn add @mui/icons-material
 
 ```bash pnpm
 pnpm add @mui/icons-material
+```
+
+```bash bun
+bun add @mui/icons-material
 ```
 
 </codeblock>


### PR DESCRIPTION
This commit enhances the MUI installation guide by incorporating instructions for the Bun package manager alongside existing npm, yarn, and pnpm installation commands. The updated guide now accommodates users employing Bun, providing comprehensive installation steps for @mui/material, @emotion/react, and others.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
