### PR TITLE
[blog] Lint duplicate h1 on the page

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -2,6 +2,7 @@ const straightQuotes = require('./packages/markdownlint-rule-mui/straight-quotes
 const gitDiff = require('./packages/markdownlint-rule-mui/git-diff');
 const tableAlignment = require('./packages/markdownlint-rule-mui/table-alignment');
 const terminalLanguage = require('./packages/markdownlint-rule-mui/terminal-language');
+const duplicateH1 = require('./packages/markdownlint-rule-mui/duplicate-h1');
 
 // https://github.com/DavidAnson/markdownlint#rules--aliases
 module.exports = {
@@ -35,8 +36,9 @@ module.exports = {
     gitDiff: true,
     tableAlignment: true,
     terminalLanguage: true,
+    duplicateH1: true,
   },
-  customRules: [straightQuotes, gitDiff, tableAlignment, terminalLanguage],
+  customRules: [straightQuotes, gitDiff, tableAlignment, terminalLanguage, duplicateH1],
   ignores: [
     'CHANGELOG.old.md',
     '**/node_modules/**',

--- a/packages/markdownlint-rule-mui/duplicate-h1.js
+++ b/packages/markdownlint-rule-mui/duplicate-h1.js
@@ -1,0 +1,31 @@
+// This rule is an extension of MD025/no-multiple-top-level-headings.
+// The rule is buggy https://github.com/DavidAnson/markdownlint/pull/1109
+// but also blog headers don't tell you that h1 is already injected.
+module.exports = {
+  names: ['duplicateH1'],
+  description: 'Multiple top-level headings in the same document.',
+  tags: ['headings'],
+  function: (params, onError) => {
+    let hasTopLevelHeading = false;
+    params.tokens.forEach((token) => {
+      if (token.type === 'heading_open' && token.tag === 'h1') {
+        // Avoid duplicate errors with MD025.
+        if (hasTopLevelHeading !== false && hasTopLevelHeading !== 1) {
+          onError({
+            lineNumber: token.lineNumber,
+          });
+        } else if (params.name.includes('/docs/pages/blog/')) {
+          onError({
+            lineNumber: token.lineNumber,
+            details: 'In the blog, the h1 is already added using the markdown header.title value.',
+          });
+        }
+
+        // Store the first h1 of the page.
+        if (hasTopLevelHeading === false) {
+          hasTopLevelHeading = token.lineNumber;
+        }
+      }
+    });
+  },
+};


### PR DESCRIPTION
This new lint fails the ci when it sees a h1 or duplicated h1 in a page where h1 isn't the first element https://github.com/mui/material-ui/pull/40784#discussion_r1466976674.

For example:

```diff
diff --git a/docs/data/material/components/alert/alert.md b/docs/data/material/components/alert/alert.md
index 1f1a903f2c..bcde949fe0 100644
--- a/docs/data/material/components/alert/alert.md
+++ b/docs/data/material/components/alert/alert.md
@@ -6,13 +6,15 @@ githubLabel: 'component: alert'
 waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alert/
 ---

+a
+
 # Alert

 <p class="description">Alerts display brief messages for the user without interrupting their use of the app.</p>

 {{"component": "modules/components/ComponentLinkHeader.js"}}

-## Introduction
+# Introduction

 Alerts give users brief and potentially time-sensitive information in an unobtrusive manner.

diff --git a/docs/pages/blog/2022-tenerife-retreat.md b/docs/pages/blog/2022-tenerife-retreat.md
index 0d0827075e..694c7fea6f 100644
--- a/docs/pages/blog/2022-tenerife-retreat.md
+++ b/docs/pages/blog/2022-tenerife-retreat.md
@@ -7,6 +7,8 @@ tags: ['Company']
 card: true
 ---

+# A
+
 One of the toughest challenges to overcome as a fully remote team is fostering a supportive and inclusive company culture.
 How do you build trust, comradery, and—dare I say it?—_friendships_, when there are so few opportunities for spontaneous social interactions in our daily work routines?
```

<img src="https://github.com/mui/material-ui/assets/3165635/bd3b4278-65bf-4c40-bc9f-3c5a5d5c2b0b" width="524">

<img src="https://github.com/mui/material-ui/assets/3165635/29d3b483-d3e7-43f7-a26d-befb9afc5389" width="554">
