### PR TITLE
[website] Fix missing key on the Testimonials section

### DIFF
--- a/docs/src/components/home/UserFeedbacks.tsx
+++ b/docs/src/components/home/UserFeedbacks.tsx
@@ -179,8 +179,8 @@ export default function UserFeedbacks() {
     >
       <MuiStatistics />
       {TESTIMONIALS.map((item) => (
-        <Grid xs={12} sm={6}>
-          <Feedback key={item.profile.name} {...item} />
+        <Grid key={item.profile.name} xs={12} sm={6}>
+          <Feedback {...item} />
         </Grid>
       ))}
     </Grid>


### PR DESCRIPTION
Fixing

```
Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
    at renderElement (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5952:5)
    at UserFeedbacks
    at LoadableComponent (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/next@13.4.19_@babel+core@7.23.7_babel-plugin-macros@3.1.0_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/shared/lib/loadable.js:111:9)
    at div
    at /Users/janpotoms/Projects/material-ui/node_modules/.pnpm/@emotion+react@11.11.3_@types+react@18.2.48_react@18.2.0/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at Container (webpack-internal:///../packages/mui-system/src/Container/createContainer.tsx:130:19)
    at div
    at /Users/janpotoms/Projects/material-ui/node_modules/.pnpm/@emotion+react@11.11.3_@types+react@18.2.48_react@18.2.0/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at Box (webpack-internal:///../packages/mui-system/src/createBox.js:46:72)
    at Section (webpack-internal:///./src/layouts/Section.tsx:117:5)
    at div
    at /Users/janpotoms/Projects/material-ui/node_modules/.pnpm/@emotion+react@11.11.3_@types+react@18.2.48_react@18.2.0/node_modules/@emotion/react/dist/emotion-element-48d2c2e4.cjs.dev.js:70:25
    at Box (webpack-internal:///../packages/mui-system/src/createBox.js:46:72)
    at Testimonials
    at main
    at ThemeProvider (webpack-internal:///../packages/mui-private-theming/src/ThemeProvider/ThemeProvider.js:56:5)
    at ThemeProvider (webpack-internal:///../packages/mui-system/src/ThemeProvider/ThemeProvider.js:68:5)
    at CssVarsProvider (webpack-internal:///../packages/mui-system/src/cssVars/createCssVarsProvider.js:80:5)
    at BrandingCssVarsProvider (webpack-internal:///./src/BrandingCssVarsProvider.tsx:143:5)
    at Home
    at Be (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/styled-components@6.1.8_react-dom@18.2.0_react@18.2.0/node_modules/styled-components/dist/styled-components.cjs.js:1:16490)
    at StyledEngineProvider (webpack-internal:///./src/modules/utils/StyledEngineProvider.js:40:5)
    at ThemeProvider (webpack-internal:///../packages/mui-private-theming/src/ThemeProvider/ThemeProvider.js:56:5)
    at ThemeProvider (webpack-internal:///../packages/mui-system/src/ThemeProvider/ThemeProvider.js:68:5)
    at ThemeProvider (webpack-internal:///../packages/mui-material/src/styles/ThemeProvider.js:35:12)
    at ThemeProvider (webpack-internal:///./src/modules/components/ThemeContext.js:170:5)
    at CodeVariantProvider (webpack-internal:///./src/modules/utils/codeVariant.js:42:5)
    at CodeStylingProvider (webpack-internal:///./src/modules/utils/codeStylingSolution.js:42:5)
    at CodeCopyProvider (webpack-internal:///./src/modules/utils/CodeCopy.tsx:172:3)
    at UserLanguageProvider (webpack-internal:///./src/modules/utils/i18n.js:56:5)
    at AppWrapper (webpack-internal:///./pages/_app.js:199:5)
    at MyApp (webpack-internal:///./pages/_app.js:451:5)
    at EnhanceApp
    at Be (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/styled-components@6.1.8_react-dom@18.2.0_react@18.2.0/node_modules/styled-components/dist/styled-components.cjs.js:1:16490)
    at StylesProvider (webpack-internal:///../packages/mui-styles/src/StylesProvider/StylesProvider.js:65:5)
    at StyleRegistry (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/styled-jsx@5.1.1_@babel+core@7.23.7_babel-plugin-macros@3.1.0_react@18.2.0/node_modules/styled-jsx/dist/index/index.js:449:36)
    at PathnameContextProviderAdapter (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/next@13.4.19_@babel+core@7.23.7_babel-plugin-macros@3.1.0_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/shared/lib/router/adapters.js:84:11)
    at AppContainer (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/next@13.4.19_@babel+core@7.23.7_babel-plugin-macros@3.1.0_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/render.js:323:29)
    at AppContainerWithIsomorphicFiberStructure (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/next@13.4.19_@babel+core@7.23.7_babel-plugin-macros@3.1.0_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/render.js:359:57)
    at div
    at Body (/Users/janpotoms/Projects/material-ui/node_modules/.pnpm/next@13.4.19_@babel+core@7.23.7_babel-plugin-macros@3.1.0_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/render.js:659:21)
```