### PR TITLE
[Select][material-ui] Add form submission regression test

### DIFF
--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -1560,6 +1560,42 @@ describe('<Select />', () => {
     expect(container.getElementsByClassName(classes.select)[0]).to.toHaveComputedStyle(selectStyle);
   });
 
+  describe('form submission', () => {
+    it('includes Select value in formData only if the `name` attribute is provided', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // FormData is not available in JSDOM
+        this.skip();
+      }
+      const handleSubmit = (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        expect(formData.get('select-one')).to.equal('2');
+
+        const formDataAsObject = Object.fromEntries(formData);
+        expect(Object.keys(formDataAsObject).length).to.equal(1);
+      };
+
+      const { getByText } = render(
+        <form onSubmit={handleSubmit}>
+          <Select defaultValue={2} name="select-one">
+            <MenuItem value={1} />
+            <MenuItem value={2} />
+          </Select>
+          <Select defaultValue="a">
+            <MenuItem value="a" />
+            <MenuItem value="b" />
+          </Select>
+          <button type="submit">Submit</button>
+        </form>,
+      );
+
+      const button = getByText('Submit');
+      act(() => {
+        button.click();
+      });
+    });
+  });
+
   describe('theme styleOverrides:', () => {
     it('should override with error style when `native select` has `error` state', function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {


### PR DESCRIPTION
Related to https://github.com/mui/material-ui/issues/40128

This PR adds a test to ensure that the Select's value is not included in the `FormData` of a form if the `name` prop/attribute is not explicitly provided

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
