### PR TITLE
[docs] Add a 404 page

### DIFF
--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -10,10 +10,7 @@ import NotFoundHero from 'docs/src/components/NotFoundHero';
 export default function Custom404() {
   return (
     <BrandingCssVarsProvider>
-      <Head
-        title="404: This page could not be found - MUI"
-        description=""
-      />
+      <Head title="404: This page could not be found - MUI" description="" />
       <AppHeaderBanner />
       <AppHeader />
       <main id="main-content">

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import Divider from '@mui/material/Divider';
+import Head from 'docs/src/modules/components/Head';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
+import AppHeader from 'docs/src/layouts/AppHeader';
+import AppFooter from 'docs/src/layouts/AppFooter';
+import AppHeaderBanner from 'docs/src/components/banner/AppHeaderBanner';
+import NotFoundHero from 'docs/src/components/NotFoundHero';
+
+export default function NotFound() {
+  return (
+    <BrandingCssVarsProvider>
+      <Head
+        title="404: This page could not be found - MUI"
+        description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design."
+        card="/static/social-previews/home-preview.jpg"
+      />
+      <AppHeaderBanner />
+      <AppHeader gitHubRepository="https://github.com/mui/material-ui" />
+      <main id="main-content">
+        <NotFoundHero />
+        <Divider />
+      </main>
+      <AppFooter stackOverflowUrl="https://stackoverflow.com/questions/tagged/material-ui" />
+    </BrandingCssVarsProvider>
+  );
+}

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -7,7 +7,7 @@ import AppFooter from 'docs/src/layouts/AppFooter';
 import AppHeaderBanner from 'docs/src/components/banner/AppHeaderBanner';
 import NotFoundHero from 'docs/src/components/NotFoundHero';
 
-export default function NotFound() {
+export default function Custom404() {
   return (
     <BrandingCssVarsProvider>
       <Head

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -13,7 +13,6 @@ export default function Custom404() {
       <Head
         title="404: This page could not be found - MUI"
         description=""
-        card="/static/social-previews/home-preview.jpg"
       />
       <AppHeaderBanner />
       <AppHeader />

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -12,16 +12,16 @@ export default function Custom404() {
     <BrandingCssVarsProvider>
       <Head
         title="404: This page could not be found - MUI"
-        description="MUI provides a simple, customizable, and accessible library of React components. Follow your own design system, or start with Material Design."
+        description=""
         card="/static/social-previews/home-preview.jpg"
       />
       <AppHeaderBanner />
-      <AppHeader gitHubRepository="https://github.com/mui/material-ui" />
+      <AppHeader />
       <main id="main-content">
         <NotFoundHero />
         <Divider />
       </main>
-      <AppFooter stackOverflowUrl="https://stackoverflow.com/questions/tagged/material-ui" />
+      <AppFooter />
     </BrandingCssVarsProvider>
   );
 }

--- a/docs/pages/base-ui.tsx
+++ b/docs/pages/base-ui.tsx
@@ -12,7 +12,7 @@ import BaseUICustomization from 'docs/src/components/productBaseUI/BaseUICustomi
 import BaseUIEnd from 'docs/src/components/productBaseUI/BaseUIEnd';
 import BaseUITestimonial from 'docs/src/components/productBaseUI/BaseUITestimonial';
 
-export default function Core() {
+export default function BaseUI() {
   return (
     <BrandingCssVarsProvider>
       <Head

--- a/docs/pages/material-ui.tsx
+++ b/docs/pages/material-ui.tsx
@@ -14,7 +14,7 @@ import References, { CORE_CUSTOMERS } from 'docs/src/components/home/References'
 import AppFooter from 'docs/src/layouts/AppFooter';
 import AppHeaderBanner from 'docs/src/components/banner/AppHeaderBanner';
 
-export default function Core() {
+export default function MaterialUI() {
   return (
     <BrandingCssVarsProvider>
       <Head

--- a/docs/src/components/NotFoundHero.tsx
+++ b/docs/src/components/NotFoundHero.tsx
@@ -5,7 +5,6 @@ import Typography from '@mui/material/Typography';
 import Section from 'docs/src/layouts/Section';
 import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
 import SearchOffRoundedIcon from '@mui/icons-material/SearchOffRounded';
-import { DeferredAppSearch } from 'docs/src/modules/components/AppFrame';
 
 function NotFoundIllustration() {
   return (
@@ -103,9 +102,8 @@ export default function NotFoundHero() {
             Page not found
           </Typography>
         }
-        description="Apologies, but the page you were looking for wasn't found. Try using the search button below to look for another one."
+        description="Apologies, but the page you were looking for wasn't found. Try reaching for the search button on the nav bar above to look for another one."
       />
-      <DeferredAppSearch />
     </Section>
   );
 }

--- a/docs/src/components/NotFoundHero.tsx
+++ b/docs/src/components/NotFoundHero.tsx
@@ -12,8 +12,10 @@ function NotFoundIllustration() {
       sx={(theme) => ({
         mx: 'auto',
         mb: 4,
-        height: 150,
-        width: 200,
+        height: { xs: 200, sm: 150 },
+        width: { xs: 100, sm: 200 },
+        display: 'flex',
+        flexDirection: { xs: 'column-reverse', sm: 'column' },
         borderRadius: 1,
         border: '1px solid',
         borderColor: 'divider',
@@ -33,7 +35,7 @@ function NotFoundIllustration() {
       <Box
         sx={{
           p: 1.5,
-          display: 'flex',
+          display: { xs: 'none', sm: 'flex' },
           gap: 1,
           borderBottom: '1px solid',
           borderColor: 'divider',
@@ -50,7 +52,27 @@ function NotFoundIllustration() {
           sx={{ width: 10, height: 10, borderRadius: 2, bgcolor: 'success.500', opacity: '80%' }}
         />
       </Box>
-      <Box sx={{ height: '75%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Box
+        sx={{
+          pt: 1,
+          pb: '5px',
+          display: { xs: 'flex', sm: 'none' },
+          justifyContent: 'center',
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          bgcolor: 'background.paper',
+        }}
+      >
+        <Box
+          sx={{
+            height: 3,
+            width: '40%',
+            bgcolor: 'rgba(0,0,0,0.3)',
+            borderRadius: 2,
+          }}
+        />
+      </Box>
+      <Box sx={{ flexGrow: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <SearchOffRoundedIcon sx={{ fontSize: 50, color: 'primary.500', opacity: '40%' }} />
       </Box>
     </Box>

--- a/docs/src/components/NotFoundHero.tsx
+++ b/docs/src/components/NotFoundHero.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import Section from 'docs/src/layouts/Section';
 import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
 import SearchOffRoundedIcon from '@mui/icons-material/SearchOffRounded';
+import { DeferredAppSearch } from 'docs/src/modules/components/AppFrame';
 
 function NotFoundIllustration() {
   return (
@@ -17,14 +18,14 @@ function NotFoundIllustration() {
         display: 'flex',
         flexDirection: { xs: 'column-reverse', sm: 'column' },
         borderRadius: 1,
-        border: '1px solid',
-        borderColor: 'divider',
+        border: `1px solid ${theme.palette.grey[200]}`,
         overflow: 'clip',
         boxShadow: `0px 2px 8px -2px ${alpha(
           theme.palette.primary[300],
           0.3,
         )}, 0px 6px 12px -2px ${alpha(theme.palette.primary[100], 0.2)}`,
         ...theme.applyDarkStyles({
+          borderColor: theme.palette.primaryDark[700],
           boxShadow: `0px 2px 8px -2px ${alpha(
             theme.palette.common.black,
             0.3,
@@ -36,7 +37,7 @@ function NotFoundIllustration() {
         sx={{
           p: 1.5,
           display: { xs: 'none', sm: 'flex' },
-          gap: 1,
+          gap: '6px',
           borderBottom: '1px solid',
           borderColor: 'divider',
           bgcolor: 'background.paper',
@@ -84,10 +85,14 @@ export default function NotFoundHero() {
     <Section
       bg="gradient"
       sx={{
-        height: '50vh',
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        '& .MuiContainer-root': {
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
       }}
     >
       <NotFoundIllustration />
@@ -98,8 +103,9 @@ export default function NotFoundHero() {
             Page not found
           </Typography>
         }
-        description="Apologies, but the page you were looking for wasn't found."
+        description="Apologies, but the page you were looking for wasn't found. Try using the search button below to look for another page."
       />
+      <DeferredAppSearch />
     </Section>
   );
 }

--- a/docs/src/components/NotFoundHero.tsx
+++ b/docs/src/components/NotFoundHero.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Section from 'docs/src/layouts/Section';
@@ -17,9 +18,15 @@ function NotFoundIllustration() {
         border: '1px solid',
         borderColor: 'divider',
         overflow: 'clip',
-        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.05)',
+        boxShadow: `0px 2px 8px -2px ${alpha(
+          theme.palette.primary[300],
+          0.3,
+        )}, 0px 6px 12px -2px ${alpha(theme.palette.primary[100], 0.2)}`,
         ...theme.applyDarkStyles({
-          boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+          boxShadow: `0px 2px 8px -2px ${alpha(
+            theme.palette.common.black,
+            0.3,
+          )}, 0px 6px 12px -2px ${alpha(theme.palette.common.black, 0.2)}`,
         }),
       })}
     >

--- a/docs/src/components/NotFoundHero.tsx
+++ b/docs/src/components/NotFoundHero.tsx
@@ -103,7 +103,7 @@ export default function NotFoundHero() {
             Page not found
           </Typography>
         }
-        description="Apologies, but the page you were looking for wasn't found. Try using the search button below to look for another page."
+        description="Apologies, but the page you were looking for wasn't found. Try using the search button below to look for another one."
       />
       <DeferredAppSearch />
     </Section>

--- a/docs/src/components/NotFoundHero.tsx
+++ b/docs/src/components/NotFoundHero.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Section from 'docs/src/layouts/Section';
+import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
+import SearchOffRoundedIcon from '@mui/icons-material/SearchOffRounded';
+
+function NotFoundIllustration() {
+  return (
+    <Box
+      sx={(theme) => ({
+        mx: 'auto',
+        mb: 4,
+        height: 150,
+        width: 200,
+        borderRadius: 1,
+        border: '1px solid',
+        borderColor: 'divider',
+        overflow: 'clip',
+        boxShadow: '0 4px 8px rgba(0, 0, 0, 0.05)',
+        ...theme.applyDarkStyles({
+          boxShadow: '0 4px 8px rgba(0, 0, 0, 0.1)',
+        }),
+      })}
+    >
+      <Box
+        sx={{
+          p: 1.5,
+          display: 'flex',
+          gap: 1,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          bgcolor: 'background.paper',
+        }}
+      >
+        <Box
+          sx={{ width: 10, height: 10, borderRadius: 2, bgcolor: 'error.500', opacity: '80%' }}
+        />
+        <Box
+          sx={{ width: 10, height: 10, borderRadius: 2, bgcolor: 'warning.500', opacity: '80%' }}
+        />
+        <Box
+          sx={{ width: 10, height: 10, borderRadius: 2, bgcolor: 'success.500', opacity: '80%' }}
+        />
+      </Box>
+      <Box sx={{ height: '75%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <SearchOffRoundedIcon sx={{ fontSize: 50, color: 'primary.500', opacity: '40%' }} />
+      </Box>
+    </Box>
+  );
+}
+
+export default function NotFoundHero() {
+  return (
+    <Section
+      bg="gradient"
+      sx={{
+        height: '50vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <NotFoundIllustration />
+      <SectionHeadline
+        alwaysCenter
+        title={
+          <Typography component="h1" variant="h4" fontWeight="semiBold">
+            Page not found
+          </Typography>
+        }
+        description="Apologies, but the page you were looking for wasn't found."
+      />
+    </Section>
+  );
+}

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -31,10 +31,10 @@ const nProgressStart = debounce(() => {
   NProgress.start();
 }, 200);
 
-const nProgressDone = () => {
+function nProgressDone() {
   nProgressStart.clear();
   NProgress.done();
-};
+}
 
 export function NextNProgressBar() {
   const router = useRouter();
@@ -67,6 +67,7 @@ export function NextNProgressBar() {
 const sx = { minWidth: { sm: 160 } };
 
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
+
 export function DeferredAppSearch() {
   const [mounted, setMounted] = React.useState(false);
   React.useEffect(() => {

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -31,10 +31,10 @@ const nProgressStart = debounce(() => {
   NProgress.start();
 }, 200);
 
-function nProgressDone() {
+const nProgressDone = () => {
   nProgressStart.clear();
   NProgress.done();
-}
+};
 
 export function NextNProgressBar() {
   const router = useRouter();
@@ -67,7 +67,6 @@ export function NextNProgressBar() {
 const sx = { minWidth: { sm: 160 } };
 
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
-
 export function DeferredAppSearch() {
   const [mounted, setMounted] = React.useState(false);
   React.useEffect(() => {

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -118,7 +118,7 @@ const StyledAppBar = styled(AppBar, {
     borderColor: (theme.vars || theme).palette.grey[100],
     borderWidth: 0,
     borderBottomWidth: 'thin',
-    backgroundColor: 'rgba(255,255,255,0.9)',
+    backgroundColor: 'rgba(255,255,255,0.8)',
     color: (theme.vars || theme).palette.grey[800],
     ...theme.applyDarkStyles({
       borderColor: alpha(theme.palette.primary[100], 0.08),

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -80,12 +80,10 @@ const SearchButton = styled('button')(({ theme }) => [
   }),
 ]);
 
-const SearchLabel = styled('span')(({ theme }) => {
-  return {
-    marginLeft: theme.spacing(1),
-    marginRight: 'auto',
-  };
-});
+const SearchLabel = styled('span')(({ theme }) => ({
+  marginLeft: theme.spacing(1),
+  marginRight: 'auto',
+}));
 
 const Shortcut = styled('div')(({ theme }) => {
   return {
@@ -108,7 +106,7 @@ function NewStartScreen() {
   const startScreenOptions = [
     {
       category: {
-        name: 'Material UI',
+        name: 'Material UI',
       },
       items: [
         {
@@ -135,7 +133,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'Base UI',
+        name: 'Base UI',
       },
       items: [
         {
@@ -206,7 +204,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'MUI Toolpad',
+        name: 'MUI Toolpad',
       },
       items: [
         {
@@ -228,7 +226,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'MUI System',
+        name: 'MUI System',
       },
       items: [
         {
@@ -556,6 +554,15 @@ export default function AppSearch(props) {
               color: (theme.vars || theme).palette.primary[500],
               marginRight: theme.spacing(1.5),
               opacity: 0.6,
+              // Redefine SvgIcon-root style as ReactDOMServer.renderToStaticMarkup doesn't
+              // Generate the CSS.
+              // TODO v6: This hack should no longer be needed with static CSS rendering.
+              userSelect: 'none',
+              width: '1em',
+              height: '1em',
+              display: 'inline-block',
+              flexShrink: 0,
+              fill: 'currentColor',
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -54,7 +54,7 @@ const SearchButton = styled('button')(({ theme }) => [
     cursor: 'pointer',
     transitionProperty: 'all',
     transitionDuration: '150ms',
-    boxShadow: `inset 0 1px 1px ${(theme.vars || theme).palette.grey[100]}, 0 1px 0.5px ${alpha(
+    boxShadow: `inset 0 -1px 1px ${(theme.vars || theme).palette.grey[100]}, 0 1px 0.5px ${alpha(
       theme.palette.grey[100],
       0.6,
     )}`,
@@ -70,7 +70,7 @@ const SearchButton = styled('button')(({ theme }) => [
   theme.applyDarkStyles({
     backgroundColor: alpha(theme.palette.primaryDark[700], 0.4),
     borderColor: (theme.vars || theme).palette.primaryDark[700],
-    boxShadow: `inset 0 1px 1px ${(theme.vars || theme).palette.primaryDark[900]}, 0 1px 0.5px ${
+    boxShadow: `inset 0 -1px 1px ${(theme.vars || theme).palette.primaryDark[900]}, 0 1px 0.5px ${
       (theme.vars || theme).palette.common.black
     }`,
     '&:hover': {

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -80,10 +80,12 @@ const SearchButton = styled('button')(({ theme }) => [
   }),
 ]);
 
-const SearchLabel = styled('span')(({ theme }) => ({
-  marginLeft: theme.spacing(1),
-  marginRight: 'auto',
-}));
+const SearchLabel = styled('span')(({ theme }) => {
+  return {
+    marginLeft: theme.spacing(1),
+    marginRight: 'auto',
+  };
+});
 
 const Shortcut = styled('div')(({ theme }) => {
   return {
@@ -106,7 +108,7 @@ function NewStartScreen() {
   const startScreenOptions = [
     {
       category: {
-        name: 'Material UI',
+        name: 'Material UI',
       },
       items: [
         {
@@ -133,7 +135,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'Base UI',
+        name: 'Base UI',
       },
       items: [
         {
@@ -204,7 +206,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'MUI Toolpad',
+        name: 'MUI Toolpad',
       },
       items: [
         {
@@ -226,7 +228,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'MUI System',
+        name: 'MUI System',
       },
       items: [
         {
@@ -554,15 +556,6 @@ export default function AppSearch(props) {
               color: (theme.vars || theme).palette.primary[500],
               marginRight: theme.spacing(1.5),
               opacity: 0.6,
-              // Redefine SvgIcon-root style as ReactDOMServer.renderToStaticMarkup doesn't
-              // Generate the CSS.
-              // TODO v6: This hack should no longer be needed with static CSS rendering.
-              userSelect: 'none',
-              width: '1em',
-              height: '1em',
-              display: 'inline-block',
-              flexShrink: 0,
-              fill: 'currentColor',
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui/material-ui/issues/31349

Okay, this is a longstanding and quite simple PR. It adds a slightly better-designed 404 page than our standard one. Having something a little bit thoughtful for this scenario adds a lot to communicating our care for attention to detail and polish!

From what I could test, based on [the Next.js docs](https://nextjs.org/docs/pages/building-your-application/routing/custom-error), simply creating a `404.tsx` page is enough to route all of the 404 requests to it. It seems to be working well?! I'd appreciate any insights here if there's more wiring I need to do.

Preview: https://deploy-preview-40884--material-ui.netlify.app/material-ui/api/accordion-detailss/