### PR TITLE
[docs-infra] Improve StackBlitz support

### DIFF
--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -549,20 +549,6 @@ export default function DemoToolbar(props) {
           </Button>
           {demoOptions.hideEditButton ? null : (
             <React.Fragment>
-              <DemoTooltip title={t('codesandbox')} placement="bottom">
-                <IconButton
-                  data-ga-event-category="demo"
-                  data-ga-event-label={demo.gaLabel}
-                  data-ga-event-action="codesandbox"
-                  onClick={() => codeSandbox.createReactApp(demoData).openSandbox()}
-                  {...getControlProps(4)}
-                  sx={{ borderRadius: 1 }}
-                >
-                  <SvgIcon viewBox="0 0 1024 1024">
-                    <path d="M755 140.3l0.5-0.3h0.3L512 0 268.3 140h-0.3l0.8 0.4L68.6 256v512L512 1024l443.4-256V256L755 140.3z m-30 506.4v171.2L548 920.1V534.7L883.4 341v215.7l-158.4 90z m-584.4-90.6V340.8L476 534.4v385.7L300 818.5V646.7l-159.4-90.6zM511.7 280l171.1-98.3 166.3 96-336.9 194.5-337-194.6 165.7-95.7L511.7 280z" />
-                  </SvgIcon>
-                </IconButton>
-              </DemoTooltip>
               <DemoTooltip title={t('stackblitz')} placement="bottom">
                 <IconButton
                   data-ga-event-category="demo"
@@ -574,6 +560,20 @@ export default function DemoToolbar(props) {
                 >
                   <SvgIcon viewBox="0 0 19 28">
                     <path d="M8.13378 16.1087H0L14.8696 0L10.8662 11.1522L19 11.1522L4.13043 27.2609L8.13378 16.1087Z" />
+                  </SvgIcon>
+                </IconButton>
+              </DemoTooltip>
+              <DemoTooltip title={t('codesandbox')} placement="bottom">
+                <IconButton
+                  data-ga-event-category="demo"
+                  data-ga-event-label={demo.gaLabel}
+                  data-ga-event-action="codesandbox"
+                  onClick={() => codeSandbox.createReactApp(demoData).openSandbox()}
+                  {...getControlProps(4)}
+                  sx={{ borderRadius: 1 }}
+                >
+                  <SvgIcon viewBox="0 0 1024 1024">
+                    <path d="M755 140.3l0.5-0.3h0.3L512 0 268.3 140h-0.3l0.8 0.4L68.6 256v512L512 1024l443.4-256V256L755 140.3z m-30 506.4v171.2L548 920.1V534.7L883.4 341v215.7l-158.4 90z m-584.4-90.6V340.8L476 534.4v385.7L300 818.5V646.7l-159.4-90.6zM511.7 280l171.1-98.3 166.3 96-336.9 194.5-337-194.6 165.7-95.7L511.7 280z" />
                   </SvgIcon>
                 </IconButton>
               </DemoTooltip>

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -33,7 +33,7 @@ function openSandbox({ files, codeVariant, initialFile }: any) {
   document.body.removeChild(form);
 }
 
-const createReactApp = (demoData: DemoData) => {
+function createReactApp(demoData: DemoData) {
   const ext = getFileExtension(demoData.codeVariant);
   const { title, githubLocation: description } = demoData;
 
@@ -86,15 +86,15 @@ const createReactApp = (demoData: DemoData) => {
     openSandbox: (initialFile: string = `/src/Demo.${ext}`) =>
       openSandbox({ files, codeVariant: demoData.codeVariant, initialFile }),
   };
-};
+}
 
-const createJoyTemplate = (templateData: {
+function createJoyTemplate(templateData: {
   title: string;
   files: Record<string, string>;
   githubLocation: string;
   codeVariant: CodeVariant;
   codeStyling?: CodeStyling;
-}) => {
+}) {
   const ext = getFileExtension(templateData.codeVariant);
   const { title, githubLocation: description } = templateData;
 
@@ -172,7 +172,7 @@ ReactDOM.createRoot(document.querySelector("#root")${type}).render(
     openSandbox: (initialFile: string = '/App') =>
       openSandbox({ files, codeVariant: templateData.codeVariant, initialFile }),
   };
-};
+}
 
 export default {
   createReactApp,

--- a/docs/src/modules/sandbox/Dependencies.ts
+++ b/docs/src/modules/sandbox/Dependencies.ts
@@ -1,6 +1,34 @@
 import { CODE_VARIANTS } from 'docs/src/modules/constants';
 import type { MuiProductId } from 'docs/src/modules/utils/getProductInfoFromUrl';
 
+const packagesWithBundledTypes = ['date-fns', '@emotion/react', '@emotion/styled', 'dayjs'];
+
+/**
+ * WARNING: Always uses `latest` typings.
+ *
+ * Adds dependencies to @types packages only for packages that are not listed
+ * in packagesWithBundledTypes
+ *
+ * @param deps - list of dependency as `name => version`
+ */
+function addTypeDeps(deps: Record<string, string>): void {
+  const packagesWithDTPackage = Object.keys(deps)
+    .filter((name) => packagesWithBundledTypes.indexOf(name) === -1)
+    // All the MUI packages come with bundled types
+    .filter((name) => name.indexOf('@mui/') !== 0);
+
+  packagesWithDTPackage.forEach((name) => {
+    let resolvedName = name;
+    // scoped package?
+    if (name.startsWith('@')) {
+      // https://github.com/DefinitelyTyped/DefinitelyTyped#what-about-scoped-packages
+      resolvedName = name.slice(1).replace('/', '__');
+    }
+
+    deps[`@types/${resolvedName}`] = 'latest';
+  });
+}
+
 export default function SandboxDependencies(
   demo: {
     raw: string;
@@ -10,33 +38,6 @@ export default function SandboxDependencies(
   options?: { commitRef?: string },
 ) {
   const { commitRef } = options || {};
-
-  /**
-   * WARNING: Always uses `latest` typings.
-   *
-   * Adds dependencies to @types packages only for packages that are not listed
-   * in packagesWithBundledTypes
-   *
-   * @param deps - list of dependency as `name => version`
-   */
-  function addTypeDeps(deps: Record<string, string>): void {
-    const packagesWithBundledTypes = ['date-fns', '@emotion/react', '@emotion/styled', 'dayjs'];
-    const packagesWithDTPackage = Object.keys(deps)
-      .filter((name) => packagesWithBundledTypes.indexOf(name) === -1)
-      // All the MUI packages come with bundled types
-      .filter((name) => name.indexOf('@mui/') !== 0);
-
-    packagesWithDTPackage.forEach((name) => {
-      let resolvedName = name;
-      // scoped package?
-      if (name.startsWith('@')) {
-        // https://github.com/DefinitelyTyped/DefinitelyTyped#what-about-scoped-packages
-        resolvedName = name.slice(1).replace('/', '__');
-      }
-
-      deps[`@types/${resolvedName}`] = 'latest';
-    });
-  }
 
   /**
    * @param packageName - The name of a package living inside this repository.
@@ -109,8 +110,7 @@ export default function SandboxDependencies(
 
     // TODO: consider if this configuration could be injected in a "cleaner" way.
     if (muiDocConfig) {
-      const muiCommitRef = process.env.PULL_REQUEST_ID ? process.env.COMMIT_REF : undefined;
-      versions = muiDocConfig.csbGetVersions(versions, { muiCommitRef });
+      versions = muiDocConfig.csbGetVersions(versions, { muiCommitRef: commitRef });
     }
 
     const re = /^import\s'([^']+)'|import\s[\s\S]*?\sfrom\s+'([^']+)/gm;

--- a/docs/src/modules/sandbox/StackBlitz.ts
+++ b/docs/src/modules/sandbox/StackBlitz.ts
@@ -5,7 +5,7 @@ import * as CRA from 'docs/src/modules/sandbox/CreateReactApp';
 import getFileExtension from 'docs/src/modules/sandbox/FileExtension';
 import { DemoData } from 'docs/src/modules/sandbox/types';
 
-const createReactApp = (demoData: DemoData) => {
+function createReactApp(demoData: DemoData) {
   const ext = getFileExtension(demoData.codeVariant);
   const { title, githubLocation: description } = demoData;
 
@@ -52,7 +52,7 @@ const createReactApp = (demoData: DemoData) => {
       document.body.removeChild(form);
     },
   };
-};
+}
 
 export default {
   createReactApp,


### PR DESCRIPTION
### Problem

CodeSandbox is changing its pricing, see https://www.codesandbox.community/c/api-billing-updates/upcoming-pricing-billing-changes. Developers who want to report a bug or edit demos might hit a paywall. Sandboxes are paid after 20. This limit at 20 could be annoying for some of the developers browsing the docs. This can also be a problem for bug reproduction on GitHub. Community members might not be able to easily them if its on CodeSandbox, so increasing the odd for reproduction to be on StackBlitz is likely a win.

### Context

Today, CodeSandbox is 70% of the use while StackBlitz is 30%:

<img src="https://github.com/mui/material-ui/assets/3165635/52c3228e-3149-416b-b2ba-4591b381a9c9" width="216">

https://analytics.google.com/analytics/web/#/analysis/p353089763/edit/KctZ977QSou7VoMyBQMaqw

StackBlitz is up 76% from 6 months ago 83% / 17%. It's not StackBlitz that is used more but rather it seems to be that CodeSandbox is used less frequently as developers learn they can use the live edit feature of our demos in the docs. My assumption is that developers were defaulting to the easier-to-reach icon.

### Solution

This PR makes using StackBlitz less friction for users to adopt:

Before:

<img src="https://github.com/mui/material-ui/assets/3165635/db457ba8-cb1c-4598-b182-d4f08eee0fa7" width="790">

After:

<img src="https://github.com/mui/material-ui/assets/3165635/cecc203c-2784-4e19-84ab-86ba43cf2bda" width="781">

I think we need to point the community to the least friction code edition experience. It seems that StackBlitz % of use should be higher than 30%:

- Equivalent load time than Codesandbox. I suspect StackBlitz is from time to time slower, but not so easy to produce.
- It feels like StackBlitz is investing more in the in-browser dev experience. Codesandbox is more focused on the VM market, closer to Replit. For instance, they support Next.js without a server running, so cost-saving in terms of VM credits. Because we have client-side-only API, StackBlitz's focus is a bit better aligned with our audience.
- A higher limit for free in-browser apps in StackBlitz, making it less likely to create friction for new developers
- ~Fetching packages directly from the npm registry means a massive cost saving in terms of infra cost for StackBlitz to deliver this UX, something Codesandbox can't deliver as they build on the server, so they have huge bandwidth use.~

hence the PR to better balance it.

---

I noticed a small bug along the way that I reported https://github.com/codesandbox/codesandbox-client/issues/8299.