### PR TITLE
[docs-infra] Improve API page deprecation info

### DIFF
--- a/docs/src/modules/components/ApiPage/ApiAlert.tsx
+++ b/docs/src/modules/components/ApiPage/ApiAlert.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { alpha } from '@mui/system';
+import { styled } from '@mui/material/styles';
+import Alert from '@mui/material/Alert';
+import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
+import {
+  brandingDarkTheme as darkTheme,
+  brandingLightTheme as lightTheme,
+} from 'docs/src/modules/brandingTheme';
+
+const StyledAlert = styled(Alert)(
+  ({ theme }) => ({
+    '&.MuiAlert-standardWarning': {
+      alignItems: 'center',
+      padding: '2px 12px',
+      fontWeight: theme.typography.fontWeightRegular,
+      color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
+      backgroundColor: alpha(lightTheme.palette.warning[50], 0.5),
+      borderColor: `var(--muidocs-palette-warning-200, ${lightTheme.palette.warning[200]})`,
+      '& .MuiAlert-icon': {
+        height: 'fit-content',
+        padding: 0,
+      },
+      '& code': { all: 'unset' },
+      '& strong': {
+        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+      },
+      '& svg': {
+        fill: `var(--muidocs-palette-warning-600, ${lightTheme.palette.warning[600]})`,
+      },
+      '& a': {
+        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+        textDecorationColor: alpha(lightTheme.palette.warning.main, 0.4),
+        '&:hover': {
+          textDecorationColor: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+        },
+      },
+    },
+  }),
+  ({ theme }) => ({
+    [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
+      '&.MuiAlert-standardWarning': {
+        color: `var(--muidocs-palette-warning-50, ${darkTheme.palette.warning[50]})`,
+        backgroundColor: alpha(darkTheme.palette.warning[700], 0.15),
+        borderColor: alpha(darkTheme.palette.warning[600], 0.3),
+        '& strong': {
+          color: `var(--muidocs-palette-warning-200, ${darkTheme.palette.warning[200]})`,
+        },
+        '& svg': {
+          fill: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
+        },
+        '& a': {
+          color: `var(--muidocs-palette-warning-200, ${darkTheme.palette.warning[200]})`,
+          textDecorationColor: alpha(darkTheme.palette.warning.main, 0.4),
+          '&:hover': {
+            textDecorationColor: `var(--muidocs-palette-warning-200, ${darkTheme.palette.warning[200]})`,
+          },
+        },
+      },
+    },
+  }),
+);
+
+interface DeprecationAlertProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export default function ApiAlert({ children, className }: DeprecationAlertProps) {
+  return (
+    <StyledAlert
+      className={className}
+      severity="warning"
+      icon={<WarningRoundedIcon fontSize="small" />}
+    >
+      {children}
+    </StyledAlert>
+  );
+}

--- a/docs/src/modules/components/ApiPage/ApiWarning.tsx
+++ b/docs/src/modules/components/ApiPage/ApiWarning.tsx
@@ -66,7 +66,7 @@ interface DeprecationAlertProps {
   className?: string;
 }
 
