### PR TITLE
[docs-infra] Avoid layout shift on docs-pages

### DIFF
--- a/docs/src/modules/brandingTheme.ts
+++ b/docs/src/modules/brandingTheme.ts
@@ -1273,6 +1273,14 @@ export function getThemedComponents(): ThemeOptions {
         defaultProps: {
           enableColorScheme: true,
         },
+        styleOverrides: {
+          html: {
+            overflowY: 'scroll',
+            // TODO add support for it,
+            // https://github.com/mui/material-ui/issues/40748
+            // scrollbarGutter: 'stable',
+          },
+        },
       },
     },
   };


### PR DESCRIPTION
Before, layout shift on page transiton

https://github.com/mui/material-ui/assets/3165635/3d78788d-c0ea-426f-8909-7ec49f247e09


After, stable layout


https://github.com/mui/material-ui/assets/3165635/bb5cb412-d95a-4972-a0dc-1b58dcb06633


I opened https://github.com/mui/material-ui/issues/40748 for what a better solution for this would be (it's annoying to see  the scrollbar). This PR relies on a fix I introduced while back to support https://github.com/mui/material-ui/issues/17812#issuecomment-540164415