### PR TITLE
[docs-infra] Env variables should be string

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -178,7 +178,7 @@ module.exports = withDocsInfra({
     SOURCE_GITHUB_BRANCH: 'master', // #default-branch-switch
     SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '4.docs-feedback.yml',
-    BUILD_ONLY_ENGLISH_LOCALE: buildOnlyEnglishLocale,
+    BUILD_ONLY_ENGLISH_LOCALE: String(buildOnlyEnglishLocale),
   },
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -41,7 +41,7 @@ function withDocsInfra(nextConfig) {
     reactStrictMode: true,
     ...nextConfig,
     env: {
-      BUILD_ONLY_ENGLISH_LOCALE: true, // disable translations by default
+      BUILD_ONLY_ENGLISH_LOCALE: 'true', // disable translations by default
       // production | staging | pull-request | development
       DEPLOY_ENV,
       ...nextConfig.env,


### PR DESCRIPTION
I saw this in MUI X.

<img src="https://github.com/mui/material-ui/assets/3165635/7a6fc4e8-774a-4a88-bfc9-b2a8eea9a7f2" width="712">

https://webpack.js.org/plugins/environment-plugin/#usage-with-default-values

First seen in:

<img src="https://github.com/mui/mui-x/assets/3165635/bf26156c-c89b-44c6-a779-26c037d67928" width="693">

Related to https://github.com/mui/material-ui/pull/39608#issuecomment-1785232786