### PR TITLE
[docs-infra] Uplift the Algolia search modal design

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -17,6 +17,8 @@ import CollectionsBookmarkRoundedIcon from '@mui/icons-material/CollectionsBookm
 import LibraryBooksRoundedIcon from '@mui/icons-material/LibraryBooksRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import ChecklistRoundedIcon from '@mui/icons-material/ChecklistRounded';
+import DriveFileRenameOutlineRoundedIcon from '@mui/icons-material/DriveFileRenameOutlineRounded';
+import NewspaperRoundedIcon from '@mui/icons-material/NewspaperRounded';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import { alpha, styled } from '@mui/material/styles';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
@@ -99,6 +101,7 @@ const Shortcut = styled('div')(({ theme }) => {
 });
 
 function NewStartScreen() {
+  const t = useTranslate();
   const startScreenOptions = [
     {
       category: {
@@ -147,6 +150,11 @@ function NewStartScreen() {
           href: '/base-ui/getting-started/customization/',
           icon: <DesignServicesRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
+        {
+          name: 'Usage',
+          href: '/base-ui/getting-started/usage/',
+          icon: <DriveFileRenameOutlineRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
       ],
     },
     {
@@ -185,6 +193,11 @@ function NewStartScreen() {
           name: 'Licensing',
           href: '/x/introduction/licensing/',
           icon: <CopyrightRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'What is new in MUI X',
+          href: '/x/whats-new/',
+          icon: <NewspaperRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
       ],
     },
@@ -236,19 +249,22 @@ function NewStartScreen() {
     },
   ];
   return (
-    <div className="DocSearch-NewStartScreen">
-      {startScreenOptions.map(({ category, items }) => (
-        <div key={category.name} className="DocSearch-NewStartScreenCategory">
-          <div className="DocSearch-NewStartScreenTitle">{category.name}</div>
-          {items.map(({ name, icon, href }) => (
-            <NextLink key={name} href={href} className="DocSearch-NewStartScreenItem">
-              {icon}
-              {name}
-            </NextLink>
-          ))}
-        </div>
-      ))}
-    </div>
+    <React.Fragment>
+      <p className="DocSearch-NewStartScreenHeader">{t('algoliaSearchHeader')}</p>
+      <div className="DocSearch-NewStartScreen">
+        {startScreenOptions.map(({ category, items }) => (
+          <div key={category.name} className="DocSearch-NewStartScreenCategory">
+            <div className="DocSearch-NewStartScreenTitle">{category.name}</div>
+            {items.map(({ name, icon, href }) => (
+              <NextLink key={name} href={href} className="DocSearch-NewStartScreenItem">
+                {icon}
+                {name}
+              </NextLink>
+            ))}
+          </div>
+        ))}
+      </div>
+    </React.Fragment>
   );
 }
 
@@ -509,14 +525,20 @@ export default function AppSearch(props) {
               backgroundColor: alpha(theme.palette.grey[700], 0.5),
               backdropFilter: 'blur(2px)',
             },
+            '& .DocSearch-NewStartScreenHeader': {
+              fontSize: theme.typography.pxToRem(16),
+              fontWeight: theme.typography.fontWeightSemiBold,
+              color: theme.palette.text.secondary,
+              paddingLeft: theme.spacing(2),
+            },
             '& .DocSearch-StartScreen': {
               display: 'none',
             },
             '& .DocSearch-NewStartScreen': {
-              display: 'flex',
-              flexDirection: 'column',
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
               gap: theme.spacing(2),
-              padding: theme.spacing(2, 0),
+              paddingBottom: theme.spacing(2),
             },
             '& .DocSearch-NewStartScreenCategory': {
               display: 'flex',
@@ -543,7 +565,7 @@ export default function AppSearch(props) {
               alignItems: 'center',
               cursor: 'pointer',
               width: '100%',
-              height: '48px',
+              height: '42px',
               color: (theme.vars || theme).palette.primary[600],
               fontSize: theme.typography.pxToRem(14),
               fontWeight: theme.typography.fontWeightMedium,

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -158,28 +158,6 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'Joy UI',
-      },
-      items: [
-        {
-          name: 'Installation',
-          href: '/joy-ui/getting-started/installation/',
-          icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
-        },
-        {
-          name: 'Templates',
-          href: '/joy-ui/getting-started/templates/',
-          icon: <CollectionsBookmarkRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
-        },
-        {
-          name: 'Customization',
-          href: '/joy-ui/customization/approaches/',
-          icon: <DesignServicesRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
-        },
-      ],
-    },
-    {
-      category: {
         name: 'MUI X',
       },
       items: [
@@ -197,6 +175,28 @@ function NewStartScreen() {
           name: 'What is new in MUI X',
           href: '/x/whats-new/',
           icon: <NewspaperRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+      ],
+    },
+    {
+      category: {
+        name: 'Joy UI',
+      },
+      items: [
+        {
+          name: 'Installation',
+          href: '/joy-ui/getting-started/installation/',
+          icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Templates',
+          href: '/joy-ui/getting-started/templates/',
+          icon: <CollectionsBookmarkRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Customization',
+          href: '/joy-ui/customization/approaches/',
+          icon: <DesignServicesRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
       ],
     },
@@ -248,25 +248,19 @@ function NewStartScreen() {
     },
   ];
   return (
-    <React.Fragment>
-      <p className="DocSearch-NewStartScreenHeader">
-        {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-        {'Quick links'}
-      </p>
-      <div className="DocSearch-NewStartScreen">
-        {startScreenOptions.map(({ category, items }) => (
-          <div key={category.name} className="DocSearch-NewStartScreenCategory">
-            <div className="DocSearch-NewStartScreenTitle">{category.name}</div>
-            {items.map(({ name, icon, href }) => (
-              <NextLink key={name} href={href} className="DocSearch-NewStartScreenItem">
-                {icon}
-                {name}
-              </NextLink>
-            ))}
-          </div>
-        ))}
-      </div>
-    </React.Fragment>
+    <div className="DocSearch-NewStartScreen">
+      {startScreenOptions.map(({ category, items }) => (
+        <div key={category.name} className="DocSearch-NewStartScreenCategory">
+          <div className="DocSearch-NewStartScreenTitle">{category.name}</div>
+          {items.map(({ name, icon, href }) => (
+            <NextLink key={name} href={href} className="DocSearch-NewStartScreenItem">
+              {icon}
+              {name}
+            </NextLink>
+          ))}
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -526,12 +520,6 @@ export default function AppSearch(props) {
               zIndex: theme.zIndex.tooltip + 100,
               backgroundColor: alpha(theme.palette.grey[700], 0.5),
               backdropFilter: 'blur(2px)',
-            },
-            '& .DocSearch-NewStartScreenHeader': {
-              fontSize: theme.typography.pxToRem(16),
-              fontWeight: theme.typography.fontWeightSemiBold,
-              color: theme.palette.text.secondary,
-              paddingLeft: theme.spacing(2),
             },
             '& .DocSearch-StartScreen': {
               display: 'none',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -476,9 +476,11 @@ export default function AppSearch(props) {
               '&:hover, &:focus': {
                 backgroundColor: (theme.vars || theme).palette.primary[50],
                 borderColor: (theme.vars || theme).palette.primary[300],
-                '.DocSearch-NewStartScreenItemIcon': {
-                  marginLeft: theme.spacing(1),
-                },
+              },
+              '&:focus-visible': {
+                outline: '3px solid',
+                outlineColor: (theme.vars || theme).palette.primary[200],
+                outlineOffset: 0,
               },
             },
             '& .DocSearch-NewStartScreenItemIcon': {
@@ -542,12 +544,15 @@ export default function AppSearch(props) {
               '&::-webkit-scrollbar-track': {
                 backgroundColor: (theme.vars || theme).palette.background.paper,
               },
+              '* ul': {
+                marginTop: theme.spacing(1),
+              },
             },
             '& .DocSearch-Dropdown-Container': {
               '& .DocSearch-Hits:first-of-type': {
                 '& .DocSearch-Hit-source': {
                   paddingTop: theme.spacing(2.5),
-                  paddingBottom: theme.spacing(1),
+                  paddingBottom: theme.spacing(0.5),
                 },
               },
             },
@@ -578,6 +583,13 @@ export default function AppSearch(props) {
               borderRadius: theme.shape.borderRadius,
               backgroundColor: alpha(theme.palette.grey[50], 0.4),
               borderColor: alpha(theme.palette.grey[100], 0.5),
+              '&:focus-visible': {
+                outline: '3px solid',
+                outlineColor: (theme.vars || theme).palette.primary[200],
+                outlineOffset: 0,
+                backgroundColor: (theme.vars || theme).palette.primary[50],
+                borderColor: (theme.vars || theme).palette.primary[300],
+              },
             },
             '& .DocSearch-Hit-content-wrapper': {
               paddingLeft: theme.spacing(1),

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -456,7 +456,6 @@ export default function AppSearch(props) {
             '& .DocSearch-NewStartScreenTitleIcon': {
               color: (theme.vars || theme).palette.primary[500],
               marginRight: theme.spacing(1),
-              // fontSize: theme.typography.pxToRem(16),
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',
@@ -560,7 +559,7 @@ export default function AppSearch(props) {
             '& .DocSearch-Hit-source': {
               top: 'initial',
               padding: theme.spacing(1.5, 3, 1.5, 3),
-              background: (theme.vars || theme).palette.background.paper,
+              background: 'transparent',
               fontSize: theme.typography.pxToRem(11),
               fontWeight: theme.typography.fontWeightBold,
               textTransform: 'uppercase',
@@ -601,8 +600,10 @@ export default function AppSearch(props) {
               color: (theme.vars || theme).palette.text.primary,
             },
             '& .DocSearch-Hit-path': {
+              display: 'flex',
+              gap: theme.spacing(1),
               fontSize: theme.typography.pxToRem(12),
-              color: `${theme.palette.text.secondary}`,
+              color: (theme.vars || theme).palette.text.secondary,
             },
             '& .DocSearch-Hit-icon': {
               '> svg': {
@@ -657,16 +658,26 @@ export default function AppSearch(props) {
           {
             [theme.vars ? '[data-mui-color-scheme="dark"] body' : '.mode-dark']: {
               '.DocSearch-Container': {
-                backgroundColor: alpha(theme.palette.grey[900], 0.7),
+                backgroundColor: alpha(theme.palette.grey[900], 0.4),
               },
               '& .DocSearch-NewStartScreenTitleIcon': {
-                color: (theme.vars || theme).palette.primaryDark[300],
+                color: (theme.vars || theme).palette.primary[300],
               },
               '& .DocSearch-NewStartScreenItem': {
-                color: (theme.vars || theme).palette.primaryDark[300],
+                color: (theme.vars || theme).palette.primary[300],
+                backgroundColor: alpha(theme.palette.primaryDark[800], 0.5),
+                borderColor: alpha(theme.palette.primaryDark[700], 0.8),
+                '&:hover, &:focus': {
+                  backgroundColor: alpha(theme.palette.primary[900], 0.4),
+                  borderColor: alpha(theme.palette.primary[700], 0.6),
+                },
+                '&:focus-visible': {
+                  outlineColor: (theme.vars || theme).palette.primary[700],
+                },
               },
               '& .DocSearch-Modal': {
-                boxShadow: `0px 4px 20px ${alpha(theme.palette.background.paper, 0.7)}`,
+                backgroundColor: (theme.vars || theme).palette.primaryDark[900],
+                boxShadow: `0px 4px 16px ${alpha(theme.palette.common.black, 0.8)}`,
                 border: '1px solid',
                 borderColor: (theme.vars || theme).palette.primaryDark[700],
               },
@@ -680,15 +691,22 @@ export default function AppSearch(props) {
               '& .DocSearch-Dropdown': {
                 '&::-webkit-scrollbar-thumb': {
                   borderColor: (theme.vars || theme).palette.primaryDark[900],
-                  backgroundColor: (theme.vars || theme).palette.primaryDark[700],
+                  backgroundColor: (theme.vars || theme).palette.primaryDark[100],
                 },
               },
               '& .DocSearch-Hit a': {
-                borderBottomColor: (theme.vars || theme).palette.primaryDark[700],
+                backgroundColor: alpha(theme.palette.primaryDark[800], 0.5),
+                borderColor: alpha(theme.palette.primaryDark[700], 0.8),
+                '&:focus-visible': {
+                  outlineColor: alpha(theme.palette.primary[400], 0.5),
+                  backgroundColor: alpha(theme.palette.primary[900], 0.4),
+                  borderColor: alpha(theme.palette.primary[700], 0.6),
+                },
               },
               '& .DocSearch-Hit[aria-selected="true"] a': {
-                backgroundColor: (theme.vars || theme).palette.primaryDark[800],
-                borderColor: (theme.vars || theme).palette.primaryDark[400],
+                color: (theme.vars || theme).palette.primary[300],
+                backgroundColor: alpha(theme.palette.primary[900], 0.4),
+                borderColor: alpha(theme.palette.primary[700], 0.6),
               },
               '& .DocSearch-Hit-action, & .DocSearch-Hits mark': {
                 color: (theme.vars || theme).palette.primary[400],

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -676,8 +676,6 @@ export default function AppSearch(props) {
               color: (theme.vars || theme).palette.text.primary,
             },
             '& .DocSearch-Hit-path': {
-              // display: 'flex',
-              // gap: theme.spacing(1),
               fontSize: theme.typography.pxToRem(12),
               color: (theme.vars || theme).palette.text.secondary,
             },
@@ -697,7 +695,6 @@ export default function AppSearch(props) {
               borderColor: (theme.vars || theme).palette.primary[300],
             },
             '& .DocSearch-Hit-action, & .DocSearch-Hits mark': {
-              // display: 'flex',
               color: (theme.vars || theme).palette.primary[500],
               '& .DocSearch-Hit-action-button': {
                 display: 'flex',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -140,7 +140,7 @@ function NewStartScreen() {
       },
       items: [
         {
-          name: 'Quickstart',
+          name: 'Installation',
           href: '/base-ui/getting-started/quickstart/',
           icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
@@ -322,7 +322,7 @@ export default function AppSearch(props) {
     'https://cdn.jsdelivr.net/npm/@docsearch/css@3.0.0-alpha.40/dist/style.min.css',
     '#app-search',
   );
-  const FADE_DURATION = 100; // ms
+  const FADE_DURATION = 120; // ms
   const t = useTranslate();
   const userLanguage = useUserLanguage();
   const searchButtonRef = React.useRef(null);
@@ -496,7 +496,7 @@ export default function AppSearch(props) {
         styles={(theme) => ({
           html: {
             ':root': {
-              '--docsearch-primary-color': (theme.vars || theme).palette.primary[500],
+              '--docsearch-primary-color': (theme.vars || theme).palette.primary[600],
               '--docsearch-text-color': (theme.vars || theme).palette.text.primary,
               '--docsearch-muted-color': (theme.vars || theme).palette.grey[600],
               '--docsearch-searchbox-shadow': 0,
@@ -515,8 +515,8 @@ export default function AppSearch(props) {
               transition: `opacity ${FADE_DURATION}ms`,
               opacity: 0,
               zIndex: theme.zIndex.tooltip + 100,
-              backgroundColor: alpha(theme.palette.grey[600], 0.2),
-              backdropFilter: 'blur(4px)',
+              backgroundColor: alpha(theme.palette.grey[700], 0.5),
+              backdropFilter: 'blur(2px)',
             },
             '& .DocSearch-StartScreen': {
               display: 'none',
@@ -542,9 +542,10 @@ export default function AppSearch(props) {
               color: theme.palette.grey[600],
             },
             '& .DocSearch-NewStartScreenTitleIcon': {
+              fontSize: theme.typography.pxToRem(18),
               color: (theme.vars || theme).palette.primary[500],
-              marginRight: theme.spacing(1),
-              opacity: 0.8,
+              marginRight: theme.spacing(1.5),
+              opacity: 0.6,
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',
@@ -552,9 +553,9 @@ export default function AppSearch(props) {
               cursor: 'pointer',
               width: '100%',
               height: '48px',
-              color: (theme.vars || theme).palette.primary[500],
+              color: (theme.vars || theme).palette.primary[600],
               fontSize: theme.typography.pxToRem(14),
-              fontWeight: theme.typography.fontWeightSemiBold,
+              fontWeight: theme.typography.fontWeightMedium,
               padding: theme.spacing(0.25, 0),
               paddingLeft: theme.spacing(2),
               border: '1px solid transparent',
@@ -572,15 +573,10 @@ export default function AppSearch(props) {
                 outlineOffset: 0,
               },
             },
-            '& .DocSearch-NewStartScreenItemIcon': {
-              fontSize: theme.typography.pxToRem(16),
-              marginLeft: theme.spacing(0.5),
-              opacity: 0.5,
-            },
             '& .DocSearch-Modal': {
               // docsearch.css: <= 750px will be full screen modal
               maxWidth: '640px',
-              boxShadow: `0px 4px 16px ${alpha(theme.palette.grey[900], 0.2)}`,
+              boxShadow: `0px 4px 16px ${alpha(theme.palette.common.black, 0.2)}`,
               borderRadius: theme.shape.borderRadius,
               border: '1px solid',
               borderColor: (theme.vars || theme).palette.grey[300],
@@ -685,7 +681,7 @@ export default function AppSearch(props) {
             },
             '& .DocSearch-Hit-title': {
               fontSize: theme.typography.pxToRem(14),
-              fontWeight: theme.typography.fontWeightSemiBold,
+              fontWeight: theme.typography.fontWeightMedium,
               color: (theme.vars || theme).palette.text.primary,
             },
             '& .DocSearch-Hit-path': {
@@ -799,6 +795,12 @@ export default function AppSearch(props) {
               },
               '& .DocSearch-Hit-action, & .DocSearch-Hits mark': {
                 color: (theme.vars || theme).palette.primary[400],
+                '& .DocSearch-Hit-action-button': {
+                  '&:hover': {
+                    backgroundColor: alpha(theme.palette.primary[900], 0.8),
+                    borderColor: alpha(theme.palette.primary[700], 0.8),
+                  },
+                },
               },
               '& .DocSearch-Footer': {
                 borderColor: (theme.vars || theme).palette.primaryDark[700],

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -6,6 +6,7 @@ import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
 import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
 import ArticleRoundedIcon from '@mui/icons-material/ArticleRounded';
 import ToggleOffRoundedIcon from '@mui/icons-material/ToggleOffRounded';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
@@ -436,7 +437,7 @@ export default function AppSearch(props) {
               display: 'flex',
               flexDirection: 'column',
               gap: theme.spacing(2),
-              padding: theme.spacing(2, 1),
+              padding: theme.spacing(2, 0),
             },
             '& .DocSearch-NewStartScreenCategory': {
               display: 'flex',
@@ -445,7 +446,7 @@ export default function AppSearch(props) {
             '& .DocSearch-NewStartScreenTitle': {
               display: 'flex',
               alignItems: 'center',
-              paddingBottom: theme.spacing(1),
+              padding: theme.spacing(0, 3, 1.5, 2),
               fontSize: theme.typography.pxToRem(11),
               fontWeight: theme.typography.fontWeightBold,
               textTransform: 'uppercase',
@@ -619,7 +620,21 @@ export default function AppSearch(props) {
               borderColor: (theme.vars || theme).palette.primary[300],
             },
             '& .DocSearch-Hit-action, & .DocSearch-Hits mark': {
+              display: 'flex',
               color: (theme.vars || theme).palette.primary[500],
+              '& .DocSearch-Hit-action-button': {
+                display: 'flex',
+                width: '24px',
+                borderRadius: '6px',
+                border: '1px solid transparent',
+                '> svg': {
+                  margin: 0,
+                },
+                '&:hover': {
+                  backgroundColor: (theme.vars || theme).palette.primary[100],
+                  borderColor: (theme.vars || theme).palette.primary[300],
+                },
+              },
             },
             '& .DocSearch-Footer': {
               borderTop: '1px solid',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -6,13 +6,7 @@ import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
 import Chip from '@mui/material/Chip';
-import ArticleRoundedIcon from '@mui/icons-material/ArticleRounded';
-import ToggleOffRoundedIcon from '@mui/icons-material/ToggleOffRounded';
-import EditRoundedIcon from '@mui/icons-material/EditRounded';
-import HandymanRoundedIcon from '@mui/icons-material/HandymanRounded';
-import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
 import SearchIcon from '@mui/icons-material/Search';
-
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
 import StickyNote2RoundedIcon from '@mui/icons-material/StickyNote2Rounded';
 import SmartButtonRoundedIcon from '@mui/icons-material/SmartButtonRounded';
@@ -23,7 +17,6 @@ import CollectionsBookmarkRoundedIcon from '@mui/icons-material/CollectionsBookm
 import LibraryBooksRoundedIcon from '@mui/icons-material/LibraryBooksRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import ChecklistRoundedIcon from '@mui/icons-material/ChecklistRounded';
-
 import GlobalStyles from '@mui/material/GlobalStyles';
 import { alpha, styled } from '@mui/material/styles';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
@@ -743,7 +736,7 @@ export default function AppSearch(props) {
           {
             [theme.vars ? '[data-mui-color-scheme="dark"] body' : '.mode-dark']: {
               '.DocSearch-Container': {
-                backgroundColor: alpha(theme.palette.grey[900], 0.4),
+                backgroundColor: alpha(theme.palette.grey[900], 0.6),
               },
               '& .DocSearch-NewStartScreenTitleIcon': {
                 color: (theme.vars || theme).palette.primary[300],

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -101,7 +101,6 @@ const Shortcut = styled('div')(({ theme }) => {
 });
 
 function NewStartScreen() {
-  const t = useTranslate();
   const startScreenOptions = [
     {
       category: {

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -101,9 +101,21 @@ function NewStartScreen() {
         icon: <ArticleRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
       },
       items: [
-        { name: 'Installation', href: '/material-ui/getting-started/installation/' },
-        { name: 'Usage', href: '/material-ui/getting-started/usage/' },
-        { name: 'Learn', href: '/material-ui/getting-started/learn/' },
+        {
+          name: 'Installation',
+          href: '/material-ui/getting-started/installation/',
+          icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Usage',
+          href: '/material-ui/getting-started/usage/',
+          icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Learn',
+          href: '/material-ui/getting-started/learn/',
+          icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
       ],
     },
     {
@@ -144,12 +156,10 @@ function NewStartScreen() {
     <div className="DocSearch-NewStartScreen">
       {startScreenOptions.map(({ category, items }) => (
         <div key={category.name} className="DocSearch-NewStartScreenCategory">
-          <div className="DocSearch-NewStartScreenTitle">
-            {category.icon}
-            {category.name}
-          </div>
-          {items.map(({ name, href }) => (
+          <div className="DocSearch-NewStartScreenTitle">{category.name}</div>
+          {items.map(({ name, icon, href }) => (
             <NextLink key={name} href={href} className="DocSearch-NewStartScreenItem">
+              {icon}
               {name}
               <KeyboardArrowRightRounded className="DocSearch-NewStartScreenItemIcon" />
             </NextLink>
@@ -423,8 +433,8 @@ export default function AppSearch(props) {
               display: 'none',
             },
             '& .DocSearch-NewStartScreen': {
-              display: 'grid',
-              gridTemplateColumns: 'repeat(2, 1fr)',
+              display: 'flex',
+              flexDirection: 'column',
               gap: theme.spacing(2),
               padding: theme.spacing(2, 1),
             },
@@ -435,56 +445,72 @@ export default function AppSearch(props) {
             '& .DocSearch-NewStartScreenTitle': {
               display: 'flex',
               alignItems: 'center',
-              padding: theme.spacing(1, 1),
-              fontSize: theme.typography.pxToRem(14),
-              color: (theme.vars || theme).palette.text.secondary,
+              paddingBottom: theme.spacing(1),
+              fontSize: theme.typography.pxToRem(11),
+              fontWeight: theme.typography.fontWeightBold,
+              textTransform: 'uppercase',
+              letterSpacing: '.08rem',
+              color: theme.palette.grey[600],
             },
             '& .DocSearch-NewStartScreenTitleIcon': {
               color: (theme.vars || theme).palette.primary[500],
-              marginRight: theme.spacing(1.5),
-              fontSize: theme.typography.pxToRem(16),
+              marginRight: theme.spacing(1),
+              // fontSize: theme.typography.pxToRem(16),
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',
               alignItems: 'center',
               cursor: 'pointer',
               width: '100%',
-              padding: theme.spacing(0.5, 4.6),
+              height: '48px',
               color: (theme.vars || theme).palette.primary[500],
-              fontWeight: 500,
               fontSize: theme.typography.pxToRem(14),
+              fontWeight: theme.typography.fontWeightSemiBold,
+              padding: theme.spacing(0.25, 0),
+              paddingLeft: theme.spacing(2),
+              border: '1px solid transparent',
+              borderRadius: theme.shape.borderRadius,
+              backgroundColor: alpha(theme.palette.grey[50], 0.4),
+              borderColor: alpha(theme.palette.grey[100], 0.5),
+              marginBottom: theme.spacing(1),
               '&:hover, &:focus': {
+                backgroundColor: (theme.vars || theme).palette.primary[50],
+                borderColor: (theme.vars || theme).palette.primary[300],
                 '.DocSearch-NewStartScreenItemIcon': {
                   marginLeft: theme.spacing(1),
                 },
               },
             },
             '& .DocSearch-NewStartScreenItemIcon': {
+              fontSize: theme.typography.pxToRem(16),
               marginLeft: theme.spacing(0.5),
               transition: 'margin 0.2s',
-              fontSize: theme.typography.pxToRem(16),
             },
             '& .DocSearch-Modal': {
-              maxWidth: '700px',
-              boxShadow: `0px 4px 20px ${alpha(theme.palette.grey[700], 0.2)}`,
               // docsearch.css: <= 750px will be full screen modal
-              borderRadius: `clamp(0px, (100vw - 750px) * 9999, ${theme.shape.borderRadius}px)`,
+              maxWidth: '640px',
+              boxShadow: `0px 4px 16px ${alpha(theme.palette.grey[900], 0.2)}`,
+              borderRadius: theme.shape.borderRadius,
+              border: '1px solid',
+              borderColor: (theme.vars || theme).palette.grey[300],
             },
             '& .DocSearch-SearchBar': {
               borderBottom: '1px solid',
               borderColor: (theme.vars || theme).palette.grey[200],
-              padding: theme.spacing(1),
+              padding: theme.spacing(0.5, 1),
             },
             '& .DocSearch-Form': {
               '& .DocSearch-Reset': {
                 display: 'none',
               },
               '& .DocSearch-Input': {
-                paddingLeft: theme.spacing(2.5),
+                paddingLeft: theme.spacing(2),
+                fontSize: theme.typography.pxToRem(16),
+                fontWeight: theme.typography.fontWeightMedium,
               },
               '& .DocSearch-Search-Icon': {
-                width: '20px',
-                height: '20px',
+                width: '18px',
+                height: '18px',
               },
             },
             '& .DocSearch-Cancel': {
@@ -495,15 +521,15 @@ export default function AppSearch(props) {
               marginRight: theme.spacing(1),
               padding: theme.spacing(0.3, 0.8, 0.6, 0.8),
               fontSize: 0,
-              borderRadius: 5,
+              borderRadius: 6,
               backgroundColor: (theme.vars || theme).palette.grey[50],
               border: '1px solid',
-              borderColor: (theme.vars || theme).palette.grey[300],
+              borderColor: (theme.vars || theme).palette.grey[200],
               '&::before': {
                 content: '"esc"',
+                fontFamily: theme.typography.fontFamilyCode,
                 fontSize: theme.typography.pxToRem(12),
-                letterSpacing: '.08rem',
-                fontWeight: 700,
+                fontWeight: theme.typography.fontWeightBold,
                 color: (theme.vars || theme).palette.text.secondary,
               },
             },
@@ -520,50 +546,65 @@ export default function AppSearch(props) {
             '& .DocSearch-Dropdown-Container': {
               '& .DocSearch-Hits:first-of-type': {
                 '& .DocSearch-Hit-source': {
-                  paddingTop: theme.spacing(1),
+                  paddingTop: theme.spacing(2.5),
+                  paddingBottom: theme.spacing(1),
                 },
               },
             },
             '& .DocSearch-Hit-source': {
               top: 'initial',
-              paddingTop: theme.spacing(2),
+              padding: theme.spacing(1.5, 3, 1.5, 3),
               background: (theme.vars || theme).palette.background.paper,
-              fontSize: theme.typography.pxToRem(13),
-              fontWeight: 500,
-              color: (theme.vars || theme).palette.text.secondary,
+              fontSize: theme.typography.pxToRem(11),
+              fontWeight: theme.typography.fontWeightBold,
+              textTransform: 'uppercase',
+              lineHeight: 1,
+              letterSpacing: '.08rem',
+              color: theme.palette.grey[600],
             },
             '& .DocSearch-Hit': {
-              paddingBottom: 0,
+              paddingBottom: 8,
               '&:not(:first-of-type)': {
                 marginTop: -1,
               },
+              '& .DocSearch-Hit-Container': {
+                height: '52px',
+              },
             },
             '& .DocSearch-Hit a': {
-              backgroundColor: 'transparent',
               padding: theme.spacing(0.25, 0),
               paddingLeft: theme.spacing(2),
               border: '1px solid transparent',
-              borderBottomColor: (theme.vars || theme).palette.grey[100],
+              borderRadius: theme.shape.borderRadius,
+              backgroundColor: alpha(theme.palette.grey[50], 0.4),
+              borderColor: alpha(theme.palette.grey[100], 0.5),
             },
             '& .DocSearch-Hit-content-wrapper': {
-              paddingLeft: theme.spacing(2),
+              paddingLeft: theme.spacing(1),
             },
             '& .DocSearch-Hit-title': {
               fontSize: theme.typography.pxToRem(14),
-              color: `${theme.palette.text.primary}`,
+              fontWeight: theme.typography.fontWeightSemiBold,
+              color: (theme.vars || theme).palette.text.primary,
             },
             '& .DocSearch-Hit-path': {
               fontSize: theme.typography.pxToRem(12),
               color: `${theme.palette.text.secondary}`,
             },
+            '& .DocSearch-Hit-icon': {
+              '> svg': {
+                height: '16px',
+                width: '16px',
+                margin: 0,
+              },
+            },
             '& .DocSearch-Hit-Select-Icon': {
-              height: '15px',
-              width: '15px',
+              height: '14px',
+              width: '14px',
             },
             '& .DocSearch-Hit[aria-selected="true"] a': {
               backgroundColor: (theme.vars || theme).palette.primary[50],
-              borderColor: (theme.vars || theme).palette.primary[500],
-              borderRadius: theme.shape.borderRadius,
+              borderColor: (theme.vars || theme).palette.primary[300],
             },
             '& .DocSearch-Hit-action, & .DocSearch-Hits mark': {
               color: (theme.vars || theme).palette.primary[500],

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -6,13 +6,24 @@ import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { DocSearchModal, useDocSearchKeyboardEvents } from '@docsearch/react';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import ArticleRoundedIcon from '@mui/icons-material/ArticleRounded';
 import ToggleOffRoundedIcon from '@mui/icons-material/ToggleOffRounded';
 import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import HandymanRoundedIcon from '@mui/icons-material/HandymanRounded';
 import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
 import SearchIcon from '@mui/icons-material/Search';
+
+import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
+import StickyNote2RoundedIcon from '@mui/icons-material/StickyNote2Rounded';
+import SmartButtonRoundedIcon from '@mui/icons-material/SmartButtonRounded';
+import IntegrationInstructionsRoundedIcon from '@mui/icons-material/IntegrationInstructionsRounded';
+import DesignServicesRoundedIcon from '@mui/icons-material/DesignServicesRounded';
+import CopyrightRoundedIcon from '@mui/icons-material/CopyrightRounded';
+import CollectionsBookmarkRoundedIcon from '@mui/icons-material/CollectionsBookmarkRounded';
+import LibraryBooksRoundedIcon from '@mui/icons-material/LibraryBooksRounded';
+import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
+import ChecklistRoundedIcon from '@mui/icons-material/ChecklistRounded';
+
 import GlobalStyles from '@mui/material/GlobalStyles';
 import { alpha, styled } from '@mui/material/styles';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
@@ -98,58 +109,136 @@ function NewStartScreen() {
   const startScreenOptions = [
     {
       category: {
-        name: 'Getting started',
-        icon: <ArticleRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        name: 'Material UI',
       },
       items: [
         {
           name: 'Installation',
           href: '/material-ui/getting-started/installation/',
-          icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+          icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Available components',
+          href: '/material-ui/getting-started/supported-components/',
+          icon: <SmartButtonRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Example projects',
+          href: '/material-ui/getting-started/example-projects/',
+          icon: <LibraryBooksRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Templates',
+          href: '/material-ui/getting-started/templates/',
+          icon: <CollectionsBookmarkRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+      ],
+    },
+    {
+      category: {
+        name: 'Base UI',
+      },
+      items: [
+        {
+          name: 'Quickstart',
+          href: '/base-ui/getting-started/quickstart/',
+          icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Available components',
+          href: '/base-ui/all-components/',
+          icon: <SmartButtonRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Customization',
+          href: '/base-ui/getting-started/customization/',
+          icon: <DesignServicesRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+      ],
+    },
+    {
+      category: {
+        name: 'Joy UI',
+      },
+      items: [
+        {
+          name: 'Installation',
+          href: '/joy-ui/getting-started/installation/',
+          icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Templates',
+          href: '/joy-ui/getting-started/templates/',
+          icon: <CollectionsBookmarkRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Customization',
+          href: '/joy-ui/customization/approaches/',
+          icon: <DesignServicesRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+      ],
+    },
+    {
+      category: {
+        name: 'MUI X',
+      },
+      items: [
+        {
+          name: 'Overview',
+          href: '/x/introduction/',
+          icon: <StickyNote2RoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Licensing',
+          href: '/x/introduction/licensing/',
+          icon: <CopyrightRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+      ],
+    },
+    {
+      category: {
+        name: 'MUI Toolpad',
+      },
+      items: [
+        {
+          name: 'Overview',
+          href: '/toolpad/getting-started/overview/',
+          icon: <StickyNote2RoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Why Toolpad?',
+          href: '/toolpad/getting-started/why-toolpad/',
+          icon: <ChecklistRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+        {
+          name: 'Example applications',
+          href: '/toolpad/examples/',
+          icon: <LibraryBooksRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+        },
+      ],
+    },
+    {
+      category: {
+        name: 'MUI System',
+      },
+      items: [
+        {
+          name: 'Overview',
+          href: '/system/getting-started/',
+          icon: <StickyNote2RoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
         {
           name: 'Usage',
-          href: '/material-ui/getting-started/usage/',
-          icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+          href: '/system/getting-started/usage/',
+          icon: (
+            <IntegrationInstructionsRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />
+          ),
         },
         {
-          name: 'Learn',
-          href: '/material-ui/getting-started/learn/',
-          icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
+          name: 'The sx prop',
+          href: '/system/getting-started/the-sx-prop/',
+          icon: <SettingsRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
-      ],
-    },
-    {
-      category: {
-        name: 'Popular searches',
-        icon: <ToggleOffRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
-      },
-      items: [
-        { name: 'Material Icons', href: '/material-ui/material-icons/' },
-        { name: 'Text Field', href: '/material-ui/react-text-field/' },
-        { name: 'Button', href: '/material-ui/react-button/' },
-      ],
-    },
-    {
-      category: {
-        name: 'Customization',
-        icon: <EditRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
-      },
-      items: [
-        { name: 'How to customize', href: '/material-ui/customization/how-to-customize/' },
-        { name: 'Theming', href: '/material-ui/customization/theming/' },
-        { name: 'Default theme', href: '/material-ui/customization/default-theme/' },
-      ],
-    },
-    {
-      category: {
-        name: 'System',
-        icon: <HandymanRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
-      },
-      items: [
-        { name: 'Overview', href: '/system/getting-started/' },
-        { name: 'Properties', href: '/system/properties/' },
-        { name: 'The sx prop', href: '/system/getting-started/the-sx-prop/' },
       ],
     },
   ];
@@ -162,7 +251,6 @@ function NewStartScreen() {
             <NextLink key={name} href={href} className="DocSearch-NewStartScreenItem">
               {icon}
               {name}
-              <KeyboardArrowRightRounded className="DocSearch-NewStartScreenItemIcon" />
             </NextLink>
           ))}
         </div>
@@ -316,7 +404,7 @@ export default function AppSearch(props) {
     return () => {};
   }, [isOpen]);
 
-  const search = `${t('algoliaSearch')}…`;
+  const search = `${t('algoliaSearch')}`;
 
   const optionalFilters = [];
   if (pageContext.productId !== 'null') {
@@ -456,6 +544,7 @@ export default function AppSearch(props) {
             '& .DocSearch-NewStartScreenTitleIcon': {
               color: (theme.vars || theme).palette.primary[500],
               marginRight: theme.spacing(1),
+              opacity: 0.8,
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',
@@ -486,7 +575,7 @@ export default function AppSearch(props) {
             '& .DocSearch-NewStartScreenItemIcon': {
               fontSize: theme.typography.pxToRem(16),
               marginLeft: theme.spacing(0.5),
-              transition: 'margin 0.2s',
+              opacity: 0.5,
             },
             '& .DocSearch-Modal': {
               // docsearch.css: <= 750px will be full screen modal

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -114,7 +114,7 @@ function NewStartScreen() {
           icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
         {
-          name: 'Available components',
+          name: 'Components',
           href: '/material-ui/getting-started/supported-components/',
           icon: <SmartButtonRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
@@ -141,7 +141,7 @@ function NewStartScreen() {
           icon: <DownloadRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },
         {
-          name: 'Available components',
+          name: 'Components',
           href: '/base-ui/all-components/',
           icon: <SmartButtonRoundedIcon className="DocSearch-NewStartScreenTitleIcon" />,
         },

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -397,8 +397,6 @@ export default function AppSearch(props) {
     return () => {};
   }, [isOpen]);
 
-  const search = `${t('algoliaSearch')}`;
-
   const optionalFilters = [];
   if (pageContext.productId !== 'null') {
     optionalFilters.push(`productId:${pageContext.productId}`);
@@ -423,7 +421,7 @@ export default function AppSearch(props) {
             }),
           })}
         />
-        <SearchLabel id="app-search-label">{search}</SearchLabel>
+        <SearchLabel id="app-search-label">{t('searchButton')}</SearchLabel>
         <Shortcut aria-hidden="true">
           {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
           {macOS ? '⌘' : 'Ctrl+'}K
@@ -458,7 +456,7 @@ export default function AppSearch(props) {
               analyticsTags: [facetFilterLanguage, `product:${pageContext.productId}`],
               hitsPerPage: 40,
             }}
-            placeholder={search}
+            placeholder={`${t('algoliaSearch')}`}
             transformItems={(items) => {
               return items.map((item) => {
                 // `url` contains the domain
@@ -678,8 +676,8 @@ export default function AppSearch(props) {
               color: (theme.vars || theme).palette.text.primary,
             },
             '& .DocSearch-Hit-path': {
-              display: 'flex',
-              gap: theme.spacing(1),
+              // display: 'flex',
+              // gap: theme.spacing(1),
               fontSize: theme.typography.pxToRem(12),
               color: (theme.vars || theme).palette.text.secondary,
             },
@@ -699,7 +697,7 @@ export default function AppSearch(props) {
               borderColor: (theme.vars || theme).palette.primary[300],
             },
             '& .DocSearch-Hit-action, & .DocSearch-Hits mark': {
-              display: 'flex',
+              // display: 'flex',
               color: (theme.vars || theme).palette.primary[500],
               '& .DocSearch-Hit-action-button': {
                 display: 'flex',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -250,7 +250,10 @@ function NewStartScreen() {
   ];
   return (
     <React.Fragment>
-      <p className="DocSearch-NewStartScreenHeader">{t('algoliaSearchHeader')}</p>
+      <p className="DocSearch-NewStartScreenHeader">
+        {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
+        {'Quick links'}
+      </p>
       <div className="DocSearch-NewStartScreen">
         {startScreenOptions.map(({ category, items }) => (
           <div key={category.name} className="DocSearch-NewStartScreenCategory">

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -537,7 +537,7 @@ export default function AppSearch(props) {
             '& .DocSearch-NewStartScreenTitle': {
               display: 'flex',
               alignItems: 'center',
-              padding: theme.spacing(0, 3, 1.5, 2),
+              padding: theme.spacing(2, 3, 1.5, 2),
               fontSize: theme.typography.pxToRem(11),
               fontWeight: theme.typography.fontWeightBold,
               textTransform: 'uppercase',

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -63,6 +63,7 @@
   "albumTitle": "Album",
   "searchButton": "Search…",
   "algoliaSearch": "What are you looking for?",
+  "algoliaSearchHeader": "Quick links",
   "appFrame": {
     "changeLanguage": "Change language",
     "github": "GitHub repository",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -63,7 +63,6 @@
   "albumTitle": "Album",
   "searchButton": "Search…",
   "algoliaSearch": "What are you looking for?",
-  "algoliaSearchHeader": "Quick links",
   "appFrame": {
     "changeLanguage": "Change language",
     "github": "GitHub repository",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -61,6 +61,7 @@
   },
   "albumDescr": "A responsive album / gallery page layout with a hero unit and footer.",
   "albumTitle": "Album",
+  "searchButton": "Search…",
   "algoliaSearch": "What are you looking for?",
   "appFrame": {
     "changeLanguage": "Change language",

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -61,7 +61,7 @@
   },
   "albumDescr": "A responsive album / gallery page layout with a hero unit and footer.",
   "albumTitle": "Album",
-  "algoliaSearch": "Search",
+  "algoliaSearch": "What are you looking for?",
   "appFrame": {
     "changeLanguage": "Change language",
     "github": "GitHub repository",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adds several design adjustments to the Algolia search modal. Felt like it needed a little bit of a revision there, mainly as it was sort of broken in dark mode with the low background opacity. Ended up also taking advantage of the opportunity to refresh the default content list, displaying stuff about every MUI product as opposed to just Material UI-focused ones.

https://deploy-preview-40186--material-ui.netlify.app/ — And, here are visual diffs for an easier grasp of the changes:

| Before | After |
|--------|--------|
| <img width="901" alt="Screen Shot 2023-12-12 at 10 24 40" src="https://github.com/mui/material-ui/assets/67129314/d5f17b2d-cd7d-4a2b-bbbe-1603387473ec"> | <img width="901" alt="Screen Shot 2023-12-12 at 10 24 43" src="https://github.com/mui/material-ui/assets/67129314/bf19e660-3b8a-4d9e-917e-58f45e45ad6a"> | 
| <img width="901" alt="Screen Shot 2023-12-12 at 10 24 51" src="https://github.com/mui/material-ui/assets/67129314/513e82a3-6930-4bc1-891b-650b70cd626a"> | <img width="901" alt="Screen Shot 2023-12-12 at 10 25 34" src="https://github.com/mui/material-ui/assets/67129314/273da28c-244e-4ffe-a111-cbfcdde9110f"> | 





