### PR TITLE
[docs] Link new MUI X components in sidnav

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -134,7 +134,9 @@ const pages: MuiPage[] = [
         subheader: 'MUI X',
         children: [
           { pathname: '/x/react-data-grid', title: 'Data Grid' },
-          { pathname: '/x/react-date-pickers/getting-started', title: 'Date & Time Pickers' },
+          { pathname: '/x/react-date-pickers', title: 'Date & Time Pickers' },
+          { pathname: '/x/react-charts' },
+          { pathname: '/x/react-tree-view', title: 'Tree View' },
         ],
       },
       {


### PR DESCRIPTION
A quick win I noticed by chance.

<img src="https://github.com/mui/material-ui/assets/3165635/ab3bace4-3889-4fa1-acba-2e1114d04f1f" width="296">

