### PR TITLE
[docs-infra] Remove random layout assignment

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -21,6 +21,7 @@ import ClassesSection, {
   getClassesToC,
 } from 'docs/src/modules/components/ApiPage/sections/ClassesSection';
 import SlotsSection from 'docs/src/modules/components/ApiPage/sections/SlotsSection';
+import { DEFAULT_API_LAYOUT_STORAGE_KEYS } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 
 export function getTranslatedHeader(t, header) {
   const translations = {
@@ -73,7 +74,7 @@ export default function ApiPage(props) {
     disableAd = false,
     pageContent,
     defaultLayout = 'table',
-    layoutStorageKey,
+    layoutStorageKey = DEFAULT_API_LAYOUT_STORAGE_KEYS,
   } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
@@ -264,7 +265,7 @@ export default function ApiPage(props) {
           componentName={pageContent.name}
           spreadHint={spreadHint}
           defaultLayout={defaultLayout}
-          layoutStorageKey={layoutStorageKey?.props}
+          layoutStorageKey={layoutStorageKey.props}
         />
         {cssComponent && (
           <React.Fragment>
@@ -323,7 +324,7 @@ export default function ApiPage(props) {
             t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
           }
           defaultLayout={defaultLayout}
-          layoutStorageKey={layoutStorageKey?.slots}
+          layoutStorageKey={layoutStorageKey.slots}
         />
         <ClassesSection
           componentClasses={componentClasses}
@@ -332,7 +333,7 @@ export default function ApiPage(props) {
           spreadHint={t('api-docs.classesDescription')}
           styleOverridesLink={styleOverridesLink}
           defaultLayout={defaultLayout}
-          layoutStorageKey={layoutStorageKey?.classes}
+          layoutStorageKey={layoutStorageKey.classes}
           displayClassKeys
         />
       </MarkdownElement>

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -68,7 +68,7 @@ Heading.propTypes = {
 };
 
 export default function ApiPage(props) {
-  const { descriptions, disableAd = false, pageContent } = props;
+  const { descriptions, disableAd = false, pageContent, defaultLayout = 'table' } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
 
@@ -257,6 +257,7 @@ export default function ApiPage(props) {
           propertiesDescriptions={propDescriptions}
           componentName={pageContent.name}
           spreadHint={spreadHint}
+          defaultLayout={defaultLayout}
         />
         {cssComponent && (
           <React.Fragment>
@@ -314,6 +315,7 @@ export default function ApiPage(props) {
             slotGuideLink &&
             t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
           }
+          defaultLayout={defaultLayout}
         />
         <ClassesSection
           componentClasses={componentClasses}
@@ -321,6 +323,7 @@ export default function ApiPage(props) {
           classDescriptions={classDescriptions}
           spreadHint={t('api-docs.classesDescription')}
           styleOverridesLink={styleOverridesLink}
+          defaultLayout={defaultLayout}
           displayClassKeys
         />
       </MarkdownElement>
@@ -334,6 +337,7 @@ export default function ApiPage(props) {
 }
 
 ApiPage.propTypes = {
+  defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
   disableAd: PropTypes.bool,
   pageContent: PropTypes.object.isRequired,

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -350,9 +350,9 @@ ApiPage.propTypes = {
   descriptions: PropTypes.object.isRequired,
   disableAd: PropTypes.bool,
   layoutStorageKey: PropTypes.shape({
+    classes: PropTypes.string,
     props: PropTypes.string,
     slots: PropTypes.string,
-    classes: PropTypes.string,
   }),
   pageContent: PropTypes.object.isRequired,
 };

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -68,7 +68,13 @@ Heading.propTypes = {
 };
 
 export default function ApiPage(props) {
-  const { descriptions, disableAd = false, pageContent, defaultLayout = 'table' } = props;
+  const {
+    descriptions,
+    disableAd = false,
+    pageContent,
+    defaultLayout = 'table',
+    layoutStorageKey,
+  } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
 
@@ -258,6 +264,7 @@ export default function ApiPage(props) {
           componentName={pageContent.name}
           spreadHint={spreadHint}
           defaultLayout={defaultLayout}
+          layoutStorageKey={layoutStorageKey?.props}
         />
         {cssComponent && (
           <React.Fragment>
@@ -316,6 +323,7 @@ export default function ApiPage(props) {
             t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
           }
           defaultLayout={defaultLayout}
+          layoutStorageKey={layoutStorageKey?.slots}
         />
         <ClassesSection
           componentClasses={componentClasses}
@@ -324,6 +332,7 @@ export default function ApiPage(props) {
           spreadHint={t('api-docs.classesDescription')}
           styleOverridesLink={styleOverridesLink}
           defaultLayout={defaultLayout}
+          layoutStorageKey={layoutStorageKey?.classes}
           displayClassKeys
         />
       </MarkdownElement>
@@ -340,6 +349,11 @@ ApiPage.propTypes = {
   defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
   disableAd: PropTypes.bool,
+  layoutStorageKey: PropTypes.shape({
+    props: PropTypes.string,
+    slots: PropTypes.string,
+    classes: PropTypes.string,
+  }),
   pageContent: PropTypes.object.isRequired,
 };
 

--- a/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'docs/src/modules/utils/i18n';
 import { ComponentClassDefinition } from '@mui-internal/docs-utilities';
 import Box from '@mui/material/Box';
 import ToggleDisplayOption, {
-  API_LAYOUT_STORAGE_KEYS,
   ApiDisplayOptions,
   useApiPageOption,
 } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
@@ -51,7 +50,7 @@ export type ClassesSectionProps = {
   titleHash: string;
   level?: 'h2' | 'h3' | 'h4';
   defaultLayout: ApiDisplayOptions;
-  layoutStorageKey?: string;
+  layoutStorageKey: string;
   displayClassKeys: boolean;
   styleOverridesLink: string;
 };
@@ -68,7 +67,7 @@ export default function ClassesSection(props: ClassesSectionProps) {
     displayClassKeys,
     styleOverridesLink,
     defaultLayout,
-    layoutStorageKey = API_LAYOUT_STORAGE_KEYS.classes,
+    layoutStorageKey,
   } = props;
   const t = useTranslate();
 

--- a/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
@@ -5,6 +5,7 @@ import { ComponentClassDefinition } from '@mui-internal/docs-utilities';
 import Box from '@mui/material/Box';
 import ToggleDisplayOption, {
   API_LAYOUT_STORAGE_KEYS,
+  ApiDisplayOptions,
   useApiPageOption,
 } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 import ClassesList, { getHash } from 'docs/src/modules/components/ApiPage/list/ClassesList';
@@ -49,6 +50,8 @@ export type ClassesSectionProps = {
   title: string;
   titleHash: string;
   level?: 'h2' | 'h3' | 'h4';
+  defaultLayout: ApiDisplayOptions;
+  layoutStorageKey?: string;
   displayClassKeys: boolean;
   styleOverridesLink: string;
 };
@@ -64,10 +67,12 @@ export default function ClassesSection(props: ClassesSectionProps) {
     level: Level = 'h2',
     displayClassKeys,
     styleOverridesLink,
+    defaultLayout,
+    layoutStorageKey = API_LAYOUT_STORAGE_KEYS.classes,
   } = props;
   const t = useTranslate();
 
-  const [displayOption, setDisplayOption] = useApiPageOption(API_LAYOUT_STORAGE_KEYS.classes);
+  const [displayOption, setDisplayOption] = useApiPageOption(layoutStorageKey, defaultLayout);
 
   if (!componentClasses || componentClasses.length === 0) {
     return null;
@@ -101,7 +106,11 @@ export default function ClassesSection(props: ClassesSectionProps) {
             </svg>
           </a>
         </Level>
-        <ToggleDisplayOption displayOption={displayOption} setDisplayOption={setDisplayOption} />
+        <ToggleDisplayOption
+          displayOption={displayOption}
+          setDisplayOption={setDisplayOption}
+          sectionType="classes"
+        />
       </Box>
       {spreadHint && <p dangerouslySetInnerHTML={{ __html: spreadHint }} />}
       {displayOption === 'table' ? (

--- a/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
+++ b/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
@@ -51,10 +51,12 @@ export default function PropertiesSection(props) {
     spreadHint,
     hooksParameters = false,
     hooksReturnValue = false,
+    defaultLayout,
+    layoutStorageKey = API_LAYOUT_STORAGE_KEYS.props,
   } = props;
   const t = useTranslate();
 
-  const [displayOption, setDisplayOption] = useApiPageOption(API_LAYOUT_STORAGE_KEYS.props);
+  const [displayOption, setDisplayOption] = useApiPageOption(layoutStorageKey, defaultLayout);
   const formatedProperties = Object.entries(properties)
     .filter(([, propData]) => propData.description !== '@ignore')
     .map(([propName, propData]) => {
@@ -131,7 +133,11 @@ export default function PropertiesSection(props) {
             </svg>
           </a>
         </Level>
-        <ToggleDisplayOption displayOption={displayOption} setDisplayOption={setDisplayOption} />
+        <ToggleDisplayOption
+          displayOption={displayOption}
+          setDisplayOption={setDisplayOption}
+          sectionType="props"
+        />
       </Box>
       {spreadHint && <p dangerouslySetInnerHTML={{ __html: spreadHint }} />}
       {displayOption === 'table' ? (
@@ -145,8 +151,10 @@ export default function PropertiesSection(props) {
 
 PropertiesSection.propTypes = {
   componentName: PropTypes.string,
+  defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']).isRequired,
   hooksParameters: PropTypes.bool,
   hooksReturnValue: PropTypes.bool,
+  layoutStorageKey: PropTypes.string,
   level: PropTypes.string,
   properties: PropTypes.object.isRequired,
   propertiesDescriptions: PropTypes.object.isRequired,

--- a/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
+++ b/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import ToggleDisplayOption, {
-  API_LAYOUT_STORAGE_KEYS,
   useApiPageOption,
 } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 import PropertiesList, { getHash } from 'docs/src/modules/components/ApiPage/list/PropertiesList';
@@ -52,7 +51,7 @@ export default function PropertiesSection(props) {
     hooksParameters = false,
     hooksReturnValue = false,
     defaultLayout,
-    layoutStorageKey = API_LAYOUT_STORAGE_KEYS.props,
+    layoutStorageKey,
   } = props;
   const t = useTranslate();
 
@@ -154,7 +153,7 @@ PropertiesSection.propTypes = {
   defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']).isRequired,
   hooksParameters: PropTypes.bool,
   hooksReturnValue: PropTypes.bool,
-  layoutStorageKey: PropTypes.string,
+  layoutStorageKey: PropTypes.string.isRequired,
   level: PropTypes.string,
   properties: PropTypes.object.isRequired,
   propertiesDescriptions: PropTypes.object.isRequired,

--- a/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import ToggleDisplayOption, {
-  API_LAYOUT_STORAGE_KEYS,
   ApiDisplayOptions,
   useApiPageOption,
 } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
@@ -18,7 +17,7 @@ export type SlotsSectionProps = {
   titleHash?: string;
   level?: 'h2' | 'h3' | 'h4';
   defaultLayout: ApiDisplayOptions;
-  layoutStorageKey?: string;
+  layoutStorageKey: string;
   spreadHint?: string;
 };
 
@@ -32,7 +31,7 @@ export default function SlotsSection(props: SlotsSectionProps) {
     level: Level = 'h2',
     spreadHint,
     defaultLayout,
-    layoutStorageKey = API_LAYOUT_STORAGE_KEYS.slots,
+    layoutStorageKey,
   } = props;
   const t = useTranslate();
 

--- a/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import ToggleDisplayOption, {
   API_LAYOUT_STORAGE_KEYS,
+  ApiDisplayOptions,
   useApiPageOption,
 } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 import SlotsList from 'docs/src/modules/components/ApiPage/list/SlotsList';
@@ -16,6 +17,8 @@ export type SlotsSectionProps = {
   title?: string;
   titleHash?: string;
   level?: 'h2' | 'h3' | 'h4';
+  defaultLayout: ApiDisplayOptions;
+  layoutStorageKey?: string;
   spreadHint?: string;
 };
 
@@ -28,10 +31,12 @@ export default function SlotsSection(props: SlotsSectionProps) {
     titleHash = 'slots',
     level: Level = 'h2',
     spreadHint,
+    defaultLayout,
+    layoutStorageKey = API_LAYOUT_STORAGE_KEYS.slots,
   } = props;
   const t = useTranslate();
 
-  const [displayOption, setDisplayOption] = useApiPageOption(API_LAYOUT_STORAGE_KEYS.slots);
+  const [displayOption, setDisplayOption] = useApiPageOption(layoutStorageKey, defaultLayout);
 
   if (!componentSlots || componentSlots.length === 0) {
     return null;
@@ -63,7 +68,11 @@ export default function SlotsSection(props: SlotsSectionProps) {
             </svg>
           </a>
         </Level>
-        <ToggleDisplayOption displayOption={displayOption} setDisplayOption={setDisplayOption} />
+        <ToggleDisplayOption
+          displayOption={displayOption}
+          setDisplayOption={setDisplayOption}
+          sectionType="slots"
+        />
       </Box>
       {spreadHint && <p dangerouslySetInnerHTML={{ __html: spreadHint }} />}
       {displayOption === 'table' ? (

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -11,7 +11,7 @@ export type ApiDisplayOptions = 'collapsed' | 'expanded' | 'table';
 
 const options: ApiDisplayOptions[] = ['collapsed', 'expanded', 'table'];
 
-export const API_LAYOUT_STORAGE_KEYS = {
+export const DEFAULT_API_LAYOUT_STORAGE_KEYS = {
   slots: 'apiPage_slots',
   props: 'apiPage_props',
   classes: 'apiPage_classes',
@@ -69,20 +69,6 @@ export function useApiPageOption(
   );
 
   return [option, updateOption];
-}
-
-export function getApiPageLayout() {
-  const rep: { [key: string]: string } = {};
-
-  Object.values(API_LAYOUT_STORAGE_KEYS).forEach((localStorageKey) => {
-    try {
-      const savedOption = localStorage.getItem(localStorageKey);
-      rep[localStorageKey] = savedOption || 'none';
-    } catch {
-      rep[localStorageKey] = 'none';
-    }
-  });
-  return rep;
 }
 
 // Fix Toggle buton highlight (taken from https://github.com/mui/material-ui/issues/18091)

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -7,52 +7,21 @@ import TableChartRoundedIcon from '@mui/icons-material/TableChartRounded';
 import ReorderRoundedIcon from '@mui/icons-material/ReorderRounded';
 import useEnhancedEffect from '@mui/utils/useEnhancedEffect';
 
-type ApiDisplayOptions = 'collapsed' | 'expanded' | 'table';
+export type ApiDisplayOptions = 'collapsed' | 'expanded' | 'table';
 
 const options: ApiDisplayOptions[] = ['collapsed', 'expanded', 'table'];
-const DEFAULT_LAYOUT: ApiDisplayOptions = 'expanded';
 
 export const API_LAYOUT_STORAGE_KEYS = {
-  default: 'apiPage_default',
   slots: 'apiPage_slots',
   props: 'apiPage_props',
-  css: 'apiPage_css',
   classes: 'apiPage_classes',
 } as const;
 
-// https://stackoverflow.com/a/20084661
-function isBot() {
-  return /bot|googlebot|crawler|spider|robot|crawling/i.test(navigator.userAgent);
-}
-
-function getRandomOption() {
-  if (isBot()) {
-    // When crawlers visit the page, they should not have to expand items
-    return DEFAULT_LAYOUT;
-  }
-  // A default layout is saved in localstorage at first render to make sure all section start with the same layout.
-  const savedDefaultOption = localStorage.getItem(
-    API_LAYOUT_STORAGE_KEYS.default,
-  ) as null | ApiDisplayOptions;
-
-  if (savedDefaultOption !== null && options.includes(savedDefaultOption)) {
-    return savedDefaultOption;
-  }
-
-  const randomOption = options[Math.floor(options.length * Math.random())];
-  try {
-    localStorage.setItem(API_LAYOUT_STORAGE_KEYS.default, randomOption);
-  } catch (error) {
-    // Do nothing
-  }
-  return randomOption;
-}
-
 let neverHydrated = true;
 
-function getOption(storageKey: string) {
+function getOption(storageKey: string, defaultValue: ApiDisplayOptions): ApiDisplayOptions {
   if (neverHydrated) {
-    return DEFAULT_LAYOUT;
+    return defaultValue;
   }
   try {
     const savedOption = localStorage.getItem(storageKey);
@@ -60,34 +29,32 @@ function getOption(storageKey: string) {
     if (savedOption !== null && options.includes(savedOption as ApiDisplayOptions)) {
       return savedOption as ApiDisplayOptions;
     }
-
-    const randomOption = getRandomOption();
-
-    return randomOption;
   } catch (error) {
-    return DEFAULT_LAYOUT;
+    return defaultValue;
   }
+  return defaultValue;
 }
 
 export function useApiPageOption(
   storageKey: string,
+  defaultValue: ApiDisplayOptions,
 ): [ApiDisplayOptions, (newOption: ApiDisplayOptions) => void] {
-  const [option, setOption] = React.useState(getOption(storageKey));
+  const [option, setOption] = React.useState(getOption(storageKey, defaultValue));
 
   useEnhancedEffect(() => {
     neverHydrated = false;
-    const newOption = getOption(storageKey);
+    const newOption = getOption(storageKey, defaultValue);
     setOption(newOption);
-  }, [storageKey]);
+  }, [storageKey, defaultValue]);
 
   React.useEffect(() => {
-    if (option !== DEFAULT_LAYOUT) {
+    if (option !== defaultValue) {
       const id = document.location.hash.slice(1);
       const element = document.getElementById(id);
       element?.scrollIntoView();
     }
     return undefined;
-  }, [option]);
+  }, [option, defaultValue]);
 
   const updateOption = React.useCallback(
     (newOption: ApiDisplayOptions) => {
@@ -141,10 +108,14 @@ const TooltipToggleButton = React.forwardRef<HTMLButtonElement, TooltipToggleBut
 interface ToggleDisplayOptionProps {
   displayOption: ApiDisplayOptions;
   setDisplayOption: (newValue: ApiDisplayOptions) => void;
+  /**
+   * The type of section. This value is used to send correct event to Google Analytics.
+   */
+  sectionType: 'classes' | 'props' | 'slots';
 }
 
 export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
-  const { displayOption, setDisplayOption } = props;
+  const { displayOption, setDisplayOption, sectionType } = props;
 
   const handleAlignment = (
     event: React.MouseEvent<HTMLElement>,
@@ -182,13 +153,31 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
         },
       }}
     >
-      <TooltipToggleButton value="collapsed" aria-label="colapsed list" title="Collapse list view">
+      <TooltipToggleButton
+        value="collapsed"
+        aria-label="colapsed list"
+        title="Collapse list view"
+        data-ga-event-action="collapsed"
+        data-ga-event-category={sectionType}
+      >
         <ReorderRoundedIcon size="small" />
       </TooltipToggleButton>
-      <TooltipToggleButton value="expanded" aria-label="expanded list" title="Expand list view">
+      <TooltipToggleButton
+        value="expanded"
+        aria-label="expanded list"
+        title="Expand list view"
+        data-ga-event-action="expanded"
+        data-ga-event-category={sectionType}
+      >
         <CalendarViewDayRoundedIcon />
       </TooltipToggleButton>
-      <TooltipToggleButton value="table" aria-label="table" title="Table view">
+      <TooltipToggleButton
+        value="table"
+        aria-label="table"
+        title="Table view"
+        data-ga-event-action="table"
+        data-ga-event-category={sectionType}
+      >
         <TableChartRoundedIcon />
       </TooltipToggleButton>
     </ToggleButtonGroup>

--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -157,8 +157,9 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
         value="collapsed"
         aria-label="colapsed list"
         title="Collapse list view"
-        data-ga-event-action="collapsed"
-        data-ga-event-category={sectionType}
+        data-ga-event-category="layout"
+        data-ga-event-action={sectionType}
+        data-ga-event-label="collapsed"
       >
         <ReorderRoundedIcon size="small" />
       </TooltipToggleButton>
@@ -166,8 +167,9 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
         value="expanded"
         aria-label="expanded list"
         title="Expand list view"
-        data-ga-event-action="expanded"
-        data-ga-event-category={sectionType}
+        data-ga-event-category="layout"
+        data-ga-event-action={sectionType}
+        data-ga-event-label="expanded"
       >
         <CalendarViewDayRoundedIcon />
       </TooltipToggleButton>
@@ -175,8 +177,9 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
         value="table"
         aria-label="table"
         title="Table view"
-        data-ga-event-action="table"
-        data-ga-event-category={sectionType}
+        data-ga-event-category="layout"
+        data-ga-event-action={sectionType}
+        data-ga-event-label="table"
       >
         <TableChartRoundedIcon />
       </TooltipToggleButton>

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -49,7 +49,7 @@ Heading.propTypes = {
 };
 
 export default function ComponentsApiContent(props) {
-  const { descriptions, pageContents, defaultLayout = 'table' } = props;
+  const { descriptions, pageContents, defaultLayout = 'table', layoutStorageKey } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
   const router = useRouter();
@@ -151,6 +151,7 @@ export default function ComponentsApiContent(props) {
             level="h3"
             titleHash={`${componentNameKebabCase}-props`}
             defaultLayout={defaultLayout}
+            layoutStorageKey={layoutStorageKey?.props}
           />
           <br />
           {cssComponent && (
@@ -218,6 +219,7 @@ export default function ComponentsApiContent(props) {
               t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
             }
             defaultLayout={defaultLayout}
+            layoutStorageKey={layoutStorageKey?.slots}
           />
           <ClassesSection
             componentClasses={componentClasses}
@@ -227,6 +229,7 @@ export default function ComponentsApiContent(props) {
             titleHash={`${componentNameKebabCase}-classes`}
             level="h3"
             defaultLayout={defaultLayout}
+            layoutStorageKey={layoutStorageKey?.classes}
           />
         </MarkdownElement>
         <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
@@ -242,6 +245,11 @@ export default function ComponentsApiContent(props) {
 ComponentsApiContent.propTypes = {
   defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
+  layoutStorageKey: PropTypes.shape({
+    props: PropTypes.string,
+    slots: PropTypes.string,
+    classes: PropTypes.string,
+  }),
   pageContents: PropTypes.object.isRequired,
 };
 

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -49,7 +49,7 @@ Heading.propTypes = {
 };
 
 export default function ComponentsApiContent(props) {
-  const { descriptions, pageContents } = props;
+  const { descriptions, pageContents, defaultLayout = 'table' } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
   const router = useRouter();
@@ -150,6 +150,7 @@ export default function ComponentsApiContent(props) {
             spreadHint={spreadHint}
             level="h3"
             titleHash={`${componentNameKebabCase}-props`}
+            defaultLayout={defaultLayout}
           />
           <br />
           {cssComponent && (
@@ -216,6 +217,7 @@ export default function ComponentsApiContent(props) {
               slotGuideLink &&
               t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
             }
+            defaultLayout={defaultLayout}
           />
           <ClassesSection
             componentClasses={componentClasses}
@@ -224,6 +226,7 @@ export default function ComponentsApiContent(props) {
             spreadHint={t('api-docs.classesDescription')}
             titleHash={`${componentNameKebabCase}-classes`}
             level="h3"
+            defaultLayout={defaultLayout}
           />
         </MarkdownElement>
         <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">
@@ -237,6 +240,7 @@ export default function ComponentsApiContent(props) {
 }
 
 ComponentsApiContent.propTypes = {
+  defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
   pageContents: PropTypes.object.isRequired,
 };

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -10,6 +10,7 @@ import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import PropertiesSection from 'docs/src/modules/components/ApiPage/sections/PropertiesSection';
 import ClassesSection from 'docs/src/modules/components/ApiPage/sections/ClassesSection';
 import SlotsSection from 'docs/src/modules/components/ApiPage/sections/SlotsSection';
+import { DEFAULT_API_LAYOUT_STORAGE_KEYS } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 
 function getTranslatedHeader(t, header, text) {
   const translations = {
@@ -49,7 +50,12 @@ Heading.propTypes = {
 };
 
 export default function ComponentsApiContent(props) {
-  const { descriptions, pageContents, defaultLayout = 'table', layoutStorageKey } = props;
+  const {
+    descriptions,
+    pageContents,
+    defaultLayout = 'table',
+    layoutStorageKey = DEFAULT_API_LAYOUT_STORAGE_KEYS,
+  } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
   const router = useRouter();
@@ -151,7 +157,7 @@ export default function ComponentsApiContent(props) {
             level="h3"
             titleHash={`${componentNameKebabCase}-props`}
             defaultLayout={defaultLayout}
-            layoutStorageKey={layoutStorageKey?.props}
+            layoutStorageKey={layoutStorageKey.props}
           />
           <br />
           {cssComponent && (
@@ -219,7 +225,7 @@ export default function ComponentsApiContent(props) {
               t('api-docs.slotDescription').replace(/{{slotGuideLink}}/, slotGuideLink)
             }
             defaultLayout={defaultLayout}
-            layoutStorageKey={layoutStorageKey?.slots}
+            layoutStorageKey={layoutStorageKey.slots}
           />
           <ClassesSection
             componentClasses={componentClasses}
@@ -229,7 +235,7 @@ export default function ComponentsApiContent(props) {
             titleHash={`${componentNameKebabCase}-classes`}
             level="h3"
             defaultLayout={defaultLayout}
-            layoutStorageKey={layoutStorageKey?.classes}
+            layoutStorageKey={layoutStorageKey.classes}
           />
         </MarkdownElement>
         <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -246,9 +246,9 @@ ComponentsApiContent.propTypes = {
   defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
   layoutStorageKey: PropTypes.shape({
+    classes: PropTypes.string,
     props: PropTypes.string,
     slots: PropTypes.string,
-    classes: PropTypes.string,
   }),
   pageContents: PropTypes.object.isRequired,
 };

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -6,7 +6,6 @@ import { useNoSsrCodeVariant } from 'docs/src/modules/utils/codeVariant';
 import { useNoSsrCodeStyling } from 'docs/src/modules/utils/codeStylingSolution';
 import { useUserLanguage } from 'docs/src/modules/utils/i18n';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
-import { getApiPageLayout } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 
 // So we can write code like:
 //
@@ -138,12 +137,6 @@ function GoogleAnalytics() {
       codeStylingVariant,
     });
   }, [codeStylingVariant]);
-
-  React.useEffect(() => {
-    window.gtag('set', 'user_properties', {
-      ...getApiPageLayout(),
-    });
-  }, []);
 
   return null;
 }

--- a/docs/src/modules/components/HooksApiContent.js
+++ b/docs/src/modules/components/HooksApiContent.js
@@ -7,6 +7,7 @@ import { useTranslate, useUserLanguage } from 'docs/src/modules/utils/i18n';
 import PropertiesSection from 'docs/src/modules/components/ApiPage/sections/PropertiesSection';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
+import { DEFAULT_API_LAYOUT_STORAGE_KEYS } from 'docs/src/modules/components/ApiPage/sections/ToggleDisplayOption';
 
 function getTranslatedHeader(t, header, text) {
   const translations = {
@@ -43,7 +44,12 @@ Heading.propTypes = {
 };
 
 export default function HooksApiContent(props) {
-  const { descriptions, pagesContents, defaultLayout = 'table', layoutStorageKey } = props;
+  const {
+    descriptions,
+    pagesContents,
+    defaultLayout = 'table',
+    layoutStorageKey = DEFAULT_API_LAYOUT_STORAGE_KEYS,
+  } = props;
   const userLanguage = useUserLanguage();
   const t = useTranslate();
 

--- a/docs/src/modules/components/HooksApiContent.js
+++ b/docs/src/modules/components/HooksApiContent.js
@@ -43,7 +43,7 @@ Heading.propTypes = {
 };
 
 export default function HooksApiContent(props) {
-  const { descriptions, pagesContents, defaultLayout = 'table' } = props;
+  const { descriptions, pagesContents, defaultLayout = 'table', layoutStorageKey } = props;
   const userLanguage = useUserLanguage();
   const t = useTranslate();
 
@@ -77,6 +77,7 @@ export default function HooksApiContent(props) {
               title="api-docs.parameters"
               titleHash={`${hookNameKebabCase}-parameters`}
               defaultLayout={defaultLayout}
+              layoutStorageKey={layoutStorageKey}
             />
           ) : (
             <span>{t('api-docs.hooksNoParameters')}</span>
@@ -91,6 +92,7 @@ export default function HooksApiContent(props) {
             title="api-docs.returnValue"
             titleHash={`${hookNameKebabCase}-return-value`}
             defaultLayout={defaultLayout}
+            layoutStorageKey={layoutStorageKey}
           />
           <br />
         </MarkdownElement>
@@ -107,6 +109,7 @@ export default function HooksApiContent(props) {
 HooksApiContent.propTypes = {
   defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
+  layoutStorageKey: PropTypes.string,
   pagesContents: PropTypes.object.isRequired,
 };
 

--- a/docs/src/modules/components/HooksApiContent.js
+++ b/docs/src/modules/components/HooksApiContent.js
@@ -43,7 +43,7 @@ Heading.propTypes = {
 };
 
 export default function HooksApiContent(props) {
-  const { descriptions, pagesContents } = props;
+  const { descriptions, pagesContents, defaultLayout = 'table' } = props;
   const userLanguage = useUserLanguage();
   const t = useTranslate();
 
@@ -76,6 +76,7 @@ export default function HooksApiContent(props) {
               level="h3"
               title="api-docs.parameters"
               titleHash={`${hookNameKebabCase}-parameters`}
+              defaultLayout={defaultLayout}
             />
           ) : (
             <span>{t('api-docs.hooksNoParameters')}</span>
@@ -89,6 +90,7 @@ export default function HooksApiContent(props) {
             level="h3"
             title="api-docs.returnValue"
             titleHash={`${hookNameKebabCase}-return-value`}
+            defaultLayout={defaultLayout}
           />
           <br />
         </MarkdownElement>
@@ -103,6 +105,7 @@ export default function HooksApiContent(props) {
 }
 
 HooksApiContent.propTypes = {
+  defaultLayout: PropTypes.oneOf(['collapsed', 'expanded', 'table']),
   descriptions: PropTypes.object.isRequired,
   pagesContents: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
API page component can get props to:
- define what is the default layout
- define which localeStorage key is saving the layout

This should allow to have a specific layout for data grid and save it in distinct key/value. Plus it's flexible since you can customize that at the page level.


The GA behavior is also modified. We stop the experiement so no need to compare the default and current layout.
However it can be interesting in the future to know what people are using per page. So the toggle button send an event to google analytics to know when user modify the layout

See for why: https://groups.google.com/a/mui.com/g/docs-infra/c/bzqriS4u3_M/m/8Me75UBAAgAJ. The layout shifts, it's not a great page load experience.

Preview: https://deploy-preview-40862--material-ui.netlify.app/material-ui/api/alert/


Works as expected. If you go on [pickers API page](https://deploy-preview-11876--material-ui-x.netlify.app/x/api/date-pickers/date-time-range-picker-toolbar/) you get a table layout, and on [data grid API page](https://deploy-preview-11876--material-ui-x.netlify.app/x/api/data-grid/data-grid-premium/) you get the list layout :tada:
