### PR TITLE
Fix/#34136

### DIFF
--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -208,7 +208,7 @@ export function rgbToHsl(color) {
   const hsl = [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
   const type = color.type === 'rgba' ? 'hsla' : 'hsl';
 
-  if (color.type === 'rgba') {
+  if (color.type === 'rgba' || values[3] !== 'undefined') {
     hsl.push(values[3]);
   }
 
@@ -229,11 +229,10 @@ export function hslToRgb(color) {
   const a = s * Math.min(l, 1 - l);
   const f = (n, k = (n + h / 30) % 12) => l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
 
-  let type = 'rgb';
+  let type = color.type === 'hsla' ? 'rgba' : 'rgb';
   const rgb = [Math.round(f(0) * 255), Math.round(f(8) * 255), Math.round(f(4) * 255)];
 
-  if (color.type === 'hsla') {
-    type += 'a';
+  if (values[3]) {
     rgb.push(values[3]);
   }
 

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -166,6 +166,56 @@ export function rgbToHex(color) {
 }
 
 /**
+ * Converts a color from rgb format to hsl format.
+ * @param {string} color - RGB color values
+ * @returns {string} hsl color values
+ */
+export function rgbToHsl(color) {
+  color = decomposeColor(color);
+  const { values } = color;
+  const r = values[0] / 255;
+  const g = values[1] / 255;
+  const b = values[2] / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h, s, l;
+
+  l = (max + min) / 2;
+
+  if (max === min) {
+    h = 0;
+    s = 0;
+  } else {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+
+    h /= 6;
+  }
+
+  const hsl = [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+  const type = color.type === 'rgba' ? 'hsla' : 'hsl';
+
+  if (color.type === 'rgba') {
+    hsl.push(values[3]);
+  }
+
+  return recomposeColor({ type, values: hsl });
+}
+
+/**
  * Converts a color from hsl format to rgb format.
  * @param {string} color - HSL color values
  * @returns {string} rgb color values
@@ -274,11 +324,16 @@ export function darken(color, coefficient) {
 
   if (color.type.indexOf('hsl') !== -1) {
     color.values[2] *= 1 - coefficient;
-  } else if (color.type.indexOf('rgb') !== -1 || color.type.indexOf('color') !== -1) {
+  } else if (color.type.indexOf('rgb') !== -1) {
+    color = decomposeColor(rgbToHsl(color));
+    color.values[2] *= 1 - coefficient;
+    color = decomposeColor(hslToRgb(color));
+  } else if (color.type.indexOf('color') !== -1) {
     for (let i = 0; i < 3; i += 1) {
       color.values[i] *= 1 - coefficient;
     }
   }
+
   return recomposeColor(color);
 }
 export function private_safeDarken(color, coefficient, warning) {

--- a/packages/mui-system/src/colorManipulator.test.js
+++ b/packages/mui-system/src/colorManipulator.test.js
@@ -325,15 +325,15 @@ describe('utils/colorManipulator', () => {
     });
 
     it('darkens rgb white by 10% when coefficient is 0.1', () => {
-      expect(darken('rgb(255, 255, 255)', 0.1)).to.equal('rgb(229, 229, 229)');
+      expect(darken('rgb(255, 255, 255)', 0.1)).to.equal('rgb(230, 230, 230)');
     });
 
     it('darkens rgb red by 50% when coefficient is 0.5', () => {
-      expect(darken('rgb(255, 0, 0)', 0.5)).to.equal('rgb(127, 0, 0)');
+      expect(darken('rgb(255, 0, 0)', 0.5)).to.equal('rgb(128, 0, 0)');
     });
 
     it('darkens rgb grey by 50% when coefficient is 0.5', () => {
-      expect(darken('rgb(127, 127, 127)', 0.5)).to.equal('rgb(63, 63, 63)');
+      expect(darken('rgb(127, 127, 127)', 0.5)).to.equal('rgb(64, 64, 64)');
     });
 
     it("doesn't modify rgb colors when coefficient is 0", () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

Resolves #34136 by using the correct algorithm for darkening colors that will produce consistent results regardless of color format. Previously, a color darkened by a coefficient would produce different results if the color was an rgb color vs. hsl color. 

| Before | After |
| ------ | ----- |
|<img width="742" alt="image" src="https://github.com/mui/material-ui/assets/298336/eff1c3b8-b21d-40d2-85d9-9beea334e9be">|<img width="739" alt="image" src="https://github.com/mui/material-ui/assets/298336/a24da0b6-b01e-495a-952a-ab766f00d7c0">|