### PR TITLE
[styled-engine-sc][system] Use namespaced theme prop for css functions in styled-engine-sc

### DIFF
--- a/packages/mui-material/src/styles/index.d.ts
+++ b/packages/mui-material/src/styles/index.d.ts
@@ -1,3 +1,10 @@
+import { MUICssWithTheme } from '@mui/system';
+import { Theme } from './createTheme';
+
+declare const css: MUICssWithTheme<Theme>;
+
+export { css };
+
 export { default as THEME_ID } from './identifier';
 export {
   default as createTheme,
@@ -47,7 +54,6 @@ export {
   Interpolation,
   CSSInterpolation,
   CSSObject,
-  css,
   keyframes,
   // color manipulators
   hexToRgb,

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -397,3 +397,23 @@ export interface MUIStyledComponent<
     tag: Tag,
   ): MUIStyledComponent<ComponentProps, JSX.IntrinsicElements[Tag]>;
 }
+
+type RuleSet<Props> = Interpolation<Props>[];
+
+export type MUICssWithTheme<Theme extends object = {}> = {
+  (
+    styles:
+      | TemplateStringsArray
+      | CSSObject
+      | InterpolationFunction<ThemedStyledProps<object, Theme>>,
+    ...interpolations: Interpolation<ThemedStyledProps<object, Theme>>[]
+  ): RuleSet<object>;
+
+  <Props extends object>(
+    styles:
+      | TemplateStringsArray
+      | CSSObject
+      | InterpolationFunction<ThemedStyledProps<Props, Theme>>,
+    ...interpolations: Interpolation<ThemedStyledProps<Props, Theme>>[]
+  ): RuleSet<Props>;
+};

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as CSS from 'csstype';
 import { StyledComponent, StyledOptions } from '@emotion/styled';
-import { PropsOf } from '@emotion/react';
+import { css, PropsOf } from '@emotion/react';
 
 export * from '@emotion/styled';
 export { default } from '@emotion/styled';
@@ -214,3 +214,6 @@ export interface CreateMUIStyled<
     options?: StyledOptions<MUIStyledCommonProps> & MuiStyledOptions,
   ): CreateStyledComponent<MUIStyledCommonProps, JSX.IntrinsicElements[Tag], {}, Theme>;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type MUICssWithTheme<Theme extends object = {}> = typeof css;

--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-underscore-dangle */
-import styledEngineStyled, { internal_processStyles as processStyles } from '@mui/styled-engine';
+import defaultStyledEngineStyled, {
+  internal_processStyles as defaultProcessStyles,
+} from '@mui/styled-engine';
 import {
   getDisplayName,
   unstable_capitalize as capitalize,
@@ -203,6 +205,8 @@ const createResolveExpression = ({ defaultTheme, themeId }) => {
 
 export default function createStyled(input = {}) {
   const {
+    styledEngineStyled = defaultStyledEngineStyled,
+    processStyles = defaultProcessStyles,
     themeId,
     defaultTheme = systemDefaultTheme,
     rootShouldForwardProp = shouldForwardProp,

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -1,3 +1,5 @@
+import { MUICssWithTheme as MUICssWithThemeStyledEngine } from '@mui/styled-engine';
+import { Theme as DefaultTheme } from './createTheme';
 import {
   ComposedStyleFunction,
   StyleFunction,
@@ -96,7 +98,6 @@ export type ResponsiveStyleValue<T> = T | Array<T | null> | { [key: string]: T |
 export { DefaultTheme } from '@mui/private-theming';
 
 export {
-  css,
   keyframes,
   StyledEngineProvider,
   Interpolation,
@@ -105,6 +106,13 @@ export {
 } from '@mui/styled-engine';
 export { default as GlobalStyles } from './GlobalStyles';
 export type { GlobalStylesProps } from './GlobalStyles';
+
+export type MUICssWithTheme<Theme extends object = DefaultTheme> =
+  MUICssWithThemeStyledEngine<Theme>;
+
+declare const css: MUICssWithTheme;
+
+export { css };
 
 export * from './style';
 export * from './spacing';

--- a/test/integration/mui-system/createStyled.test.js
+++ b/test/integration/mui-system/createStyled.test.js
@@ -40,6 +40,10 @@ describe('createStyled', () => {
         ${cssStub}
       `;
 
+      beforeEach(() => {
+        cssStub.resetHistory();
+      });
+
       it('should resolve nested functions with props', () => {
         const { container } = render(<Div color={redColor}>Test</Div>);
 
@@ -69,6 +73,10 @@ describe('createStyled', () => {
       const Div = scStyled('div')`
         ${({ color }) => color && nestedCss}
       `;
+
+      beforeEach(() => {
+        cssStub.resetHistory();
+      });
 
       it('should resolve nested functions with props', () => {
         const { container } = render(<Div color={redColor}>Test</Div>);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes part 2 of https://github.com/mui/material-ui/issues/40140

Codesandbox: https://codesandbox.io/p/devbox/fix-styled-engine-sc-css-theme-object-lpkkcv?file=%2Fsrc%2FApp.tsx%3A11%2C1

This PR could probably be considered as a breaking change.