-export default function ApiAlert({ children, className }: DeprecationAlertProps) {
+export default function ApiWarning({ children, className }: DeprecationAlertProps) {
   return (
     <StyledAlert
       className={className}

--- a/docs/src/modules/components/ApiPage/list/ClassesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/ClassesList.tsx
@@ -9,7 +9,10 @@ import { useTranslate } from 'docs/src/modules/utils/i18n';
 import ExpandableApiItem, {
   ApiItemContaier,
 } from 'docs/src/modules/components/ApiPage/list/ExpandableApiItem';
-import { brandingDarkTheme as darkTheme } from 'docs/src/modules/brandingTheme';
+import {
+  brandingLightTheme as lightTheme,
+  brandingDarkTheme as darkTheme,
+} from 'docs/src/modules/brandingTheme';
 
 const StyledApiItem = styled(ExpandableApiItem)(
   ({ theme }) => ({
@@ -27,14 +30,24 @@ const StyledApiItem = styled(ExpandableApiItem)(
     '& .prop-list-class': {
       margin: 0,
     },
-    '& .classes-list-deprecated': {
-      '& code': { all: 'unset' },
+    '&.classes-list-deprecated-item': {
+      '& .MuiApi-item-note': {
+        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+      },
+      '& .classes-list-alert': {
+        '& code': { all: 'unset' },
+      },
     },
   }),
   ({ theme }) => ({
     [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
       '& .prop-list-title': {
         color: `var(--muidocs-palette-grey-50, ${darkTheme.palette.grey[50]})`,
+      },
+      '&.classes-list-deprecated-item': {
+        '& .MuiApi-item-note': {
+          color: `var(--muidocs-palette-warning-400, ${lightTheme.palette.warning[400]})`,
+        },
       },
     },
   }),
@@ -67,11 +80,14 @@ export default function ClassesList(props: ClassesListProps) {
           <StyledApiItem
             id={getHash({ componentName, className: key })}
             key={key}
-            note={isGlobal ? t('api-docs.state') : ''}
+            note={
+              (isGlobal && t('api-docs.state')) || (isDeprecated && t('api-docs.deprecated')) || ''
+            }
             title={`.${className}`}
             type="classes"
             displayOption={displayOption}
             isExtendable={!!description}
+            className={isDeprecated ? 'classes-list-deprecated-item' : ''}
           >
             {description && <p dangerouslySetInnerHTML={{ __html: description }} />}
             {displayClassKeys && !isGlobal && (
@@ -82,7 +98,7 @@ export default function ClassesList(props: ClassesListProps) {
             )}
             {isDeprecated && (
               <Alert
-                className="MuiApi-collapsible classes-list-deprecated"
+                className="MuiApi-collapsible classes-list-alert"
                 severity="warning"
                 icon={<WarningRoundedIcon fontSize="small" />}
                 sx={{

--- a/docs/src/modules/components/ApiPage/list/ClassesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/ClassesList.tsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import kebabCase from 'lodash/kebabCase';
+import Alert from '@mui/material/Alert';
+import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import { ComponentClassDefinition } from '@mui-internal/docs-utilities';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import ExpandableApiItem, {
@@ -24,6 +26,9 @@ const StyledApiItem = styled(ExpandableApiItem)(
     },
     '& .prop-list-class': {
       margin: 0,
+    },
+    '& .classes-list-deprecated': {
+      '& code': { all: 'unset' },
     },
   }),
   ({ theme }) => ({
@@ -55,7 +60,8 @@ export default function ClassesList(props: ClassesListProps) {
   return (
     <ApiItemContaier>
       {classes.map((classDefinition) => {
-        const { className, key, description, isGlobal } = classDefinition;
+        const { className, key, description, isGlobal, isDeprecated, deprecationInfo } =
+          classDefinition;
 
         return (
           <StyledApiItem
@@ -73,6 +79,31 @@ export default function ClassesList(props: ClassesListProps) {
                 <span className="prop-list-title">{'Rule name'}:</span>
                 <code className="Api-code">{key}</code>
               </p>
+            )}
+            {isDeprecated && (
+              <Alert
+                className="MuiApi-collapsible classes-list-deprecated"
+                severity="warning"
+                icon={<WarningRoundedIcon fontSize="small" />}
+                sx={{
+                  '& .MuiAlert-icon': {
+                    height: 'fit-content',
+                    py: '8px',
+                  },
+                }}
+              >
+                {t('api-docs.deprecated')}
+                {deprecationInfo && (
+                  <React.Fragment>
+                    {' - '}
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: deprecationInfo,
+                      }}
+                    />
+                  </React.Fragment>
+                )}
+              </Alert>
             )}
           </StyledApiItem>
         );

--- a/docs/src/modules/components/ApiPage/list/ClassesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/ClassesList.tsx
@@ -2,8 +2,6 @@
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
 import kebabCase from 'lodash/kebabCase';
-import Alert from '@mui/material/Alert';
-import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import { ComponentClassDefinition } from '@mui-internal/docs-utilities';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import ExpandableApiItem, {
@@ -13,6 +11,7 @@ import {
   brandingLightTheme as lightTheme,
   brandingDarkTheme as darkTheme,
 } from 'docs/src/modules/brandingTheme';
+import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
 
 const StyledApiItem = styled(ExpandableApiItem)(
   ({ theme }) => ({
@@ -32,11 +31,12 @@ const StyledApiItem = styled(ExpandableApiItem)(
     },
     '&.classes-list-deprecated-item': {
       '& .MuiApi-item-note': {
-        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+        color: `var(--muidocs-palette-warning-700, ${lightTheme.palette.warning[700]})`,
       },
-      '& .classes-list-alert': {
-        '& code': { all: 'unset' },
-      },
+    },
+    '& .classes-list-alert': {
+      marginTop: 12,
+      marginBottom: 16,
     },
   }),
   ({ theme }) => ({
@@ -90,24 +90,8 @@ export default function ClassesList(props: ClassesListProps) {
             className={isDeprecated ? 'classes-list-deprecated-item' : ''}
           >
             {description && <p dangerouslySetInnerHTML={{ __html: description }} />}
-            {displayClassKeys && !isGlobal && (
-              <p className="prop-list-class">
-                <span className="prop-list-title">{'Rule name'}:</span>
-                <code className="Api-code">{key}</code>
-              </p>
-            )}
             {isDeprecated && (
-              <Alert
-                className="MuiApi-collapsible classes-list-alert"
-                severity="warning"
-                icon={<WarningRoundedIcon fontSize="small" />}
-                sx={{
-                  '& .MuiAlert-icon': {
-                    height: 'fit-content',
-                    py: '8px',
-                  },
-                }}
-              >
+              <ApiAlert className="MuiApi-collapsible classes-list-alert">
                 {t('api-docs.deprecated')}
                 {deprecationInfo && (
                   <React.Fragment>
@@ -119,7 +103,13 @@ export default function ClassesList(props: ClassesListProps) {
                     />
                   </React.Fragment>
                 )}
-              </Alert>
+              </ApiAlert>
+            )}
+            {displayClassKeys && !isGlobal && (
+              <p className="prop-list-class">
+                <span className="prop-list-title">{'Rule name'}:</span>
+                <code className="Api-code">{key}</code>
+              </p>
             )}
           </StyledApiItem>
         );

--- a/docs/src/modules/components/ApiPage/list/ClassesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/ClassesList.tsx
@@ -76,13 +76,17 @@ export default function ClassesList(props: ClassesListProps) {
         const { className, key, description, isGlobal, isDeprecated, deprecationInfo } =
           classDefinition;
 
+        let note = isGlobal ? t('api-docs.state') : '';
+
+        if (isDeprecated) {
+          note = [note, t('api-docs.deprecated')].filter(Boolean).join(' - ');
+        }
+
         return (
           <StyledApiItem
             id={getHash({ componentName, className: key })}
             key={key}
-            note={
-              (isGlobal && t('api-docs.state')) || (isDeprecated && t('api-docs.deprecated')) || ''
-            }
+            note={note}
             title={`.${className}`}
             type="classes"
             displayOption={displayOption}

--- a/docs/src/modules/components/ApiPage/list/ClassesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/ClassesList.tsx
@@ -11,7 +11,7 @@ import {
   brandingLightTheme as lightTheme,
   brandingDarkTheme as darkTheme,
 } from 'docs/src/modules/brandingTheme';
-import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
+import ApiWarning from 'docs/src/modules/components/ApiPage/ApiWarning';
 
 const StyledApiItem = styled(ExpandableApiItem)(
   ({ theme }) => ({
@@ -91,7 +91,7 @@ export default function ClassesList(props: ClassesListProps) {
           >
             {description && <p dangerouslySetInnerHTML={{ __html: description }} />}
             {isDeprecated && (
-              <ApiAlert className="MuiApi-collapsible classes-list-alert">
+              <ApiWarning className="MuiApi-collapsible classes-list-alert">
                 {t('api-docs.deprecated')}
                 {deprecationInfo && (
                   <React.Fragment>
@@ -103,7 +103,7 @@ export default function ClassesList(props: ClassesListProps) {
                     />
                   </React.Fragment>
                 )}
-              </ApiAlert>
+              </ApiWarning>
             )}
             {displayClassKeys && !isGlobal && (
               <p className="prop-list-class">

--- a/docs/src/modules/components/ApiPage/list/ClassesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/ClassesList.tsx
@@ -46,7 +46,7 @@ const StyledApiItem = styled(ExpandableApiItem)(
       },
       '&.classes-list-deprecated-item': {
         '& .MuiApi-item-note': {
-          color: `var(--muidocs-palette-warning-400, ${lightTheme.palette.warning[400]})`,
+          color: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
         },
       },
     },

--- a/docs/src/modules/components/ApiPage/list/ExpandableApiItem.tsx
+++ b/docs/src/modules/components/ApiPage/list/ExpandableApiItem.tsx
@@ -93,21 +93,6 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
         },
       },
     },
-    '& .MuiAlert-standardWarning': {
-      padding: '6px 12px',
-      fontWeight: theme.typography.fontWeightMedium,
-      border: '1px solid',
-      borderColor: `var(--muidocs-palette-warning-300, ${lightTheme.palette.warning[300]})`,
-      borderRadius: 12,
-      backgroundColor: `var(--muidocs-palette-warning-50, ${lightTheme.palette.warning[50]})`,
-      color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
-      marginBottom: 16,
-      '.MuiAlert-icon': {
-        display: 'flex',
-        alignItems: 'center',
-        fill: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
-      },
-    },
     '& code.Api-code': {
       ...theme.typography.caption,
       fontFamily: theme.typography.fontFamilyCode,
@@ -150,14 +135,6 @@ const Root = styled('div')<{ ownerState: { type?: DescriptionType } }>(
         },
         '& .MuiApi-item-note': {
           color: `var(--muidocs-palette-success-400, ${darkTheme.palette.success[400]})`,
-        },
-      },
-      '& .MuiAlert-standardWarning': {
-        borderColor: alpha(darkTheme.palette.warning[800], 0.3),
-        backgroundColor: alpha(darkTheme.palette.warning[800], 0.2),
-        color: `var(--muidocs-palette-warning-100, ${darkTheme.palette.warning[100]})`,
-        '.MuiAlert-icon svg': {
-          fill: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
         },
       },
       '& code.Api-code': {

--- a/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
@@ -86,7 +86,7 @@ const StyledApiItem = styled(ExpandableApiItem)(
       },
       '&.prop-list-deprecated-item': {
         '& .MuiApi-item-note': {
-          color: `var(--muidocs-palette-warning-400, ${lightTheme.palette.warning[400]})`,
+          color: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
         },
       },
     },

--- a/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
@@ -179,17 +179,20 @@ export default function PropertiesList(props: PropertiesListProps) {
           signatureArgs,
           signatureReturnDescription,
         } = params;
+
+        let note =
+          (isOptional && t('api-docs.optional')) || (isRequired && t('api-docs.required')) || '';
+
+        if (isDeprecated) {
+          note = [note, t('api-docs.deprecated')].filter(Boolean).join(' - ');
+        }
+
         return (
           <StyledApiItem
             key={propName}
             id={getHash({ componentName, propName, hooksParameters, hooksReturnValue })}
             title={propName}
-            note={
-              (isOptional && t('api-docs.optional')) ||
-              (isRequired && t('api-docs.required')) ||
-              (isDeprecated && t('api-docs.deprecated')) ||
-              ''
-            }
+            note={note}
             type="props"
             displayOption={displayOption}
             className={isDeprecated ? 'prop-list-deprecated-item' : ''}

--- a/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
 import { styled } from '@mui/material/styles';
-import Alert from '@mui/material/Alert';
-import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import kebabCase from 'lodash/kebabCase';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import {
@@ -12,6 +10,7 @@ import {
 import ExpandableApiItem, {
   ApiItemContaier,
 } from 'docs/src/modules/components/ApiPage/list/ExpandableApiItem';
+import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
 
 const StyledApiItem = styled(ExpandableApiItem)(
   ({ theme }) => ({
@@ -39,11 +38,12 @@ const StyledApiItem = styled(ExpandableApiItem)(
     },
     '&.prop-list-deprecated-item': {
       '& .MuiApi-item-note': {
-        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+        color: `var(--muidocs-palette-warning-700, ${lightTheme.palette.warning[700]})`,
       },
-      '& .prop-list-alert': {
-        '& code': { all: 'unset' },
-      },
+    },
+    '& .prop-list-alert': {
+      marginTop: 12,
+      marginBottom: 16,
     },
     '& .prop-list-default-props': {
       ...theme.typography.body2,
@@ -197,22 +197,13 @@ export default function PropertiesList(props: PropertiesListProps) {
             {description && <PropDescription description={description} />}
             {seeMoreDescription && <p dangerouslySetInnerHTML={{ __html: seeMoreDescription }} />}
             {requiresRef && (
-              <Alert
-                severity="warning"
-                icon={<WarningRoundedIcon fontSize="small" />}
-                sx={{
-                  '& .MuiAlert-icon': {
-                    height: 'fit-content',
-                    py: '8px',
-                  },
-                }}
-              >
+              <ApiAlert className="MuiApi-collapsible prop-list-alert">
                 <span
                   dangerouslySetInnerHTML={{
                     __html: t('api-docs.requires-ref'),
                   }}
                 />
-              </Alert>
+              </ApiAlert>
             )}
             {additionalInfo.map((key) => (
               <p
@@ -224,17 +215,7 @@ export default function PropertiesList(props: PropertiesListProps) {
               />
             ))}
             {isDeprecated && (
-              <Alert
-                className="MuiApi-collapsible prop-list-alert"
-                severity="warning"
-                icon={<WarningRoundedIcon fontSize="small" />}
-                sx={{
-                  '& .MuiAlert-icon': {
-                    height: 'fit-content',
-                    py: '8px',
-                  },
-                }}
-              >
+              <ApiAlert className="MuiApi-collapsible prop-list-alert">
                 {t('api-docs.deprecated')}
                 {deprecationInfo && (
                   <React.Fragment>
@@ -246,7 +227,7 @@ export default function PropertiesList(props: PropertiesListProps) {
                     />
                   </React.Fragment>
                 )}
-              </Alert>
+              </ApiAlert>
             )}
             <div className="prop-list-additional-info">
               {typeName && (

--- a/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
@@ -37,8 +37,13 @@ const StyledApiItem = styled(ExpandableApiItem)(
         fontSize: theme.typography.pxToRem(12),
       },
     },
-    '& .prop-list-deprecated': {
-      '& code': { all: 'unset' },
+    '&.prop-list-deprecated-item': {
+      '& .MuiApi-item-note': {
+        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+      },
+      '& .prop-list-alert': {
+        '& code': { all: 'unset' },
+      },
     },
     '& .prop-list-default-props': {
       ...theme.typography.body2,
@@ -78,6 +83,11 @@ const StyledApiItem = styled(ExpandableApiItem)(
       },
       '& .prop-list-default-props': {
         color: `var(--muidocs-palette-grey-300, ${darkTheme.palette.grey[300]})`,
+      },
+      '&.prop-list-deprecated-item': {
+        '& .MuiApi-item-note': {
+          color: `var(--muidocs-palette-warning-400, ${lightTheme.palette.warning[400]})`,
+        },
       },
     },
   }),
@@ -174,9 +184,15 @@ export default function PropertiesList(props: PropertiesListProps) {
             key={propName}
             id={getHash({ componentName, propName, hooksParameters, hooksReturnValue })}
             title={propName}
-            note={(isOptional && 'Optional') || (isRequired && 'Required') || ''}
+            note={
+              (isOptional && t('api-docs.optional')) ||
+              (isRequired && t('api-docs.required')) ||
+              (isDeprecated && t('api-docs.deprecated')) ||
+              ''
+            }
             type="props"
             displayOption={displayOption}
+            className={isDeprecated ? 'prop-list-deprecated-item' : ''}
           >
             {description && <PropDescription description={description} />}
             {seeMoreDescription && <p dangerouslySetInnerHTML={{ __html: seeMoreDescription }} />}
@@ -209,7 +225,7 @@ export default function PropertiesList(props: PropertiesListProps) {
             ))}
             {isDeprecated && (
               <Alert
-                className="MuiApi-collapsible prop-list-deprecated"
+                className="MuiApi-collapsible prop-list-alert"
                 severity="warning"
                 icon={<WarningRoundedIcon fontSize="small" />}
                 sx={{

--- a/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
+++ b/docs/src/modules/components/ApiPage/list/PropertiesList.tsx
@@ -10,7 +10,7 @@ import {
 import ExpandableApiItem, {
   ApiItemContaier,
 } from 'docs/src/modules/components/ApiPage/list/ExpandableApiItem';
-import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
+import ApiWarning from 'docs/src/modules/components/ApiPage/ApiWarning';
 
 const StyledApiItem = styled(ExpandableApiItem)(
   ({ theme }) => ({
@@ -197,13 +197,13 @@ export default function PropertiesList(props: PropertiesListProps) {
             {description && <PropDescription description={description} />}
             {seeMoreDescription && <p dangerouslySetInnerHTML={{ __html: seeMoreDescription }} />}
             {requiresRef && (
-              <ApiAlert className="MuiApi-collapsible prop-list-alert">
+              <ApiWarning className="MuiApi-collapsible prop-list-alert">
                 <span
                   dangerouslySetInnerHTML={{
                     __html: t('api-docs.requires-ref'),
                   }}
                 />
-              </ApiAlert>
+              </ApiWarning>
             )}
             {additionalInfo.map((key) => (
               <p
@@ -215,7 +215,7 @@ export default function PropertiesList(props: PropertiesListProps) {
               />
             ))}
             {isDeprecated && (
-              <ApiAlert className="MuiApi-collapsible prop-list-alert">
+              <ApiWarning className="MuiApi-collapsible prop-list-alert">
                 {t('api-docs.deprecated')}
                 {deprecationInfo && (
                   <React.Fragment>
@@ -227,7 +227,7 @@ export default function PropertiesList(props: PropertiesListProps) {
                     />
                   </React.Fragment>
                 )}
-              </ApiAlert>
+              </ApiWarning>
             )}
             <div className="prop-list-additional-info">
               {typeName && (

--- a/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
@@ -38,6 +38,7 @@ type ClassDescription = {
     description: string;
     nodeName?: string;
     conditions?: string;
+    deprecationInfo?: string;
   };
 };
 export type ClassesSectionProps = {
@@ -80,6 +81,7 @@ export default function ClassesSection(props: ClassesSectionProps) {
           ?.replace(/{{conditions}}/, classDescriptions[classDefinition.key].conditions!)
           ?.replace(/{{nodeName}}/, classDescriptions[classDefinition.key].nodeName!) ??
         classDefinition.description,
+      deprecationInfo: classDescriptions[classDefinition.key]?.deprecationInfo,
     };
   });
 

--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -9,7 +9,7 @@ import {
 import { getHash } from 'docs/src/modules/components/ApiPage/list/ClassesList';
 import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/StyledTableContainer';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
-import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
+import ApiWarning from 'docs/src/modules/components/ApiPage/ApiWarning';
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
@@ -94,7 +94,7 @@ export default function ClassesTable(props: ClassesTableProps) {
                     }}
                   />
                   {isDeprecated && (
-                    <ApiAlert className="classes-table-alert">
+                    <ApiWarning className="classes-table-alert">
                       {t('api-docs.deprecated')}
                       {deprecationInfo && (
                         <React.Fragment>
@@ -106,7 +106,7 @@ export default function ClassesTable(props: ClassesTableProps) {
                           />
                         </React.Fragment>
                       )}
-                    </ApiAlert>
+                    </ApiWarning>
                   )}
                 </td>
               </tr>

--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -2,12 +2,15 @@
 import * as React from 'react';
 import { ComponentClassDefinition } from '@mui-internal/docs-utilities';
 import { styled, alpha } from '@mui/material/styles';
+import Alert from '@mui/material/Alert';
+import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import {
   brandingDarkTheme as darkTheme,
   brandingLightTheme as lightTheme,
 } from 'docs/src/modules/brandingTheme';
 import { getHash } from 'docs/src/modules/components/ApiPage/list/ClassesList';
 import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/StyledTableContainer';
+import { useTranslate } from 'docs/src/modules/utils/i18n';
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
@@ -47,6 +50,32 @@ const StyledTable = styled('table')(
         backgroundColor: alpha(darkTheme.palette.primary[900], 0.4),
       },
     },
+    '& .classes-table-deprecated': {
+      '& code ': { all: 'unset' },
+    },
+    '& .classes-table-alert': {
+      padding: '2px 12px',
+      marginTop: 12,
+      color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
+      backgroundColor: alpha(lightTheme.palette.warning[50], 0.5),
+      borderColor: `var(--muidocs-palette-warning-200, ${lightTheme.palette.warning[200]})`,
+      '& .MuiAlert-icon': {
+        padding: 0,
+      },
+      '& strong': {
+        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+      },
+      '&>svg': {
+        fill: `var(--muidocs-palette-warning-600, ${lightTheme.palette.warning[600]})`,
+      },
+      '& a': {
+        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
+        textDecorationColor: alpha(lightTheme.palette.warning.main, 0.4),
+        '&:hover': {
+          textDecorationColor: 'inherit',
+        },
+      },
+    },
   }),
 );
 
@@ -58,6 +87,8 @@ interface ClassesTableProps {
 
 export default function ClassesTable(props: ClassesTableProps) {
   const { classes, componentName, displayClassKeys } = props;
+  const t = useTranslate();
+
   return (
     <StyledTableContainer>
       <StyledTable>
@@ -70,7 +101,7 @@ export default function ClassesTable(props: ClassesTableProps) {
         </thead>
         <tbody>
           {classes.map((params) => {
-            const { className, key, description, isGlobal } = params;
+            const { className, key, description, isGlobal, isDeprecated, deprecationInfo } = params;
 
             return (
               <tr key={className} id={getHash({ componentName, className: key })}>
@@ -86,6 +117,26 @@ export default function ClassesTable(props: ClassesTableProps) {
                       __html: description || '',
                     }}
                   />
+                  {isDeprecated && (
+                    <Alert
+                      severity="warning"
+                      className="classes-table-alert classes-table-deprecated"
+                      icon={<WarningRoundedIcon fontSize="small" />}
+                      sx={{ mb: 1, py: 0, alignItems: 'center' }}
+                    >
+                      {t('api-docs.deprecated')}
+                      {deprecationInfo && (
+                        <React.Fragment>
+                          {' - '}
+                          <span
+                            dangerouslySetInnerHTML={{
+                              __html: deprecationInfo,
+                            }}
+                          />
+                        </React.Fragment>
+                      )}
+                    </Alert>
+                  )}
                 </td>
               </tr>
             );

--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -38,18 +38,6 @@ const StyledTable = styled('table')(
       borderColor: alpha(darkTheme.palette.primary[100], 0.8),
       backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
     },
-  }),
-  ({ theme }) => ({
-    [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
-      '& .class-name': {
-        color: `var(--muidocs-palette-primary-200, ${darkTheme.palette.primary[200]})`,
-      },
-      '& .class-key': {
-        color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
-        borderColor: alpha(darkTheme.palette.primary[400], 0.1),
-        backgroundColor: alpha(darkTheme.palette.primary[900], 0.4),
-      },
-    },
     '& .classes-table-deprecated': {
       '& code ': { all: 'unset' },
     },
@@ -73,6 +61,32 @@ const StyledTable = styled('table')(
         textDecorationColor: alpha(lightTheme.palette.warning.main, 0.4),
         '&:hover': {
           textDecorationColor: 'inherit',
+        },
+      },
+    },
+  }),
+  ({ theme }) => ({
+    [`:where(${theme.vars ? '[data-mui-color-scheme="dark"]' : '.mode-dark'}) &`]: {
+      '& .class-name': {
+        color: `var(--muidocs-palette-primary-200, ${darkTheme.palette.primary[200]})`,
+      },
+      '& .class-key': {
+        color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
+        borderColor: alpha(darkTheme.palette.primary[400], 0.1),
+        backgroundColor: alpha(darkTheme.palette.primary[900], 0.4),
+      },
+      '& .classes-table-alert': {
+        color: `var(--muidocs-palette-warning-50, ${darkTheme.palette.warning[50]})`,
+        backgroundColor: alpha(darkTheme.palette.warning[700], 0.15),
+        borderColor: alpha(darkTheme.palette.warning[600], 0.3),
+        '& strong': {
+          color: `var(--muidocs-palette-warning-200, ${darkTheme.palette.warning[200]})`,
+        },
+        '&>svg': {
+          fill: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
+        },
+        '& a': {
+          color: `var(--muidocs-palette-warning-100, ${darkTheme.palette.warning[100]})`,
         },
       },
     },

--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -2,8 +2,6 @@
 import * as React from 'react';
 import { ComponentClassDefinition } from '@mui-internal/docs-utilities';
 import { styled, alpha } from '@mui/material/styles';
-import Alert from '@mui/material/Alert';
-import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import {
   brandingDarkTheme as darkTheme,
   brandingLightTheme as lightTheme,
@@ -11,6 +9,7 @@ import {
 import { getHash } from 'docs/src/modules/components/ApiPage/list/ClassesList';
 import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/StyledTableContainer';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
+import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
@@ -38,31 +37,8 @@ const StyledTable = styled('table')(
       borderColor: alpha(darkTheme.palette.primary[100], 0.8),
       backgroundColor: `var(--muidocs-palette-primary-50, ${lightTheme.palette.primary[50]})`,
     },
-    '& .classes-table-deprecated': {
-      '& code ': { all: 'unset' },
-    },
     '& .classes-table-alert': {
-      padding: '2px 12px',
       marginTop: 12,
-      color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
-      backgroundColor: alpha(lightTheme.palette.warning[50], 0.5),
-      borderColor: `var(--muidocs-palette-warning-200, ${lightTheme.palette.warning[200]})`,
-      '& .MuiAlert-icon': {
-        padding: 0,
-      },
-      '& strong': {
-        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
-      },
-      '&>svg': {
-        fill: `var(--muidocs-palette-warning-600, ${lightTheme.palette.warning[600]})`,
-      },
-      '& a': {
-        color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
-        textDecorationColor: alpha(lightTheme.palette.warning.main, 0.4),
-        '&:hover': {
-          textDecorationColor: 'inherit',
-        },
-      },
     },
   }),
   ({ theme }) => ({
@@ -74,20 +50,6 @@ const StyledTable = styled('table')(
         color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
         borderColor: alpha(darkTheme.palette.primary[400], 0.1),
         backgroundColor: alpha(darkTheme.palette.primary[900], 0.4),
-      },
-      '& .classes-table-alert': {
-        color: `var(--muidocs-palette-warning-50, ${darkTheme.palette.warning[50]})`,
-        backgroundColor: alpha(darkTheme.palette.warning[700], 0.15),
-        borderColor: alpha(darkTheme.palette.warning[600], 0.3),
-        '& strong': {
-          color: `var(--muidocs-palette-warning-200, ${darkTheme.palette.warning[200]})`,
-        },
-        '&>svg': {
-          fill: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
-        },
-        '& a': {
-          color: `var(--muidocs-palette-warning-100, ${darkTheme.palette.warning[100]})`,
-        },
       },
     },
   }),
@@ -132,12 +94,7 @@ export default function ClassesTable(props: ClassesTableProps) {
                     }}
                   />
                   {isDeprecated && (
-                    <Alert
-                      severity="warning"
-                      className="classes-table-alert classes-table-deprecated"
-                      icon={<WarningRoundedIcon fontSize="small" />}
-                      sx={{ mb: 1, py: 0, alignItems: 'center' }}
-                    >
+                    <ApiAlert className="classes-table-alert">
                       {t('api-docs.deprecated')}
                       {deprecationInfo && (
                         <React.Fragment>
@@ -149,7 +106,7 @@ export default function ClassesTable(props: ClassesTableProps) {
                           />
                         </React.Fragment>
                       )}
-                    </Alert>
+                    </ApiAlert>
                   )}
                 </td>
               </tr>

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -11,7 +11,7 @@ import {
   getHash,
 } from 'docs/src/modules/components/ApiPage/list/PropertiesList';
 import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/StyledTableContainer';
-import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
+import ApiWarning from 'docs/src/modules/components/ApiPage/ApiWarning';
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
@@ -191,13 +191,13 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                     />
                   )}
                   {requiresRef && (
-                    <ApiAlert className="prop-table-alert">
+                    <ApiWarning className="prop-table-alert">
                       <span
                         dangerouslySetInnerHTML={{
                           __html: t('api-docs.requires-ref'),
                         }}
                       />
-                    </ApiAlert>
+                    </ApiWarning>
                   )}
                   {additionalInfo.map((key) => (
                     <p
@@ -209,7 +209,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                     />
                   ))}
                   {isDeprecated && (
-                    <ApiAlert className="prop-table-alert">
+                    <ApiWarning className="prop-table-alert">
                       {t('api-docs.deprecated')}
                       {deprecationInfo && (
                         <React.Fragment>
@@ -221,7 +221,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                           />
                         </React.Fragment>
                       )}
-                    </ApiAlert>
+                    </ApiWarning>
                   )}
                   {signature && (
                     <div className="prop-table-signature">

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable react/no-danger */
 import * as React from 'react';
 import { styled, alpha } from '@mui/material/styles';
-import Alert from '@mui/material/Alert';
-import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import {
   brandingDarkTheme as darkTheme,
@@ -13,6 +11,7 @@ import {
   getHash,
 } from 'docs/src/modules/components/ApiPage/list/PropertiesList';
 import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/StyledTableContainer';
+import ApiAlert from 'docs/src/modules/components/ApiPage/ApiAlert';
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
@@ -66,31 +65,8 @@ const StyledTable = styled('table')(
         marginTop: 12,
         marginBottom: 0,
       },
-      '& .prop-table-deprecated': {
-        '& code ': { all: 'unset' },
-      },
       '& .prop-table-alert': {
-        padding: '2px 12px',
         marginTop: 12,
-        color: `var(--muidocs-palette-grey-900, ${lightTheme.palette.grey[900]})`,
-        backgroundColor: alpha(lightTheme.palette.warning[50], 0.5),
-        borderColor: `var(--muidocs-palette-warning-200, ${lightTheme.palette.warning[200]})`,
-        '& .MuiAlert-icon': {
-          padding: 0,
-        },
-        '& strong': {
-          color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
-        },
-        '&>svg': {
-          fill: `var(--muidocs-palette-warning-600, ${lightTheme.palette.warning[600]})`,
-        },
-        '& a': {
-          color: `var(--muidocs-palette-warning-800, ${lightTheme.palette.warning[800]})`,
-          textDecorationColor: alpha(lightTheme.palette.warning.main, 0.4),
-          '&:hover': {
-            textDecorationColor: 'inherit',
-          },
-        },
       },
     },
     '& .prop-table-signature': {
@@ -122,22 +98,6 @@ const StyledTable = styled('table')(
       '& .prop-table-signature': {
         '& .prop-table-title': {
           color: `var(--muidocs-palette-text-primary, ${darkTheme.palette.text.primary})`,
-        },
-      },
-      '& .MuiPropTable-description-column': {
-        '& .prop-table-alert': {
-          color: `var(--muidocs-palette-warning-50, ${darkTheme.palette.warning[50]})`,
-          backgroundColor: alpha(darkTheme.palette.warning[700], 0.15),
-          borderColor: alpha(darkTheme.palette.warning[600], 0.3),
-          '& strong': {
-            color: `var(--muidocs-palette-warning-200, ${darkTheme.palette.warning[200]})`,
-          },
-          '&>svg': {
-            fill: `var(--muidocs-palette-warning-400, ${darkTheme.palette.warning[400]})`,
-          },
-          '& a': {
-            color: `var(--muidocs-palette-warning-100, ${darkTheme.palette.warning[100]})`,
-          },
         },
       },
     },
@@ -231,26 +191,13 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                     />
                   )}
                   {requiresRef && (
-                    <Alert
-                      className="prop-table-alert"
-                      severity="warning"
-                      icon={<WarningRoundedIcon fontSize="small" />}
-                      sx={{
-                        alignItems: 'center',
-                        '& .MuiAlert-icon': {
-                          height: 'fit-content',
-                          p: 0,
-                          mr: 1,
-                          mb: 0.3,
-                        },
-                      }}
-                    >
+                    <ApiAlert className="prop-table-alert">
                       <span
                         dangerouslySetInnerHTML={{
                           __html: t('api-docs.requires-ref'),
                         }}
                       />
-                    </Alert>
+                    </ApiAlert>
                   )}
                   {additionalInfo.map((key) => (
                     <p
@@ -262,12 +209,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                     />
                   ))}
                   {isDeprecated && (
-                    <Alert
-                      severity="warning"
-                      className="prop-table-alert prop-table-deprecated"
-                      icon={<WarningRoundedIcon fontSize="small" />}
-                      sx={{ mb: 1, py: 0, alignItems: 'center' }}
-                    >
+                    <ApiAlert className="prop-table-alert">
                       {t('api-docs.deprecated')}
                       {deprecationInfo && (
                         <React.Fragment>
@@ -279,7 +221,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                           />
                         </React.Fragment>
                       )}
-                    </Alert>
+                    </ApiAlert>
                   )}
                   {signature && (
                     <div className="prop-table-signature">

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -50,6 +50,8 @@
     "slotDescription": "To learn how to customize the slot, check out the <a href={{slotGuideLink}}>Overriding component structure</a> guide.",
     "slotName": "Slot name",
     "type": "Type",
+    "required": "Required",
+    "optional": "Optional",
     "additional-info": {
       "cssApi": "See <a href='#css'>CSS API</a> below for more details.",
       "sx": "See the <a href='/system/getting-started/the-sx-prop/'>`sx` page</a> for more details.",

--- a/packages/docs-utilities/ComponentClassDefinition.ts
+++ b/packages/docs-utilities/ComponentClassDefinition.ts
@@ -3,4 +3,6 @@ export interface ComponentClassDefinition {
   className: string;
   description: string;
   isGlobal: boolean;
+  isDeprecated?: boolean;
+  deprecationInfo?: string;
 }


### PR DESCRIPTION
## Summary

- Standardize API page warnings
- Add "DEPRECATED" label to props and class lists
- Add support for class deprecation

Details of each are below

### Standardize API page alert

Introduce the `ApiWarning` component to standardize all API page warning alerts: deprecations and "needs to be able to hold a ref" alerts on both table and list views.

**This doesn't include other warnings throughout the docs**, which might be something we should look into but goes beyond the scope of this PR.

<img width="334" alt="Screenshot 2024-01-09 at 19 47 12" src="https://github.com/mui/material-ui/assets/16889233/4f04ed90-e652-4b03-8803-e4c425b9b5fc">
<img width="334" alt="Screenshot 2024-01-09 at 19 46 37" src="https://github.com/mui/material-ui/assets/16889233/036bd73b-f974-4fcc-9f0e-dc6aaa8d2d0d">



### Add "DEPRECATED" label to props and class lists

This indicates deprecations when lists are collapsed. Without this change, deprecations cannot be seen until the prop is expanded.

<img width="891" alt="Screenshot 2024-01-09 at 16 24 32" src="https://github.com/mui/material-ui/assets/16889233/a7fa45d8-d552-402e-9fa6-a2ee4adced2f">

### Add support for class deprecation in API docs:

This is required, for example, for https://github.com/mui/material-ui/pull/40418. Here's [an example of how it would look like](https://deploy-preview-40418--material-ui.netlify.app/material-ui/api/accordion-summary/#AccordionSummary-classes-contentGutters).

<img width="804" alt="Screenshot 2024-01-05 at 12 27 23" src="https://github.com/mui/material-ui/assets/16889233/47c048b1-9460-4049-b363-ce2694fa0fad">

### Notes

This is my first docs-infra PR, so please correct anything I might not be aware of 😊.
