### PR TITLE
[docs] Fix 301 link to Base UI

### DIFF
--- a/docs/pages/joy-ui/api/menu.json
+++ b/docs/pages/joy-ui/api/menu.json
@@ -162,7 +162,10 @@
   "muiName": "JoyMenu",
   "forwardsRefTo": "HTMLUListElement",
   "filename": "/packages/mui-joy/src/Menu/Menu.tsx",
-  "inheritance": { "component": "Popper", "pathname": "/base-ui/api/popper/" },
+  "inheritance": {
+    "component": "Popper",
+    "pathname": "/base-ui/react-popper/components-api/#popper"
+  },
   "demos": "<ul><li><a href=\"/joy-ui/react-menu/\">Menu</a></li></ul>",
   "cssComponent": false
 }

--- a/packages/api-docs-builder-core/baseUi/generateApiLinks.ts
+++ b/packages/api-docs-builder-core/baseUi/generateApiLinks.ts
@@ -16,24 +16,24 @@ export function generateApiLinks(
     }
 
     const { value } = build as PromiseFulfilledResult<ComponentReactApi | HookReactApi>;
-    const { name, demos } = value;
     // find a potential # in the pathname
-    const hashIdx = demos.length > 0 ? demos[0].demoPathname.indexOf('#') : -1;
+    const hashIdx = value.demos.length > 0 ? value.demos[0].demoPathname.indexOf('#') : -1;
 
     let pathname = null;
 
-    if (demos.length > 0) {
+    if (value.demos.length > 0) {
       // make sure the pathname doesn't contain #
-      pathname = hashIdx >= 0 ? demos[0].demoPathname.substr(0, hashIdx) : demos[0].demoPathname;
+      pathname =
+        hashIdx >= 0 ? value.demos[0].demoPathname.substr(0, hashIdx) : value.demos[0].demoPathname;
     }
 
     if (pathname !== null) {
       // add the new apiLink, where pathame is in format of /react-component/components-api
       apiLinks.push({
         pathname: `${pathname}${
-          name.startsWith('use') ? 'hooks-api' : 'components-api'
-        }/#${kebabCase(name)}`,
-        title: name,
+          value.name.startsWith('use') ? 'hooks-api' : 'components-api'
+        }/#${kebabCase(value.name)}`,
+        title: value.name,
       });
     }
   });

