### PR TITLE
[code-infra] Don't require noreferrer on target link

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -163,6 +163,9 @@ module.exports = {
     'react/state-in-constructor': 'off',
     // stylistic opinion. For conditional assignment we want it outside, otherwise as static
     'react/static-property-placement': 'off',
+    // noopener is enough, no IE 11 support
+    // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md#rule-options
+    'react/jsx-no-target-blank': ['error', { allowReferrer: true }],
 
     'no-restricted-syntax': [
       // See https://github.com/eslint/eslint/issues/9192 for why it's needed
@@ -209,7 +212,6 @@ module.exports = {
         // matching the pattern of the test runner
         '*.test.mjs',
         '*.test.js',
-        '*.test.mjs',
         '*.test.ts',
         '*.test.tsx',
       ],

--- a/apps/zero-runtime-next-app/src/app/page.tsx
+++ b/apps/zero-runtime-next-app/src/app/page.tsx
@@ -170,7 +170,7 @@ export default function Home() {
           <a
             href="https://vercel.com?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
           >
             By{' '}
             <Image
@@ -200,7 +200,7 @@ export default function Home() {
         <Card
           href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           <h2>
             Docs <span>-&gt;</span>
@@ -211,7 +211,7 @@ export default function Home() {
         <Card
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           <h2>
             Learn <span>-&gt;</span>
@@ -222,7 +222,7 @@ export default function Home() {
         <Card
           href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           <h2>
             Templates <span>-&gt;</span>
@@ -230,7 +230,7 @@ export default function Home() {
           <p>Explore the Next.js 13 playground.</p>
         </Card>
 
-        <Card as={Link} href="/slider" rel="noopener noreferrer">
+        <Card as={Link} href="/slider" rel="noopener">
           <h2>
             Checkout Slider <span>-&gt;</span>
           </h2>

--- a/docs/data/joy/customization/overriding-component-structure/OverridingRootSlot.js
+++ b/docs/data/joy/customization/overriding-component-structure/OverridingRootSlot.js
@@ -7,7 +7,7 @@ export default function OverridingRootSlot() {
       component="a"
       href="https://mui.com/about/"
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
     >
       About us
     </Button>

--- a/docs/data/joy/customization/overriding-component-structure/OverridingRootSlot.tsx
+++ b/docs/data/joy/customization/overriding-component-structure/OverridingRootSlot.tsx
@@ -7,7 +7,7 @@ export default function OverridingRootSlot() {
       component="a"
       href="https://mui.com/about/"
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
     >
       About us
     </Button>

--- a/docs/data/joy/customization/overriding-component-structure/OverridingRootSlot.tsx.preview
+++ b/docs/data/joy/customization/overriding-component-structure/OverridingRootSlot.tsx.preview
@@ -2,7 +2,7 @@
   component="a"
   href="https://mui.com/about/"
   target="_blank"
-  rel="noopener noreferrer"
+  rel="noopener"
 >
   About us
 </Button>

--- a/docs/data/joy/getting-started/templates/TemplateCollection.js
+++ b/docs/data/joy/getting-started/templates/TemplateCollection.js
@@ -216,7 +216,7 @@ export default function TemplateCollection() {
                     <Link
                       href={template.author.link}
                       target="_blank"
-                      rel="noopener noreferrer"
+                      rel="noopener nofollow"
                     >
                       <b>{template.author.name}</b>
                     </Link>
@@ -241,7 +241,7 @@ export default function TemplateCollection() {
                       <Link
                         href={template.design.link}
                         target="_blank"
-                        rel="noopener noreferrer nofollow"
+                        rel="noopener nofollow"
                       >
                         <b>{template.design.name}</b>
                       </Link>

--- a/docs/data/system/flexbox/flexbox.md
+++ b/docs/data/system/flexbox/flexbox.md
@@ -18,7 +18,7 @@ If you are **new to or unfamiliar with flexbox**, we encourage you to read this 
 ### flex-direction
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction" target="_blank" rel="noopener noreferrer">flex-direction</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction" target="_blank" rel="noopener">flex-direction</a>
 on MDN.
 
 {{"demo": "FlexDirection.js", "defaultCodeOpen": false, "bg": true}}
@@ -33,7 +33,7 @@ on MDN.
 ### flex-wrap
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap" target="_blank" rel="noopener noreferrer">flex-wrap</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap" target="_blank" rel="noopener">flex-wrap</a>
 on MDN.
 
 {{"demo": "FlexWrap.js", "defaultCodeOpen": false, "bg": true}}
@@ -47,7 +47,7 @@ on MDN.
 ### justify-content
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content" target="_blank" rel="noopener noreferrer">justify-content</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content" target="_blank" rel="noopener">justify-content</a>
 on MDN.
 
 {{"demo": "JustifyContent.js", "defaultCodeOpen": false, "bg": true}}
@@ -64,7 +64,7 @@ on MDN.
 ### align-items
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/align-items" target="_blank" rel="noopener noreferrer">align-items</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/align-items" target="_blank" rel="noopener">align-items</a>
 on MDN.
 
 {{"demo": "AlignItems.js", "defaultCodeOpen": false, "bg": true}}
@@ -80,7 +80,7 @@ on MDN.
 ### align-content
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/align-content" target="_blank" rel="noopener noreferrer">align-content</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/align-content" target="_blank" rel="noopener">align-content</a>
 on MDN.
 
 {{"demo": "AlignContent.js", "defaultCodeOpen": false, "bg": true}}
@@ -99,7 +99,7 @@ on MDN.
 ### order
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/order" target="_blank" rel="noopener noreferrer">order</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/order" target="_blank" rel="noopener">order</a>
 on MDN.
 
 {{"demo": "Order.js", "defaultCodeOpen": false, "bg": true}}
@@ -113,7 +113,7 @@ on MDN.
 ### flex-grow
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow" target="_blank" rel="noopener noreferrer">flex-grow</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow" target="_blank" rel="noopener">flex-grow</a>
 on MDN.
 
 {{"demo": "FlexGrow.js", "defaultCodeOpen": false, "bg": true}}
@@ -127,7 +127,7 @@ on MDN.
 ### flex-shrink
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink" target="_blank" rel="noopener noreferrer">flex-shrink</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink" target="_blank" rel="noopener">flex-shrink</a>
 on MDN.
 
 {{"demo": "FlexShrink.js", "defaultCodeOpen": false, "bg": true}}
@@ -141,7 +141,7 @@ on MDN.
 ### align-self
 
 For more information please see
-<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/align-self" target="_blank" rel="noopener noreferrer">align-self</a>
+<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/align-self" target="_blank" rel="noopener">align-self</a>
 on MDN.
 
 {{"demo": "AlignSelf.js", "defaultCodeOpen": false, "bg": true}}

--- a/docs/src/components/about/Team.tsx
+++ b/docs/src/components/about/Team.tsx
@@ -148,7 +148,7 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
               component="a"
               href={`https://github.com/${props.github}`}
               target="_blank"
-              rel="noreferrer noopener"
+              rel="noopener"
             >
               <GitHubIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>
@@ -159,7 +159,7 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
               component="a"
               href={`https://twitter.com/${props.twitter}`}
               target="_blank"
-              rel="noreferrer noopener"
+              rel="noopener"
             >
               <XIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>
@@ -170,7 +170,7 @@ function Person(props: Profile & { sx?: PaperProps['sx'] }) {
               component="a"
               href={`https://www.linkedin.com/${props.linkedin}`}
               target="_blank"
-              rel="noreferrer noopener"
+              rel="noopener"
             >
               <LinkedInIcon fontSize="small" sx={{ color: 'grey.500' }} />
             </IconButton>

--- a/docs/src/components/home/DiamondSponsors.tsx
+++ b/docs/src/components/home/DiamondSponsors.tsx
@@ -72,7 +72,7 @@ export default function DiamondSponsors() {
                 component="a"
                 href="mailto:sales@mui.com"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 color="primary"
                 sx={(theme) => ({
                   mr: 2,
@@ -91,7 +91,7 @@ export default function DiamondSponsors() {
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   To join us, contact us at{' '}
-                  <Link href="mailto:sales@mui.com" target="_blank" rel="noopener noreferrer">
+                  <Link href="mailto:sales@mui.com" target="_blank" rel="noopener">
                     sales@mui.com
                   </Link>{' '}
                   for pre-approval.

--- a/docs/src/components/home/GoldSponsors.tsx
+++ b/docs/src/components/home/GoldSponsors.tsx
@@ -118,7 +118,7 @@ export default function GoldSponsors() {
               component="a"
               href={ROUTES.goldSponsor}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               color="primary"
               sx={(theme) => ({
                 mr: 2,
@@ -137,7 +137,7 @@ export default function GoldSponsors() {
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Find out how{' '}
-                <Link href={ROUTES.goldSponsor} target="_blank" rel="noopener noreferrer">
+                <Link href={ROUTES.goldSponsor} target="_blank" rel="noopener">
                   you can support MUI.
                 </Link>
               </Typography>

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -137,7 +137,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Box>
             <Link href={ROUTES.support}>Support</Link>
             <Link href={ROUTES.privacyPolicy}>Privacy policy</Link>
-            <Link target="_blank" rel="noopener noreferrer" href="mailto:contact@mui.com">
+            <Link target="_blank" rel="noopener" href="mailto:contact@mui.com">
               Contact us
             </Link>
           </Box>
@@ -157,7 +157,7 @@ export default function AppFooter(props: AppFooterProps) {
         <Stack spacing={1} direction="row" flexWrap="wrap" useFlexGap>
           <IconButton
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href="https://github.com/mui"
             aria-label="github"
             title="GitHub"
@@ -167,7 +167,7 @@ export default function AppFooter(props: AppFooterProps) {
           </IconButton>
           <IconButton
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href={ROUTES.rssFeed}
             aria-label="RSS Feed"
             title="RSS Feed"
@@ -177,7 +177,7 @@ export default function AppFooter(props: AppFooterProps) {
           </IconButton>
           <IconButton
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href="https://twitter.com/MUI_hq"
             aria-label="twitter"
             title="X"
@@ -187,7 +187,7 @@ export default function AppFooter(props: AppFooterProps) {
           </IconButton>
           <IconButton
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href="https://www.linkedin.com/company/mui/"
             aria-label="linkedin"
             title="LinkedIn"
@@ -197,7 +197,7 @@ export default function AppFooter(props: AppFooterProps) {
           </IconButton>
           <IconButton
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href="https://www.youtube.com/@MUI_hq"
             aria-label="YouTube"
             title="YouTube"
@@ -207,7 +207,7 @@ export default function AppFooter(props: AppFooterProps) {
           </IconButton>
           <IconButton
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             href="https://mui.com/r/discord/"
             aria-label="Discord"
             title="Discord"
@@ -218,7 +218,7 @@ export default function AppFooter(props: AppFooterProps) {
           {stackOverflowUrl ? (
             <IconButton
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               href={stackOverflowUrl}
               aria-label="Stack Overflow"
               title="Stack Overflow"

--- a/docs/src/modules/components/AdDisplay.js
+++ b/docs/src/modules/components/AdDisplay.js
@@ -1,4 +1,3 @@
-/* eslint react/jsx-no-target-blank: ["error", { allowReferrer: true }] */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';

--- a/docs/src/modules/components/AdInHouse.js
+++ b/docs/src/modules/components/AdInHouse.js
@@ -1,4 +1,3 @@
-/* eslint react/jsx-no-target-blank: ["error", { allowReferrer: true }] */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import AdDisplay from 'docs/src/modules/components/AdDisplay';

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -72,7 +72,7 @@ export default class DemoErrorBoundary extends React.Component {
           </Typography>
           <Typography>
             {'We would appreciate it if you '}
-            <Link href={issueLink} rel="noreferrer" target="_blank">
+            <Link href={issueLink} rel="noopener" target="_blank">
               report this error
             </Link>
             {` directly in our issue tracker with the steps you took to trigger it.

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -79,7 +79,7 @@ export default function DiamondSponsors() {
           data-ga-event-action="docs-premium"
           data-ga-event-label="octopus.com"
           href="https://octopus.com/?utm_source=materialui&utm_medium=referral"
-          rel="noopener noreferrer sponsored"
+          rel="noopener sponsored"
           target="_blank"
         >
           <Box
@@ -102,7 +102,7 @@ export default function DiamondSponsors() {
           data-ga-event-action="docs-premium"
           data-ga-event-label="doit.com"
           href="https://www.doit.com/flexsave/?utm_source=materialui&utm_medium=referral"
-          rel="noopener noreferrer sponsored"
+          rel="noopener sponsored"
           target="_blank"
         >
           <Box

--- a/docs/src/modules/components/MaterialShowcase.js
+++ b/docs/src/modules/components/MaterialShowcase.js
@@ -519,7 +519,7 @@ export default function Showcase() {
                   }),
                 })}
               >
-                <a href={app.link} rel="noopener nofollow noreferrer" target="_blank">
+                <a href={app.link} rel="noopener nofollow" target="_blank">
                   <CardMedia
                     component="img"
                     loading="lazy"

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -383,7 +383,7 @@ export default function TopLayoutBlog(props) {
                       <Link
                         href={`https://github.com/${authors[author].github}`}
                         target="_blank"
-                        rel="noreferrer noopener"
+                        rel="noopener"
                         color="primary"
                         variant="body2"
                         sx={{ fontWeight: 500 }}

--- a/docs/src/modules/joy/getMinimalJoyTemplate.ts
+++ b/docs/src/modules/joy/getMinimalJoyTemplate.ts
@@ -74,7 +74,7 @@ export default function App() {
               component="a"
               href="https://mui.com/joy-ui/main-features/global-variants/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               Main features &nbsp; <span role="img">↗</span>️
             </ListItemButton>
@@ -84,7 +84,7 @@ export default function App() {
               component="a"
               href="https://mui.com/joy-ui/react-autocomplete/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               Browse components &nbsp; <span role="img">↗</span>️
             </ListItemButton>
@@ -94,7 +94,7 @@ export default function App() {
               component="a"
               href="https://mui.com/joy-ui/customization/approaches/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               Check out theming and customization &nbsp;{" "}
               <span role="img">↗</span>️
@@ -108,7 +108,7 @@ export default function App() {
           underline="always"
           href="https://mui.com/about"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
         >
           MUI
         </Link>{" "}


### PR DESCRIPTION
IE 11 requires `rel="noreferrer"` for security. We don't support IE anymore, so the eslint config needs to change. We don't need to enforce it.

With the other browsers:

- Adding `noreferrer` implies adding `noopener`.
- On target="_blank" links, `noopener` is added automatically by the browser, see https://x.com/wesbos/status/1734619070127915021 or https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener. All the browsers had rolled out this change by the end of 2021. Lighthouse removed the warning too https://github.com/GoogleChrome/lighthouse/issues/9531.

Then, the question is, when do we want to use noreferrer? By default, it lets the site we link to know that we link them; it sounds like a positive thing overall.

For sponsor links, we definitely don't want to have noreferrer.

---

I think we must keep `noreferrer` on the templates/examples for now, as we don't want developers using the default config of eslint to have a warning when they copy & paste our content. We can wait for eslint to change its default. I reported the problem at https://github.com/jsx-eslint/eslint-plugin-react/issues/3672.

#10307 is no longer relevant now.