### PR TITLE
[POC][material-ui] SelectField POC

### DIFF
--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -1,7 +1,7 @@
 ---
 productId: material-ui
 title: React Text Field component
-components: FilledInput, FormControl, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField
+components: FilledInput, FormControl, FormHelperText, Input, InputAdornment, InputBase, InputLabel, OutlinedInput, TextField, SelectField
 githubLabel: 'component: text field'
 materialDesign: https://m2.material.io/components/text-fields
 unstyled: /base-ui/react-input/

--- a/docs/data/material/pagesApi.js
+++ b/docs/data/material/pagesApi.js
@@ -87,6 +87,7 @@ module.exports = [
   { pathname: '/material-ui/api/rating' },
   { pathname: '/material-ui/api/scoped-css-baseline' },
   { pathname: '/material-ui/api/select' },
+  { pathname: '/material-ui/api/select-field' },
   { pathname: '/material-ui/api/skeleton' },
   { pathname: '/material-ui/api/slide' },
   { pathname: '/material-ui/api/slider' },

--- a/docs/pages/material-ui/api/select-field.js
+++ b/docs/pages/material-ui/api/select-field.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import ApiPage from 'docs/src/modules/components/ApiPage';
+import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
+import jsonPageContent from './select-field.json';
+
+export default function Page(props) {
+  const { descriptions, pageContent } = props;
+  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+}
+
+Page.getInitialProps = () => {
+  const req = require.context(
+    'docs/translations/api-docs/select-field',
+    false,
+    /select-field.*.json$/,
+  );
+  const descriptions = mapApiPageTranslations(req);
+
+  return {
+    descriptions,
+    pageContent: jsonPageContent,
+  };
+};

--- a/docs/pages/material-ui/api/select-field.json
+++ b/docs/pages/material-ui/api/select-field.json
@@ -1,0 +1,89 @@
+{
+  "props": {
+    "autoComplete": { "type": { "name": "string" } },
+    "autoFocus": { "type": { "name": "bool" }, "default": "false" },
+    "classes": { "type": { "name": "object" }, "additionalInfo": { "cssApi": true } },
+    "color": {
+      "type": {
+        "name": "union",
+        "description": "'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'error'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;string"
+      },
+      "default": "'primary'"
+    },
+    "defaultValue": { "type": { "name": "any" } },
+    "disabled": { "type": { "name": "bool" }, "default": "false" },
+    "error": { "type": { "name": "bool" }, "default": "false" },
+    "FormHelperTextProps": { "type": { "name": "object" } },
+    "fullWidth": { "type": { "name": "bool" }, "default": "false" },
+    "helperText": { "type": { "name": "node" } },
+    "id": { "type": { "name": "string" } },
+    "InputLabelProps": { "type": { "name": "object" } },
+    "inputProps": { "type": { "name": "object" } },
+    "InputProps": { "type": { "name": "object" } },
+    "inputRef": { "type": { "name": "custom", "description": "ref" } },
+    "label": { "type": { "name": "node" } },
+    "margin": {
+      "type": {
+        "name": "enum",
+        "description": "'dense'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'"
+      },
+      "default": "'none'"
+    },
+    "maxRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
+    "minRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
+    "multiline": { "type": { "name": "bool" }, "default": "false" },
+    "name": { "type": { "name": "string" } },
+    "onChange": {
+      "type": { "name": "func" },
+      "signature": { "type": "function(event: object) => void", "describedArgs": ["event"] }
+    },
+    "placeholder": { "type": { "name": "string" } },
+    "required": { "type": { "name": "bool" }, "default": "false" },
+    "rows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
+    "select": { "type": { "name": "bool" }, "default": "false" },
+    "SelectProps": { "type": { "name": "object" } },
+    "size": {
+      "type": {
+        "name": "union",
+        "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
+      }
+    },
+    "sx": {
+      "type": {
+        "name": "union",
+        "description": "Array&lt;func<br>&#124;&nbsp;object<br>&#124;&nbsp;bool&gt;<br>&#124;&nbsp;func<br>&#124;&nbsp;object"
+      },
+      "additionalInfo": { "sx": true }
+    },
+    "type": { "type": { "name": "string" } },
+    "value": { "type": { "name": "any" } },
+    "variant": {
+      "type": {
+        "name": "enum",
+        "description": "'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'"
+      },
+      "default": "'outlined'"
+    }
+  },
+  "name": "SelectField",
+  "imports": [
+    "import SelectField from '@mui/material/SelectField';",
+    "import { SelectField } from '@mui/material';"
+  ],
+  "classes": [
+    {
+      "key": "root",
+      "className": "MuiSelectField-root",
+      "description": "Styles applied to the root element.",
+      "isGlobal": false
+    }
+  ],
+  "spread": true,
+  "themeDefaultProps": true,
+  "muiName": "MuiSelectField",
+  "forwardsRefTo": "HTMLDivElement",
+  "filename": "/packages/mui-material/src/SelectField/SelectField.js",
+  "inheritance": { "component": "FormControl", "pathname": "/material-ui/api/form-control/" },
+  "demos": "<ul><li><a href=\"/material-ui/react-text-field/\">Text Field</a></li></ul>",
+  "cssComponent": false
+}

--- a/docs/pages/material-ui/api/select-field.json
+++ b/docs/pages/material-ui/api/select-field.json
@@ -44,7 +44,7 @@
     "slotProps": {
       "type": {
         "name": "shape",
-        "description": "{ formHelperText?: { root?: object }, input?: { input?: object, root?: object }, inputLabel?: { root?: object }, root?: object, select?: { listbox?: object, popper?: object, root?: object } }"
+        "description": "{ formHelperText?: { root?: object }, input?: { input?: object, root?: object }, inputLabel?: { root?: object }, root?: object, select?: { root?: object } }"
       },
       "default": "{}"
     },

--- a/docs/pages/material-ui/api/select-field.json
+++ b/docs/pages/material-ui/api/select-field.json
@@ -22,13 +22,6 @@
     "InputProps": { "type": { "name": "object" } },
     "inputRef": { "type": { "name": "custom", "description": "ref" } },
     "label": { "type": { "name": "node" } },
-    "margin": {
-      "type": {
-        "name": "enum",
-        "description": "'dense'<br>&#124;&nbsp;'none'<br>&#124;&nbsp;'normal'"
-      },
-      "default": "'none'"
-    },
     "maxRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
     "minRows": { "type": { "name": "union", "description": "number<br>&#124;&nbsp;string" } },
     "multiline": { "type": { "name": "bool" }, "default": "false" },
@@ -47,6 +40,13 @@
         "name": "union",
         "description": "'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;string"
       }
+    },
+    "slotProps": {
+      "type": {
+        "name": "shape",
+        "description": "{ formHelperText?: { root?: object }, input?: { input?: object, root?: object }, inputLabel?: { root?: object }, root?: object, select?: { listbox?: object, popper?: object, root?: object } }"
+      },
+      "default": "{}"
     },
     "sx": {
       "type": {

--- a/docs/translations/api-docs/select-field/select-field.json
+++ b/docs/translations/api-docs/select-field/select-field.json
@@ -67,7 +67,9 @@
       "description": "Props applied to the <a href=\"/material-ui/api/select/\"><code>Select</code></a> element."
     },
     "size": { "description": "The size of the component." },
-    "slotProps": { "description": "slotProps" },
+    "slotProps": {
+      "description": "The extra props for the slot components. You can override the existing props or add new ones."
+    },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     },

