### PR TITLE
[InputSlotProps.tsx] Fix the min & max in slot props for date-type Input Element

### DIFF
--- a/docs/data/joy/components/input/InputSlotProps.tsx
+++ b/docs/data/joy/components/input/InputSlotProps.tsx
@@ -22,8 +22,8 @@ export default function InputSlotProps() {
         type="date"
         slotProps={{
           input: {
-            min: '2018-06-07T00:00',
-            max: '2018-06-14T00:00',
+            min: '2018-06-07',
+            max: '2018-06-14',
           },
         }}
       />


### PR DESCRIPTION
Earlier, the values were set as "2018-06-07T00:00", which does not work. Changing these values to the "2018-06-07" format works perfectly.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
