### PR TITLE
[website] Fix Toggle Button styles in the homepage demos

### DIFF
--- a/docs/src/components/showcase/ThemeToggleButton.tsx
+++ b/docs/src/components/showcase/ThemeToggleButton.tsx
@@ -22,7 +22,6 @@ export default function ThemeToggleButton() {
               textTransform: 'none',
               fontWeight: 600,
               color: 'grey.700',
-              borderColor: 'grey.200',
               '&.Mui-selected': {
                 color: 'primary.600',
                 bgcolor: 'primary.100',
@@ -34,7 +33,6 @@ export default function ThemeToggleButton() {
               bgcolor: 'primaryDark.900',
               '& .MuiToggleButton-root': {
                 color: 'grey.400',
-                borderColor: 'primaryDark.700',
                 '&.Mui-selected': {
                   color: 'primary.100',
                   bgcolor: 'primary.900',

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -1153,7 +1153,6 @@ export function getThemedComponents(): ThemeOptions {
               fontWeight: 500,
               color: theme.palette.grey[700],
               borderColor: theme.palette.grey[200],
-              zIndex: 1,
               ...(ownerState.size === 'small' && {
                 padding: '0.375rem 0.75rem',
               }),
@@ -1161,7 +1160,6 @@ export function getThemedComponents(): ThemeOptions {
                 color: (theme.vars || theme).palette.primary[500],
                 borderColor: `${(theme.vars || theme).palette.primary[500]} !important`,
                 backgroundColor: (theme.vars || theme).palette.primary[50],
-                zIndex: 2,
                 '&:hover': {
                   backgroundColor: (theme.vars || theme).palette.primary[100],
                 },

--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -1153,6 +1153,7 @@ export function getThemedComponents(): ThemeOptions {
               fontWeight: 500,
               color: theme.palette.grey[700],
               borderColor: theme.palette.grey[200],
+              zIndex: 1,
               ...(ownerState.size === 'small' && {
                 padding: '0.375rem 0.75rem',
               }),
@@ -1160,6 +1161,7 @@ export function getThemedComponents(): ThemeOptions {
                 color: (theme.vars || theme).palette.primary[500],
                 borderColor: `${(theme.vars || theme).palette.primary[500]} !important`,
                 backgroundColor: (theme.vars || theme).palette.primary[50],
+                zIndex: 2,
                 '&:hover': {
                   backgroundColor: (theme.vars || theme).palette.primary[100],
                 },


### PR DESCRIPTION
This PR fixes the MuiToggleButton for selected button right border overlap issue by adding z-index property as higher layer for "Mui-selected" class and "MuiToggleButton" class lower z-index. 

Closes https://github.com/mui/material-ui/issues/40727

| Before | After |
|--------|--------|
| ![Screenshot from 2024-01-23 03-27-36](https://github.com/mui/material-ui/assets/27009987/bc4a12e8-4312-45b9-979a-6df0652156aa) | ![Screenshot from 2024-01-23 03-28-11](https://github.com/mui/material-ui/assets/27009987/4f4fab56-9231-4dc7-9456-e1e82557d95b) | 




 
