### PR TITLE
[docs-infra] Fix API table full-width

### DIFF
--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -7,10 +7,16 @@ import {
   brandingLightTheme as lightTheme,
 } from 'docs/src/modules/brandingTheme';
 import { getHash } from 'docs/src/modules/components/ApiPage/list/ClassesList';
+import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/StyledTableContainer';
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
     textAlign: 'left',
+    // Override docs/src/modules/components/MarkdownElement styles
+    '&&': {
+      display: 'table',
+      width: '100%',
+    },
     '& .class-name': {
       flexShrink: 0,
       fontWeight: theme.typography.fontWeightSemiBold,
@@ -53,35 +59,39 @@ interface ClassesTableProps {
 export default function ClassesTable(props: ClassesTableProps) {
   const { classes, componentName, displayClassKeys } = props;
   return (
-    <StyledTable>
-      <thead>
-        <tr>
-          <th>Class name</th>
-          {displayClassKeys && <th>Rule name</th>}
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        {classes.map((params) => {
-          const { className, key, description, isGlobal } = params;
+    <StyledTableContainer>
+      <StyledTable>
+        <thead>
+          <tr>
+            <th>Class name</th>
+            {displayClassKeys && <th>Rule name</th>}
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {classes.map((params) => {
+            const { className, key, description, isGlobal } = params;
 
-          return (
-            <tr key={className} id={getHash({ componentName, className: key })}>
-              <td>
-                <span className="class-name">.{className}</span>
-              </td>
-              {displayClassKeys && <td>{!isGlobal && <span className="class-key">{key}</span>}</td>}
-              <td>
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: description || '',
-                  }}
-                />
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </StyledTable>
+            return (
+              <tr key={className} id={getHash({ componentName, className: key })}>
+                <td>
+                  <span className="class-name">.{className}</span>
+                </td>
+                {displayClassKeys && (
+                  <td>{!isGlobal && <span className="class-key">{key}</span>}</td>
+                )}
+                <td>
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: description || '',
+                    }}
+                  />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </StyledTable>
+    </StyledTableContainer>
   );
 }

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -16,6 +16,11 @@ import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/Styl
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
+    // Override docs/src/modules/components/MarkdownElement styles
+    '&&': {
+      display: 'table',
+      width: '100%',
+    },
     '& .type-column': {
       minWidth: '20%',
     },

--- a/docs/src/modules/components/ApiPage/table/SlotsTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/SlotsTable.tsx
@@ -11,6 +11,11 @@ import StyledTableContainer from 'docs/src/modules/components/ApiPage/table/Styl
 
 const StyledTable = styled('table')(
   ({ theme }) => ({
+    // Override docs/src/modules/components/MarkdownElement styles
+    '&&': {
+      display: 'table',
+      width: '100%',
+    },
     '& .slot-name': {
       fontFamily: theme.typography.fontFamilyCode,
       fontWeight: theme.typography.fontWeightSemiBold,

--- a/docs/src/modules/components/ApiPage/table/StyledTableContainer.tsx
+++ b/docs/src/modules/components/ApiPage/table/StyledTableContainer.tsx
@@ -4,7 +4,7 @@ import { brandingDarkTheme as darkTheme } from 'docs/src/modules/brandingTheme';
 const StyledTableContainer = styled('div')(
   ({ theme }) => ({
     borderRadius: 12,
-    overflow: 'hidden',
+    overflowX: 'auto',
     '& table': {
       marginLeft: -1,
       marginRight: -1,


### PR DESCRIPTION
I was triggered by `overflow: hidden`, this is 99% of the time a red flag. Turns out, we can improve the table view. The solution reproduces the stable used by the Material UI Table (same as Bootstrap).

Before https://mui.com/base-ui/react-menu/components-api/#menu-item-slots

<img src="https://github.com/mui/material-ui/assets/3165635/a438eff4-3640-4af2-b7b6-db0ec5cd48f2" width="800">

After https://deploy-preview-40476--material-ui.netlify.app/base-ui/react-menu/components-api/#menu-item-slots

<img src="https://github.com/mui/material-ui/assets/3165635/38c705bc-e925-4831-a7a0-03de624565e5" width="815">