### PR TITLE
[styled-engine-sc] Fix `theme` being of type any

### DIFF
--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -257,17 +257,11 @@ export interface ThemedStyledFunctionBase<
 > {
   (first: TemplateStringsArray): StyledComponent<C, T, O, A>;
   (
-    first:
-      | TemplateStringsArray
-      | CSSObject
-      | InterpolationFunction<ThemedStyledProps<O, T>>,
+    first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<O, T>>,
     ...rest: Array<Interpolation<ThemedStyledProps<O, T>>>
   ): StyledComponent<C, T, O, A>;
   <U extends object>(
-    first:
-      | TemplateStringsArray
-      | CSSObject
-      | InterpolationFunction<ThemedStyledProps<O & U, T>>,
+    first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<O & U, T>>,
     ...rest: Array<Interpolation<ThemedStyledProps<O & U, T>>>
   ): StyledComponent<C, T, O & U, A>;
 }

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -244,9 +244,7 @@ type ThemedStyledComponentFactories<T extends object> = {
 
 export type StyledComponentPropsWithRef<
   C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
-> = C extends AnyStyledComponent
-  ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
-  : React.ComponentPropsWithRef<C>;
+> = React.ComponentPropsWithRef<C>;
 
 // Same as in styled-components, but copied here so that it would use the Interpolation & CSS typings from above
 export interface ThemedStyledFunctionBase<
@@ -257,12 +255,18 @@ export interface ThemedStyledFunctionBase<
 > {
   (first: TemplateStringsArray): StyledComponent<C, T, O, A>;
   (
-    first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<O, T>>,
-    ...rest: Array<Interpolation<ThemedStyledProps<O, T>>>
+    first:
+      | TemplateStringsArray
+      | CSSObject
+      | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>,
+    ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>>
   ): StyledComponent<C, T, O, A>;
   <U extends object>(
-    first: TemplateStringsArray | CSSObject | InterpolationFunction<ThemedStyledProps<O & U, T>>,
-    ...rest: Array<Interpolation<ThemedStyledProps<O & U, T>>>
+    first:
+      | TemplateStringsArray
+      | CSSObject
+      | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>,
+    ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>>
   ): StyledComponent<C, T, O & U, A>;
 }
 
@@ -286,32 +290,85 @@ export interface StyledConfig<O extends object = {}> {
   // TODO: Add all types from the original StyledComponentWrapperProperties
   componentId?: string;
   displayName?: string;
+  label?: string;
+  target?: string;
   shouldForwardProp?:
     | ((prop: keyof O, defaultValidatorFn: (prop: keyof O) => boolean) => boolean)
     | undefined;
+}
+
+/** Same as StyledConfig but shouldForwardProp must be a type guard */
+export interface FilteringStyledOptions<Props, ForwardedProps extends keyof Props = keyof Props> {
+  componentId?: string;
+  displayName?: string;
+  label?: string;
+  shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps;
+  target?: string;
 }
 
 // same as ThemedBaseStyledInterface in styled-components, but with added options & common props for MUI components
 export interface ThemedBaseStyledInterface<
   MUIStyledCommonProps extends object,
   MuiStyledOptions extends object,
-  T extends object,
-> extends ThemedStyledComponentFactories<T> {
-  <C extends AnyStyledComponent>(
+  Theme extends object,
+> extends ThemedStyledComponentFactories<Theme> {
+  <
+    C extends React.ComponentClass<React.ComponentProps<C>>,
+    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
+  >(
     component: C,
-    options?: StyledConfig<any> & MuiStyledOptions,
-  ): ThemedStyledFunction<
-    StyledComponentInnerComponent<C>,
-    T,
-    StyledComponentInnerOtherProps<C> & MUIStyledCommonProps,
-    StyledComponentInnerAttrs<C>
+    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
+  ): CreateStyledComponent<
+    Pick<PropsOf<C>, ForwardedProps> & MUIStyledCommonProps,
+    {},
+    {
+      ref?: React.Ref<InstanceType<C>>;
+    },
+    Theme
   >;
-  <C extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
-    // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
-    // causes tests to fail in TS 3.1
+
+  <C extends React.ComponentClass<React.ComponentProps<C>>>(
     component: C,
-    options?: StyledConfig<any> & MuiStyledOptions,
-  ): ThemedStyledFunction<C, T, MUIStyledCommonProps>;
+    options?: StyledConfig<PropsOf<C> & MUIStyledCommonProps> & MuiStyledOptions,
+  ): CreateStyledComponent<
+    PropsOf<C> & MUIStyledCommonProps,
+    {},
+    {
+      ref?: React.Ref<InstanceType<C>>;
+    },
+    Theme
+  >;
+
+  <
+    C extends React.JSXElementConstructor<React.ComponentProps<C>>,
+    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>,
+  >(
+    component: C,
+    options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps> & MuiStyledOptions,
+  ): CreateStyledComponent<Pick<PropsOf<C>, ForwardedProps> & MUIStyledCommonProps, {}, {}, Theme>;
+
+  <C extends React.JSXElementConstructor<React.ComponentProps<C>>>(
+    component: C,
+    options?: StyledConfig<PropsOf<C> & MUIStyledCommonProps> & MuiStyledOptions,
+  ): CreateStyledComponent<PropsOf<C> & MUIStyledCommonProps, {}, {}, Theme>;
+
+  <
+    Tag extends keyof JSX.IntrinsicElements,
+    ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
+  >(
+    tag: Tag,
+    options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
+  ): CreateStyledComponent<
+    MUIStyledCommonProps,
+    Pick<JSX.IntrinsicElements[Tag], ForwardedProps>,
+    {},
+    Theme
+  >;
+
+  <Tag extends keyof JSX.IntrinsicElements>(
+    tag: Tag,
+    options?: StyledConfig<MUIStyledCommonProps> & MuiStyledOptions,
+  ): CreateStyledComponent<MUIStyledCommonProps, JSX.IntrinsicElements[Tag], {}, Theme>;
 }
 
 export type CreateMUIStyled<

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -245,8 +245,8 @@ type ThemedStyledComponentFactories<T extends object> = {
 export type StyledComponentPropsWithRef<
   C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
 > = C extends AnyStyledComponent
-? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
-: React.ComponentPropsWithRef<C>;
+  ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
+  : React.ComponentPropsWithRef<C>;
 
 // Same as in styled-components, but copied here so that it would use the Interpolation & CSS typings from above
 export interface ThemedStyledFunctionBase<

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -244,7 +244,9 @@ type ThemedStyledComponentFactories<T extends object> = {
 
 export type StyledComponentPropsWithRef<
   C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
-> = React.ComponentPropsWithRef<C>;
+> = C extends AnyStyledComponent
+? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
+: React.ComponentPropsWithRef<C>;
 
 // Same as in styled-components, but copied here so that it would use the Interpolation & CSS typings from above
 export interface ThemedStyledFunctionBase<

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -108,7 +108,7 @@ export interface CSSObject
     Omit<CSSOthersObject, 'variants'> {}
 
 interface CSSObjectWithVariants<Props> extends Omit<CSSObject, 'variants'> {
-  variants: Array<{ props: Props; variants: CSSObject }>;
+  variants?: Array<{ props: Props; variants: CSSObject }>;
 }
 
 export type FalseyValue = undefined | null | false;

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -108,7 +108,7 @@ export interface CSSObject
     Omit<CSSOthersObject, 'variants'> {}
 
 interface CSSObjectWithVariants<Props> extends Omit<CSSObject, 'variants'> {
-  variants?: Array<{ props: Props; variants: CSSObject }>;
+  variants: Array<{ props: Props; variants: CSSObject }>;
 }
 
 export type FalseyValue = undefined | null | false;
@@ -260,15 +260,15 @@ export interface ThemedStyledFunctionBase<
     first:
       | TemplateStringsArray
       | CSSObject
-      | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>,
-    ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>>>
+      | InterpolationFunction<ThemedStyledProps<O, T>>,
+    ...rest: Array<Interpolation<ThemedStyledProps<O, T>>>
   ): StyledComponent<C, T, O, A>;
   <U extends object>(
     first:
       | TemplateStringsArray
       | CSSObject
-      | InterpolationFunction<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>,
-    ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>>
+      | InterpolationFunction<ThemedStyledProps<O & U, T>>,
+    ...rest: Array<Interpolation<ThemedStyledProps<O & U, T>>>
   ): StyledComponent<C, T, O & U, A>;
 }
 

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -62,7 +62,7 @@ export interface CSSObject
     Omit<CSSOthersObject, 'variants'> {}
 
 interface CSSObjectWithVariants<Props> extends Omit<CSSObject, 'variants'> {
-  variants?: Array<{ props: Props; variants: CSSObject }>;
+  variants: Array<{ props: Props; variants: CSSObject }>;
 }
 
 export interface ComponentSelector {

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -62,7 +62,7 @@ export interface CSSObject
     Omit<CSSOthersObject, 'variants'> {}
 
 interface CSSObjectWithVariants<Props> extends Omit<CSSObject, 'variants'> {
-  variants: Array<{ props: Props; variants: CSSObject }>;
+  variants?: Array<{ props: Props; variants: CSSObject }>;
 }
 
 export interface ComponentSelector {


### PR DESCRIPTION
Repository for testing the changes: https://github.com/mnajdova/mui-styled-engine-sc-theme-type

Check the theme type in the three use-cases in App.tsx.

Fixes https://github.com/mui/material-ui/issues/39783. The types were taken and adopted from @mui/styled-engine.