### PR TITLE
[website] Add why Design Engineer for data grid

### DIFF
--- a/docs/pages/careers/ROLE_TEMPLATE.md
+++ b/docs/pages/careers/ROLE_TEMPLATE.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/ROLE_TEMPLATE.md
+++ b/docs/pages/careers/ROLE_TEMPLATE.md
@@ -38,10 +38,10 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 XXXXXX
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/accessibility-engineer.md
+++ b/docs/pages/careers/accessibility-engineer.md
@@ -43,7 +43,7 @@ Accessibility is a strategic opportunity for MUI, across our products:
 1. We are building Base UI for the developers that are looking for a relatively lower-level API while keeping a strong baseline to build on top of that saves them time. For them, it's about having a better customizability experience (style & behavior). The most exigent users of Base UI, the ones that are spreading the viral growth of the product in the community, have strong a11y requirements. So we have to meet them for Base UI to be successful.
 2. Accessibility is mandated by law. For example, in the US, the Americans with Disabilities Act (ADA) is a US law enacted in 1990 to ensure people with disabilities are not discriminated against. In the EU, the European Accessibility Act (AEE) will soon be enacted. Our paid customers are increasingly asking about compliance with WCAG.
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 
 ### Why this is interesting

--- a/docs/pages/careers/accessibility-engineer.md
+++ b/docs/pages/careers/accessibility-engineer.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/design-engineer-x-grid.md
+++ b/docs/pages/careers/design-engineer-x-grid.md
@@ -45,7 +45,6 @@ It's an even bigger problem when developers work on projects around a single maj
 Up until now, we're solving a subset of these problems by smoothly integrating the MUI X Data Grid with Material UI.
 But the time has come to take a step further and double down on design by expanding the Data Grid capacities to integrate nicely with _any_ React project rather than just a Material UI-based one.
 
-The MUI X Data Grid team has no dedicated designer, so we are opening this role to give us the means of this objective.
 
 Overall, both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!

