### PR TITLE
[code-infra] Demonstrate moving docs pages to typescript

### DIFF
--- a/docs/modules.d.ts
+++ b/docs/modules.d.ts
@@ -1,0 +1,13 @@
+declare module '*?raw' {
+  const raw: string;
+  export default raw;
+}
+
+declare module '*?@mui/markdown' {
+  import { Docs, Demos, DemoComponents, SrcComponents } from '@mui/markdown';
+
+  export const docs: Docs;
+  export const demos: Demos;
+  export const demoComponents: DemoComponents;
+  export const srcComponents: SrcComponents;
+}

--- a/docs/pages/material-ui/react-button.tsx
+++ b/docs/pages/material-ui/react-button.tsx
@@ -7,6 +7,6 @@ export default function Page() {
   return <MarkdownDocs {...pageProps} />;
 }
 
-Page.getLayout = (page) => {
+Page.getLayout = (page: React.ReactNode) => {
   return <AppFrame>{page}</AppFrame>;
 };

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -158,6 +158,7 @@ const StyledAppNavDrawer = styled(AppNavDrawer)(({ disablePermanent, theme }) =>
 
 export const HEIGHT = 64;
 
+/** @type {React.FC} */
 export default function AppFrame(props) {
   const { children, disableDrawer = false, className, BannerComponent = AppFrameBanner } = props;
   const t = useTranslate();

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["next-env.d.ts", "types", "src", "pages", "data", "next.config.js"],
+  "include": ["next-env.d.ts", "types", "src", "pages", "data", "next.config.js", "modules.d.ts"],
   "compilerOptions": {
     "allowJs": true,
     "isolatedModules": true,

--- a/packages/markdown/index.d.ts
+++ b/packages/markdown/index.d.ts
@@ -17,3 +17,38 @@ export function getHeaders(markdown: string): Record<string, string | string[]>;
 export function getTitle(markdown: string): string;
 
 export function renderMarkdown(markdown: string): string;
+
+export interface Doc {
+  rendered: Array<string | { component: string } | { demo: string }>;
+}
+
+export type Docs = Record<string, Doc>;
+
+export interface Demo {
+  module: string;
+  raw: string;
+  moduleTailwind?: string;
+  rawTailwind?: string;
+  moduleTSTailwind?: string;
+  rawTailwindTS?: string;
+  moduleCSS?: string;
+  rawCSS?: string;
+  moduleTSCSS?: string;
+  rawCSSTS?: string;
+  tailwindJsxPreview?: string;
+  cssJsxPreview?: string;
+  jsxPreview?: string;
+}
+
+export type Demos = Record<string, Demo>;
+
+export type DemoComponents = Record<string, string>;
+
+export type SrcComponents = Record<string, string>;
+
+export interface MarkDownProps {
+  docs: Docs;
+  demos: Demos;
+  demoComponents: DemoComponents;
+  srcComponents: SrcComponents;
+}


### PR DESCRIPTION
In an effort to create type safety between the markdown loader output and the docs internal components


=> https://deploy-preview-40794--material-ui.netlify.app/material-ui/react-button/

Converted only one page as a proof of concept.