--- a/packages/api-docs-builder-core/baseUi/getBaseUiComponentInfo.test.ts
+++ b/packages/api-docs-builder-core/baseUi/getBaseUiComponentInfo.test.ts
@@ -6,10 +6,10 @@ import { getBaseUiComponentInfo } from './getBaseUiComponentInfo';
 
 describe('getBaseUiComponentInfo', () => {
   it('return correct info for base component file', () => {
-    const info = getBaseUiComponentInfo(
+    const componentInfo = getBaseUiComponentInfo(
       path.join(process.cwd(), `/packages/mui-base/src/Button/Button.tsx`),
     );
-    sinon.assert.match(info, {
+    sinon.assert.match(componentInfo, {
       name: 'Button',
       apiPathname: '/base-ui/react-button/components-api/#button',
       muiName: 'MuiButton',
@@ -18,9 +18,9 @@ describe('getBaseUiComponentInfo', () => {
       ),
     });
 
-    info.readFile();
+    componentInfo.readFile();
 
-    expect(info.getInheritance()).to.deep.equal(null);
+    expect(componentInfo.getInheritance()).to.deep.equal(null);
 
     let existed = false;
     try {
@@ -29,7 +29,7 @@ describe('getBaseUiComponentInfo', () => {
       // eslint-disable-next-line no-empty
     } catch (error) {}
     if (existed) {
-      expect(info.getDemos()).to.deep.equal([
+      expect(componentInfo.getDemos()).to.deep.equal([
         {
           demoPageTitle: 'Button',
           demoPathname: '/base-ui/react-button/',

--- a/packages/api-docs-builder-core/baseUi/getBaseUiComponentInfo.ts
+++ b/packages/api-docs-builder-core/baseUi/getBaseUiComponentInfo.ts
@@ -14,33 +14,11 @@ import {
 import findPagesMarkdown from '@mui-internal/api-docs-builder/utils/findPagesMarkdown';
 import { migratedBaseComponents } from './migratedBaseComponents';
 
-function findBaseDemos(
-  componentName: string,
-  pagesMarkdown: ReadonlyArray<{
-    pathname: string;
-    components: readonly string[];
-    markdownContent: string;
-  }>,
-) {
-  return pagesMarkdown
-    .filter((page) => page.components.includes(componentName))
-    .map((page) => ({
-      demoPageTitle: getTitle(page.markdownContent),
-      demoPathname: fixPathname(page.pathname),
-    }));
-}
-
-export function getBaseUiComponentInfo(filename: string): ComponentInfo {
-  const { name } = extractPackageFile(filename);
-  let srcInfo: null | ReturnType<ComponentInfo['readFile']> = null;
-  if (!name) {
-    throw new Error(`Could not find the component name from: ${filename}`);
-  }
-
+export function getBaseUiDemos(name: string, filename?: string) {
   // resolve demos, so that we can getch the API url
   const allMarkdowns = findPagesMarkdown()
     .filter((markdown) => {
-      if (migratedBaseComponents.some((component) => filename.includes(component))) {
+      if (migratedBaseComponents.some((component) => (filename ?? name).includes(component))) {
         return markdown.filename.match(/[\\/]data[\\/]base[\\/]/);
       }
       return true;
@@ -56,14 +34,29 @@ export function getBaseUiComponentInfo(filename: string): ComponentInfo {
       };
     });
 
-  const demos = findBaseDemos(name, allMarkdowns);
-  const apiPath = getApiPath(demos, name);
+  return allMarkdowns
+    .filter((page) => page.components.includes(name))
+    .map((page) => ({
+      demoPageTitle: getTitle(page.markdownContent),
+      demoPathname: fixPathname(page.pathname),
+    }));
+}
+
+export function getBaseUiComponentInfo(filename: string): ComponentInfo {
+  const { name } = extractPackageFile(filename);
+  let srcInfo: null | ReturnType<ComponentInfo['readFile']> = null;
+  if (!name) {
+    throw new Error(`Could not find the component name from: ${filename}`);
+  }
+
+  const demos = getBaseUiDemos(name, filename);
+  const apiPath = getApiPath(demos, name) || '';
 
   return {
     filename,
     name,
     muiName: getMuiName(name),
-    apiPathname: apiPath ?? `/base-ui/api/${kebabCase(name)}/`,
+    apiPathname: apiPath,
     apiPagesDirectory: path.join(process.cwd(), `docs/pages/base-ui/api`),
     isSystemComponent: getSystemComponents().includes(name),
     readFile: () => {

--- a/packages/api-docs-builder-core/baseUi/getBaseUiHookInfo.ts
+++ b/packages/api-docs-builder-core/baseUi/getBaseUiHookInfo.ts
@@ -41,7 +41,7 @@ export function getBaseUiHookInfo(filename: string): HookInfo {
   const demos = findBaseHooksDemos(name, allMarkdowns);
   const apiPath = getApiPath(demos, name);
 
-  const result = {
+  return {
     filename,
     name,
     apiPathname: apiPath ?? `/base-ui/api/${kebabCase(name)}/`,
@@ -52,7 +52,6 @@ export function getBaseUiHookInfo(filename: string): HookInfo {
     },
     getDemos: () => demos,
   };
-  return result;
 }
 
 function findBaseHooksDemos(

--- a/packages/api-docs-builder-core/joyUi/getJoyUiComponentInfo.ts
+++ b/packages/api-docs-builder-core/joyUi/getJoyUiComponentInfo.ts
@@ -33,6 +33,18 @@ export function getJoyUiComponentInfo(filename: string): ComponentInfo {
       if (!inheritedComponent) {
         return null;
       }
+
+      const urlComponentName = kebabCase(inheritedComponent.replace(/unstyled/i, ''));
+
+      // TODO: build a map for Base UI component name -> API URL path
+      // or even better, migrate away from the /components-api/ and /hooks-api/ URLs, flatten.
+      if (inheritedComponent === 'PopperUnstyled') {
+        return {
+          name: 'Popper',
+          apiPathname: `/base-ui/react-popper/components-api/#${urlComponentName}`,
+        };
+      }
+
       // `inheritedComponent` node is coming from test files.
       // `inheritedComponent` must include `Unstyled` suffix for parser to recognise that the component inherits Base UI component
       // e.g., Joy Menu inherits Base UI Popper, and its test file uses the name `PopperUnstyled` so that we can recognise here that
@@ -42,7 +54,7 @@ export function getJoyUiComponentInfo(filename: string): ComponentInfo {
         name: inheritedComponent.replace(/unstyled/i, ''),
         apiPathname: `/${
           inheritedComponent.match(/unstyled/i) ? 'base-ui' : 'joy-ui'
-        }/api/${kebabCase(inheritedComponent.replace(/unstyled/i, ''))}/`,
+        }/api/${urlComponentName}/`,
       };
     },
     getDemos: () => {

--- a/packages/api-docs-builder-core/materialUi/getMaterialUiComponentInfo.test.ts
+++ b/packages/api-docs-builder-core/materialUi/getMaterialUiComponentInfo.test.ts
@@ -6,10 +6,10 @@ import { getMaterialUiComponentInfo } from './getMaterialUiComponentInfo';
 
 describe('getMaterialUiComponentInfo', () => {
   it('return correct info for material component file', () => {
-    const info = getMaterialUiComponentInfo(
+    const componentInfo = getMaterialUiComponentInfo(
       path.join(process.cwd(), `/packages/mui-material/src/Button/Button.js`),
     );
-    sinon.assert.match(info, {
+    sinon.assert.match(componentInfo, {
       name: 'Button',
       apiPathname: '/material-ui/api/button/',
       muiName: 'MuiButton',
@@ -18,7 +18,7 @@ describe('getMaterialUiComponentInfo', () => {
       ),
     });
 
-    expect(info.getInheritance('ButtonBase')).to.deep.equal({
+    expect(componentInfo.getInheritance('ButtonBase')).to.deep.equal({
       name: 'ButtonBase',
       apiPathname: '/material-ui/api/button-base/',
     });
@@ -30,7 +30,7 @@ describe('getMaterialUiComponentInfo', () => {
       // eslint-disable-next-line no-empty
     } catch (error) {}
     if (existed) {
-      expect(info.getDemos()).to.deep.equal([
+      expect(componentInfo.getDemos()).to.deep.equal([
         {
           demoPageTitle: 'Button Group',
           demoPathname: '/material-ui/react-button-group/',

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -688,28 +688,16 @@ export default async function generateComponentApi(
   project: TypeScriptProject,
   projectSettings: ProjectSettings,
 ) {
-  const {
-    filename,
-    name,
-    muiName,
-    apiPathname,
-    apiPagesDirectory,
-    getInheritance,
-    getDemos,
-    readFile,
-    skipApiGeneration,
-    isSystemComponent,
-  } = componentInfo;
-
-  const { shouldSkip, spread, EOL, src } = readFile();
+  const { shouldSkip, spread, EOL, src } = componentInfo.readFile();
 
   if (shouldSkip) {
     return null;
   }
 
+  const filename = componentInfo.filename;
   let reactApi: ReactApi;
 
-  if (isSystemComponent) {
+  if (componentInfo.isSystemComponent) {
     try {
       reactApi = docgenParse(
         src,
@@ -732,7 +720,7 @@ export default async function generateComponentApi(
                 if (expression.value?.callee) {
                   const definitionName = expression.value.callee.name;
 
-                  if (definitionName === `create${name}`) {
+                  if (definitionName === `create${componentInfo.name}`) {
                     node = expression;
                   }
                 }
@@ -769,12 +757,12 @@ export default async function generateComponentApi(
     reactApi.description = reactApi.description.slice(0, annotatedDescriptionMatch.index).trim();
   }
   reactApi.filename = filename;
-  reactApi.name = name;
-  reactApi.imports = getComponentImports(name, filename);
-  reactApi.muiName = muiName;
-  reactApi.apiPathname = apiPathname;
+  reactApi.name = componentInfo.name;
+  reactApi.imports = getComponentImports(componentInfo.name, filename);
+  reactApi.muiName = componentInfo.muiName;
+  reactApi.apiPathname = componentInfo.apiPathname;
   reactApi.EOL = EOL;
-  reactApi.demos = getDemos();
+  reactApi.demos = componentInfo.getDemos();
   if (reactApi.demos.length === 0) {
     throw new Error(
       'Unable to find demos. \n' +
@@ -788,7 +776,7 @@ export default async function generateComponentApi(
   reactApi.forwardsRefTo = testInfo.forwardsRefTo;
   reactApi.spread = testInfo.spread ?? spread;
   reactApi.themeDefaultProps = testInfo.themeDefaultProps;
-  reactApi.inheritance = getInheritance(testInfo.inheritComponent);
+  reactApi.inheritance = componentInfo.getInheritance(testInfo.inheritComponent);
 
   const { slots, classes } = parseSlotsAndClasses({
     project,
@@ -808,7 +796,7 @@ export default async function generateComponentApi(
   const normalizedApiPathname = reactApi.apiPathname.replace(/\\/g, '/');
   const normalizedFilename = reactApi.filename.replace(/\\/g, '/');
 
-  if (!skipApiGeneration) {
+  if (!componentInfo.skipApiGeneration) {
     // Generate pages, json and translations
     let translationPagesDirectory = 'docs/translations/api-docs';
     if (normalizedApiPathname.startsWith('/joy-ui') && normalizedFilename.includes('mui-joy/src')) {
@@ -828,7 +816,12 @@ export default async function generateComponentApi(
 
     // Once we have the tabs API in all projects, we can make this default
     const generateOnlyJsonFile = normalizedApiPathname.startsWith('/base');
-    generateApiPage(apiPagesDirectory, translationPagesDirectory, reactApi, generateOnlyJsonFile);
+    generateApiPage(
+      componentInfo.apiPagesDirectory,
+      translationPagesDirectory,
+      reactApi,
+      generateOnlyJsonFile,
+    );
 
     // Add comment about demo & api links (including inherited component) to the component file
     await annotateComponentDefinition(reactApi);

--- a/packages/api-docs-builder/buildApiUtils.ts
+++ b/packages/api-docs-builder/buildApiUtils.ts
@@ -160,10 +160,10 @@ export type HookInfo = {
   skipApiGeneration?: boolean;
 };
 
-export const getApiPath = (
+export function getApiPath(
   demos: Array<{ demoPageTitle: string; demoPathname: string }>,
   name: string,
-) => {
+) {
   let apiPath = null;
 
   if (demos && demos.length > 0) {
@@ -175,7 +175,7 @@ export const getApiPath = (
   }
 
   return apiPath;
-};
+}
 
 export function formatType(rawType: string) {
   if (!rawType) {

--- a/packages/mui-joy/src/Menu/Menu.tsx
+++ b/packages/mui-joy/src/Menu/Menu.tsx
@@ -79,7 +79,7 @@ const MenuRoot = styled(StyledList, {
  * API:
  *
  * - [Menu API](https://mui.com/joy-ui/api/menu/)
- * - inherits [Popper API](https://mui.com/base-ui/api/popper/)
+ * - inherits [Popper API](https://mui.com/base-ui/react-popper/components-api/#popper)
  */
 const Menu = React.forwardRef(function Menu(inProps, ref: React.ForwardedRef<HTMLUListElement>) {
   const props = useThemeProps({


### PR DESCRIPTION
Not the cleanest solution but it works to solve 

<img src="https://github.com/mui/material-ui/assets/3165635/c58b1bea-ca6d-4255-8a77-1f0c851afdba" width="1080">

https://app.ahrefs.com/site-audit/3524616/99/data-explorer?columns=pageRating%2Curl%2Ctraffic%2ChttpCode%2CredirectChainUrls%2CisRedirectLoop%2CincomingAllLinks%2CincomingRedirect%2Corigin&filterId=808b08e88c934ee19e04fdec4ed87a5a&issueId=c64d12c1-d0f4-11e7-8ed1-001e67ed4656&sorting=-pageRating

---

**Off-topic.** When it comes to my own use of the components, the UX before #35938 likely work better with my workflows. Now, some would clearly prefer the new UX. Still, I think that it means that for the new approach to have a higher chance of winning, we have to fill the gaps with the older one:

1. The title of the different pages are the same. https://mui.com/base-ui/react-input/ vs. https://mui.com/base-ui/react-input/components-api/ vs. https://mui.com/base-ui/react-input/hooks-api/. This is confusing when you are looking at the results on Google. See the ones that feel much better when searching for "Slider getAriaLabel"

<img src="https://github.com/mui/material-ui/assets/3165635/d5dfac90-9646-490b-9056-cfb487dde29d" width="634">

<img src="https://github.com/mui/material-ui/assets/3165635/a3a6e686-201e-4ebf-9850-fa76dd576474" width="625">

2. The TOCs don't sync correctly. It works in https://mui.com/material-ui/api/accordion/ but doesn't in https://mui.com/base-ui/react-switch/components-api/ (40px scroll offset bug and nested layer not synced)
3. We have translations we shouldn't have, e.g. https://github.com/mui/material-ui/blob/48251abb01cac73ee9924feb804286f97c2e45ff/docs/translations/translations.json#L305
4. When we rename components, we can hardly implement URL redirections because these are anchor links. We will need to invest into an anchor redirect logic.

---

**Off-topic**

@alexfauquette I wonder if it would make sense to format more the HTML of the API pages, with h4, h3 so Google can more easily return relevant search results.

<img src="https://github.com/mui/material-ui/assets/3165635/934cd842-8713-4cac-93fe-e858e8220f57" width="509">

I have tried searching for the description of props on Google, can't really find helpful results. Maybe it's not a common workflow though, I don't recall ever trying this in the past as a user.