### PR TITLE
[docs-infra] Allow developers to build their CodeSandbox export

### DIFF
--- a/docs/src/modules/sandbox/CodeSandbox.test.js
+++ b/docs/src/modules/sandbox/CodeSandbox.test.js
@@ -41,6 +41,12 @@ describe('CodeSandbox', () => {
           devDependencies: {
             'react-scripts': 'latest',
           },
+          scripts: {
+            start: 'react-scripts start',
+            build: 'react-scripts build',
+            test: 'react-scripts test',
+            eject: 'react-scripts eject',
+          },
         },
       },
       'public/index.html': {
@@ -130,7 +136,10 @@ ReactDOM.createRoot(document.querySelector("#root")).render(
           },
           main: 'index.tsx',
           scripts: {
+            build: 'react-scripts build',
+            eject: 'react-scripts eject',
             start: 'react-scripts start',
+            test: 'react-scripts test',
           },
         },
       },

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -63,11 +63,14 @@ const createReactApp = (demoData: DemoData) => {
       description,
       dependencies,
       devDependencies,
+      scripts: {
+        start: 'react-scripts start',
+        build: 'react-scripts build',
+        test: 'react-scripts test',
+        eject: 'react-scripts ejec',
+      },
       ...(demoData.codeVariant === 'TS' && {
         main: 'index.tsx',
-        scripts: {
-          start: 'react-scripts start',
-        },
       }),
     },
   };
@@ -155,11 +158,14 @@ ReactDOM.createRoot(document.querySelector("#root")${type}).render(
       description,
       dependencies,
       devDependencies,
+      scripts: {
+        start: 'react-scripts start',
+        build: 'react-scripts build',
+        test: 'react-scripts test',
+        eject: 'react-scripts ejec',
+      },
       ...(templateData.codeVariant === 'TS' && {
         main: 'index.tsx',
-        scripts: {
-          start: 'react-scripts start',
-        },
       }),
     },
   };

--- a/docs/src/modules/sandbox/CodeSandbox.ts
+++ b/docs/src/modules/sandbox/CodeSandbox.ts
@@ -67,7 +67,7 @@ const createReactApp = (demoData: DemoData) => {
         start: 'react-scripts start',
         build: 'react-scripts build',
         test: 'react-scripts test',
-        eject: 'react-scripts ejec',
+        eject: 'react-scripts eject',
       },
       ...(demoData.codeVariant === 'TS' && {
         main: 'index.tsx',
@@ -162,7 +162,7 @@ ReactDOM.createRoot(document.querySelector("#root")${type}).render(
         start: 'react-scripts start',
         build: 'react-scripts build',
         test: 'react-scripts test',
-        eject: 'react-scripts ejec',
+        eject: 'react-scripts eject',
       },
       ...(templateData.codeVariant === 'TS' && {
         main: 'index.tsx',


### PR DESCRIPTION
This is a continuation of #32726. To make #40833 for an optimal bug reproduction experience, developers should be able to build their reproduction when they fork demos from the docs.

The current issue https://codesandbox.io/p/sandbox/intelligent-pond-fjkdsd?file=%2Fpackage.json%3A13%2C4

![Screenshot 2024-01-31 at 20 16 19](https://github.com/mui/material-ui/assets/3165635/e6ed6ea6-9d5d-4339-961e-774023899e8f)

Which is different from standard CRA projects, e.g. 

https://github.com/mui/material-ui/blob/19ff6ada02dafa827531653801a3b657d58047ba/examples/base-ui-cra-ts/package.json#L14-L18

I saw that while I was checking something else on MUI X. Thought it was a quick win.