### PR TITLE
[website] Fix pricing license model toggle style

### DIFF
--- a/docs/src/components/pricing/LicensingModelSwitch.tsx
+++ b/docs/src/components/pricing/LicensingModelSwitch.tsx
@@ -34,12 +34,16 @@ const StyledTabs = styled(Tabs)(({ theme }) => ({
     minHeight: 0,
     color: (theme.vars || theme).palette.grey[600],
     borderRadius: 20,
+    zIndex: 2,
     '&:hover': {
       color: (theme.vars || theme).palette.grey[800],
     },
     '&.Mui-selected': {
       color: (theme.vars || theme).palette.primary[500],
       fontWeight: theme.typography.fontWeightSemiBold,
+    },
+    '&.Mui-focusVisible': {
+      outline: 'none',
     },
   },
   '& .MuiTabs-indicator': {


### PR DESCRIPTION
Fix a quick regression, from #40623 (I noticed this by chance)

Before

https://github.com/mui/material-ui/assets/3165635/a1044845-4354-4f40-9d03-8079659d696f

After

https://github.com/mui/material-ui/assets/3165635/bf91b239-3830-43ab-885b-0ce60de3761a
