### PR TITLE
[docs] Add survey banner to docs and website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3712,7 +3712,7 @@ This release was mostly about 🐛 bug fixes and 📚 documentation improvements
 
 ### Core
 
-- [core] Close 2022 developer survey @oliviertassinari
+- [core] Close 2022 Developer Survey @oliviertassinari
 - [core] Fix the product license reference name (#35703) @oliviertassinari
 - [core] Use TypeScript AST instead of TTP for component doc building (#35379) @flaviendelangle
 - [test] Always use & for nesting styles (#35702) @oliviertassinari
@@ -3946,7 +3946,7 @@ A big thanks to the 19 contributors who made this release possible. Here are som
 - [docs] Fix typo in FormControl API docs (#35449) @Spanishiwa
 - [docs] Update callouts design (#35390) @danilo-leal
 - [website] New wave of open roles (#35240) @mnajdova
-- [website] Developer survey 2022 (#35407) @joserodolfofreitas
+- [website] Developer Survey 2022 (#35407) @joserodolfofreitas
 
 ### Core
 
@@ -7469,7 +7469,7 @@ This is an early release to fix `export 'useId' (imported as 'React') was not fo
 - &#8203;<!-- 9 -->[core] Fix PR run detection in test_bundle_size_monitor (#29879) @eps1lon
 - &#8203;<!-- 8 -->[core] Move bundle size monitoring to CircleCI (#29876) @eps1lon
 - &#8203;<!-- 7 -->[docs] Add keys to Responsive AppBar demo (#29884) @mbrookes
-- &#8203;<!-- 6 -->[docs] MUI's 2021 Developer survey (#29765) @prakhargupta1
+- &#8203;<!-- 6 -->[docs] MUI's 2021 Developer Survey (#29765) @prakhargupta1
 - &#8203;<!-- 5 -->[docs] Smoother image loading UX (#29858) @oliviertassinari
 - &#8203;<!-- 4 -->[Select] Fix select display value with React Nodes (#29836) @kegi
 - &#8203;<!-- 3 -->[system] Add `experimental_sx` utility (#29833) @mnajdova

--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -2331,7 +2331,7 @@ Here are some highlights ✨:
   You can [learn more about the difference](https://v4.mui.com/styles/basics/#material-ui-core-styles-vs-material-ui-styles) in the documentation.
 
 - ♿️ Improve the accessibility of the table and select components (#17696, #17773) @adeelibr, @eps1lon.
-- 📊 Launch a [developer survey](https://www.surveymonkey.com/r/5XHDL76) as a precursor to a major DatePicker enhancement effort.
+- 📊 Launch a Developer Survey as a precursor to a major DatePicker enhancement effort.
 - 💄 Add support for different [slider track mode](https://mui.com/components/slider/#track) (#17714) @slipmat.
 - And many more 🐛 bug fixes and 📚 improvements.
 
@@ -2390,7 +2390,7 @@ Here are some highlights ✨:
 - [docs] Mentioned CSS required for disabling transitions (#17802) @burtyish
 - [docs] Migrate Globals demo to TypeScript (#17785) @limatgans
 - [docs] Migrate Palette demo to TypeScript (#17683) @limatgans
-- [docs] Prepare the DatePicker developer survey notification (#17805) @oliviertassinari
+- [docs] Prepare the DatePicker Developer Survey notification (#17805) @oliviertassinari
 - [docs] Update "Who's using" (#17830) @mbrookes
 - [docs] Update notification @oliviertassinari
 - [docs] Update useMediaQuery example to avoid confusion with print (#17642) @epeicher

--- a/docs/data/joy/getting-started/roadmap/roadmap.md
+++ b/docs/data/joy/getting-started/roadmap/roadmap.md
@@ -2,13 +2,13 @@
 
 <p class="description">Keep up with ongoing projects and help shape the future of Joy UI.</p>
 
-## Priorization method
+## How we prioritize
 
 Joy UI is a community-driven project, meaning we usually pick the issues and suggestions that resonate the most with the community.
 Therefore, make sure to leave an upvote 👍 on [the GitHub issues](https://github.com/mui/material-ui/issues?q=is:open+is:issue+label:%22package:+joy-ui%22) you are most interested in.
 
-Additionally, we conduct yearly [developer surveys](/blog/?tags=Developer+survey/), which also serve as key inputs for Joy UI's roadmap.
-Your participation is invaluable—keep an eye on MUI's social media to catch the next survey and help shape the future of this product!
+Additionally, we conduct annual [developer surveys](/blog/?tags=Developer+survey/) which also serve as key inputs for Joy UI's roadmap.
+Your participation is invaluable—keep an eye on MUI's social media to catch the next survey and help shape the future of the library!
 
 ## Keeping track of the roadmap
 

--- a/docs/data/material/discover-more/roadmap/roadmap.md
+++ b/docs/data/material/discover-more/roadmap/roadmap.md
@@ -7,7 +7,7 @@
 Material UI is a community-driven project, meaning we usually pick the issues and suggestions that resonate the most with the community.
 Therefore, make sure to leave an upvote 👍 on [the GitHub issues](https://github.com/mui/material-ui/issues?q=is:open+is:issue+label:%22package:+material-ui%22) you are most interested in.
 
-Additionally, we conducts annual [developer surveys](/blog/?tags=Developer+survey/) which also serve as key inputs for Material UI's roadmap.
+Additionally, we conduct annual [developer surveys](/blog/?tags=Developer+survey/) which also serve as key inputs for Material UI's roadmap.
 Your participation is invaluable—keep an eye on MUI's social media to catch the next survey and help shape the future of the library!
 
 ## Keeping track of the roadmap

--- a/docs/lib/sourcing.ts
+++ b/docs/lib/sourcing.ts
@@ -32,7 +32,7 @@ export function getBlogPost(filePath: string): BlogPost {
 
 // Avoid typos in the blog markdown pages.
 // https://www.notion.so/mui-org/Blog-247ec2bff5fa46e799ef06a693c94917
-const ALLOWED_TAGS = ['MUI Core', 'MUI X', 'News', 'Company', 'Developer survey', 'Product'];
+const ALLOWED_TAGS = ['MUI Core', 'MUI X', 'News', 'Company', 'Developer Survey', 'Product'];
 
 export const getAllBlogPosts = () => {
   const filePaths = getBlogFilePaths();

--- a/docs/pages/blog/2019-developer-survey-results.md
+++ b/docs/pages/blog/2019-developer-survey-results.md
@@ -1,9 +1,9 @@
 ---
-title: 'The 2019 Material UI developer survey: here's what we discovered'
+title: 'The 2019 Material UI Developer Survey: here's what we discovered'
 description: Your feedback helps us to build better products. Here's what we learned about your needs in our annual survey.
 date: 2019-03-16T00:00:00.000Z
 authors: ['oliviertassinari', 'mbrookes']
-tags: ['Developer survey']
+tags: ['Developer Survey']
 card: true
 ---
 

--- a/docs/pages/blog/2019.md
+++ b/docs/pages/blog/2019.md
@@ -1,13 +1,13 @@
 ---
 title: 2019 in review and beyond
 date: 2020-01-25T00:00:00.000Z
-description: 2019 was a great year for MUI. It puts us on an exciting path to solve even greater challenges in the coming years!
+description: 2019 was a great year for Material UI. It puts us on an exciting path to solve even greater challenges in the coming years!
 authors: ['oliviertassinari']
 tags: ['Company']
 card: true
 ---
 
-2019 was a great year for MUI.
+2019 was a great year for Material UI.
 It puts us on an exciting path to solve even greater challenges in the coming years!
 
 ## Growth
@@ -44,7 +44,7 @@ Some of the key factors:
   And every time we asked ourselves, "what could have we done differently to empower this library"?
   We believe that starting from scratch, while maximizing freedom, is incredibly inefficient.
   Most UI libraries need the same features but are implemented with a wide spectrum of accessibility, developer experience, and overall design quality.
-  We won't rest until we successfully unify these efforts. It's a long term mission and will probably take years. The foundation will be the release of an un-styled version of our components.
+  We won't rest until we successfully unify these efforts. It's a long-term mission and will probably take years. The foundation will be the release of an un-styled version of our components.
 
 ## Achievements
 
@@ -78,7 +78,7 @@ We will continue in the same direction.
 
 ### Survey
 
-The developer survey we ran [last year](/blog/2019-developer-survey-results/) was so insightful that we plan to run it every year.
+The Developer Survey we ran [last year](/blog/2019-developer-survey-results/) was so insightful that we plan to run it every year.
 It's a great opportunity for us to adjust the strategy and to pause to analyze the outcome of the actions we took in the previous year.
 
 ### Open source roadmap
@@ -95,12 +95,12 @@ For Framer, we have made the key components available as a Framer package.
 
 ### Enterprise
 
-We plan to release an enterprise class offering, starting with the data grid.
-Enterprise features will build on the open source version of the components.
+We plan to release an enterprise-class offering, starting with the data grid.
+Enterprise features will build on the open-source version of the components.
 
 ### Hiring
 
 We are looking for a full-time Software Developer to join us!
 
 If you want to help us onboard more full-time developers in the team, [here are a couple of ways](/material-ui/getting-started/faq/#mui-is-an-awesome-organization-how-can-i-support-it).
-Spreading the word to other developers that are looking for a great UI framework is also extremely helpful 🙌.
+Spreading the word to other developers who are looking for a great UI framework is also extremely helpful 🙌.

--- a/docs/pages/blog/2020-developer-survey-results.md
+++ b/docs/pages/blog/2020-developer-survey-results.md
@@ -1,13 +1,13 @@
 ---
-title: 'The 2020 Material UI developer survey: here's what we discovered'
+title: 'The 2020 Material UI Developer Survey: here's what we discovered'
 description: Your feedback helps us to build better products. Here's what we learned about your needs in our annual survey.
 date: 2020-06-27T00:00:00.000Z
 authors: ['mnajdova', 'oliviertassinari', 'mbrookes']
-tags: ['Developer survey']
+tags: ['Developer Survey']
 card: true
 ---
 
-Continuing the tradition from last year, we launched a developer survey a few months ago, to which we received 1488 responses. This is twice as many as last year (734), so we thank you all for the participation!
+Continuing the tradition from last year, we launched a Developer Survey a few months ago, to which we received 1488 responses. This is twice as many as last year (734), so we thank you all for your participation!
 The survey is closed and we can now give a detailed summary of the results.
 
 Like last year, the survey was again broken into three sections: ["Introduction"](#Introduction), ["About you"](#about-you) and ["Your product"](#your-product).

--- a/docs/pages/blog/2021-developer-survey-results.md
+++ b/docs/pages/blog/2021-developer-survey-results.md
@@ -1,9 +1,9 @@
 ---
-title: 'The 2021 MUI developer survey: here's what we discovered'
+title: 'The 2021 MUI Developer Survey: here's what we discovered'
 description: Your feedback helps us to build better products. Here's what we learned about your needs in our annual survey.
 date: 2022-03-15T00:00:00.000Z
 authors: ['danilo-leal', 'samuelsycamore', 'oliviertassinari']
-tags: ['Developer survey']
+tags: ['Developer Survey']
 card: true
 ---
 

--- a/docs/pages/blog/first-look-at-joy.md
+++ b/docs/pages/blog/first-look-at-joy.md
@@ -22,7 +22,7 @@ Material UI is MUI's React implementation of Google's Material Design.
 
 Over time Material UI has established itself as the go-to library for quickly breathing life into products, mostly thanks to its design, customizability, and documentation.
 However, the components do come by default with the 2018 Google look and feel that is no longer as popular as it once was.
-And as we've confirmed with [our latest developer survey](/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), design quality is one of the most important elements that developers consider when choosing a UI library.
+And as we've confirmed with [our latest Developer Survey](/blog/2021-developer-survey-results/#what-are-your-most-important-criteria-for-choosing-a-ui-library), design quality is one of the most important elements that developers consider when choosing a UI library.
 
 ## Why not just build a new Material UI theme?
 

--- a/docs/pages/blog/making-customizable-components.md
+++ b/docs/pages/blog/making-customizable-components.md
@@ -301,7 +301,7 @@ For example, a grid can exist without its filter panel, or without its toolbar.
 
 ## Customization is key
 
-In our last two annual [developer surveys](/blog/2021-developer-survey-results/), our users made it clear that customization is always a top priority when choosing a UI library.
+In our last two annual [Developer Surveys](/blog/2021-developer-survey-results/), our users made it clear that customization is always a top priority when choosing a UI library.
 
 Thanks to the slot strategy and the introduction of supplementary tools like [MUI System's `sx` prop](https://mui.com/system/getting-started/the-sx-prop/), it has never been easier to customize MUI's components to suit your specific needs.
 

--- a/docs/pages/blog/march-2019-update.md
+++ b/docs/pages/blog/march-2019-update.md
@@ -30,7 +30,7 @@ Here are the most significant improvements in March:
 _(We'll do our best, no guarantee!)_
 
 - We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui/material-ui/issues/13663). You can already find [the upgrade path](/material-ui/migration/migration-v3/) from v3 to v4 in the documentation. Next, we will release the first beta version (no more breaking changes).
-  The results of the Material UI developer survey suggested that there are too many breaking changes.
+  The results of the Material UI Developer Survey suggested that there are too many breaking changes.
   Don't worry, it's almost over! We will focus on providing more components once we have released v4 stable.
 - We will continue, and hopefully complete, the tasks we undertook:
   - TypeScript demo variants.

--- a/docs/pages/blog/material-ui-v4-is-out.md
+++ b/docs/pages/blog/material-ui-v4-is-out.md
@@ -116,7 +116,7 @@ function MyComponent() {
 
 ### Documentation
 
-Documentation was reported as the 3rd most critical pain point in the developer survey. We have fixed some of the reported issues and aim to continuously improve going forward.
+Documentation was reported as the 3rd most critical pain point in the Developer Survey. We have fixed some of the reported issues and aim to continuously improve going forward.
 
 - **TypeScript**. TypeScript's growth is impressive, the traffic of their documentation website has grown by a factor of 6 in 3 years. Material UI v1 was released with built-in TypeScript definitions, but we needed to do more. Sebastian has led the effort to migrate all the demos from JavaScript to TypeScript. This has two important implications. First, we type check our demos, this drastically improves our TypeScript test coverage. We have fixed many issues during the migration. Second, if you are writing your application with TypeScript, you can directly copy & paste our demos without needing to convert them, or having to fix the obscure errors.
 

--- a/docs/pages/blog/september-2019-update.md
+++ b/docs/pages/blog/september-2019-update.md
@@ -23,7 +23,7 @@ Here are the most significant improvements in September:
 
   ![Autofill](/static/blog/september-2019-update/autofill.png)
 
-- 📊 Launch a [developer survey](https://www.surveymonkey.com/) as a precursor to a major Date Picker enhancement effort. We plan a new investment batch of between 100 and 500 hours.
+- 📊 Launch a Developer Survey as a precursor to a major DatePicker enhancement effort.We plan a new investment batch of between 100 and 500 hours.
 
 - 📚 Change imports from `@mui/styles` to `@mui/material/styles`
 

--- a/docs/pages/careers/designer.md
+++ b/docs/pages/careers/designer.md
@@ -45,7 +45,7 @@ Currently, we have five main projects that are not at all related to MD:
   Today, the flagship is the [Data Grid](https://mui.com/x/react-data-grid/), a game-changing component for presenting large amounts of data, which integrates perfectly with MUI Core.
 - MUI Toolpad: a very recent endeavor aimed at exploring how our users can visually create apps 10x faster with the power of low-code and the flexibility of pro-code.
 
-We also know, especially due to [our annual developer survey](https://mui.com/blog/2021-developer-survey-results/), that design quality plays a huge part when developers are considering component library options.
+We also know, especially due to [our annual Developer Survey](https://mui.com/blog/2021-developer-survey-results/), that design quality plays a huge part when developers are considering component library options.
 Therefore, we need to grow the design team to help us push these initiatives further.
 
 ## The role

--- a/docs/pages/careers/product-manager.md
+++ b/docs/pages/careers/product-manager.md
@@ -49,7 +49,7 @@ We need talented people to keep that going!
 Our products empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month.
 
 But providing React components isn't enough.
-In our [last developer survey](https://mui.com/blog/2021-developer-survey-results/), we learned that the majority of our audience are full-stack developers.
+In our [last Developer Survey](https://mui.com/blog/2021-developer-survey-results/), we learned that the majority of our audience are full-stack developers.
 They are looking for ways to move faster.
 They are working on a couple of new projects every year, and where the integration between the UI and the database is key.
 

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -26,18 +26,16 @@ export default function AppFrameBanner() {
       variant="caption"
       sx={[
         (theme) => ({
-          display: { xs: 'none', md: 'block' },
           padding: theme.spacing('7px', 1.5, '8px', 1.5),
+          display: { xs: 'none', md: 'block' },
+          fontWeight: 'medium',
           textWrap: 'nowrap',
           maxHeight: '34px',
           backgroundColor: (theme.vars || theme).palette.primary[50],
           border: '1px solid',
           borderColor: (theme.vars || theme).palette.grey[200],
           borderRadius: 1,
-          transitionProperty: 'all',
-          transitionTiming: 'cubic-bezier(0.4, 0, 0.2, 1)',
-          transitionDuration: '150ms',
-          fontWeight: 'medium',
+          transition: 'all 150ms ease',
           '&:hover, &:focus-visible': {
             backgroundColor: alpha(theme.palette.primary[100], 0.4),
             borderColor: (theme.vars || theme).palette.primary[200],
@@ -45,11 +43,11 @@ export default function AppFrameBanner() {
         }),
         (theme) =>
           theme.applyDarkStyles({
-            backgroundColor: alpha(theme.palette.primary[900], 0.3),
+            backgroundColor: alpha(theme.palette.primary[900], 0.2),
             borderColor: (theme.vars || theme).palette.primaryDark[700],
             '&:hover, &:focus-visible': {
               backgroundColor: alpha(theme.palette.primary[900], 0.6),
-              borderColor: (theme.vars || theme).palette.primaryDark[500],
+              borderColor: (theme.vars || theme).palette.primary[800],
             },
           }),
       ]}

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -6,7 +6,7 @@ import FEATURE_TOGGLE from 'docs/src/featureToggle';
 export default function AppFrameBanner() {
   return FEATURE_TOGGLE.enable_docsnav_banner ? (
     <Link
-      href="https://mui.com/blog/mui-x-v6/"
+      href="https://tally.so/r/3Ex4PN?source=docs-banner"
       target="_blank"
       variant="caption"
       sx={[
@@ -40,7 +40,7 @@ export default function AppFrameBanner() {
           }),
       ]}
     >
-      🚀 MUI X v6 is out! Discover what&apos;s new and get started now!
+      🚀 The MUI Developer Survey 2023 is live! Participate and help shape MUI's roadmap for 2024!
       <br />
     </Link>
   ) : null;

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -9,7 +9,7 @@ export default function AppFrameBanner() {
   const pageContext = React.useContext(PageContext);
 
   const productName = convertProductIdToName(pageContext) || 'MUI';
-  const message = `The latest Developer Survey is open! Help shape ${productName}'s roadmap for 2024!`;
+  const message = `Influence ${productName}'s 2024 roadmap! Take a few minutes to answer the latest Developer Survey`;
 
   if (message.length > 100) {
     throw new Error(

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -9,7 +9,7 @@ export default function AppFrameBanner() {
   const pageContext = React.useContext(PageContext);
 
   const productName = convertProductIdToName(pageContext) || 'MUI';
-  const message = `Influence ${productName}'s 2024 roadmap! Take a few minutes to answer the latest Developer Survey`;
+  const message = `Influence ${productName}'s 2024 roadmap! Participate in the latest Developer Survey`;
 
   if (process.env.NODE_ENV !== 'production') {
     if (message.length > 100) {

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -11,10 +11,12 @@ export default function AppFrameBanner() {
   const productName = convertProductIdToName(pageContext) || 'MUI';
   const message = `Influence ${productName}'s 2024 roadmap! Take a few minutes to answer the latest Developer Survey`;
 
-  if (message.length > 100) {
-    throw new Error(
-      `Docs-infra: AppFrameBanner message is too long. It will overflow on smaller screens.`,
-    );
+  if (process.env.NODE_ENV !== 'production') {
+    if (message.length > 100) {
+      throw new Error(
+        `Docs-infra: AppFrameBanner message is too long. It will overflow on smaller screens.`,
+      );
+    }
   }
 
   return FEATURE_TOGGLE.enable_docsnav_banner ? (

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -6,8 +6,12 @@ import PageContext from 'docs/src/modules/components/PageContext';
 import { convertProductIdToName } from 'docs/src/modules/components/AppSearch';
 
 export default function AppFrameBanner() {
-  const pageContext = React.useContext(PageContext);
+  if (!FEATURE_TOGGLE.enable_docsnav_banner) {
+    return null;
+  }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const pageContext = React.useContext(PageContext);
   const productName = convertProductIdToName(pageContext) || 'MUI';
   const message = `Influence ${productName}'s 2024 roadmap! Participate in the latest Developer Survey`;
 
@@ -19,7 +23,7 @@ export default function AppFrameBanner() {
     }
   }
 
-  return FEATURE_TOGGLE.enable_docsnav_banner ? (
+  return (
     <Link
       href="https://tally.so/r/3Ex4PN?source=docs-banner"
       target="_blank"
@@ -54,5 +58,5 @@ export default function AppFrameBanner() {
     >
       {message}
     </Link>
-  ) : null;
+  );
 }

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -11,8 +11,9 @@ export default function AppFrameBanner() {
       variant="caption"
       sx={[
         (theme) => ({
-          display: { xs: 'none', lg: 'block' },
-          p: 1,
+          display: { xs: 'none', md: 'block' },
+          padding: theme.spacing('7px', 1.5, '8px', 1.5),
+          textWrap: 'nowrap',
           maxHeight: '34px',
           backgroundColor: (theme.vars || theme).palette.primary[50],
           border: '1px solid',
@@ -21,7 +22,6 @@ export default function AppFrameBanner() {
           transitionProperty: 'all',
           transitionTiming: 'cubic-bezier(0.4, 0, 0.2, 1)',
           transitionDuration: '150ms',
-          color: (theme.vars || theme).palette.primary[600],
           fontWeight: 'medium',
           '&:hover, &:focus-visible': {
             backgroundColor: alpha(theme.palette.primary[100], 0.4),
@@ -32,7 +32,6 @@ export default function AppFrameBanner() {
           theme.applyDarkStyles({
             backgroundColor: alpha(theme.palette.primary[900], 0.3),
             borderColor: (theme.vars || theme).palette.primaryDark[700],
-            color: (theme.vars || theme).palette.primary[100],
             '&:hover, &:focus-visible': {
               backgroundColor: alpha(theme.palette.primary[900], 0.6),
               borderColor: (theme.vars || theme).palette.primaryDark[500],
@@ -41,7 +40,6 @@ export default function AppFrameBanner() {
       ]}
     >
       🚀 The MUI Developer Survey 2023 is live! Participate and help shape MUI's roadmap for 2024!
-      <br />
     </Link>
   ) : null;
 }

--- a/docs/src/components/banner/AppFrameBanner.tsx
+++ b/docs/src/components/banner/AppFrameBanner.tsx
@@ -2,8 +2,21 @@ import * as React from 'react';
 import { alpha } from '@mui/material/styles';
 import Link from 'docs/src/modules/components/Link';
 import FEATURE_TOGGLE from 'docs/src/featureToggle';
+import PageContext from 'docs/src/modules/components/PageContext';
+import { convertProductIdToName } from 'docs/src/modules/components/AppSearch';
 
 export default function AppFrameBanner() {
+  const pageContext = React.useContext(PageContext);
+
+  const productName = convertProductIdToName(pageContext) || 'MUI';
+  const message = `The latest Developer Survey is open! Help shape ${productName}'s roadmap for 2024!`;
+
+  if (message.length > 100) {
+    throw new Error(
+      `Docs-infra: AppFrameBanner message is too long. It will overflow on smaller screens.`,
+    );
+  }
+
   return FEATURE_TOGGLE.enable_docsnav_banner ? (
     <Link
       href="https://tally.so/r/3Ex4PN?source=docs-banner"
@@ -39,7 +52,7 @@ export default function AppFrameBanner() {
           }),
       ]}
     >
-      🚀 The MUI Developer Survey 2023 is live! Participate and help shape MUI's roadmap for 2024!
+      {message}
     </Link>
   ) : null;
 }

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -7,7 +7,8 @@ import FEATURE_TOGGLE from 'docs/src/featureToggle';
 function getSurveyMessage() {
   return (
     <React.Fragment>
-      🚀&nbsp;You can influence MUI's 2024 roadmap!&nbsp;&nbsp;Please take a few minutes for the&nbsp;
+      🚀&nbsp;You can influence MUI's 2024 roadmap!&nbsp;&nbsp;Please take a few minutes for
+      the&nbsp;
       <Link
         href="https://tally.so/r/3Ex4PN?source=website"
         target="_blank"

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -7,7 +7,7 @@ import FEATURE_TOGGLE from 'docs/src/featureToggle';
 function getSurveyMessage() {
   return (
     <React.Fragment>
-      {`🚀 Influence MUI's 2024 roadmap! Take a few minutes to answer the latest`}
+      {`🚀 Influence MUI's 2024 roadmap! Participate in the latest`}
       &nbsp;
       <Link
         href="https://tally.so/r/3Ex4PN?source=website"

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -19,7 +19,7 @@ function getSurveyMessage() {
           },
         }}
       >
-        MUI Developer survey 2023 →
+        MUI Developer Survey 2023 →
       </Link>
     </React.Fragment>
   );

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -7,9 +7,9 @@ import FEATURE_TOGGLE from 'docs/src/featureToggle';
 function getSurveyMessage() {
   return (
     <React.Fragment>
-      🚀&nbsp;Influence the future of MUI!&nbsp;&nbsp;Please take a few minutes for the&nbsp;
+      🚀&nbsp;You can influence MUI's 2024 roadmap!&nbsp;&nbsp;Please take a few minutes for the&nbsp;
       <Link
-        href="https://www.surveymonkey.com/r/mui-developer-survey-2022?source=website"
+        href="https://tally.so/r/3Ex4PN?source=website"
         target="_blank"
         color="inherit"
         underline="always"
@@ -19,7 +19,7 @@ function getSurveyMessage() {
           },
         }}
       >
-        MUI Developer survey 2022 →
+        MUI Developer survey 2023 →
       </Link>
     </React.Fragment>
   );
@@ -48,7 +48,7 @@ function getDefaultHiringMessage() {
 }
 
 export default function AppHeaderBanner() {
-  const showSurveyMessage = false;
+  const showSurveyMessage = true;
   const bannerMessage = showSurveyMessage ? getSurveyMessage() : getDefaultHiringMessage();
 
   return FEATURE_TOGGLE.enable_website_banner ? (

--- a/docs/src/components/banner/AppHeaderBanner.tsx
+++ b/docs/src/components/banner/AppHeaderBanner.tsx
@@ -7,8 +7,8 @@ import FEATURE_TOGGLE from 'docs/src/featureToggle';
 function getSurveyMessage() {
   return (
     <React.Fragment>
-      🚀&nbsp;You can influence MUI's 2024 roadmap!&nbsp;&nbsp;Please take a few minutes for
-      the&nbsp;
+      {`🚀 Influence MUI's 2024 roadmap! Take a few minutes to answer the latest`}
+      &nbsp;
       <Link
         href="https://tally.so/r/3Ex4PN?source=website"
         target="_blank"
@@ -20,7 +20,7 @@ function getSurveyMessage() {
           },
         }}
       >
-        MUI Developer Survey 2023 →
+        Developer Survey →
       </Link>
     </React.Fragment>
   );

--- a/docs/src/featureToggle.js
+++ b/docs/src/featureToggle.js
@@ -1,7 +1,7 @@
 // need to use commonjs export so that @mui/markdown can use
 module.exports = {
-  enable_website_banner: false,
+  enable_website_banner: true,
   enable_toc_banner: true,
-  enable_docsnav_banner: false,
+  enable_docsnav_banner: true,
   enable_job_banner: false,
 };

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -268,7 +268,7 @@ function NewStartScreen() {
   );
 }
 
-const displayTagProductId = {
+const productNameProductId = {
   'material-ui': 'Material UI',
   'joy-ui': 'Joy UI',
   'base-ui': 'Base UI',
@@ -277,27 +277,30 @@ const displayTagProductId = {
   toolpad: 'Toolpad',
 };
 
+export function convertProductIdToName(productInfo) {
+  return (
+    productNameProductId[productInfo.productId] ||
+    productNameProductId[productInfo.productCategoryId]
+  );
+}
+
 function getDisplayTag(hit) {
   if (hit.productId === undefined || hit.productCategoryId === undefined) {
     return null;
   }
 
-  const productInfo = {
+  const productName = convertProductIdToName({
     productId: hit.productId,
     productCategoryId: hit.productCategoryId,
-  };
+  });
 
-  const displayTag =
-    displayTagProductId[productInfo.productId] ||
-    displayTagProductId[productInfo.productCategoryId];
-
-  if (!displayTag) {
+  if (!productName) {
     console.error(
-      `getDisplayTag missing mapping for productId: ${productInfo.productId}, pathname: ${hit.pathname}.`,
+      `getDisplayTag missing mapping for productId: ${hit.productId}, pathname: ${hit.pathname}.`,
     );
   }
 
-  return <Chip label={displayTag} size="small" variant="outlined" sx={{ mr: 1 }} />;
+  return <Chip label={productName} size="small" variant="outlined" sx={{ mr: 1 }} />;
 }
 
 function DocSearchHit(props) {


### PR DESCRIPTION
## Website banner

<img width="1336" alt="Screenshot 2024-01-12 at 08 50 12" src="https://github.com/mui/material-ui/assets/550141/02f878e5-4b99-409f-ab86-95f77e36e298">

https://deploy-preview-40553--material-ui.netlify.app/

## Docs banner
<img width="1333" alt="Screenshot 2024-01-12 at 08 50 00" src="https://github.com/mui/material-ui/assets/550141/3f47fdf8-f655-4fdb-a6d9-748931c4019d">

https://deploy-preview-40553--material-ui.netlify.app/material-ui/getting-started/