### PR TITLE
[docs-infra] Support markdown link in slots descriptions

### DIFF
--- a/docs/translations/api-docs/accordion/accordion.json
+++ b/docs/translations/api-docs/accordion/accordion.json
@@ -60,6 +60,6 @@
     }
   },
   "slotDescriptions": {
-    "transition": "The component that renders the transition.\n[Follow this guide](/material-ui/transitions/#transitioncomponent-prop) to learn more about the requirements for this component."
+    "transition": "The component that renders the transition. <a href=\"/material-ui/transitions/#transitioncomponent-prop\">Follow this guide</a> to learn more about the requirements for this component."
   }
 }

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -475,7 +475,7 @@ const attachTranslations = (reactApi: ReactApi, settings?: CreateDescribeablePro
     translations.slotDescriptions = {};
     reactApi.slots.forEach((slot: Slot) => {
       const { name, description } = slot;
-      translations.slotDescriptions![name] = description;
+      translations.slotDescriptions![name] = renderMarkdown(description);
     });
   }
 


### PR DESCRIPTION
Fix the following issue on X. Seems it also occures in core

![image](https://github.com/mui/material-ui/assets/45398769/41804468-180f-4769-aa29-b5fd33f22254)
