### PR TITLE
[zero] Always replace the `createUseThemeProps` call

### DIFF
--- a/packages/zero-runtime/src/processors/createUseThemeProps.ts
+++ b/packages/zero-runtime/src/processors/createUseThemeProps.ts
@@ -44,21 +44,17 @@ export class CreateUseThemePropsProcessor extends BaseProcessor {
     const t = this.astService;
 
     const { themeArgs: { theme } = {} } = this.options as IOptions;
-    if (!theme?.components?.[this.componentName]?.defaultProps) {
-      return;
-    }
 
     const useThemePropsImportIdentifier = t.addNamedImport(
       this.tagSource.imported,
       process.env.PACKAGE_NAME as string,
     );
 
-    this.replacer(
-      t.callExpression(useThemePropsImportIdentifier, [
-        valueToLiteral(theme.components[this.componentName].defaultProps),
-      ]),
-      true,
-    );
+    let replacement: Expression = t.stringLiteral(this.componentName);
+    if (theme?.components?.[this.componentName]?.defaultProps) {
+      replacement = valueToLiteral(theme.components[this.componentName].defaultProps);
+    }
+    this.replacer(t.callExpression(useThemePropsImportIdentifier, [replacement]), true);
   }
 
   public override get asSelector(): string {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

If there are no default props provided, the Badge still uses `useThemeProps` from the system.

The build result:

```js
import { createUseThemeProps } from "../zero-styled";
…
const useThemeProps = createUseThemeProps("MuiBadge");
```

## After

Always replace the call with zero-runtime tag if the import is used.

The build result:

```js
import { createUseThemeProps as _createUseThemeProps } from "@mui/zero-runtime";
…
const useThemeProps = /*#__PURE__*/_createUseThemeProps("MuiBadge");
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
