### PR TITLE
[lab] Add use client directive

### DIFF
--- a/packages/mui-lab/src/Alert/Alert.js
+++ b/packages/mui-lab/src/Alert/Alert.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import Alert from '@mui/material/Alert';
 

--- a/packages/mui-lab/src/AlertTitle/AlertTitle.js
+++ b/packages/mui-lab/src/AlertTitle/AlertTitle.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import AlertTitle from '@mui/material/AlertTitle';
 

--- a/packages/mui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-lab/src/Autocomplete/Autocomplete.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
 

--- a/packages/mui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-lab/src/AvatarGroup/AvatarGroup.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import AvatarGroup from '@mui/material/AvatarGroup';
 

--- a/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { chainPropTypes } from '@mui/utils';

--- a/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 let warnedOnce = false;

--- a/packages/mui-lab/src/Masonry/Masonry.js
+++ b/packages/mui-lab/src/Masonry/Masonry.js
@@ -1,3 +1,4 @@
+'use client';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import * as ReactDOM from 'react-dom';
 import { styled, useThemeProps } from '@mui/material/styles';

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/Pagination/Pagination.js
+++ b/packages/mui-lab/src/Pagination/Pagination.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import Pagination from '@mui/material/Pagination';
 

--- a/packages/mui-lab/src/Pagination/usePagination.js
+++ b/packages/mui-lab/src/Pagination/usePagination.js
@@ -1,1 +1,2 @@
+'use client';
 export { default } from '@mui/material/usePagination';

--- a/packages/mui-lab/src/PaginationItem/PaginationItem.js
+++ b/packages/mui-lab/src/PaginationItem/PaginationItem.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PaginationItem from '@mui/material/PaginationItem';
 

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/Rating/Rating.js
+++ b/packages/mui-lab/src/Rating/Rating.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import Rating from '@mui/material/Rating';
 

--- a/packages/mui-lab/src/Skeleton/Skeleton.js
+++ b/packages/mui-lab/src/Skeleton/Skeleton.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import Skeleton from '@mui/material/Skeleton';
 

--- a/packages/mui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/mui-lab/src/SpeedDial/SpeedDial.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import SpeedDial from '@mui/material/SpeedDial';
 

--- a/packages/mui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/mui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import SpeedDialAction from '@mui/material/SpeedDialAction';
 

--- a/packages/mui-lab/src/SpeedDialIcon/SpeedDialIcon.js
+++ b/packages/mui-lab/src/SpeedDialIcon/SpeedDialIcon.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import SpeedDialIcon from '@mui/material/SpeedDialIcon';
 

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/TabContext/TabContext.js
+++ b/packages/mui-lab/src/TabContext/TabContext.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 

--- a/packages/mui-lab/src/TabList/TabList.js
+++ b/packages/mui-lab/src/TabList/TabList.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import Tabs from '@mui/material/Tabs';

--- a/packages/mui-lab/src/TabPanel/TabPanel.js
+++ b/packages/mui-lab/src/TabPanel/TabPanel.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/Timeline/Timeline.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.js
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/mui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/mui-lab/src/ToggleButton/ToggleButton.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import ToggleButton from '@mui/material/ToggleButton';
 

--- a/packages/mui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/mui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 

--- a/packages/mui-lab/src/TreeItem/TreeItem.tsx
+++ b/packages/mui-lab/src/TreeItem/TreeItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 let warnedOnce = false;

--- a/packages/mui-lab/src/TreeView/TreeView.tsx
+++ b/packages/mui-lab/src/TreeView/TreeView.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/mui-lab/src/YearPicker/YearPicker.tsx
@@ -1,3 +1,4 @@
+'use client';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 

--- a/packages/mui-lab/src/internal/svg-icons/ArrowDropDown.js
+++ b/packages/mui-lab/src/internal/svg-icons/ArrowDropDown.js
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/ArrowDropDown.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/ArrowDropDown.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/ArrowLeft.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/ArrowLeft.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/ArrowRight.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/ArrowRight.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/Calendar.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/Calendar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/Clock.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/Clock.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/DateRange.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/DateRange.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/Pen.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/Pen.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/mui-lab/src/internal/svg-icons/Time.tsx
+++ b/packages/mui-lab/src/internal/svg-icons/Time.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { createSvgIcon } from '@mui/material/utils';
 

--- a/packages/rsc-builder/buildRsc.ts
+++ b/packages/rsc-builder/buildRsc.ts
@@ -48,6 +48,10 @@ const PROJECTS: Project[] = [
     additionalPaths: ['custom'],
     additionalFiles: ['src/utils/createSvgIcon.js'],
   },
+  {
+    name: 'lab',
+    rootPath: path.join(process.cwd(), 'packages/mui-lab'),
+  },
 ];
 
 async function processFile(


### PR DESCRIPTION
Add `@mui/lab` to the RSC build step and run it for the first time, adding the corresponding `'use client'` directives.

Fix #40349