### PR TITLE
[joy-ui][docs] Adjust the Select accessibility section

### DIFF
--- a/docs/data/joy/components/select/SelectFieldDemo.js
+++ b/docs/data/joy/components/select/SelectFieldDemo.js
@@ -8,9 +8,7 @@ import Option from '@mui/joy/Option';
 export default function SelectFieldDemo() {
   return (
     <FormControl sx={{ width: 240 }}>
-      <FormLabel id="select-field-demo-label" htmlFor="select-field-demo-button">
-        Favorite pet
-      </FormLabel>
+      <FormLabel htmlFor="select-field-demo-button">Favorite pet</FormLabel>
       <Select
         defaultValue="dog"
         slotProps={{

--- a/docs/data/joy/components/select/SelectFieldDemo.tsx
+++ b/docs/data/joy/components/select/SelectFieldDemo.tsx
@@ -8,9 +8,7 @@ import Option from '@mui/joy/Option';
 export default function SelectFieldDemo() {
   return (
     <FormControl sx={{ width: 240 }}>
-      <FormLabel id="select-field-demo-label" htmlFor="select-field-demo-button">
-        Favorite pet
-      </FormLabel>
+      <FormLabel htmlFor="select-field-demo-button">Favorite pet</FormLabel>
       <Select
         defaultValue="dog"
         slotProps={{

--- a/docs/data/joy/components/select/select.md
+++ b/docs/data/joy/components/select/select.md
@@ -243,9 +243,9 @@ If you'd like to set a `max-height` for a long list of options, make sure to spe
 
 ## Accessibility
 
-In order for the select to be accessible, **it should be linked to a label**.
+To ensure the Select is accessible, make sure to add label linked to it.
 
-The `FormControl` automatically generates a unique id that links the select with the `FormLabel` component:
+If you use the Form Label component, together with the Form Control, Joy UI automatically generates a unique id that links the Select to it.
 
 {{"demo": "SelectFieldDemo.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR tackles a recently received docs-feedback entry:

> Accessibility section says:
> "The FormControl automatically generates a unique id that links the select with the FormLabel component"
However next example code does not use the feature and specifies id by hand

I've removed the manually added `id` from the Select demo to demonstrate how the component presumably really creates an id for it if associated with a Form Label, within the Form Control, component!

👉 https://deploy-preview-40053--material-ui.netlify.app/joy-ui/react-select/#accessibility