### PR TITLE
[docs-infra] Enforce brand name rules

### DIFF
--- a/.github/styles/Blog/BrandName.yml
+++ b/.github/styles/Blog/BrandName.yml
@@ -1,11 +1,11 @@
 extends: substitution
-message: Do you mean '%s' instead of '%s'?
+message: Do you mean '%s' instead of '%s'? Notice the non-breaking space
 level: error
 ignorecase: true
 # swap maps tokens in form of bad: good
 # for more information: https://vale.sh/docs/topics/styles/#substitution
 swap:
-  bellow: below
-  eg: e.g.
-  eg.: e.g.
-  'e.g ': 'e.g. '
+  Material UI: Material UI
+  MUI X: MUI X
+  Base UI: Base UI
+  MUI System: MUI System

--- a/.github/styles/Blog/BrandName.yml
+++ b/.github/styles/Blog/BrandName.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: Do you mean '%s' instead of '%s'? Notice the non-breaking space
+message: Use a non-breaking space for brand name ('%s' instead of '%s')
 level: error
 ignorecase: true
 # swap maps tokens in form of bad: good

--- a/.github/styles/Blog/BrandName.yml
+++ b/.github/styles/Blog/BrandName.yml
@@ -1,3 +1,4 @@
+# Without a non-breaking space, brand names can be split in the middle, with the start and end on two different lines.
 extends: substitution
 message: Use a non-breaking space for brand name ('%s' instead of '%s')
 level: error

--- a/.github/styles/Blog/ComposedWords.yml
+++ b/.github/styles/Blog/ComposedWords.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: To be consistent with the rest of the documentation, consider using '%s' instead of '%s'.
-level: warning
+level: error
 ignorecase: true
 # swap maps tokens in form of bad: good
 # for more information: https://vale.sh/docs/topics/styles/#substitution

--- a/.github/styles/Blog/NamingConventions.yml
+++ b/.github/styles/Blog/NamingConventions.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: To be consistent with capitalization, consider using '%s' instead of '%s'.
-level: warning
+level: error
 ignorecase: false
 # swap maps tokens in form of bad: good
 # for more information: https://vale.sh/docs/topics/styles/#substitution

--- a/.github/styles/Blog/NoCompanyName.yml
+++ b/.github/styles/Blog/NoCompanyName.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: We avoid referencing the company name '%s'. Instead you can reference a product or the team or use we.
+message: We avoid referencing the company name '%s'. Instead you can reference a product or the team.
 level: warning
 ignorecase: false
 tokens:

--- a/.github/styles/Blog/NoCompanyName.yml
+++ b/.github/styles/Blog/NoCompanyName.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: We avoid referencing the company name '%s'. Instead you can reference a product or the team or use we.
+level: warning
+ignorecase: false
+tokens:
+  - 'MUI \w+'
+exceptions:
+  - 'MUI X'
+  - 'MUI X'
+  - 'MUI System'
+  - 'MUI System'

--- a/.vale.ini
+++ b/.vale.ini
@@ -14,13 +14,15 @@ BlockIgnores = {{.*
 Blog.ComposedWords = YES
 Blog.NamingConventions = YES
 Blog.Typos = YES
+Blog.BrandName = YES
+Blog.NoCompanyName = YES
 
 # Google:
 Google.FirstPerson = YES # Avoid first-person pronouns such as I, me, ...'.
 Google.GenderBias = YES # Avoid gendered profession
 Google.OxfordComma = YES
 Google.Quotes = YES # Commas and periods go inside quotation marks.
-Google.Spelling = YES #In general, use American spelling (word ending with 'nised' or 'logue')
+Google.Spelling = YES # In general, use American spelling (word ending with 'nised' or 'logue')
 Google.We = YES # Try to avoid using first-person plural
 Google.Latin = YES # Try to avoid latin expressions e.g. and i.e.
 

--- a/docs/pages/blog/mui-x-v6.md
+++ b/docs/pages/blog/mui-x-v6.md
@@ -252,7 +252,7 @@ If you're coming from previous versions, we recommend you check our migration gu
 We also provide codemods to automate some of the necessary updates in your codebase.
 
 ```bash
-npx @mui/x-codemod v6.0.0/preset-safe <path>
+npx @mui/x-codemod@latest v6.0.0/preset-safe <path>
 ```
 
 ## What's next?


### PR DESCRIPTION
This is a continuation of https://github.com/mui/mui-x/pull/11645#issuecomment-1885369455. See how annoying it is when a non-breaking space is missed with MUI X. That line breaks in the middle 🙈. The other objective is to flag all the cases where we use MUI. In 80% of the time, this shouldn't happen in the first place.

This seems to work:

https://github.com/mui/material-ui/assets/3165635/c4466145-12c9-4913-ae72-60bbbbbc92a2
