### PR TITLE
[base-ui][Input] Add OTP input demo

### DIFF
--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
@@ -113,42 +114,60 @@ function OTP({ seperator, inputCount, value, onChange }) {
     }
   };
 
-  return new Array(inputCount).fill(null).map((_, index) => (
-    <React.Fragment key={index}>
-      <BaseInput
-        slots={{
-          input: InputElement,
-        }}
-        aria-label={`Digit ${index + 1} of OTP`}
-        slotProps={{
-          input: {
-            ref: (ele) => {
-              inputRefs.current[index] = ele;
-            },
-            onKeyDown: (event) => handleKeyDown(event, index),
-            onChange: (event) => handleChange(event, index),
-            onClick: (event) => handleClick(event, index),
-            onPaste: (event) => handlePaste(event, index),
-            value: value[index],
-          },
-        }}
-      />
-      {index === inputCount - 1 ? null : seperator}
-    </React.Fragment>
-  ));
+  return (
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+      {new Array(inputCount).fill(null).map((_, index) => (
+        <React.Fragment key={index}>
+          <BaseInput
+            slots={{
+              input: InputElement,
+            }}
+            aria-label={`Digit ${index + 1} of OTP`}
+            slotProps={{
+              input: {
+                ref: (ele) => {
+                  inputRefs.current[index] = ele;
+                },
+                onKeyDown: (event) => handleKeyDown(event, index),
+                onChange: (event) => handleChange(event, index),
+                onClick: (event) => handleClick(event, index),
+                onPaste: (event) => handlePaste(event, index),
+                value: value[index],
+              },
+            }}
+          />
+          {index === inputCount - 1 ? null : seperator}
+        </React.Fragment>
+      ))}
+    </Box>
+  );
 }
