### PR TITLE
[docs-infra] Remove old tocs banners

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -152,7 +152,6 @@ function shouldShowJobAd() {
   return true;
 }
 
-const showSurveyBanner = false;
 const showJobAd = featureToggle.enable_job_banner && shouldShowJobAd();
 
 export default function AppTableOfContents(props) {
@@ -246,54 +245,7 @@ export default function AppTableOfContents(props) {
     <Nav aria-label={t('pageTOC')}>
       <TableOfContentsBanner />
       <NoSsr>
-        {showSurveyBanner && (
-          <Link
-            href="https://www.surveymonkey.com/r/mui-developer-survey-2022?source=docs"
-            target="_blank"
-            sx={[
-              (theme) => ({
-                mb: 2,
-                p: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'flex-start',
-                backgroundColor: alpha(theme.palette.grey[50], 0.4),
-                border: '1px solid',
-                borderColor: (theme.vars || theme).palette.grey[200],
-                borderRadius: 1,
-                transitionProperty: 'all',
-                transitionTiming: 'cubic-bezier(0.4, 0, 0.2, 1)',
-                transitionDuration: '150ms',
-                '&:hover, &:focus-visible': {
-                  borderColor: (theme.vars || theme).palette.primary[200],
-                },
-              }),
-              (theme) =>
-                theme.applyDarkStyles({
-                  backgroundColor: alpha(theme.palette.primary[900], 0.2),
-                  borderColor: (theme.vars || theme).palette.primaryDark[700],
-                  '&:hover, &:focus-visible': {
-                    borderColor: (theme.vars || theme).palette.primaryDark[500],
-                  },
-                }),
-            ]}
-          >
-            <Typography component="span" variant="button" fontWeight="500" color="text.primary">
-              {'📫 MUI Developer survey 2022 is live!'}
-            </Typography>
-            <Typography
-              component="span"
-              variant="caption"
-              fontWeight="normal"
-              color="text.secondary"
-              sx={{ mt: 0.5 }}
-            >
-              {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-              {'Influence the future of MUI. Help define the roadmap for 2023!'}
-            </Typography>
-          </Link>
-        )}
-        {!showSurveyBanner && showJobAd && (
+        {showJobAd && (
           <Link
             href="https://jobs.ashbyhq.com/MUI?utm_source=2vOWXNv1PE"
             target="_blank"


### PR DESCRIPTION
This is dead code, as far as I know, we won't use this again.

We already have an app banner notification for this, this is legacy:

<img src="https://github.com/mui/material-ui/assets/3165635/c5d43c10-92e7-40c4-b5a1-b7d2860532f9" width="367">

---

Edit, I reverted this in the end, it's not that a bad idea after all, Base UI users sounds like good matches.

~I think we learned that people who use Material UI are not the people we should hire to work on it. It much better to hire the people who think Material UI is crap and who had to rebuild it themselves because of it (e.g. my own story, and what we are doing again today, Material UI is stuck 1,2 years in the past).~

~For Base UI and MUI System, maybe the rationale would be different. People who use Base UI could be a great fit for Material UI. So why not keep this, but then the design is outdated, so we would need to redo it anyway, and better tailor the audience. Overall, we already have so many candidate applications, that I don't know if it's so relevant:~

<img src="https://github.com/mui/material-ui/assets/3165635/5814cbbd-a019-43a1-b58c-d9c647b448f8" width="343">
