### PR TITLE
[material-ui] Add missing dependencies in the Next.js package

### DIFF
--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -36,6 +36,9 @@
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-material-nextjs/**/*.test.{js,ts,tsx}'",
     "typescript": "tsc -p tsconfig.json"
   },
+  "dependencies": {
+    "@babel/runtime": "^7.23.8"
+  },
   "devDependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.3",
@@ -47,6 +50,7 @@
   "peerDependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/server": "^11.11.0",
+    "@emotion/react": "^11.11.0",
     "@mui/material": "^5.0.0",
     "@types/react": "^17.0.0 || ^18.0.0",
     "next": "^13.0.0 || ^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1705,6 +1705,9 @@ importers:
 
   packages/mui-material-nextjs:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.23.8
+        version: 7.23.8
       '@mui/material':
         specifier: ^5.0.0
         version: link:../mui-material/build


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

- @babel/runtime is missing, but seems to be required due to the build setup. This is adding it as a direct dependency similar to how its used in other packages
- @emotion/react is directly used by `appRouterV13.tsx`, but was not declared as peerDependency. This is adding that peer dependency. I'm not sure if it should also be marked optional here or not. The usage in the code did not seem to check for it being optional, but the same is true for `@emotion/cache`, which is currently marked optional. Please advise in this regard