+
+OTP.propTypes = {
+  inputCount: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+  seperator: PropTypes.node,
+  value: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
 
 export default function OTPInput() {
   const inputCount = 5;
   const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
   return (
-    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
       <OTP
         seperator={<span>-</span>}
         value={otp}
         onChange={setOtp}
         inputCount={inputCount}
       />
+      <span>Entered value: {otp.join('')}</span>
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -24,12 +24,14 @@ export default function OTPInput() {
     switch (event.key) {
       case 'ArrowLeft':
         if (currentIndex > 0) {
+          event.preventDefault();
           focusInput(currentIndex - 1);
           selectInput(currentIndex - 1);
         }
         break;
       case 'ArrowRight':
         if (currentIndex < inputCount - 1) {
+          event.preventDefault();
           focusInput(currentIndex + 1);
           selectInput(currentIndex + 1);
         }
@@ -59,7 +61,17 @@ export default function OTPInput() {
     setOtp((prev) => {
       const otpArray = [...prev];
       const lastValue = value[value.length - 1];
-      otpArray[currentIndex] = lastValue;
+      let indexToEnter = 0;
+
+      while (indexToEnter <= currentIndex) {
+        if (prev[indexToEnter]) {
+          indexToEnter+=1;
+        } else {
+          break;
+        }
+      }
+
+      otpArray[indexToEnter] = lastValue;
       return otpArray;
     });
     if (value !== '') {

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -18,15 +18,15 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
   const handleKeyDown = (event, currentIndex) => {
     switch (event.key) {
       case 'ArrowLeft':
+        event.preventDefault();
         if (currentIndex > 0) {
-          event.preventDefault();
           focusInput(currentIndex - 1);
           selectInput(currentIndex - 1);
         }
         break;
       case 'ArrowRight':
+        event.preventDefault();
         if (currentIndex < inputCount - 1) {
-          event.preventDefault();
           focusInput(currentIndex + 1);
           selectInput(currentIndex + 1);
         }

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -85,7 +85,7 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
         slots={{
           input: InputElement,
         }}
-        aria-label="OTP input field"
+        aria-label={`Digit ${index + 1} of OTP`}
         slotProps={{
           input: {
             ref: (ele) => {

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -36,6 +36,7 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
         }
         break;
       case 'Backspace':
+      case 'Delete':
         event.preventDefault();
         if (currentIndex > 0) {
           focusInput(currentIndex - 1);

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -86,6 +86,7 @@ function OTP({ seperator, inputCount }) {
         slots={{
           input: InputElement,
         }}
+        aria-label="OTP input field"
         slotProps={{
           input: {
             ref: (ele) => {

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -131,7 +131,7 @@ const grey = {
 
 const InputElement = styled('input')(
   ({ theme }) => `
-  width: 15px;
+  width: 40px;
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
   font-weight: 400;

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -17,6 +17,10 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
 
   const handleKeyDown = (event, currentIndex) => {
     switch (event.key) {
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        break;
       case 'ArrowLeft':
         event.preventDefault();
         if (currentIndex > 0) {

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -79,6 +79,35 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
     selectInput(currentIndex);
   };
 
+  const handlePaste = (event, currentIndex) => {
+    event.preventDefault();
+    const clipboardData = event.clipboardData;
+
+    // Check if there is text data in the clipboard
+    if (clipboardData.types.includes('text/plain')) {
+      let pastedText = clipboardData.getData('text/plain');
+      pastedText = pastedText.substring(0, inputCount);
+      let indexToEnter = 0;
+
+      while (indexToEnter <= currentIndex) {
+        if (otp[indexToEnter] && indexToEnter < currentIndex) {
+          indexToEnter += 1;
+        } else {
+          break;
+        }
+      }
+
+      const otpArray = [...otp];
+
+      for (let i = indexToEnter; i < inputCount; i += 1) {
+        const lastValue = pastedText[i - indexToEnter] ?? '';
+        otpArray[i] = lastValue;
+      }
+
+      setOtp(otpArray);
+    }
+  };
+
   return new Array(inputCount).fill(null).map((_, index) => (
     <React.Fragment key={index}>
       <BaseInput
@@ -94,6 +123,7 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
             onKeyDown: (event) => handleKeyDown(event, index),
             onChange: (event) => handleChange(event, index),
             onClick: (event) => handleClick(event, index),
+            onPaste: (event) => handlePaste(event, index),
             value: otp[index],
           },
         }}

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-function OTP({ seperator, inputCount }) {
+function OTP({ seperator, inputCount, otp, setOtp }) {
   const inputRefs = React.useRef(new Array(inputCount).fill(null));
-  const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
 
   const focusInput = (targetIndex) => {
     const targetInput = inputRefs.current[targetIndex];
@@ -105,9 +104,16 @@ function OTP({ seperator, inputCount }) {
 }
 
 export default function OTPInput() {
+  const inputCount = 5;
+  const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
   return (
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-      <OTP seperator={<span>-</span>} inputCount={5} />
+      <OTP
+        seperator={<span>-</span>}
+        otp={otp}
+        setOtp={setOtp}
+        inputCount={inputCount}
+      />
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -106,8 +106,8 @@ function OTP({ seperator, inputCount }) {
 
 export default function OTPInput() {
   return (
-    <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-      <OTP seperator={<span>-</span>} inputCount={6} />
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+      <OTP seperator={<span>-</span>} inputCount={5} />
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -40,10 +40,10 @@ function OTP({ separator, inputCount, value, onChange }) {
         event.preventDefault();
 
         onChange((prev) => {
-          const otpArray = [...prev];
+          const otpArray = prev.split('');
           otpArray.splice(currentIndex, 1);
           otpArray.push('');
-          return otpArray;
+          return otpArray.join('');
         });
 
         break;
@@ -55,10 +55,10 @@ function OTP({ separator, inputCount, value, onChange }) {
         }
 
         onChange((prev) => {
-          const otpArray = [...prev];
+          const otpArray = prev.split('');
           otpArray.splice(currentIndex, 1);
           otpArray.push('');
-          return otpArray;
+          return otpArray.join('');
         });
 
         break;
@@ -79,10 +79,10 @@ function OTP({ separator, inputCount, value, onChange }) {
       }
     }
     onChange((prev) => {
-      const otpArray = [...prev];
+      const otpArray = prev.split('');
       const lastValue = currentValue[currentValue.length - 1];
       otpArray[indexToEnter] = lastValue;
-      return otpArray;
+      return otpArray.join('');
     });
     if (currentValue !== '') {
       if (currentIndex < inputCount - 1) {
@@ -113,14 +113,14 @@ function OTP({ separator, inputCount, value, onChange }) {
         }
       }
 
-      const otpArray = [...value];
+      const otpArray = value.split('');
 
       for (let i = indexToEnter; i < inputCount; i += 1) {
         const lastValue = pastedText[i - indexToEnter] ?? '';
         otpArray[i] = lastValue;
       }
 
-      onChange(otpArray);
+      onChange(otpArray.join(''));
     }
   };
 
@@ -157,12 +157,11 @@ OTP.propTypes = {
   inputCount: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   separator: PropTypes.node,
-  value: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.string.isRequired,
 };
 
 export default function OTPInput() {
-  const inputCount = 5;
-  const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
+  const [otp, setOtp] = React.useState('');
   return (
     <Box
       sx={{
@@ -171,13 +170,8 @@ export default function OTPInput() {
         gap: 2,
       }}
     >
-      <OTP
-        separator={<span>-</span>}
-        value={otp}
-        onChange={setOtp}
-        inputCount={otp.length}
-      />
-      <span>Entered value: {otp.join('')}</span>
+      <OTP separator={<span>-</span>} value={otp} onChange={setOtp} inputCount={5} />
+      <span>Entered value: {otp}</span>
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -146,7 +146,7 @@ const InputElement = styled('input')(
   text-align: center;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[500]};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   box-shadow: 0px 2px 4px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -40,8 +40,8 @@ function OTP({ separator, inputCount, value, onChange }) {
       case 'Delete':
         event.preventDefault();
         onChange((prevOtp) => {
-          let otp = prevOtp;
-          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          const otp =
+            prevOtp.slice(0, currentIndex) + prevOtp.slice(currentIndex + 1);
           return otp;
         });
 
@@ -54,11 +54,10 @@ function OTP({ separator, inputCount, value, onChange }) {
         }
 
         onChange((prevOtp) => {
-          let otp = prevOtp;
-          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          const otp =
+            prevOtp.slice(0, currentIndex) + prevOtp.slice(currentIndex + 1);
           return otp;
         });
-
         break;
 
       default:

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -175,7 +175,7 @@ export default function OTPInput() {
         seperator={<span>-</span>}
         value={otp}
         onChange={setOtp}
-        inputCount={inputCount}
+        inputCount={otp.length}
       />
       <span>Entered value: {otp.join('')}</span>
     </Box>

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-function OTP({ separator, inputCount, value, onChange }) {
-  const inputRefs = React.useRef(new Array(inputCount).fill(null));
+function OTP({ separator, length, value, onChange }) {
+  const inputRefs = React.useRef(new Array(length).fill(null));
 
   const focusInput = (targetIndex) => {
     const targetInput = inputRefs.current[targetIndex];
@@ -32,7 +32,7 @@ function OTP({ separator, inputCount, value, onChange }) {
         break;
       case 'ArrowRight':
         event.preventDefault();
-        if (currentIndex < inputCount - 1) {
+        if (currentIndex < length - 1) {
           focusInput(currentIndex + 1);
           selectInput(currentIndex + 1);
         }
@@ -83,7 +83,7 @@ function OTP({ separator, inputCount, value, onChange }) {
       return otpArray.join('');
     });
     if (currentValue !== '') {
-      if (currentIndex < inputCount - 1) {
+      if (currentIndex < length - 1) {
         focusInput(currentIndex + 1);
       }
     }
@@ -100,7 +100,7 @@ function OTP({ separator, inputCount, value, onChange }) {
     // Check if there is text data in the clipboard
     if (clipboardData.types.includes('text/plain')) {
       let pastedText = clipboardData.getData('text/plain');
-      pastedText = pastedText.substring(0, inputCount).trim();
+      pastedText = pastedText.substring(0, length).trim();
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
@@ -113,7 +113,7 @@ function OTP({ separator, inputCount, value, onChange }) {
 
       const otpArray = value.split('');
 
-      for (let i = indexToEnter; i < inputCount; i += 1) {
+      for (let i = indexToEnter; i < length; i += 1) {
         const lastValue = pastedText[i - indexToEnter] ?? ' ';
         otpArray[i] = lastValue;
       }
@@ -124,7 +124,7 @@ function OTP({ separator, inputCount, value, onChange }) {
 
   return (
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-      {new Array(inputCount).fill(null).map((_, index) => (
+      {new Array(length).fill(null).map((_, index) => (
         <React.Fragment key={index}>
           <BaseInput
             slots={{
@@ -144,7 +144,7 @@ function OTP({ separator, inputCount, value, onChange }) {
               },
             }}
           />
-          {index === inputCount - 1 ? null : separator}
+          {index === length - 1 ? null : separator}
         </React.Fragment>
       ))}
     </Box>
@@ -152,7 +152,7 @@ function OTP({ separator, inputCount, value, onChange }) {
 }
 
 OTP.propTypes = {
-  inputCount: PropTypes.number.isRequired,
+  length: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   separator: PropTypes.node,
   value: PropTypes.string.isRequired,
@@ -169,7 +169,7 @@ export default function OTPInput() {
         gap: 2,
       }}
     >
-      <OTP separator={<span>-</span>} value={otp} onChange={setOtp} inputCount={5} />
+      <OTP separator={<span>-</span>} value={otp} onChange={setOtp} length={5} />
       <span>Entered value: {otp}</span>
     </Box>
   );

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -2,13 +2,9 @@ import * as React from 'react';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-export default function OTPInput() {
-  const inputCount = 6;
+function OTP({ seperator, inputCount }) {
   const inputRefs = React.useRef(new Array(6).fill(null));
   const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
-
-  const otpAsString = otp.join('');
-  console.log(otpAsString);
 
   const focusInput = (targetIndex) => {
     const targetInput = inputRefs.current[targetIndex];
@@ -58,19 +54,18 @@ export default function OTPInput() {
 
   const handleChange = (event, currentIndex) => {
     const value = event.target.value;
+    let indexToEnter = 0;
+
+    while (indexToEnter <= currentIndex) {
+      if (otp[indexToEnter] && indexToEnter < currentIndex) {
+        indexToEnter += 1;
+      } else {
+        break;
+      }
+    }
     setOtp((prev) => {
       const otpArray = [...prev];
       const lastValue = value[value.length - 1];
-      let indexToEnter = 0;
-
-      while (indexToEnter <= currentIndex) {
-        if (prev[indexToEnter]) {
-          indexToEnter+=1;
-        } else {
-          break;
-        }
-      }
-
       otpArray[indexToEnter] = lastValue;
       return otpArray;
     });
@@ -85,25 +80,33 @@ export default function OTPInput() {
     selectInput(currentIndex);
   };
 
-  return (
-    <Box sx={{ display: 'flex', gap: '1rem' }}>
-      {new Array(inputCount).fill(null).map((_, index) => (
-        <BaseInput
-          key={index}
-          slots={{ input: InputElement }}
-          slotProps={{
-            input: {
-              ref: (ele) => {
-                inputRefs.current[index] = ele;
-              },
-              onKeyDown: (event) => handleKeyDown(event, index),
-              onChange: (event) => handleChange(event, index),
-              onClick: (event) => handleClick(event, index),
-              value: otp[index],
+  return new Array(inputCount).fill(null).map((_, index) => (
+    <React.Fragment key={index}>
+      <BaseInput
+        slots={{
+          input: InputElement,
+        }}
+        slotProps={{
+          input: {
+            ref: (ele) => {
+              inputRefs.current[index] = ele;
             },
-          }}
-        />
-      ))}
+            onKeyDown: (event) => handleKeyDown(event, index),
+            onChange: (event) => handleChange(event, index),
+            onClick: (event) => handleClick(event, index),
+            value: otp[index],
+          },
+        }}
+      />
+      {index === inputCount - 1 ? null : seperator}
+    </React.Fragment>
+  ));
+}
+
+export default function OTPInput() {
+  return (
+    <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <OTP seperator={<span>-</span>} inputCount={6} />
     </Box>
   );
 }
@@ -137,12 +140,12 @@ const InputElement = styled('input')(
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1.5;
-  padding: 8px 12px;
+  padding: 8px 0px;
   border-radius: 8px;
   text-align: center;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[500]};
   box-shadow: 0px 2px 4px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -2,18 +2,6 @@ import * as React from 'react';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-const CustomNumberInput = React.forwardRef(function CustomNumberInput(props, ref) {
-  return (
-    <BaseInput
-      slots={{
-        input: InputElement,
-      }}
-      {...props}
-      ref={ref}
-    />
-  );
-});
-
 export default function OTPInput() {
   const inputCount = 6;
   const inputRefs = React.useRef(new Array(6).fill(null));
@@ -88,8 +76,9 @@ export default function OTPInput() {
   return (
     <Box sx={{ display: 'flex', gap: '1rem' }}>
       {new Array(inputCount).fill(null).map((_, index) => (
-        <CustomNumberInput
+        <BaseInput
           key={index}
+          slots={{ input: InputElement }}
           slotProps={{
             input: {
               ref: (ele) => {

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-function OTP({ seperator, inputCount, value, onChange }) {
+function OTP({ separator, inputCount, value, onChange }) {
   const inputRefs = React.useRef(new Array(inputCount).fill(null));
 
   const focusInput = (targetIndex) => {
@@ -146,7 +146,7 @@ function OTP({ seperator, inputCount, value, onChange }) {
               },
             }}
           />
-          {index === inputCount - 1 ? null : seperator}
+          {index === inputCount - 1 ? null : separator}
         </React.Fragment>
       ))}
     </Box>
@@ -156,7 +156,7 @@ function OTP({ seperator, inputCount, value, onChange }) {
 OTP.propTypes = {
   inputCount: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
-  seperator: PropTypes.node,
+  separator: PropTypes.node,
   value: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
@@ -172,7 +172,7 @@ export default function OTPInput() {
       }}
     >
       <OTP
-        seperator={<span>-</span>}
+        separator={<span>-</span>}
         value={otp}
         onChange={setOtp}
         inputCount={otp.length}

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -36,8 +36,18 @@ function OTP({ seperator, inputCount, value, onChange }) {
           selectInput(currentIndex + 1);
         }
         break;
-      case 'Backspace':
       case 'Delete':
+        event.preventDefault();
+
+        onChange((prev) => {
+          const otpArray = [...prev];
+          otpArray.splice(currentIndex, 1);
+          otpArray.push('');
+          return otpArray;
+        });
+
+        break;
+      case 'Backspace':
         event.preventDefault();
         if (currentIndex > 0) {
           focusInput(currentIndex - 1);

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { Input as BaseInput } from '@mui/base/Input';
+import { Box, styled } from '@mui/system';
+
+const CustomNumberInput = React.forwardRef(function CustomNumberInput(props, ref) {
+  return (
+    <BaseInput
+      slots={{
+        input: InputElement,
+      }}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+
+export default function OTPInput() {
+  const inputCount = 6;
+  const inputRefs = React.useRef(new Array(6).fill(null));
+  const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
+
+  const otpAsString = otp.join('');
+  console.log(otpAsString);
+
+  const focusInput = (targetIndex) => {
+    const targetInput = inputRefs.current[targetIndex];
+    targetInput.focus();
+  };
+
+  const selectInput = (targetIndex) => {
+    const targetInput = inputRefs.current[targetIndex];
+    targetInput.select();
+  };
+
+  const handleKeyDown = (event, currentIndex) => {
+    switch (event.key) {
+      case 'ArrowLeft':
+        if (currentIndex > 0) {
+          focusInput(currentIndex - 1);
+          selectInput(currentIndex - 1);
+        }
+        break;
+      case 'ArrowRight':
+        if (currentIndex < inputCount - 1) {
+          focusInput(currentIndex + 1);
+          selectInput(currentIndex + 1);
+        }
+        break;
+      case 'Backspace':
+        event.preventDefault();
+        if (currentIndex > 0) {
+          focusInput(currentIndex - 1);
+          selectInput(currentIndex - 1);
+        }
+
+        setOtp((prev) => {
+          const otpArray = [...prev];
+          otpArray.splice(currentIndex, 1);
+          otpArray.push('');
+          return otpArray;
+        });
+
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleChange = (event, currentIndex) => {
+    const value = event.target.value;
+    setOtp((prev) => {
+      const otpArray = [...prev];
+      const lastValue = value[value.length - 1];
+      otpArray[currentIndex] = lastValue;
+      return otpArray;
+    });
+    if (value !== '') {
+      if (currentIndex < inputCount - 1) {
+        focusInput(currentIndex + 1);
+      }
+    }
+  };
+
+  const handleClick = (event, currentIndex) => {
+    selectInput(currentIndex);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: '1rem' }}>
+      {new Array(inputCount).fill(null).map((_, index) => (
+        <CustomNumberInput
+          key={index}
+          slotProps={{
+            input: {
+              ref: (ele) => {
+                inputRefs.current[index] = ele;
+              },
+              onKeyDown: (event) => handleKeyDown(event, index),
+              onChange: (event) => handleChange(event, index),
+              onClick: (event) => handleClick(event, index),
+              value: otp[index],
+            },
+          }}
+        />
+      ))}
+    </Box>
+  );
+}
+
+const blue = {
+  100: '#DAECFF',
+  200: '#80BFFF',
+  400: '#3399FF',
+  500: '#007FFF',
+  600: '#0072E5',
+  700: '#0059B2',
+};
+
+const grey = {
+  50: '#F3F6F9',
+  100: '#E5EAF2',
+  200: '#DAE2ED',
+  300: '#C7D0DD',
+  400: '#B0B8C4',
+  500: '#9DA8B7',
+  600: '#6B7A90',
+  700: '#434D5B',
+  800: '#303740',
+  900: '#1C2025',
+};
+
+const InputElement = styled('input')(
+  ({ theme }) => `
+  width: 15px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.5;
+  padding: 8px 12px;
+  border-radius: 8px;
+  text-align: center;
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: 0px 2px 4px ${
+    theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
+  };
+
+  &:hover {
+    border-color: ${blue[400]};
+  }
+
+  &:focus {
+    border-color: ${blue[400]};
+    box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
+  }
+
+  // firefox
+  &:focus-visible {
+    outline: 0;
+  }
+`,
+);

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-function OTP({ seperator, inputCount, otp, setOtp }) {
+function OTP({ seperator, inputCount, value, onChange }) {
   const inputRefs = React.useRef(new Array(inputCount).fill(null));
 
   const focusInput = (targetIndex) => {
@@ -43,7 +43,7 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
           selectInput(currentIndex - 1);
         }
 
-        setOtp((prev) => {
+        onChange((prev) => {
           const otpArray = [...prev];
           otpArray.splice(currentIndex, 1);
           otpArray.push('');
@@ -57,23 +57,23 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
   };
 
   const handleChange = (event, currentIndex) => {
-    const value = event.target.value;
+    const currentValue = event.target.value;
     let indexToEnter = 0;
 
     while (indexToEnter <= currentIndex) {
-      if (otp[indexToEnter] && indexToEnter < currentIndex) {
+      if (value[indexToEnter] && indexToEnter < currentIndex) {
         indexToEnter += 1;
       } else {
         break;
       }
     }
-    setOtp((prev) => {
+    onChange((prev) => {
       const otpArray = [...prev];
-      const lastValue = value[value.length - 1];
+      const lastValue = currentValue[currentValue.length - 1];
       otpArray[indexToEnter] = lastValue;
       return otpArray;
     });
-    if (value !== '') {
+    if (currentValue !== '') {
       if (currentIndex < inputCount - 1) {
         focusInput(currentIndex + 1);
       }
@@ -95,21 +95,21 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
-        if (otp[indexToEnter] && indexToEnter < currentIndex) {
+        if (value[indexToEnter] && indexToEnter < currentIndex) {
           indexToEnter += 1;
         } else {
           break;
         }
       }
 
-      const otpArray = [...otp];
+      const otpArray = [...value];
 
       for (let i = indexToEnter; i < inputCount; i += 1) {
         const lastValue = pastedText[i - indexToEnter] ?? '';
         otpArray[i] = lastValue;
       }
 
-      setOtp(otpArray);
+      onChange(otpArray);
     }
   };
 
@@ -129,7 +129,7 @@ function OTP({ seperator, inputCount, otp, setOtp }) {
             onChange: (event) => handleChange(event, index),
             onClick: (event) => handleClick(event, index),
             onPaste: (event) => handlePaste(event, index),
-            value: otp[index],
+            value: value[index],
           },
         }}
       />
@@ -145,8 +145,8 @@ export default function OTPInput() {
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
       <OTP
         seperator={<span>-</span>}
-        otp={otp}
-        setOtp={setOtp}
+        value={otp}
+        onChange={setOtp}
         inputCount={inputCount}
       />
     </Box>

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -39,12 +39,10 @@ function OTP({ separator, inputCount, value, onChange }) {
         break;
       case 'Delete':
         event.preventDefault();
-
-        onChange((prev) => {
-          const otpArray = prev.split('');
-          otpArray.splice(currentIndex, 1);
-          otpArray.push(' ');
-          return otpArray.join('');
+        onChange((prevOtp) => {
+          let otp = prevOtp;
+          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          return otp;
         });
 
         break;
@@ -55,11 +53,10 @@ function OTP({ separator, inputCount, value, onChange }) {
           selectInput(currentIndex - 1);
         }
 
-        onChange((prev) => {
-          const otpArray = prev.split('');
-          otpArray.splice(currentIndex, 1);
-          otpArray.push(' ');
-          return otpArray.join('');
+        onChange((prevOtp) => {
+          let otp = prevOtp;
+          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          return otp;
         });
 
         break;
@@ -74,7 +71,7 @@ function OTP({ separator, inputCount, value, onChange }) {
     let indexToEnter = 0;
 
     while (indexToEnter <= currentIndex) {
-      if (value[indexToEnter] && indexToEnter < currentIndex) {
+      if (inputRefs.current[indexToEnter].value && indexToEnter < currentIndex) {
         indexToEnter += 1;
       } else {
         break;
@@ -108,7 +105,7 @@ function OTP({ separator, inputCount, value, onChange }) {
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
-        if (value[indexToEnter] && indexToEnter < currentIndex) {
+        if (inputRefs.current[indexToEnter].value && indexToEnter < currentIndex) {
           indexToEnter += 1;
         } else {
           break;
@@ -144,7 +141,7 @@ function OTP({ separator, inputCount, value, onChange }) {
                 onChange: (event) => handleChange(event, index),
                 onClick: (event) => handleClick(event, index),
                 onPaste: (event) => handlePaste(event, index),
-                value: value[index],
+                value: value[index] ?? '',
               },
             }}
           />
@@ -164,6 +161,7 @@ OTP.propTypes = {
 
 export default function OTPInput() {
   const [otp, setOtp] = React.useState('');
+
   return (
     <Box
       sx={{

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -3,7 +3,7 @@ import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
 function OTP({ seperator, inputCount }) {
-  const inputRefs = React.useRef(new Array(6).fill(null));
+  const inputRefs = React.useRef(new Array(inputCount).fill(null));
   const [otp, setOtp] = React.useState(new Array(inputCount).fill(''));
 
   const focusInput = (targetIndex) => {

--- a/docs/data/base/components/input/OTPInput.js
+++ b/docs/data/base/components/input/OTPInput.js
@@ -20,6 +20,7 @@ function OTP({ separator, inputCount, value, onChange }) {
     switch (event.key) {
       case 'ArrowUp':
       case 'ArrowDown':
+      case ' ':
         event.preventDefault();
         break;
       case 'ArrowLeft':
@@ -42,7 +43,7 @@ function OTP({ separator, inputCount, value, onChange }) {
         onChange((prev) => {
           const otpArray = prev.split('');
           otpArray.splice(currentIndex, 1);
-          otpArray.push('');
+          otpArray.push(' ');
           return otpArray.join('');
         });
 
@@ -57,11 +58,12 @@ function OTP({ separator, inputCount, value, onChange }) {
         onChange((prev) => {
           const otpArray = prev.split('');
           otpArray.splice(currentIndex, 1);
-          otpArray.push('');
+          otpArray.push(' ');
           return otpArray.join('');
         });
 
         break;
+
       default:
         break;
     }
@@ -102,7 +104,7 @@ function OTP({ separator, inputCount, value, onChange }) {
     // Check if there is text data in the clipboard
     if (clipboardData.types.includes('text/plain')) {
       let pastedText = clipboardData.getData('text/plain');
-      pastedText = pastedText.substring(0, inputCount);
+      pastedText = pastedText.substring(0, inputCount).trim();
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
@@ -116,7 +118,7 @@ function OTP({ separator, inputCount, value, onChange }) {
       const otpArray = value.split('');
 
       for (let i = indexToEnter; i < inputCount; i += 1) {
-        const lastValue = pastedText[i - indexToEnter] ?? '';
+        const lastValue = pastedText[i - indexToEnter] ?? ' ';
         otpArray[i] = lastValue;
       }
 

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -2,13 +2,15 @@ import * as React from 'react';
 import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
-export default function OTPInput() {
-  const inputCount = 6;
+function OTP({
+  seperator,
+  inputCount,
+}: {
+  seperator: React.ReactNode;
+  inputCount: number;
+}) {
   const inputRefs = React.useRef<HTMLInputElement[]>(new Array(6).fill(null));
   const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
-
-  const otpAsString = otp.join('');
-  console.log(otpAsString);
 
   const focusInput = (targetIndex: number) => {
     const targetInput = inputRefs.current[targetIndex];
@@ -64,10 +66,19 @@ export default function OTPInput() {
     currentIndex: number,
   ) => {
     const value = event.target.value;
+    let indexToEnter = 0;
+
+    while (indexToEnter <= currentIndex) {
+      if (otp[indexToEnter] && indexToEnter < currentIndex) {
+        indexToEnter += 1;
+      } else {
+        break;
+      }
+    }
     setOtp((prev) => {
       const otpArray = [...prev];
       const lastValue = value[value.length - 1];
-      otpArray[currentIndex] = lastValue;
+      otpArray[indexToEnter] = lastValue;
       return otpArray;
     });
     if (value !== '') {
@@ -85,28 +96,35 @@ export default function OTPInput() {
   };
 
   return (
-    <Box sx={{ display: 'flex', gap: '1rem' }}>
+    <Box sx={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
       {new Array(inputCount).fill(null).map((_, index) => (
-        <BaseInput
-          slots={{
-            input: InputElement,
-          }}
-          key={index}
-          slotProps={{
-            input: {
-              ref: (ele) => {
-                inputRefs.current[index] = ele!;
+        <React.Fragment>
+          <BaseInput
+            slots={{
+              input: InputElement,
+            }}
+            key={index}
+            slotProps={{
+              input: {
+                ref: (ele) => {
+                  inputRefs.current[index] = ele!;
+                },
+                onKeyDown: (event) => handleKeyDown(event, index),
+                onChange: (event) => handleChange(event, index),
+                onClick: (event) => handleClick(event, index),
+                value: otp[index],
               },
-              onKeyDown: (event) => handleKeyDown(event, index),
-              onChange: (event) => handleChange(event, index),
-              onClick: (event) => handleClick(event, index),
-              value: otp[index],
-            },
-          }}
-        />
+            }}
+          />
+          {index === inputCount - 1 ? null : seperator}
+        </React.Fragment>
       ))}
     </Box>
   );
+}
+
+export default function OTPInput() {
+  return <OTP seperator={<span>-</span>} inputCount={6} />;
 }
 
 const blue = {
@@ -143,7 +161,7 @@ const InputElement = styled('input')(
   text-align: center;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[400]};
   box-shadow: 0px 2px 4px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -137,42 +137,53 @@ function OTP({
     }
   };
 
-  return new Array(inputCount).fill(null).map((_, index) => (
-    <React.Fragment key={index}>
-      <BaseInput
-        slots={{
-          input: InputElement,
-        }}
-        aria-label={`Digit ${index + 1} of OTP`}
-        slotProps={{
-          input: {
-            ref: (ele) => {
-              inputRefs.current[index] = ele!;
-            },
-            onKeyDown: (event) => handleKeyDown(event, index),
-            onChange: (event) => handleChange(event, index),
-            onClick: (event) => handleClick(event, index),
-            onPaste: (event) => handlePaste(event, index),
-            value: value[index],
-          },
-        }}
-      />
-      {index === inputCount - 1 ? null : seperator}
-    </React.Fragment>
-  ));
+  return (
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+      {new Array(inputCount).fill(null).map((_, index) => (
+        <React.Fragment key={index}>
+          <BaseInput
+            slots={{
+              input: InputElement,
+            }}
+            aria-label={`Digit ${index + 1} of OTP`}
+            slotProps={{
+              input: {
+                ref: (ele) => {
+                  inputRefs.current[index] = ele!;
+                },
+                onKeyDown: (event) => handleKeyDown(event, index),
+                onChange: (event) => handleChange(event, index),
+                onClick: (event) => handleClick(event, index),
+                onPaste: (event) => handlePaste(event, index),
+                value: value[index],
+              },
+            }}
+          />
+          {index === inputCount - 1 ? null : seperator}
+        </React.Fragment>
+      ))}
+    </Box>
+  );
 }
 
 export default function OTPInput() {
   const inputCount = 5;
   const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
   return (
-    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
       <OTP
         seperator={<span>-</span>}
         value={otp}
         onChange={setOtp}
         inputCount={inputCount}
       />
+      <span>Entered value: {otp.join('')}</span>
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -33,15 +33,15 @@ function OTP({
   ) => {
     switch (event.key) {
       case 'ArrowLeft':
+        event.preventDefault();
         if (currentIndex > 0) {
-          event.preventDefault();
           focusInput(currentIndex - 1);
           selectInput(currentIndex - 1);
         }
         break;
       case 'ArrowRight':
+        event.preventDefault();
         if (currentIndex < inputCount - 1) {
-          event.preventDefault();
           focusInput(currentIndex + 1);
           selectInput(currentIndex + 1);
         }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -100,6 +100,38 @@ function OTP({
     selectInput(currentIndex);
   };
 
+  const handlePaste = (
+    event: React.ClipboardEvent<HTMLInputElement>,
+    currentIndex: number,
+  ) => {
+    event.preventDefault();
+    const clipboardData = event.clipboardData;
+
+    // Check if there is text data in the clipboard
+    if (clipboardData.types.includes('text/plain')) {
+      let pastedText = clipboardData.getData('text/plain');
+      pastedText = pastedText.substring(0, inputCount);
+      let indexToEnter = 0;
+
+      while (indexToEnter <= currentIndex) {
+        if (otp[indexToEnter] && indexToEnter < currentIndex) {
+          indexToEnter += 1;
+        } else {
+          break;
+        }
+      }
+
+      const otpArray = [...otp];
+
+      for (let i = indexToEnter; i < inputCount; i += 1) {
+        const lastValue = pastedText[i - indexToEnter] ?? '';
+        otpArray[i] = lastValue;
+      }
+
+      setOtp(otpArray);
+    }
+  };
+
   return new Array(inputCount).fill(null).map((_, index) => (
     <React.Fragment key={index}>
       <BaseInput
@@ -115,6 +147,7 @@ function OTP({
             onKeyDown: (event) => handleKeyDown(event, index),
             onChange: (event) => handleChange(event, index),
             onClick: (event) => handleClick(event, index),
+            onPaste: (event) => handlePaste(event, index),
             value: otp[index],
           },
         }}

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -50,8 +50,18 @@ function OTP({
           selectInput(currentIndex + 1);
         }
         break;
-      case 'Backspace':
       case 'Delete':
+        event.preventDefault();
+
+        onChange((prev) => {
+          const otpArray = [...prev];
+          otpArray.splice(currentIndex, 1);
+          otpArray.push('');
+          return otpArray;
+        });
+
+        break;
+      case 'Backspace':
         event.preventDefault();
         if (currentIndex > 0) {
           focusInput(currentIndex - 1);

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -5,13 +5,13 @@ import { Box, styled } from '@mui/system';
 function OTP({
   seperator,
   inputCount,
-  otp,
-  setOtp,
+  value,
+  onChange,
 }: {
   seperator: React.ReactNode;
   inputCount: number;
-  otp: string[];
-  setOtp: React.Dispatch<React.SetStateAction<string[]>>;
+  value: string[];
+  onChange: React.Dispatch<React.SetStateAction<string[]>>;
 }) {
   const inputRefs = React.useRef<HTMLInputElement[]>(
     new Array(inputCount).fill(null),
@@ -58,7 +58,7 @@ function OTP({
           selectInput(currentIndex - 1);
         }
 
-        setOtp((prev) => {
+        onChange((prev) => {
           const otpArray = [...prev];
           otpArray.splice(currentIndex, 1);
           otpArray.push('');
@@ -75,23 +75,23 @@ function OTP({
     event: React.ChangeEvent<HTMLInputElement>,
     currentIndex: number,
   ) => {
-    const value = event.target.value;
+    const currentValue = event.target.value;
     let indexToEnter = 0;
 
     while (indexToEnter <= currentIndex) {
-      if (otp[indexToEnter] && indexToEnter < currentIndex) {
+      if (value[indexToEnter] && indexToEnter < currentIndex) {
         indexToEnter += 1;
       } else {
         break;
       }
     }
-    setOtp((prev) => {
+    onChange((prev) => {
       const otpArray = [...prev];
-      const lastValue = value[value.length - 1];
+      const lastValue = currentValue[currentValue.length - 1];
       otpArray[indexToEnter] = lastValue;
       return otpArray;
     });
-    if (value !== '') {
+    if (currentValue !== '') {
       if (currentIndex < inputCount - 1) {
         focusInput(currentIndex + 1);
       }
@@ -119,21 +119,21 @@ function OTP({
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
-        if (otp[indexToEnter] && indexToEnter < currentIndex) {
+        if (value[indexToEnter] && indexToEnter < currentIndex) {
           indexToEnter += 1;
         } else {
           break;
         }
       }
 
-      const otpArray = [...otp];
+      const otpArray = [...value];
 
       for (let i = indexToEnter; i < inputCount; i += 1) {
         const lastValue = pastedText[i - indexToEnter] ?? '';
         otpArray[i] = lastValue;
       }
 
-      setOtp(otpArray);
+      onChange(otpArray);
     }
   };
 
@@ -153,7 +153,7 @@ function OTP({
             onChange: (event) => handleChange(event, index),
             onClick: (event) => handleClick(event, index),
             onPaste: (event) => handlePaste(event, index),
-            value: otp[index],
+            value: value[index],
           },
         }}
       />
@@ -169,8 +169,8 @@ export default function OTPInput() {
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
       <OTP
         seperator={<span>-</span>}
-        otp={otp}
-        setOtp={setOtp}
+        value={otp}
+        onChange={setOtp}
         inputCount={inputCount}
       />
     </Box>

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -1,21 +1,6 @@
 import * as React from 'react';
-import { Input as BaseInput, InputProps } from '@mui/base/Input';
+import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
-
-const CustomNumberInput = React.forwardRef(function CustomNumberInput(
-  props: InputProps,
-  ref: React.ForwardedRef<HTMLDivElement>,
-) {
-  return (
-    <BaseInput
-      slots={{
-        input: InputElement,
-      }}
-      {...props}
-      ref={ref}
-    />
-  );
-});
 
 export default function OTPInput() {
   const inputCount = 6;
@@ -100,7 +85,10 @@ export default function OTPInput() {
   return (
     <Box sx={{ display: 'flex', gap: '1rem' }}>
       {new Array(inputCount).fill(null).map((_, index) => (
-        <CustomNumberInput
+        <BaseInput
+          slots={{
+            input: InputElement,
+          }}
           key={index}
           slotProps={{
             input: {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -95,36 +95,35 @@ function OTP({
     selectInput(currentIndex);
   };
 
-  return (
-    <Box sx={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
-      {new Array(inputCount).fill(null).map((_, index) => (
-        <React.Fragment>
-          <BaseInput
-            slots={{
-              input: InputElement,
-            }}
-            key={index}
-            slotProps={{
-              input: {
-                ref: (ele) => {
-                  inputRefs.current[index] = ele!;
-                },
-                onKeyDown: (event) => handleKeyDown(event, index),
-                onChange: (event) => handleChange(event, index),
-                onClick: (event) => handleClick(event, index),
-                value: otp[index],
-              },
-            }}
-          />
-          {index === inputCount - 1 ? null : seperator}
-        </React.Fragment>
-      ))}
-    </Box>
-  );
+  return new Array(inputCount).fill(null).map((_, index) => (
+    <React.Fragment key={index}>
+      <BaseInput
+        slots={{
+          input: InputElement,
+        }}
+        slotProps={{
+          input: {
+            ref: (ele) => {
+              inputRefs.current[index] = ele!;
+            },
+            onKeyDown: (event) => handleKeyDown(event, index),
+            onChange: (event) => handleChange(event, index),
+            onClick: (event) => handleClick(event, index),
+            value: otp[index],
+          },
+        }}
+      />
+      {index === inputCount - 1 ? null : seperator}
+    </React.Fragment>
+  ));
 }
 
 export default function OTPInput() {
-  return <OTP seperator={<span>-</span>} inputCount={6} />;
+  return (
+    <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <OTP seperator={<span>-</span>} inputCount={6} />
+    </Box>
+  );
 }
 
 const blue = {
@@ -156,12 +155,12 @@ const InputElement = styled('input')(
   font-size: 0.875rem;
   font-weight: 400;
   line-height: 1.5;
-  padding: 8px 12px;
+  padding: 8px 0px;
   border-radius: 8px;
   text-align: center;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[400]};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[500]};
   box-shadow: 0px 2px 4px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -27,12 +27,14 @@ export default function OTPInput() {
     switch (event.key) {
       case 'ArrowLeft':
         if (currentIndex > 0) {
+          event.preventDefault();
           focusInput(currentIndex - 1);
           selectInput(currentIndex - 1);
         }
         break;
       case 'ArrowRight':
         if (currentIndex < inputCount - 1) {
+          event.preventDefault();
           focusInput(currentIndex + 1);
           selectInput(currentIndex + 1);
         }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -13,9 +13,7 @@ function OTP({
   value: string;
   onChange: React.Dispatch<React.SetStateAction<string>>;
 }) {
-  const inputRefs = React.useRef<HTMLInputElement[]>(
-    new Array(length).fill(null),
-  );
+  const inputRefs = React.useRef<HTMLInputElement[]>(new Array(length).fill(null));
 
   const focusInput = (targetIndex: number) => {
     const targetInput = inputRefs.current[targetIndex];

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -9,7 +9,9 @@ function OTP({
   seperator: React.ReactNode;
   inputCount: number;
 }) {
-  const inputRefs = React.useRef<HTMLInputElement[]>(new Array(inputCount).fill(null));
+  const inputRefs = React.useRef<HTMLInputElement[]>(
+    new Array(inputCount).fill(null),
+  );
   const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
 
   const focusInput = (targetIndex: number) => {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -106,7 +106,7 @@ function OTP({
         slots={{
           input: InputElement,
         }}
-        aria-label="OTP input field"
+        aria-label={`Digit ${index + 1} of OTP`}
         slotProps={{
           input: {
             ref: (ele) => {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -9,7 +9,7 @@ function OTP({
   seperator: React.ReactNode;
   inputCount: number;
 }) {
-  const inputRefs = React.useRef<HTMLInputElement[]>(new Array(6).fill(null));
+  const inputRefs = React.useRef<HTMLInputElement[]>(new Array(inputCount).fill(null));
   const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
 
   const focusInput = (targetIndex: number) => {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -53,12 +53,10 @@ function OTP({
         break;
       case 'Delete':
         event.preventDefault();
-
-        onChange((prev) => {
-          const otpArray = prev.split('');
-          otpArray.splice(currentIndex, 1);
-          otpArray.push(' ');
-          return otpArray.join('');
+        onChange((prevOtp) => {
+          let otp = prevOtp;
+          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          return otp;
         });
 
         break;
@@ -69,11 +67,10 @@ function OTP({
           selectInput(currentIndex - 1);
         }
 
-        onChange((prev) => {
-          const otpArray = prev.split('');
-          otpArray.splice(currentIndex, 1);
-          otpArray.push(' ');
-          return otpArray.join('');
+        onChange((prevOtp) => {
+          let otp = prevOtp;
+          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          return otp;
         });
 
         break;
@@ -91,7 +88,7 @@ function OTP({
     let indexToEnter = 0;
 
     while (indexToEnter <= currentIndex) {
-      if (value[indexToEnter] && indexToEnter < currentIndex) {
+      if (inputRefs.current[indexToEnter].value && indexToEnter < currentIndex) {
         indexToEnter += 1;
       } else {
         break;
@@ -131,7 +128,7 @@ function OTP({
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
-        if (value[indexToEnter] && indexToEnter < currentIndex) {
+        if (inputRefs.current[indexToEnter].value && indexToEnter < currentIndex) {
           indexToEnter += 1;
         } else {
           break;
@@ -167,7 +164,7 @@ function OTP({
                 onChange: (event) => handleChange(event, index),
                 onClick: (event) => handleClick(event, index),
                 onPaste: (event) => handlePaste(event, index),
-                value: value[index],
+                value: value[index] ?? '',
               },
             }}
           />
@@ -180,6 +177,7 @@ function OTP({
 
 export default function OTPInput() {
   const [otp, setOtp] = React.useState('');
+
   return (
     <Box
       sx={{

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -101,6 +101,7 @@ function OTP({
         slots={{
           input: InputElement,
         }}
+        aria-label='OTP input field'
         slotProps={{
           input: {
             ref: (ele) => {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -191,7 +191,7 @@ export default function OTPInput() {
         seperator={<span>-</span>}
         value={otp}
         onChange={setOtp}
-        inputCount={inputCount}
+        inputCount={otp.length}
       />
       <span>Entered value: {otp.join('')}</span>
     </Box>

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -4,17 +4,17 @@ import { Box, styled } from '@mui/system';
 
 function OTP({
   separator,
-  inputCount,
+  length,
   value,
   onChange,
 }: {
   separator: React.ReactNode;
-  inputCount: number;
+  length: number;
   value: string;
   onChange: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const inputRefs = React.useRef<HTMLInputElement[]>(
-    new Array(inputCount).fill(null),
+    new Array(length).fill(null),
   );
 
   const focusInput = (targetIndex: number) => {
@@ -46,7 +46,7 @@ function OTP({
         break;
       case 'ArrowRight':
         event.preventDefault();
-        if (currentIndex < inputCount - 1) {
+        if (currentIndex < length - 1) {
           focusInput(currentIndex + 1);
           selectInput(currentIndex + 1);
         }
@@ -100,7 +100,7 @@ function OTP({
       return otpArray.join('');
     });
     if (currentValue !== '') {
-      if (currentIndex < inputCount - 1) {
+      if (currentIndex < length - 1) {
         focusInput(currentIndex + 1);
       }
     }
@@ -123,7 +123,7 @@ function OTP({
     // Check if there is text data in the clipboard
     if (clipboardData.types.includes('text/plain')) {
       let pastedText = clipboardData.getData('text/plain');
-      pastedText = pastedText.substring(0, inputCount).trim();
+      pastedText = pastedText.substring(0, length).trim();
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
@@ -136,7 +136,7 @@ function OTP({
 
       const otpArray = value.split('');
 
-      for (let i = indexToEnter; i < inputCount; i += 1) {
+      for (let i = indexToEnter; i < length; i += 1) {
         const lastValue = pastedText[i - indexToEnter] ?? ' ';
         otpArray[i] = lastValue;
       }
@@ -147,7 +147,7 @@ function OTP({
 
   return (
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-      {new Array(inputCount).fill(null).map((_, index) => (
+      {new Array(length).fill(null).map((_, index) => (
         <React.Fragment key={index}>
           <BaseInput
             slots={{
@@ -167,7 +167,7 @@ function OTP({
               },
             }}
           />
-          {index === inputCount - 1 ? null : separator}
+          {index === length - 1 ? null : separator}
         </React.Fragment>
       ))}
     </Box>
@@ -185,7 +185,7 @@ export default function OTPInput() {
         gap: 2,
       }}
     >
-      <OTP separator={<span>-</span>} value={otp} onChange={setOtp} inputCount={5} />
+      <OTP separator={<span>-</span>} value={otp} onChange={setOtp} length={5} />
       <span>Entered value: {otp}</span>
     </Box>
   );

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -101,7 +101,7 @@ function OTP({
         slots={{
           input: InputElement,
         }}
-        aria-label='OTP input field'
+        aria-label="OTP input field"
         slotProps={{
           input: {
             ref: (ele) => {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -143,7 +143,7 @@ const grey = {
 
 const InputElement = styled('input')(
   ({ theme }) => `
-  width: 15px;
+  width: 40px;
   font-family: 'IBM Plex Sans', sans-serif;
   font-size: 0.875rem;
   font-weight: 400;

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -3,12 +3,12 @@ import { Input as BaseInput } from '@mui/base/Input';
 import { Box, styled } from '@mui/system';
 
 function OTP({
-  seperator,
+  separator,
   inputCount,
   value,
   onChange,
 }: {
-  seperator: React.ReactNode;
+  separator: React.ReactNode;
   inputCount: number;
   value: string[];
   onChange: React.Dispatch<React.SetStateAction<string[]>>;
@@ -169,7 +169,7 @@ function OTP({
               },
             }}
           />
-          {index === inputCount - 1 ? null : seperator}
+          {index === inputCount - 1 ? null : separator}
         </React.Fragment>
       ))}
     </Box>
@@ -188,7 +188,7 @@ export default function OTPInput() {
       }}
     >
       <OTP
-        seperator={<span>-</span>}
+        separator={<span>-</span>}
         value={otp}
         onChange={setOtp}
         inputCount={otp.length}

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -121,8 +121,8 @@ function OTP({
 
 export default function OTPInput() {
   return (
-    <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-      <OTP seperator={<span>-</span>} inputCount={6} />
+    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+      <OTP seperator={<span>-</span>} inputCount={5} />
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -51,6 +51,7 @@ function OTP({
         }
         break;
       case 'Backspace':
+      case 'Delete':
         event.preventDefault();
         if (currentIndex > 0) {
           focusInput(currentIndex - 1);

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -5,14 +5,17 @@ import { Box, styled } from '@mui/system';
 function OTP({
   seperator,
   inputCount,
+  otp,
+  setOtp,
 }: {
   seperator: React.ReactNode;
   inputCount: number;
+  otp: string[];
+  setOtp: React.Dispatch<React.SetStateAction<string[]>>;
 }) {
   const inputRefs = React.useRef<HTMLInputElement[]>(
     new Array(inputCount).fill(null),
   );
-  const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
 
   const focusInput = (targetIndex: number) => {
     const targetInput = inputRefs.current[targetIndex];
@@ -122,9 +125,16 @@ function OTP({
 }
 
 export default function OTPInput() {
+  const inputCount = 5;
+  const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
   return (
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-      <OTP seperator={<span>-</span>} inputCount={5} />
+      <OTP
+        seperator={<span>-</span>}
+        otp={otp}
+        setOtp={setOtp}
+        inputCount={inputCount}
+      />
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -34,6 +34,7 @@ function OTP({
     switch (event.key) {
       case 'ArrowUp':
       case 'ArrowDown':
+      case ' ':
         event.preventDefault();
         break;
       case 'ArrowLeft':
@@ -76,6 +77,7 @@ function OTP({
         });
 
         break;
+
       default:
         break;
     }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -54,8 +54,8 @@ function OTP({
       case 'Delete':
         event.preventDefault();
         onChange((prevOtp) => {
-          let otp = prevOtp;
-          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          const otp =
+            prevOtp.slice(0, currentIndex) + prevOtp.slice(currentIndex + 1);
           return otp;
         });
 
@@ -68,11 +68,10 @@ function OTP({
         }
 
         onChange((prevOtp) => {
-          let otp = prevOtp;
-          otp = otp.slice(0, currentIndex) + otp.slice(currentIndex + 1);
+          const otp =
+            prevOtp.slice(0, currentIndex) + prevOtp.slice(currentIndex + 1);
           return otp;
         });
-
         break;
 
       default:

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react';
+import { Input as BaseInput, InputProps } from '@mui/base/Input';
+import { Box, styled } from '@mui/system';
+
+const CustomNumberInput = React.forwardRef(function CustomNumberInput(
+  props: InputProps,
+  ref: React.ForwardedRef<HTMLDivElement>,
+) {
+  return (
+    <BaseInput
+      slots={{
+        input: InputElement,
+      }}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+
+export default function OTPInput() {
+  const inputCount = 6;
+  const inputRefs = React.useRef<HTMLInputElement[]>(new Array(6).fill(null));
+  const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
+
+  const otpAsString = otp.join('');
+  console.log(otpAsString);
+
+  const focusInput = (targetIndex: number) => {
+    const targetInput = inputRefs.current[targetIndex];
+    targetInput.focus();
+  };
+
+  const selectInput = (targetIndex: number) => {
+    const targetInput = inputRefs.current[targetIndex];
+    targetInput.select();
+  };
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    currentIndex: number,
+  ) => {
+    switch (event.key) {
+      case 'ArrowLeft':
+        if (currentIndex > 0) {
+          focusInput(currentIndex - 1);
+          selectInput(currentIndex - 1);
+        }
+        break;
+      case 'ArrowRight':
+        if (currentIndex < inputCount - 1) {
+          focusInput(currentIndex + 1);
+          selectInput(currentIndex + 1);
+        }
+        break;
+      case 'Backspace':
+        event.preventDefault();
+        if (currentIndex > 0) {
+          focusInput(currentIndex - 1);
+          selectInput(currentIndex - 1);
+        }
+
+        setOtp((prev) => {
+          const otpArray = [...prev];
+          otpArray.splice(currentIndex, 1);
+          otpArray.push('');
+          return otpArray;
+        });
+
+        break;
+      default:
+        break;
+    }
+  };
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    currentIndex: number,
+  ) => {
+    const value = event.target.value;
+    setOtp((prev) => {
+      const otpArray = [...prev];
+      const lastValue = value[value.length - 1];
+      otpArray[currentIndex] = lastValue;
+      return otpArray;
+    });
+    if (value !== '') {
+      if (currentIndex < inputCount - 1) {
+        focusInput(currentIndex + 1);
+      }
+    }
+  };
+
+  const handleClick = (
+    event: React.MouseEvent<HTMLInputElement, MouseEvent>,
+    currentIndex: number,
+  ) => {
+    selectInput(currentIndex);
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: '1rem' }}>
+      {new Array(inputCount).fill(null).map((_, index) => (
+        <CustomNumberInput
+          key={index}
+          slotProps={{
+            input: {
+              ref: (ele) => {
+                inputRefs.current[index] = ele!;
+              },
+              onKeyDown: (event) => handleKeyDown(event, index),
+              onChange: (event) => handleChange(event, index),
+              onClick: (event) => handleClick(event, index),
+              value: otp[index],
+            },
+          }}
+        />
+      ))}
+    </Box>
+  );
+}
+
+const blue = {
+  100: '#DAECFF',
+  200: '#80BFFF',
+  400: '#3399FF',
+  500: '#007FFF',
+  600: '#0072E5',
+  700: '#0059B2',
+};
+
+const grey = {
+  50: '#F3F6F9',
+  100: '#E5EAF2',
+  200: '#DAE2ED',
+  300: '#C7D0DD',
+  400: '#B0B8C4',
+  500: '#9DA8B7',
+  600: '#6B7A90',
+  700: '#434D5B',
+  800: '#303740',
+  900: '#1C2025',
+};
+
+const InputElement = styled('input')(
+  ({ theme }) => `
+  width: 15px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.5;
+  padding: 8px 12px;
+  border-radius: 8px;
+  text-align: center;
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: 0px 2px 4px ${
+    theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
+  };
+
+  &:hover {
+    border-color: ${blue[400]};
+  }
+
+  &:focus {
+    border-color: ${blue[400]};
+    box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
+  }
+
+  // firefox
+  &:focus-visible {
+    outline: 0;
+  }
+`,
+);

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -32,6 +32,10 @@ function OTP({
     currentIndex: number,
   ) => {
     switch (event.key) {
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        break;
       case 'ArrowLeft':
         event.preventDefault();
         if (currentIndex > 0) {

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -10,8 +10,8 @@ function OTP({
 }: {
   separator: React.ReactNode;
   inputCount: number;
-  value: string[];
-  onChange: React.Dispatch<React.SetStateAction<string[]>>;
+  value: string;
+  onChange: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const inputRefs = React.useRef<HTMLInputElement[]>(
     new Array(inputCount).fill(null),
@@ -54,10 +54,10 @@ function OTP({
         event.preventDefault();
 
         onChange((prev) => {
-          const otpArray = [...prev];
+          const otpArray = prev.split('');
           otpArray.splice(currentIndex, 1);
-          otpArray.push('');
-          return otpArray;
+          otpArray.push(' ');
+          return otpArray.join('');
         });
 
         break;
@@ -69,10 +69,10 @@ function OTP({
         }
 
         onChange((prev) => {
-          const otpArray = [...prev];
+          const otpArray = prev.split('');
           otpArray.splice(currentIndex, 1);
-          otpArray.push('');
-          return otpArray;
+          otpArray.push(' ');
+          return otpArray.join('');
         });
 
         break;
@@ -96,10 +96,10 @@ function OTP({
       }
     }
     onChange((prev) => {
-      const otpArray = [...prev];
+      const otpArray = prev.split('');
       const lastValue = currentValue[currentValue.length - 1];
       otpArray[indexToEnter] = lastValue;
-      return otpArray;
+      return otpArray.join('');
     });
     if (currentValue !== '') {
       if (currentIndex < inputCount - 1) {
@@ -125,7 +125,7 @@ function OTP({
     // Check if there is text data in the clipboard
     if (clipboardData.types.includes('text/plain')) {
       let pastedText = clipboardData.getData('text/plain');
-      pastedText = pastedText.substring(0, inputCount);
+      pastedText = pastedText.substring(0, inputCount).trim();
       let indexToEnter = 0;
 
       while (indexToEnter <= currentIndex) {
@@ -136,14 +136,14 @@ function OTP({
         }
       }
 
-      const otpArray = [...value];
+      const otpArray = value.split('');
 
       for (let i = indexToEnter; i < inputCount; i += 1) {
-        const lastValue = pastedText[i - indexToEnter] ?? '';
+        const lastValue = pastedText[i - indexToEnter] ?? ' ';
         otpArray[i] = lastValue;
       }
 
-      onChange(otpArray);
+      onChange(otpArray.join(''));
     }
   };
 
@@ -177,8 +177,7 @@ function OTP({
 }
 
 export default function OTPInput() {
-  const inputCount = 5;
-  const [otp, setOtp] = React.useState<string[]>(new Array(inputCount).fill(''));
+  const [otp, setOtp] = React.useState('');
   return (
     <Box
       sx={{
@@ -187,13 +186,8 @@ export default function OTPInput() {
         gap: 2,
       }}
     >
-      <OTP
-        separator={<span>-</span>}
-        value={otp}
-        onChange={setOtp}
-        inputCount={otp.length}
-      />
-      <span>Entered value: {otp.join('')}</span>
+      <OTP separator={<span>-</span>} value={otp} onChange={setOtp} inputCount={5} />
+      <span>Entered value: {otp}</span>
     </Box>
   );
 }

--- a/docs/data/base/components/input/OTPInput.tsx
+++ b/docs/data/base/components/input/OTPInput.tsx
@@ -161,7 +161,7 @@ const InputElement = styled('input')(
   text-align: center;
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[500]};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
   box-shadow: 0px 2px 4px ${
     theme.palette.mode === 'dark' ? 'rgba(0,0,0, 0.5)' : 'rgba(0,0,0, 0.05)'
   };

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,7 +1,2 @@
-<OTP
-  separator={<span>-</span>}
-  value={otp}
-  onChange={setOtp}
-  inputCount={otp.length}
-/>
-<span>Entered value: {otp.join('')}</span>
+<OTP separator={<span>-</span>} value={otp} onChange={setOtp} inputCount={5} />
+<span>Entered value: {otp}</span>

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,16 +1,1 @@
-{new Array(inputCount).fill(null).map((_, index) => (
-  <CustomNumberInput
-    key={index}
-    slotProps={{
-      input: {
-        ref: (ele) => {
-          inputRefs.current[index] = ele!;
-        },
-        onKeyDown: (event) => handleKeyDown(event, index),
-        onChange: (event) => handleChange(event, index),
-        onClick: (event) => handleClick(event, index),
-        value: otp[index],
-      },
-    }}
-  />
-))}
+<OTP seperator={<span>-</span>} inputCount={6} />

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,1 +1,6 @@
-<OTP seperator={<span>-</span>} inputCount={5} />
+<OTP
+  seperator={<span>-</span>}
+  otp={otp}
+  setOtp={setOtp}
+  inputCount={inputCount}
+/>

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,6 +1,6 @@
 <OTP
   seperator={<span>-</span>}
-  otp={otp}
-  setOtp={setOtp}
+  value={otp}
+  onChange={setOtp}
   inputCount={inputCount}
 />

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -4,3 +4,4 @@
   onChange={setOtp}
   inputCount={inputCount}
 />
+<span>Entered value: {otp.join('')}</span>

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,5 +1,5 @@
 <OTP
-  seperator={<span>-</span>}
+  separator={<span>-</span>}
   value={otp}
   onChange={setOtp}
   inputCount={otp.length}

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -2,6 +2,6 @@
   seperator={<span>-</span>}
   value={otp}
   onChange={setOtp}
-  inputCount={inputCount}
+  inputCount={otp.length}
 />
 <span>Entered value: {otp.join('')}</span>

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,1 +1,1 @@
-<OTP seperator={<span>-</span>} inputCount={6} />
+<OTP seperator={<span>-</span>} inputCount={5} />

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,2 +1,2 @@
-<OTP separator={<span>-</span>} value={otp} onChange={setOtp} inputCount={5} />
+<OTP separator={<span>-</span>} value={otp} onChange={setOtp} length={5} />
 <span>Entered value: {otp}</span>

--- a/docs/data/base/components/input/OTPInput.tsx.preview
+++ b/docs/data/base/components/input/OTPInput.tsx.preview
@@ -1,0 +1,16 @@
+{new Array(inputCount).fill(null).map((_, index) => (
+  <CustomNumberInput
+    key={index}
+    slotProps={{
+      input: {
+        ref: (ele) => {
+          inputRefs.current[index] = ele!;
+        },
+        onKeyDown: (event) => handleKeyDown(event, index),
+        onChange: (event) => handleChange(event, index),
+        onClick: (event) => handleClick(event, index),
+        value: otp[index],
+      },
+    }}
+  />
+))}

--- a/docs/data/base/components/input/input.md
+++ b/docs/data/base/components/input/input.md
@@ -139,4 +139,6 @@ The following demo shows how to insert a Textarea Autosize component into an Inp
 
 ### OTP Input
 
+The following demo shows how to build a one-time password component using `Input`.
+
 {{"demo": "OTPInput.js"}}

--- a/docs/data/base/components/input/input.md
+++ b/docs/data/base/components/input/input.md
@@ -134,3 +134,9 @@ To set minimum and maximum sizes, add the `minRows` and `maxRows` props.
 The following demo shows how to insert a Textarea Autosize component into an Input so that its height grows with the length of the content:
 
 {{"demo": "InputMultilineAutosize.js"}}
+
+## Common examples
+
+### OTP Input
+
+{{"demo": "OTPInput.js"}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Demo: https://deploy-preview-40539--material-ui.netlify.app/base-ui/react-input/#otp-input

looking at downloads of https://www.npmjs.com/package/react-otp-input and considering its applicability in various everyday scenarios, I believe this component warrants inclusion as the demo.

few Inspiration/ benchmarks:

- https://github.com/devfolioco/react-otp-input
- https://github.com/shubhanus/otp-input-react

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
