### PR TITLE
[base-ui][Button] Make demos more readable, modern, and robust

### DIFF
--- a/docs/data/base/components/button/UnstyledButtonIntroduction/css/index.js
+++ b/docs/data/base/components/button/UnstyledButtonIntroduction/css/index.js
@@ -1,19 +1,21 @@
 import * as React from 'react';
 import { Button } from '@mui/base/Button';
 import { useTheme } from '@mui/system';
-import Stack from '@mui/material/Stack';
 
 export default function UnstyledButtonsIntroduction() {
   return (
-    <React.Fragment>
-      <Stack spacing={2} direction="row">
-        <Button className="IntroductionButton">Button</Button>
-        <Button className="IntroductionButton" disabled>
-          Disabled
-        </Button>
-      </Stack>
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+      }}
+    >
+      <Button className="Button">Button</Button>
+      <Button className="Button" disabled>
+        Disabled
+      </Button>
       <Styles />
-    </React.Fragment>
+    </div>
   );
 }
 
@@ -54,42 +56,62 @@ function Styles() {
 
   return (
     <style>{`
-  .IntroductionButton {
-    font-family: 'IBM Plex Sans', sans-serif;
-    font-weight: 600;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    background-color: ${cyan[500]};
-    padding: 8px 16px;
-    border-radius: 8px;
-    color: white;
-    transition: all 150ms ease;
-    cursor: pointer;
-    border: 1px solid ${cyan[500]};
-    box-shadow: 0 2px 1px ${
-      isDarkMode ? 'rgba(0, 0, 0, 0.5)' : 'rgba(45, 45, 60, 0.2)'
+      .Button {
+        all: unset;
+        align-items: center;
+        background-clip: padding-box;
+        background-color: ${cyan[500]};
+        border-color: ${cyan[500]};
+        border-radius: .5rem;
+        border-style: solid;
+        border-width: .063rem;
+        box-shadow: 0 1px 2px ${
+          isDarkMode ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
+        }, 0 2px 3px ${
+      isDarkMode ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
     }, inset 0 1.5px 1px ${cyan[400]}, inset 0 -2px 1px ${cyan[600]};
-  }
-  .IntroductionButton:hover {
-    background-color: ${cyan[600]};
-  }
-  .IntroductionButton.base--active {
-    background-color: ${cyan[700]};
-    box-shadow: none;
-    transform: scale(0.99);
-  }
-  .IntroductionButton.base--focusVisible {
-    box-shadow: 0 0 0 4px ${isDarkMode ? cyan[300] : cyan[200]};
-    outline: none;
-  }
-  .IntroductionButton.base--disabled {
-    background-color: ${isDarkMode ? grey[700] : grey[200]};
-    color: ${isDarkMode ? grey[200] : grey[700]};
-    border: 0;
-    cursor: default;
-    box-shadow: none;
-    transform: scale(1);
-  }
+        box-sizing: border-box;
+        color: white;
+        display: inline-flex;
+        flex-shrink: 0;
+        font-family: 'IBM Plex Sans', sans-serif;
+        font-size: .875rem;
+        font-weight: 600;
+        height: 2.5rem;
+        justify-content: center;
+        line-height: 1;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        user-select: none;
+        vertical-align: middle;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        transition-duration: 150ms;
+        transition-property: background-color, box-shadow;
+        transition-timing-function: ease;
+      }
+      @media (any-hover: hover) {
+        .Button:hover {
+          background-color: ${cyan[600]};
+        }
+      }
+      .Button.base--active {
+        background-color: ${cyan[700]};
+        box-shadow: none;
+      }
+      .Button.base--focusVisible {
+        outline-width: 2px;
+        outline-style: solid;
+        outline-color: ${isDarkMode ? cyan[300] : cyan[200]};
+        outline-offset: 2px;
+      }
+      .Button.base--disabled {
+        background-color: ${isDarkMode ? grey[700] : grey[200]};
+        color: ${isDarkMode ? grey[200] : grey[700]};
+        border: none;
+        box-shadow: none;
+        cursor: not-allowed;
+      }
   `}</style>
   );
 }

