### PR TITLE
[code-infra] Add `run` command to deploy docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs:build": "pnpm --filter docs build",
     "docs:build-sw": "pnpm --filter docs build-sw",
     "docs:build-color-preview": "babel-node scripts/buildColorTypes",
-    "docs:deploy": "pnpm --filter docs deploy",
+    "docs:deploy": "pnpm --filter docs run deploy",
     "docs:dev": "pnpm --filter docs dev",
     "docs:export": "pnpm --filter docs export",
     "docs:icons": "pnpm --filter docs icons",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I guess "deploy" points to `pnpm deploy` command before looking at `docs deploy` so I switch to `run deploy` instead.

**Before**:

<img width="608" alt="image" src="https://github.com/mui/material-ui/assets/18292247/e50bd136-51b5-40f0-b541-ba4d194fd2d2">

**After**:

<img width="599" alt="image" src="https://github.com/mui/material-ui/assets/18292247/7758ce2a-c331-4717-b7bd-93f71d0b59c7">


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
