### PR TITLE
[material-ui][Accordion] Deprecate *Props props and classes for v6

### DIFF
--- a/docs/data/material/components/accordion/AccordionTransition.js
+++ b/docs/data/material/components/accordion/AccordionTransition.js
@@ -18,8 +18,8 @@ export default function AccordionTransition() {
       <Accordion
         expanded={expanded}
         onChange={handleExpansion}
-        TransitionComponent={Fade}
-        TransitionProps={{ timeout: 200 }}
+        slots={{ transition: Fade }}
+        slotProps={{ transition: { timeout: 400 } }}
         sx={{
           '& .MuiAccordion-region': { height: expanded ? 'auto' : 0 },
           '& .MuiAccordionDetails-root': { display: expanded ? 'block' : 'none' },

--- a/docs/data/material/components/accordion/AccordionTransition.tsx
+++ b/docs/data/material/components/accordion/AccordionTransition.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Accordion, { AccordionProps } from '@mui/material/Accordion';
+import Accordion, { AccordionSlots } from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
@@ -18,8 +18,8 @@ export default function AccordionTransition() {
       <Accordion
         expanded={expanded}
         onChange={handleExpansion}
-        TransitionComponent={Fade as AccordionProps['TransitionComponent']}
-        TransitionProps={{ timeout: 200 }}
+        slots={{ transition: Fade as AccordionSlots['transition'] }}
+        slotProps={{ transition: { timeout: 400 } }}
         sx={{
           '& .MuiAccordion-region': { height: expanded ? 'auto' : 0 },
           '& .MuiAccordionDetails-root': { display: expanded ? 'block' : 'none' },

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -92,7 +92,7 @@ This default behavior has server-side rendering and SEO in mind.
 If you render the Accordion Details with a big component tree nested inside, or if you have many Accordions, you may want to change this behavior by setting `unmountOnExit` to `true` inside the `TransitionProps` prop to improve performance:
 
 ```jsx
-<Accordion TransitionProps={{ unmountOnExit: true }} />
+<Accordion slotProps={{ transition: { unmountOnExit: true } }} />
 ```
 
 ## Accessibility

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -51,7 +51,7 @@ Use the `defaultExpanded` prop on the Accordion component to have it opened by d
 
 ### Transition
 
-Use the `TransitionComponent` and `TransitionProps` props to change the Accordion's default transition.
+Use the `slots.transition` and `slotProps.transition` props to change the Accordion's default transition.
 
 {{"demo": "AccordionTransition.js", "bg": true}}
 

--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -89,7 +89,7 @@ The demo below also shows a bit of visual customziation.
 The Accordion content is mounted by default even if it's not expanded.
 This default behavior has server-side rendering and SEO in mind.
 
-If you render the Accordion Details with a big component tree nested inside, or if you have many Accordions, you may want to change this behavior by setting `unmountOnExit` to `true` inside the `TransitionProps` prop to improve performance:
+If you render the Accordion Details with a big component tree nested inside, or if you have many Accordions, you may want to change this behavior by setting `unmountOnExit` to `true` inside the `slotProps.transition` prop to improve performance:
 
 ```jsx
 <Accordion slotProps={{ transition: { unmountOnExit: true } }} />

--- a/docs/pages/material-ui/api/accordion-summary.json
+++ b/docs/pages/material-ui/api/accordion-summary.json
@@ -28,7 +28,9 @@
       "key": "contentGutters",
       "className": "MuiAccordionSummary-contentGutters",
       "description": "Styles applied to the children wrapper element unless `disableGutters={true}`.",
-      "isGlobal": false
+      "isGlobal": false,
+      "isDeprecated": true,
+      "deprecationInfo": "Combine the <a href=\"/material-ui/api/accordion-summary/#AccordionSummary-classes-gutters\">.MuiAccordionSummary-gutters</a> and <a href=\"/material-ui/api/accordion-summary/#AccordionSummary-classes-content\">.MuiAccordionSummary-content</a> classes instead."
     },
     {
       "key": "disabled",

--- a/docs/pages/material-ui/api/accordion-summary.json
+++ b/docs/pages/material-ui/api/accordion-summary.json
@@ -29,8 +29,7 @@
       "className": "MuiAccordionSummary-contentGutters",
       "description": "Styles applied to the children wrapper element unless `disableGutters={true}`.",
       "isGlobal": false,
-      "isDeprecated": true,
-      "deprecationInfo": "Combine the <a href=\"/material-ui/api/accordion-summary/#AccordionSummary-classes-gutters\">.MuiAccordionSummary-gutters</a> and <a href=\"/material-ui/api/accordion-summary/#AccordionSummary-classes-content\">.MuiAccordionSummary-content</a> classes instead."
+      "isDeprecated": true
     },
     {
       "key": "disabled",

--- a/docs/pages/material-ui/api/accordion.json
+++ b/docs/pages/material-ui/api/accordion.json
@@ -14,7 +14,7 @@
       }
     },
     "slotProps": {
-      "type": { "name": "shape", "description": "{ transition?: object }" },
+      "type": { "name": "shape", "description": "{ transition?: func<br>&#124;&nbsp;object }" },
       "default": "{}"
     },
     "slots": {
@@ -44,6 +44,14 @@
   "imports": [
     "import Accordion from '@mui/material/Accordion';",
     "import { Accordion } from '@mui/material';"
+  ],
+  "slots": [
+    {
+      "name": "transition",
+      "description": "The component that renders the transition.",
+      "default": "Collapse",
+      "class": null
+    }
   ],
   "classes": [
     {

--- a/docs/pages/material-ui/api/accordion.json
+++ b/docs/pages/material-ui/api/accordion.json
@@ -48,7 +48,7 @@
   "slots": [
     {
       "name": "transition",
-      "description": "The component that renders the transition.",
+      "description": "The component that renders the transition.\n[Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.",
       "default": "Collapse",
       "class": null
     }

--- a/docs/pages/material-ui/api/accordion.json
+++ b/docs/pages/material-ui/api/accordion.json
@@ -13,6 +13,14 @@
         "describedArgs": ["event", "expanded"]
       }
     },
+    "slotProps": {
+      "type": { "name": "shape", "description": "{ transition?: object }" },
+      "default": "{}"
+    },
+    "slots": {
+      "type": { "name": "shape", "description": "{ transition?: elementType }" },
+      "default": "{}"
+    },
     "square": { "type": { "name": "bool" }, "default": "false" },
     "sx": {
       "type": {
@@ -21,8 +29,16 @@
       },
       "additionalInfo": { "sx": true }
     },
-    "TransitionComponent": { "type": { "name": "elementType" }, "default": "Collapse" },
-    "TransitionProps": { "type": { "name": "object" } }
+    "TransitionComponent": {
+      "type": { "name": "elementType" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slots.transition</code> instead. This prop will be removed in v7."
+    },
+    "TransitionProps": {
+      "type": { "name": "object" },
+      "deprecated": true,
+      "deprecationInfo": "Use <code>slotProps.transition</code> instead. This prop will be removed in v7."
+    }
   },
   "name": "Accordion",
   "imports": [

--- a/docs/translations/api-docs/accordion-summary/accordion-summary.json
+++ b/docs/translations/api-docs/accordion-summary/accordion-summary.json
@@ -19,7 +19,8 @@
     "contentGutters": {
       "description": "Styles applied to {{nodeName}} unless {{conditions}}.",
       "nodeName": "the children wrapper element",
-      "conditions": "<code>disableGutters={true}</code>"
+      "conditions": "<code>disableGutters={true}</code>",
+      "deprecationInfo": "Combine the <a href=\"/material-ui/api/accordion-summary/#AccordionSummary-classes-gutters\">.MuiAccordionSummary-gutters</a> and <a href=\"/material-ui/api/accordion-summary/#AccordionSummary-classes-content\">.MuiAccordionSummary-content</a> classes instead."
     },
     "disabled": {
       "description": "State class applied to {{nodeName}} if {{conditions}}.",

--- a/docs/translations/api-docs/accordion/accordion.json
+++ b/docs/translations/api-docs/accordion/accordion.json
@@ -59,5 +59,7 @@
       "conditions": "<code>square={true}</code>"
     }
   },
-  "slotDescriptions": { "transition": "The component that renders the transition." }
+  "slotDescriptions": {
+    "transition": "The component that renders the transition.\n[Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component."
+  }
 }

--- a/docs/translations/api-docs/accordion/accordion.json
+++ b/docs/translations/api-docs/accordion/accordion.json
@@ -18,9 +18,7 @@
         "expanded": "The <code>expanded</code> state of the accordion."
       }
     },
-    "slotProps": {
-      "description": "The extra props for the slot components. You can override the existing props or add new ones."
-    },
+    "slotProps": { "description": "The props used for each slot inside." },
     "slots": { "description": "The components used for each slot inside." },
     "square": { "description": "If <code>true</code>, rounded corners are disabled." },
     "sx": {
@@ -60,5 +58,6 @@
       "nodeName": "the root element",
       "conditions": "<code>square={true}</code>"
     }
-  }
+  },
+  "slotDescriptions": { "transition": "The component that renders the transition." }
 }

--- a/docs/translations/api-docs/accordion/accordion.json
+++ b/docs/translations/api-docs/accordion/accordion.json
@@ -18,6 +18,10 @@
         "expanded": "The <code>expanded</code> state of the accordion."
       }
     },
+    "slotProps": {
+      "description": "The extra props for the slot components. You can override the existing props or add new ones."
+    },
+    "slots": { "description": "The components used for each slot inside." },
     "square": { "description": "If <code>true</code>, rounded corners are disabled." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."

--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -6,6 +6,8 @@ import { AccordionClasses } from './accordionClasses';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ExtendPaperTypeMap } from '../Paper/Paper';
 
+export interface AccordionTransitionSlotPropsOverrides {}
+
 export type AccordionTypeMap<
   AdditionalProps = {},
   RootComponent extends React.ElementType = 'div',
@@ -48,13 +50,32 @@ export type AccordionTypeMap<
        */
       onChange?: (event: React.SyntheticEvent, expanded: boolean) => void;
       /**
+       * The components used for each slot inside.
+       *
+       * @default {}
+       */
+      slots?: {
+        transition?: React.JSXElementConstructor<
+          TransitionProps & { children?: React.ReactElement<any, any> }
+        >;
+      };
+      /**
+       * The extra props for the slot components.
+       * You can override the existing props or add new ones.
+       *
+       * @default {}
+       */
+      slotProps?: {
+        transition?: TransitionProps & AccordionTransitionSlotPropsOverrides;
+      };
+      /**
        * The system prop that allows defining system overrides as well as additional CSS styles.
        */
       sx?: SxProps<Theme>;
       /**
        * The component used for the transition.
        * [Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
-       * @default Collapse
+       * @deprecated Use `slots.transition` instead. This prop will be removed in v7.
        */
       TransitionComponent?: React.JSXElementConstructor<
         TransitionProps & { children?: React.ReactElement<any, any> }
@@ -62,6 +83,7 @@ export type AccordionTypeMap<
       /**
        * Props applied to the transition element.
        * By default, the element is based on this [`Transition`](http://reactcommunity.org/react-transition-group/transition/) component.
+       * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7.
        */
       TransitionProps?: TransitionProps;
     };

--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -5,8 +5,28 @@ import { TransitionProps } from '../transitions/transition';
 import { AccordionClasses } from './accordionClasses';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ExtendPaperTypeMap } from '../Paper/Paper';
+import { CreateSlotsAndSlotProps, SlotProps } from '../utils/slotsTypes';
+
+export interface AccordionSlots {
+  /**
+   * The component that renders the transition.
+   * @default Collapse
+   */
+  transition?: React.ElementType;
+}
 
 export interface AccordionTransitionSlotPropsOverrides {}
+
+export type AccordionSlotsAndSlotProps = CreateSlotsAndSlotProps<
+  AccordionSlots,
+  {
+    transition: SlotProps<
+      React.ElementType<TransitionProps>,
+      AccordionTransitionSlotPropsOverrides,
+      AccordionOwnerState
+    >;
+  }
+>;
 
 export type AccordionTypeMap<
   AdditionalProps = {},
@@ -50,25 +70,6 @@ export type AccordionTypeMap<
        */
       onChange?: (event: React.SyntheticEvent, expanded: boolean) => void;
       /**
-       * The components used for each slot inside.
-       *
-       * @default {}
-       */
-      slots?: {
-        transition?: React.JSXElementConstructor<
-          TransitionProps & { children?: React.ReactElement<any, any> }
-        >;
-      };
-      /**
-       * The extra props for the slot components.
-       * You can override the existing props or add new ones.
-       *
-       * @default {}
-       */
-      slotProps?: {
-        transition?: TransitionProps & AccordionTransitionSlotPropsOverrides;
-      };
-      /**
        * The system prop that allows defining system overrides as well as additional CSS styles.
        */
       sx?: SxProps<Theme>;
@@ -86,7 +87,7 @@ export type AccordionTypeMap<
        * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7.
        */
       TransitionProps?: TransitionProps;
-    };
+    } & AccordionSlotsAndSlotProps;
     defaultComponent: RootComponent;
   },
   'onChange' | 'classes'
@@ -111,5 +112,7 @@ export type AccordionProps<
 > = OverrideProps<AccordionTypeMap<AdditionalProps, RootComponent>, RootComponent> & {
   component?: React.ElementType;
 };
+
+export interface AccordionOwnerState extends AccordionProps {}
 
 export default Accordion;

--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -10,9 +10,12 @@ import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 export interface AccordionSlots {
   /**
    * The component that renders the transition.
+   * [Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
    * @default Collapse
    */
-  transition?: React.ElementType;
+  transition?: React.JSXElementConstructor<
+    TransitionProps & { children?: React.ReactElement<any, any> }
+  >;
 }
 
 export interface AccordionTransitionSlotPropsOverrides {}

--- a/packages/mui-material/src/Accordion/Accordion.d.ts
+++ b/packages/mui-material/src/Accordion/Accordion.d.ts
@@ -5,7 +5,7 @@ import { TransitionProps } from '../transitions/transition';
 import { AccordionClasses } from './accordionClasses';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ExtendPaperTypeMap } from '../Paper/Paper';
-import { CreateSlotsAndSlotProps, SlotProps } from '../utils/slotsTypes';
+import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
 
 export interface AccordionSlots {
   /**

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -180,6 +180,8 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
     ownerState,
   });
 
+  delete transitionProps.ownerState;
+
   return (
     <AccordionRoot
       className={clsx(classes.root, className)}

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -126,8 +126,10 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
     expanded: expandedProp,
     onChange,
     square = false,
-    TransitionComponent = Collapse,
-    TransitionProps,
+    slots = {},
+    slotProps = {},
+    TransitionComponent: TransitionComponentProp,
+    TransitionProps: TransitionPropsProp,
     ...other
   } = props;
 
@@ -165,6 +167,9 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
+  const TransitionSlot = slots.transition ?? TransitionComponentProp ?? Collapse;
+  const transitionProps = slotProps.transition ?? TransitionPropsProp;
+
   return (
     <AccordionRoot
       className={clsx(classes.root, className)}
@@ -174,7 +179,7 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
       {...other}
     >
       <AccordionContext.Provider value={contextValue}>{summary}</AccordionContext.Provider>
-      <TransitionComponent in={expanded} timeout="auto" {...TransitionProps}>
+      <TransitionSlot in={expanded} timeout="auto" {...transitionProps}>
         <div
           aria-labelledby={summary.props.id}
           id={summary.props['aria-controls']}
@@ -183,7 +188,7 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
         >
           {children}
         </div>
-      </TransitionComponent>
+      </TransitionSlot>
     </AccordionRoot>
   );
 });
@@ -247,6 +252,23 @@ Accordion.propTypes /* remove-proptypes */ = {
    */
   onChange: PropTypes.func,
   /**
+   * The extra props for the slot components.
+   * You can override the existing props or add new ones.
+   *
+   * @default {}
+   */
+  slotProps: PropTypes.shape({
+    transition: PropTypes.object,
+  }),
+  /**
+   * The components used for each slot inside.
+   *
+   * @default {}
+   */
+  slots: PropTypes.shape({
+    transition: PropTypes.elementType,
+  }),
+  /**
    * If `true`, rounded corners are disabled.
    * @default false
    */
@@ -262,12 +284,13 @@ Accordion.propTypes /* remove-proptypes */ = {
   /**
    * The component used for the transition.
    * [Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
-   * @default Collapse
+   * @deprecated Use `slots.transition` instead. This prop will be removed in v7.
    */
   TransitionComponent: PropTypes.elementType,
   /**
    * Props applied to the transition element.
    * By default, the element is based on this [`Transition`](http://reactcommunity.org/react-transition-group/transition/) component.
+   * @deprecated Use `slotProps.transition` instead. This prop will be removed in v7.
    */
   TransitionProps: PropTypes.object,
 };

--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -11,6 +11,7 @@ import Collapse from '../Collapse';
 import Paper from '../Paper';
 import AccordionContext from './AccordionContext';
 import useControlled from '../utils/useControlled';
+import useSlot from '../utils/useSlot';
 import accordionClasses, { getAccordionUtilityClass } from './accordionClasses';
 
 const useUtilityClasses = (ownerState) => {
@@ -167,8 +168,17 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  const TransitionSlot = slots.transition ?? TransitionComponentProp ?? Collapse;
-  const transitionProps = slotProps.transition ?? TransitionPropsProp;
+  const backwardCompatibleSlots = { transition: TransitionComponentProp, ...slots };
+  const backwardCompatibleSlotProps = { transition: TransitionPropsProp, ...slotProps };
+
+  const [TransitionSlot, transitionProps] = useSlot('transition', {
+    elementType: Collapse,
+    externalForwardedProps: {
+      slots: backwardCompatibleSlots,
+      slotProps: backwardCompatibleSlotProps,
+    },
+    ownerState,
+  });
 
   return (
     <AccordionRoot
@@ -252,17 +262,14 @@ Accordion.propTypes /* remove-proptypes */ = {
    */
   onChange: PropTypes.func,
   /**
-   * The extra props for the slot components.
-   * You can override the existing props or add new ones.
-   *
+   * The props used for each slot inside.
    * @default {}
    */
   slotProps: PropTypes.shape({
-    transition: PropTypes.object,
+    transition: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   }),
   /**
    * The components used for each slot inside.
-   *
    * @default {}
    */
   slots: PropTypes.shape({

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -30,7 +30,7 @@ describe('<Accordion />', () => {
     testVariantProps: { variant: 'rounded' },
     slots: {
       transition: {
-        expectedClassName: '',
+        testWithElement: null,
       },
     },
     skip: ['componentProp', 'componentsProp', 'slotPropsCallback'],
@@ -225,6 +225,30 @@ describe('<Accordion />', () => {
       );
 
       expect(getByTestId('transition-testid')).not.to.equal(null);
+    });
+  });
+
+  describe('details unmounting behavior', () => {
+    it('does not unmount by default', () => {
+      const { queryByTestId } = render(
+        <Accordion expanded={false}>
+          <AccordionSummary>Summary</AccordionSummary>
+          <div data-testid="details">Details</div>
+        </Accordion>,
+      );
+
+      expect(queryByTestId('details')).not.to.equal(null);
+    });
+
+    it('unmounts if opted in via slotProps.transition', () => {
+      const { queryByTestId } = render(
+        <Accordion expanded={false} slotProps={{ transition: { unmountOnExit: true } }}>
+          <AccordionSummary>Summary</AccordionSummary>
+          <div data-testid="details">Details</div>
+        </Accordion>,
+      );
+
+      expect(queryByTestId('details')).to.equal(null);
     });
   });
 });

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -28,7 +28,12 @@ describe('<Accordion />', () => {
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiAccordion',
     testVariantProps: { variant: 'rounded' },
-    skip: ['componentProp', 'componentsProp'],
+    slots: {
+      transition: {
+        expectedClassName: '',
+      },
+    },
+    skip: ['componentProp', 'componentsProp', 'slotPropsCallback'],
   }));
 
   it('should render and not be controlled', () => {
@@ -209,5 +214,17 @@ describe('<Accordion />', () => {
     expect(() => setProps({ expanded: true })).toErrorDev(
       'MUI: A component is changing the uncontrolled expanded state of Accordion to be controlled.',
     );
+  });
+
+  describe('prop: TransitionProps', () => {
+    it('should apply properties to the Transition component', () => {
+      const { getByTestId } = render(
+        <Accordion TransitionProps={{ 'data-testid': 'transition-testid' }}>
+          {minimalChildren}
+        </Accordion>,
+      );
+
+      expect(getByTestId('transition-testid')).not.to.equal(null);
+    });
   });
 });

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -33,7 +33,7 @@ describe('<Accordion />', () => {
         testWithElement: null,
       },
     },
-    skip: ['componentProp', 'componentsProp', 'slotPropsCallback'],
+    skip: ['componentProp', 'componentsProp'],
   }));
 
   it('should render and not be controlled', () => {

--- a/packages/mui-material/src/AccordionSummary/accordionSummaryClasses.ts
+++ b/packages/mui-material/src/AccordionSummary/accordionSummaryClasses.ts
@@ -12,7 +12,10 @@ export interface AccordionSummaryClasses {
   disabled: string;
   /** Styles applied to the root element unless `disableGutters={true}`. */
   gutters: string;
-  /** Styles applied to the children wrapper element unless `disableGutters={true}`. */
+  /**
+   * Styles applied to the children wrapper element unless `disableGutters={true}`.
+   * @deprecated Combine the [.MuiAccordionSummary-gutters](/material-ui/api/accordion-summary/#AccordionSummary-classes-gutters) and [.MuiAccordionSummary-content](/material-ui/api/accordion-summary/#AccordionSummary-classes-content) classes instead.
+   */
   contentGutters: string;
   /** Styles applied to the children wrapper element. */
   content: string;

--- a/packages/mui-material/src/utils/slotsTypes.ts
+++ b/packages/mui-material/src/utils/slotsTypes.ts
@@ -1,0 +1,39 @@
+import { SxProps } from '@mui/system';
+
+export type SlotCommonProps = {
+  component?: React.ElementType;
+  sx?: SxProps;
+};
+
+export type SlotProps<TSlotComponent extends React.ElementType, TOverrides, TOwnerState> =
+  // omit `color` from HTML attributes because it conflicts with Material UI `color` prop.
+  | (Omit<React.ComponentPropsWithRef<TSlotComponent>, 'color'> &
+      TOverrides &
+      SlotCommonProps &
+      Record<string, unknown>)
+  | ((
+      ownerState: TOwnerState,
+    ) => Omit<React.ComponentPropsWithRef<TSlotComponent>, 'color'> &
+      TOverrides &
+      SlotCommonProps &
+      Record<string, unknown>);
+
+/**
+ * Use the keys of `Slots` to make sure that K contains all of the keys
+ *
+ * @example CreateSlotsAndSlotProps<{ root: React.ElementType, decorator: React.ElementType }, { root: ..., decorator: ... }>
+ */
+export type CreateSlotsAndSlotProps<Slots, K extends Record<keyof Slots, any>> = {
+  /**
+   * The components used for each slot inside.
+   * @default {}
+   */
+  slots?: Slots;
+  /**
+   * The props used for each slot inside.
+   * @default {}
+   */
+  slotProps?: {
+    [P in keyof K]?: K[P];
+  };
+};

--- a/packages/mui-material/src/utils/types.ts
+++ b/packages/mui-material/src/utils/types.ts
@@ -1,22 +1,16 @@
 import { SxProps } from '@mui/system';
+import { SlotComponentProps } from '@mui/base';
 
 export type SlotCommonProps = {
   component?: React.ElementType;
   sx?: SxProps;
 };
 
-export type SlotProps<TSlotComponent extends React.ElementType, TOverrides, TOwnerState> =
-  // omit `color` from HTML attributes because it conflicts with Material UI `color` prop.
-  | (Omit<React.ComponentPropsWithRef<TSlotComponent>, 'color'> &
-      TOverrides &
-      SlotCommonProps &
-      Record<string, unknown>)
-  | ((
-      ownerState: TOwnerState,
-    ) => Omit<React.ComponentPropsWithRef<TSlotComponent>, 'color'> &
-      TOverrides &
-      SlotCommonProps &
-      Record<string, unknown>);
+export type SlotProps<
+  TSlotComponent extends React.ElementType,
+  TOverrides,
+  TOwnerState,
+> = SlotComponentProps<TSlotComponent, SlotCommonProps & TOverrides, TOwnerState>;
 
 /**
  * Use the keys of `Slots` to make sure that K contains all of the keys

--- a/packages/mui-material/src/utils/useSlot.test.tsx
+++ b/packages/mui-material/src/utils/useSlot.test.tsx
@@ -1,0 +1,290 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { createRenderer } from '@mui-internal/test-utils';
+import { Popper } from '@mui/base/Popper';
+import { styled } from '../styles';
+import { SlotProps } from './slotsTypes';
+import useSlot from './useSlot';
+
+describe('useSlot', () => {
+  const { render } = createRenderer();
+
+  describe('single slot', () => {
+    const ItemRoot = styled('button')({});
+    const Item = React.forwardRef<
+      HTMLButtonElement,
+      { component?: React.ElementType; href?: string }
+    >((props, ref) => {
+      const [SlotRoot, rootProps] = useSlot('root', {
+        ref,
+        className: 'root',
+        elementType: ItemRoot,
+        externalForwardedProps: props,
+        ownerState: {},
+      });
+      return <SlotRoot {...rootProps} />;
+    });
+
+    it('should render correct tag', () => {
+      const { getByRole } = render(<Item />);
+      expect(getByRole('button')).toBeVisible();
+    });
+
+    it('should change leaf component and spread props', () => {
+      const { getByRole } = render(<Item component="a" href="/" />);
+      expect(getByRole('link')).toBeVisible();
+    });
+  });
+
+  describe('multiple slots', () => {
+    const ItemRoot = styled('button')({});
+    const ItemDecorator = styled('span')({});
+    const Item = React.forwardRef<
+      HTMLButtonElement,
+      {
+        className?: string;
+        component?: React.ElementType;
+        href?: string;
+        slots?: { root?: React.ElementType; decorator?: React.ElementType };
+        slotProps?: {
+          root?: SlotProps<'button', Record<string, any>, {}>;
+          decorator?: SlotProps<'span', { size?: 'sm' | 'md' } & Record<string, any>, {}>;
+        };
+      }
+    >((props, ref) => {
+      const [SlotRoot, rootProps] = useSlot('root', {
+        ref,
+        className: 'root',
+        elementType: ItemRoot,
+        externalForwardedProps: props,
+        ownerState: {},
+      });
+      const [SlotDecorator, decoratorProps] = useSlot('decorator', {
+        className: 'decorator',
+        elementType: ItemDecorator,
+        externalForwardedProps: props,
+        ownerState: {},
+        getSlotOwnerState: (mergedProps) => ({
+          size: mergedProps.size ?? 'md',
+        }),
+      });
+      return (
+        <SlotRoot {...rootProps}>
+          <SlotDecorator
+            {...decoratorProps}
+            className={`${decoratorProps.className} size-${decoratorProps.ownerState.size}`}
+          />
+        </SlotRoot>
+      );
+    });
+
+    it('should render both tags', () => {
+      const { getByRole } = render(<Item />);
+      expect(getByRole('button')).toBeVisible();
+      expect(getByRole('button').firstChild).to.have.tagName('span');
+    });
+
+    it('should have classes', () => {
+      const { getByRole } = render(<Item />);
+      expect(getByRole('button')).to.have.class('root');
+      expect(getByRole('button').firstChild).to.have.class('decorator');
+    });
+
+    it('should append classes', () => {
+      const { getByRole } = render(
+        <Item className="foo-bar" slotProps={{ decorator: { className: 'foo-bar' } }} />,
+      );
+      expect(getByRole('button')).to.have.class('root');
+      expect(getByRole('button')).to.have.class('foo-bar');
+      expect(getByRole('button').firstChild).to.have.class('decorator');
+      expect(getByRole('button').firstChild).to.have.class('foo-bar');
+    });
+
+    it('slot has default size `md`', () => {
+      const { getByRole } = render(<Item />);
+      expect(getByRole('button').firstChild).to.have.class('size-md');
+    });
+
+    it('slot ownerstate should be overridable', () => {
+      const { getByRole } = render(<Item slotProps={{ decorator: { size: 'sm' } }} />);
+      expect(getByRole('button').firstChild).to.have.class('size-sm');
+    });
+
+    it('slotProps has higher priority', () => {
+      const { getByRole } = render(
+        <Item data-item="foo" slotProps={{ root: { 'data-item': 'bar' } }} />,
+      );
+      expect(getByRole('button')).to.have.attribute('data-item', 'bar');
+    });
+
+    it('can change root leaf component with `component` prop', () => {
+      const { getByRole } = render(<Item component="a" href="/" />);
+      expect(getByRole('link')).toBeVisible();
+    });
+
+    it('use slotProps `component` over `component` prop', () => {
+      const { getByRole } = render(
+        <Item component="div" slotProps={{ root: { component: 'a', href: '/' } }} />,
+      );
+      expect(getByRole('link')).toBeVisible();
+    });
+
+    it('can change decorator leaf component', () => {
+      const { getByRole } = render(<Item slotProps={{ decorator: { component: 'div' } }} />);
+      expect(getByRole('button').firstChild).to.have.tagName('div');
+    });
+  });
+
+  /**
+   * Simulate `Tooltip`, ...etc
+   */
+  describe('unstyled popper as the root slot', () => {
+    const ItemRoot = styled('div')({});
+    function Item(props: {
+      component?: React.ElementType;
+      slots?: {
+        root?: React.ElementType;
+      };
+      slotProps?: {
+        root?: SlotProps<'div', Record<string, any>, {}>;
+      };
+    }) {
+      const ref = React.useRef(null);
+      const [SlotRoot, rootProps] = useSlot('root', {
+        ref,
+        className: 'root',
+        elementType: Popper,
+        externalForwardedProps: props,
+        ownerState: {},
+        additionalProps: {
+          open: true, // !!force the popper to always visible for testing
+          anchorEl: () => document.createElement('div'),
+        },
+        internalForwardedProps: {
+          slots: { root: ItemRoot },
+        },
+      });
+      return <SlotRoot {...rootProps} />;
+    }
+
+    it('should render popper with styled-component', () => {
+      const { getByRole } = render(<Item />);
+      expect(getByRole('tooltip')).toBeVisible();
+      expect(getByRole('tooltip')).to.have.tagName('div');
+    });
+
+    it('the root slot should be replaceable', () => {
+      const Listbox = React.forwardRef<HTMLUListElement, { component?: React.ElementType }>(
+        function Listbox({ component }, ref) {
+          return <ul ref={ref} data-component={component} />;
+        },
+      );
+
+      const { getByRole } = render(<Item slots={{ root: Listbox }} />);
+      expect(getByRole('list')).toBeVisible();
+      expect(getByRole('list')).not.to.have.attribute('class');
+      // to test that the `component` prop should not forward to the custom slot.
+      expect(getByRole('list')).not.to.have.attribute('data-component');
+    });
+
+    it('the root component can be changed', () => {
+      const { getByRole } = render(<Item slotProps={{ root: { component: 'aside' } }} />);
+      expect(getByRole('tooltip')).to.have.tagName('aside');
+    });
+  });
+
+  /**
+   * Simulate `Autocomplete`, `Select`, ...etc
+   */
+  describe('multiple slots with unstyled popper', () => {
+    const ItemRoot = styled('button')({});
+    const ItemListbox = styled('ul')({
+      margin: 'initial', // prevent Popper error.
+    });
+    const ItemOption = styled('div')({});
+
+    function Item(props: {
+      component?: React.ElementType;
+      slots?: {
+        root?: React.ElementType;
+        listbox?: React.ElementType;
+        option?: React.ElementType;
+      };
+      slotProps?: {
+        root?: SlotProps<'button', Record<string, any>, {}>;
+        listbox?: SlotProps<'ul', Record<string, any>, {}>;
+        option?: SlotProps<'div', Record<string, any>, {}>;
+      };
+    }) {
+      const ref = React.useRef(null);
+      const [SlotRoot, rootProps] = useSlot('root', {
+        ref,
+        className: 'root',
+        elementType: ItemRoot,
+        externalForwardedProps: props,
+        ownerState: {},
+      });
+      const [SlotListbox, listboxProps] = useSlot('listbox', {
+        className: 'listbox',
+        elementType: Popper as unknown as 'ul',
+        externalForwardedProps: props,
+        ownerState: {},
+        additionalProps: {
+          open: true, // !!force the popper to always visible for testing
+          role: 'menu',
+          anchorEl: () => document.createElement('div'),
+        },
+        internalForwardedProps: {
+          slots: { root: ItemListbox },
+        },
+      });
+      const [SlotOption, optionProps] = useSlot('option', {
+        className: 'option',
+        elementType: ItemOption,
+        externalForwardedProps: props,
+        ownerState: {},
+        additionalProps: {
+          role: 'menuitem',
+        },
+      });
+      return (
+        <React.Fragment>
+          <SlotRoot {...rootProps} />
+          <SlotListbox {...listboxProps}>
+            <SlotOption as="li" {...optionProps} />
+          </SlotListbox>
+        </React.Fragment>
+      );
+    }
+
+    it('should render popper with styled-component', () => {
+      const { getByRole } = render(<Item />);
+      expect(getByRole('menu')).toBeVisible();
+      expect(getByRole('menu')).to.have.tagName('ul');
+      expect(getByRole('menu')).to.have.class('listbox');
+      expect(getByRole('menuitem')).to.have.tagName('li');
+    });
+
+    it('the listbox slot should be replaceable', () => {
+      function Listbox({ component }: { component?: React.ElementType }) {
+        return <ul data-component={component} />;
+      }
+
+      const { getByRole } = render(<Item slots={{ listbox: Listbox }} />);
+      expect(getByRole('list')).toBeVisible();
+      expect(getByRole('list')).not.to.have.attribute('class');
+      // to test that the `component` prop should not forward to the custom slot.
+      expect(getByRole('list')).not.to.have.attribute('data-component');
+    });
+
+    it('the listbox leaf component can be changed', () => {
+      const { getByRole } = render(<Item slotProps={{ listbox: { component: 'div' } }} />);
+      expect(getByRole('menu')).to.have.tagName('div');
+    });
+
+    it('the option leaf component can be changed', () => {
+      const { getByRole } = render(<Item slotProps={{ option: { component: 'div' } }} />);
+      expect(getByRole('menuitem')).to.have.tagName('div');
+    });
+  });
+});

--- a/packages/mui-material/src/utils/useSlot.test.tsx
+++ b/packages/mui-material/src/utils/useSlot.test.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createRenderer } from '@mui-internal/test-utils';
 import { Popper } from '@mui/base/Popper';
 import { styled } from '../styles';
-import { SlotProps } from './slotsTypes';
+import { SlotProps } from './types';
 import useSlot from './useSlot';
 
 describe('useSlot', () => {

--- a/packages/mui-material/src/utils/useSlot.ts
+++ b/packages/mui-material/src/utils/useSlot.ts
@@ -1,0 +1,172 @@
+'use client';
+import * as React from 'react';
+import { ClassValue } from 'clsx';
+import { unstable_useForkRef as useForkRef } from '@mui/utils';
+import { appendOwnerState, resolveComponentProps, mergeSlotProps } from '@mui/base/utils';
+
+export type WithCommonProps<T> = T & {
+  className?: string;
+  style?: React.CSSProperties;
+  ref?: React.Ref<any>;
+};
+
+type EventHandlers = Record<string, React.EventHandler<any>>;
+
+type ExtractComponentProps<P> = P extends infer T | ((ownerState: any) => infer T) ? T : never;
+
+/**
+ * An internal function to create a Material UI slot.
+ *
+ * This is an advanced version of Base UI `useSlotProps` because Material UI allows leaf component to be customized via `component` prop
+ * while Base UI does not need to support leaf component customization.
+ *
+ * @param {string} name: name of the slot
+ * @param {object} parameters
+ * @returns {[Slot, slotProps]} The slot's React component and the slot's props
+ *
+ * Note: the returned slot's props
+ * - will never contain `component` prop.
+ * - might contain `as` prop.
+ */
+export default function useSlot<
+  T extends string,
+  ElementType extends React.ElementType,
+  SlotProps,
+  OwnerState extends {},
+  ExternalSlotProps extends { component?: React.ElementType; ref?: React.Ref<any> },
+  ExternalForwardedProps extends {
+    component?: React.ElementType;
+    slots?: { [k in T]?: React.ElementType };
+    slotProps?: {
+      [k in T]?: ExternalSlotProps | ((ownerState: OwnerState) => ExternalSlotProps);
+    };
+  },
+  AdditionalProps,
+  SlotOwnerState extends {},
+>(
+  /**
+   * The slot's name. All Material UI components should have `root` slot.
+   *
+   * If the name is `root`, the logic behaves differently from other slots,
+   * e.g. the `externalForwardedProps` are spread to `root` slot but not other slots.
+   */
+  name: T,
+  parameters: (T extends 'root' // root slot must pass a `ref` as a parameter
+    ? { ref: React.ForwardedRef<any> }
+    : { ref?: React.ForwardedRef<any> }) & {
+    /**
+     * The slot's className
+     */
+    className: ClassValue | ClassValue[];
+    /**
+     * The slot's default styled-component
+     */
+    elementType: ElementType;
+    /**
+     * The component's ownerState
+     */
+    ownerState: OwnerState;
+    /**
+     * The `other` props from the consumer. It has to contain `component`, `slots`, and `slotProps`.
+     * The function will use those props to calculate the final rendered element and the returned props.
+     *
+     * If the slot is not `root`, the rest of the `externalForwardedProps` are neglected.
+     */
+    externalForwardedProps: ExternalForwardedProps;
+    getSlotProps?: (other: EventHandlers) => WithCommonProps<SlotProps>;
+    additionalProps?: WithCommonProps<AdditionalProps>;
+
+    // Material UI specifics
+    /**
+     * For overriding the component's ownerState for the slot.
+     * This is required for some components that need styling via `ownerState`.
+     *
+     * It is a function because `slotProps.{slot}` can be a function which has to be resolved first.
+     */
+    getSlotOwnerState?: (
+      mergedProps: AdditionalProps &
+        SlotProps &
+        ExternalSlotProps &
+        ExtractComponentProps<
+          Exclude<Exclude<ExternalForwardedProps['slotProps'], undefined>[T], undefined>
+        >,
+    ) => SlotOwnerState;
+    /**
+     * props forward to `T` only if the `slotProps.*.component` is not provided.
+     * e.g. Autocomplete's listbox uses Popper + StyledComponent
+     */
+    internalForwardedProps?: any;
+  },
+) {
+  const {
+    className,
+    elementType: initialElementType,
+    ownerState,
+    externalForwardedProps,
+    getSlotOwnerState,
+    internalForwardedProps,
+    ...useSlotPropsParams
+  } = parameters;
+  const {
+    component: rootComponent,
+    slots = { [name]: undefined },
+    slotProps = { [name]: undefined },
+    ...other
+  } = externalForwardedProps;
+
+  const elementType = slots[name] || initialElementType;
+
+  // `slotProps[name]` can be a callback that receives the component's ownerState.
+  // `resolvedComponentsProps` is always a plain object.
+  const resolvedComponentsProps = resolveComponentProps(slotProps[name], ownerState);
+
+  const {
+    props: { component: slotComponent, ...mergedProps },
+    internalRef,
+  } = mergeSlotProps({
+    className,
+    ...useSlotPropsParams,
+    externalForwardedProps: name === 'root' ? other : undefined,
+    externalSlotProps: resolvedComponentsProps,
+  });
+
+  const ref = useForkRef(internalRef, resolvedComponentsProps?.ref, parameters.ref);
+
+  const slotOwnerState = getSlotOwnerState ? getSlotOwnerState(mergedProps as any) : {};
+  const finalOwnerState = { ...ownerState, ...slotOwnerState } as any;
+
+  const LeafComponent = (name === 'root' ? slotComponent || rootComponent : slotComponent) as
+    | React.ElementType
+    | undefined;
+
+  const props = appendOwnerState(
+    elementType,
+    {
+      ...(name === 'root' && !rootComponent && !slots[name] && internalForwardedProps),
+      ...(name !== 'root' && !slots[name] && internalForwardedProps),
+      ...mergedProps,
+      ...(LeafComponent && {
+        as: LeafComponent,
+      }),
+      ref,
+    },
+    finalOwnerState,
+  );
+
+  Object.keys(slotOwnerState).forEach((propName) => {
+    delete props[propName];
+  });
+
+  return [elementType, props] as [
+    ElementType,
+    {
+      className: string;
+      ownerState: OwnerState & SlotOwnerState;
+    } & AdditionalProps &
+      SlotProps &
+      ExternalSlotProps &
+      ExtractComponentProps<
+        Exclude<Exclude<ExternalForwardedProps['slotProps'], undefined>[T], undefined>
+      >,
+  ];
+}


### PR DESCRIPTION
Part of: https://github.com/mui/material-ui/issues/40417

Review accordion-related components:

- **Accordion**: Add deprecations for transition props and the slots API that should replace it.
- **AccordionActions**: No changes
- **AccordionDetails**: No changes
- **AccordionSummary**: Deprecate contentGutters class

Because this is the first deprecations PR, it also adds slot pattern utils developed for Joy UI. This is done as the slots pattern will replace the *Props and *Component type props.

## Questions for reviewers
- I took the slot utils from Joy with minor modifications. Something I'm unsure about is the following: Joy's useSlot adds common slot props `component` and `sx`. I kept this as it applies to Material UI, but I was unsure whether to do it.
- I left more questions in the code.
- Are there any other deprecations we should add to these components?
