### PR TITLE
[codemod] Allow `json` files to be transformed

### DIFF
--- a/packages/mui-codemod/codemod.js
+++ b/packages/mui-codemod/codemod.js
@@ -40,7 +40,7 @@ async function runTransform(transform, files, flags, codemodFlags) {
     transformerPath,
     ...codemodFlags,
     '--extensions',
-    'js,ts,jsx,tsx',
+    'js,ts,jsx,tsx,json',
     '--parser',
     flags.parser || 'tsx',
     '--ignore-pattern',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #40362

----
## Testing

As the codemod.js script lacks tests, I performed local testing with the following steps:

1. Navigate to the `packages/mui-codemod` directory (`cd packages/mui-codemod`).
2. Create a new json file for testing by adding a `package.json` file under the `src/v5.0.0/mui-replace.test` folder and adding the following code:
```json
{
  "name": "mui-codemods",
  "version": "1.0.0",
  "description": "",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "MIT",
  "dependencies": {
    "@material-ui/core": "^4.11.0",
    "@material-ui/icons": "^4.9.1",
    "@material-ui/lab": "4.0.0-alpha.57"
  }
}

```
3. Execute `node codemod.js v5.0.0/mui-replace ./src/v5.0.0/mui-replace.test`. This command replaces the occurrences of `@material-ui/*` with `@mui/*`. If the json extension in the list is not there, the replacement fails to work.