### PR TITLE
[joy-ui][ModalDialog] Fix ModalDialog layout prop override

### DIFF
--- a/packages/mui-joy/src/ModalDialog/ModalDialogProps.ts
+++ b/packages/mui-joy/src/ModalDialog/ModalDialogProps.ts
@@ -60,7 +60,7 @@ export interface ModalDialogTypeMap<P = {}, D extends React.ElementType = 'div'>
      * The layout of the dialog
      * @default 'center'
      */
-    layout?: 'center' | 'fullscreen';
+    layout?: OverridableStringUnion<'center' | 'fullscreen', ModalDialogPropsLayoutOverrides>;
     /**
      * The component orientation.
      * @default 'vertical'


### PR DESCRIPTION
This update fixes a type error in ModalDialog layout props that cannot be overridden with ModalDialogPropsLayoutOverrides.

closes #40331

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
