### PR TITLE
[docs] Document bundle size

### DIFF
--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,1 +1,2 @@
 Broken links found by `pnpm docs:link-check` that exist:
+

--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,3 +1,1 @@
 Broken links found by `pnpm docs:link-check` that exist:
-
-- https://mui.com/size-snapshot/

--- a/docs/.link-check-errors.txt
+++ b/docs/.link-check-errors.txt
@@ -1,2 +1,3 @@
 Broken links found by `pnpm docs:link-check` that exist:
 
+- https://mui.com/size-snapshot/

--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -14,7 +14,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
-- 📦 [4.5 kB gzipped](/size-snapshot/).
+- 📦 [4.5 kB gzipped](https://bundlephobia.com/package/@mui/base).
 
 ## Introduction
 

--- a/docs/data/base/components/autocomplete/autocomplete.md
+++ b/docs/data/base/components/autocomplete/autocomplete.md
@@ -14,6 +14,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [4.5 kB gzipped](/size-snapshot/).
+
 ## Introduction
 
 An autocomplete component is an enhanced text input that shows a list of suggested options as users type, and lets them select an option from the list.

--- a/docs/data/base/components/badge/badge.md
+++ b/docs/data/base/components/badge/badge.md
@@ -14,6 +14,8 @@ githubLabel: 'component: badge'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [2.2 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 A badge is a small descriptor for UI elements.

--- a/docs/data/base/components/button/button.md
+++ b/docs/data/base/components/button/button.md
@@ -15,6 +15,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [3.3 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Button component replaces the native HTML `<button>` element, and offers expanded options for styling and accessibility.

--- a/docs/data/base/components/click-away-listener/click-away-listener.md
+++ b/docs/data/base/components/click-away-listener/click-away-listener.md
@@ -13,7 +13,7 @@ githubLabel: 'component: ClickAwayListener'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
-- 📦 [0.9 kB gzipped](/size-snapshot/).
+- 📦 [0.9 kB gzipped](https://bundlephobia.com/package/@mui/base).
 
 ## Introduction
 

--- a/docs/data/base/components/click-away-listener/click-away-listener.md
+++ b/docs/data/base/components/click-away-listener/click-away-listener.md
@@ -13,6 +13,8 @@ githubLabel: 'component: ClickAwayListener'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [0.9 kB gzipped](/size-snapshot/).
+
 ## Introduction
 
 Click-Away Listener is a utility component that listens for click events outside of its child.

--- a/docs/data/base/components/focus-trap/focus-trap.md
+++ b/docs/data/base/components/focus-trap/focus-trap.md
@@ -13,7 +13,7 @@ githubLabel: 'component: FocusTrap'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
-- 📦 [1.6 kB gzipped](/size-snapshot/).
+- 📦 [1.6 kB gzipped](https://bundlephobia.com/package/@mui/base).
 
 ## Introduction
 

--- a/docs/data/base/components/focus-trap/focus-trap.md
+++ b/docs/data/base/components/focus-trap/focus-trap.md
@@ -13,6 +13,8 @@ githubLabel: 'component: FocusTrap'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [1.6 kB gzipped](/size-snapshot/).
+
 ## Introduction
 
 Focus Trap is a utility component that's useful when implementing an overlay such as a [modal dialog](/base-ui/react-modal/), which should block all interactions outside of it while open.

--- a/docs/data/base/components/form-control/form-control.md
+++ b/docs/data/base/components/form-control/form-control.md
@@ -14,6 +14,8 @@ githubLabel: 'component: FormControl'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [2.4 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 Form Control is a utility that wraps an input component with other associated components in order to make the state of the input available to those components.

--- a/docs/data/base/components/input/input.md
+++ b/docs/data/base/components/input/input.md
@@ -14,6 +14,8 @@ githubLabel: 'component: input'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [3.3 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 An input is a UI element that accepts text data from the user.

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -15,6 +15,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [14.3 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Base UI Dropdown Menu is implemented using a collection of related components:

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -15,7 +15,7 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
-- 📦 [5.1 kB gzipped](/size-snapshot/).
+- 📦 [5.1 kB gzipped](https://bundlephobia.com/package/@mui/base).
 
 ## Introduction
 

--- a/docs/data/base/components/modal/modal.md
+++ b/docs/data/base/components/modal/modal.md
@@ -15,6 +15,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [5.1 kB gzipped](/size-snapshot/).
+
 ## Introduction
 
 Modal is a utility component that renders its children in front of a backdrop.

--- a/docs/data/base/components/no-ssr/no-ssr.md
+++ b/docs/data/base/components/no-ssr/no-ssr.md
@@ -12,6 +12,8 @@ components: NoSsr
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [0.3 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 No-SSR is a utility component that prevents its children from being rendered on the server.

--- a/docs/data/base/components/number-input/number-input.md
+++ b/docs/data/base/components/number-input/number-input.md
@@ -14,6 +14,8 @@ githubLabel: 'component: number input'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [4.3 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 A number input is a UI element that accepts numeric values from the user.

--- a/docs/data/base/components/popper/popper.md
+++ b/docs/data/base/components/popper/popper.md
@@ -14,6 +14,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [9.6 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Popper is a utility component for creating various kinds of popups.

--- a/docs/data/base/components/popup/popup.md
+++ b/docs/data/base/components/popup/popup.md
@@ -14,6 +14,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [9.0 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Popup is a utility component for creating various kinds of popups.

--- a/docs/data/base/components/portal/portal.md
+++ b/docs/data/base/components/portal/portal.md
@@ -13,6 +13,8 @@ githubLabel: 'component: Portal'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [0.6 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 Portal is a utility component built around [React's `createPortal()` API](https://react.dev/reference/react-dom/createPortal).

--- a/docs/data/base/components/select/select.md
+++ b/docs/data/base/components/select/select.md
@@ -15,6 +15,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-sel
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [16.8 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 A select is a UI element that gives users a list of options to choose from.

--- a/docs/data/base/components/slider/slider.md
+++ b/docs/data/base/components/slider/slider.md
@@ -16,6 +16,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [6.8 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Slider component lets users make selections from a range of values along a horizontal or vertical bar.

--- a/docs/data/base/components/snackbar/snackbar.md
+++ b/docs/data/base/components/snackbar/snackbar.md
@@ -14,6 +14,8 @@ githubLabel: 'component: snackbar'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [3.1 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 A snackbar provides users with a brief, temporary message about app processes without interrupting their activity or experience.

--- a/docs/data/base/components/switch/switch.md
+++ b/docs/data/base/components/switch/switch.md
@@ -15,6 +15,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/switch/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [3.1 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Switch component provides users with a switch for toggling between two mutually exclusive states.

--- a/docs/data/base/components/table-pagination/table-pagination.md
+++ b/docs/data/base/components/table-pagination/table-pagination.md
@@ -13,6 +13,8 @@ githubLabel: 'component: TablePagination'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [3.5 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 The Table Pagination component lets you add pagination controls to a table.

--- a/docs/data/base/components/tabs/tabs.md
+++ b/docs/data/base/components/tabs/tabs.md
@@ -15,6 +15,8 @@ waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [2.9 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 Tabs are implemented using a collection of related components:

--- a/docs/data/base/components/textarea-autosize/textarea-autosize.md
+++ b/docs/data/base/components/textarea-autosize/textarea-autosize.md
@@ -13,6 +13,8 @@ githubLabel: 'component: TextareaAutosize'
 
 {{"component": "modules/components/ComponentPageTabs.js"}}
 
+- 📦 [1.6 kB gzipped](https://bundlephobia.com/package/@mui/base).
+
 ## Introduction
 
 Textarea Autosize is a utility component that replaces the native `<textarea>` HTML.

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -172,6 +172,8 @@ The `useAutocomplete` hook is also reexported from @mui/material for convenience
 import useAutocomplete from '@mui/material/useAutocomplete';
 ```
 
+- 📦 [4.5 kB gzipped](/size-snapshot/).
+
 {{"demo": "UseAutocomplete.js", "defaultCodeOpen": false}}
 
 ### Customized hook

--- a/docs/data/material/components/autocomplete/autocomplete.md
+++ b/docs/data/material/components/autocomplete/autocomplete.md
@@ -172,7 +172,7 @@ The `useAutocomplete` hook is also reexported from @mui/material for convenience
 import useAutocomplete from '@mui/material/useAutocomplete';
 ```
 
-- 📦 [4.5 kB gzipped](/size-snapshot/).
+- 📦 [4.6 kB gzipped](https://bundlephobia.com/package/@mui/material).
 
 {{"demo": "UseAutocomplete.js", "defaultCodeOpen": false}}
 

--- a/docs/data/material/components/use-media-query/use-media-query.md
+++ b/docs/data/material/components/use-media-query/use-media-query.md
@@ -12,7 +12,7 @@ Some of the key features:
 
 - ⚛️ It has an idiomatic React API.
 - 🚀 It's performant, it observes the document to detect when its media queries change, instead of polling the values periodically.
-- 📦 [1 kB gzipped](/size-snapshot/).
+- 📦 [1.1 kB gzipped](https://bundlephobia.com/package/@mui/material).
 - 🤖 It supports server-side rendering.
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}

--- a/docs/data/material/components/use-media-query/use-media-query.md
+++ b/docs/data/material/components/use-media-query/use-media-query.md
@@ -12,6 +12,7 @@ Some of the key features:
 
 - ⚛️ It has an idiomatic React API.
 - 🚀 It's performant, it observes the document to detect when its media queries change, instead of polling the values periodically.
+- 📦 [1 kB gzipped](/size-snapshot/).
 - 🤖 It supports server-side rendering.
 
 {{"component": "modules/components/ComponentLinkHeader.js", "design": false}}

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -5,7 +5,7 @@
 /spam / 301
 /sign-up / 301
 
-/size-snapshot https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/master/latest/size-snapshot.json 200
+/size-snapshot/ https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/master/latest/size-snapshot.json 200
 
 # To add when we finish work on v6
 # https://next.mui.com/* https://mui.com/:splat 301!


### PR DESCRIPTION
See https://github.com/mui/material-ui/pull/40547#discussion_r1449373874

Bundle size matters. I think it's important we document it in the docs. Documenting:

- Forces us to measure it
- Means developers know we know what it is
- Means developers easily know if it's good enough for their use cases

https://deploy-preview-40549--material-ui.netlify.app/base-ui/react-autocomplete/

For example, see https://github.com/propeldata/ui-kit/issues/157 for why, there is a reputation for bloat to debunk (Base UI) and solve (Material UI).

<img src="https://github.com/mui/material-ui/assets/3165635/ec2b46c6-bb07-4de8-abcd-cfa611dc9034" width="300">

---

Ok, this PR solution it's not very clean, solving #40591 correctly would be a dream, but I think this is better than nothing. I would 💯 to add this to all the Base UI docs pages. I started to add it on a few more pages.