### PR TITLE
[material-next][Switch] Apply MD3 style and use Base UI hooks

### DIFF
--- a/docs/data/material/components/switches/SwitchMaterialYouPlayground.js
+++ b/docs/data/material/components/switches/SwitchMaterialYouPlayground.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material-next/Switch';
+import MaterialYouUsageDemo from 'docs/src/modules/components/MaterialYouUsageDemo';
+
+export default function SwitchMaterialYouPlayground() {
+  return (
+    <MaterialYouUsageDemo
+      componentName="Switch"
+      data={[
+        {
+          propName: 'color',
+          knob: 'select',
+          defaultValue: 'primary',
+          options: ['primary', 'secondary', 'tertiary'],
+        },
+        {
+          propName: 'disabled',
+          knob: 'switch',
+          defaultValue: false,
+        },
+      ]}
+      renderDemo={(props) => (
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Switch {...props} />
+        </Box>
+      )}
+    />
+  );
+}

--- a/docs/data/material/components/switches/switches.md
+++ b/docs/data/material/components/switches/switches.md
@@ -82,3 +82,18 @@ You can change the placement of the label:
 ```jsx
 <Switch value="checkedA" inputProps={{ 'aria-label': 'Switch A' }} />
 ```
+
+## Experimental APIs
+
+### Material 3 version
+
+The default Material UI Switch component follows the Material Design 2 specs.
+To get the [Material 3](https://m3.material.io/) version, use the new experimental `@mui/material-next` package.
+
+```js
+import Switch from '@mui/material-next/Switch';
+```
+
+{{"demo": "SwitchMaterialYouPlayground.js", "hideToolbar": true, "bg": "playground"}}
+
+For more instructions on how to use it, visit the [detailed guide](/material-ui/guides/material-3-components/).


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Switch issue:** #39886
**Material You umbrella issue:** #29345
**Preview**: https://deploy-preview-40442--material-ui.netlify.app/material-ui/react-switch/#material-3-version

## Changes
- Add playground to docs