### PR TITLE
[examples] Fix build on Next.js Pages Router examples

### DIFF
--- a/examples/joy-ui-nextjs-ts/src/components/ThemeRegistry/EmotionCache.tsx
+++ b/examples/joy-ui-nextjs-ts/src/components/ThemeRegistry/EmotionCache.tsx
@@ -9,10 +9,7 @@ export type NextAppDirEmotionCacheProviderProps = {
   /** This is the options passed to createCache() from 'import createCache from "@emotion/cache"' */
   options: Omit<OptionsOfCreateCache, 'insertionPoint'>;
   /** By default <CacheProvider /> from 'import { CacheProvider } from "@emotion/react"' */
-  CacheProvider?: (props: {
-    value: EmotionCache;
-    children: React.ReactNode;
-  }) => React.JSX.Element | null;
+  CacheProvider?: React.ElementType<{ value: EmotionCache }>;
   children: React.ReactNode;
 };
 

--- a/examples/material-ui-nextjs-pages-router-ts/pages/_document.tsx
+++ b/examples/material-ui-nextjs-pages-router-ts/pages/_document.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Html, Head, Main, NextScript, DocumentProps, DocumentContext } from 'next/document';
-import { DocumentHeadTags, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
+import { DocumentHeadTags, DocumentHeadTagsProps, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
 import theme, { roboto } from '../src/theme';
 
-export default function MyDocument(props: DocumentProps) {
+export default function MyDocument(props: DocumentProps & DocumentHeadTagsProps) {
   return (
     <Html lang="en" className={roboto.className}>
       <Head>

--- a/examples/material-ui-nextjs-pages-router-ts/pages/_document.tsx
+++ b/examples/material-ui-nextjs-pages-router-ts/pages/_document.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { Html, Head, Main, NextScript, DocumentProps, DocumentContext } from 'next/document';
-import { DocumentHeadTags, DocumentHeadTagsProps, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
+import {
+  DocumentHeadTags,
+  DocumentHeadTagsProps,
+  documentGetInitialProps,
+} from '@mui/material-nextjs/v14-pagesRouter';
 import theme, { roboto } from '../src/theme';
 
 export default function MyDocument(props: DocumentProps & DocumentHeadTagsProps) {

--- a/examples/material-ui-nextjs-ts-v4-v5-migration/pages/_document.tsx
+++ b/examples/material-ui-nextjs-ts-v4-v5-migration/pages/_document.tsx
@@ -9,11 +9,11 @@ import {
   DocumentContext,
 } from 'next/document';
 import { AppProps } from 'next/app';
-import { DocumentHeadTags, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
+import { DocumentHeadTags, DocumentHeadTagsProps, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
 import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import theme from '../src/theme';
 
-export default function MyDocument(props: DocumentProps) {
+export default function MyDocument(props: DocumentProps & DocumentHeadTagsProps) {
   return (
     <Html lang="en">
       <Head>

--- a/examples/material-ui-nextjs-ts-v4-v5-migration/pages/_document.tsx
+++ b/examples/material-ui-nextjs-ts-v4-v5-migration/pages/_document.tsx
@@ -9,7 +9,11 @@ import {
   DocumentContext,
 } from 'next/document';
 import { AppProps } from 'next/app';
-import { DocumentHeadTags, DocumentHeadTagsProps, documentGetInitialProps } from '@mui/material-nextjs/v14-pagesRouter';
+import {
+  DocumentHeadTags,
+  DocumentHeadTagsProps,
+  documentGetInitialProps,
+} from '@mui/material-nextjs/v14-pagesRouter';
 import { ServerStyleSheets as JSSServerStyleSheets } from '@mui/styles';
 import theme from '../src/theme';
 

--- a/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+++ b/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
@@ -18,10 +18,7 @@ export type AppRouterCacheProviderProps = {
   /**
    * By default <CacheProvider /> from 'import { CacheProvider } from "@emotion/react"'.
    */
-  CacheProvider?: (props: {
-    value: EmotionCache;
-    children: React.ReactNode;
-  }) => React.JSX.Element | null;
+  CacheProvider?: React.ElementType<{ value: EmotionCache }>;
   children: React.ReactNode;
 };
 

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -37,7 +37,7 @@ export function createGetInitialProps(plugins: Plugin[]) {
 }
 
 export interface DocumentHeadTagsProps {
-  emotionStyleTags: React.JSX.Element[];
+  emotionStyleTags: React.ReactElement[];
 }
 
 export function DocumentHeadTags(props: DocumentHeadTagsProps) {


### PR DESCRIPTION
I noticed that the reproduction of #37500 still leads to an error (but a different kind):

![Screenshot 2024-01-18 at 01 39 28](https://github.com/mui/material-ui/assets/3165635/9492ed40-4b79-487c-aaf6-210e9593c8d5)

This is a regression from #40199. It's a quick fix, so I thought I might as well go for it.