### PR TITLE
[core] Remove duplicate devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "dependencies": {
     "@googleapis/sheets": "^5.0.5",
     "@slack/bolt": "^3.17.0",
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^9.4.1"
   },
   "devDependencies": {
     "@argos-ci/core": "^1.4.0",
@@ -98,7 +98,6 @@
     "@babel/preset-env": "^7.23.7",
     "@babel/preset-react": "^7.23.3",
     "@babel/register": "^7.23.7",
-    "@googleapis/sheets": "^5.0.5",
     "@mnajdova/enzyme-adapter-react-18": "^0.2.0",
     "@mui-internal/api-docs-builder": "workspace:^",
     "@mui-internal/api-docs-builder-core": "workspace:^",
@@ -110,7 +109,6 @@
     "@next/eslint-plugin-next": "^14.0.4",
     "@octokit/rest": "^20.0.2",
     "@playwright/test": "1.40.1",
-    "@slack/bolt": "^3.17.0",
     "@slack/web-api": "^6.11.1",
     "@types/enzyme": "^3.10.18",
     "@types/fs-extra": "^11.0.4",
@@ -153,7 +151,6 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "globby": "^13.2.2",
-    "google-auth-library": "^9.4.1",
     "karma": "^6.4.2",
     "karma-browserstack-launcher": "~1.6.0",
     "karma-chrome-launcher": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^3.17.0
         version: 3.17.0
       google-auth-library:
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^9.4.1
+        version: 9.4.1
     devDependencies:
       '@argos-ci/core':
         specifier: ^1.4.0
@@ -12616,8 +12616,8 @@ packages:
       wide-align: 1.1.5
     dev: true
 
-  /gaxios@6.0.4:
-    resolution: {integrity: sha512-mwKfHJn7f3pLRfahdEPNyvygXRwjwgsgDPaIIoBRIDkgP4SFyezkYGWQ2aLCfrAnzimSrP+mAg1aSUj5gidXvw==}
+  /gaxios@6.1.1:
+    resolution: {integrity: sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==}
     engines: {node: '>=14'}
     dependencies:
       extend: 3.0.2
@@ -12629,11 +12629,11 @@ packages:
       - supports-color
     dev: false
 
-  /gcp-metadata@6.0.0:
-    resolution: {integrity: sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==}
+  /gcp-metadata@6.1.0:
+    resolution: {integrity: sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==}
     engines: {node: '>=14'}
     dependencies:
-      gaxios: 6.0.4
+      gaxios: 6.1.1
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -12969,17 +12969,16 @@ packages:
       csstype: 3.1.2
     dev: false
 
-  /google-auth-library@9.0.0:
-    resolution: {integrity: sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==}
+  /google-auth-library@9.4.1:
+    resolution: {integrity: sha512-Chs7cuzDuav8W/BXOoRgSXw4u0zxYtuqAHETDR5Q6dG1RwNwz7NUKjsDDHAsBV3KkiiJBtJqjbzy1XU1L41w1g==}
     engines: {node: '>=14'}
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.0.4
-      gcp-metadata: 6.0.0
+      gaxios: 6.1.1
+      gcp-metadata: 6.1.0
       gtoken: 7.0.1
       jws: 4.0.0
-      lru-cache: 6.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -12990,8 +12989,8 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       extend: 3.0.2
-      gaxios: 6.0.4
-      google-auth-library: 9.0.0
+      gaxios: 6.1.1
+      google-auth-library: 9.4.1
       qs: 6.11.0
       url-template: 2.0.8
       uuid: 9.0.1
@@ -13033,7 +13032,7 @@ packages:
     resolution: {integrity: sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      gaxios: 6.0.4
+      gaxios: 6.1.1
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
Removed packages duplicated between dependencies and devDependencies. They are used by the Netlify function, so they should live in dependencies.

Also log warnings:

![Screenshot 2024-01-06 at 19 06 30](https://github.com/mui/material-ui/assets/3165635/0ba8f581-448a-413e-bd29-39f546b046bc)
