### PR TITLE
[docs-infra] Fix a11y violation rule

### DIFF
--- a/docs/src/modules/components/ComponentLinkHeader.js
+++ b/docs/src/modules/components/ComponentLinkHeader.js
@@ -65,7 +65,7 @@ export default function ComponentLinkHeader(props) {
         </li>
       ) : null}
       <li>
-        <Tooltip title={t('bundleSizeTooltip')}>
+        <Tooltip title={t('bundleSizeTooltip')} describeChild>
           <Chip
             clickable
             role={undefined}


### PR DESCRIPTION
Fix one of the reports from https://pagespeed.web.dev/analysis/https-mui-com-material-ui-react-button/zomrvia5y0?form_factor=desktop

![Screenshot 2024-01-01 at 21 12 42](https://github.com/mui/material-ui/assets/3165635/4468fcb4-5ced-4b74-8bb9-221690d38731)

We were not respecting this rule https://dequeuniversity.com/rules/axe/4.7/label-content-name-mismatch.

Part of the value of this fix is to remove the noise from the docs-infra so we can more easily spot the issues on our components.