### PR TITLE
[core] Remove unneeded use-clients

### DIFF
--- a/packages/mui-base/src/index.js
+++ b/packages/mui-base/src/index.js
@@ -1,4 +1,3 @@
-'use client';
 export * from './utils';
 export * from './Badge';
 export * from './Button';

--- a/packages/mui-base/src/useAutocomplete/index.js
+++ b/packages/mui-base/src/useAutocomplete/index.js
@@ -1,2 +1,1 @@
-'use client';
 export * from './useAutocomplete';

--- a/packages/mui-material/src/Accordion/index.js
+++ b/packages/mui-material/src/Accordion/index.js
@@ -1,4 +1,3 @@
-'use client';
 export { default } from './Accordion';
 
 export { default as accordionClasses } from './accordionClasses';

--- a/packages/mui-material/src/AccordionActions/index.js
+++ b/packages/mui-material/src/AccordionActions/index.js
@@ -1,4 +1,3 @@
-'use client';
 export { default } from './AccordionActions';
 
 export { default as accordionActionsClasses } from './accordionActionsClasses';

--- a/packages/mui-material/src/AccordionDetails/index.js
+++ b/packages/mui-material/src/AccordionDetails/index.js
@@ -1,4 +1,3 @@
-'use client';
 export { default } from './AccordionDetails';
 
 export { default as accordionDetailsClasses } from './accordionDetailsClasses';

--- a/packages/mui-material/src/AccordionSummary/index.js
+++ b/packages/mui-material/src/AccordionSummary/index.js
@@ -1,4 +1,3 @@
-'use client';
 export { default } from './AccordionSummary';
 
 export { default as accordionSummaryClasses } from './accordionSummaryClasses';

--- a/packages/mui-material/src/Rating/index.js
+++ b/packages/mui-material/src/Rating/index.js
@@ -1,4 +1,3 @@
-'use client';
 export { default } from './Rating';
 
 export { default as ratingClasses } from './ratingClasses';

--- a/packages/mui-material/src/Toolbar/index.js
+++ b/packages/mui-material/src/Toolbar/index.js
@@ -1,4 +1,3 @@
-'use client';
 export { default } from './Toolbar';
 
 export { default as toolbarClasses } from './toolbarClasses';

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -1,4 +1,3 @@
-'use client';
 /* eslint-disable import/export */
 import * as colors from './colors';
 

--- a/packages/mui-system/src/index.js
+++ b/packages/mui-system/src/index.js
@@ -1,4 +1,3 @@
-'use client';
 import MuiError from '@mui-internal/babel-macros/MuiError.macro';
 
 export { css, keyframes, StyledEngineProvider } from '@mui/styled-engine';

--- a/packages/mui-utils/src/index.ts
+++ b/packages/mui-utils/src/index.ts
@@ -1,4 +1,3 @@
-'use client';
 export { default as chainPropTypes } from './chainPropTypes';
 export { default as deepmerge } from './deepmerge';
 export { isPlainObject } from './deepmerge';


### PR DESCRIPTION
I'm randomly removing a few of what I believe are harmful "use client" from our bundle to prove my point in https://github.com/mui/material-ui/issues/39010#issuecomment-1732602132. My idea is that if this goes smoothly in production after a couple of weeks, we can go all-in.