### PR TITLE
[docs-infra] Prefetch pages on hover

### DIFF
--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -16,10 +16,7 @@ export function samePageLinkNavigation(event) {
   return false;
 }
 
-/**
- * @param {MouseEvent} event
- */
-function handleClick(event) {
+function isLink(event) {
   let activeElement = event.target;
   while (activeElement?.nodeType === Node.ELEMENT_NODE && activeElement.nodeName !== 'A') {
     activeElement = activeElement.parentElement;
@@ -33,6 +30,18 @@ function handleClick(event) {
     activeElement.getAttribute('data-no-markdown-link') === 'true' ||
     activeElement.getAttribute('href').indexOf('/') !== 0
   ) {
+    return null;
+  }
+
+  return activeElement;
+}
+
+/**
+ * @param {MouseEvent} event
+ */
+function handleClick(event) {
+  const activeElement = isLink(event);
+  if (activeElement === null) {
     return;
   }
 
@@ -47,11 +56,43 @@ function handleClick(event) {
   Router.push(canonicalPathname, as);
 }
 
+/**
+ * Source copied from https://github.com/vercel/next.js/blob/ebc4eaaa2564b4283711646079d68e430496c88b/packages/next/src/client/link.tsx
+ */
+function handleMouseOver(event) {
+  const activeElement = isLink(event);
+  if (activeElement === null) {
+    return;
+  }
+
+  const as = activeElement.getAttribute('href');
+  const canonicalPathname = pathnameToLanguage(as).canonicalPathname;
+
+  // In dev, do not prefetch to avoid wasting resources as the prefetch will trigger compiling the page.
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  const prefetchPromise = Router.prefetch(canonicalPathname, as, { priority: true });
+  // Prefetch the JSON page if asked (only in the client)
+  // We need to handle a prefetch error here since we may be
+  // loading with priority which can reject but we don't
+  // want to force navigation since this is only a prefetch
+  Promise.resolve(prefetchPromise).catch((err) => {
+    if (process.env.NODE_ENV !== 'production') {
+      // rethrow to show invalid URL errors
+      throw err;
+    }
+  });
+}
+
 export default function MarkdownLinks() {
   React.useEffect(() => {
     document.addEventListener('click', handleClick);
+    document.addEventListener('mouseover', handleMouseOver);
     return () => {
-      document.addEventListener('click', handleClick);
+      document.removeEventListener('click', handleClick);
+      document.removeEventListener('mouseover', handleMouseOver);
     };
   }, []);
 

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -68,11 +68,6 @@ function handleMouseOver(event) {
   const as = activeElement.getAttribute('href');
   const canonicalPathname = pathnameToLanguage(as).canonicalPathname;
 
-  // In dev, do not prefetch to avoid wasting resources as the prefetch will trigger compiling the page.
-  if (process.env.NODE_ENV !== 'production') {
-    return;
-  }
-
   const prefetchPromise = Router.prefetch(canonicalPathname, as, { priority: true });
   // Prefetch the JSON page if asked (only in the client)
   // We need to handle a prefetch error here since we may be


### PR DESCRIPTION
Inspired by #40313. The idea is to reproduce what we do for the side nav but for all the markdown links.

Before: https://deploy-preview-40310--material-ui.netlify.app/material-ui/getting-started/usage/

https://github.com/mui/material-ui/assets/3165635/548ca3ed-6191-4d37-8d11-3b353c063f25

After: https://deploy-preview-40314--material-ui.netlify.app/material-ui/getting-started/usage/

https://github.com/mui/material-ui/assets/3165635/6cd53646-11f3-4cd3-9f58-dba623dea713

We save about 100-200ms in the page transition, that time here:

![Screenshot 2023-12-25 at 18 26 10](https://github.com/mui/material-ui/assets/3165635/b16007ca-d78b-4a64-a835-6b170aa317b2)

This is a significant UX improvement on my end, but there is still a lot we could do to make the docs feel super responsive. It doesn't feel great yet.

---

In the future, we should be able to make the whole markdown a server-side component with Next.js link as client-side components. The whole React bypass with markdown is kind of crap.