### PR TITLE
[joy-ui][Typography] Allow `dangerouslySetInnerHTML`

### DIFF
--- a/packages/mui-joy/src/Typography/Typography.tsx
+++ b/packages/mui-joy/src/Typography/Typography.tsx
@@ -234,9 +234,12 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
     ownerState,
   });
 
-  return (
-    <TypographyNestedContext.Provider value>
-      <SlotRoot {...rootProps}>
+  const renderResult = (() => {
+    if (rootProps.dangerouslySetInnerHTML) {
+      return undefined;
+    }
+    return (
+      <>
         {startDecorator && (
           <SlotStartDecorator {...startDecoratorProps}>{startDecorator}</SlotStartDecorator>
         )}
@@ -247,7 +250,13 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
             })
           : children}
         {endDecorator && <SlotEndDecorator {...endDecoratorProps}>{endDecorator}</SlotEndDecorator>}
-      </SlotRoot>
+      </>
+    );
+  })();
+
+  return (
+    <TypographyNestedContext.Provider value>
+      <SlotRoot {...rootProps}>{renderResult}</SlotRoot>
     </TypographyNestedContext.Provider>
   );
 }) as OverridableComponent<TypographyTypeMap>;


### PR DESCRIPTION
Resolves #40058

important questions are:
- is this (iife) how it is done most often here?
- do we want a more specific check (like `=== undefined`), 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
