### PR TITLE
[docs][joy-ui] Fix image size on the Files template

### DIFF
--- a/docs/data/joy/getting-started/templates/files/App.tsx
+++ b/docs/data/joy/getting-started/templates/files/App.tsx
@@ -426,7 +426,8 @@ export default function FilesExample() {
                 <AspectRatio ratio="16/9" color="primary" sx={{ borderRadius: 0 }}>
                   <img
                     alt=""
-                    src="https://images.unsplash.com/photo-1621351183012-e2f9972dd9bf?auto=format&fit=crop&q=80&w=3024&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                    src="https://images.unsplash.com/photo-1621351183012-e2f9972dd9bf?w=400&h=400&auto=format"
+                    srcSet="https://images.unsplash.com/photo-1621351183012-e2f9972dd9bf?w=400&h=400&auto=format&dpr=2 2x"
                   />
                 </AspectRatio>
               </CardOverflow>
@@ -576,7 +577,8 @@ export default function FilesExample() {
               <CardCover>
                 <img
                   alt=""
-                  src="https://images.unsplash.com/photo-1534067783941-51c9c23ecefd?auto=format&fit=crop&w=774"
+                  src="https://images.unsplash.com/photo-1534067783941-51c9c23ecefd?w=400&h=400&auto=format"
+                  srcSet="https://images.unsplash.com/photo-1534067783941-51c9c23ecefd?w=400&h=400&auto=format&dpr=2 2x"
                 />
               </CardCover>
               <CardCover
@@ -656,7 +658,8 @@ export default function FilesExample() {
               <CardCover>
                 <img
                   alt=""
-                  src="https://images.unsplash.com/photo-1599593752325-ffa41031056e?auto=format&fit=crop&q=80&w=3570&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                  src="https://images.unsplash.com/photo-1599593752325-ffa41031056e?w=400&h=400&auto=format"
+                  srcSet="https://images.unsplash.com/photo-1599593752325-ffa41031056e?w=400&h=400&auto=format&dpr=2 2x"
                 />
               </CardCover>
               <CardCover
@@ -726,7 +729,8 @@ export default function FilesExample() {
                 <AspectRatio ratio="16/9" color="primary" sx={{ borderRadius: 0 }}>
                   <img
                     alt=""
-                    src="https://images.unsplash.com/photo-1572445271230-a78b5944a659?auto=format&fit=crop&q=80&w=3024&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                    src="https://images.unsplash.com/photo-1572445271230-a78b5944a659?w=400&h=400&auto=format"
+                    srcSet="https://images.unsplash.com/photo-1572445271230-a78b5944a659?w=400&h=400&auto=format&dpr=2 2x"
                   />
                 </AspectRatio>
               </CardOverflow>
@@ -838,7 +842,8 @@ export default function FilesExample() {
               <AspectRatio ratio="21/9">
                 <img
                   alt=""
-                  src="https://images.unsplash.com/photo-1534067783941-51c9c23ecefd?auto=format&fit=crop&w=774"
+                  src="https://images.unsplash.com/photo-1534067783941-51c9c23ecefd?w=400&h=400&auto=format"
+                  srcSet="https://images.unsplash.com/photo-1534067783941-51c9c23ecefd?w=400&h=400&auto=format&dpr=2 2x"
                 />
               </AspectRatio>
               <Box sx={{ p: 2, display: 'flex', gap: 1, alignItems: 'center' }}>


### PR DESCRIPTION
This got flagged in https://app.ahrefs.com/site-audit/3524616/98/data-explorer?columns=pageRating%2Curl%2ChttpCode%2CcontentType%2Csize%2CloadingTime%2CincomingImage&filterId=ad5863095a819f761d42b32931a29649&issueId=c64d8113-d0f4-11e7-8ed1-001e67ed4656&sorting=-size

### Before

<img src="https://github.com/mui/material-ui/assets/3165635/b7f88065-68e8-4b81-a987-816f2bf3583f" width="651">

https://mui.com/joy-ui/getting-started/templates/files/

### After

<img src="https://github.com/mui/material-ui/assets/3165635/dc8bc33a-0abb-4ebd-8543-45e962a80acf" width="641">


