### PR TITLE
[material-ui][tabs] Refine scrollable tabs description

### DIFF
--- a/docs/data/material/components/tabs/tabs.md
+++ b/docs/data/material/components/tabs/tabs.md
@@ -67,13 +67,13 @@ The `centered` prop should be used for larger views.
 
 ### Automatic scroll buttons
 
-Using the attributes `variant="scrollable"` and `scrollButtons="auto"`, left and right scroll buttons are automatically displayed on desktop, while on mobile they are hidden based on the viewport width.
+Use the `variant="scrollable"` and `scrollButtons="auto"` props to display left and right scroll buttons on desktop that are hidden on mobile:
 
 {{"demo": "ScrollableTabsButtonAuto.js", "bg": true}}
 
 ### Forced scroll buttons
 
-To present the Left and right scroll buttons (reserve space) regardless of the viewport, use `scrollButtons={true}` and `allowScrollButtonsMobile`:
+Apply `scrollButtons={true}` and the `allowScrollButtonsMobile` prop to display the left and right scroll buttons on all viewports:
 
 {{"demo": "ScrollableTabsButtonForce.js", "bg": true}}
 

--- a/docs/data/material/components/tabs/tabs.md
+++ b/docs/data/material/components/tabs/tabs.md
@@ -67,13 +67,13 @@ The `centered` prop should be used for larger views.
 
 ### Automatic scroll buttons
 
-By default, left and right scroll buttons are automatically presented on desktop and hidden on mobile. (based on viewport width)
+Using the attributes `variant="scrollable"` and `scrollButtons="auto"`, left and right scroll buttons are automatically displayed on desktop, while on mobile they are hidden based on the viewport width.
 
 {{"demo": "ScrollableTabsButtonAuto.js", "bg": true}}
 
 ### Forced scroll buttons
 
-Left and right scroll buttons be presented (reserve space) regardless of the viewport width with `scrollButtons={true}` `allowScrollButtonsMobile`:
+To present the Left and right scroll buttons (reserve space) regardless of the viewport, use `scrollButtons={true}` and `allowScrollButtonsMobile`:
 
 {{"demo": "ScrollableTabsButtonForce.js", "bg": true}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a few text adjustments to make the text description more concise. 

Previously, it was possible to understand that scrolling would be automatic on the desktop, and the properties would only be necessary on mobile. However, what the text actually means is that the props, when applied, will only display the *buttons* on the desktop version.

| Current | New |
|--------|--------|
| <img width="400" alt="Screenshot 2023-11-29 at 09 50 31" src="https://github.com/mui/material-ui/assets/37222944/56a45e7f-b3ff-44e9-a080-f396ae66a768"> | <img width="400" alt="Screenshot 2023-11-29 at 09 50 01" src="https://github.com/mui/material-ui/assets/37222944/c5ee3f92-af75-4645-8c1b-89c5ceb08882"> | 