### PR TITLE
[material-ui][docs] Adjust the terminology: Material 3 instead of Material You

### DIFF
--- a/docs/data/material/components/badges/badges.md
+++ b/docs/data/material/components/badges/badges.md
@@ -74,10 +74,10 @@ You should provide a full description, for instance, with `aria-label`:
 
 ## Experimental APIs
 
-### Material You version
+### Material 3 version
 
-The default Material UI Badge component follows the Material Design 2 specs.
-To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
+The default Material UI Badge component follows the [Material Design 2](https://m2.material.io/) specs.
+To get the Material Design 3 ([Material You](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Badge from '@mui/material-next/Badge';

--- a/docs/data/material/components/buttons/buttons.md
+++ b/docs/data/material/components/buttons/buttons.md
@@ -199,10 +199,10 @@ To prevent this, ensure that the contents of the Loading Button are nested insid
 
 :::
 
-### Material You version
+### Material 3 version
 
-The default Material UI Button component follows the Material Design 2 specs.
-To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
+The default Material UI Button component follows the [Material Design 2](https://m2.material.io/) specs.
+To get the Material Design 3 ([Material You](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Button from '@mui/material-next/Button';

--- a/docs/data/material/components/chips/chips.md
+++ b/docs/data/material/components/chips/chips.md
@@ -99,10 +99,10 @@ gain depth while clicked or touched.
 
 ## Experimental API
 
-### Material You version
+### Material 3 version
 
-The default Material UI Chip component follows the Material Design 2 specs.
-To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
+The default Material UI Chip component follows the [Material Design 2](https://m2.material.io/) specs.
+To get the Material Design 3 ([Material You](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Chip from '@mui/material-next/Chip';

--- a/docs/data/material/components/progress/progress.md
+++ b/docs/data/material/components/progress/progress.md
@@ -153,10 +153,10 @@ You can solve the latter with:
 
 ## Experimental APIs
 
-### Material You version
+### Material 3 version
 
-The default Material UI Progress components follows the Material Design 2 specs.
-To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
+The default Material UI Progress components follows the [Material Design 2](https://m2.material.io/) specs.
+To get the Material Design 3 ([Material You](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import CircularProgress from '@mui/material-next/CircularProgress';

--- a/docs/data/material/components/slider/slider.md
+++ b/docs/data/material/components/slider/slider.md
@@ -161,10 +161,10 @@ You can solve the issue with:
 
 ## Experimental APIs
 
-### Material You version
+### Material 3 version
 
-The default Material UI Slider component follows the Material Design 2 specs.
-To get the Material You ([Material Design 3](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
+The default Material UI Slider component follows the [Material Design 2](https://m2.material.io/) specs.
+To get the Material Design 3 ([Material You](https://m3.material.io/)) version, use the new experimental `@mui/material-next` package:
 
 ```js
 import Slider from '@mui/material-next/Slider';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR adjusts instances where we were referring to the latest version of Material Design as **Material You** instead of **Material 3**, the latter being the preferred one now. The reason for that is that it seems even Google themselves are not using "Material You" that much anymore — e.g., if you browse around their docs, you'll quickly find way more mentions of "Material 3". So, this change is to be on the same page, as well as facilitate comprehension.