### PR TITLE
[material-ui][Divider] Remove light prop references from docs

### DIFF
--- a/docs/data/material/components/dividers/IntroDivider.js
+++ b/docs/data/material/components/dividers/IntroDivider.js
@@ -5,7 +5,6 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { grey } from '@mui/material/colors';
 
 export default function IntroDivider() {
   return (
@@ -24,7 +23,7 @@ export default function IntroDivider() {
           just down the hall.
         </Typography>
       </Box>
-      <Divider sx={{ bgcolor: grey[50] }} />
+      <Divider />
       <Box sx={{ p: 2 }}>
         <Typography gutterBottom variant="body2">
           Select type

--- a/docs/data/material/components/dividers/IntroDivider.js
+++ b/docs/data/material/components/dividers/IntroDivider.js
@@ -24,7 +24,7 @@ export default function IntroDivider() {
           just down the hall.
         </Typography>
       </Box>
-      <Divider sx={{ bgcolor: grey[100] }} />
+      <Divider sx={{ bgcolor: grey[50] }} />
       <Box sx={{ p: 2 }}>
         <Typography gutterBottom variant="body2">
           Select type

--- a/docs/data/material/components/dividers/IntroDivider.js
+++ b/docs/data/material/components/dividers/IntroDivider.js
@@ -5,6 +5,7 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
+import { grey } from '@mui/material/colors';
 
 export default function IntroDivider() {
   return (
@@ -23,7 +24,7 @@ export default function IntroDivider() {
           just down the hall.
         </Typography>
       </Box>
-      <Divider light />
+      <Divider sx={{ bgcolor: grey[100] }} />
       <Box sx={{ p: 2 }}>
         <Typography gutterBottom variant="body2">
           Select type

--- a/docs/data/material/components/dividers/IntroDivider.tsx
+++ b/docs/data/material/components/dividers/IntroDivider.tsx
@@ -5,7 +5,6 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import { grey } from '@mui/material/colors';
 
 export default function IntroDivider() {
   return (
@@ -24,7 +23,7 @@ export default function IntroDivider() {
           just down the hall.
         </Typography>
       </Box>
-      <Divider sx={{ bgcolor: grey[50] }} />
+      <Divider />
       <Box sx={{ p: 2 }}>
         <Typography gutterBottom variant="body2">
           Select type

--- a/docs/data/material/components/dividers/IntroDivider.tsx
+++ b/docs/data/material/components/dividers/IntroDivider.tsx
@@ -24,7 +24,7 @@ export default function IntroDivider() {
           just down the hall.
         </Typography>
       </Box>
-      <Divider sx={{ bgcolor: grey[100] }} />
+      <Divider sx={{ bgcolor: grey[50] }} />
       <Box sx={{ p: 2 }}>
         <Typography gutterBottom variant="body2">
           Select type

--- a/docs/data/material/components/dividers/IntroDivider.tsx
+++ b/docs/data/material/components/dividers/IntroDivider.tsx
@@ -5,6 +5,7 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
+import { grey } from '@mui/material/colors';
 
 export default function IntroDivider() {
   return (
@@ -23,7 +24,7 @@ export default function IntroDivider() {
           just down the hall.
         </Typography>
       </Box>
-      <Divider light />
+      <Divider sx={{ bgcolor: grey[100] }} />
       <Box sx={{ p: 2 }}>
         <Typography gutterBottom variant="body2">
           Select type

--- a/docs/data/material/components/dividers/ListDividers.js
+++ b/docs/data/material/components/dividers/ListDividers.js
@@ -3,7 +3,6 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
-import { grey } from '@mui/material/colors';
 
 const style = {
   p: 0,
@@ -21,15 +20,15 @@ export default function ListDividers() {
       <ListItem>
         <ListItemText primary="Inbox" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[50] }} />
+      <Divider component="li" />
       <ListItem>
         <ListItemText primary="Drafts" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[50] }} />
+      <Divider component="li" />
       <ListItem>
         <ListItemText primary="Trash" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[50] }} />
+      <Divider component="li" />
       <ListItem>
         <ListItemText primary="Spam" />
       </ListItem>

--- a/docs/data/material/components/dividers/ListDividers.js
+++ b/docs/data/material/components/dividers/ListDividers.js
@@ -21,15 +21,15 @@ export default function ListDividers() {
       <ListItem>
         <ListItemText primary="Inbox" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[100] }} />
+      <Divider component="li" sx={{ bgcolor: grey[50] }} />
       <ListItem>
         <ListItemText primary="Drafts" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[100] }} />
+      <Divider component="li" sx={{ bgcolor: grey[50] }} />
       <ListItem>
         <ListItemText primary="Trash" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[100] }} />
+      <Divider component="li" sx={{ bgcolor: grey[50] }} />
       <ListItem>
         <ListItemText primary="Spam" />
       </ListItem>

--- a/docs/data/material/components/dividers/ListDividers.js
+++ b/docs/data/material/components/dividers/ListDividers.js
@@ -3,6 +3,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
+import { grey } from '@mui/material/colors';
 
 const style = {
   p: 0,
@@ -20,15 +21,15 @@ export default function ListDividers() {
       <ListItem>
         <ListItemText primary="Inbox" />
       </ListItem>
-      <Divider component="li" light />
+      <Divider component="li" sx={{ bgcolor: grey[100] }} />
       <ListItem>
         <ListItemText primary="Drafts" />
       </ListItem>
-      <Divider component="li" light />
+      <Divider component="li" sx={{ bgcolor: grey[100] }} />
       <ListItem>
         <ListItemText primary="Trash" />
       </ListItem>
-      <Divider component="li" light />
+      <Divider component="li" sx={{ bgcolor: grey[100] }} />
       <ListItem>
         <ListItemText primary="Spam" />
       </ListItem>

--- a/docs/data/material/components/dividers/ListDividers.tsx
+++ b/docs/data/material/components/dividers/ListDividers.tsx
@@ -3,7 +3,6 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
-import { grey } from '@mui/material/colors';
 
 const style = {
   p: 0,
@@ -21,15 +20,15 @@ export default function ListDividers() {
       <ListItem>
         <ListItemText primary="Inbox" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[50] }} />
+      <Divider component="li" />
       <ListItem>
         <ListItemText primary="Drafts" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[50] }} />
+      <Divider component="li" />
       <ListItem>
         <ListItemText primary="Trash" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[50] }} />
+      <Divider component="li" />
       <ListItem>
         <ListItemText primary="Spam" />
       </ListItem>

--- a/docs/data/material/components/dividers/ListDividers.tsx
+++ b/docs/data/material/components/dividers/ListDividers.tsx
@@ -21,15 +21,15 @@ export default function ListDividers() {
       <ListItem>
         <ListItemText primary="Inbox" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[100] }} />
+      <Divider component="li" sx={{ bgcolor: grey[50] }} />
       <ListItem>
         <ListItemText primary="Drafts" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[100] }} />