--- a/docs/data/base/components/button/UnstyledButtonIntroduction/css/index.tsx
+++ b/docs/data/base/components/button/UnstyledButtonIntroduction/css/index.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
 import { Button } from '@mui/base/Button';
 import { useTheme } from '@mui/system';
-import Stack from '@mui/material/Stack';
 
 export default function UnstyledButtonsIntroduction() {
   return (
-    <React.Fragment>
-      <Stack spacing={2} direction="row">
-        <Button className="IntroductionButton">Button</Button>
-        <Button className="IntroductionButton" disabled>
-          Disabled
-        </Button>
-      </Stack>
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+      }}
+    >
+      <Button className="Button">Button</Button>
+      <Button className="Button" disabled>
+        Disabled
+      </Button>
       <Styles />
-    </React.Fragment>
+    </div>
   );
 }
 
@@ -54,42 +56,62 @@ function Styles() {
 
   return (
     <style>{`
-  .IntroductionButton {
-    font-family: 'IBM Plex Sans', sans-serif;
-    font-weight: 600;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    background-color: ${cyan[500]};
-    padding: 8px 16px;
-    border-radius: 8px;
-    color: white;
-    transition: all 150ms ease;
-    cursor: pointer;
-    border: 1px solid ${cyan[500]};
-    box-shadow: 0 2px 1px ${
-      isDarkMode ? 'rgba(0, 0, 0, 0.5)' : 'rgba(45, 45, 60, 0.2)'
+      .Button {
+        all: unset;
+        align-items: center;
+        background-clip: padding-box;
+        background-color: ${cyan[500]};
+        border-color: ${cyan[500]};
+        border-radius: .5rem;
+        border-style: solid;
+        border-width: .063rem;
+        box-shadow: 0 1px 2px ${
+          isDarkMode ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
+        }, 0 2px 3px ${
+      isDarkMode ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
     }, inset 0 1.5px 1px ${cyan[400]}, inset 0 -2px 1px ${cyan[600]};
-  }
-  .IntroductionButton:hover {
-    background-color: ${cyan[600]};
-  }
-  .IntroductionButton.base--active {
-    background-color: ${cyan[700]};
-    box-shadow: none;
-    transform: scale(0.99);
-  }
-  .IntroductionButton.base--focusVisible {
-    box-shadow: 0 0 0 4px ${isDarkMode ? cyan[300] : cyan[200]};
-    outline: none;
-  }
-  .IntroductionButton.base--disabled {
-    background-color: ${isDarkMode ? grey[700] : grey[200]};
-    color: ${isDarkMode ? grey[200] : grey[700]};
-    border: 0;
-    cursor: default;
-    box-shadow: none;
-    transform: scale(1);
-  }
+        box-sizing: border-box;
+        color: white;
+        display: inline-flex;
+        flex-shrink: 0;
+        font-family: 'IBM Plex Sans', sans-serif;
+        font-size: .875rem;
+        font-weight: 600;
+        height: 2.5rem;
+        justify-content: center;
+        line-height: 1;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        user-select: none;
+        vertical-align: middle;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        transition-duration: 150ms;
+        transition-property: background-color, box-shadow;
+        transition-timing-function: ease;
+      }
+      @media (any-hover: hover) {
+        .Button:hover {
+          background-color: ${cyan[600]};
+        }
+      }
+      .Button.base--active {
+        background-color: ${cyan[700]};
+        box-shadow: none;
+      }
+      .Button.base--focusVisible {
+        outline-width: 2px;
+        outline-style: solid;
+        outline-color: ${isDarkMode ? cyan[300] : cyan[200]};
+        outline-offset: 2px;
+      }
+      .Button.base--disabled {
+        background-color: ${isDarkMode ? grey[700] : grey[200]};
+        color: ${isDarkMode ? grey[200] : grey[700]};
+        border: none;
+        box-shadow: none;
+        cursor: not-allowed;
+      }
   `}</style>
   );
 }

