### PR TITLE
[website] Polish dark mode colors

### DIFF
--- a/docs/pages/blog.tsx
+++ b/docs/pages/blog.tsx
@@ -270,9 +270,9 @@ export default function Blog(props: InferGetStaticPropsType<typeof getStaticProp
         `,
             ...theme.applyDarkStyles({
               background: `linear-gradient(180deg, ${
-                (theme.vars || theme).palette.primaryDark[800]
+                (theme.vars || theme).palette.primaryDark[900]
               } 50%,
-          ${alpha(theme.palette.primary[900], 0.2)} 100%)
+          ${alpha(theme.palette.primary[800], 0.2)} 100%)
           `,
             }),
           })}

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
@@ -83,7 +83,8 @@ const Accordion = styled(MuiAccordion)(({ theme }) => ({
   transition: theme.transitions.create('box-shadow'),
   borderRadius: theme.shape.borderRadius,
   '&:hover': {
-    boxShadow: '0 4px 8px 0 rgb(90 105 120 / 20%)',
+    borderColor: theme.palette.primary[300],
+    boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
   },
   '&:not(:last-of-type)': {
     marginBottom: theme.spacing(2),
@@ -94,6 +95,12 @@ const Accordion = styled(MuiAccordion)(({ theme }) => ({
   '&:after': {
     display: 'none',
   },
+  ...theme.applyDarkStyles({
+    '&:hover': {
+      borderColor: alpha(theme.palette.primary[600], 0.6),
+      boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.8)',
+    },
+  }),
 }));
 
 const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
@@ -469,7 +476,7 @@ function CareersContent() {
       <Divider />
       {/* Next roles */}
       {nextRolesData.length > 0 && (
-        <Box data-mui-color-scheme="dark" sx={{ bgcolor: 'primaryDark.900' }}>
+        <Box data-mui-color-scheme="dark" sx={{ bgcolor: 'common.black' }}>
           <Section bg="transparent">
             <SectionHeadline
               title={

--- a/docs/src/components/about/Team.tsx
+++ b/docs/src/components/about/Team.tsx
@@ -378,7 +378,7 @@ export default function Team() {
       </Section>
       <Divider />
       {/* Community contributors */}
-      <Box data-mui-color-scheme="dark" sx={{ bgcolor: 'primaryDark.900' }}>
+      <Box data-mui-color-scheme="dark" sx={{ bgcolor: 'common.black' }}>
         <Container sx={{ py: { xs: 4, sm: 8 } }}>
           <Typography component="h3" variant="h4" color="primary.200" fontWeight="semiBold">
             Community contributors

--- a/docs/src/components/action/StylingInfo.tsx
+++ b/docs/src/components/action/StylingInfo.tsx
@@ -42,7 +42,7 @@ export default function StylingInfo({
         px: 2,
         pt: 1,
         pb: 2,
-        background: ({ palette }) => alpha(palette.primaryDark[900], 0.95),
+        background: ({ palette }) => alpha(palette.common.black, 0.5),
         backdropFilter: 'blur(8px)',
         zIndex: 1,
         borderTop: '1px solid',

--- a/docs/src/components/footer/EmailSubscribe.tsx
+++ b/docs/src/components/footer/EmailSubscribe.tsx
@@ -144,11 +144,11 @@ export default function EmailSubscribe({ sx }: { sx?: SxProps<Theme> }) {
             }),
             (theme) =>
               theme.applyDarkStyles({
-                bgcolor: 'primaryDark.900',
+                bgcolor: 'primaryDark.800',
                 boxShadow: `inset 0 1px 1px ${
                   (theme.vars || theme).palette.primaryDark[900]
                 }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
