### PR TITLE
[material-ui][docs] Update the related projects page to list `mui-tiptap` for rich text

### DIFF
--- a/docs/data/material/discover-more/related-projects/related-projects.md
+++ b/docs/data/material/discover-more/related-projects/related-projects.md
@@ -55,7 +55,7 @@ Feel free to submit a pull request!
 
 ### Rich text
 
-- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap): A customizable Material UI styled WYSIWYG rich text editor, using [Tiptap](https://tiptap.dev/).
+- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap): A customizable Material UI-styled WYSIWYG (What You See Is What You Get) rich text editor, using [Tiptap](https://tiptap.dev/).
 
 ### Sparkline
 

--- a/docs/data/material/discover-more/related-projects/related-projects.md
+++ b/docs/data/material/discover-more/related-projects/related-projects.md
@@ -53,6 +53,10 @@ Feel free to submit a pull request!
 - [mui-color-input](https://github.com/viclafouch/mui-color-input): A color input designed for use with Material UI, built with [TinyColor](https://tinycolor.vercel.app/).
 - [material-ui-color](https://github.com/mikbry/material-ui-color): Collections of color components for Material UI. No dependencies, small, highly customizable, and supports theming.
 
+### Rich text
+
+- [mui-tiptap](https://github.com/sjdemartini/mui-tiptap): A customizable Material UI styled WYSIWYG rich text editor, using [Tiptap](https://tiptap.dev/).
+
 ### Sparkline
 
 - [mui-plus](https://mui-plus.vercel.app/components/Sparkline): A sparkline is a tiny chart that can be used to indicate the trend of a value.


### PR DESCRIPTION
As suggested by @oliviertassinari in https://github.com/sjdemartini/mui-tiptap/pull/81#issue-1781366193, this proposes adding a link to [mui-tiptap](https://github.com/sjdemartini/mui-tiptap) as a rich text option in the Material UI docs on related project components. (I noticed we recently crossed 100 stars :D )

Thanks in advance for considering, and for the work you all do maintaining such a valuable component library!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