--- a/docs/data/base/components/button/UnstyledButtonIntroduction/css/index.tsx
+++ b/docs/data/base/components/button/UnstyledButtonIntroduction/css/index.tsx
@@ -86,9 +86,11 @@ function Styles() {
         vertical-align: middle;
       }
       @media (prefers-reduced-motion: no-preference) {
-        transition-duration: 150ms;
-        transition-property: background-color, box-shadow;
-        transition-timing-function: ease;
+        .Button {
+          transition-duration: 150ms;
+          transition-property: background-color, box-shadow;
+          transition-timing-function: ease;
+        }
       }
       @media (any-hover: hover) {
         .Button:hover {
@@ -107,9 +109,9 @@ function Styles() {
       }
       .Button.base--disabled {
         background-color: ${isDarkMode ? grey[700] : grey[200]};
-        color: ${isDarkMode ? grey[200] : grey[700]};
         border: none;
         box-shadow: none;
+        color: ${isDarkMode ? grey[200] : grey[700]};
         cursor: not-allowed;
       }
   `}</style>

--- a/docs/data/base/components/button/UnstyledButtonIntroduction/system/index.js
+++ b/docs/data/base/components/button/UnstyledButtonIntroduction/system/index.js
@@ -1,14 +1,18 @@
 import * as React from 'react';
 import { Button as BaseButton, buttonClasses } from '@mui/base/Button';
 import { styled } from '@mui/system';
-import Stack from '@mui/material/Stack';
 
 export default function UnstyledButtonsIntroduction() {
   return (
-    <Stack spacing={2} direction="row">
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+      }}
+    >
       <Button>Button</Button>
       <Button disabled>Disabled</Button>
-    </Stack>
+    </div>
   );
 }
 
@@ -36,20 +40,36 @@ const grey = {
 
 const Button = styled(BaseButton)(
   ({ theme }) => `
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 600;
-  font-size: 0.875rem;
-  line-height: 1.5;
+  all: unset;
+  align-items: center;
+  background-clip: padding-box;
   background-color: ${blue[500]};
-  padding: 8px 16px;
-  border-radius: 8px;
-  color: white;
-  transition: all 150ms ease;
-  cursor: pointer;
-  border: 1px solid ${blue[500]};
-  box-shadow: 0 2px 1px ${
-    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(45, 45, 60, 0.2)'
+  border-color: ${blue[500]};
+  border-radius: .5rem;
+  border-style: solid;
+  border-width: .063rem;
+  box-shadow: 0 1px 2px ${
+    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
+  }, 0 2px 4px ${
+    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
   }, inset 0 1.5px 1px ${blue[400]}, inset 0 -2px 1px ${blue[600]};
+  box-sizing: border-box;
+  color: white;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: .875rem;
+  font-weight: 600;
+  height: 2.5rem;
+  justify-content: center;
+  line-height: 1;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  user-select: none;
+  vertical-align: middle;
+  transition-duration: 150ms;
+  transition-property: background-color, box-shadow;
+  transition-timing-function: ease;
 
   &:hover {
     background-color: ${blue[600]};
@@ -58,21 +78,21 @@ const Button = styled(BaseButton)(
   &.${buttonClasses.active} {
     background-color: ${blue[700]};
     box-shadow: none;
-    transform: scale(0.99);
   }
 
   &.${buttonClasses.focusVisible} {
-    box-shadow: 0 0 0 4px ${theme.palette.mode === 'dark' ? blue[300] : blue[200]};
-    outline: none;
+    outline-width: 2px;
+    outline-style: solid;
+    outline-color: ${theme.palette.mode === 'dark' ? blue[300] : blue[200]};
+    outline-offset: 2px;
   }
 
   &.${buttonClasses.disabled} {
     background-color: ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
-    color: ${theme.palette.mode === 'dark' ? grey[200] : grey[700]};
-    border: 0;
-    cursor: default;
+    border: none;
     box-shadow: none;
-    transform: scale(1);
+    color: ${theme.palette.mode === 'dark' ? grey[200] : grey[700]};
+    cursor: not-allowed;
   }
   `,
 );

--- a/docs/data/base/components/button/UnstyledButtonIntroduction/system/index.tsx
+++ b/docs/data/base/components/button/UnstyledButtonIntroduction/system/index.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
 import { Button as BaseButton, buttonClasses } from '@mui/base/Button';
 import { styled } from '@mui/system';
-import Stack from '@mui/material/Stack';
 
 export default function UnstyledButtonsIntroduction() {
   return (
-    <Stack spacing={2} direction="row">
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+      }}
+    >
       <Button>Button</Button>
       <Button disabled>Disabled</Button>
-    </Stack>
+    </div>
   );
 }
 
@@ -36,20 +40,36 @@ const grey = {
 
 const Button = styled(BaseButton)(
   ({ theme }) => `
-  font-family: 'IBM Plex Sans', sans-serif;
-  font-weight: 600;
-  font-size: 0.875rem;
-  line-height: 1.5;
+  all: unset;
+  align-items: center;
+  background-clip: padding-box;
   background-color: ${blue[500]};
-  padding: 8px 16px;
-  border-radius: 8px;
-  color: white;
-  transition: all 150ms ease;
-  cursor: pointer;
-  border: 1px solid ${blue[500]};
-  box-shadow: 0 2px 1px ${
-    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(45, 45, 60, 0.2)'
+  border-color: ${blue[500]};
+  border-radius: .5rem;
+  border-style: solid;
+  border-width: .063rem;
+  box-shadow: 0 1px 2px ${
+    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
+  }, 0 2px 4px ${
+    theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.15)' : 'rgba(60, 86, 118, 0.2)'
   }, inset 0 1.5px 1px ${blue[400]}, inset 0 -2px 1px ${blue[600]};
+  box-sizing: border-box;
+  color: white;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: .875rem;
+  font-weight: 600;
+  height: 2.5rem;
+  justify-content: center;
+  line-height: 1;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  user-select: none;
+  vertical-align: middle;
+  transition-duration: 150ms;
+  transition-property: background-color, box-shadow;
+  transition-timing-function: ease;
 
   &:hover {
     background-color: ${blue[600]};
@@ -58,21 +78,21 @@ const Button = styled(BaseButton)(
   &.${buttonClasses.active} {
     background-color: ${blue[700]};
     box-shadow: none;
-    transform: scale(0.99);
   }
 
   &.${buttonClasses.focusVisible} {
-    box-shadow: 0 0 0 4px ${theme.palette.mode === 'dark' ? blue[300] : blue[200]};
-    outline: none;
+    outline-width: 2px;
+    outline-style: solid;
+    outline-color: ${theme.palette.mode === 'dark' ? blue[300] : blue[200]};
+    outline-offset: 2px;
   }
 
   &.${buttonClasses.disabled} {
     background-color: ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
-    color: ${theme.palette.mode === 'dark' ? grey[200] : grey[700]};
-    border: 0;
-    cursor: default;
+    border: none;
     box-shadow: none;
-    transform: scale(1);
+    color: ${theme.palette.mode === 'dark' ? grey[200] : grey[700]};
+    cursor: not-allowed;
   }
   `,
 );

--- a/docs/data/base/components/button/UnstyledButtonIntroduction/tailwind/index.tsx
+++ b/docs/data/base/components/button/UnstyledButtonIntroduction/tailwind/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button as BaseButton, ButtonProps } from '@mui/base/Button';
-import Stack from '@mui/material/Stack';
 import clsx from 'clsx';
 import { useTheme } from '@mui/system';
 
@@ -15,10 +14,15 @@ export default function UnstyledButtonsIntroduction() {
 
   return (
     <div className={`${isDarkMode ? 'dark' : undefined}`}>
-      <Stack spacing={2} direction="row">
+      <div
+        style={{
+          display: 'flex',
+          gap: 16,
+        }}
+      >
         <CustomButton>Button</CustomButton>
         <CustomButton disabled>Disabled</CustomButton>
-      </Stack>
+      </div>
     </div>
   );
 }
@@ -30,7 +34,7 @@ const CustomButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <BaseButton
         ref={ref}
         className={clsx(
-          'cursor-pointer transition text-sm font-sans font-semibold leading-normal bg-violet-500 text-white rounded-lg px-4 py-2 border border-solid border-violet-500 shadow-[0_2px_1px_rgb(45_45_60_/_0.2),_inset_0_1.5px_1px_#a78bfa,_inset_0_-2px_1px_#7c3aed] dark:shadow-[0_2px_1px_rgb(0_0_0/_0.5),_inset_0_1.5px_1px_#a78bfa,_inset_0_-2px_1px_#7c3aed] hover:bg-violet-600 active:bg-violet-700 active:shadow-none active:scale-[0.99] focus-visible:shadow-[0_0_0_4px_#ddd6fe] dark:focus-visible:shadow-[0_0_0_4px_#a78bfa] focus-visible:outline-none ui-disabled:text-slate-700 ui-disabled:dark:text-slate-200 ui-disabled:bg-slate-200 ui-disabled:dark:bg-slate-700 ui-disabled:cursor-default ui-disabled:shadow-none ui-disabled:dark:shadow-none ui-disabled:hover:bg-slate-200 ui-disabled:hover:dark:bg-slate-700 ui-disabled:border-none',
+          'transition text-sm font-sans font-semibold leading-none h-10 shrink-0 select-none align-middle inline-flex items-center justify-center bg-clip-padding box-border bg-violet-500 text-white rounded-lg px-4 border border-solid border-violet-500 shadow-[0_1px_2px_rgb(60_86_118_/_0.2),0_2px_4px_rgb(60_86_118_/_0.2),_inset_0_1.5px_1px_#a78bfa,_inset_0_-2px_1px_#7c3aed] dark:shadow-[0_1px_2px_rgb(0_0_0/_0.15),0_2px_4px_rgb(0_0_0/_0.15),_inset_0_1.5px_1px_#a78bfa,_inset_0_-2px_1px_#7c3aed] hover:bg-violet-600 active:bg-violet-700 active:shadow-none focus-visible:shadow-[0_0_0_4px_#ddd6fe] dark:focus-visible:shadow-[0_0_0_4px_#a78bfa] focus-visible:outline-none ui-disabled:text-slate-700 ui-disabled:dark:text-slate-200 ui-disabled:bg-slate-200 ui-disabled:dark:bg-slate-700 ui-disabled:cursor-default ui-disabled:shadow-none ui-disabled:dark:shadow-none ui-disabled:hover:bg-slate-200 ui-disabled:hover:dark:bg-slate-700 ui-disabled:border-none',
           className,
         )}
         {...other}


### PR DESCRIPTION
[WIP]

Will fix mui/base-ui#78 

- Rename the root class to “Button”, so it’s more copy/pasteable for the target audience.
- Replace MUI Stack with a simple div, and remove the import.
- Apply `cursor: not-allowed` to disabled controls.
- Apply more modern, robust, and functional CSS (reset, flex, box-sizing, vertical-align, flex-shrink, user-select etc.)
- Remove `cursor: pointer` (that value is intended to indicate a link)
- Convert longhand CSS properties to shorthand for improved editing and readability.
- Convert all `px` values to `rem`.
- Remove unnecessary `0` from decimal values.
- Remove `transform: scale` effect (browsers rasterise text before scaling it, so it looks weird/blurry).
- Alphabetise CSS declarations.
- Set component size based on an 8px baseline for to enable and centering, and for consistency across all UI controls.
- Replace `transition-property: all` with explicit declarations for improved performance and manipulation.
- Remove `<React.Fragment />`.
- Use outline for focus styles to enable offset focus rings, and clean up the box-shadow values.
- Improve shadow rendering by declaring multiple blended values, increasing saturation, and setting `background-clip: padding-box`, so shadows can bleed through borders.
- Wrap hover styles in a media query.
- Wrap transitions in a media query.

Currently looking for feedback on these changes before I copy the changes to all button demos.

https://deploy-preview-40742--material-ui.netlify.app/base-ui/react-button/#introduction