### PR TITLE
[material-ui][ClickAwayListener] Fix export of types

### DIFF
--- a/packages/mui-material/src/ClickAwayListener/index.ts
+++ b/packages/mui-material/src/ClickAwayListener/index.ts
@@ -1,2 +1,2 @@
 export { ClickAwayListener as default } from '@mui/base/ClickAwayListener';
-export { type ClickAwayListenerProps } from '@mui/base/ClickAwayListener';
+export type { ClickAwayListenerProps } from '@mui/base/ClickAwayListener';

--- a/packages/mui-material/src/ClickAwayListener/index.ts
+++ b/packages/mui-material/src/ClickAwayListener/index.ts
@@ -1,4 +1,2 @@
-export {
-  ClickAwayListener as default,
-  type ClickAwayListenerProps,
-} from '@mui/base/ClickAwayListener';
+export { ClickAwayListener as default } from '@mui/base/ClickAwayListener';
+export { type ClickAwayListenerProps } from '@mui/base/ClickAwayListener';


### PR DESCRIPTION
Removes a tailing comma so it is compatible with older supported TypeScript versions.

Fixes #38837 

The benefit is mui v5 works with older supported TypeScript versions. Important when upgrading older projects from material-ui v4.

```ts
node_modules/@mui/material/ClickAwayListener/index.d.ts:1:45 - error TS1005: ',' expected.

1 export { ClickAwayListener as default, type ClickAwayListenerProps, } from '@mui/base/ClickAwayListener';
                                              ~~~~~~~~~~~~~~~~~~~~~~

Found 1 error.
```

### Reproducer

You can reproduce the error using TypeScript 4.4.3.

```
cd examples/material-ui-cra-ts

# edit package.json so typescript dependency is 4.4.3

npm install

./node_modules/.bin/tsc --version
Version 4.4.3
./node_modules/.bin/tsc
node_modules/@mui/material/ClickAwayListener/index.d.ts:1:45 - error TS1005: ',' expected.

1 export { ClickAwayListener as default, type ClickAwayListenerProps, } from '@mui/base/ClickAwayListener';
                                              ~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
