### PR TITLE
[utils] Remove unnecessary default export

### DIFF
--- a/packages/mui-utils/src/scrollLeft/index.ts
+++ b/packages/mui-utils/src/scrollLeft/index.ts
@@ -1,2 +1,1 @@
-export { default } from './scrollLeft';
 export * from './scrollLeft';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Got this warning when building zero demo next-app

```
../../packages/mui-utils/build/esm/scrollLeft/index.js
export 'default' (reexported as 'default') was not found in './scrollLeft' (possible exports: detectScrollType, getNormalizedScrollLeft)
```

It turns out that the `scrollLeft.ts` does not have default export but the index file try to do it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
