### PR TITLE
[base-ui][docs] Add the planned Alert Dialog page

### DIFF
--- a/docs/data/base/components/alert-dialog/alert-dialog.md
+++ b/docs/data/base/components/alert-dialog/alert-dialog.md
@@ -1,0 +1,14 @@
+---
+productId: base-ui
+title: React Alert Dialog component
+githubLabel: 'component: alert dialog'
+waiAria: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
+---
+
+# Alert Dialog 🚧
+
+<p class="description">Alert dialogs are interruptive modals that prompt users to take action.</p>
+
+:::warning
+The Base UI Alert Dialog component isn't available yet, but you can upvote [this GitHub issue](https://github.com/mui/material-ui/issues/40886) to see it arrive sooner.
+:::

--- a/docs/data/base/pages.ts
+++ b/docs/data/base/pages.ts
@@ -52,6 +52,7 @@ const pages: readonly MuiPage[] = [
         pathname: '/base-ui/components/feedback',
         subheader: 'feedback',
         children: [
+          { pathname: '/base-ui/alert-dialog', title: 'Alert Dialog', planned: true },
           {
             pathname: '/base-ui/react-snackbar',
             title: 'Snackbar',

--- a/docs/pages/base-ui/react-alert-dialog/index.js
+++ b/docs/pages/base-ui/react-alert-dialog/index.js
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
+import AppFrame from 'docs/src/modules/components/AppFrame';
+import * as pageProps from 'docs/data/base/components/alert-dialog/alert-dialog.md?@mui/markdown';
+
+export default function Page(props) {
+  const { userLanguage, ...other } = props;
+  return <MarkdownDocs {...pageProps} {...other} />;
+}
+
+Page.getLayout = (page) => {
+  return <AppFrame>{page}</AppFrame>;
+};

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -268,6 +268,7 @@
     "/base-ui/react-badge": "Badge",
     "/base-ui/react-tooltip": "Tooltip",
     "feedback": "Feedback",
+    "/base-ui/alert-dialog": "Alert Dialog",
     "/base-ui/react-snackbar": "Snackbar",
     "surfaces": "Surfaces",
     "/base-ui/react-accordion": "Accordion",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

As the title says — that's one of the components we're considering for the v1 release that isn't yet on the docs marked as planned.
