### PR TITLE
[base-ui][Menu] Use Popup instead of Popper

### DIFF
--- a/docs/data/base/components/menu/MenuIntroduction/css/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/css/index.js
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { Menu } from '@mui/base/Menu';
 import { MenuItem, menuItemClasses } from '@mui/base/MenuItem';
 import { MenuButton } from '@mui/base/MenuButton';
 import { Dropdown } from '@mui/base/Dropdown';
 import { useTheme } from '@mui/system';
+import { CssTransition } from '@mui/base/Transitions';
+import { PopupContext } from '@mui/base/Unstable_Popup';
 
 export default function MenuIntroduction() {
   const createHandleMenuClick = (menuItem) => {
@@ -18,6 +21,9 @@ export default function MenuIntroduction() {
 
       <Menu
         className="CustomMenuIntroduction"
+        slots={{
+          listbox: AnimatedListbox,
+        }}
         slotProps={{
           listbox: { className: 'CustomMenuIntroduction--listbox' },
         }}
@@ -45,6 +51,33 @@ export default function MenuIntroduction() {
     </Dropdown>
   );
 }
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <ul {...other} ref={ref} />
+    </CssTransition>
+  );
+});
+
+AnimatedListbox.propTypes = {
+  ownerState: PropTypes.object.isRequired,
+};
 
 const cyan = {
   50: '#E9F8FC',
@@ -97,6 +130,26 @@ function Styles() {
       border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
       color: ${isDarkMode ? grey[300] : grey[900]};
       box-shadow: 0px 4px 30px ${isDarkMode ? grey[900] : grey[200]};
+
+      .closed & {
+        opacity: 0;
+        transform: scale(0.95, 0.8);
+        transition: opacity 200ms ease-in, transform 200ms ease-in;
+      }
+      
+      .open & {
+        opacity: 1;
+        transform: scale(1, 1);
+        transition: opacity 100ms ease-out, transform 100ms cubic-bezier(0.43, 0.29, 0.37, 1.48);
+      }
+    
+      .placement-top & {
+        transform-origin: bottom;
+      }
+    
+      .placement-bottom & {
+        transform-origin: top;
+      }
     }
 
     .CustomMenuIntroduction--item {
@@ -155,7 +208,6 @@ function Styles() {
         outline: none;
       }
     }
-
 
     .CustomMenuIntroduction {
       z-index: 1;

--- a/docs/data/base/components/menu/MenuIntroduction/css/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/css/index.js
@@ -22,7 +22,7 @@ export default function MenuIntroduction() {
       <Menu
         className="CustomMenuIntroduction"
         slots={{
-          listbox: AnimatedListbox,
+          listbox: Listbox,
         }}
         slotProps={{
           listbox: { className: 'CustomMenuIntroduction--listbox' },
@@ -52,13 +52,13 @@ export default function MenuIntroduction() {
   );
 }
 
-const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
+const Listbox = React.forwardRef(function Listbox(props, ref) {
   const { ownerState, ...other } = props;
   const popupContext = React.useContext(PopupContext);
 
   if (popupContext == null) {
     throw new Error(
-      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+      'The `Listbox` component cannot be rendered outside a `Popup` component',
     );
   }
 
@@ -75,7 +75,7 @@ const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
   );
 });
 
-AnimatedListbox.propTypes = {
+Listbox.propTypes = {
   ownerState: PropTypes.object.isRequired,
 };
 

--- a/docs/data/base/components/menu/MenuIntroduction/css/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/css/index.tsx
@@ -21,7 +21,7 @@ export default function MenuIntroduction() {
       <Menu
         className="CustomMenuIntroduction"
         slots={{
-          listbox: AnimatedListbox,
+          listbox: Listbox,
         }}
         slotProps={{
           listbox: { className: 'CustomMenuIntroduction--listbox' },
@@ -51,7 +51,7 @@ export default function MenuIntroduction() {
   );
 }
 
-const AnimatedListbox = React.forwardRef(function AnimatedListbox(
+const Listbox = React.forwardRef(function Listbox(
   props: MenuListboxSlotProps,
   ref: React.ForwardedRef<HTMLUListElement>,
 ) {
@@ -60,7 +60,7 @@ const AnimatedListbox = React.forwardRef(function AnimatedListbox(
 
   if (popupContext == null) {
     throw new Error(
-      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+      'The `Listbox` component cannot be rendered outside a `Popup` component',
     );
   }
 

--- a/docs/data/base/components/menu/MenuIntroduction/css/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/css/index.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { Menu } from '@mui/base/Menu';
+import { Menu, MenuListboxSlotProps } from '@mui/base/Menu';
 import { MenuItem, menuItemClasses } from '@mui/base/MenuItem';
 import { MenuButton } from '@mui/base/MenuButton';
 import { Dropdown } from '@mui/base/Dropdown';
 import { useTheme } from '@mui/system';
+import { CssTransition } from '@mui/base/Transitions';
+import { PopupContext } from '@mui/base/Unstable_Popup';
 
 export default function MenuIntroduction() {
   const createHandleMenuClick = (menuItem: string) => {
@@ -18,6 +20,9 @@ export default function MenuIntroduction() {
 
       <Menu
         className="CustomMenuIntroduction"
+        slots={{
+          listbox: AnimatedListbox,
+        }}
         slotProps={{
           listbox: { className: 'CustomMenuIntroduction--listbox' },
         }}
@@ -45,6 +50,32 @@ export default function MenuIntroduction() {
     </Dropdown>
   );
 }
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(
+  props: MenuListboxSlotProps,
+  ref: React.ForwardedRef<HTMLUListElement>,
+) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <ul {...other} ref={ref} />
+    </CssTransition>
+  );
+});
 
 const cyan = {
   50: '#E9F8FC',
@@ -97,6 +128,26 @@ function Styles() {
       border: 1px solid ${isDarkMode ? grey[700] : grey[200]};
       color: ${isDarkMode ? grey[300] : grey[900]};
       box-shadow: 0px 4px 30px ${isDarkMode ? grey[900] : grey[200]};
+
+      .closed & {
+        opacity: 0;
+        transform: scale(0.95, 0.8);
+        transition: opacity 200ms ease-in, transform 200ms ease-in;
+      }
+      
+      .open & {
+        opacity: 1;
+        transform: scale(1, 1);
+        transition: opacity 100ms ease-out, transform 100ms cubic-bezier(0.43, 0.29, 0.37, 1.48);
+      }
+    
+      .placement-top & {
+        transform-origin: bottom;
+      }
+    
+      .placement-bottom & {
+        transform-origin: top;
+      }
     }
 
     .CustomMenuIntroduction--item {
@@ -155,7 +206,6 @@ function Styles() {
         outline: none;
       }
     }
-
 
     .CustomMenuIntroduction {
       z-index: 1;

--- a/docs/data/base/components/menu/MenuIntroduction/system/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/system/index.js
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { Dropdown } from '@mui/base/Dropdown';
 import { Menu } from '@mui/base/Menu';
 import { MenuButton as BaseMenuButton } from '@mui/base/MenuButton';
 import { MenuItem as BaseMenuItem, menuItemClasses } from '@mui/base/MenuItem';
 import { styled } from '@mui/system';
+import { CssTransition } from '@mui/base/Transitions';
+import { PopupContext } from '@mui/base/Unstable_Popup';
 
 export default function MenuIntroduction() {
   const createHandleMenuClick = (menuItem) => {
@@ -15,7 +18,7 @@ export default function MenuIntroduction() {
   return (
     <Dropdown>
       <MenuButton>My account</MenuButton>
-      <Menu slots={{ listbox: Listbox }}>
+      <Menu slots={{ listbox: AnimatedListbox }}>
         <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
         <MenuItem onClick={createHandleMenuClick('Language settings')}>
           Language settings
@@ -68,8 +71,55 @@ const Listbox = styled('ul')(
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   box-shadow: 0px 4px 30px ${theme.palette.mode === 'dark' ? grey[900] : grey[200]};
   z-index: 1;
+
+  .closed & {
+    opacity: 0;
+    transform: scale(0.95, 0.8);
+    transition: opacity 200ms ease-in, transform 200ms ease-in;
+  }
+  
+  .open & {
+    opacity: 1;
+    transform: scale(1, 1);
+    transition: opacity 100ms ease-out, transform 100ms cubic-bezier(0.43, 0.29, 0.37, 1.48);
+  }
+
+  .placement-top & {
+    transform-origin: bottom;
+  }
+
+  .placement-bottom & {
+    transform-origin: top;
+  }
   `,
 );
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <Listbox {...other} ref={ref} />
+    </CssTransition>
+  );
+});
+
+AnimatedListbox.propTypes = {
+  ownerState: PropTypes.object.isRequired,
+};
 
 const MenuItem = styled(BaseMenuItem)(
   ({ theme }) => `

--- a/docs/data/base/components/menu/MenuIntroduction/system/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/system/index.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Dropdown } from '@mui/base/Dropdown';
-import { Menu } from '@mui/base/Menu';
+import { Menu, MenuListboxSlotProps } from '@mui/base/Menu';
 import { MenuButton as BaseMenuButton } from '@mui/base/MenuButton';
 import { MenuItem as BaseMenuItem, menuItemClasses } from '@mui/base/MenuItem';
 import { styled } from '@mui/system';
+import { CssTransition } from '@mui/base/Transitions';
+import { PopupContext } from '@mui/base/Unstable_Popup';
 
 export default function MenuIntroduction() {
   const createHandleMenuClick = (menuItem: string) => {
@@ -15,7 +17,7 @@ export default function MenuIntroduction() {
   return (
     <Dropdown>
       <MenuButton>My account</MenuButton>
-      <Menu slots={{ listbox: Listbox }}>
+      <Menu slots={{ listbox: AnimatedListbox }}>
         <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
         <MenuItem onClick={createHandleMenuClick('Language settings')}>
           Language settings
@@ -68,8 +70,54 @@ const Listbox = styled('ul')(
   color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
   box-shadow: 0px 4px 30px ${theme.palette.mode === 'dark' ? grey[900] : grey[200]};
   z-index: 1;
+
+  .closed & {
+    opacity: 0;
+    transform: scale(0.95, 0.8);
+    transition: opacity 200ms ease-in, transform 200ms ease-in;
+  }
+  
+  .open & {
+    opacity: 1;
+    transform: scale(1, 1);
+    transition: opacity 100ms ease-out, transform 100ms cubic-bezier(0.43, 0.29, 0.37, 1.48);
+  }
+
+  .placement-top & {
+    transform-origin: bottom;
+  }
+
+  .placement-bottom & {
+    transform-origin: top;
+  }
   `,
 );
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(
+  props: MenuListboxSlotProps,
+  ref: React.ForwardedRef<HTMLUListElement>,
+) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <Listbox {...other} ref={ref} />
+    </CssTransition>
+  );
+});
 
 const MenuItem = styled(BaseMenuItem)(
   ({ theme }) => `

--- a/docs/data/base/components/menu/MenuIntroduction/system/index.tsx.preview
+++ b/docs/data/base/components/menu/MenuIntroduction/system/index.tsx.preview
@@ -1,6 +1,6 @@
 <Dropdown>
   <MenuButton>My account</MenuButton>
-  <Menu slots={{ listbox: Listbox }}>
+  <Menu slots={{ listbox: AnimatedListbox }}>
     <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
     <MenuItem onClick={createHandleMenuClick('Language settings')}>
       Language settings

--- a/docs/data/base/components/menu/MenuIntroduction/tailwind/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/tailwind/index.js
@@ -51,7 +51,7 @@ const Menu = React.forwardRef((props, ref) => {
       ref={ref}
       {...props}
       slots={{
-        listbox: AnimatedListbox,
+        listbox: Listbox,
       }}
       slotProps={{
         ...props.slotProps,
@@ -136,13 +136,13 @@ MenuItem.propTypes = {
   className: PropTypes.string,
 };
 
-const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
+const Listbox = React.forwardRef(function Listbox(props, ref) {
   const { ownerState, ...other } = props;
   const popupContext = React.useContext(PopupContext);
 
   if (popupContext == null) {
     throw new Error(
-      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+      'The `Listbox` component cannot be rendered outside a `Popup` component',
     );
   }
 
@@ -151,14 +151,13 @@ const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
   return (
     <CssTransition
       className={`placement-${verticalPlacement}`}
-      enterClassName="open"
-      exitClassName="closed"
+      enterClassName="base--expanded"
     >
       <ul {...other} ref={ref} />
     </CssTransition>
   );
 });
 
-AnimatedListbox.propTypes = {
+Listbox.propTypes = {
   ownerState: PropTypes.object.isRequired,
 };

--- a/docs/data/base/components/menu/MenuIntroduction/tailwind/index.js
+++ b/docs/data/base/components/menu/MenuIntroduction/tailwind/index.js
@@ -6,6 +6,8 @@ import { MenuButton as BaseMenuButton } from '@mui/base/MenuButton';
 import { MenuItem as BaseMenuItem } from '@mui/base/MenuItem';
 import { Dropdown } from '@mui/base/Dropdown';
 import { useTheme } from '@mui/system';
+import { PopupContext } from '@mui/base/Unstable_Popup';
+import { CssTransition } from '@mui/base/Transitions';
 
 function useIsDarkMode() {
   const theme = useTheme();
@@ -48,6 +50,9 @@ const Menu = React.forwardRef((props, ref) => {
     <BaseMenu
       ref={ref}
       {...props}
+      slots={{
+        listbox: AnimatedListbox,
+      }}
       slotProps={{
         ...props.slotProps,
         root: (ownerState) => {
@@ -71,7 +76,7 @@ const Menu = React.forwardRef((props, ref) => {
           return {
             ...resolvedSlotProps,
             className: clsx(
-              'text-sm box-border font-sans p-1.5 my-3 mx-0 rounded-xl overflow-auto outline-0 bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-300 min-w-listbox shadow-md dark:shadow-slate-900',
+              'text-sm box-border font-sans p-1.5 my-3 mx-0 rounded-xl overflow-auto outline-0 bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-300 min-w-listbox shadow-md dark:shadow-slate-900 [.open_&]:opacity-100 [.open_&]:scale-100 transition-[opacity,transform] [.closed_&]:opacity-0 [.closed_&]:scale-90 [.placement-top_&]:origin-bottom [.placement-bottom_&]:origin-top',
               resolvedSlotProps?.className,
             ),
           };
@@ -129,4 +134,31 @@ const MenuItem = React.forwardRef((props, ref) => {
 
 MenuItem.propTypes = {
   className: PropTypes.string,
+};
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <ul {...other} ref={ref} />
+    </CssTransition>
+  );
+});
+
+AnimatedListbox.propTypes = {
+  ownerState: PropTypes.object.isRequired,
 };

--- a/docs/data/base/components/menu/MenuIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/tailwind/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import clsx from 'clsx';
-import { Menu as BaseMenu, MenuProps } from '@mui/base/Menu';
+import { Menu as BaseMenu, MenuListboxSlotProps, MenuProps } from '@mui/base/Menu';
 import { MenuButton as BaseMenuButton, MenuButtonProps } from '@mui/base/MenuButton';
 import { MenuItem as BaseMenuItem, MenuItemProps } from '@mui/base/MenuItem';
 import { Dropdown } from '@mui/base/Dropdown';
 import { useTheme } from '@mui/system';
+import { PopupContext } from '@mui/base/Unstable_Popup';
+import { CssTransition } from '@mui/base/Transitions';
 
 function useIsDarkMode() {
   const theme = useTheme();
@@ -48,6 +50,9 @@ const Menu = React.forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
     <BaseMenu
       ref={ref}
       {...props}
+      slots={{
+        listbox: AnimatedListbox,
+      }}
       slotProps={{
         ...props.slotProps,
         root: (ownerState) => {
@@ -71,7 +76,7 @@ const Menu = React.forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
           return {
             ...resolvedSlotProps,
             className: clsx(
-              'text-sm box-border font-sans p-1.5 my-3 mx-0 rounded-xl overflow-auto outline-0 bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-300 min-w-listbox shadow-md dark:shadow-slate-900',
+              'text-sm box-border font-sans p-1.5 my-3 mx-0 rounded-xl overflow-auto outline-0 bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-700 text-slate-900 dark:text-slate-300 min-w-listbox shadow-md dark:shadow-slate-900 [.open_&]:opacity-100 [.open_&]:scale-100 transition-[opacity,transform] [.closed_&]:opacity-0 [.closed_&]:scale-90 [.placement-top_&]:origin-bottom [.placement-bottom_&]:origin-top',
               resolvedSlotProps?.className,
             ),
           };
@@ -108,5 +113,31 @@ const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => 
       )}
       {...other}
     />
+  );
+});
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(
+  props: MenuListboxSlotProps,
+  ref: React.ForwardedRef<HTMLUListElement>,
+) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <ul {...other} ref={ref} />
+    </CssTransition>
   );
 });

--- a/docs/data/base/components/menu/MenuIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/menu/MenuIntroduction/tailwind/index.tsx
@@ -51,7 +51,7 @@ const Menu = React.forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
       ref={ref}
       {...props}
       slots={{
-        listbox: AnimatedListbox,
+        listbox: Listbox,
       }}
       slotProps={{
         ...props.slotProps,
@@ -116,7 +116,7 @@ const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => 
   );
 });
 
-const AnimatedListbox = React.forwardRef(function AnimatedListbox(
+const Listbox = React.forwardRef(function Listbox(
   props: MenuListboxSlotProps,
   ref: React.ForwardedRef<HTMLUListElement>,
 ) {
@@ -125,7 +125,7 @@ const AnimatedListbox = React.forwardRef(function AnimatedListbox(
 
   if (popupContext == null) {
     throw new Error(
-      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+      'The `Listbox` component cannot be rendered outside a `Popup` component',
     );
   }
 
@@ -134,8 +134,7 @@ const AnimatedListbox = React.forwardRef(function AnimatedListbox(
   return (
     <CssTransition
       className={`placement-${verticalPlacement}`}
-      enterClassName="open"
-      exitClassName="closed"
+      enterClassName="base--expanded"
     >
       <ul {...other} ref={ref} />
     </CssTransition>

--- a/docs/data/base/components/menu/MenuTransitions.js
+++ b/docs/data/base/components/menu/MenuTransitions.js
@@ -1,0 +1,183 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from '@mui/base/Dropdown';
+import { Menu } from '@mui/base/Menu';
+import { MenuButton as BaseMenuButton } from '@mui/base/MenuButton';
+import { MenuItem as BaseMenuItem, menuItemClasses } from '@mui/base/MenuItem';
+import { styled } from '@mui/system';
+import { CssTransition } from '@mui/base/Transitions';
+import { PopupContext } from '@mui/base/Unstable_Popup';
+
+export default function MenuTransitions() {
+  const createHandleMenuClick = (menuItem) => {
+    return () => {
+      console.log(`Clicked on ${menuItem}`);
+    };
+  };
+
+  return (
+    <Dropdown>
+      <MenuButton>My account</MenuButton>
+      <Menu slots={{ listbox: AnimatedListbox }}>
+        <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
+        <MenuItem onClick={createHandleMenuClick('Language settings')}>
+          Language settings
+        </MenuItem>
+        <MenuItem onClick={createHandleMenuClick('Log out')}>Log out</MenuItem>
+      </Menu>
+    </Dropdown>
+  );
+}
+
+const blue = {
+  50: '#F0F7FF',
+  100: '#C2E0FF',
+  200: '#99CCF3',
+  300: '#66B2FF',
+  400: '#3399FF',
+  500: '#007FFF',
+  600: '#0072E6',
+  700: '#0059B3',
+  800: '#004C99',
+  900: '#003A75',
+};
+
+const grey = {
+  50: '#F3F6F9',
+  100: '#E5EAF2',
+  200: '#DAE2ED',
+  300: '#C7D0DD',
+  400: '#B0B8C4',
+  500: '#9DA8B7',
+  600: '#6B7A90',
+  700: '#434D5B',
+  800: '#303740',
+  900: '#1C2025',
+};
+
+const Listbox = styled('ul')(
+  ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+  padding: 6px;
+  margin: 12px 0;
+  min-width: 200px;
+  border-radius: 12px;
+  overflow: auto;
+  outline: 0px;
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  box-shadow: 0px 4px 30px ${theme.palette.mode === 'dark' ? grey[900] : grey[200]};
+  z-index: 1;
+
+  .closed & {
+    opacity: 0;
+    transform: scale(0.95, 0.8);
+    transition: opacity 200ms ease-in, transform 200ms ease-in;
+  }
+  
+  .open & {
+    opacity: 1;
+    transform: scale(1, 1);
+    transition: opacity 100ms ease-out, transform 100ms cubic-bezier(0.43, 0.29, 0.37, 1.48);
+  }
+
+  .placement-top & {
+    transform-origin: bottom;
+  }
+
+  .placement-bottom & {
+    transform-origin: top;
+  }
+  `,
+);
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(props, ref) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <Listbox {...other} ref={ref} />
+    </CssTransition>
+  );
+});
+
+AnimatedListbox.propTypes = {
+  ownerState: PropTypes.object.isRequired,
+};
+
+const MenuItem = styled(BaseMenuItem)(
+  ({ theme }) => `
+  list-style: none;
+  padding: 8px;
+  border-radius: 8px;
+  cursor: default;
+  user-select: none;
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  &.${menuItemClasses.focusVisible} {
+    outline: 3px solid ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
+    background-color: ${theme.palette.mode === 'dark' ? grey[800] : grey[100]};
+    color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  }
+
+  &.${menuItemClasses.disabled} {
+    color: ${theme.palette.mode === 'dark' ? grey[700] : grey[400]};
+  }
+
+  &:hover:not(.${menuItemClasses.disabled}) {
+    background-color: ${theme.palette.mode === 'dark' ? blue[900] : blue[50]};
+    color: ${theme.palette.mode === 'dark' ? blue[100] : blue[900]};
+  }
+  `,
+);
+
+const MenuButton = styled(BaseMenuButton)(
+  ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  padding: 8px 16px;
+  border-radius: 8px;
+  color: white;
+  transition: all 150ms ease;
+  cursor: pointer;
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  color: ${theme.palette.mode === 'dark' ? grey[200] : grey[900]};
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+
+  &:hover {
+    background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
+    border-color: ${theme.palette.mode === 'dark' ? grey[600] : grey[300]};
+  }
+
+  &:active {
+    background: ${theme.palette.mode === 'dark' ? grey[700] : grey[100]};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 4px ${theme.palette.mode === 'dark' ? blue[300] : blue[200]};
+    outline: none;
+  }
+  `,
+);

--- a/docs/data/base/components/menu/MenuTransitions.tsx
+++ b/docs/data/base/components/menu/MenuTransitions.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import { Dropdown } from '@mui/base/Dropdown';
+import { Menu, MenuListboxSlotProps } from '@mui/base/Menu';
+import { MenuButton as BaseMenuButton } from '@mui/base/MenuButton';
+import { MenuItem as BaseMenuItem, menuItemClasses } from '@mui/base/MenuItem';
+import { styled } from '@mui/system';
+import { CssTransition } from '@mui/base/Transitions';
+import { PopupContext } from '@mui/base/Unstable_Popup';
+
+export default function MenuTransitions() {
+  const createHandleMenuClick = (menuItem: string) => {
+    return () => {
+      console.log(`Clicked on ${menuItem}`);
+    };
+  };
+
+  return (
+    <Dropdown>
+      <MenuButton>My account</MenuButton>
+      <Menu slots={{ listbox: AnimatedListbox }}>
+        <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
+        <MenuItem onClick={createHandleMenuClick('Language settings')}>
+          Language settings
+        </MenuItem>
+        <MenuItem onClick={createHandleMenuClick('Log out')}>Log out</MenuItem>
+      </Menu>
+    </Dropdown>
+  );
+}
+
+const blue = {
+  50: '#F0F7FF',
+  100: '#C2E0FF',
+  200: '#99CCF3',
+  300: '#66B2FF',
+  400: '#3399FF',
+  500: '#007FFF',
+  600: '#0072E6',
+  700: '#0059B3',
+  800: '#004C99',
+  900: '#003A75',
+};
+
+const grey = {
+  50: '#F3F6F9',
+  100: '#E5EAF2',
+  200: '#DAE2ED',
+  300: '#C7D0DD',
+  400: '#B0B8C4',
+  500: '#9DA8B7',
+  600: '#6B7A90',
+  700: '#434D5B',
+  800: '#303740',
+  900: '#1C2025',
+};
+
+const Listbox = styled('ul')(
+  ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 0.875rem;
+  box-sizing: border-box;
+  padding: 6px;
+  margin: 12px 0;
+  min-width: 200px;
+  border-radius: 12px;
+  overflow: auto;
+  outline: 0px;
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  box-shadow: 0px 4px 30px ${theme.palette.mode === 'dark' ? grey[900] : grey[200]};
+  z-index: 1;
+
+  .closed & {
+    opacity: 0;
+    transform: scale(0.95, 0.8);
+    transition: opacity 200ms ease-in, transform 200ms ease-in;
+  }
+  
+  .open & {
+    opacity: 1;
+    transform: scale(1, 1);
+    transition: opacity 100ms ease-out, transform 100ms cubic-bezier(0.43, 0.29, 0.37, 1.48);
+  }
+
+  .placement-top & {
+    transform-origin: bottom;
+  }
+
+  .placement-bottom & {
+    transform-origin: top;
+  }
+  `,
+);
+
+const AnimatedListbox = React.forwardRef(function AnimatedListbox(
+  props: MenuListboxSlotProps,
+  ref: React.ForwardedRef<HTMLUListElement>,
+) {
+  const { ownerState, ...other } = props;
+  const popupContext = React.useContext(PopupContext);
+
+  if (popupContext == null) {
+    throw new Error(
+      'The `AnimatedListbox` component cannot be rendered outside a `Popup` component',
+    );
+  }
+
+  const verticalPlacement = popupContext.placement.split('-')[0];
+
+  return (
+    <CssTransition
+      className={`placement-${verticalPlacement}`}
+      enterClassName="open"
+      exitClassName="closed"
+    >
+      <Listbox {...other} ref={ref} />
+    </CssTransition>
+  );
+});
+
+const MenuItem = styled(BaseMenuItem)(
+  ({ theme }) => `
+  list-style: none;
+  padding: 8px;
+  border-radius: 8px;
+  cursor: default;
+  user-select: none;
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  &.${menuItemClasses.focusVisible} {
+    outline: 3px solid ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
+    background-color: ${theme.palette.mode === 'dark' ? grey[800] : grey[100]};
+    color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  }
+
+  &.${menuItemClasses.disabled} {
+    color: ${theme.palette.mode === 'dark' ? grey[700] : grey[400]};
+  }
+
+  &:hover:not(.${menuItemClasses.disabled}) {
+    background-color: ${theme.palette.mode === 'dark' ? blue[900] : blue[50]};
+    color: ${theme.palette.mode === 'dark' ? blue[100] : blue[900]};
+  }
+  `,
+);
+
+const MenuButton = styled(BaseMenuButton)(
+  ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  padding: 8px 16px;
+  border-radius: 8px;
+  color: white;
+  transition: all 150ms ease;
+  cursor: pointer;
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  color: ${theme.palette.mode === 'dark' ? grey[200] : grey[900]};
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+
+  &:hover {
+    background: ${theme.palette.mode === 'dark' ? grey[800] : grey[50]};
+    border-color: ${theme.palette.mode === 'dark' ? grey[600] : grey[300]};
+  }
+
+  &:active {
+    background: ${theme.palette.mode === 'dark' ? grey[700] : grey[100]};
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 4px ${theme.palette.mode === 'dark' ? blue[300] : blue[200]};
+    outline: none;
+  }
+  `,
+);

--- a/docs/data/base/components/menu/MenuTransitions.tsx.preview
+++ b/docs/data/base/components/menu/MenuTransitions.tsx.preview
@@ -1,0 +1,10 @@
+<Dropdown>
+  <MenuButton>My account</MenuButton>
+  <Menu slots={{ listbox: AnimatedListbox }}>
+    <MenuItem onClick={createHandleMenuClick('Profile')}>Profile</MenuItem>
+    <MenuItem onClick={createHandleMenuClick('Language settings')}>
+      Language settings
+    </MenuItem>
+    <MenuItem onClick={createHandleMenuClick('Log out')}>Log out</MenuItem>
+  </Menu>
+</Dropdown>

--- a/docs/data/base/components/menu/menu.md
+++ b/docs/data/base/components/menu/menu.md
@@ -102,6 +102,13 @@ The same applies to props specific to custom primitive elements:
 <Menu<'ol'> slots={{ root: 'ol' }} start={5} />
 ```
 
+### Transitions
+
+The Menu component supports the [Transitions API](/base-ui/react-transitions/), so it's possible to animate the appearing and disappearing Listbox.
+To do this, override the Listbox slot of the Menu and wrap it with a transition component ([CssTransition](/base-ui/react-transitions/#css-transition), [CssAnimation](/base-ui/react-transitions/#css-animation), or a custom-built one).
+
+{{"demo": "MenuTransitions.js", "defaultCodeOpen": false}}
+
 ## Hooks
 
 ```jsx

--- a/docs/pages/base-ui/api/popup.json
+++ b/docs/pages/base-ui/api/popup.json
@@ -42,8 +42,7 @@
     "strategy": {
       "type": { "name": "enum", "description": "'absolute'<br>&#124;&nbsp;'fixed'" },
       "default": "'absolute'"
-    },
-    "withTransition": { "type": { "name": "bool" }, "default": "false" }
+    }
   },
   "name": "Popup",
   "imports": [

--- a/docs/translations/api-docs-base/popup/popup.json
+++ b/docs/translations/api-docs-base/popup/popup.json
@@ -27,10 +27,7 @@
     "slots": {
       "description": "The components used for each slot inside the Popup. Either a string to use a HTML element or a component."
     },
-    "strategy": { "description": "The type of CSS position property to use (absolute or fixed)." },
-    "withTransition": {
-      "description": "If <code>true</code>, the popup will not disappear immediately when it needs to be closed but wait until the exit transition has finished. In such a case, a function form of <code>children</code> must be used and <code>onExited</code> callback function must be called when the transition or animation finish."
-    }
+    "strategy": { "description": "The type of CSS position property to use (absolute or fixed)." }
   },
   "classDescriptions": {
     "open": {

--- a/packages/mui-base/src/Menu/Menu.test.tsx
+++ b/packages/mui-base/src/Menu/Menu.test.tsx
@@ -435,7 +435,7 @@ describe('<Menu />', () => {
             <DropdownContext.Provider value={testContext}>
               <Menu
                 anchor={anchor}
-                slotProps={{ root: { 'data-testid': 'popup', placement: 'bottom-start' } }}
+                slotProps={{ root: { 'data-testid': 'popup', placement: 'bottom-start' } as any }}
               >
                 <MenuItem>1</MenuItem>
                 <MenuItem>2</MenuItem>
@@ -487,7 +487,7 @@ describe('<Menu />', () => {
         <DropdownContext.Provider value={testContext}>
           <Menu
             anchor={virtualElement}
-            slotProps={{ root: { 'data-testid': 'popup', placement: 'bottom-start' } }}
+            slotProps={{ root: { 'data-testid': 'popup', placement: 'bottom-start' } as any }}
           >
             <MenuItem>1</MenuItem>
             <MenuItem>2</MenuItem>

--- a/packages/mui-base/src/Menu/Menu.test.tsx
+++ b/packages/mui-base/src/Menu/Menu.test.tsx
@@ -7,6 +7,9 @@ import {
   describeConformanceUnstyled,
   fireEvent,
   act,
+  MuiRenderResult,
+  RenderOptions,
+  flushMicrotasks,
 } from '@mui-internal/test-utils';
 import { Menu, menuClasses } from '@mui/base/Menu';
 import { MenuItem, MenuItemRootSlotProps } from '@mui/base/MenuItem';
@@ -23,7 +26,16 @@ const testContext: DropdownContextValue = {
 
 describe('<Menu />', () => {
   const mount = createMount();
-  const { render } = createRenderer();
+  const { render: internalRender } = createRenderer();
+
+  async function render(
+    element: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
+    options?: RenderOptions,
+  ): Promise<MuiRenderResult> {
+    const rendered = internalRender(element, options);
+    await flushMicrotasks();
+    return rendered;
+  }
 
   describeConformanceUnstyled(<Menu />, () => ({
     inheritComponent: 'div',
@@ -63,8 +75,8 @@ describe('<Menu />', () => {
       );
     }
 
-    it('highlights the first item when the menu is opened', () => {
-      const { getAllByRole } = render(<Test />);
+    it('highlights the first item when the menu is opened', async () => {
+      const { getAllByRole } = await render(<Test />);
       const [firstItem, ...otherItems] = getAllByRole('menuitem');
 
       expect(firstItem.tabIndex).to.equal(0);
@@ -75,8 +87,8 @@ describe('<Menu />', () => {
   });
 
   describe('keyboard navigation', () => {
-    it('changes the highlighted item using the arrow keys', () => {
-      const { getByTestId } = render(
+    it('changes the highlighted item using the arrow keys', async () => {
+      const { getByTestId } = await render(
         <DropdownContext.Provider value={testContext}>
           <Menu>
             <MenuItem data-testid="item-1">1</MenuItem>
@@ -104,8 +116,8 @@ describe('<Menu />', () => {
       expect(document.activeElement).to.equal(item2);
     });
 
-    it('changes the highlighted item using the Home and End keys', () => {
-      const { getByTestId } = render(
+    it('changes the highlighted item using the Home and End keys', async () => {
+      const { getByTestId } = await render(
         <DropdownContext.Provider value={testContext}>
           <Menu>
             <MenuItem data-testid="item-1">1</MenuItem>
@@ -129,8 +141,8 @@ describe('<Menu />', () => {
       expect(document.activeElement).to.equal(getByTestId('item-1'));
     });
 
-    it('includes disabled items during keyboard navigation', () => {
-      const { getByTestId } = render(
+    it('includes disabled items during keyboard navigation', async () => {
+      const { getByTestId } = await render(
         <DropdownContext.Provider value={testContext}>
           <Menu>
             <MenuItem data-testid="item-1">1</MenuItem>
@@ -155,14 +167,14 @@ describe('<Menu />', () => {
     });
 
     describe('text navigation', () => {
-      it('changes the highlighted item', function test() {
+      it('changes the highlighted item', async function test() {
         if (/jsdom/.test(window.navigator.userAgent)) {
           // useMenu Text navigation match menu items using HTMLElement.innerText
           // innerText is not supported by JsDom
           this.skip();
         }
 
-        const { getByText, getAllByRole } = render(
+        const { getByText, getAllByRole } = await render(
           <DropdownContext.Provider value={testContext}>
             <Menu>
               <MenuItem>Aa</MenuItem>
@@ -190,14 +202,14 @@ describe('<Menu />', () => {
         expect(getByText('Cd')).to.have.attribute('tabindex', '0');
       });
 
-      it('repeated keys circulate all items starting with that letter', function test() {
+      it('repeated keys circulate all items starting with that letter', async function test() {
         if (/jsdom/.test(window.navigator.userAgent)) {
           // useMenu Text navigation match menu items using HTMLElement.innerText
           // innerText is not supported by JsDom
           this.skip();
         }
 
-        const { getByText, getAllByRole } = render(
+        const { getByText, getAllByRole } = await render(
           <DropdownContext.Provider value={testContext}>
             <Menu>
               <MenuItem>Aa</MenuItem>
@@ -227,8 +239,8 @@ describe('<Menu />', () => {
         expect(getByText('Ba')).to.have.attribute('tabindex', '0');
       });
 
-      it('changes the highlighted item using text navigation on label prop', () => {
-        const { getAllByRole } = render(
+      it('changes the highlighted item using text navigation on label prop', async () => {
+        const { getAllByRole } = await render(
           <DropdownContext.Provider value={testContext}>
             <Menu>
               <MenuItem label="Aa">1</MenuItem>
@@ -258,14 +270,14 @@ describe('<Menu />', () => {
         expect(items[1]).to.have.attribute('tabindex', '0');
       });
 
-      it('skips the non-stringifiable items', function test() {
+      it('skips the non-stringifiable items', async function test() {
         if (/jsdom/.test(window.navigator.userAgent)) {
           // useMenu Text navigation match menu items using HTMLElement.innerText
           // innerText is not supported by JsDom
           this.skip();
         }
 
-        const { getByText, getAllByRole } = render(
+        const { getByText, getAllByRole } = await render(
           <DropdownContext.Provider value={testContext}>
             <Menu>
               <MenuItem>Aa</MenuItem>
@@ -300,14 +312,14 @@ describe('<Menu />', () => {
         expect(getByText('Ba')).to.have.attribute('tabindex', '0');
       });
 
-      it('navigate to options with diacritic characters', function test() {
+      it('navigate to options with diacritic characters', async function test() {
         if (/jsdom/.test(window.navigator.userAgent)) {
           // useMenu Text navigation match menu items using HTMLElement.innerText
           // innerText is not supported by JsDom
           this.skip();
         }
 
-        const { getByText, getAllByRole } = render(
+        const { getByText, getAllByRole } = await render(
           <DropdownContext.Provider value={testContext}>
             <Menu>
               <MenuItem>Aa</MenuItem>
@@ -335,14 +347,14 @@ describe('<Menu />', () => {
         expect(getByText('Bą')).to.have.attribute('tabindex', '0');
       });
 
-      it('navigate to next options with beginning diacritic characters', function test() {
+      it('navigate to next options with beginning diacritic characters', async function test() {
         if (/jsdom/.test(window.navigator.userAgent)) {
           // useMenu Text navigation match menu items using HTMLElement.innerText
           // innerText is not supported by JsDom
           this.skip();
         }
 
-        const { getByText, getAllByRole } = render(
+        const { getByText, getAllByRole } = await render(
           <DropdownContext.Provider value={testContext}>
             <Menu>
               <MenuItem>Aa</MenuItem>
@@ -381,10 +393,10 @@ describe('<Menu />', () => {
   });
 
   describe('prop: onItemsChange', () => {
-    it('should be called when the menu items change', () => {
+    it('should be called when the menu items change', async () => {
       const handleItemsChange = spy();
 
-      const { setProps } = render(
+      const { setProps } = await render(
         <DropdownContext.Provider value={testContext}>
           <Menu onItemsChange={handleItemsChange}>
             <MenuItem key="1">1</MenuItem>
@@ -410,7 +422,11 @@ describe('<Menu />', () => {
   });
 
   describe('prop: anchor', () => {
-    it('should be placed near the specified element', async () => {
+    it('should be placed near the specified element', async function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
       function TestComponent() {
         const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
 
@@ -430,19 +446,29 @@ describe('<Menu />', () => {
         );
       }
 
-      const { getByTestId } = render(<TestComponent />);
+      const { getByTestId } = await render(<TestComponent />);
 
       const popup = getByTestId('popup');
       const anchor = getByTestId('anchor');
 
       const anchorPosition = anchor.getBoundingClientRect();
 
-      expect(popup.style.getPropertyValue('transform')).to.equal(
-        `translate(${anchorPosition.left}px, ${anchorPosition.bottom}px)`,
-      );
+      await new Promise<void>((resolve) => {
+        // position gets updated in the next frame
+        requestAnimationFrame(() => {
+          expect(popup.style.getPropertyValue('transform')).to.equal(
+            `translate(${anchorPosition.left}px, ${anchorPosition.bottom}px)`,
+          );
+          resolve();
+        });
+      });
     });
 
-    it('should be placed at the specified position', async () => {
+    it('should be placed at the specified position', async function test() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        this.skip();
+      }
+
       const boundingRect = {
         x: 200,
         y: 100,
@@ -457,7 +483,7 @@ describe('<Menu />', () => {
 
       const virtualElement = { getBoundingClientRect: () => boundingRect };
 
-      const { getByTestId } = render(
+      const { getByTestId } = await render(
         <DropdownContext.Provider value={testContext}>
           <Menu
             anchor={virtualElement}
@@ -469,11 +495,18 @@ describe('<Menu />', () => {
         </DropdownContext.Provider>,
       );
       const popup = getByTestId('popup');
-      expect(popup.style.getPropertyValue('transform')).to.equal(`translate(200px, 100px)`);
+
+      await new Promise<void>((resolve) => {
+        // position gets updated in the next frame
+        requestAnimationFrame(() => {
+          expect(popup.style.getPropertyValue('transform')).to.equal(`translate(200px, 100px)`);
+          resolve();
+        });
+      });
     });
   });
 
-  it('perf: does not rerender menu items unnecessarily', () => {
+  it('perf: does not rerender menu items unnecessarily', async () => {
     const renderItem1Spy = spy();
     const renderItem2Spy = spy();
     const renderItem3Spy = spy();
@@ -488,7 +521,7 @@ describe('<Menu />', () => {
       return <li {...other} ref={ref} />;
     });
 
-    const { getAllByRole } = render(
+    const { getAllByRole } = await render(
       <DropdownContext.Provider value={testContext}>
         <Menu>
           <MenuItem

--- a/packages/mui-base/src/Menu/Menu.tsx
+++ b/packages/mui-base/src/Menu/Menu.tsx
@@ -101,7 +101,7 @@ const Menu = React.forwardRef(function Menu<RootComponentType extends React.Elem
   }
 
   return (
-    <Popup {...rootProps} open={open} anchor={anchor} slots={{ root: Root }}>
+    <Popup keepMounted {...rootProps} open={open} anchor={anchor} slots={{ root: Root }}>
       <Listbox {...listboxProps}>
         <MenuProvider value={contextValue}>{children}</MenuProvider>
       </Listbox>

--- a/packages/mui-base/src/Menu/Menu.tsx
+++ b/packages/mui-base/src/Menu/Menu.tsx
@@ -8,7 +8,7 @@ import { getMenuUtilityClass } from './menuClasses';
 import { useMenu } from '../useMenu';
 import { MenuProvider } from '../useMenu/MenuProvider';
 import { unstable_composeClasses as composeClasses } from '../composeClasses';
-import { Popper } from '../Popper';
+import { Unstable_Popup as Popup } from '../Unstable_Popup';
 import { useSlotProps } from '../utils/useSlotProps';
 import { useClassNamesOverride } from '../utils/ClassNameConfigurator';
 import { WithOptionalOwnerState } from '../utils';
@@ -101,11 +101,11 @@ const Menu = React.forwardRef(function Menu<RootComponentType extends React.Elem
   }
 
   return (
-    <Popper {...rootProps} open={open} anchorEl={anchor} slots={{ root: Root }}>
+    <Popup {...rootProps} open={open} anchor={anchor} slots={{ root: Root }}>
       <Listbox {...listboxProps}>
         <MenuProvider value={contextValue}>{children}</MenuProvider>
       </Listbox>
-    </Popper>
+    </Popup>
   );
 }) as PolymorphicComponent<MenuTypeMap>;
 

--- a/packages/mui-base/src/Menu/Menu.types.ts
+++ b/packages/mui-base/src/Menu/Menu.types.ts
@@ -89,7 +89,7 @@ export type MenuRootSlotProps = {
   ref: React.Ref<any>;
 };
 
-export type MenuPopupSlotProps = UseMenuListboxSlotProps & {
+export type MenuListboxSlotProps = UseMenuListboxSlotProps & {
   children?: React.ReactNode;
   className?: string;
   ownerState: MenuOwnerState;

--- a/packages/mui-base/src/Menu/Menu.types.ts
+++ b/packages/mui-base/src/Menu/Menu.types.ts
@@ -3,7 +3,7 @@ import { Simplify } from '@mui/types';
 import { PolymorphicProps, SlotComponentProps } from '../utils';
 import { UseMenuListboxSlotProps } from '../useMenu';
 import { ListAction } from '../useList';
-import { Popper, PopperProps } from '../Popper';
+import { PopupProps } from '../Unstable_Popup';
 
 export interface MenuRootSlotPropsOverrides {}
 export interface MenuListboxSlotPropsOverrides {}
@@ -27,7 +27,7 @@ export interface MenuOwnProps {
   /**
    * The element based on which the menu is positioned.
    */
-  anchor?: PopperProps['anchorEl'];
+  anchor?: PopupProps['anchor'];
   children?: React.ReactNode;
   className?: string;
   /**
@@ -39,8 +39,7 @@ export interface MenuOwnProps {
    * @default {}
    */
   slotProps?: {
-    root?: SlotComponentProps<'div', MenuRootSlotPropsOverrides, MenuOwnerState> &
-      Partial<React.ComponentPropsWithoutRef<typeof Popper>>;
+    root?: SlotComponentProps<'div', MenuRootSlotPropsOverrides & PopupProps, MenuOwnerState>;
     listbox?: SlotComponentProps<'ul', MenuListboxSlotPropsOverrides, MenuOwnerState>;
   };
   /**

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -10,6 +10,7 @@ import {
   screen,
   MuiRenderResult,
   RenderOptions,
+  flushMicrotasks,
 } from '@mui-internal/test-utils';
 import userEvent from '@testing-library/user-event';
 import { Select, SelectListboxSlotProps, selectClasses } from '@mui/base/Select';
@@ -20,13 +21,6 @@ import { OptionGroup } from '@mui/base/OptionGroup';
 // TODO v6: initialize @testing-library/user-event using userEvent.setup() instead of directly calling methods e.g. userEvent.click() for all related tests in this file
 // currently the setup() method uses the ClipboardEvent constructor which is incompatible with our lowest supported version of iOS Safari (12.2) https://github.com/mui/material-ui/blob/master/.browserslistrc#L44
 // userEvent.setup() requires Safari 14 or up to work
-
-async function flushMicrotasks() {
-  if (/jsdom/.test(window.navigator.userAgent)) {
-    // This is only needed for JSDOM and causes issues in real browsers
-    await act(() => async () => {});
-  }
-}
 
 describe('<Select />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
+++ b/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
@@ -293,12 +293,12 @@ describe('<Popup />', () => {
     });
   });
 
-  describe('prop: withTransition', () => {
+  describe('transitions', () => {
     clock.withFakeTimers();
 
     it('should work', async () => {
       const { queryByRole, getByRole, setProps } = render(
-        <Popup {...defaultProps} withTransition>
+        <Popup {...defaultProps}>
           <FakeTransition>
             <span>Hello World</span>
           </FakeTransition>
@@ -334,7 +334,7 @@ describe('<Popup />', () => {
               <button type="button" onClick={this.handleClick}>
                 Toggle Tooltip
               </button>
-              <Popup {...defaultProps} open={this.state.open} withTransition>
+              <Popup {...defaultProps} open={this.state.open}>
                 <FakeTransition>
                   <p>Hello World</p>
                 </FakeTransition>

--- a/packages/mui-base/src/Unstable_Popup/Popup.tsx
+++ b/packages/mui-base/src/Unstable_Popup/Popup.tsx
@@ -16,10 +16,10 @@ import {
 } from '@mui/utils';
 import { unstable_composeClasses as composeClasses } from '../composeClasses';
 import { Portal } from '../Portal';
-import { useSlotProps } from '../utils';
+import { useSlotProps, WithOptionalOwnerState } from '../utils';
 import { useClassNamesOverride } from '../utils/ClassNameConfigurator';
 import { getPopupUtilityClass } from './popupClasses';
-import { PopupOwnerState, PopupProps } from './Popup.types';
+import { PopupOwnerState, PopupProps, PopupRootSlotProps } from './Popup.types';
 import { useTransitionTrigger, TransitionContext } from '../useTransition';
 import { PopupContext, PopupContextValue } from './PopupContext';
 
@@ -72,7 +72,6 @@ const Popup = React.forwardRef(function Popup<RootComponentType extends React.El
     slotProps = {},
     slots = {},
     strategy = 'absolute',
-    withTransition = false,
     ...other
   } = props;
 
@@ -113,7 +112,6 @@ const Popup = React.forwardRef(function Popup<RootComponentType extends React.El
     placement,
     finalPlacement,
     strategy,
-    withTransition,
   };
 
   const { contextValue, hasExited: hasTransitionExited } = useTransitionTrigger(open);
@@ -122,7 +120,7 @@ const Popup = React.forwardRef(function Popup<RootComponentType extends React.El
   const classes = useUtilityClasses(ownerState);
 
   const Root = slots?.root ?? 'div';
-  const rootProps = useSlotProps({
+  const rootProps: WithOptionalOwnerState<PopupRootSlotProps> = useSlotProps({
     elementType: Root,
     externalSlotProps: slotProps.root,
     externalForwardedProps: other,
@@ -285,15 +283,6 @@ Popup.propTypes /* remove-proptypes */ = {
    * @see https://floating-ui.com/docs/computePosition#strategy
    */
   strategy: PropTypes.oneOf(['absolute', 'fixed']),
-  /**
-   * If `true`, the popup will not disappear immediately when it needs to be closed
-   * but wait until the exit transition has finished.
-   * In such a case, a function form of `children` must be used and `onExited`
-   * callback function must be called when the transition or animation finish.
-   *
-   * @default false
-   */
-  withTransition: PropTypes.bool,
 } as any;
 
 export { Popup };

--- a/packages/mui-base/src/Unstable_Popup/Popup.types.ts
+++ b/packages/mui-base/src/Unstable_Popup/Popup.types.ts
@@ -103,15 +103,6 @@ export interface PopupOwnProps {
    * @see https://floating-ui.com/docs/computePosition#strategy
    */
   strategy?: PopupStrategy;
-  /**
-   * If `true`, the popup will not disappear immediately when it needs to be closed
-   * but wait until the exit transition has finished.
-   * In such a case, a function form of `children` must be used and `onExited`
-   * callback function must be called when the transition or animation finish.
-   *
-   * @default false
-   */
-  withTransition?: boolean;
 }
 
 export interface PopupSlots {
@@ -142,5 +133,12 @@ export interface PopupOwnerState extends PopupOwnProps {
   placement: PopupPlacement;
   finalPlacement: PopupPlacement;
   strategy: PopupStrategy;
-  withTransition: boolean;
 }
+
+export type PopupRootSlotProps = {
+  className?: string;
+  children?: React.ReactNode;
+  ownerState: PopupOwnerState;
+  style: React.CSSProperties;
+  role: React.AriaRole;
+};

--- a/packages/mui-base/src/useTransition/useTransitionTrigger.ts
+++ b/packages/mui-base/src/useTransition/useTransitionTrigger.ts
@@ -63,8 +63,6 @@ export function useTransitionTrigger(requestEnter: boolean): UseTransitionTrigge
     hasExited = !hasPendingExitTransition.current && exitTransitionFinished;
   }
 
-  // console.log({ hasExited, requestEnter, hasPendingExitTransition, exitTransitionFinished });
-
   const contextValue: TransitionContextValue = React.useMemo(
     () => ({
       requestedEnter: requestEnter,

--- a/packages/test-utils/src/flushMicrotasks.ts
+++ b/packages/test-utils/src/flushMicrotasks.ts
@@ -1,0 +1,8 @@
+import { act } from './createRenderer';
+
+export default async function flushMicrotasks() {
+  if (/jsdom/.test(window.navigator.userAgent)) {
+    // This is only needed for JSDOM and causes issues in real browsers
+    await act(() => async () => {});
+  }
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -15,6 +15,7 @@ export {
 export {} from './initMatchers';
 export * as fireDiscreteEvent from './fireDiscreteEvent';
 export * as userEvent from './userEvent';
+export { default as flushMicrotasks } from './flushMicrotasks';
 
 /**
  * Set to true if console logs during [lifecycles that are invoked twice in `React.StrictMode`](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects) are suppressed.


### PR DESCRIPTION
Replaced the Popper with Popup in the Menu implementation.

Similar to #40524, but with Menu.

# Breaking change

- The `slotProps.root` now accepts the `PopupProps` instead of the `PopperProps`

Preview: https://deploy-preview-40731--material-ui.netlify.app/base-ui/react-menu/

