### PR TITLE
[docs-infra] Fix footer links to link to the main domain

### DIFF
--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -27,7 +27,6 @@ import RssFeedIcon from '@mui/icons-material/RssFeed';
 import ArrowOutwardRoundedIcon from '@mui/icons-material/ArrowOutwardRounded';
 import DiscordIcon from 'docs/src/icons/DiscordIcon';
 // Other imports
-import ROUTES from 'docs/src/route';
 import Link from 'docs/src/modules/components/Link';
 import PageContext from 'docs/src/modules/components/PageContext';
 import EditPage from 'docs/src/modules/components/EditPage';
@@ -542,13 +541,13 @@ export default function AppLayoutDocsFooter(props) {
           spacing={{ xs: 3, sm: 1 }}
         >
           <Stack direction="row" alignItems="center" spacing={1.2} sx={{ flexGrow: 1 }}>
-            <Link href="/" aria-label="Go to homepage" sx={{ mb: 2 }}>
+            <Link href="https://mui.com/" aria-label="Go to homepage" sx={{ mb: 2 }}>
               <SvgMuiLogotype height={24} width={72} />
             </Link>
             <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
               &bull;
             </Typography>
-            <Link href={ROUTES.blog} target="_blank" rel="noopener noreferrer">
+            <Link href="https://mui.com/blog/" target="_blank" rel="noopener noreferrer">
               <FooterLink>
                 Blog <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>
@@ -556,7 +555,7 @@ export default function AppLayoutDocsFooter(props) {
             <Typography color="grey.500" fontSize={13} sx={{ opacity: '70%' }}>
               &bull;
             </Typography>
-            <Link href={ROUTES.store} target="_blank" rel="noopener noreferrer">
+            <Link href="https://mui.com/store/" target="_blank" rel="noopener noreferrer">
               <FooterLink>
                 Store <ArrowOutwardRoundedIcon sx={{ fontSize: 14 }} />
               </FooterLink>
@@ -566,7 +565,7 @@ export default function AppLayoutDocsFooter(props) {
             <IconButton
               target="_blank"
               rel="noopener noreferrer"
-              href={ROUTES.rssFeed}
+              href="https://mui.com/feed/blog/rss.xml"
               aria-label="RSS Feed"
               title="RSS Feed"
               size="small"


### PR DESCRIPTION
We can't have the links be a relative URL `/blog/` they need to be an absolute URL `https://mui.com/blog/`. This is because once the current version of the docs is archived, e.g. to a subdomain: https://v4.mui.com/, we don't want the links to the blog to point to https://v4.mui.com/blog/

---

Future. Some docs like Hashicorp store their docs as subfolders https://developer.hashicorp.com/terraform/language/v1.7.x, we could do this, it's not hard, allowing to revert this PR, but we don't do it currently. I have no idea if a subfolder is better than a subdomain for historized docs, we never really poured much thought into it.