### PR TITLE
[docs][joy-ui] Fix dashboard template console errors

### DIFF
--- a/docs/data/joy/getting-started/templates/order-dashboard/components/OrderTable.tsx
+++ b/docs/data/joy/getting-started/templates/order-dashboard/components/OrderTable.tsx
@@ -127,7 +127,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1234',
+    id: 'INV-1225',
     date: 'Feb 3, 2023',
     status: 'Paid',
     customer: {
@@ -137,7 +137,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1233',
+    id: 'INV-1224',
     date: 'Feb 3, 2023',
     status: 'Cancelled',
     customer: {
@@ -147,7 +147,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1232',
+    id: 'INV-1223',
     date: 'Feb 3, 2023',
     status: 'Paid',
     customer: {
@@ -157,7 +157,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1231',
+    id: 'INV-1221',
     date: 'Feb 3, 2023',
     status: 'Refunded',
     customer: {
@@ -167,7 +167,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1230',
+    id: 'INV-1220',
     date: 'Feb 3, 2023',
     status: 'Paid',
     customer: {
@@ -177,7 +177,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1229',
+    id: 'INV-1219',
     date: 'Feb 3, 2023',
     status: 'Cancelled',
     customer: {
@@ -187,7 +187,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1228',
+    id: 'INV-1218',
     date: 'Feb 3, 2023',
     status: 'Cancelled',
     customer: {
@@ -197,7 +197,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1227',
+    id: 'INV-1217',
     date: 'Feb 3, 2023',
     status: 'Paid',
     customer: {
@@ -207,7 +207,7 @@ const rows = [
     },
   },
   {
-    id: 'INV-1226',
+    id: 'INV-1216',
     date: 'Feb 3, 2023',
     status: 'Cancelled',
     customer: {


### PR DESCRIPTION
This template wasn't usable IMHO, I'm a new user, overwhelmed, short in time: I see this, I close my tab 😄

### Before
 
https://github.com/mui/material-ui/assets/3165635/734d9a14-b4ed-4815-a8ae-878592e26100

http://0.0.0.0:3000/joy-ui/getting-started/templates/order-dashboard/

### After

The error is gone. There are still others in the Joy UI templates, but at least this massive spam is gone.

---

Noticed by chance while I was fixing #40315. Now, to be fair, I still don't think that this template is fully usable in production for a developer if you compare the report of:

- https://pagespeed.web.dev/
- https://validator.w3.org/
- https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh
- console warnings

between https://ui.shadcn.com/examples/dashboard and https://mui.com/joy-ui/getting-started/templates/order-dashboard/ it's a completely different story (Shadcn is close to having no problems). Or at least, we negatively differentiate with it (makes Shadcn more appealing) in this dimension.