### PR TITLE
[core] add colorManipulator.blend

### DIFF
--- a/packages/mui-system/src/colorManipulator.d.ts
+++ b/packages/mui-system/src/colorManipulator.d.ts
@@ -27,3 +27,4 @@ export function darken(color: string, coefficient: number): string;
 export function private_safeDarken(color: string, coefficient: number, warning?: string): string;
 export function lighten(color: string, coefficient: number): string;
 export function private_safeLighten(color: string, coefficient: number, warning?: string): string;
+export function blend(background: string, overlay: string, opacity: number, gamma?: number): string;

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -351,23 +351,23 @@ export function private_safeEmphasize(color, coefficient, warning) {
 
 /**
  * Blend a transparent overlay color with a background color, resulting in a single
- * RGB color. The color space is gamma-corrected with a standard value of 2.2.
+ * RGB color.
  * @param {string} background - CSS color
  * @param {string} overlay - CSS color
  * @param {number} opacity - Opacity multiplier in the range 0 - 1
  * @param {number} [gamma=1.0] - Gamma correction factor. For gamma-correct blending, 2.2 is usual.
  */
 export function blend(background, overlay, opacity, gamma = 1.0) {
-  const f = (b, o) =>
+  const blendChannel = (b, o) =>
     Math.round((b ** (1 / gamma) * (1 - opacity) + o ** (1 / gamma) * opacity) ** gamma);
 
   const backgroundColor = decomposeColor(background);
   const overlayColor = decomposeColor(overlay);
 
   const rgb = [
-    f(backgroundColor.values[0], overlayColor.values[0]),
-    f(backgroundColor.values[1], overlayColor.values[1]),
-    f(backgroundColor.values[2], overlayColor.values[2]),
+    blendChannel(backgroundColor.values[0], overlayColor.values[0]),
+    blendChannel(backgroundColor.values[1], overlayColor.values[1]),
+    blendChannel(backgroundColor.values[2], overlayColor.values[2]),
   ];
 
   return recomposeColor({

--- a/packages/mui-system/src/colorManipulator.js
+++ b/packages/mui-system/src/colorManipulator.js
@@ -348,3 +348,30 @@ export function private_safeEmphasize(color, coefficient, warning) {
     return color;
   }
 }
+
+/**
+ * Blend a transparent overlay color with a background color, resulting in a single
+ * RGB color. The color space is gamma-corrected with a standard value of 2.2.
+ * @param {string} background - CSS color
+ * @param {string} overlay - CSS color
+ * @param {number} opacity - Opacity multiplier in the range 0 - 1
+ * @param {number} [gamma=1.0] - Gamma correction factor. For gamma-correct blending, 2.2 is usual.
+ */
+export function blend(background, overlay, opacity, gamma = 1.0) {
+  const f = (b, o) =>
+    Math.round((b ** (1 / gamma) * (1 - opacity) + o ** (1 / gamma) * opacity) ** gamma);
+
+  const backgroundColor = decomposeColor(background);
+  const overlayColor = decomposeColor(overlay);
+
+  const rgb = [
+    f(backgroundColor.values[0], overlayColor.values[0]),
+    f(backgroundColor.values[1], overlayColor.values[1]),
+    f(backgroundColor.values[2], overlayColor.values[2]),
+  ];
+
+  return recomposeColor({
+    type: 'rgb',
+    values: rgb,
+  });
+}

--- a/packages/mui-system/src/colorManipulator.test.js
+++ b/packages/mui-system/src/colorManipulator.test.js
@@ -12,6 +12,7 @@ import {
   getLuminance,
   lighten,
   colorChannel,
+  blend,
 } from '@mui/system';
 
 describe('utils/colorManipulator', () => {
@@ -450,6 +451,24 @@ describe('utils/colorManipulator', () => {
 
     it('converts hsla to a color channel` ', () => {
       expect(colorChannel('hsla(235, 100%, 50%, .5)')).to.equal('235 100% 50%');
+    });
+  });
+
+  describe('blend', () => {
+    it('works', () => {
+      expect(blend('rgb(90, 90, 90)', 'rgb(10, 100, 255)', 0.5)).to.equal('rgb(50, 95, 173)');
+    });
+
+    it('works with a gamma correction factor', () => {
+      expect(blend('rgb(90, 90, 90)', 'rgb(10, 100, 255)', 0.5, 2.2)).to.equal('rgb(39, 95, 161)');
+    });
+
+    it('selects only the background color with an opacity of 0.0', () => {
+      expect(blend('rgb(90, 90, 90)', 'rgb(10, 100, 255)', 0.0)).to.equal('rgb(90, 90, 90)');
+    });
+
+    it('selects only the overlay color with an opacity of 1.0', () => {
+      expect(blend('rgb(90, 90, 90)', 'rgb(10, 100, 255)', 1.0)).to.equal('rgb(10, 100, 255)');
     });
   });
 });


### PR DESCRIPTION
Add a blend function to `colorManipulator.js`, which is used in https://github.com/mui/mui-x/pull/10059.
