### PR TITLE
[code-infra] Configure build dependencies in nx

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,8 @@
   "extends": "nx/presets/npm.json",
   "targetDefaults": {
     "build": {
-      "cache": true
+      "cache": true,
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
Configure Lerna to look for project dependencies when running the `build` command.

This should solve the issue described in https://github.com/mui/material-ui/pull/40426#discussion_r1442768438