### PR TITLE
[zero] Fix build for demo next.js app

### DIFF
--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -89,6 +89,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
+    "@mui/zero-runtime": "workspace:^",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/zero-unplugin/src/index.ts
+++ b/packages/zero-unplugin/src/index.ts
@@ -175,7 +175,7 @@ export const plugin = createUnplugin<PluginOptions, true>((options) => {
                 return tagResult;
               }
               if (source.endsWith('/zero-styled')) {
-                return `${process.env.RUNTIME_PACKAGE_NAME}/exports/${tag}`;
+                return require.resolve(`${process.env.RUNTIME_PACKAGE_NAME}/exports/${tag}`);
               }
               return null;
             },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1528,6 +1528,9 @@ importers:
       '@mui/utils':
         specifier: workspace:^
         version: link:../mui-utils/build
+      '@mui/zero-runtime':
+        specifier: workspace:^
+        version: link:../zero-runtime
       '@types/react-transition-group':
         specifier: ^4.4.10
         version: 4.4.10


### PR DESCRIPTION
This requires adding zero runtime as a peer dep of material (at least when using pnpm). Otherwise getting this error -

<img width="628" alt="Screenshot 2024-01-30 at 2 20 44 PM" src="https://github.com/mui/material-ui/assets/717550/a6d3ee56-3c8f-4038-873e-f7b3912c2076">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
