### PR TITLE
[docs-infra] Remove border from the side nav

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -423,12 +423,7 @@ export default function AppNavDrawer(props) {
             pb: 5,
             overflowY: 'auto',
             flexGrow: 1,
-            ...(swipeableDrawer
-              ? {}
-              : {
-                  borderRight: '1px solid',
-                  borderColor: 'divider',
-                }),
+            ...swipeableDrawer,
           }}
         >
           <PersistScroll slot="side" enabled>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR removes the `border-right` from the documentation side nav. I've been flirting with this idea for a while, feeling like the docs are "heavy" somehow, and doing so helps a lot in alleviating this sentiment. 

- Before: https://mui.com/material-ui/getting-started/installation/
- After: https://deploy-preview-40326--material-ui.netlify.app/material-ui/getting-started/installation/