### PR TITLE
[docs] Reduce network use on the All Components pages

### DIFF
--- a/docs/src/components/action/ComponentShowcaseCard.tsx
+++ b/docs/src/components/action/ComponentShowcaseCard.tsx
@@ -28,10 +28,12 @@ export default function ComponentShowcaseCard({
   md3,
   noGuidelines,
 }: Props) {
+  // Fix overloading with prefetch={false}, only prefetch on hover.
   return (
     <Card
       component={Link}
       noLinkStyle
+      prefetch={false}
       variant="outlined"
       href={link}
       sx={(theme) => ({

--- a/docs/src/components/action/ComponentShowcaseCard.tsx
+++ b/docs/src/components/action/ComponentShowcaseCard.tsx
@@ -7,27 +7,20 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Link from 'docs/src/modules/components/Link';
 
-interface Props {
-  name: string;
+interface ComponentShowcaseCardProps {
+  imgLoading?: 'eager';
   link: string;
-  srcLight: string;
-  srcDark: string;
   md1?: React.ReactNode;
   md2?: React.ReactNode;
   md3?: React.ReactNode;
+  name: string;
   noGuidelines?: React.ReactNode;
+  srcDark: string;
+  srcLight: string;
 }
 
-export default function ComponentShowcaseCard({
-  link,
-  srcLight,
-  srcDark,
-  name,
-  md1,
-  md2,
-  md3,
-  noGuidelines,
-}: Props) {
+export default function ComponentShowcaseCard(props: ComponentShowcaseCardProps) {
+  const { link, srcLight, srcDark, name, md1, md2, md3, noGuidelines, imgLoading = 'lazy' } = props;
   // Fix overloading with prefetch={false}, only prefetch on hover.
   return (
     <Card
@@ -51,7 +44,7 @@ export default function ComponentShowcaseCard({
       <CardMedia
         component="img"
         alt=""
-        loading="lazy"
+        loading={imgLoading}
         image={srcLight}
         sx={(theme) => ({
           aspectRatio: '16 / 9',

--- a/docs/src/components/action/InfoCard.tsx
+++ b/docs/src/components/action/InfoCard.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import Link from 'docs/src/modules/components/Link';
+import Link, { LinkProps } from 'docs/src/modules/components/Link';
 
 interface GlowingIconContainerProps {
   icon: React.ReactNode;
@@ -37,7 +37,7 @@ export function GlowingIconContainer({ icon }: GlowingIconContainerProps) {
   );
 }
 
-interface InfoCardProps {
+interface InfoCardProps extends LinkProps {
   title: string;
   classNameTitle?: string;
   description?: string;
@@ -49,8 +49,17 @@ interface InfoCardProps {
 }
 
 export default function InfoCard(props: InfoCardProps) {
-  const { icon, svg, title, classNameTitle, description, classNameDescription, link, dense } =
-    props;
+  const {
+    icon,
+    svg,
+    title,
+    classNameTitle,
+    description,
+    classNameDescription,
+    link,
+    dense,
+    ...other
+  } = props;
   return (
     <Paper
       variant="outlined"
@@ -71,6 +80,7 @@ export default function InfoCard(props: InfoCardProps) {
           borderColor: 'primaryDark.700',
         }),
       })}
+      {...other}
     >
       {svg && svg}
       {icon && <GlowingIconContainer icon={icon} />}

--- a/docs/src/components/action/InfoCard.tsx
+++ b/docs/src/components/action/InfoCard.tsx
@@ -37,27 +37,28 @@ export function GlowingIconContainer({ icon }: GlowingIconContainerProps) {
   );
 }
 
-interface InfoCardProps extends LinkProps {
-  title: string;
-  classNameTitle?: string;
-  description?: string;
+interface InfoCardProps {
   classNameDescription?: string;
-  link?: string;
-  icon?: React.ReactNode;
-  svg?: React.ReactNode;
+  classNameTitle?: string;
   dense?: boolean;
+  description?: string;
+  icon?: React.ReactNode;
+  link?: string;
+  prefetch?: LinkProps['prefetch'];
+  svg?: React.ReactNode;
+  title: string;
 }
 
 export default function InfoCard(props: InfoCardProps) {
   const {
+    classNameDescription,
+    classNameTitle,
+    dense,
+    description,
     icon,
+    link,
     svg,
     title,
-    classNameTitle,
-    description,
-    classNameDescription,
-    link,
-    dense,
     ...other
   } = props;
   return (

--- a/docs/src/components/home/MaterialDesignDemo.tsx
+++ b/docs/src/components/home/MaterialDesignDemo.tsx
@@ -17,7 +17,7 @@ export const componentCode = `<Card>
   <Box sx={{ p: 2, display: 'flex' }}>
     <Avatar variant="rounded" src="avatar.jpg" />
     <Stack spacing={0.5}>
-      <Typography fontWeight="bold">Lucas Smith</Typography>  
+      <Typography fontWeight="bold">Lucas Smith</Typography>
       <Typography variant="body2" color="text.secondary">
       <LocationOn sx={{color: grey[500]}} /> Scranton, PA, United States
       </Typography>

--- a/docs/src/components/home/Testimonials.tsx
+++ b/docs/src/components/home/Testimonials.tsx
@@ -9,7 +9,7 @@ import MuiStatistics from 'docs/src/components/home/MuiStatistics';
 
 const UserFeedbacks = dynamic(() => import('./UserFeedbacks'));
 
-function Testimonials() {
+export default function Testimonials() {
   const { ref, inView } = useInView({
     triggerOnce: true,
     threshold: 0,
@@ -38,5 +38,3 @@ function Testimonials() {
     </Box>
   );
 }
-
-export default Testimonials;

--- a/docs/src/components/home/ValueProposition.tsx
+++ b/docs/src/components/home/ValueProposition.tsx
@@ -37,7 +37,7 @@ const content = [
   },
 ];
 
-function ValueProposition() {
+export default function ValueProposition() {
   return (
     <Section>
       <SectionHeadline
@@ -59,5 +59,3 @@ function ValueProposition() {
     </Section>
   );
 }
-
-export default ValueProposition;

--- a/docs/src/modules/components/BaseUIComponents.js
+++ b/docs/src/modules/components/BaseUIComponents.js
@@ -132,13 +132,15 @@ function components() {
 }
 
 export default function BaseUIComponents() {
+  // Fix overloading with prefetch={false}, only prefetch on hover.
   return (
     <Grid container spacing={2} sx={{ pt: 2, pb: 4 }}>
-      {components().map((component) => (
+      {components().map((component, index) => (
         <Grid item xs={12} sm={4} sx={{ flexGrow: 1 }} key={component.title}>
           <Card
             component={Link}
             noLinkStyle
+            prefetch={false}
             variant="outlined"
             href={component.href}
             sx={(theme) => ({
@@ -156,6 +158,7 @@ export default function BaseUIComponents() {
             <CardMedia
               component="img"
               alt=""
+              loading={index <= 5 ? 'eager' : 'lazy'}
               image={component.srcLight}
               sx={(theme) => ({
                 aspectRatio: '16 / 9',

--- a/docs/src/modules/components/MaterialUIComponents/MaterialInputComponents.js
+++ b/docs/src/modules/components/MaterialUIComponents/MaterialInputComponents.js
@@ -149,6 +149,7 @@ export default function MaterialInputComponents() {
             md2={md2}
             md3={md3}
             noGuidelines={noGuidelines}
+            imgLoading="eager"
           />
         </Grid>
       ))}

--- a/docs/src/modules/components/MaterialUIComponents/MaterialUtilComponents.js
+++ b/docs/src/modules/components/MaterialUIComponents/MaterialUtilComponents.js
@@ -66,11 +66,12 @@ const utilComponents = [
 ];
 
 export default function MaterialUtilComponents() {
+  // Fix overloading with prefetch={false}, only prefetch on hover.
   return (
     <Grid container spacing={2}>
       {utilComponents.map(({ icon, title, link }) => (
         <Grid key={title} xs={12} sm={4}>
-          <InfoCard dense link={link} title={title} icon={icon} />
+          <InfoCard dense link={link} title={title} icon={icon} prefetch={false} />
         </Grid>
       ))}
     </Grid>


### PR DESCRIPTION
Act on https://github.com/mui/material-ui/pull/40256#discussion_r1435873800

Before

<img src="https://github.com/mui/material-ui/assets/3165635/0bf4321e-8e58-488c-9c1b-011c283a2489" width="407">

https://deploy-preview-40311--material-ui.netlify.app/material-ui/all-components/

After

<img src="https://github.com/mui/material-ui/assets/3165635/faaed967-87ea-46ce-8410-f3dbcedf3836" width="330">

https://deploy-preview-40313--material-ui.netlify.app/material-ui/all-components/

We reduce by half the use of the network.

---

I'm also working a bit on the images, we only want loading="lazy" for images below the fold, as otherwise, it means that the browser can't start loading images until it knows their position. We already know that the first images will be visible, so we can use loading="eager" for them.