### PR TITLE
[docs-infra] Fix scroll position with anchor links

### DIFF
--- a/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
@@ -110,6 +110,7 @@ export default function ClassesSection(props: ClassesSectionProps) {
         />
       ) : (
         <ClassesList
+          key={displayOption} // Remount so toggle doesn't need to wait a raf
           classes={classesWithTranslatedDescriptions}
           componentName={componentName}
           displayOption={displayOption}

--- a/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
+++ b/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
@@ -128,7 +128,11 @@ export default function PropertiesSection(props) {
       {displayOption === 'table' ? (
         <PropertiesTable properties={formatedProperties} />
       ) : (
-        <PropertiesList properties={formatedProperties} displayOption={displayOption} />
+        <PropertiesList
+          key={displayOption} // Remount so toggle doesn't need to wait a raf
+          properties={formatedProperties}
+          displayOption={displayOption}
+        />
       )}
     </React.Fragment>
   );

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -70,10 +70,13 @@ function getOption(storageKey: string) {
   }
 }
 
+let scrollTimeout: any;
+
 export function useApiPageOption(
   storageKey: string,
 ): [ApiDisplayOptions, (newOption: ApiDisplayOptions) => void] {
   const [option, setOption] = React.useState(getOption(storageKey));
+  const [firstRender, setFirstRender] = React.useState(true);
 
   useEnhancedEffect(() => {
     neverHydrated = false;
@@ -82,13 +85,19 @@ export function useApiPageOption(
   }, [storageKey]);
 
   React.useEffect(() => {
-    if (option !== DEFAULT_LAYOUT) {
-      const id = document.location.hash.slice(1);
-      const element = document.getElementById(id);
-      element?.scrollIntoView();
+    setFirstRender(false); // Prevent overriding scroll after first render.
+
+    if (option !== DEFAULT_LAYOUT && firstRender === true) {
+      // Deduplicate calls to scrollIntoView.
+      clearTimeout(scrollTimeout);
+      scrollTimeout = setTimeout(() => {
+        const id = document.location.hash.slice(1);
+        const element = document.getElementById(id);
+        element?.scrollIntoView();
+      });
     }
     return undefined;
-  }, [option]);
+  }, [option, firstRender]);
 
   const updateOption = React.useCallback(
     (newOption: ApiDisplayOptions) => {


### PR DESCRIPTION
Before: https://mui.com/base-ui/react-slider/components-api/#Slider-classes-active

You can see the two bugs at once on this recording. First the scroll get messed up when I change the display type. Second the scroll restoration is wrong when I load the page.

https://github.com/mui/material-ui/assets/3165635/fe664551-a056-45d1-9b79-48dbc811d51b

After: https://deploy-preview-40395--material-ui.netlify.app/base-ui/react-slider/components-api/#Slider-classes-active