### PR TITLE
[docs-infra] Add types for withDocsInfra

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,4 +1,6 @@
+// @ts-check
 const path = require('path');
+// @ts-ignore
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const pkg = require('../package.json');
 const withDocsInfra = require('./nextConfigDocsInfra');
@@ -12,7 +14,7 @@ const {
 
 const workspaceRoot = path.join(__dirname, '../');
 
-const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD) && process.env.NETLIFY === 'true';
+const l10nPRInNetlify = /^l10n_/.test(process.env.HEAD || '') && process.env.NETLIFY === 'true';
 const vercelDeploy = Boolean(process.env.VERCEL);
 const isDeployPreview = Boolean(process.env.PULL_REQUEST_ID);
 // For crowdin PRs we want to build all locales for testing.
@@ -48,6 +50,7 @@ module.exports = withDocsInfra({
       const [nextExternals, ...externals] = config.externals;
 
       config.externals = [
+        // @ts-ignore
         (ctx, callback) => {
           const { request } = ctx;
           const hasDependencyOnRepoPackages = [
@@ -71,8 +74,9 @@ module.exports = withDocsInfra({
       ];
     }
 
-    config.module.rules.forEach((r) => {
-      r.resourceQuery = { not: [/raw/] };
+    // @ts-ignore
+    config.module.rules.forEach((rule) => {
+      rule.resourceQuery = { not: [/raw/] };
     });
 
     return {
@@ -83,6 +87,7 @@ module.exports = withDocsInfra({
         // resolve .tsx first
         extensions: [
           '.tsx',
+          // @ts-ignore
           ...config.resolve.extensions.filter((extension) => extension !== '.tsx'),
         ],
       },
@@ -171,25 +176,29 @@ module.exports = withDocsInfra({
     };
   },
   env: {
-    GITHUB_AUTH: process.env.GITHUB_AUTH
-      ? `Basic ${Buffer.from(process.env.GITHUB_AUTH).toString('base64')}`
-      : null,
+    // docs-infra
     LIB_VERSION: pkg.version,
-    FEEDBACK_URL: process.env.FEEDBACK_URL,
-    SOURCE_GITHUB_BRANCH: 'master', // #default-branch-switch
     SOURCE_CODE_REPO: 'https://github.com/mui/material-ui',
+    SOURCE_GITHUB_BRANCH: 'master', // #default-branch-switch
     GITHUB_TEMPLATE_DOCS_FEEDBACK: '4.docs-feedback.yml',
     BUILD_ONLY_ENGLISH_LOCALE: String(buildOnlyEnglishLocale),
+    // MUI Core related
+    GITHUB_AUTH: process.env.GITHUB_AUTH
+      ? `Basic ${Buffer.from(process.env.GITHUB_AUTH).toString('base64')}`
+      : '',
   },
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
+  // @ts-ignore
   exportPathMap: () => {
     const pages = findPages();
     const map = {};
 
+    // @ts-ignore
     function traverse(pages2, userLanguage) {
       const prefix = userLanguage === 'en' ? '' : `/${userLanguage}`;
 
+      // @ts-ignore
       pages2.forEach((page) => {
         // The experiments pages are only meant for experiments, they shouldn't leak to production.
         if (
@@ -206,6 +215,7 @@ module.exports = withDocsInfra({
           // map api-docs to api
           // i: /api-docs/* > /api/* (old structure)
           // ii: /*/api-docs/* > /*/api/* (for new structure)
+          // @ts-ignore
           map[`${prefix}${page.pathname.replace(/^(\/[^/]+)?\/api-docs\/(.*)/, '$1/api/$2')}`] = {
             page: page.pathname,
             query: {

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -33,6 +33,19 @@ if (
 
 process.env.DEPLOY_ENV = DEPLOY_ENV;
 
+/**
+ * @typedef {import('next').NextConfig} NextConfig
+ * @typedef {NextConfig['env']} NextConfigEnv
+ * @typedef {{env : {
+ *  LIB_VERSION: string;
+ *  SOURCE_CODE_REPO: string;
+ *  SOURCE_GITHUB_BRANCH: string;
+ *  GITHUB_TEMPLATE_DOCS_FEEDBACK: string;
+ * }} & NextConfig} NextConfigInput
+
+ * @param {NextConfigInput} nextConfig
+ * @returns {NextConfig}
+ */
 function withDocsInfra(nextConfig) {
   return {
     trailingSlash: true,
@@ -44,6 +57,7 @@ function withDocsInfra(nextConfig) {
       BUILD_ONLY_ENGLISH_LOCALE: 'true', // disable translations by default
       // production | staging | pull-request | development
       DEPLOY_ENV,
+      FEEDBACK_URL: process.env.FEEDBACK_URL,
       ...nextConfig.env,
       // https://docs.netlify.com/configure-builds/environment-variables/#git-metadata
       // reference ID (also known as "SHA" or "hash") of the commit we're building.

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["next-env.d.ts", "types", "src", "pages", "data"],
+  "include": ["next-env.d.ts", "types", "src", "pages", "data", "next.config.js"],
   "compilerOptions": {
     "allowJs": true,
     "isolatedModules": true,


### PR DESCRIPTION
This catches issues like in https://github.com/mui/mui-toolpad/pull/3026, proof:

<img src="https://github.com/mui/material-ui/assets/3165635/d29f573c-5b74-4645-bffe-e37ad673bd60" width="719">

It seems that we won't see a next.config.ts support anytime soon: https://github.com/vercel/next.js/issues/5318. But why not lint the file anyway. The alternative would be to have a runtime check of the params like done by Next.js in https://github.com/vercel/next.js/pull/58247 but I don't know, TypeScript feels meant for this purpose.

Assuming that all current & future projects that use docs-infra have to link the config file, it should be OK. We are not playing this card https://github.com/facebook/docusaurus yet.

Now, to be fair, I like how zod also allows us to flag outdated params, ones that do nothing https://github.com/vercel/next.js/blob/0fc1d9e982c9fe2a8da23d95943cd161de4c3178/packages/next/src/server/config.ts#L1004.