### PR TITLE
[code-infra] Remove unnecessary @mui/utils dependency from api-docs-builder

### DIFF
--- a/packages/api-docs-builder/package.json
+++ b/packages/api-docs-builder/package.json
@@ -13,7 +13,6 @@
     "@babel/traverse": "^7.23.7",
     "@mui-internal/docs-utilities": "workspace:^",
     "@mui/markdown": "workspace:^",
-    "@mui/utils": "workspace:^",
     "ast-types": "^0.14.2",
     "doctrine": "^3.0.0",
     "fast-glob": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -926,9 +926,6 @@ importers:
       '@mui/markdown':
         specifier: workspace:^
         version: link:../markdown
-      '@mui/utils':
-        specifier: workspace:^
-        version: link:../mui-utils/build
       ast-types:
         specifier: ^0.14.2
         version: 0.14.2


### PR DESCRIPTION
The @mui-internal/api-docs-builder had a leftover @mui/utils dependency declared in its package.json. Since it isn't used, it's safe to remove it.