### PR TITLE
[material-ui] Fix createEmotionServer in Next.js integration package

### DIFF
--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13.tsx
@@ -113,6 +113,7 @@ export async function documentGetInitialProps(
   // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
   // However, be aware that it can have global side effects.
   const cache = options?.emotionCache ?? createEmotionCache();
+  const { extractCriticalToChunks } = createEmotionServer(cache);
 
   return createGetInitialProps([
     {
@@ -123,7 +124,6 @@ export async function documentGetInitialProps(
           return <App emotionCache={cache} {...props} />;
         },
       resolveProps: async (initialProps) => {
-        const { extractCriticalToChunks } = createEmotionServer(cache);
         const { styles } = extractCriticalToChunks(initialProps.html);
         return {
           ...initialProps,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The emotion server shouldn't be created after rendering the App tree. Because `cache.compat === undefined`, emotion doesn't set styles on the cache and they are rendered in style tags inside `<body>`.

See how `createEmotionServer()` isn't pure, it has a side effect https://github.com/emotion-js/emotion/blob/b0014b4edc6be047e0a94d8c627d4e52ecccd371/packages/server/src/create-instance/index.js#L12.

So, the Next.js server sends the HTML with styles placed beside Material UI components, rather than inside `<head>`.

A fix on #39947