### PR TITLE
[Badge][material-next] Apply new OwnerState type to Badge

### DIFF
--- a/packages/mui-material-next/src/Badge/Badge.types.ts
+++ b/packages/mui-material-next/src/Badge/Badge.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SxProps } from '@mui/system';
-import { OverridableStringUnion, OverrideProps } from '@mui/types';
+import { OverridableStringUnion, OverrideProps, PartiallyRequired } from '@mui/types';
 import { SlotComponentProps } from '@mui/base';
 import { Theme } from '../styles';
 import { BadgeClasses } from './badgeClasses';
@@ -126,10 +126,8 @@ export type BadgeProps<
   AdditionalProps = {},
 > = OverrideProps<BadgeTypeMap<RootComponent, AdditionalProps>, RootComponent>;
 
-export interface BadgeOwnerState extends BadgeProps {
-  size: NonNullable<BadgeProps['size']>;
-  variant: NonNullable<BadgeProps['variant']>;
-  anchorOrigin: NonNullable<BadgeProps['anchorOrigin']>;
-  overlap: NonNullable<BadgeProps['overlap']>;
-  color: NonNullable<BadgeProps['color']>;
-}
+export interface BadgeOwnerState
+  extends PartiallyRequired<
+    BadgeProps,
+    'anchorOrigin' | 'color' | 'overlap' | 'size' | 'variant'
+  > {}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds the new type #39935 to the OwnerState of the `Badge` component.