### PR TITLE
Specify the default <Box /> component in the doc

### DIFF
--- a/packages/mui-system/src/Box/Box.d.ts
+++ b/packages/mui-system/src/Box/Box.d.ts
@@ -186,7 +186,7 @@ export interface BoxOwnProps<Theme extends object = SystemTheme> extends SystemP
   children?: React.ReactNode;
   /**
    * The component used for the root node.
-   * Either a string to use a HTML element or a component.
+   * Either a string to use a HTML element or a component. Default is a div element.
    */
   component?: React.ElementType;
   ref?: React.Ref<unknown>;


### PR DESCRIPTION
When we look at the documentation on the Box API page, the default value for the component property is not specified.

It would be nice to specify it. I never remember whether it is a `<div>` or `<span>` that is rendered by default.

But it is actually a div.

We can see it in the following line: https://github.com/mui/material-ui/blob/a1005d6cedcba5731cbf8f0c4837229432ec8d38/packages/mui-system/src/Box/Box.d.ts#L201

Confirmed by this [codesandbox](https://codesandbox.io/p/sandbox/adoring-haze-jw7lgv?file=%2Fsrc%2FApp.tsx%3A7%2C1&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clr7kh0h00006356jvupi0vu0%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clr7kh0gz0002356jydozpwzu%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clr7kh0h00003356jzemqocje%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clr7kh0h00005356jv3cgl28c%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clr7kh0gz0002356jydozpwzu%2522%253A%257B%2522id%2522%253A%2522clr7kh0gz0002356jydozpwzu%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clr7kl1u30002356jvvuxok2v%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A7%252C%2522startColumn%2522%253A1%252C%2522endLineNumber%2522%253A7%252C%2522endColumn%2522%253A1%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252FApp.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clr7kl1u30002356jvvuxok2v%2522%257D%252C%2522clr7kh0h00005356jv3cgl28c%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clr7kh0h00004356jrdftea6a%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clr7kh0h00005356jv3cgl28c%2522%252C%2522activeTabId%2522%253A%2522clr7kh0h00004356jrdftea6a%2522%257D%252C%2522clr7kh0h00003356jzemqocje%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clr7kh0h00003356jzemqocje%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D).