-                borderColor: 'primaryDark.500',
+                borderColor: 'primaryDark.600',
                 '&:hover': {
                   borderColor: 'primaryDark.400',
                   boxShadow: `inset 0 1px 1px ${

--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -60,8 +60,8 @@ const Navigation = styled('nav')(({ theme }) => [
       '& > a, & > button': {
         '&:hover': {
           color: (theme.vars || theme).palette.primary[50],
-          backgroundColor: (theme.vars || theme).palette.primaryDark[700],
-          borderColor: alpha(theme.palette.primaryDark[600], 0.5),
+          backgroundColor: alpha(theme.palette.primaryDark[700], 0.8),
+          borderColor: (theme.vars || theme).palette.divider,
         },
         '&:focus-visible': {
           color: (theme.vars || theme).palette.primary[50],

--- a/docs/src/components/header/HeaderNavDropdown.tsx
+++ b/docs/src/components/header/HeaderNavDropdown.tsx
@@ -164,7 +164,7 @@ export default function HeaderNavDropdown() {
             right: 0,
             boxShadow: `0px 4px 20px rgba(170, 180, 190, 0.3)`,
             ...theme.applyDarkStyles({
-              boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.5)',
+              boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.8)',
             }),
           })}
         >

--- a/docs/src/components/home/DiamondSponsors.tsx
+++ b/docs/src/components/home/DiamondSponsors.tsx
@@ -59,17 +59,13 @@ export default function DiamondSponsors() {
           <Grid item xs={12} sm={6} md={4}>
             <Paper
               variant="outlined"
-              sx={(theme) => ({
+              sx={{
                 p: 2,
                 display: 'flex',
                 alignItems: 'center',
                 height: '100%',
                 borderStyle: 'dashed',
-                borderColor: 'grey.300',
-                ...theme.applyDarkStyles({
-                  borderColor: 'primaryDark.400',
-                }),
-              })}
+              }}
             >
               <IconButton
                 aria-label="Become MUI sponsor"
@@ -83,7 +79,7 @@ export default function DiamondSponsors() {
                   border: '1px solid',
                   borderColor: 'grey.300',
                   ...theme.applyDarkStyles({
-                    borderColor: 'primaryDark.400',
+                    borderColor: 'primaryDark.600',
                   }),
                 })}
               >

--- a/docs/src/components/home/GoldSponsors.tsx
+++ b/docs/src/components/home/GoldSponsors.tsx
@@ -100,17 +100,13 @@ export default function GoldSponsors() {
         <Grid item xs={12} sm={6} md={4} lg={3}>
           <Paper
             variant="outlined"
-            sx={(theme) => ({
+            sx={{
               p: 2,
               display: 'flex',
               alignItems: 'center',
               height: '100%',
               borderStyle: 'dashed',
-              borderColor: 'grey.300',
-              ...theme.applyDarkStyles({
-                borderColor: 'primaryDark.400',
-              }),
-            })}
+            }}
           >
             <IconButton
               aria-label="Sponsor MUI"
@@ -124,7 +120,7 @@ export default function GoldSponsors() {
                 border: '1px solid',
                 borderColor: 'grey.300',
                 ...theme.applyDarkStyles({
-                  borderColor: 'primaryDark.400',
+                  borderColor: 'primaryDark.600',
                 }),
               })}
             >

--- a/docs/src/components/home/HeroEnd.tsx
+++ b/docs/src/components/home/HeroEnd.tsx
@@ -25,7 +25,7 @@ export default function HeroEnd() {
         `,
         ...theme.applyDarkStyles({
           background: `linear-gradient(180deg, ${
-            (theme.vars || theme).palette.primaryDark[800]
+            (theme.vars || theme).palette.primaryDark[900]
           } 50%,
           ${alpha(theme.palette.primary[900], 0.2)} 100%)
           `,

--- a/docs/src/components/home/MaterialDesignComponents.tsx
+++ b/docs/src/components/home/MaterialDesignComponents.tsx
@@ -342,7 +342,7 @@ export function buildTheme(): ThemeOptions {
               },
             },
             theme.applyDarkStyles({
-              backgroundColor: alpha(theme.palette.primaryDark[900], 0.5),
+              backgroundColor: alpha(theme.palette.primaryDark[700], 0.5),
               color: (theme.vars || theme).palette.primaryDark[50],
               borderColor: alpha(theme.palette.primaryDark[500], 0.2),
               '& .MuiAlert-icon': {
@@ -419,17 +419,17 @@ export function buildTheme(): ThemeOptions {
                 borderColor: (theme.vars || theme).palette.primary[300],
               },
               '& .MuiOutlinedInput-input': {
-                backgroundColor: 'transparent',
+                backgroundColor: (theme.vars || theme).palette.primaryDark[900],
               },
               '& .MuiFilledInput-root': {
-                borderColor: (theme.vars || theme).palette.primaryDark[800],
-                backgroundColor: alpha(theme.palette.primaryDark[800], 0.5),
+                borderColor: (theme.vars || theme).palette.primaryDark[700],
+                backgroundColor: alpha(theme.palette.primaryDark[900], 0.5),
                 '&:after': {
                   borderColor: (theme.vars || theme).palette.primary[300],
                 },
                 '&:hover': {
                   backgroundColor: alpha(theme.palette.primaryDark[700], 0.8),
-                  borderColor: (theme.vars || theme).palette.primaryDark[500],
+                  borderColor: (theme.vars || theme).palette.primaryDark[600],
                 },
               },
               '& .MuiInputLabel-filled.Mui-focused': {
@@ -437,7 +437,7 @@ export function buildTheme(): ThemeOptions {
               },
               '& .MuiInput-root.Mui-focused': {
                 '&:after': {
-                  borderColor: (theme.vars || theme).palette.primaryDark[800],
+                  borderColor: (theme.vars || theme).palette.primaryDark[400],
                 },
               },
               '& .MuiInputLabel-root.Mui-focused': {

--- a/docs/src/components/home/ProductSuite.tsx
+++ b/docs/src/components/home/ProductSuite.tsx
@@ -50,17 +50,15 @@ function ProductSuite() {
     <Section bg="gradient" ref={ref}>
       <Grid container spacing={2}>
         <Grid item md={6}>
-          <Box sx={{ maxWidth: 500 }}>
-            <SectionHeadline
-              overline="Products"
-              title={
-                <Typography variant="h2" sx={{ my: 1 }}>
-                  Every component you need is <GradientText>ready for production</GradientText>
-                </Typography>
-              }
-              description="Build at an accelerated pace without sacrificing flexibility or control."
-            />
-          </Box>
+          <SectionHeadline
+            overline="Products"
+            title={
+              <Typography variant="h2" sx={{ my: 1 }}>
+                Every component you need is <GradientText>ready for production</GradientText>
+              </Typography>
+            }
+            description="Build at an accelerated pace without sacrificing flexibility or control."
+          />
           <Box sx={{ mt: 4 }} />
           <ProductsSwitcher
             inView={inView}

--- a/docs/src/components/home/ShowcaseContainer.tsx
+++ b/docs/src/components/home/ShowcaseContainer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Box, { BoxProps } from '@mui/material/Box';
 import Fade from '@mui/material/Fade';
 import NoSsr from '@mui/material/NoSsr';
@@ -44,7 +45,7 @@ export default function ShowcaseContainer({
             },
             (theme) =>
               theme.applyDarkStyles({
-                bgcolor: 'primaryDark.700',
+                bgcolor: alpha(theme.palette.primaryDark[800], 0.5),
                 borderColor: 'divider',
               }),
             ...(Array.isArray(previewSx) ? previewSx : [previewSx]),
@@ -64,14 +65,10 @@ export default function ShowcaseContainer({
               borderWidth: '0 1px 1px 1px',
               borderStyle: 'solid',
               borderColor: 'divider',
-              bgcolor: 'primaryDark.800',
-              borderBottomLeftRadius: 10,
-              borderBottomRightRadius: 10,
+              bgcolor: 'common.black',
+              borderBottomLeftRadius: 12,
+              borderBottomRightRadius: 12,
             },
-            (theme) =>
-              theme.applyDarkStyles({
-                borderColor: 'divider',
-              }),
             ...(Array.isArray(codeSx) ? codeSx : [codeSx]),
           ]}
         >

--- a/docs/src/components/home/Testimonials.tsx
+++ b/docs/src/components/home/Testimonials.tsx
@@ -21,8 +21,8 @@ function Testimonials() {
       ref={ref}
       sx={(theme) => ({
         background: `linear-gradient(180deg, ${
-          (theme.vars || theme).palette.primaryDark[900]
-        } 2%, ${alpha(theme.palette.primaryDark[700], 0.5)} 80%),
+          (theme.vars || theme).palette.primaryDark[800]
+        } 2%, ${alpha(theme.palette.primaryDark[700], 0.4)} 80%),
         ${(theme.vars || theme).palette.primaryDark[900]}
         `,
       })}

--- a/docs/src/components/pricing/PricingFAQ.tsx
+++ b/docs/src/components/pricing/PricingFAQ.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unescaped-entities */
 import * as React from 'react';
-import { styled } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Link from '@mui/material/Link';
@@ -200,7 +200,8 @@ const Accordion = styled(MuiAccordion)(({ theme }) => ({
     borderRadius: theme.shape.borderRadius,
   },
   '&:hover': {
-    boxShadow: '1px 1px 20px 0 rgb(90 105 120 / 20%)',
+    borderColor: theme.palette.primary[300],
+    boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
   },
   '&:not(:last-of-type)': {
     marginBottom: theme.spacing(2),
@@ -211,6 +212,12 @@ const Accordion = styled(MuiAccordion)(({ theme }) => ({
   '&:after': {
     display: 'none',
   },
+  ...theme.applyDarkStyles({
+    '&:hover': {
+      borderColor: alpha(theme.palette.primary[600], 0.6),
+      boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.8)',
+    },
+  }),
 }));
 
 const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
@@ -287,7 +294,7 @@ export default function PricingFAQ() {
               borderColor: 'grey.300',
               bgcolor: 'white',
               ...theme.applyDarkStyles({
-                borderColor: 'primaryDark.400',
+                borderColor: 'divider',
                 bgcolor: 'primaryDark.800',
               }),
             })}

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -339,7 +339,7 @@ function ColumnHeadHighlight(props: BoxProps) {
         (theme) =>
           theme.applyDarkStyles({
             borderColor: 'primaryDark.700',
-            background: alpha(theme.palette.primaryDark[900], 0.5),
+            background: alpha(theme.palette.primaryDark[700], 0.3),
           }),
         ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
       ]}
@@ -373,7 +373,7 @@ function Cell({ highlighted = false, ...props }: BoxProps & { highlighted?: bool
           theme.applyDarkStyles({
             ...(highlighted && {
               borderColor: 'primaryDark.700',
-              bgcolor: alpha(theme.palette.primaryDark[900], 0.5),
+              bgcolor: alpha(theme.palette.primaryDark[700], 0.3),
             }),
           }),
         ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
@@ -402,7 +402,7 @@ function RowHead({ children, startIcon, ...props }: BoxProps & { startIcon?: Rea
         },
         (theme) =>
           theme.applyDarkStyles({
-            bgcolor: 'primaryDark.900',
+            bgcolor: 'primaryDark.800',
           }),
         ...(Array.isArray(props.sx) ? props.sx : [props.sx]),
       ]}
@@ -1118,7 +1118,7 @@ function renderMasterRow(key: string, gridSx: object, plans: Array<any>) {
           },
           ...theme.applyDarkStyles({
             '&:hover > div': {
-              bgcolor: alpha(theme.palette.primaryDark[900], 0.5),
+              bgcolor: theme.palette.primaryDark[800],
             },
           }),
         }),

--- a/docs/src/components/productBaseUI/BaseUIEnd.tsx
+++ b/docs/src/components/productBaseUI/BaseUIEnd.tsx
@@ -20,9 +20,9 @@ export default function BaseUIEnd() {
       sx={{
         color: 'text.secondary',
         background: (theme) =>
-          `linear-gradient(180deg, ${(theme.vars || theme).palette.primaryDark[800]} 50%, 
+          `linear-gradient(180deg, ${(theme.vars || theme).palette.primaryDark[900]} 50%, 
           ${alpha(theme.palette.primary[800], 0.2)} 100%), ${
-            (theme.vars || theme).palette.primaryDark[800]
+            (theme.vars || theme).palette.primaryDark[900]
           }`,
       }}
     >

--- a/docs/src/components/productBaseUI/BaseUITestimonial.tsx
+++ b/docs/src/components/productBaseUI/BaseUITestimonial.tsx
@@ -49,7 +49,7 @@ export default function BaseUITestimonial() {
           </Box>
           <Typography variant="body2" sx={{ mt: 2 }}>
             Nhost&apos;s new dashboard, powered by Base UI &nbsp;&nbsp;
-            <Typography component="span" variant="inherit" color="divider">
+            <Typography component="span" variant="inherit" color="grey.500" sx={{ opacity: '50%' }}>
               /
             </Typography>
             &nbsp;&nbsp;

--- a/docs/src/components/productCore/CoreHeroEnd.tsx
+++ b/docs/src/components/productCore/CoreHeroEnd.tsx
@@ -19,9 +19,9 @@ export default function CoreHeroEnd() {
       data-mui-color-scheme="dark"
       sx={{
         background: (theme) =>
-          `linear-gradient(180deg, ${(theme.vars || theme).palette.primaryDark[800]} 50%,
+          `linear-gradient(180deg, ${(theme.vars || theme).palette.primaryDark[900]} 50%,
         ${alpha(theme.palette.primary[800], 0.2)} 100%), ${
-            (theme.vars || theme).palette.primaryDark[800]
+            (theme.vars || theme).palette.primaryDark[900]
           }`,
       }}
     >

--- a/docs/src/components/productX/XHero.tsx
+++ b/docs/src/components/productX/XHero.tsx
@@ -135,13 +135,13 @@ export default function XHero() {
               backgroundColor: '#fff',
               border: '1px solid',
               borderColor: 'divider',
-              boxShadow: `0px 4px 12px ${alpha(theme.palette.grey[200], 0.6)}`,
+              boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
               mb: { md: 2, lg: 3, xl: 4 },
               overflow: 'hidden',
               ...theme.applyDarkStyles({
-                borderColor: 'divider',
-                backgroundColor: 'primaryDark.800',
-                boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.4)',
+                borderColor: 'primaryDark.700',
+                backgroundColor: 'primaryDark.900',
+                boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
               }),
             })}
           >
@@ -293,11 +293,11 @@ export default function XHero() {
                 flexGrow: 1,
                 backgroundColor: '#fff',
                 borderColor: 'divider',
-                boxShadow: `0px 4px 12px ${alpha(theme.palette.grey[200], 0.6)}`,
+                boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
                 ...theme.applyDarkStyles({
-                  borderColor: 'divider',
-                  backgroundColor: 'primaryDark.800',
-                  boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.4)',
+                  borderColor: 'primaryDark.700',
+                  backgroundColor: 'primaryDark.900',
+                  boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
                 }),
               })}
             >
@@ -353,9 +353,9 @@ export default function XHero() {
                 },
                 (theme) =>
                   theme.applyDarkStyles({
-                    borderColor: 'divider',
-                    boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.4)',
-                    backgroundColor: 'primaryDark.800',
+                    borderColor: 'primaryDark.700',
+                    boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
+                    backgroundColor: 'primaryDark.900',
                     '& .MuiDateRangePickerDay-day.Mui-selected': {
                       color: '#FFF',
                     },

--- a/docs/src/components/productX/XRoadmap.tsx
+++ b/docs/src/components/productX/XRoadmap.tsx
@@ -94,9 +94,9 @@ export default function XRoadmap() {
       sx={{
         color: 'text.secondary',
         background: (theme) =>
-          `linear-gradient(180deg, ${(theme.vars || theme).palette.primaryDark[800]} 50%, 
+          `linear-gradient(180deg, ${(theme.vars || theme).palette.primaryDark[900]} 50%, 
         ${alpha(theme.palette.primary[800], 0.2)} 100%), ${
-            (theme.vars || theme).palette.primaryDark[800]
+            (theme.vars || theme).palette.primaryDark[900]
           }`,
       }}
     >

--- a/docs/src/components/showcase/FolderTable.tsx
+++ b/docs/src/components/showcase/FolderTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Theme } from '@mui/material/styles';
+import { Theme, alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Table from '@mui/material/Table';
@@ -91,6 +91,7 @@ export default function BasicTable() {
       sx={[
         {
           maxWidth: 260,
+          boxShadow: (theme) => `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
           [`& .${tableCellClasses.root}`]: {
             borderColor: 'grey.200',
           },
@@ -102,6 +103,7 @@ export default function BasicTable() {
           theme.applyDarkStyles({
             bgcolor: 'primaryDark.900',
             borderColor: 'primaryDark.700',
+            boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
             [`& .${tableCellClasses.root}`]: {
               borderColor: 'primaryDark.700',
             },

--- a/docs/src/components/showcase/NotificationCard.tsx
+++ b/docs/src/components/showcase/NotificationCard.tsx
@@ -17,9 +17,11 @@ export default function NotificationCard() {
           p: 2,
           gap: 2,
           maxWidth: 283,
+          boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
           ...theme.applyDarkStyles({
             bgcolor: 'primaryDark.900',
             borderColor: 'primaryDark.700',
+            boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
           }),
         })}
       >

--- a/docs/src/components/showcase/PlayerCard.tsx
+++ b/docs/src/components/showcase/PlayerCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Stack from '@mui/material/Stack';
 import Card from '@mui/material/Card';
 import CardMedia from '@mui/material/CardMedia';
@@ -33,7 +34,10 @@ export default function PlayerCard({
             alignItems: 'center',
             borderColor: extraStyles ? 'primary.200' : 'grey.200',
             gap: 2,
-            boxShadow: extraStyles ? '0 2px 4px rgba(0, 127, 255, 0.15)' : 'none',
+            boxShadow: (theme) =>
+              extraStyles
+                ? '0 2px 4px rgba(0, 127, 255, 0.2)'
+                : `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
             ...(!disableTheming && {
               [`& .${iconButtonClasses.root}`]: {
                 border: '1px solid',
@@ -58,6 +62,9 @@ export default function PlayerCard({
               theme.applyDarkStyles({
                 bgcolor: 'primaryDark.900',
                 borderColor: extraStyles ? 'primary.800' : 'primaryDark.700',
+                boxShadow: extraStyles
+                  ? '0 2px 4px rgba(0, 127, 255, 0.2)'
+                  : '0px 4px 8px rgba(0, 0, 0, 0.4)',
                 [`& .${iconButtonClasses.root}`]: {
                   bgcolor: 'primary.900',
                   color: 'primary.200',

--- a/docs/src/components/showcase/ThemeAccordion.tsx
+++ b/docs/src/components/showcase/ThemeAccordion.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Accordion, { accordionClasses } from '@mui/material/Accordion';
 import AccordionSummary, { accordionSummaryClasses } from '@mui/material/AccordionSummary';
 import AccordionDetails, { accordionDetailsClasses } from '@mui/material/AccordionDetails';
@@ -23,6 +24,8 @@ export default function ThemeAccordion() {
           {
             [`& .${accordionClasses.root}`]: {
               bgcolor: '#fff',
+              boxShadow: (theme) => `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
+
               [`&.${accordionClasses.expanded}`]: {
                 margin: 0,
               },
@@ -56,6 +59,7 @@ export default function ThemeAccordion() {
               [`& .${accordionClasses.root}`]: {
                 bgcolor: 'primaryDark.900',
                 borderColor: 'primaryDark.700',
+                boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
               },
               [`& .${accordionSummaryClasses.root}`]: {
                 [`& .${accordionSummaryClasses.content}`]: {

--- a/docs/src/components/showcase/ThemeDatePicker.tsx
+++ b/docs/src/components/showcase/ThemeDatePicker.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Fade from '@mui/material/Fade';
 import { iconButtonClasses } from '@mui/material/IconButton';
@@ -17,6 +18,7 @@ export default function ThemeDatePicker() {
                 border: '1px solid',
                 borderColor: 'grey.200',
                 borderRadius: 1,
+                boxShadow: (theme) => `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
               },
               '& > div > div > div': {
                 width: '100%',
@@ -92,12 +94,11 @@ export default function ThemeDatePicker() {
               theme.applyDarkStyles({
                 '& > div': {
                   borderColor: 'primaryDark.700',
+                  bgcolor: 'primaryDark.900',
+                  boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
                 },
                 [`& .${iconButtonClasses.root}`]: {
                   color: 'primary.300',
-                },
-                '& .MuiPickerStaticWrapper-root': {
-                  bgcolor: 'primaryDark.800',
                 },
                 '& .MuiDateCalendar-root': {
                   '& .MuiPickersDay-root': {

--- a/docs/src/components/showcase/ThemeSlider.tsx
+++ b/docs/src/components/showcase/ThemeSlider.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Fade from '@mui/material/Fade';
 import Slider, { sliderClasses } from '@mui/material/Slider';
@@ -12,17 +13,19 @@ export default function ThemeSlider() {
     <Fade in timeout={700}>
       <Box
         sx={(theme) => ({
+          px: 3,
+          py: 4,
           display: 'flex',
           justifyContent: 'center',
           bgcolor: '#fff',
           border: '1px solid',
           borderColor: 'grey.200',
           borderRadius: 1,
-          px: 3,
-          py: 4,
+          boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
           ...theme.applyDarkStyles({
             bgcolor: 'primaryDark.900',
             borderColor: 'primaryDark.700',
+            boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
           }),
         })}
       >

--- a/docs/src/components/showcase/ThemeTimeline.tsx
+++ b/docs/src/components/showcase/ThemeTimeline.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import Fade from '@mui/material/Fade';
@@ -20,9 +21,11 @@ export default function BasicTimeline() {
           pb: 1,
           display: 'flex',
           alignItems: 'flex-start',
+          boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
           ...theme.applyDarkStyles({
             bgcolor: 'primaryDark.900',
             borderColor: 'primaryDark.700',
+            boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.4)',
           }),
         })}
       >

--- a/docs/src/layouts/HeroContainer.tsx
+++ b/docs/src/layouts/HeroContainer.tsx
@@ -78,7 +78,7 @@ export default function HeroContainer(props: HeroContainerProps) {
             ...(linearGradient && {
               background: `radial-gradient(farthest-corner circle at 0% 0%, ${alpha(
                 theme.palette.primary[900],
-                0.3,
+                0.2,
               )} 0%, ${(theme.vars || theme).palette.primaryDark[900]} 100%)`,
             }),
           }),

--- a/docs/src/layouts/Section.tsx
+++ b/docs/src/layouts/Section.tsx
@@ -14,7 +14,7 @@ interface SelectionProps extends BoxProps {
 const map = {
   white: {
     light: 'common.white',
-    dark: 'primaryDark.800',
+    dark: 'primaryDark.900',
   },
   comfort: {
     light: 'grey.50',
@@ -46,8 +46,8 @@ const Section = React.forwardRef<HTMLDivElement, SelectionProps>(function Sectio
                 } 100%)`,
                 ...theme.applyDarkStyles({
                   background: `linear-gradient(180deg, ${
-                    (theme.vars || theme).palette.primaryDark[800]
-                  } 0%, ${alpha(theme.palette.primary[900], 0.2)} 100%)`,
+                    (theme.vars || theme).palette.primaryDark[900]
+                  } 0%, ${alpha(theme.palette.primary[900], 0.16)} 100%)`,
                 }),
               }
             : {

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -193,13 +193,13 @@ export const getDesignTokens = (mode: 'light' | 'dark') =>
           contrastText: blueDark[600],
         }),
       },
-      divider: mode === 'dark' ? alpha(blueDark[100], 0.08) : grey[100],
+      divider: mode === 'dark' ? alpha(blueDark[500], 0.2) : grey[100],
       primaryDark: blueDark,
       mode,
       ...(mode === 'dark' && {
         background: {
-          default: blueDark[800],
-          paper: blueDark[900],
+          default: blueDark[900],
+          paper: alpha(blueDark[800], 0.8),
         },
       }),
       common: {
@@ -840,7 +840,7 @@ export function getThemedComponents(): ThemeOptions {
           root: ({ theme }) => ({
             borderColor: (theme.vars || theme).palette.grey[100],
             ...theme.applyDarkStyles({
-              borderColor: alpha(theme.palette.primary[100], 0.08),
+              borderColor: alpha(theme.palette.primaryDark[700], 0.8),
             }),
           }),
         },
@@ -1070,7 +1070,7 @@ export function getThemedComponents(): ThemeOptions {
                   textDecorationLine: 'none',
                   boxShadow: `inset 0 1px 2px ${
                     (theme.vars || theme).palette.grey[50]
-                  }, 0 1px 0.5px ${alpha(theme.palette.grey[100], 0.6)}`,
+                  }, 0 1px 2px ${alpha(theme.palette.grey[100], 0.6)}`,
                   '&:hover': {
                     borderColor: (theme.vars || theme).palette.primary[200],
                     boxShadow: `0px 4px 16px ${(theme.vars || theme).palette.grey[200]}`,
@@ -1087,15 +1087,15 @@ export function getThemedComponents(): ThemeOptions {
             theme.applyDarkStyles({
               backgroundColor: (theme.vars || theme).palette.primaryDark[900],
               ...(ownerState.variant === 'outlined' && {
-                borderColor: (theme.vars || theme).palette.primaryDark[600],
-                backgroundColor: alpha(theme.palette.primaryDark[700], 0.5),
+                borderColor: (theme.vars || theme).palette.primaryDark[700],
+                backgroundColor: alpha(theme.palette.primaryDark[800], 0.8),
                 '&[href]': {
                   textDecorationLine: 'none',
                   boxShadow: `inset 0 1px 1px ${
                     (theme.vars || theme).palette.primaryDark[900]
-                  }, 0 1px 0.5px ${(theme.vars || theme).palette.common.black}`,
+                  }, 0 1px 2px ${(theme.vars || theme).palette.common.black}`,
                   '&:hover': {
-                    borderColor: (theme.vars || theme).palette.primary[700],
+                    borderColor: alpha(theme.palette.primary[600], 0.5),
                     boxShadow: `0px 4px 24px ${(theme.vars || theme).palette.common.black}`,
                   },
                 },

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -216,9 +216,9 @@ const Root = styled('div')(
   ({ theme }) =>
     theme.applyDarkStyles({
       background: `linear-gradient(180deg, ${alpha(theme.palette.primary[900], 0.2)} 0%, ${
-        (theme.vars || theme).palette.primaryDark[800]
+        (theme.vars || theme).palette.primaryDark[900]
       } 100%)`,
-      backgroundSize: '100% 500px',
+      backgroundSize: '100% 1000px',
       backgroundRepeat: 'no-repeat',
       [`& .${classes.container}`]: {
         '& strong': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR objective is to run through components used in the marketing pages and update their colors, primarily focused in dark mode. It's been a while since I have this feeling something's off with the website design, and I just recently realized the background color for all the pages is the `primaryDark[800]` instead of 900, as it is in the documentation space. This feels like an opportunity to standardize and make the whole design more consistent! At the same, it also removes a bit of the muddiness that the 800 shade was elevating, at least to me.

So, as a result, the marketing pages feel a bit darker now, _but_ more polished! It looks like many changes, but most of them are super tiny (color shade change). And, of course, there are some stray tweaks here and there, although I tried not to deviate too much from the main objective! 😬 

- Before: https://mui.com/
- After: https://deploy-preview-40052--material-ui.netlify.app/

