### PR TITLE
[website] Evolve the Developer Advocate role

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -174,7 +174,7 @@ const openRolesData = [
     title: 'Developer Experience',
     roles: [
       {
-        title: 'Developer Advocate',
+        title: 'Developer Advocate / Content Engineer',
         description:
           'You will strategize and implement educational initiatives from end to end to help developers build better UIs, faster.',
         url: '/careers/developer-advocate/',

--- a/docs/pages/careers/developer-advocate.md
+++ b/docs/pages/careers/developer-advocate.md
@@ -1,4 +1,4 @@
-# Developer Advocate
+# Developer Advocate / Content Engineer
 
 <p class="description">You will strategize and implement educational initiatives from end to end to help developers build better UIs, faster.</p>
 
@@ -92,11 +92,13 @@ For the right candidate:
 - Hands-on developer and skilled React engineer
 - Experience as a teacher, tutor, or mentor
 - Experience as a technical writer or content creator
+- Sensibility to great design and product design
+- Some design skills
 
 ### Nice to have (but not required)
 
-- Great taste in product design
-- Knowledge of design trends
+- Strong sensibility to great design and product design
+- Good design skills
 - Experience in open-source
 - Experience with design systems
 - Experience with MUI products

--- a/docs/pages/careers/developer-advocate.md
+++ b/docs/pages/careers/developer-advocate.md
@@ -97,7 +97,7 @@ For the right candidate:
 
 ### Nice to have (but not required)
 
-- Strong sensibility to great design and product design
+- Great product design sensibilities
 - Good design skills
 - Experience in open-source
 - Experience with design systems

--- a/docs/pages/careers/developer-advocate.md
+++ b/docs/pages/careers/developer-advocate.md
@@ -93,7 +93,7 @@ For the right candidate:
 - Experience as a teacher, tutor, or mentor
 - Experience as a technical writer or content creator
 - Good product design sensibilities
-- Some design skills
+- Basic design skills
 
 ### Nice to have (but not required)
 

--- a/docs/pages/careers/developer-advocate.md
+++ b/docs/pages/careers/developer-advocate.md
@@ -92,7 +92,7 @@ For the right candidate:
 - Hands-on developer and skilled React engineer
 - Experience as a teacher, tutor, or mentor
 - Experience as a technical writer or content creator
-- Sensibility to great design and product design
+- Good product design sensibilities
 - Some design skills
 
 ### Nice to have (but not required)


### PR DESCRIPTION
I don't think it would work to have a person with no product design sensibility in this new role we open. The most successful content creators I see in this space match this criterion: https://www.notion.so/mui-org/Developer-Advocate-DevEx-Engineer-634b2a699266480abf8663c045768902?pvs=4#a6fc0d1aec064fddb2f167e5e7b194aa.

Based on the discussion in https://groups.google.com/a/mui.com/g/devex/c/FOyh_tMixgQ, being clearer about it would help. I structured it so that there is a clear graduation between "required" and "nice to have". The bar is set lower than for our "Designer Engineer" roles (because otherwise we will search a unicorn forever).