### PR TITLE
[base-ui][docs] Remove redundant "Styled" prefix

### DIFF
--- a/docs/data/base/components/autocomplete/ControlledStates.js
+++ b/docs/data/base/components/autocomplete/ControlledStates.js
@@ -32,20 +32,21 @@ export default function ControlledStates() {
       <Pre>
         inputValue: <code>{inputValue ?? ' '}</code>
       </Pre>
-      <StyledAutocomplete>
-        <StyledInputRoot {...getRootProps()} className={focused ? 'focused' : ''}>
-          <StyledInput {...getInputProps()} />
-        </StyledInputRoot>
+      <AutocompleteWrapper>
+        <AutocompleteRoot
+          {...getRootProps()}
+          className={focused ? 'Mui-focused' : ''}
+        >
+          <Input {...getInputProps()} />
+        </AutocompleteRoot>
         {groupedOptions.length > 0 && (
-          <StyledListbox {...getListboxProps()}>
+          <Listbox {...getListboxProps()}>
             {groupedOptions.map((option, index) => (
-              <StyledOption {...getOptionProps({ option, index })}>
-                {option}
-              </StyledOption>
+              <Option {...getOptionProps({ option, index })}>{option}</Option>
             ))}
-          </StyledListbox>
+          </Listbox>
         )}
-      </StyledAutocomplete>
+      </AutocompleteWrapper>
     </Layout>
   );
 }
@@ -73,11 +74,11 @@ const grey = {
   900: '#1C2025',
 };
 
-const StyledAutocomplete = styled('div')`
+const AutocompleteWrapper = styled('div')`
   position: relative;
 `;
 
-const StyledInputRoot = styled('div')(
+const AutocompleteRoot = styled('div')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -94,7 +95,7 @@ const StyledInputRoot = styled('div')(
   overflow: hidden;
   width: 320px;
 
-  &.focused {
+  &.Mui-focused {
     border-color: ${blue[400]};
     box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[700] : blue[200]};
   }
@@ -109,7 +110,7 @@ const StyledInputRoot = styled('div')(
 `,
 );
 
