### PR TITLE
[material-ui][Avatar] Simplify valid children assertion

### DIFF
--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -183,6 +183,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
         {...imgProps}
       />
     );
+
     // Consider the children valid to render as long as not flasy and not 0.
   } else if (!(!childrenProp && childrenProp !== 0)) {
     children = childrenProp;

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -184,7 +184,8 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
       />
     );
 
-    // Consider the children valid to render as long as not flasy and not 0.
+    // We only render valid children, non valid children are rendered with a fallback
+    // We consider that invalid children are all falsy values, except 0, which is valid.
   } else if (!(!childrenProp && childrenProp !== 0)) {
     children = childrenProp;
   } else if (hasImg && alt) {

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -183,7 +183,8 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
         {...imgProps}
       />
     );
-  } else if (childrenProp != null && childrenProp !== '' && typeof childrenProp !== 'boolean') {
+    // Consider the children valid to render as long as not flasy and not 0.
+  } else if (!(!childrenProp && childrenProp !== 0)) {
     children = childrenProp;
   } else if (hasImg && alt) {
     children = alt[0];

--- a/packages/mui-material/src/Avatar/Avatar.js
+++ b/packages/mui-material/src/Avatar/Avatar.js
@@ -186,7 +186,7 @@ const Avatar = React.forwardRef(function Avatar(inProps, ref) {
 
     // We only render valid children, non valid children are rendered with a fallback
     // We consider that invalid children are all falsy values, except 0, which is valid.
-  } else if (!(!childrenProp && childrenProp !== 0)) {
+  } else if (!!childrenProp || childrenProp === 0) {
     children = childrenProp;
   } else if (hasImg && alt) {
     children = alt[0];

--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -493,6 +493,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
   const handleRef = useForkRef(children.ref, focusVisibleRef, setChildNode, ref);
 
   // There is no point in displaying an empty tooltip.
+  // So we exclude all falsy values, except 0, which is valid.
   if (!title && title !== 0) {
     open = false;
   }


### PR DESCRIPTION
A simplification on #40766 to save bundle size.

![Screenshot 2024-01-29 at 01 13 40](https://github.com/mui/material-ui/assets/3165635/ccc3a7c6-f749-4717-b6e7-137e14735f18)

https://mui-dashboard.netlify.app/size-comparison?circleCIBuildNumber=643588&baseRef=master&baseCommit=4f793a13d5105373a3eb3765a60bfd17d1d8960c&prNumber=40834
