### PR TITLE
[joy-ui][templates] Fix layout shift on Profile template

### DIFF
--- a/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
+++ b/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
@@ -118,7 +118,6 @@ export default function MyProfile() {
                 flex: 'initial',
                 bgcolor: 'transparent',
                 [`&.${tabClasses.selected}`]: {
-                  fontWeight: '600',
                   '&::after': {
                     height: '2px',
                     bgcolor: 'primary.500',

--- a/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
+++ b/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
@@ -115,6 +115,7 @@ export default function MyProfile() {
               },
               justifyContent: 'left',
               [`&& .${tabClasses.root}`]: {
+                fontWeight: '600',
                 flex: 'initial',
                 bgcolor: 'transparent',
                 [`&.${tabClasses.selected}`]: {

--- a/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
+++ b/docs/data/joy/getting-started/templates/profile-dashboard/components/MyProfile.tsx
@@ -117,8 +117,10 @@ export default function MyProfile() {
               [`&& .${tabClasses.root}`]: {
                 fontWeight: '600',
                 flex: 'initial',
-                bgcolor: 'transparent',
+                color: 'text.tertiary',
                 [`&.${tabClasses.selected}`]: {
+                  bgcolor: 'transparent',
+                  color: 'text.primary',
                   '&::after': {
                     height: '2px',
                     bgcolor: 'primary.500',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


Removed `fontWeight: '600'` from the tabs to prevent the layout shift based on [this comment
](https://github.com/mui/material-ui/pull/40017#issuecomment-1826844322)

<img width="330" alt="Screenshot 2023-11-27 at 13 48 52" src="https://github.com/mui/material-ui/assets/37222944/02ce5d06-c870-4af4-b93c-c8adaf610327">

👉 https://deploy-preview-40022--material-ui.netlify.app/joy-ui/getting-started/templates/profile-dashboard/