### PR TITLE
[material-next][MenuItem] Fix spec import

### DIFF
--- a/packages/mui-material-next/src/MenuItem/MenuItem.spec.tsx
+++ b/packages/mui-material-next/src/MenuItem/MenuItem.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expectType } from '@mui/types';
-import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
+import MenuItem, { MenuItemProps } from '@mui/material-next/MenuItem';
 import Link from '@mui/material/Link';
 
 const CustomComponent: React.FC<{ stringProp: string; numberProp: number }> =


### PR DESCRIPTION
Import `MenuItem` from `material-next` in spec, not `material`.