--- a/docs/translations/api-docs/select-field/select-field.json
+++ b/docs/translations/api-docs/select-field/select-field.json
@@ -1,0 +1,85 @@
+{
+  "componentDescription": "The `SelectField` is extracted out of `<TextField select />`",
+  "propDescriptions": {
+    "autoComplete": {
+      "description": "This prop helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it&#39;s more like an autofill. You can learn more about it <a href=\"https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill\">following the specification</a>."
+    },
+    "autoFocus": {
+      "description": "If <code>true</code>, the <code>input</code> element is focused during the first mount."
+    },
+    "classes": { "description": "Override or extend the styles applied to the component." },
+    "color": {
+      "description": "The color of the component. It supports both default and custom theme colors, which can be added as shown in the <a href=\"https://mui.com/material-ui/customization/palette/#custom-colors\">palette customization guide</a>."
+    },
+    "defaultValue": {
+      "description": "The default value. Use when the component is not controlled."
+    },
+    "disabled": { "description": "If <code>true</code>, the component is disabled." },
+    "error": { "description": "If <code>true</code>, the label is displayed in an error state." },
+    "FormHelperTextProps": {
+      "description": "Props applied to the <a href=\"/material-ui/api/form-helper-text/\"><code>FormHelperText</code></a> element."
+    },
+    "fullWidth": {
+      "description": "If <code>true</code>, the input will take up the full width of its container."
+    },
+    "helperText": { "description": "The helper text content." },
+    "id": {
+      "description": "The id of the <code>input</code> element. Use this prop to make <code>label</code> and <code>helperText</code> accessible for screen readers."
+    },
+    "InputLabelProps": {
+      "description": "Props applied to the <a href=\"/material-ui/api/input-label/\"><code>InputLabel</code></a> element. Pointer events like <code>onClick</code> are enabled if and only if <code>shrink</code> is <code>true</code>."
+    },
+    "inputProps": {
+      "description": "<a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes\">Attributes</a> applied to the <code>input</code> element."
+    },
+    "InputProps": {
+      "description": "Props applied to the Input element. It will be a <a href=\"/material-ui/api/filled-input/\"><code>FilledInput</code></a>, <a href=\"/material-ui/api/outlined-input/\"><code>OutlinedInput</code></a> or <a href=\"/material-ui/api/input/\"><code>Input</code></a> component depending on the <code>variant</code> prop value."
+    },
+    "inputRef": { "description": "Pass a ref to the <code>input</code> element." },
+    "label": { "description": "The label content." },
+    "margin": {
+      "description": "If <code>dense</code> or <code>normal</code>, will adjust vertical spacing of this and contained components."
+    },
+    "maxRows": {
+      "description": "Maximum number of rows to display when multiline option is set to true."
+    },
+    "minRows": {
+      "description": "Minimum number of rows to display when multiline option is set to true."
+    },
+    "multiline": {
+      "description": "If <code>true</code>, a <code>textarea</code> element is rendered instead of an input."
+    },
+    "name": { "description": "Name attribute of the <code>input</code> element." },
+    "onChange": {
+      "description": "Callback fired when the value is changed.",
+      "typeDescriptions": {
+        "event": "The event source of the callback. You can pull out the new value by accessing <code>event.target.value</code> (string)."
+      }
+    },
+    "placeholder": {
+      "description": "The short hint displayed in the <code>input</code> before the user enters a value."
+    },
+    "required": {
+      "description": "If <code>true</code>, the label is displayed as required and the <code>input</code> element is required."
+    },
+    "rows": { "description": "Number of rows to display when multiline option is set to true." },
+    "select": {
+      "description": "Render a <a href=\"/material-ui/api/select/\"><code>Select</code></a> element while passing the Input element to <code>Select</code> as <code>input</code> parameter. If this option is set you must pass the options of the select as children."
+    },
+    "SelectProps": {
+      "description": "Props applied to the <a href=\"/material-ui/api/select/\"><code>Select</code></a> element."
+    },
+    "size": { "description": "The size of the component." },
+    "sx": {
+      "description": "The system prop that allows defining system overrides as well as additional CSS styles."
+    },
+    "type": {
+      "description": "Type of the <code>input</code> element. It should be <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types\">a valid HTML5 input type</a>."
+    },
+    "value": {
+      "description": "The value of the <code>input</code> element, required for a controlled component."
+    },
+    "variant": { "description": "The variant to use." }
+  },
+  "classDescriptions": { "root": { "description": "Styles applied to the root element." } }
+}

--- a/docs/translations/api-docs/select-field/select-field.json
+++ b/docs/translations/api-docs/select-field/select-field.json
@@ -37,9 +37,6 @@
     },
     "inputRef": { "description": "Pass a ref to the <code>input</code> element." },
     "label": { "description": "The label content." },
-    "margin": {
-      "description": "If <code>dense</code> or <code>normal</code>, will adjust vertical spacing of this and contained components."
-    },
     "maxRows": {
       "description": "Maximum number of rows to display when multiline option is set to true."
     },
@@ -70,6 +67,7 @@
       "description": "Props applied to the <a href=\"/material-ui/api/select/\"><code>Select</code></a> element."
     },
     "size": { "description": "The size of the component." },
+    "slotProps": { "description": "slotProps" },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     },

