### PR TITLE
Revert "[Select][material-ui] Add name to hidden input element"

### DIFF
--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -119,11 +119,6 @@ const InputLabelRoot = styled(FormLabel, {
       transform: 'translate(14px, -9px) scale(0.75)',
     }),
   }),
-  ...(ownerState.variant === 'standard' && {
-    '&:not(label) + div': {
-      marginTop: 16,
-    },
-  }),
 }));
 
 const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -489,8 +489,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
 
   const listboxId = useId();
 
-  const hiddenInputId = useId();
-
   return (
     <React.Fragment>
       <SelectSelect
@@ -525,7 +523,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       <SelectNativeInput
         aria-invalid={error}
         value={Array.isArray(value) ? value.join(',') : value}
-        name={name ?? hiddenInputId}
+        name={name}
         ref={inputRef}
         aria-hidden
         onChange={handleChange}


### PR DESCRIPTION
Reverts mui/material-ui#39414

The change affected native form submission behavior which was reported in https://github.com/mui/material-ui/issues/40128

I've also added a regression test in https://github.com/mui/material-ui/pull/40176