### PR TITLE
[docs] Improve instructions about peer dependencies

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -30,7 +30,7 @@ pnpm add @mui/base
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed for Base UI to work.
 
 ```json
 "peerDependencies": {

--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -30,7 +30,7 @@ pnpm add @mui/base
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed for Base UI to work.
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed before installing Base UI.
 
 ```json
 "peerDependencies": {

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -2,6 +2,8 @@
 
 <p class="description">Install Joy UI, a library of beautifully designed React UI components.</p>
 
+## Default installation
+
 Run one of the following commands to add Joy UI to your project:
 
 <codeblock storageKey="package-manager">
@@ -19,11 +21,11 @@ pnpm add @mui/joy @emotion/react @emotion/styled
 
 </codeblock>
 
-## Peer dependencies
+### Peer dependencies
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed for Joy UI to work.
 
 ```json
 "peerDependencies": {

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -25,7 +25,7 @@ pnpm add @mui/joy @emotion/react @emotion/styled
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed for Joy UI to work.
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed before installing Joy UI.
 
 ```json
 "peerDependencies": {

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -26,7 +26,7 @@ pnpm add @mui/material @emotion/react @emotion/styled
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed for Material UI to work.
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed before installing Material UI.
 
 ```json
 "peerDependencies": {

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -22,6 +22,19 @@ pnpm add @mui/material @emotion/react @emotion/styled
 
 </codeblock>
 
+### Peer dependencies
+
+<!-- #react-peer-version -->
+
+Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies, meaning you should ensure they are installed for Material UI to work.
+
+```json
+"peerDependencies": {
+  "react": "^17.0.0 || ^18.0.0",
+  "react-dom": "^17.0.0 || ^18.0.0"
+},
+```
+
 ## With styled-components
 
 Material UI uses [Emotion](https://emotion.sh/docs/introduction) as its default styling engine.
@@ -52,19 +65,6 @@ See [this GitHub issue](https://github.com/mui/material-ui/issues/29742) for mor
 
 We **strongly recommend** using Emotion for SSR projects.
 :::
-
-## Peer dependencies
-
-<!-- #react-peer-version -->
-
-Please note that [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom) are peer dependencies too:
-
-```json
-"peerDependencies": {
-  "react": "^17.0.0 || ^18.0.0",
-  "react-dom": "^17.0.0 || ^18.0.0"
-},
-```
 
 ## Roboto font
 

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -26,7 +26,7 @@ pnpm add @mui/system @emotion/react @emotion/styled
 
 <!-- #react-peer-version -->
 
-Please note that [react](https://www.npmjs.com/package/react) is peer dependencies, meaning you should ensure it's installed for MUI System to work.
+Please note that [react](https://www.npmjs.com/package/react) is a peer dependency, meaning you should ensure it is installed before installing MUI System.
 
 ```json
 "peerDependencies": {

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -22,6 +22,18 @@ pnpm add @mui/system @emotion/react @emotion/styled
 
 </codeblock>
 
+### Peer dependencies
+
+<!-- #react-peer-version -->
+
+Please note that [react](https://www.npmjs.com/package/react) is peer dependencies, meaning you should ensure it's installed for MUI System to work.
+
+```json
+"peerDependencies": {
+  "react": "^17.0.0 || ^18.0.0"
+},
+```
+
 ## With styled-components
 
 MUI System uses [Emotion](https://emotion.sh/docs/introduction) as its default styling engine.
@@ -50,15 +62,3 @@ See [this GitHub issue](https://github.com/mui/material-ui/issues/29742) for mor
 
 We **strongly recommend** using Emotion for SSR projects.
 :::
-
-## Peer dependencies
-
-<!-- #react-peer-version -->
-
-Please note that [react](https://www.npmjs.com/package/react) is a peer dependency too:
-
-```json
-"peerDependencies": {
-  "react": "^17.0.0 || ^18.0.0"
-},
-```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR, inspired by [a recent docs-feedback entry](https://mui-org.slack.com/archives/C041SDSF32L/p1705341275066149), adds instructions about what to do regarding the peer dependencies we call out in the Installation pages. I also took advantage of the opportunity to standardize the formatting so that the "Peer dependency" title is an H3.

- https://deploy-preview-40621--material-ui.netlify.app/material-ui/getting-started/installation/#peer-dependencies
- https://deploy-preview-40621--material-ui.netlify.app/joy-ui/getting-started/installation/#peer-dependencies
- https://deploy-preview-40621--material-ui.netlify.app/base-ui/getting-started/quickstart/#peer-dependencies
- https://deploy-preview-40621--material-ui.netlify.app/system/getting-started/installation/#peer-dependencies