+      <Divider component="li" sx={{ bgcolor: grey[50] }} />
       <ListItem>
         <ListItemText primary="Trash" />
       </ListItem>
-      <Divider component="li" sx={{ bgcolor: grey[100] }} />
+      <Divider component="li" sx={{ bgcolor: grey[50] }} />
       <ListItem>
         <ListItemText primary="Spam" />
       </ListItem>

--- a/docs/data/material/components/dividers/ListDividers.tsx
+++ b/docs/data/material/components/dividers/ListDividers.tsx
@@ -3,6 +3,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
+import { grey } from '@mui/material/colors';
 
 const style = {
   p: 0,
@@ -20,15 +21,15 @@ export default function ListDividers() {
       <ListItem>
         <ListItemText primary="Inbox" />
       </ListItem>
-      <Divider component="li" light />
+      <Divider component="li" sx={{ bgcolor: grey[100] }} />
       <ListItem>
         <ListItemText primary="Drafts" />
       </ListItem>
-      <Divider component="li" light />
+      <Divider component="li" sx={{ bgcolor: grey[100] }} />
       <ListItem>
         <ListItemText primary="Trash" />
       </ListItem>
-      <Divider component="li" light />
+      <Divider component="li" sx={{ bgcolor: grey[100] }} />
       <ListItem>
         <ListItemText primary="Spam" />
       </ListItem>

--- a/docs/data/material/components/dividers/dividers.md
+++ b/docs/data/material/components/dividers/dividers.md
@@ -18,10 +18,6 @@ The Material UI Divider component renders as a dark gray `<hr>` by default, and 
 
 {{"demo": "IntroDivider.js", "bg": true}}
 
-:::success
-Use the handy `light` prop to make the Divider slightly lighter.
-:::
-
 ## Basics
 
 ```jsx


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

part of https://github.com/mui/material-ui/issues/40417 (Missed this handling in https://github.com/mui/material-ui/pull/40563)

address: https://mui-org.slack.com/archives/C041SDSF32L/p1706187993110469 (Also good to know people are noticing deprecations)

**i guess argos failing is expected since <Divider light/ is exactly not equivalent to <Divider sx={{bgcolor: grey[50]}}**

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
