### PR TITLE
[material-ui][docs][Popper] Update Positioned Popper demo styles

### DIFF
--- a/docs/data/material/components/popper/PositionedPopper.js
+++ b/docs/data/material/components/popper/PositionedPopper.js
@@ -20,7 +20,14 @@ export default function PositionedPopper() {
 
   return (
     <Box sx={{ width: 500 }}>
-      <Popper open={open} anchorEl={anchorEl} placement={placement} transition>
+      <Popper
+        // Note: The following style is specifically for documentation purposes and may not be necessary in your code.
+        sx={{ zIndex: 1200 }}
+        open={open}
+        anchorEl={anchorEl}
+        placement={placement}
+        transition
+      >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={350}>
             <Paper>

--- a/docs/data/material/components/popper/PositionedPopper.js
+++ b/docs/data/material/components/popper/PositionedPopper.js
@@ -21,7 +21,7 @@ export default function PositionedPopper() {
   return (
     <Box sx={{ width: 500 }}>
       <Popper
-        // Note: The zIndex below is needed for our documentation, but shouldn't be necessary in your app.
+        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your application.
         sx={{ zIndex: 1200 }}
         open={open}
         anchorEl={anchorEl}

--- a/docs/data/material/components/popper/PositionedPopper.js
+++ b/docs/data/material/components/popper/PositionedPopper.js
@@ -21,7 +21,7 @@ export default function PositionedPopper() {
   return (
     <Box sx={{ width: 500 }}>
       <Popper
-        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your code.
+        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your application.
         sx={{ zIndex: 1200 }}
         open={open}
         anchorEl={anchorEl}

--- a/docs/data/material/components/popper/PositionedPopper.js
+++ b/docs/data/material/components/popper/PositionedPopper.js
@@ -21,7 +21,7 @@ export default function PositionedPopper() {
   return (
     <Box sx={{ width: 500 }}>
       <Popper
-        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your application.
+        // Note: The zIndex below is needed for our documentation, but shouldn't be necessary in your app.
         sx={{ zIndex: 1200 }}
         open={open}
         anchorEl={anchorEl}

--- a/docs/data/material/components/popper/PositionedPopper.js
+++ b/docs/data/material/components/popper/PositionedPopper.js
@@ -21,7 +21,7 @@ export default function PositionedPopper() {
   return (
     <Box sx={{ width: 500 }}>
       <Popper
-        // Note: The following style is specifically for documentation purposes and may not be necessary in your code.
+        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your code.
         sx={{ zIndex: 1200 }}
         open={open}
         anchorEl={anchorEl}

--- a/docs/data/material/components/popper/PositionedPopper.tsx
+++ b/docs/data/material/components/popper/PositionedPopper.tsx
@@ -23,7 +23,7 @@ export default function PositionedPopper() {
   return (
     <Box sx={{ width: 500 }}>
       <Popper
-        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your code.
+        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your application.
         sx={{ zIndex: 1200 }}
         open={open}
         anchorEl={anchorEl}

--- a/docs/data/material/components/popper/PositionedPopper.tsx
+++ b/docs/data/material/components/popper/PositionedPopper.tsx
@@ -23,7 +23,7 @@ export default function PositionedPopper() {
   return (
     <Box sx={{ width: 500 }}>
       <Popper
-        // Note: The following style is specifically for documentation purposes and may not be necessary in your code.
+        // Note: The following zIndex style is specifically for documentation purposes and may not be necessary in your code.
         sx={{ zIndex: 1200 }}
         open={open}
         anchorEl={anchorEl}

--- a/docs/data/material/components/popper/PositionedPopper.tsx
+++ b/docs/data/material/components/popper/PositionedPopper.tsx
@@ -22,7 +22,14 @@ export default function PositionedPopper() {
 
   return (
     <Box sx={{ width: 500 }}>
-      <Popper open={open} anchorEl={anchorEl} placement={placement} transition>
+      <Popper
+        // Note: The following style is specifically for documentation purposes and may not be necessary in your code.
+        sx={{ zIndex: 1200 }}
+        open={open}
+        anchorEl={anchorEl}
+        placement={placement}
+        transition
+      >
         {({ TransitionProps }) => (
           <Fade {...TransitionProps} timeout={350}>
             <Paper>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR places content of Popper above drawer so that text inside popper is clearly visible

preview: https://deploy-preview-40170--material-ui.netlify.app/material-ui/react-popper/#positioned-popper

### Before

<img width="1433" alt="Screenshot 2023-12-10 at 12 00 15 PM" src="https://github.com/mui/material-ui/assets/60743144/b89f6b3b-dcd3-4006-b3e2-6c076559f420">

### After


<img width="1433" alt="Screenshot 2023-12-10 at 12 19 12 PM" src="https://github.com/mui/material-ui/assets/60743144/ea0b6880-fe1b-4aef-9f39-d0183bae0f51">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