--- a/docs/pages/careers/design-engineer-x-grid.md
+++ b/docs/pages/careers/design-engineer-x-grid.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 
@@ -42,8 +42,8 @@ For additional details about the culture you can check our [careers](https://mui
 
 It's an even bigger problem when developers work on projects around a single major component, like the Data Grid. It's not just the interaction that needs to feel great but the developer experience of working with that component also needs to be excellent, to allow a smooth integration with the rest of their app.
 
-Up until now, we're solving a subset of these problems by smoothly integrating the MUI X Data Grid with Material UI.
-But the time has come to take a step further and double-down on design by expanding the Data Grid capacities to integrate nicely with _any_ React project rather than just a Material UI-based one.
+Up until now, we're solving a subset of these problems by smoothly integrating the MUI X Data Grid with Material UI.
+But the time has come to take a step further and double down on design by expanding the Data Grid capacities to integrate nicely with _any_ React project rather than just a Material UI-based one.
 
 The MUI X Data Grid team has no dedicated designer, so we are opening this role to give us the means of this objective.
 

--- a/docs/pages/careers/design-engineer-x-grid.md
+++ b/docs/pages/careers/design-engineer-x-grid.md
@@ -45,7 +45,6 @@ It's an even bigger problem when developers work on projects around a single maj
 Up until now, we're solving a subset of these problems by smoothly integrating the MUI X Data Grid with Material UI.
 But the time has come to take a step further and double down on design by expanding the Data Grid capacities to integrate nicely with _any_ React project rather than just a Material UI-based one.
 
-
 Overall, both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 

--- a/docs/pages/careers/design-engineer-x-grid.md
+++ b/docs/pages/careers/design-engineer-x-grid.md
@@ -38,12 +38,12 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-[According to our last survey](https://mui.com/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), the quality of the design execution (UX & UI) is the most important criterion used by developers & designers to pick their next general-purpose UI library.
+[According to our last survey](https://mui.com/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), the quality of the design execution (UX & UI) is the most important criterion used by developers & designers to choose a component UI library.
 
-We hear an even bigger pain around _design_ from developers who adopt projects specialized into one UI component, e.g. data grid. For them, it's not only the default behaviors that need to be great but also the ease of customizing the components to their needs and integrating into the rest of their application.
+It's an even bigger problem when developers work on projects around a single major component, like the Data Grid. It's not just the interaction that needs to feel great but the developer experience of working with that component also needs to be excellent, to allow a smooth integration with the rest of their app.
 
-Up until now, we solved a subset of these problems by specializing in a MUI X Data Grid that deeply integrates with Material UI.
-We feel that the timing is right to take a step further and invest in the design of MUI X to have the best data grid not only for Material UI but for **any** React project.
+Up until now, we're solving a subset of these problems by smoothly integrating the MUI X Data Grid with Material UI.
+But the time has come to take a step further and double-down on design by expanding the Data Grid capacities to integrate nicely with _any_ React project rather than just a Material UI-based one.
 
 The MUI X Data Grid team has no dedicated designer, so we are opening this role to give us the means of this objective.
 

--- a/docs/pages/careers/design-engineer-x-grid.md
+++ b/docs/pages/careers/design-engineer-x-grid.md
@@ -38,11 +38,17 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
+[According to our last survey](https://mui.com/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), the quality of the design execution (UX & UI) is the most important criterion used by developers & designers to pick their next general-purpose UI library.
 
-We are aiming to make high-end design accessible to the many, empowering developers who lack access to a designer as well as saving time for designers with a source they can trust.
-[According to our last survey](https://mui.com/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), the quality of the design execution (UX & UI) is the most important criterion used by developers & designers to pick their next UI library.
+We hear an even bigger pain around _design_ from developers who adopt projects specialized into one UI component, e.g. data grid. For them, it's not only the default behaviors that need to be great but also the ease of customizing the components to their needs and integrating into the rest of their application.
+
+Up until now, we solved a subset of these problems by specializing in a MUI X Data Grid that deeply integrates with Material UI.
+We feel that the timing is right to take a step further and invest in the design of MUI X to have the best data grid not only for Material UI but for **any** React project.
+
+The MUI X Data Grid team has no dedicated designer, so we are opening this role to give us the means of this objective.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/design-engineer.md
+++ b/docs/pages/careers/design-engineer.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/design-engineer.md
+++ b/docs/pages/careers/design-engineer.md
@@ -38,11 +38,11 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 We are aiming to make high-end design accessible to the many, empowering developers that lack access to a designer as well as saving time for designers with a source they can trust.
 [According to our last survey](https://mui.com/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), the quality of the design execution (UX & UI) is the most important criteria used by developers & designers to pick their next UI library.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/designer.md
+++ b/docs/pages/careers/designer.md
@@ -27,7 +27,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/developer-experience-engineer.md
+++ b/docs/pages/careers/developer-experience-engineer.md
@@ -38,9 +38,6 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 Developer Experience matters, [a lot](https://future.com/the-case-for-developer-experience/).
 We are looking for somebody to build the best developer experience ever created around a component library, earning the love of developers everywhere.
 This is about focusing on the outcome: success, that developers can have a wonderful workflow with our product.
@@ -50,6 +47,9 @@ We are looking for someone that can contribute to the following outcomes:
 - Amplify the need of the community so the product direction aims at what people need the most.
 - Improve the overall developer experience, resulting in better NPS & CSAT scores.
 - Create momentum in the React community and drive adoption of the library.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/developer-experience-engineer.md
+++ b/docs/pages/careers/developer-experience-engineer.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/engineering-manager.md
+++ b/docs/pages/careers/engineering-manager.md
@@ -38,9 +38,6 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 Our mission is to empower as many people as possible to build great UIs, faster.
 The faster and simpler it is, and the broader the audience that can create custom UIs, the better.
 We believe that the best way to improve on these dimensions is to eliminate [80%](https://www.youtube.com/watch?v=GnO7D5UaDig&t=2451s) of the code that has to be written.
@@ -48,6 +45,9 @@ We believe that the best way to improve on these dimensions is to eliminate [80%
 A few months back we started to work on [MUI Toolpad](https://github.com/mui/mui-toolpad), an ambitious project to deliver on this objective.
 We have found the beginning of a market fit in this low-code segment.
 We need help to structure & grow the engineering team.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/engineering-manager.md
+++ b/docs/pages/careers/engineering-manager.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/full-stack-engineer.md
+++ b/docs/pages/careers/full-stack-engineer.md
@@ -23,7 +23,7 @@ We are building [a low-code platform](https://mui.com/toolpad/) for developers t
 We are a fully distributed team, spread across multiple time zones.
 We work mainly asynchronously, relying mostly on written collaboration.
 Every contributor has the freedom to define how they work — the rest of us won't know what you're doing day-to-day unless you tell us.
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/full-stack-engineer.md
+++ b/docs/pages/careers/full-stack-engineer.md
@@ -27,14 +27,14 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 Our mission is to empower as many people as possible to build great UIs, faster.
 The faster and simpler it is, and the broader the audience that can create custom UIs, the better.
 We believe that the best way to improve on these dimensions is to eliminate [80%](https://www.youtube.com/watch?v=GnO7D5UaDig&t=2451s) of the code that has to be written.
 
 We're in the early stages of exploring what our role could be in the currently emerging low-code space. We've assembled a team to work on a new product and plan to bring it to market in 2022. We have made our initial research and need help to accelerate the development of our MVP.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/head-of-operations.md
+++ b/docs/pages/careers/head-of-operations.md
@@ -33,7 +33,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/head-of-operations.md
+++ b/docs/pages/careers/head-of-operations.md
@@ -37,14 +37,14 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 We have found market fit but we increasingly don't have the tools (in the broad sense) necessary to keep up with the requests from our users.
 Up to recently, the founders of MUI were the only ones to work on business operations.
 There is now a tiny team of two people working to support the operations needs.
 But this isn't enough, the department is increasingly a bottleneck in growing the company.
 We are looking for a Head of Operations to take ownership of designing, implementing, and overseeing most of the business operations to support MUI's growth.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/people-operation-manager.md
+++ b/docs/pages/careers/people-operation-manager.md
@@ -33,7 +33,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/people-operation-manager.md
+++ b/docs/pages/careers/people-operation-manager.md
@@ -37,11 +37,11 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 At the current growth rate, we target 50 new hires in 2023. We would reach 75 people.
 We need somebody to lead our HR strategy including hiring, onboarding, diversity & inclusion, learning & development, and employee happiness.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/product-engineer.md
+++ b/docs/pages/careers/product-engineer.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/product-engineer.md
+++ b/docs/pages/careers/product-engineer.md
@@ -38,12 +38,12 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 The development and operations of the store are currently almost exclusively run by the executive team of the company (the co-founders).
 This team doesn't have enough bandwidth, the store doesn't receive the care it deserves.
 You will be responsible to step up and carry forward the development of the store on new fronts.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/product-manager.md
+++ b/docs/pages/careers/product-manager.md
@@ -33,7 +33,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/product-manager.md
+++ b/docs/pages/careers/product-manager.md
@@ -37,12 +37,12 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 Our mission is to empower as many people as possible to build great UIs, faster.
 The faster and simpler it is, and the broader the audience that can create custom UIs, the better.
 We believe that the best way to improve on these dimensions is to eliminate [80%](https://www.youtube.com/watch?v=GnO7D5UaDig&t=2451s) of the code that has to be written: low-code.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/product-marketing-manager.md
+++ b/docs/pages/careers/product-marketing-manager.md
@@ -38,15 +38,15 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 Up to this point we have operated:
 
 - on the open-source side, through word of mouth and SEO
 - on the commercial side, through inbound leads with $0 investment in marketing
 
 We believe that we could do a lot better. This is a white canvas opportunity at the company, this role is critical to our growth plans. Product Marketing will be a cross-functional role at MUI, partnering with Design, Product, Developer Experience and Sales.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/product-marketing-manager.md
+++ b/docs/pages/careers/product-marketing-manager.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-community-engineer.md
+++ b/docs/pages/careers/react-community-engineer.md
@@ -38,9 +38,6 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 We need a Community Engineer to solve friction points of users.
 We face challenges on multiple fronts:
 
@@ -48,6 +45,9 @@ We face challenges on multiple fronts:
 - The commercial version of the library is growing, but our community of developers is still small and has a reduced incentive to contribute compared to the community plan.
 - Software engineers at MUI are tasked with doing support, however, they could benefit from the help of a dedicated person in the company, for instance to improve the workflows and tooling.
 - The MUI X Premium plan will offer a technical advisor service, we need a Community Engineer to help deliver it.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/react-community-engineer.md
+++ b/docs/pages/careers/react-community-engineer.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-engineer-core.md
+++ b/docs/pages/careers/react-engineer-core.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-engineer-core.md
+++ b/docs/pages/careers/react-engineer-core.md
@@ -43,7 +43,7 @@ They are working on 4 products (Material UI, Base UI, Joy UI, and MUI System) wi
 
 We also need help to continue to improve the health of the open-source product: make the core components easier to use, increase the contributions by engaging and collaborating with the community, polish all the details, make the components more accessible, guide developers to answers, and just generally be a positive presence in the open-source community.
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 
 ## The role

--- a/docs/pages/careers/react-engineer-x-charts.md
+++ b/docs/pages/careers/react-engineer-x-charts.md
@@ -55,6 +55,8 @@ We will then provide extra paid features so developers can use a single charting
 
 In the long term, we envision using the pro-code charting API as a distribution channel for building more abstract charting primitives, using low-code and AI.
 
+Overall both our open-source community and our premium products are growing fast (x2 YoY). We need talented people to keep that going!
+
 ### Why this is interesting
 
 The advanced components portfolio is still small, with a million interesting and challenging problems to solve.

--- a/docs/pages/careers/react-engineer-x-charts.md
+++ b/docs/pages/careers/react-engineer-x-charts.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-engineer-x-grid.md
+++ b/docs/pages/careers/react-engineer-x-grid.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-engineer-x-grid.md
+++ b/docs/pages/careers/react-engineer-x-grid.md
@@ -38,15 +38,15 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 The data grid team (part of MUI X) needs help.
 We have started with the [data grid](https://mui.com/x/react-data-grid/#commercial-version) component.
 We need to build new features on it and introduce new components.
 The enterprise version is built on the open-source version of the components.
 
 We also need help to continue to improve the health of the open-source product: make the advanced components easier to use, make it support more use cases, improve performance, make it more accessible, increase the contributions by engaging and collaborating with the community, guide developers to answers, and just generally be a positive presence in the open-source community.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/react-engineer-x.md
+++ b/docs/pages/careers/react-engineer-x.md
@@ -38,10 +38,10 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 We also need help to continue to improve the health of the open-source product: make the advanced components easier to use, make it support more use cases, improve performance, make it more accessible, increase the contributions by engaging and collaborating with the community, guide developers to answers, and just generally be a positive presence in the open-source community.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/react-engineer-x.md
+++ b/docs/pages/careers/react-engineer-x.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-tech-lead-core.md
+++ b/docs/pages/careers/react-tech-lead-core.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/react-tech-lead-core.md
+++ b/docs/pages/careers/react-tech-lead-core.md
@@ -43,7 +43,7 @@ They are working on 4 products (Material UI, Base UI, Joy UI, and MUI System) wi
 
 We also need help to continue to improve the health of the open-source product: make the core components easier to use, increase the contributions by engaging and collaborating with the community, polish all the details, make the components more accessible, guide developers to answers, and just generally be a positive presence in the open-source community.
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
 We need talented people to keep that going!
 
 ### Why this is interesting

--- a/docs/pages/careers/react-tech-lead-x-grid.md
+++ b/docs/pages/careers/react-tech-lead-x-grid.md
@@ -38,9 +38,6 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 The data grid team (part of MUI X) needs your help.
 The component is off [a great start](https://npm-stat.com/charts.html?package=%40mui%2Fx-data-grid&package=react-table&package=ag-grid-community&from=2021-06-01), however we have only started to scratch the surface for the potential of this component. There is x10 more to build.
 We need to:
@@ -50,6 +47,9 @@ We need to:
 - build a strong integration with backend APIs, e.g. to handle >100M rows.
 
 We also need help to continue to make the components easier to use, make it more customizable, [improve performance](https://www.causal.app/blog/react-perf), make it more accessible, improve the health of the open-source by engaging and collaborating with the community, guide developers to answers, and just generally being a positive presence in the community.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/react-tech-lead-x-grid.md
+++ b/docs/pages/careers/react-tech-lead-x-grid.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/senior-designer.md
+++ b/docs/pages/careers/senior-designer.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/senior-designer.md
+++ b/docs/pages/careers/senior-designer.md
@@ -38,11 +38,11 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 We are aiming to make high-end design accessible to the many, empowering developers that lack access to a designer as well as saving time for designers with a source they can trust.
 [According to our last survey](https://mui.com/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), the quality of the design execution (UX & UI) is the most important criteria used by developers & designers to pick their next UI library.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/support-agent.md
+++ b/docs/pages/careers/support-agent.md
@@ -33,7 +33,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/support-agent.md
+++ b/docs/pages/careers/support-agent.md
@@ -37,10 +37,10 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 The support on the store is currently almost exclusively done by the executive team of the company (e.g. CSO). This team does no longer has enough bandwidth. You will be responsible to step up and carry forward the support provided to customers of the store on multiple fronts: answering license questions, processing purchase orders, granting refunds, identifying recurring problems, and a lot more.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/technical-product-manager.md
+++ b/docs/pages/careers/technical-product-manager.md
@@ -33,7 +33,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 

--- a/docs/pages/careers/technical-product-manager.md
+++ b/docs/pages/careers/technical-product-manager.md
@@ -37,12 +37,12 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 The advanced components team (X) needs help to build its best features.
 We have started with the [data grid](https://mui.com/x/react-data-grid/) a year ago, but it's the beginning.
 Our users are continuously providing feedback on the most important [pains they face](https://github.com/mui/mui-x/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc).
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ## The role
 

--- a/docs/pages/careers/technical-recruiter.md
+++ b/docs/pages/careers/technical-recruiter.md
@@ -38,10 +38,10 @@ For additional details about the culture you can check our [careers](https://mui
 
 ## Why we're hiring
 
-Both our open-source community and our premium products are growing fast (x2 YoY).
-We need talented people to keep that going!
-
 We anticipate the need to hire >5 people/month in 2023. This is not an outcome that the managers at MUI can deliver on their own.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
 
 ### Why this is interesting
 

--- a/docs/pages/careers/technical-recruiter.md
+++ b/docs/pages/careers/technical-recruiter.md
@@ -34,7 +34,7 @@ The majority of our work is asynchronous, and we rely on written communication t
 We're radically transparent: nearly all of our work happens in public.
 Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
 
-For additional details about the culture you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
 
 ## Why we're hiring
 


### PR DESCRIPTION
I wasn't sold on why we needed this Design Engineer role for the Data Grid (more than others). But since the presentation of the goal for 2024, it now makes a lot more sense to me. I have updated https://www.notion.so/mui-org/Design-Engineer-xGrid-3b9a645faa434fe18fa8ebd5ed2fc086 accordingly.

Preview: https://deploy-preview-40016--material-ui.netlify.app/careers/design-engineer-x-grid/#why-were-hiring