--- a/packages/mui-material/src/Select/Select.js
+++ b/packages/mui-material/src/Select/Select.js
@@ -91,7 +91,7 @@ const Select = React.forwardRef(function Select(inProps, ref) {
       {React.cloneElement(InputComponent, {
         // Most of the logic is implemented in `SelectInput`.
         // The `Select` component is a simple API wrapper to expose something better to play with.
-        inputComponent,
+        inputComponent, // this is passed to InputBase as the the equivalent of the `component` prop
         inputProps: {
           children,
           error: fcs.error,

--- a/packages/mui-material/src/SelectField/SelectField.d.ts
+++ b/packages/mui-material/src/SelectField/SelectField.d.ts
@@ -158,6 +158,27 @@ export interface BaseSelectFieldProps
    * The value of the `input` element, required for a controlled component.
    */
   value?: unknown;
+  /**
+   * slotProps
+   */
+  slotProps?: {
+    root?: Record<string, unknown>;
+    inputLabel?: {
+      root?: Record<string, unknown>;
+    };
+    select?: {
+      root?: Record<string, unknown>;
+      listbox?: Record<string, unknown>;
+      popper?: Record<string, unknown>;
+    };
+    input?: {
+      root?: Record<string, unknown>;
+      input?: Record<string, unknown>;
+    };
+    formHelperText?: {
+      root?: Record<string, unknown>;
+    };
+  };
 }
 
 export interface StandardSelectFieldProps extends BaseSelectFieldProps {

--- a/packages/mui-material/src/SelectField/SelectField.d.ts
+++ b/packages/mui-material/src/SelectField/SelectField.d.ts
@@ -159,28 +159,6 @@ export interface BaseSelectFieldProps
    * The value of the `input` element, required for a controlled component.
    */
   value?: unknown;
-  /**
-   * slotProps
-   * @default {}
-   */
-  slotProps?: {
-    root?: Record<string, unknown>;
-    inputLabel?: {
-      root?: Record<string, unknown>;
-    };
-    select?: {
-      root?: Record<string, unknown>;
-      listbox?: Record<string, unknown>;
-      popper?: Record<string, unknown>;
-    };
-    input?: {
-      root?: Record<string, unknown>;
-      input?: Record<string, unknown>;
-    };
-    formHelperText?: {
-      root?: Record<string, unknown>;
-    };
-  };
 }
 
 export interface StandardSelectFieldProps extends BaseSelectFieldProps {
@@ -203,6 +181,30 @@ export interface StandardSelectFieldProps extends BaseSelectFieldProps {
    * component depending on the `variant` prop value.
    */
   InputProps?: Partial<StandardInputProps>;
+  /**
+   * The extra props for the slot components.
+   * You can override the existing props or add new ones.
+   *
+   * @default {}
+   */
+  slotProps?: {
+    root?: Partial<BaseSelectFieldProps>;
+    inputLabel?: {
+      root?: Partial<InputLabelProps>;
+    };
+    select?: {
+      root?: Partial<SelectProps>;
+      // listbox?: Record<string, unknown>;
+      // popper?: Record<string, unknown>;
+    };
+    input?: {
+      root?: Partial<StandardInputProps>;
+      input?: InputBaseProps['inputProps'];
+    };
+    formHelperText?: {
+      root?: Partial<FormHelperTextProps>;
+    };
+  };
 }
 
 export interface FilledSelectFieldProps extends BaseSelectFieldProps {
@@ -225,6 +227,30 @@ export interface FilledSelectFieldProps extends BaseSelectFieldProps {
    * component depending on the `variant` prop value.
    */
   InputProps?: Partial<FilledInputProps>;
+  /**
+   * The extra props for the slot components.
+   * You can override the existing props or add new ones.
+   *
+   * @default {}
+   */
+  slotProps?: {
+    root?: Partial<BaseSelectFieldProps>;
+    inputLabel?: {
+      root?: Partial<InputLabelProps>;
+    };
+    select?: {
+      root?: Partial<SelectProps>;
+      // listbox?: Record<string, unknown>;
+      // popper?: Record<string, unknown>;
+    };
+    input?: {
+      root?: Partial<FilledInputProps>;
+      input?: InputBaseProps['inputProps'];
+    };
+    formHelperText?: {
+      root?: Partial<FormHelperTextProps>;
+    };
+  };
 }
 
 export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
@@ -247,6 +273,30 @@ export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
    * component depending on the `variant` prop value.
    */
   InputProps?: Partial<OutlinedInputProps>;
+  /**
+   * The extra props for the slot components.
+   * You can override the existing props or add new ones.
+   *
+   * @default {}
+   */
+  slotProps?: {
+    root?: Partial<BaseSelectFieldProps>;
+    inputLabel?: {
+      root?: Partial<InputLabelProps>;
+    };
+    select?: {
+      root?: Partial<SelectProps>;
+      // listbox?: Record<string, unknown>;
+      // popper?: Record<string, unknown>;
+    };
+    input?: {
+      root?: Partial<OutlinedInputProps>;
+      input?: InputBaseProps['inputProps'];
+    };
+    formHelperText?: {
+      root?: Partial<FormHelperTextProps>;
+    };
+  };
 }
 
 export type SelectFieldProps<Variant extends TextFieldVariants = TextFieldVariants> =

--- a/packages/mui-material/src/SelectField/SelectField.d.ts
+++ b/packages/mui-material/src/SelectField/SelectField.d.ts
@@ -237,6 +237,15 @@ export type SelectFieldProps<Variant extends TextFieldVariants = TextFieldVarian
 
 /**
  * The `SelectField` is extracted out of `<TextField select />`
+ *
+ * Demos:
+ *
+ * - [Text Field](https://mui.com/material-ui/react-text-field/)
+ *
+ * API:
+ *
+ * - [SelectField API](https://mui.com/material-ui/api/select-field/)
+ * - inherits [FormControl API](https://mui.com/material-ui/api/form-control/)
  */
 export default function SelectField<Variant extends TextFieldVariants>(
   props: {

--- a/packages/mui-material/src/SelectField/SelectField.d.ts
+++ b/packages/mui-material/src/SelectField/SelectField.d.ts
@@ -11,6 +11,7 @@ import { OutlinedInputProps } from '../OutlinedInput';
 import { InputLabelProps } from '../InputLabel';
 import { SelectProps } from '../Select';
 import { Theme } from '../styles';
+import { TextFieldVariants } from '../TextField';
 import { SelectFieldClasses } from './selectFieldClasses';
 
 export interface SelectFieldPropsColorOverrides {}
@@ -246,8 +247,6 @@ export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
    */
   InputProps?: Partial<OutlinedInputProps>;
 }
-
-export type TextFieldVariants = 'outlined' | 'standard' | 'filled';
 
 export type SelectFieldProps<Variant extends TextFieldVariants = TextFieldVariants> =
   Variant extends 'filled'

--- a/packages/mui-material/src/SelectField/SelectField.d.ts
+++ b/packages/mui-material/src/SelectField/SelectField.d.ts
@@ -161,6 +161,7 @@ export interface BaseSelectFieldProps
   value?: unknown;
   /**
    * slotProps
+   * @default {}
    */
   slotProps?: {
     root?: Record<string, unknown>;

--- a/packages/mui-material/src/SelectField/SelectField.d.ts
+++ b/packages/mui-material/src/SelectField/SelectField.d.ts
@@ -1,0 +1,249 @@
+import * as React from 'react';
+import { SxProps } from '@mui/system';
+import { OverridableStringUnion } from '@mui/types';
+import { InternalStandardProps as StandardProps } from '..';
+import { FormControlProps } from '../FormControl';
+import { FormHelperTextProps } from '../FormHelperText';
+import { InputBaseProps } from '../InputBase';
+import { InputProps as StandardInputProps } from '../Input';
+import { FilledInputProps } from '../FilledInput';
+import { OutlinedInputProps } from '../OutlinedInput';
+import { InputLabelProps } from '../InputLabel';
+import { SelectProps } from '../Select';
+import { Theme } from '../styles';
+import { SelectFieldClasses } from './selectFieldClasses';
+
+export interface SelectFieldPropsColorOverrides {}
+export interface SelectFieldPropsSizeOverrides {}
+
+export interface BaseSelectFieldProps
+  extends StandardProps<
+    FormControlProps,
+    // event handlers are declared on derived interfaces
+    'onChange' | 'onBlur' | 'onFocus' | 'defaultValue'
+  > {
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete?: string;
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   * @default false
+   */
+  autoFocus?: boolean;
+  /**
+   * @ignore
+   */
+  children?: React.ReactNode;
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: Partial<SelectFieldClasses>;
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'primary'
+   */
+  color?: OverridableStringUnion<
+    'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning',
+    SelectFieldPropsColorOverrides
+  >;
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue?: unknown;
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * If `true`, the label is displayed in an error state.
+   * @default false
+   */
+  error?: boolean;
+  /**
+   * Props applied to the [`FormHelperText`](/material-ui/api/form-helper-text/) element.
+   */
+  FormHelperTextProps?: Partial<FormHelperTextProps>;
+  /**
+   * If `true`, the input will take up the full width of its container.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * The helper text content.
+   */
+  helperText?: React.ReactNode;
+  /**
+   * The id of the `input` element.
+   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   */
+  id?: string;
+  /**
+   * Props applied to the [`InputLabel`](/material-ui/api/input-label/) element.
+   * Pointer events like `onClick` are enabled if and only if `shrink` is `true`.
+   */
+  InputLabelProps?: Partial<InputLabelProps>;
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps?: InputBaseProps['inputProps'];
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef?: React.Ref<any>;
+  /**
+   * The label content.
+   */
+  label?: React.ReactNode;
+  /**
+   * If `true`, a `textarea` element is rendered instead of an input.
+   * @default false
+   */
+  multiline?: boolean;
+  /**
+   * Name attribute of the `input` element.
+   */
+  name?: string;
+  onBlur?: InputBaseProps['onBlur'];
+  onFocus?: StandardInputProps['onFocus'];
+  /**
+   * The short hint displayed in the `input` before the user enters a value.
+   */
+  placeholder?: string;
+  /**
+   * If `true`, the label is displayed as required and the `input` element is required.
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * Number of rows to display when multiline option is set to true.
+   */
+  rows?: string | number;
+  /**
+   * Maximum number of rows to display when multiline option is set to true.
+   */
+  maxRows?: string | number;
+  /**
+   * Minimum number of rows to display when multiline option is set to true.
+   */
+  minRows?: string | number;
+  /**
+   * Render a [`Select`](/material-ui/api/select/) element while passing the Input element to `Select` as `input` parameter.
+   * If this option is set you must pass the options of the select as children.
+   * @default false
+   */
+  select?: boolean;
+  /**
+   * Props applied to the [`Select`](/material-ui/api/select/) element.
+   */
+  SelectProps?: Partial<SelectProps>;
+  /**
+   * The size of the component.
+   */
+  size?: OverridableStringUnion<'small' | 'medium', SelectFieldPropsSizeOverrides>;
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx?: SxProps<Theme>;
+  /**
+   * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
+   */
+  type?: React.InputHTMLAttributes<unknown>['type'];
+  /**
+   * The value of the `input` element, required for a controlled component.
+   */
+  value?: unknown;
+}
+
+export interface StandardSelectFieldProps extends BaseSelectFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: StandardInputProps['onChange'];
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant?: 'standard';
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/material-ui/api/filled-input/),
+   * [`OutlinedInput`](/material-ui/api/outlined-input/) or [`Input`](/material-ui/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps?: Partial<StandardInputProps>;
+}
+
+export interface FilledSelectFieldProps extends BaseSelectFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: FilledInputProps['onChange'];
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: 'filled';
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/material-ui/api/filled-input/),
+   * [`OutlinedInput`](/material-ui/api/outlined-input/) or [`Input`](/material-ui/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps?: Partial<FilledInputProps>;
+}
+
+export interface OutlinedSelectFieldProps extends BaseSelectFieldProps {
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange?: OutlinedInputProps['onChange'];
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: 'outlined';
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/material-ui/api/filled-input/),
+   * [`OutlinedInput`](/material-ui/api/outlined-input/) or [`Input`](/material-ui/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps?: Partial<OutlinedInputProps>;
+}
+
+export type TextFieldVariants = 'outlined' | 'standard' | 'filled';
+
+export type SelectFieldProps<Variant extends TextFieldVariants = TextFieldVariants> =
+  Variant extends 'filled'
+    ? FilledSelectFieldProps
+    : Variant extends 'standard'
+    ? StandardSelectFieldProps
+    : OutlinedSelectFieldProps;
+
+/**
+ * The `SelectField` is extracted out of `<TextField select />`
+ */
+export default function SelectField<Variant extends TextFieldVariants>(
+  props: {
+    /**
+     * The variant to use.
+     * @default 'outlined'
+     */
+    variant?: Variant;
+  } & Omit<SelectFieldProps, 'variant'>,
+): JSX.Element;

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -13,7 +13,7 @@ import InputLabel from '../InputLabel';
 import FormControl from '../FormControl';
 import FormHelperText from '../FormHelperText';
 import Select from '../Select';
-import { getTextFieldUtilityClass } from '../TextField/textFieldClasses';
+import { getSelectFieldUtilityClass } from './selectFieldClasses';
 
 const variantComponent = {
   standard: Input,
@@ -28,7 +28,7 @@ const useUtilityClasses = (ownerState) => {
     root: ['root'],
   };
 
-  return composeClasses(slots, getTextFieldUtilityClass, classes);
+  return composeClasses(slots, getSelectFieldUtilityClass, classes);
 };
 
 const SelectFieldRoot = styled(FormControl, {

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -351,6 +351,27 @@ SelectField.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
+   * slotProps
+   */
+  slotProps: PropTypes.shape({
+    formHelperText: PropTypes.shape({
+      root: PropTypes.object,
+    }),
+    input: PropTypes.shape({
+      input: PropTypes.object,
+      root: PropTypes.object,
+    }),
+    inputLabel: PropTypes.shape({
+      root: PropTypes.object,
+    }),
+    root: PropTypes.object,
+    select: PropTypes.shape({
+      listbox: PropTypes.object,
+      popper: PropTypes.object,
+      root: PropTypes.object,
+    }),
+  }),
+  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -51,13 +51,13 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     defaultValue,
     disabled = false,
     error = false,
-    FormHelperTextProps,
+    FormHelperTextProps: FormHelperTextPropsFromProps,
     fullWidth = false,
     helperText,
     id: idOverride,
-    InputLabelProps,
-    inputProps,
-    InputProps,
+    InputLabelProps: InputLabelPropsFromProps,
+    inputProps: inputPropsFromProps,
+    InputProps: InputPropsFromProps,
     inputRef,
     label,
     maxRows,
@@ -70,10 +70,13 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     placeholder,
     required = false,
     rows,
-    SelectProps,
+    SelectProps: SelectPropsFromProps,
     type,
     value,
     variant = 'outlined',
+    // slots = {},
+    // eslint-disable-next-line react/prop-types
+    slotProps = {},
     ...other
   } = props;
 
@@ -100,6 +103,8 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
 
   const InputMore = {};
 
+  const InputLabelProps = slotProps.inputLabel?.root ?? InputLabelPropsFromProps;
+
   if (variant === 'outlined') {
     if (InputLabelProps && typeof InputLabelProps.shrink !== 'undefined') {
       InputMore.notched = InputLabelProps.shrink;
@@ -107,11 +112,16 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     InputMore.label = label;
   }
 
+  const SelectProps = slotProps.select?.root ?? SelectPropsFromProps;
+
   // unset defaults from textbox inputs
-  if (!SelectProps || !SelectProps.native) {
+  if (!SelectPropsFromProps || !SelectPropsFromProps.native) {
     InputMore.id = undefined;
   }
   InputMore['aria-describedby'] = undefined;
+
+  const InputProps = slotProps.input?.root ?? InputPropsFromProps;
+  const inputProps = slotProps.input?.input ?? inputPropsFromProps;
 
   const id = useId(idOverride);
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
@@ -142,6 +152,8 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
       {...InputProps}
     />
   );
+
+  const FormHelperTextProps = slotProps.formHelperText?.root ?? FormHelperTextPropsFromProps;
 
   return (
     <SelectFieldRoot // slots.root

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -351,7 +351,9 @@ SelectField.propTypes /* remove-proptypes */ = {
     PropTypes.string,
   ]),
   /**
-   * slotProps
+   * The extra props for the slot components.
+   * You can override the existing props or add new ones.
+   *
    * @default {}
    */
   slotProps: PropTypes.shape({
@@ -367,8 +369,6 @@ SelectField.propTypes /* remove-proptypes */ = {
     }),
     root: PropTypes.object,
     select: PropTypes.shape({
-      listbox: PropTypes.object,
-      popper: PropTypes.object,
       root: PropTypes.object,
     }),
   }),

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -289,11 +289,6 @@ SelectField.propTypes /* remove-proptypes */ = {
    */
   label: PropTypes.node,
   /**
-   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
-   * @default 'none'
-   */
-  margin: PropTypes.oneOf(['dense', 'none', 'normal']),
-  /**
    * Maximum number of rows to display when multiline option is set to true.
    */
   maxRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -1,0 +1,370 @@
+'use client';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
+import { refType, unstable_useId as useId } from '@mui/utils';
+import styled from '../styles/styled';
+import useThemeProps from '../styles/useThemeProps';
+import Input from '../Input';
+import FilledInput from '../FilledInput';
+import OutlinedInput from '../OutlinedInput';
+import InputLabel from '../InputLabel';
+import FormControl from '../FormControl';
+import FormHelperText from '../FormHelperText';
+import Select from '../Select';
+import { getTextFieldUtilityClass } from '../TextField/textFieldClasses';
+
+const variantComponent = {
+  standard: Input,
+  filled: FilledInput,
+  outlined: OutlinedInput,
+};
+
+const useUtilityClasses = (ownerState) => {
+  const { classes } = ownerState;
+
+  const slots = {
+    root: ['root'],
+  };
+
+  return composeClasses(slots, getTextFieldUtilityClass, classes);
+};
+
+const SelectFieldRoot = styled(FormControl, {
+  name: 'MuiSelectField',
+  slot: 'Root',
+  overridesResolver: (props, styles) => styles.root,
+})({});
+
+/**
+ * The `SelectField` is extracted out of `<TextField select />`
+ */
+const SelectField = React.forwardRef(function SelectField(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiSelectField' });
+  const {
+    autoComplete,
+    autoFocus = false,
+    children,
+    className,
+    color = 'primary',
+    defaultValue,
+    disabled = false,
+    error = false,
+    FormHelperTextProps,
+    fullWidth = false,
+    helperText,
+    id: idOverride,
+    InputLabelProps,
+    inputProps,
+    InputProps,
+    inputRef,
+    label,
+    maxRows,
+    minRows,
+    multiline = false,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    placeholder,
+    required = false,
+    rows,
+    SelectProps,
+    type,
+    value,
+    variant = 'outlined',
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    autoFocus,
+    color,
+    disabled,
+    error,
+    fullWidth,
+    multiline,
+    required,
+    select: true,
+    variant,
+  };
+
+  const classes = useUtilityClasses(ownerState);
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (!children) {
+      console.error('MUI: `children` must be passed when using the `SelectField` component.');
+    }
+  }
+
+  const InputMore = {};
+
+  if (variant === 'outlined') {
+    if (InputLabelProps && typeof InputLabelProps.shrink !== 'undefined') {
+      InputMore.notched = InputLabelProps.shrink;
+    }
+    InputMore.label = label;
+  }
+
+  // unset defaults from textbox inputs
+  if (!SelectProps || !SelectProps.native) {
+    InputMore.id = undefined;
+  }
+  InputMore['aria-describedby'] = undefined;
+
+  const id = useId(idOverride);
+  const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
+  const inputLabelId = label && id ? `${id}-label` : undefined;
+  const InputComponent = variantComponent[variant];
+  const InputElement = (
+    <InputComponent // this will be <FilledInput or <OutlinedInput
+      aria-describedby={helperTextId}
+      autoComplete={autoComplete}
+      autoFocus={autoFocus}
+      defaultValue={defaultValue}
+      fullWidth={fullWidth}
+      multiline={multiline}
+      name={name}
+      rows={rows}
+      maxRows={maxRows}
+      minRows={minRows}
+      type={type}
+      value={value}
+      id={id}
+      inputRef={inputRef}
+      onBlur={onBlur}
+      onChange={onChange}
+      onFocus={onFocus}
+      placeholder={placeholder}
+      inputProps={inputProps}
+      {...InputMore}
+      {...InputProps}
+    />
+  );
+
+  return (
+    <SelectFieldRoot // slots.root
+      className={clsx(classes.root, className)}
+      disabled={disabled}
+      error={error}
+      fullWidth={fullWidth}
+      ref={ref}
+      required={required}
+      color={color}
+      variant={variant}
+      ownerState={ownerState}
+      {...other}
+    >
+      {label != null &&
+        label !== '' && ( // slots.inputLabel.root, slots.inputLabel.asterisk (private)
+          <InputLabel htmlFor={id} id={inputLabelId} {...InputLabelProps}>
+            {label}
+          </InputLabel>
+        )}
+
+      <Select // slots.select.root, slots.select.listbox, slots.select.popper
+        aria-describedby={helperTextId}
+        id={id}
+        labelId={inputLabelId}
+        value={value}
+        input={InputElement} // slots.input.root, slots.input.input
+        {...SelectProps}
+      >
+        {children}
+      </Select>
+
+      {helperText && ( // slots.formHelperText.root
+        <FormHelperText id={helperTextId} {...FormHelperTextProps}>
+          {helperText}
+        </FormHelperText>
+      )}
+    </SelectFieldRoot>
+  );
+});
+
+SelectField.propTypes /* remove-proptypes */ = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
+  /**
+   * This prop helps users to fill forms faster, especially on mobile devices.
+   * The name can be confusing, as it's more like an autofill.
+   * You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill).
+   */
+  autoComplete: PropTypes.string,
+  /**
+   * If `true`, the `input` element is focused during the first mount.
+   * @default false
+   */
+  autoFocus: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes: PropTypes.object,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The color of the component.
+   * It supports both default and custom theme colors, which can be added as shown in the
+   * [palette customization guide](https://mui.com/material-ui/customization/palette/#custom-colors).
+   * @default 'primary'
+   */
+  color: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['primary', 'secondary', 'error', 'info', 'success', 'warning']),
+    PropTypes.string,
+  ]),
+  /**
+   * The default value. Use when the component is not controlled.
+   */
+  defaultValue: PropTypes.any,
+  /**
+   * If `true`, the component is disabled.
+   * @default false
+   */
+  disabled: PropTypes.bool,
+  /**
+   * If `true`, the label is displayed in an error state.
+   * @default false
+   */
+  error: PropTypes.bool,
+  /**
+   * Props applied to the [`FormHelperText`](/material-ui/api/form-helper-text/) element.
+   */
+  FormHelperTextProps: PropTypes.object,
+  /**
+   * If `true`, the input will take up the full width of its container.
+   * @default false
+   */
+  fullWidth: PropTypes.bool,
+  /**
+   * The helper text content.
+   */
+  helperText: PropTypes.node,
+  /**
+   * The id of the `input` element.
+   * Use this prop to make `label` and `helperText` accessible for screen readers.
+   */
+  id: PropTypes.string,
+  /**
+   * Props applied to the [`InputLabel`](/material-ui/api/input-label/) element.
+   * Pointer events like `onClick` are enabled if and only if `shrink` is `true`.
+   */
+  InputLabelProps: PropTypes.object,
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
+  /**
+   * Props applied to the Input element.
+   * It will be a [`FilledInput`](/material-ui/api/filled-input/),
+   * [`OutlinedInput`](/material-ui/api/outlined-input/) or [`Input`](/material-ui/api/input/)
+   * component depending on the `variant` prop value.
+   */
+  InputProps: PropTypes.object,
+  /**
+   * Pass a ref to the `input` element.
+   */
+  inputRef: refType,
+  /**
+   * The label content.
+   */
+  label: PropTypes.node,
+  /**
+   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
+   * @default 'none'
+   */
+  margin: PropTypes.oneOf(['dense', 'none', 'normal']),
+  /**
+   * Maximum number of rows to display when multiline option is set to true.
+   */
+  maxRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * Minimum number of rows to display when multiline option is set to true.
+   */
+  minRows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * If `true`, a `textarea` element is rendered instead of an input.
+   * @default false
+   */
+  multiline: PropTypes.bool,
+  /**
+   * Name attribute of the `input` element.
+   */
+  name: PropTypes.string,
+  /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
+  /**
+   * Callback fired when the value is changed.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
+  onChange: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
+  /**
+   * The short hint displayed in the `input` before the user enters a value.
+   */
+  placeholder: PropTypes.string,
+  /**
+   * If `true`, the label is displayed as required and the `input` element is required.
+   * @default false
+   */
+  required: PropTypes.bool,
+  /**
+   * Number of rows to display when multiline option is set to true.
+   */
+  rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * Render a [`Select`](/material-ui/api/select/) element while passing the Input element to `Select` as `input` parameter.
+   * If this option is set you must pass the options of the select as children.
+   * @default false
+   */
+  select: PropTypes.bool,
+  /**
+   * Props applied to the [`Select`](/material-ui/api/select/) element.
+   */
+  SelectProps: PropTypes.object,
+  /**
+   * The size of the component.
+   */
+  size: PropTypes /* @typescript-to-proptypes-ignore */.oneOfType([
+    PropTypes.oneOf(['medium', 'small']),
+    PropTypes.string,
+  ]),
+  /**
+   * The system prop that allows defining system overrides as well as additional CSS styles.
+   */
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.bool])),
+    PropTypes.func,
+    PropTypes.object,
+  ]),
+  /**
+   * Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types).
+   */
+  type: PropTypes /* @typescript-to-proptypes-ignore */.string,
+  /**
+   * The value of the `input` element, required for a controlled component.
+   */
+  value: PropTypes.any,
+  /**
+   * The variant to use.
+   * @default 'outlined'
+   */
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
+};
+
+export default SelectField;

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -352,6 +352,7 @@ SelectField.propTypes /* remove-proptypes */ = {
   ]),
   /**
    * slotProps
+   * @default {}
    */
   slotProps: PropTypes.shape({
     formHelperText: PropTypes.shape({

--- a/packages/mui-material/src/SelectField/SelectField.js
+++ b/packages/mui-material/src/SelectField/SelectField.js
@@ -75,7 +75,6 @@ const SelectField = React.forwardRef(function SelectField(inProps, ref) {
     value,
     variant = 'outlined',
     // slots = {},
-    // eslint-disable-next-line react/prop-types
     slotProps = {},
     ...other
   } = props;

--- a/packages/mui-material/src/SelectField/SelectField.test.js
+++ b/packages/mui-material/src/SelectField/SelectField.test.js
@@ -6,8 +6,7 @@ import FormControl from '@mui/material/FormControl';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import MenuItem from '@mui/material/MenuItem';
 import { outlinedInputClasses } from '@mui/material/OutlinedInput';
-import { textFieldClasses as classes } from '@mui/material/TextField';
-import SelectField from '@mui/material/SelectField';
+import SelectField, { selectFieldClasses as classes } from '@mui/material/SelectField';
 
 describe('<SelectField />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/SelectField/SelectField.test.js
+++ b/packages/mui-material/src/SelectField/SelectField.test.js
@@ -1,0 +1,312 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import FormControl from '@mui/material/FormControl';
+import { inputBaseClasses } from '@mui/material/InputBase';
+import MenuItem from '@mui/material/MenuItem';
+import { outlinedInputClasses } from '@mui/material/OutlinedInput';
+import { textFieldClasses as classes } from '@mui/material/TextField';
+import SelectField from '@mui/material/SelectField';
+
+describe('<SelectField />', () => {
+  const { render } = createRenderer();
+
+  describeConformance(
+    <SelectField variant="standard" value="10">
+      <MenuItem value={10}>Ten</MenuItem>
+    </SelectField>,
+    () => ({
+      classes,
+      inheritComponent: FormControl,
+      render,
+      muiName: 'MuiSelectField',
+      refInstanceof: window.HTMLDivElement,
+      testVariantProps: { variant: 'outlined' },
+      skip: ['componentProp', 'componentsProp'],
+    }),
+  );
+
+  describe('structure', () => {
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('should have an input as the only child', () => {
+      const { getAllByRole } = render(<SelectField variant="standard" />);
+
+      expect(getAllByRole('textbox')).to.have.lengthOf(1);
+    });
+
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('should forward the multiline prop to Input', () => {
+      const { getByRole } = render(
+        <SelectField variant="standard" value="10" multiline>
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('textbox', { hidden: false })).to.have.class(
+        inputBaseClasses.inputMultiline,
+      );
+    });
+
+    // TODO: support slots.input.root
+    it('should forward the fullWidth prop to Input', () => {
+      const { getByTestId } = render(
+        <SelectField
+          variant="standard"
+          value="10"
+          fullWidth
+          InputProps={{ 'data-testid': 'mui-input-base-root' }}
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByTestId('mui-input-base-root')).to.have.class(inputBaseClasses.fullWidth);
+    });
+  });
+
+  describe('with a label', () => {
+    it('label the input', () => {
+      const { getByRole } = render(
+        <SelectField label="Foo bar" variant="standard" value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox')).toHaveAccessibleName('Foo bar');
+    });
+
+    // TODO: support slots.inputLabel.root
+    it('should apply the className to the label', () => {
+      const { container } = render(
+        <SelectField
+          label="Foo bar"
+          InputLabelProps={{ className: 'foo' }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(container.querySelector('label')).to.have.class('foo');
+    });
+
+    ['', undefined].forEach((label) => {
+      it(`should not render empty (${label}) label element`, () => {
+        const { container } = render(
+          <SelectField label={label} variant="standard" value="10">
+            <MenuItem value={10}>Ten</MenuItem>
+          </SelectField>,
+        );
+
+        expect(container.querySelector('label')).to.equal(null);
+      });
+    });
+  });
+
+  describe('with a helper text', () => {
+    // TODO: support slots.formHelperText.root
+    it('should apply the className to the FormHelperText', () => {
+      const { getDescriptionOf, getByRole } = render(
+        <SelectField
+          helperText="Foo bar"
+          FormHelperTextProps={{ className: 'foo' }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getDescriptionOf(getByRole('combobox'))).to.have.class('foo');
+    });
+
+    // TODO: support slots.formHelperText.root
+    it('has an accessible description', () => {
+      const { getByRole } = render(
+        <SelectField
+          helperText="Foo bar"
+          FormHelperTextProps={{ className: 'foo' }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox')).toHaveAccessibleDescription('Foo bar');
+    });
+  });
+
+  describe('with an outline', () => {
+    // TODO: support slots.input.root
+    it('should set outline props', () => {
+      const { container, getAllByTestId } = render(
+        <SelectField
+          InputProps={{ classes: { notchedOutline: 'notch' } }}
+          label={<div data-testid="label">label</div>}
+          required
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      const [, fakeLabel] = getAllByTestId('label');
+      const notch = container.querySelector('.notch legend');
+      expect(notch).to.contain(fakeLabel);
+      expect(notch).to.have.text('label\u2009*');
+    });
+
+    // TODO: support slots.inputLabel.root
+    it('should set shrink prop on outline from label', () => {
+      const { container } = render(
+        <SelectField InputLabelProps={{ shrink: true }} classes={{}} value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(container.querySelector('fieldset')).to.have.class(
+        outlinedInputClasses.notchedOutline,
+      );
+    });
+    // TODO: support slots.input.root
+    it('should render `0` label properly', () => {
+      const { container } = render(
+        <SelectField
+          InputProps={{ classes: { notchedOutline: 'notch' } }}
+          label={0}
+          required
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      const notch = container.querySelector('.notch legend');
+      expect(notch).to.have.text('0\u2009*');
+    });
+    // TODO: support slots.input.root
+    it('should not set padding for empty, null or undefined label props', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const spanStyle = { paddingLeft: '0px', paddingRight: '0px' };
+      ['', undefined, null].forEach((prop) => {
+        const { container: container1 } = render(
+          <SelectField
+            InputProps={{ classes: { notchedOutline: 'notch' } }}
+            label={prop}
+            value="10"
+          >
+            <MenuItem value={10}>Ten</MenuItem>
+          </SelectField>,
+        );
+        expect(container1.querySelector('span')).toHaveComputedStyle(spanStyle);
+      });
+    });
+  });
+
+  // TODO: support slots.input.root
+  describe('prop: InputProps', () => {
+    it('should apply additional props to the Input component', () => {
+      const { getByTestId } = render(
+        <SelectField InputProps={{ 'data-testid': 'InputComponent' }} variant="standard" value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByTestId('InputComponent')).not.to.equal(null);
+    });
+  });
+
+  describe('prop: select', () => {
+    // TODO: support slots.select.root
+    it('can render a <select /> when `native`', () => {
+      const currencies = [
+        { value: 'USD', label: '$' },
+        { value: 'BTC', label: '฿' },
+      ];
+
+      const { container } = render(
+        <SelectField SelectProps={{ native: true }} variant="standard">
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>,
+      );
+
+      const select = container.querySelector('select');
+      expect(select).not.to.equal(null);
+      expect(select.options).to.have.lengthOf(2);
+    });
+    // TODO: support slots.select.root
+    it('associates the label with the <select /> when `native={true}`', () => {
+      const { getByRole } = render(
+        <SelectField label="Currency:" SelectProps={{ native: true }} value="$" variant="standard">
+          <option value="dollar">$</option>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox', { name: 'Currency:' })).to.have.property('value', 'dollar');
+    });
+
+    it('renders a combobox with the appropriate accessible name', () => {
+      const { getByRole } = render(
+        <SelectField label="Release: " value="stable" variant="standard">
+          <MenuItem value="alpha">Alpha</MenuItem>
+          <MenuItem value="beta">Beta</MenuItem>
+          <MenuItem value="stable">Stable</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox')).toHaveAccessibleName('Release:');
+    });
+
+    it('creates an input[hidden] that has no accessible properties', () => {
+      const { container } = render(
+        <SelectField label="Release: " value="stable" variant="standard">
+          <MenuItem value="stable">Stable</MenuItem>
+        </SelectField>,
+      );
+
+      const input = container.querySelector('input[aria-hidden]');
+      expect(input).not.to.have.attribute('id');
+      expect(input).not.to.have.attribute('aria-describedby');
+    });
+
+    it('renders a combobox with the appropriate accessible description', () => {
+      const { getByRole } = render(
+        <SelectField helperText="Foo bar" value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox')).toHaveAccessibleDescription('Foo bar');
+    });
+  });
+
+  describe('event: click', () => {
+    it('registers `onClick` on the root slot', () => {
+      const handleClick = spy((event) => event.currentTarget);
+      const { getByTestId, getByRole } = render(
+        <SelectField data-testid="root" onClick={handleClick} value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      const input = getByRole('textbox');
+
+      const root = getByTestId('root');
+
+      fireEvent.click(input);
+
+      expect(handleClick.callCount).to.equal(1);
+      // return value is event.currentTarget
+      expect(handleClick.returned(root)).to.equal(true);
+    });
+  });
+});

--- a/packages/mui-material/src/SelectField/SelectField.test.js
+++ b/packages/mui-material/src/SelectField/SelectField.test.js
@@ -47,7 +47,6 @@ describe('<SelectField />', () => {
       );
     });
 
-    // TODO: support slots.input.root
     it('should forward the fullWidth prop to Input', () => {
       const { getByTestId } = render(
         <SelectField
@@ -55,6 +54,21 @@ describe('<SelectField />', () => {
           value="10"
           fullWidth
           InputProps={{ 'data-testid': 'mui-input-base-root' }}
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByTestId('mui-input-base-root')).to.have.class(inputBaseClasses.fullWidth);
+    });
+
+    it('slotProps: should forward the fullWidth prop to Input', () => {
+      const { getByTestId } = render(
+        <SelectField
+          variant="standard"
+          value="10"
+          fullWidth
+          slotProps={{ input: { root: { 'data-testid': 'mui-input-base-root' } } }}
         >
           <MenuItem value={10}>Ten</MenuItem>
         </SelectField>,
@@ -75,12 +89,26 @@ describe('<SelectField />', () => {
       expect(getByRole('combobox')).toHaveAccessibleName('Foo bar');
     });
 
-    // TODO: support slots.inputLabel.root
     it('should apply the className to the label', () => {
       const { container } = render(
         <SelectField
           label="Foo bar"
           InputLabelProps={{ className: 'foo' }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(container.querySelector('label')).to.have.class('foo');
+    });
+
+    it('slotProps: should apply the className to the label', () => {
+      const { container } = render(
+        <SelectField
+          label="Foo bar"
+          slotProps={{ inputLabel: { root: { className: 'foo' } } }}
           variant="standard"
           value="10"
         >
@@ -105,7 +133,6 @@ describe('<SelectField />', () => {
   });
 
   describe('with a helper text', () => {
-    // TODO: support slots.formHelperText.root
     it('should apply the className to the FormHelperText', () => {
       const { getDescriptionOf, getByRole } = render(
         <SelectField
@@ -121,7 +148,21 @@ describe('<SelectField />', () => {
       expect(getDescriptionOf(getByRole('combobox'))).to.have.class('foo');
     });
 
-    // TODO: support slots.formHelperText.root
+    it('slotProps: should apply the className to the FormHelperText', () => {
+      const { getDescriptionOf, getByRole } = render(
+        <SelectField
+          helperText="Foo bar"
+          slotProps={{ formHelperText: { root: { className: 'foo' } } }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getDescriptionOf(getByRole('combobox'))).to.have.class('foo');
+    });
+
     it('has an accessible description', () => {
       const { getByRole } = render(
         <SelectField
@@ -136,10 +177,24 @@ describe('<SelectField />', () => {
 
       expect(getByRole('combobox')).toHaveAccessibleDescription('Foo bar');
     });
+
+    it('slotProps: has an accessible description', () => {
+      const { getByRole } = render(
+        <SelectField
+          helperText="Foo bar"
+          slotProps={{ formHelperText: { root: { className: 'foo' } } }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox')).toHaveAccessibleDescription('Foo bar');
+    });
   });
 
   describe('with an outline', () => {
-    // TODO: support slots.input.root
     it('should set outline props', () => {
       const { container, getAllByTestId } = render(
         <SelectField
@@ -158,7 +213,24 @@ describe('<SelectField />', () => {
       expect(notch).to.have.text('label\u2009*');
     });
 
-    // TODO: support slots.inputLabel.root
+    it('slotProps: should set outline props', () => {
+      const { container, getAllByTestId } = render(
+        <SelectField
+          slotProps={{ input: { root: { classes: { notchedOutline: 'notch' } } } }}
+          label={<div data-testid="label">label</div>}
+          required
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      const [, fakeLabel] = getAllByTestId('label');
+      const notch = container.querySelector('.notch legend');
+      expect(notch).to.contain(fakeLabel);
+      expect(notch).to.have.text('label\u2009*');
+    });
+
     it('should set shrink prop on outline from label', () => {
       const { container } = render(
         <SelectField InputLabelProps={{ shrink: true }} classes={{}} value="10">
@@ -170,7 +242,19 @@ describe('<SelectField />', () => {
         outlinedInputClasses.notchedOutline,
       );
     });
-    // TODO: support slots.input.root
+
+    it('slotProps: should set shrink prop on outline from label', () => {
+      const { container } = render(
+        <SelectField slotProps={{ inputLabel: { root: { shrink: true } } }} classes={{}} value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(container.querySelector('fieldset')).to.have.class(
+        outlinedInputClasses.notchedOutline,
+      );
+    });
+
     it('should render `0` label properly', () => {
       const { container } = render(
         <SelectField
@@ -186,7 +270,23 @@ describe('<SelectField />', () => {
       const notch = container.querySelector('.notch legend');
       expect(notch).to.have.text('0\u2009*');
     });
-    // TODO: support slots.input.root
+
+    it('slotProps: should render `0` label properly', () => {
+      const { container } = render(
+        <SelectField
+          slotProps={{ input: { root: { classes: { notchedOutline: 'notch' } } } }}
+          label={0}
+          required
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      const notch = container.querySelector('.notch legend');
+      expect(notch).to.have.text('0\u2009*');
+    });
+
     it('should not set padding for empty, null or undefined label props', function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
@@ -205,9 +305,27 @@ describe('<SelectField />', () => {
         expect(container1.querySelector('span')).toHaveComputedStyle(spanStyle);
       });
     });
+
+    it('slotProps: should not set padding for empty, null or undefined label props', function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+      const spanStyle = { paddingLeft: '0px', paddingRight: '0px' };
+      ['', undefined, null].forEach((prop) => {
+        const { container: container1 } = render(
+          <SelectField
+            slotProps={{ input: { root: { classes: { notchedOutline: 'notch' } } } }}
+            label={prop}
+            value="10"
+          >
+            <MenuItem value={10}>Ten</MenuItem>
+          </SelectField>,
+        );
+        expect(container1.querySelector('span')).toHaveComputedStyle(spanStyle);
+      });
+    });
   });
 
-  // TODO: support slots.input.root
   describe('prop: InputProps', () => {
     it('should apply additional props to the Input component', () => {
       const { getByTestId } = render(
@@ -218,10 +336,23 @@ describe('<SelectField />', () => {
 
       expect(getByTestId('InputComponent')).not.to.equal(null);
     });
+
+    it('slotProps: should apply additional props to the Input component', () => {
+      const { getByTestId } = render(
+        <SelectField
+          slotProps={{ input: { root: { 'data-testid': 'InputComponent' } } }}
+          variant="standard"
+          value="10"
+        >
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectField>,
+      );
+
+      expect(getByTestId('InputComponent')).not.to.equal(null);
+    });
   });
 
   describe('prop: select', () => {
-    // TODO: support slots.select.root
     it('can render a <select /> when `native`', () => {
       const currencies = [
         { value: 'USD', label: '$' },
@@ -242,10 +373,46 @@ describe('<SelectField />', () => {
       expect(select).not.to.equal(null);
       expect(select.options).to.have.lengthOf(2);
     });
-    // TODO: support slots.select.root
+
+    it('slotProps: can render a <select /> when `native`', () => {
+      const currencies = [
+        { value: 'USD', label: '$' },
+        { value: 'BTC', label: '฿' },
+      ];
+
+      const { container } = render(
+        <SelectField slotProps={{ select: { root: { native: true } } }} variant="standard">
+          {currencies.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </SelectField>,
+      );
+
+      const select = container.querySelector('select');
+      expect(select).not.to.equal(null);
+      expect(select.options).to.have.lengthOf(2);
+    });
+
     it('associates the label with the <select /> when `native={true}`', () => {
       const { getByRole } = render(
         <SelectField label="Currency:" SelectProps={{ native: true }} value="$" variant="standard">
+          <option value="dollar">$</option>
+        </SelectField>,
+      );
+
+      expect(getByRole('combobox', { name: 'Currency:' })).to.have.property('value', 'dollar');
+    });
+
+    it('slotProps: associates the label with the <select /> when `native={true}`', () => {
+      const { getByRole } = render(
+        <SelectField
+          label="Currency:"
+          slotProps={{ select: { root: { native: true } } }}
+          value="$"
+          variant="standard"
+        >
           <option value="dollar">$</option>
         </SelectField>,
       );
@@ -297,11 +464,11 @@ describe('<SelectField />', () => {
         </SelectField>,
       );
 
-      const input = getByRole('textbox');
+      const combobox = getByRole('combobox');
 
       const root = getByTestId('root');
 
-      fireEvent.click(input);
+      fireEvent.click(combobox);
 
       expect(handleClick.callCount).to.equal(1);
       // return value is event.currentTarget

--- a/packages/mui-material/src/SelectField/index.d.ts
+++ b/packages/mui-material/src/SelectField/index.d.ts
@@ -1,0 +1,5 @@
+export { default } from './SelectField';
+export * from './SelectField';
+
+export { default as selectFieldClasses } from './selectFieldClasses';
+export * from './selectFieldClasses';

--- a/packages/mui-material/src/SelectField/index.js
+++ b/packages/mui-material/src/SelectField/index.js
@@ -1,2 +1,5 @@
 'use client';
 export { default } from './SelectField';
+
+export { default as selectFieldClasses } from './selectFieldClasses';
+export * from './selectFieldClasses';

--- a/packages/mui-material/src/SelectField/index.js
+++ b/packages/mui-material/src/SelectField/index.js
@@ -1,0 +1,2 @@
+'use client';
+export { default } from './SelectField';

--- a/packages/mui-material/src/SelectField/selectFieldClasses.ts
+++ b/packages/mui-material/src/SelectField/selectFieldClasses.ts
@@ -1,0 +1,17 @@
+import { unstable_generateUtilityClasses as generateUtilityClasses } from '@mui/utils';
+import generateUtilityClass from '../generateUtilityClass';
+
+export interface SelectFieldClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type SelectFieldClassKey = keyof SelectFieldClasses;
+
+export function getSelectFieldUtilityClass(slot: string): string {
+  return generateUtilityClass('MuiSelectField', slot);
+}
+
+const selectFieldClasses: SelectFieldClasses = generateUtilityClasses('MuiSelectField', ['root']);
+
+export default selectFieldClasses;

--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -347,6 +347,9 @@ export * from './ScopedCssBaseline';
 export { default as Select } from './Select';
 export * from './Select';
 
+export { default as SelectField } from './SelectField';
+export * from './SelectField';
+
 export { default as Skeleton } from './Skeleton';
 export * from './Skeleton';
 

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -278,6 +278,9 @@ export * from './ScopedCssBaseline';
 export { default as Select } from './Select';
 export * from './Select';
 
+export { default as SelectField } from './SelectField';
+export * from './SelectField';
+
 export { default as Skeleton } from './Skeleton';
 export * from './Skeleton';
 


### PR DESCRIPTION
This PR aims to shape out the API for a `SelectField` component with minimal changes to the (visual) design and internals

Topics:
1. Nested `slots` and `slotProps`
2. ??

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
