### PR TITLE
[docs-infra] Repare icon selection

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -226,7 +226,7 @@ const FontSizeComponent = styled('span')(({ theme }) => ({
 }));
 
 const ContextComponent = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'contextColor',
+  shouldForwardProp: (prop) => !['contextColor', 'as'].includes(prop),
 })(({ theme, contextColor }) => ({
   margin: theme.spacing(0.5),
   padding: theme.spacing(1, 2),
@@ -268,6 +268,7 @@ const DialogDetails = React.memo(function DialogDetails(props) {
 
     setCopied(true);
   };
+  // console.log();
 
   return (
     <Dialog fullWidth maxWidth="sm" open={open} onClose={handleClose}>
@@ -309,7 +310,7 @@ const DialogDetails = React.memo(function DialogDetails(props) {
             <Grid container>
               <Grid item xs>
                 <Grid container justifyContent="center">
-                  <CanvasComponent component={selectedIcon.Component} />
+                  <CanvasComponent as={selectedIcon.Component} />
                 </Grid>
               </Grid>
               <Grid item xs>
@@ -338,31 +339,31 @@ const DialogDetails = React.memo(function DialogDetails(props) {
                 </Grid>
                 <Grid container justifyContent="center">
                   <ContextComponent
-                    component={selectedIcon.Component}
+                    as={selectedIcon.Component}
                     contextColor="primary"
                   />
                   <ContextComponent
-                    component={selectedIcon.Component}
+                    as={selectedIcon.Component}
                     contextColor="primaryInverse"
                   />
                 </Grid>
                 <Grid container justifyContent="center">
                   <ContextComponent
-                    component={selectedIcon.Component}
+                    as={selectedIcon.Component}
                     contextColor="textPrimary"
                   />
                   <ContextComponent
-                    component={selectedIcon.Component}
+                    as={selectedIcon.Component}
                     contextColor="textPrimaryInverse"
                   />
                 </Grid>
                 <Grid container justifyContent="center">
                   <ContextComponent
-                    component={selectedIcon.Component}
+                    as={selectedIcon.Component}
                     contextColor="textSecondary"
                   />
                   <ContextComponent
-                    component={selectedIcon.Component}
+                    as={selectedIcon.Component}
                     contextColor="textSecondaryInverse"
                   />
                 </Grid>


### PR DESCRIPTION
The icon selection has been broken during #40449

![image](https://github.com/mui/material-ui/assets/45398769/f91be173-02be-4498-b1fc-8d0cc28b7927)

Here is a deployment of a previous PR for comparison

https://deploy-preview-40447--material-ui.netlify.app/material-ui/material-icons/?query=Undo&theme=Two+tone&selected=RedoTwoTone

![image](https://github.com/mui/material-ui/assets/45398769/8ac586a6-8442-42e4-b4a7-35c736974454)
