### PR TITLE
[styled-engine-sc] Fix types for `css` function of styled-engine-sc

### DIFF
--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as CSS from 'csstype';
 import * as hoistNonReactStatics from 'hoist-non-react-statics';
+import { DefaultTheme } from 'styled-components';
 
 type WithOptionalTheme<P extends { theme?: T | undefined }, T> = OmitU<P, 'theme'> & {
   theme?: T | undefined;
@@ -271,6 +272,26 @@ export interface ThemedStyledFunctionBase<
     ...rest: Array<Interpolation<ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>>>
   ): StyledComponent<C, T, O & U, A>;
 }
+
+type RuleSet<Props> = Interpolation<Props>[];
+
+declare function css(
+  styles:
+    | TemplateStringsArray
+    | CSSObject
+    | InterpolationFunction<ThemedStyledProps<object, DefaultTheme>>,
+  ...interpolations: Interpolation<ThemedStyledProps<object, DefaultTheme>>[]
+): RuleSet<ThemedStyledProps<object, DefaultTheme>>;
+
+declare function css<Props extends object>(
+  styles:
+    | TemplateStringsArray
+    | CSSObject
+    | InterpolationFunction<ThemedStyledProps<Props, DefaultTheme>>,
+  ...interpolations: Interpolation<ThemedStyledProps<Props, DefaultTheme>>[]
+): RuleSet<ThemedStyledProps<Props, DefaultTheme>>;
+
+export { css };
 
 // same as ThemedStyledFunction in styled-components, but without attrs, and withConfig
 export interface ThemedStyledFunction<

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -281,7 +281,7 @@ declare function css(
     | CSSObject
     | InterpolationFunction<ThemedStyledProps<object, DefaultTheme>>,
   ...interpolations: Interpolation<ThemedStyledProps<object, DefaultTheme>>[]
-): RuleSet<ThemedStyledProps<object, DefaultTheme>>;
+): RuleSet<object>;
 
 declare function css<Props extends object>(
   styles:
@@ -289,7 +289,7 @@ declare function css<Props extends object>(
     | CSSObject
     | InterpolationFunction<ThemedStyledProps<Props, DefaultTheme>>,
   ...interpolations: Interpolation<ThemedStyledProps<Props, DefaultTheme>>[]
-): RuleSet<ThemedStyledProps<Props, DefaultTheme>>;
+): RuleSet<Props>;
 
 export { css };
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui/material-ui/issues/40498 and part 1 of https://github.com/mui/material-ui/issues/40140

Codesandbox: https://codesandbox.io/p/devbox/styled-engine-sc-css-function-types-49tz5g?file=%2Fsrc%2FApp.tsx%3A7%2C12