### PR TITLE
[material-nextjs] Fix order of emotion server

### DIFF
--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13.tsx
@@ -113,6 +113,8 @@ export async function documentGetInitialProps(
   // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
   // However, be aware that it can have global side effects.
   const cache = options?.emotionCache ?? createEmotionCache();
+  // The createEmotionServer has to be called directly after the cache creation due to the side effect of cache.compat = true,
+  // otherwise the <style> tag will not come with the HTML string from the server.
   const { extractCriticalToChunks } = createEmotionServer(cache);
 
   return createGetInitialProps([

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13.tsx
@@ -113,6 +113,7 @@ export async function documentGetInitialProps(
   // You can consider sharing the same Emotion cache between all the SSR requests to speed up performance.
   // However, be aware that it can have global side effects.
   const cache = options?.emotionCache ?? createEmotionCache();
+  const { extractCriticalToChunks } = createEmotionServer(cache);
 
   return createGetInitialProps([
     {
@@ -123,7 +124,6 @@ export async function documentGetInitialProps(
           return <App emotionCache={cache} {...props} />;
         },
       resolveProps: async (initialProps) => {
-        const { extractCriticalToChunks } = createEmotionServer(cache);
         const { styles } = extractCriticalToChunks(initialProps.html);
         return {
           ...initialProps,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The `createEmotionServer` has to be called directly after cache creation due to the side effect of [`cache.compat = true`](https://github.com/emotion-js/emotion/blob/b0014b4edc6be047e0a94d8c627d4e52ecccd371/packages/server/src/create-instance/index.js#L12), otherwise the `<style>` tag will not come with the HTML string from the server.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
