### PR TITLE
[code-infra] Correct API Docs Builder dependencies

### DIFF
--- a/packages/api-docs-builder-core/package.json
+++ b/packages/api-docs-builder-core/package.json
@@ -9,9 +9,9 @@
     "typescript": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@mui-internal/api-docs-builder": "^1.0.0",
-    "@mui/markdown": "^5.0.0",
-    "docs": "^5.0.0",
+    "@mui-internal/api-docs-builder": "workspace:^",
+    "@mui/markdown": "workspace:^",
+    "docs": "workspace:^",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/api-docs-builder/package.json
+++ b/packages/api-docs-builder/package.json
@@ -22,6 +22,7 @@
     "react-docgen": "^5.4.3",
     "recast": "^0.23.4",
     "remark": "^13.0.0",
+    "typescript": "^5.3.3",
     "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {
@@ -35,7 +36,6 @@
     "@types/react-docgen": "workspace:*",
     "@types/sinon": "^10.0.20",
     "chai": "^4.4.1",
-    "sinon": "^15.2.0",
-    "typescript": "^5.3.3"
+    "sinon": "^15.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,6 +953,9 @@ importers:
       remark:
         specifier: ^13.0.0
         version: 13.0.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
       unist-util-visit:
         specifier: ^2.0.3
         version: 2.0.3
@@ -990,20 +993,17 @@ importers:
       sinon:
         specifier: ^15.2.0
         version: 15.2.0
-      typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
 
   packages/api-docs-builder-core:
     dependencies:
       '@mui-internal/api-docs-builder':
-        specifier: ^1.0.0
+        specifier: workspace:^
         version: link:../api-docs-builder
       '@mui/markdown':
-        specifier: ^5.0.0
+        specifier: workspace:^
         version: link:../markdown
       docs:
-        specifier: ^5.0.0
+        specifier: workspace:^
         version: link:../../docs
       lodash:
         specifier: ^4.17.21


### PR DESCRIPTION
Internal dependencies of API docs builder's Core config were incorrectly not specified using the workspace protocol.
Also, `typescript` was incorrectly defined as a devDependency of @mui-internal/api-docs-builder but it's used at runtime.

This PR fixes both of these issues.