### PR TITLE
[zero-runtime] Use lodash instead of its subpackages

### DIFF
--- a/packages/zero-runtime/package.json
+++ b/packages/zero-runtime/package.json
@@ -26,9 +26,7 @@
     "@linaria/tags": "^5.0.2",
     "@linaria/utils": "^5.0.2",
     "@mui/system": "workspace:^",
-    "lodash.merge": "^4.6.2",
-    "lodash.set": "^4.3.2",
-    "lodash.get": "^4.4.2",
+    "lodash": "^4.17.21",
     "stylis": "^4.2.0"
   },
   "devDependencies": {
@@ -36,9 +34,7 @@
     "@types/babel__helper-module-imports": "^7.18.3",
     "@types/babel__helper-plugin-utils": "^7.10.3",
     "@types/cssesc": "^3.0.2",
-    "@types/lodash.get": "^4.4.9",
-    "@types/lodash.merge": "^4.6.9",
-    "@types/lodash.set": "^4.3.9",
+    "@types/lodash": "^4.14.202",
     "@types/node": "^18.19.10",
     "@types/react": "^18.2.48",
     "@types/stylis": "^4.2.0",

--- a/packages/zero-runtime/src/processors/css.ts
+++ b/packages/zero-runtime/src/processors/css.ts
@@ -10,7 +10,7 @@ import type {
 import type { Replacements, Rules } from '@linaria/utils';
 import { ValueType } from '@linaria/utils';
 import type { CSSInterpolation } from '@emotion/css';
-import deepMerge from 'lodash.merge';
+import deepMerge from 'lodash/merge';
 import BaseProcessor from './base-processor';
 import type { IOptions } from './styled';
 import { cache, css } from '../utils/emotion';

--- a/packages/zero-runtime/src/utils/cssFunctionTransformerPlugin.ts
+++ b/packages/zero-runtime/src/utils/cssFunctionTransformerPlugin.ts
@@ -1,6 +1,6 @@
 import { declare } from '@babel/helper-plugin-utils';
 import defaultSxConfig from '@mui/system/styleFunctionSx/defaultSxConfig';
-import get from 'lodash.get';
+import get from 'lodash/get';
 import type { PluginCustomOptions } from './cssFnValueToVariable';
 
 type Theme = { [key: 'unstable_sxConfig' | string]: string | number | Theme };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2357,15 +2357,9 @@ importers:
       csstype:
         specifier: ^3.1.2
         version: 3.1.2
-      lodash.get:
-        specifier: ^4.4.2
-        version: 4.4.2
-      lodash.merge:
-        specifier: ^4.6.2
-        version: 4.6.2
-      lodash.set:
-        specifier: ^4.3.2
-        version: 4.3.2
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       stylis:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2382,15 +2376,9 @@ importers:
       '@types/cssesc':
         specifier: ^3.0.2
         version: 3.0.2
-      '@types/lodash.get':
-        specifier: ^4.4.9
-        version: 4.4.9
-      '@types/lodash.merge':
-        specifier: ^4.6.9
-        version: 4.6.9
-      '@types/lodash.set':
-        specifier: ^4.3.9
-        version: 4.3.9
+      '@types/lodash':
+        specifier: ^4.14.202
+        version: 4.14.202
       '@types/node':
         specifier: ^18.19.10
         version: 18.19.10
@@ -7837,29 +7825,11 @@ packages:
       '@types/node': 18.19.10
     dev: true
 
-  /@types/lodash.get@4.4.9:
-    resolution: {integrity: sha512-J5dvW98sxmGnamqf+/aLP87PYXyrha9xIgc2ZlHl6OHMFR2Ejdxep50QfU0abO1+CH6+ugx+8wEUN1toImAinA==}
-    dependencies:
-      '@types/lodash': 4.14.202
-    dev: true
-
-  /@types/lodash.merge@4.6.9:
-    resolution: {integrity: sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==}
-    dependencies:
-      '@types/lodash': 4.14.202
-    dev: true
-
   /@types/lodash.mergewith@4.6.7:
     resolution: {integrity: sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==}
     dependencies:
       '@types/lodash': 4.14.202
     dev: false
-
-  /@types/lodash.set@4.3.9:
-    resolution: {integrity: sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==}
-    dependencies:
-      '@types/lodash': 4.14.202
-    dev: true
 
   /@types/lodash@4.14.202:
     resolution: {integrity: sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==}
@@ -15308,13 +15278,10 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
 
   /lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
-
-  /lodash.set@4.3.2:
-    resolution: {integrity: sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==}
-    dev: false
 
   /lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}


### PR DESCRIPTION
The individually packaged lodash functions do not receive updates. I changed them to the main lodash package to resolve https://github.com/mui/material-ui/security/dependabot/152
