### PR TITLE
[material-ui][docs] Add details on appropriate usage to component demo pages

### DIFF
--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -10,6 +10,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 
 <p class="description">An alert displays a short, important message in a way that attracts the user's attention without interrupting the user's task.</p>
 
+An Alert is designed for immediate attention and user interaction. It is perfect for displaying critical information that requires user acknowledgement. Alerts are disruptive and should be used sparingly to capture the user's focus when important actions or updates occur, such as form submission success or error alerts. For less intrusive notifications, consider using Snackbar or Dialogs.
+
 :::info
 This component is not documented in the [Material Design guidelines](https://m2.material.io/), but it is available in Material UI.
 :::

--- a/docs/data/material/components/avatars/avatars.md
+++ b/docs/data/material/components/avatars/avatars.md
@@ -9,6 +9,11 @@ githubLabel: 'component: avatar'
 
 <p class="description">Avatars are found throughout material design with uses in everything from tables to dialog menus.</p>
 
+Avatars are a flexible component that can be used for a wide range of applications, from
+displaying user profile images to representing text or icons in a UI. They also offer
+features like styling variants, handling image loading errors, and work well alongside
+groups and badges to enhance the user interface.
+
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Image avatars

--- a/docs/data/material/components/badges/badges.md
+++ b/docs/data/material/components/badges/badges.md
@@ -10,6 +10,8 @@ unstyled: /base-ui/react-badge/
 
 <p class="description">Badge generates a small badge to the top-right of its child(ren).</p>
 
+Badges are useful for various purposes, such as indicating notifications, counts, or changes in an application's user interface. This helps provide a visual feedback indicating change in the application.
+
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 
 ## Basic badge

--- a/docs/data/material/components/dialogs/dialogs.md
+++ b/docs/data/material/components/dialogs/dialogs.md
@@ -13,7 +13,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 A Dialog is a type of [modal](/material-ui/react-modal/) window that appears in front of app content to provide critical information or ask for a decision. Dialogs disable all app functionality when they appear, and remain on screen until confirmed, dismissed, or a required action has been taken.
 
-Dialogs are purposefully interruptive, so they should be used sparingly.
+Dialogs are perfect for scenarios where you need the user's input, confirmation, or a detailed display of information. They are useful when you want to temporarily block the main application flow to address critical actions, such as confirming a deletion. While Dialogs offer more flexibility and interaction, they are generally heavier than Snackbars and are purposefully interruptive, so they should be used sparingly.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 

--- a/docs/data/material/components/snackbars/snackbars.md
+++ b/docs/data/material/components/snackbars/snackbars.md
@@ -14,7 +14,8 @@ waiAria: https://www.w3.org/TR/wai-aria-1.1/#alert
 Snackbars inform users of a process that an app has performed or will perform. They appear temporarily, towards the bottom of the screen. They shouldn't interrupt the user experience, and they don't require user input to disappear.
 
 Snackbars contain a single line of text directly related to the operation performed.
-They may contain a text action, but no icons. You can use them to display notifications.
+They may contain a text action, but no icons. You can use them to display notifications like success or warning messages.
+Due to the non-intrusive nature of Snackbars, for more urgent or interactive messages, use the Alert or Dialog components.
 
 {{"component": "modules/components/ComponentLinkHeader.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Part of #39735

Added some documentation that may help clarify when a specific component is more useful than another similar one. For example Alert vs Snackbar.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
