### PR TITLE
[code-infra] Disable pnpm package cache on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,6 @@ commands:
             node scripts/useReactVersion.mjs
             # log a patch for maintainers who want to check out this change
             git --no-pager diff HEAD
-      - restore_cache:
-          name: Restore pnpm package cache
-          keys:
-            - pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
       - when:
           condition: << parameters.browsers >>
           steps:
@@ -107,14 +103,6 @@ commands:
             - run:
                 name: Install playwright browsers
                 command: pnpm playwright install --with-deps
-      - save_cache:
-          name: Save pnpm package cache
-          key: pnpm-packages-{{ checksum "pnpm-lock.yaml" }}
-          paths:
-            - node_modules
-      - when:
-          condition: << parameters.browsers >>
-          steps:
             - save_cache:
                 name: Save playwright cache
                 key: v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}


### PR DESCRIPTION
Investigating what effect disabling package cache has on build times.

It seems that in cases where cache would be hit, the restore + install step takes roughly the same time as installing fresh packages from the registry.
In the cache miss scenario, however, saving the downloaded packages to the cache store take a lot of time (over a minute), so we can optimize this scenario.

[Cache hit](https://app.circleci.com/pipelines/github/mui/material-ui/118730/workflows/0d119699-ff79-42e1-a524-a7737ce25829/jobs/638242): restore + install: 27s + 2s = **29s**
[Cache miss](https://app.circleci.com/pipelines/github/mui/material-ui/118720/workflows/47a15199-8c3e-4a90-9b76-7a2757988ca9/jobs/638192): install + store = 34s + 68s = **102s**
[Fresh install](https://app.circleci.com/pipelines/github/mui/material-ui/118731/workflows/103b4c32-6bb7-469c-b4e3-3802233053b3/jobs/638261): **31s**

In addition, dropping the cache would save us storage costs (for example, in November 2023 we used 547 GB-months of storage, which was 14% of our total CircleCI credits usage).