### PR TITLE
[fix] mui material styled does not imported from '@mui/material/styles'

### DIFF
--- a/packages/mui-material/src/index.d.ts
+++ b/packages/mui-material/src/index.d.ts
@@ -70,6 +70,7 @@ export namespace PropTypes {
 import * as colors from './colors';
 
 export { colors };
+export { default as styled } from './styles';
 export * from './styles';
 
 export * from './utils';

--- a/packages/mui-material/src/index.js
+++ b/packages/mui-material/src/index.js
@@ -3,6 +3,7 @@
 import * as colors from './colors';
 
 export { colors };
+export { default as styled } from './styles';
 export * from './styles';
 
 // TODO remove, import directly from Base UI or create one folder per module


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [✓] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

when i set eslintrc.cjs like this:
```
 rules: {
    // ...foo
    'mui-path-imports/mui-path-imports': 'error',
   // bar...
  },
```
styled dose not imported form '@mui/material/styles'.
others can use path imports.
This makes reducing bundle size difficult.
```
import Box from "@mui/material/Box";
import Button from "@mui/material/Button";
import Pagination from "@mui/material/Pagination";
import Skeleton from "@mui/material/Skeleton";
import Typography from "@mui/material/Typography";
import { styled } from "@mui/material";
```
