### PR TITLE
[joy-ui][Checkbox] fix text-align problem in RTL for  Checkbox.tsx

### DIFF
--- a/packages/mui-joy/src/Checkbox/Checkbox.tsx
+++ b/packages/mui-joy/src/Checkbox/Checkbox.tsx
@@ -145,7 +145,7 @@ const CheckboxAction = styled('span', {
     borderRadius: `var(--Checkbox-actionRadius, ${
       ownerState.overlay ? 'var(--unstable_actionRadius, inherit)' : 'inherit'
     })`,
-    textAlign: 'left', // prevent text-align inheritance
+    textAlign: 'start', // prevent text-align inheritance
     position: 'absolute',
     top: 'calc(-1 * var(--variant-borderWidth, 0px))', // clickable on the border and focus outline does not move when checked/unchecked
     left: 'calc(-1 * var(--variant-borderWidth, 0px))',


### PR DESCRIPTION
using the normal property : text-align: left for checkbox in RTL direction will cause the following problem : https://i.imgur.com/fWf6KQm.gif

solution: use a logical property instead 
text-align : left ❌
text-align : start ✔ 

note: the same problem happens to radio buttons

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
