### PR TITLE
[core] Sync playwright cache between MUI X and Material UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,6 @@ commands:
             - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps
-                environment:
-                  PLAYWRIGHT_BROWSERS_PATH: /tmp/pw-browsers
       - save_cache:
           name: Save pnpm package cache
           key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}


### PR DESCRIPTION
The problem was solved differently between:

- https://github.com/mui/material-ui/pull/39131/files
- https://github.com/mui/mui-x/pull/9413/files

This PR matches the solution. It looks like Lukas was right, this env variable is already defined earlier.

Same as https://github.com/mui/mui-x/pull/11607