### PR TITLE
[material-ui-nextjs] Support Nonces in the App Router Provider

### DIFF
--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -81,6 +81,7 @@ export default function AppRouterCacheProvider(props: AppRouterCacheProviderProp
       <React.Fragment>
         {globals.map(({ name, style }) => (
           <style
+            nonce={options?.nonce}
             key={name}
             data-emotion={`${registry.cache.key}-global ${name}`}
             // eslint-disable-next-line react/no-danger
@@ -89,6 +90,7 @@ export default function AppRouterCacheProvider(props: AppRouterCacheProviderProp
         ))}
         {styles && (
           <style
+            nonce={options?.nonce}
             data-emotion={dataEmotionAttribute}
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: styles }}


### PR DESCRIPTION
## Summary
Add CSP support by passing the `nonce` createCache option down into the `useServerInsertedHTML` script tags.

With this change, you can now follow the [NextJS guide](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy) on CSP, and in `layout.tsx` pass the `nonce` from headers down into the `AppRouterCacheProvider` to prevent `inline style` `style-src` CSP errors.

✅ Tested the code with mui docs and local project with code sandbox build

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
