### PR TITLE
[material-ui][Alert] Add action, icon, and iconMapping tests

### DIFF
--- a/packages/mui-material/src/Alert/Alert.test.js
+++ b/packages/mui-material/src/Alert/Alert.test.js
@@ -73,6 +73,12 @@ describe('<Alert />', () => {
         ),
       ).not.to.throw();
     });
+
+    it('should render the action provided into the Alert', () => {
+      render(<Alert action={<button data-testid="action">Action</button>}>Hello World</Alert>);
+
+      expect(screen.getByTestId('action')).toBeVisible();
+    });
   });
 
   describe('prop: components', () => {
@@ -146,6 +152,48 @@ describe('<Alert />', () => {
       const closeIcon = screen.getByTestId('closeIcon');
       expect(closeIcon).to.have.class(svgIconClasses.fontSizeLarge);
       expect(closeIcon).to.have.class('my-class');
+    });
+  });
+
+  describe('prop: icon', () => {
+    it('should render the icon provided into the Alert', () => {
+      render(<Alert icon={<div data-testid="icon" />}>Hello World</Alert>);
+
+      expect(screen.getByTestId('icon')).toBeVisible();
+    });
+
+    it('should not render any icon if false is provided', () => {
+      render(
+        <Alert
+          icon={false}
+          severity="success"
+          iconMapping={{ success: <div data-testid="success-icon" /> }}
+        >
+          Hello World
+        </Alert>,
+      );
+
+      expect(screen.queryByTestId('success-icon')).to.eq(null);
+    });
+  });
+
+  describe('prop: iconMapping', () => {
+    const severities = ['success', 'info', 'warning', 'error'];
+    const iconMapping = severities.reduce((acc, severity) => {
+      acc[severity] = <div data-testid={`${severity}-icon`} />;
+      return acc;
+    }, {});
+
+    severities.forEach((severity) => {
+      it(`should render the icon provided into the Alert for severity ${severity}`, () => {
+        render(
+          <Alert severity={severity} iconMapping={iconMapping}>
+            Hello World
+          </Alert>,
+        );
+
+        expect(screen.getByTestId(`${severity}-icon`)).toBeVisible();
+      });
     });
   });
 });


### PR DESCRIPTION
While working on https://github.com/mui/material-ui/pull/40681 I noticed we were missing tests for the `action`, `icon`, and `iconMapping` props.
