### PR TITLE
[material-ui][docs] Fix typo in the Next.js integration page

### DIFF
--- a/docs/data/material/guides/nextjs/nextjs.md
+++ b/docs/data/material/guides/nextjs/nextjs.md
@@ -6,7 +6,7 @@
 
 This section walks through the Material UI integration with the Next.js [App Router](https://nextjs.org/docs/app), an evolution of the [Pages Router](#pages-router), and, currently, the recommended way of building new Next.js applications starting from version 13.
 
-### Intalling the dependencies
+### Installing the dependencies
 
 Start by ensuring that you already have `@mui/material` and `next` installed.
 Then, run one of the following commands to install the dependencies:


### PR DESCRIPTION
change intalling to installing

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
