### PR TITLE
[core] Update `no-response` workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,8 +1,10 @@
 name: No response
 
-# Both `issue_comment` and `scheduled` event types are required for this Action
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
 # to work properly.
 on:
+  issues:
+    types: [closed]
   issue_comment:
     types: [created]
   schedule:
@@ -18,13 +20,15 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb # v0.5.0
+      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: 'status: needs more information'
+          responseRequiredLabel: 'status: waiting for author'
+          # Label to add back when required label is removed
+          optionalFollowupLabel: 'status: waiting for maintainer'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Addresses point # 4 of https://github.com/mui/mui-x/issues/10810

Just before merging this PR, the GitHub label `status: needs more information` should be renamed to `status: waiting for author`, and a new label `status: waiting for maintainer` should be created.