### PR TITLE
[material-next][theme] Move ref palette out of color schemes

### DIFF
--- a/docs/pages/experiments/md3/buttons.tsx
+++ b/docs/pages/experiments/md3/buttons.tsx
@@ -201,17 +201,8 @@ function DemoComponents() {
 
 // custom MD3 theme
 const cssVarsTheme = extendTheme({
-  colorSchemes: {
-    light: {
-      ref: {
-        palette: customPalette,
-      },
-    },
-    dark: {
-      ref: {
-        palette: customPalette,
-      },
-    },
+  ref: {
+    palette: customPalette,
   },
 });
 

--- a/packages/mui-material-next/src/styles/Theme.types.ts
+++ b/packages/mui-material-next/src/styles/Theme.types.ts
@@ -239,6 +239,7 @@ export interface Motion {
 export interface MD3CssVarsThemeOptions extends Omit<MD2CssVarsThemeOptions, 'colorSchemes'> {
   ref?: {
     typeface?: Partial<MD3Typeface>;
+    palette?: Partial<MD3Palettes>;
   };
   sys?: {
     typescale?: Partial<MD3Typescale>;
@@ -250,9 +251,6 @@ export interface MD3CssVarsThemeOptions extends Omit<MD2CssVarsThemeOptions, 'co
 }
 
 export interface ColorSystemOptions extends MD2ColorSystemOptions {
-  ref?: {
-    palette?: Partial<MD3Palettes>;
-  };
   sys?: {
     color?: Partial<MD3ColorSchemeTokens>;
     elevation?: string[];

--- a/packages/mui-material-next/src/styles/extendTheme.ts
+++ b/packages/mui-material-next/src/styles/extendTheme.ts
@@ -90,7 +90,7 @@ export default function extendTheme(options: CssVarsThemeOptions = {}, ...args: 
     ref: {
       ...input.ref,
       typeface,
-      palette: deepmerge(md3CommonPalette, colorSchemesInput.light?.ref?.palette),
+      palette: deepmerge(md3CommonPalette, input.ref?.palette),
     },
     sys: {
       ...input.sys,
@@ -121,7 +121,7 @@ export default function extendTheme(options: CssVarsThemeOptions = {}, ...args: 
     ref: {
       ...input.ref,
       typeface,
-      palette: deepmerge(md3CommonPalette, colorSchemesInput.dark?.ref?.palette),
+      palette: deepmerge(md3CommonPalette, input.ref?.palette),
     },
     sys: {
       ...input.sys,


### PR DESCRIPTION
Move the `ref.palette` out of `colorSchemes` as it doesn't depend on the color mode (`light | dark`). Having it inside the `colorSchemes.light` might confuse users. The change in usage is the following:

```diff
 const customTheme = extendTheme({
-  colorSchemes: {
-   light: {
       ref: {
         palette: {
           // ...
         },
       },
-     },
-  },
 });
```
