### PR TITLE
[zero] Identify zero runtime styled path

### DIFF
--- a/packages/mui-material/src/Badge/Badge.js
+++ b/packages/mui-material/src/Badge/Badge.js
@@ -6,7 +6,7 @@ import { usePreviousProps } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '@mui/base/composeClasses';
 import { useBadge } from '@mui/base/useBadge';
 import { useSlotProps } from '@mui/base';
-import styled from '../styles/styled';
+import { styled } from '../zero-styled';
 import useThemeProps from '../styles/useThemeProps';
 import capitalize from '../utils/capitalize';
 import badgeClasses, { getBadgeUtilityClass } from './badgeClasses';

--- a/packages/mui-material/src/zero-styled/index.d.ts
+++ b/packages/mui-material/src/zero-styled/index.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as styled } from '../styles/styled';

--- a/packages/mui-material/src/zero-styled/index.js
+++ b/packages/mui-material/src/zero-styled/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as styled } from '../styles/styled';

--- a/packages/zero-runtime/package.json
+++ b/packages/zero-runtime/package.json
@@ -87,8 +87,20 @@
       "import": "./utils/index.mjs",
       "require": "./utils/index.js"
     },
+    "./exports/generateAtomics": {
+      "default": "./exports/generateAtomics.js"
+    },
+    "./exports/keyframes": {
+      "default": "./exports/keyframes.js"
+    },
+    "./exports/styled": {
+      "default": "./exports/styled.js"
+    },
     "./exports/sx-plugin": {
       "default": "./exports/sx-plugin.js"
+    },
+    "./exports/sx": {
+      "default": "./exports/sx.js"
     }
   }
 }

--- a/packages/zero-runtime/src/processors/styled.ts
+++ b/packages/zero-runtime/src/processors/styled.ts
@@ -338,7 +338,10 @@ export class StyledProcessor extends BaseProcessor {
       );
     }
 
-    const styledImportIdentifier = t.addNamedImport(this.tagSource.imported, this.tagSource.source);
+    const styledImportIdentifier = t.addNamedImport(
+      this.tagSource.imported,
+      process.env.PACKAGE_NAME as string,
+    );
     const styledCall = t.callExpression(
       styledImportIdentifier,
       componentMetaExpression ? [componentName, componentMetaExpression] : [componentName],

--- a/packages/zero-unplugin/src/index.ts
+++ b/packages/zero-unplugin/src/index.ts
@@ -99,6 +99,7 @@ export const plugin = createUnplugin<PluginOptions, true>((options) => {
     sourceMap = false,
     transformSx = true,
     overrideContext,
+    tagResolver,
     ...rest
   } = options;
   const themeArgs = { theme };
@@ -166,6 +167,7 @@ export const plugin = createUnplugin<PluginOptions, true>((options) => {
           root: process.cwd(),
           preprocessor,
           pluginOptions: {
+            ...rest,
             themeArgs: {
               theme,
             },
@@ -179,7 +181,16 @@ export const plugin = createUnplugin<PluginOptions, true>((options) => {
               }
               return context;
             },
-            ...rest,
+            tagResolver(source: string, tag: string) {
+              const tagResult = tagResolver?.(source, tag);
+              if (tagResult) {
+                return tagResult;
+              }
+              if (source.endsWith('/zero-styled')) {
+                return `${process.env.RUNTIME_PACKAGE_NAME}/exports/${tag}`;
+              }
+              return null;
+            },
             babelOptions: {
               ...rest.babelOptions,
               plugins: [

--- a/packages/zero-vite-plugin/src/zero-vite-plugin.ts
+++ b/packages/zero-vite-plugin/src/zero-vite-plugin.ts
@@ -43,6 +43,7 @@ export default function zeroVitePlugin({
   preprocessor,
   transformLibraries = [],
   overrideContext,
+  tagResolver,
   ...rest
 }: VitePluginOptions = {}): Plugin {
   const filter = createFilter(include, exclude);
@@ -116,7 +117,7 @@ export default function zeroVitePlugin({
       let shouldReturn = url.includes('node_modules');
 
       if (shouldReturn) {
-        shouldReturn = !transformLibraries.some((libName) => url.includes(libName));
+        shouldReturn = !transformLibraries.some((libName: string) => url.includes(libName));
       }
 
       if (shouldReturn) {
@@ -194,6 +195,16 @@ export default function zeroVitePlugin({
                     context.$RefreshSig$ = outerNoop;
                   }
                   return context;
+                },
+                tagResolver(source: string, tag: string) {
+                  const tagResult = tagResolver?.(source, tag);
+                  if (tagResult) {
+                    return tagResult;
+                  }
+                  if (source.endsWith('/zero-styled')) {
+                    return `${process.env.RUNTIME_PACKAGE_NAME}/exports/${tag}`;
+                  }
+                  return null;
                 },
               },
             },

--- a/packages/zero-vite-plugin/tsup.config.ts
+++ b/packages/zero-vite-plugin/tsup.config.ts
@@ -1,5 +1,6 @@
 import { Options, defineConfig } from 'tsup';
 import config from '../../tsup.config';
+import zeroPkgJson from '../zero-runtime/package.json';
 
 const external = ['@mui/zero-runtime/utils'];
 
@@ -7,6 +8,9 @@ const baseConfig: Options = {
   ...(config as Options),
   tsconfig: './tsconfig.build.json',
   external,
+  env: {
+    RUNTIME_PACKAGE_NAME: zeroPkgJson.name,
+  },
 };
 
 export default defineConfig([


### PR DESCRIPTION
and replace emotion/system with zero runtime at build time.

To test locally, see the README of this [repo](https://github.com/brijeshb42/next-js-zero-runtime-intermediate-pkg).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
