### PR TITLE
[material-ui][docs] Adding autoFocus on Virtual Popover

### DIFF
--- a/docs/data/material/components/popover/VirtualElementPopover.js
+++ b/docs/data/material/components/popover/VirtualElementPopover.js
@@ -48,6 +48,7 @@ export default function VirtualElementPopover() {
         anchorEl={anchorEl}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         onClose={handleClose}
+        disableAutoFocus
       >
         <Paper>
           <Typography sx={{ p: 2 }}>The content of the Popover.</Typography>

--- a/docs/data/material/components/popover/VirtualElementPopover.tsx
+++ b/docs/data/material/components/popover/VirtualElementPopover.tsx
@@ -48,6 +48,7 @@ export default function VirtualElementPopover() {
         anchorEl={anchorEl}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         onClose={handleClose}
+        disableAutoFocus
       >
         <Paper>
           <Typography sx={{ p: 2 }}>The content of the Popover.</Typography>


### PR DESCRIPTION
Preview: https://deploy-preview-40239--material-ui.netlify.app/material-ui/react-popover/#virtual-element

Closes #40137

The issue was that with the Popover opening, the selection lost focus on Safari, disabling the autoFocus fixes this issue.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