-const StyledInput = styled('input')(
+const Input = styled('input')(
   ({ theme }) => `
   font-size: 0.875rem;
   font-family: inherit;
@@ -125,7 +126,7 @@ const StyledInput = styled('input')(
 `,
 );
 
-const StyledListbox = styled('ul')(
+const Listbox = styled('ul')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -150,7 +151,7 @@ const StyledListbox = styled('ul')(
   `,
 );
 
-const StyledOption = styled('li')(
+const Option = styled('li')(
   ({ theme }) => `
   list-style: none;
   padding: 8px;

--- a/docs/data/base/components/autocomplete/ControlledStates.tsx
+++ b/docs/data/base/components/autocomplete/ControlledStates.tsx
@@ -32,20 +32,21 @@ export default function ControlledStates() {
       <Pre>
         inputValue: <code>{inputValue ?? ' '}</code>
       </Pre>
-      <StyledAutocomplete>
-        <StyledInputRoot {...getRootProps()} className={focused ? 'focused' : ''}>
-          <StyledInput {...getInputProps()} />
-        </StyledInputRoot>
+      <AutocompleteWrapper>
+        <AutocompleteRoot
+          {...getRootProps()}
+          className={focused ? 'Mui-focused' : ''}
+        >
+          <Input {...getInputProps()} />
+        </AutocompleteRoot>
         {groupedOptions.length > 0 && (
-          <StyledListbox {...getListboxProps()}>
+          <Listbox {...getListboxProps()}>
             {(groupedOptions as string[]).map((option, index) => (
-              <StyledOption {...getOptionProps({ option, index })}>
-                {option}
-              </StyledOption>
+              <Option {...getOptionProps({ option, index })}>{option}</Option>
             ))}
-          </StyledListbox>
+          </Listbox>
         )}
-      </StyledAutocomplete>
+      </AutocompleteWrapper>
     </Layout>
   );
 }
@@ -73,11 +74,11 @@ const grey = {
   900: '#1C2025',
 };
 
-const StyledAutocomplete = styled('div')`
+const AutocompleteWrapper = styled('div')`
   position: relative;
 `;
 
-const StyledInputRoot = styled('div')(
+const AutocompleteRoot = styled('div')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -94,7 +95,7 @@ const StyledInputRoot = styled('div')(
   overflow: hidden;
   width: 320px;
 
-  &.focused {
+  &.Mui-focused {
     border-color: ${blue[400]};
     box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[700] : blue[200]};
   }
@@ -109,7 +110,7 @@ const StyledInputRoot = styled('div')(
 `,
 );
 
-const StyledInput = styled('input')(
+const Input = styled('input')(
   ({ theme }) => `
   font-size: 0.875rem;
   font-family: inherit;
@@ -125,7 +126,7 @@ const StyledInput = styled('input')(
 `,
 );
 
-const StyledListbox = styled('ul')(
+const Listbox = styled('ul')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -150,7 +151,7 @@ const StyledListbox = styled('ul')(
   `,
 );
 
-const StyledOption = styled('li')(
+const Option = styled('li')(
   ({ theme }) => `
   list-style: none;
   padding: 8px;

--- a/docs/data/base/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.js
@@ -22,7 +22,7 @@ export default function UseAutocomplete() {
   });
 
   return (
-    <div style={{ marginBottom: 24 }}>
+    <div style={{ marginBottom: 16 }}>
       <Label {...getInputLabelProps()}>Pick a movie</Label>
       <Root {...getRootProps()} className={focused ? 'Mui-focused' : ''}>
         <Input {...getInputProps()} />

--- a/docs/data/base/components/autocomplete/UseAutocomplete.js
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.js
@@ -23,21 +23,16 @@ export default function UseAutocomplete() {
 
   return (
     <div style={{ marginBottom: 24 }}>
-      <StyledLabel {...getInputLabelProps()}>Pick a movie</StyledLabel>
-      <StyledAutocompleteRoot
-        {...getRootProps()}
-        className={focused ? 'focused' : ''}
-      >
-        <StyledInput {...getInputProps()} />
-      </StyledAutocompleteRoot>
+      <Label {...getInputLabelProps()}>Pick a movie</Label>
+      <Root {...getRootProps()} className={focused ? 'Mui-focused' : ''}>
+        <Input {...getInputProps()} />
+      </Root>
       {groupedOptions.length > 0 && (
-        <StyledListbox {...getListboxProps()}>
+        <Listbox {...getListboxProps()}>
           {groupedOptions.map((option, index) => (
-            <StyledOption {...getOptionProps({ option, index })}>
-              {option.label}
-            </StyledOption>
+            <Option {...getOptionProps({ option, index })}>{option.label}</Option>
           ))}
-        </StyledListbox>
+        </Listbox>
       )}
     </div>
   );
@@ -66,7 +61,7 @@ const grey = {
   900: '#1C2025',
 };
 
-const StyledLabel = styled('label')`
+const Label = styled('label')`
   display: block;
   font-family: sans-serif;
   font-size: 14px;
@@ -74,7 +69,7 @@ const StyledLabel = styled('label')`
   margin-bottom: 4px;
 `;
 
-const StyledAutocompleteRoot = styled('div')(
+const Root = styled('div')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -91,7 +86,7 @@ const StyledAutocompleteRoot = styled('div')(
   overflow: hidden;
   width: 320px;
 
-  &.focused {
+  &.Mui-focused {
     border-color: ${blue[400]};
     box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
   }
@@ -106,7 +101,7 @@ const StyledAutocompleteRoot = styled('div')(
 `,
 );
 
-const StyledInput = styled('input')(
+const Input = styled('input')(
   ({ theme }) => `
   font-size: 0.875rem;
   font-family: inherit;
@@ -122,7 +117,7 @@ const StyledInput = styled('input')(
 `,
 );
 
-const StyledListbox = styled('ul')(
+const Listbox = styled('ul')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -145,7 +140,7 @@ const StyledListbox = styled('ul')(
   `,
 );
 
-const StyledOption = styled('li')(
+const Option = styled('li')(
   ({ theme }) => `
   list-style: none;
   padding: 8px;

--- a/docs/data/base/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.tsx
@@ -25,21 +25,16 @@ export default function UseAutocomplete() {
 
   return (
     <div style={{ marginBottom: 24 }}>
-      <StyledLabel {...getInputLabelProps()}>Pick a movie</StyledLabel>
-      <StyledAutocompleteRoot
-        {...getRootProps()}
-        className={focused ? 'focused' : ''}
-      >
-        <StyledInput {...getInputProps()} />
-      </StyledAutocompleteRoot>
+      <Label {...getInputLabelProps()}>Pick a movie</Label>
+      <Root {...getRootProps()} className={focused ? 'Mui-focused' : ''}>
+        <Input {...getInputProps()} />
+      </Root>
       {groupedOptions.length > 0 && (
-        <StyledListbox {...getListboxProps()}>
+        <Listbox {...getListboxProps()}>
           {(groupedOptions as typeof top100Films).map((option, index) => (
-            <StyledOption {...getOptionProps({ option, index })}>
-              {option.label}
-            </StyledOption>
+            <Option {...getOptionProps({ option, index })}>{option.label}</Option>
           ))}
-        </StyledListbox>
+        </Listbox>
       )}
     </div>
   );
@@ -68,7 +63,7 @@ const grey = {
   900: '#1C2025',
 };
 
-const StyledLabel = styled('label')`
+const Label = styled('label')`
   display: block;
   font-family: sans-serif;
   font-size: 14px;
@@ -76,7 +71,7 @@ const StyledLabel = styled('label')`
   margin-bottom: 4px;
 `;
 
-const StyledAutocompleteRoot = styled('div')(
+const Root = styled('div')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -93,7 +88,7 @@ const StyledAutocompleteRoot = styled('div')(
   overflow: hidden;
   width: 320px;
 
-  &.focused {
+  &.Mui-focused {
     border-color: ${blue[400]};
     box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
   }
@@ -108,7 +103,7 @@ const StyledAutocompleteRoot = styled('div')(
 `,
 );
 
-const StyledInput = styled('input')(
+const Input = styled('input')(
   ({ theme }) => `
   font-size: 0.875rem;
   font-family: inherit;
@@ -124,7 +119,7 @@ const StyledInput = styled('input')(
 `,
 );
 
-const StyledListbox = styled('ul')(
+const Listbox = styled('ul')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -147,7 +142,7 @@ const StyledListbox = styled('ul')(
   `,
 );
 
-const StyledOption = styled('li')(
+const Option = styled('li')(
   ({ theme }) => `
   list-style: none;
   padding: 8px;

--- a/docs/data/base/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.tsx
@@ -24,7 +24,7 @@ export default function UseAutocomplete() {
   });
 
   return (
-    <div style={{ marginBottom: 24 }}>
+    <div style={{ marginBottom: 16 }}>
       <Label {...getInputLabelProps()}>Pick a movie</Label>
       <Root {...getRootProps()} className={focused ? 'Mui-focused' : ''}>
         <Input {...getInputProps()} />

--- a/docs/data/base/components/autocomplete/UseAutocomplete.tsx.preview
+++ b/docs/data/base/components/autocomplete/UseAutocomplete.tsx.preview
@@ -1,16 +1,11 @@
-<StyledLabel {...getInputLabelProps()}>Pick a movie</StyledLabel>
-<StyledAutocompleteRoot
-  {...getRootProps()}
-  className={focused ? 'focused' : ''}
->
-  <StyledInput {...getInputProps()} />
-</StyledAutocompleteRoot>
+<Label {...getInputLabelProps()}>Pick a movie</Label>
+<Root {...getRootProps()} className={focused ? 'Mui-focused' : ''}>
+  <Input {...getInputProps()} />
+</Root>
 {groupedOptions.length > 0 && (
-  <StyledListbox {...getListboxProps()}>
+  <Listbox {...getListboxProps()}>
     {(groupedOptions as typeof top100Films).map((option, index) => (
-      <StyledOption {...getOptionProps({ option, index })}>
-        {option.label}
-      </StyledOption>
+      <Option {...getOptionProps({ option, index })}>{option.label}</Option>
     ))}
-  </StyledListbox>
+  </Listbox>
 )}

--- a/docs/data/base/components/autocomplete/UseAutocompletePopper.js
+++ b/docs/data/base/components/autocomplete/UseAutocompletePopper.js
@@ -21,13 +21,13 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
 
   return (
     <React.Fragment>
-      <StyledAutocompleteRoot
+      <Root
         {...getRootProps()}
         ref={rootRef}
-        className={focused ? 'focused' : ''}
+        className={focused ? 'Mui-focused' : ''}
       >
         <StyledInput {...getInputProps()} />
-      </StyledAutocompleteRoot>
+      </Root>
       {anchorEl && (
         <Popper
           open={popupOpen}
@@ -36,17 +36,17 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
             root: StyledPopper,
           }}
         >
-          <StyledListbox {...getListboxProps()}>
+          <Listbox {...getListboxProps()}>
             {groupedOptions.length > 0 ? (
               groupedOptions.map((option, index) => (
-                <StyledOption {...getOptionProps({ option, index })}>
+                <Option {...getOptionProps({ option, index })}>
                   {option.label}
-                </StyledOption>
+                </Option>
               ))
             ) : (
-              <StyledNoOptions>No results</StyledNoOptions>
+              <NoOptions>No results</NoOptions>
             )}
-          </StyledListbox>
+          </Listbox>
         </Popper>
       )}
     </React.Fragment>
@@ -86,7 +86,7 @@ const grey = {
   900: '#1C2025',
 };
 
-const StyledAutocompleteRoot = styled('div')(
+const Root = styled('div')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -104,7 +104,7 @@ const StyledAutocompleteRoot = styled('div')(
   width: 320px;
   margin: 1.5rem 0;
 
-  &.focused {
+  &.Mui-focused {
     border-color: ${blue[400]};
     box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[700] : blue[200]};
   }
@@ -142,7 +142,7 @@ const StyledPopper = styled('div')`
   width: 320px;
 `;
 
-const StyledListbox = styled('ul')(
+const Listbox = styled('ul')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -164,7 +164,7 @@ const StyledListbox = styled('ul')(
   `,
 );
 
-const StyledOption = styled('li')(
+const Option = styled('li')(
   ({ theme }) => `
   list-style: none;
   padding: 8px;
@@ -202,7 +202,7 @@ const StyledOption = styled('li')(
   `,
 );
 
-const StyledNoOptions = styled('li')`
+const NoOptions = styled('li')`
   list-style: none;
   padding: 8px;
   cursor: default;

--- a/docs/data/base/components/autocomplete/UseAutocompletePopper.tsx
+++ b/docs/data/base/components/autocomplete/UseAutocompletePopper.tsx
@@ -24,13 +24,13 @@ const Autocomplete = React.forwardRef(function Autocomplete(
 
   return (
     <React.Fragment>
-      <StyledAutocompleteRoot
+      <Root
         {...getRootProps()}
         ref={rootRef}
-        className={focused ? 'focused' : ''}
+        className={focused ? 'Mui-focused' : ''}
       >
         <StyledInput {...getInputProps()} />
-      </StyledAutocompleteRoot>
+      </Root>
       {anchorEl && (
         <Popper
           open={popupOpen}
@@ -39,17 +39,17 @@ const Autocomplete = React.forwardRef(function Autocomplete(
             root: StyledPopper,
           }}
         >
-          <StyledListbox {...getListboxProps()}>
+          <Listbox {...getListboxProps()}>
             {groupedOptions.length > 0 ? (
               (groupedOptions as typeof top100Films).map((option, index) => (
-                <StyledOption {...getOptionProps({ option, index })}>
+                <Option {...getOptionProps({ option, index })}>
                   {option.label}
-                </StyledOption>
+                </Option>
               ))
             ) : (
-              <StyledNoOptions>No results</StyledNoOptions>
+              <NoOptions>No results</NoOptions>
             )}
-          </StyledListbox>
+          </Listbox>
         </Popper>
       )}
     </React.Fragment>
@@ -94,7 +94,7 @@ const grey = {
   900: '#1C2025',
 };
 
-const StyledAutocompleteRoot = styled('div')(
+const Root = styled('div')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-weight: 400;
@@ -112,7 +112,7 @@ const StyledAutocompleteRoot = styled('div')(
   width: 320px;
   margin: 1.5rem 0;
 
-  &.focused {
+  &.Mui-focused {
     border-color: ${blue[400]};
     box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[700] : blue[200]};
   }
@@ -150,7 +150,7 @@ const StyledPopper = styled('div')`
   width: 320px;
 `;
 
-const StyledListbox = styled('ul')(
+const Listbox = styled('ul')(
   ({ theme }) => `
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
@@ -172,7 +172,7 @@ const StyledListbox = styled('ul')(
   `,
 );
 
-const StyledOption = styled('li')(
+const Option = styled('li')(
   ({ theme }) => `
   list-style: none;
   padding: 8px;
@@ -210,7 +210,7 @@ const StyledOption = styled('li')(
   `,
 );
 
-const StyledNoOptions = styled('li')`
+const NoOptions = styled('li')`
   list-style: none;
   padding: 8px;
   cursor: default;

--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -16,10 +16,10 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
 
 ## Introduction
 
-An autocomplete component is an enhanced text input that shows a list of suggested options as users type, and lets them select an option from the list.
+An autocomplete component is an enhanced text input that shows a list of suggested options as users type and lets them select an option from the list.
 
 Base UI provides the `useAutocomplete` hook for building a custom Autocomplete.
-It implements the WAI-ARIA Combobox pattern, and is typically used to assist users in completing form inputs or search queries faster.
+It implements the WAI-ARIA Combobox pattern and is typically used to assist users in completing form inputs or search queries faster.
 
 {{"demo": "AutocompleteIntroduction", "defaultCodeOpen": false, "bg": "gradient"}}
 
@@ -86,7 +86,7 @@ The `useAutocomplete` hook has two states that can be controlled:
 1. the "value" state with the `value`/`onChange` props combination. This state represents the value selected by the user, for instance when pressing <kbd class="key">Enter</kbd>.
 2. the "input value" state with the `inputValue`/`onInputChange` props combination. This state represents the value displayed in the textbox.
 
-These two states are isolated, and should be controlled independently.
+These two states are isolated and should be controlled independently.
 
 :::info
 


### PR DESCRIPTION
A continuation of #37029. This feels much better. Open https://mui.com/base-ui/react-autocomplete/#hook, I can't imagine developers would want to use "Styled" in their actual implementation.

- If developers use the hooks, by default, every component present in the file is styled, so "styled" is noise.
- If they use the unstyled component, I think they should rename them all to be suffixed with `Base`.
`const Button = styled(ButtonBase)({})` makes a lot more sense to me than the opposite. The button comes first, then it's nature. I think it's easier to read when the component is first.
So in https://mui.com/base-ui/react-button/#component, I think that we should rename the alias as well, the same way Radix suffix them with `Primitive` https://github.com/radix-ui/themes/blob/300260e3c3ed5fc491129b192760aad6f96c38ac/packages/radix-ui-themes/src/components/slider.tsx#L5.

Preview: https://deploy-preview-40478--material-ui.netlify.app/base-ui/react-autocomplete/#hook
