### PR TITLE
[docs-infra] Add polish to the inline code block

### DIFF
--- a/docs/pages/experiments/docs/markdown.md
+++ b/docs/pages/experiments/docs/markdown.md
@@ -2,6 +2,12 @@
 
 <p class="description">Markdown.</p>
 
+## Inline code block
+
+Use backticks to add `codeblocks` such as this one.
+
+`Superlongwordwithoutspacessuperlongwordwithoutspacessuperlongwordwithoutspacessuperlongwordwithoutspacessuperlongwordwithoutspacessuperlongwordwithoutspaces`
+
 ## Nested lists
 
 - First item

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -17,7 +17,7 @@ const Root = styled('div')(
     },
     wordBreak: 'break-word',
     '& pre': {
-      lineHeight: 1.5, // Developers likes when the code is dense.
+      lineHeight: 1.5, // Developers like when the code is dense.
       margin: theme.spacing(2, 'auto'),
       padding: theme.spacing(2),
       backgroundColor: '#0F1924', // a special, one-off, color tailored for the code blocks using MUI's branding theme blue palette as the starting point. It has a less saturaded color but still maintaining a bit of the blue tint.
@@ -50,15 +50,15 @@ const Root = styled('div')(
     },
     // inline code block
     '& :not(pre) > code': {
-      display: 'inline-block',
-      padding: '0 4px',
+      padding: '2px 4px',
       color: `var(--muidocs-palette-text-primary, ${lightTheme.palette.text.primary})`,
       backgroundColor: `var(--muidocs-palette-grey-50, ${lightTheme.palette.grey[50]})`,
       border: '1px solid',
       borderColor: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
-      borderRadius: 5,
+      borderRadius: 6,
       fontSize: lightTheme.typography.pxToRem(13),
       direction: 'ltr /*! @noflip */',
+      boxDecorationBreak: 'clone',
     },
     '& h1': {
       ...lightTheme.typography.h3,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I have just recently learned about this neat CSS property called [`box-decoration-break: clone`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break) and thought of using it for our inline code block. 😌 Instead of just being a solid block, it can now break into multiple lines while preserving the overall box look.

| Before | After |
|--------|--------|
| <img width="831" alt="Screenshot 2023-12-20 at 16 09 00" src="https://github.com/mui/material-ui/assets/67129314/d1ee77e8-cc36-450e-a3c7-ad072888eb27"> | <img width="831" alt="Screenshot 2023-12-20 at 16 09 16" src="https://github.com/mui/material-ui/assets/67129314/027b442e-93e4-4198-b9be-0c94f7b2f0ac"> | 
