### PR TITLE
Update React peer dependency in package.json

### DIFF
--- a/packages/mui-styles/package.json
+++ b/packages/mui-styles/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@types/react": "^17.0.0 || ^18.0.0",
-    "react": "^17.0.0"
+    "react": "^18.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Since React 18.2.0 is used as devDependency, I updated peerDependency to ^18.0.0 to support consuming applications using React versions higher than major v17

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
