### PR TITLE
[typescript-to-proptypes] Allow to represent dates as `PropTypes.object`

### DIFF
--- a/packages/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -114,7 +114,9 @@ function checkType({
         return createInstanceOfType({ jsDoc, instance: 'RegExp' });
       }
       case 'Date': {
-        return createInstanceOfType({ jsDoc, instance: 'Date' });
+        if (!project.shouldUseObjectForDate?.({ name })) {
+          return createInstanceOfType({ jsDoc, instance: 'Date' });
+        }
       }
       default:
         // continue with function execution
@@ -462,6 +464,7 @@ export function getPropTypesFromFile({
   project,
   shouldInclude: inShouldInclude,
   shouldResolveObject: inShouldResolveObject,
+  shouldUseObjectForDate,
   checkDeclarations,
 }: GetPropTypesFromFileOptions) {
   const sourceFile = project.program.getSourceFile(filePath);
@@ -513,6 +516,7 @@ export function getPropTypesFromFile({
     ...project,
     reactComponentName,
     shouldResolveObject,
+    shouldUseObjectForDate,
     shouldInclude,
     createPropTypeId,
   };
@@ -553,11 +557,18 @@ export interface GetPropTypesFromFileOptions
     propertyCount: number;
     depth: number;
   }) => boolean | undefined;
+  /**
+   * Called to know if a date should be represented as `PropTypes.object` or `PropTypes.instanceOf(Date)
+   * @returns true to use `PropTypes.object`, false to use `PropTypes.instanceOf(Date)`.
+   * @default false
+   */
+  shouldUseObjectForDate?: (data: { name: string }) => boolean;
 }
 
 interface PropTypesProject extends TypeScriptProject {
   reactComponentName: string | undefined;
   shouldResolveObject: NonNullable<GetPropTypesFromFileOptions['shouldResolveObject']>;
+  shouldUseObjectForDate: GetPropTypesFromFileOptions['shouldUseObjectForDate'];
   shouldInclude: NonNullable<GetPropTypesFromFileOptions['shouldInclude']>;
   createPropTypeId: (sigil: ts.Symbol | ts.Type) => number;
 }

--- a/packages/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -117,6 +117,7 @@ function checkType({
         if (!project.shouldUseObjectForDate?.({ name })) {
           return createInstanceOfType({ jsDoc, instance: 'Date' });
         }
+        break;
       }
       default:
         // continue with function execution

--- a/packages/typescript-to-proptypes/src/getPropTypesFromFile.ts
+++ b/packages/typescript-to-proptypes/src/getPropTypesFromFile.ts
@@ -117,7 +117,8 @@ function checkType({
         if (!project.shouldUseObjectForDate?.({ name })) {
           return createInstanceOfType({ jsDoc, instance: 'Date' });
         }
-        break;
+
+        return createObjectType({ jsDoc });
       }
       default:
         // continue with function execution


### PR DESCRIPTION
Needed for https://github.com/mui/mui-x/pull/11791

To give some context, on the pickers we are supporting several date libraries (dayjs, moment, date-fns and Luxon)
Date-fns is using JavaScript dates for its values and the other are using custom objects
In https://github.com/mui/mui-x/pull/11791, I'm improving the typing so that when you import an adapter (the utility that unifies all the date library APIs), you also say to the components that the props can receive a value in the date format of your date libraries.
But we have one issue, the proptypes generated are not `PropTypes.oneOfType([PropTypes.object, PropTypes.instanceOf(Date)])` due to date-fns. And this is super misleading for people using another date library.

To solve this, I added a new option to the prop-types generation to allow to represent dates as object.

If you have a better idea I'm interested