### PR TITLE
[material-ui][docs] Improve aria-label throughout the Button Group demos

### DIFF
--- a/docs/data/material/components/button-group/BasicButtonGroup.js
+++ b/docs/data/material/components/button-group/BasicButtonGroup.js
@@ -4,7 +4,7 @@ import ButtonGroup from '@mui/material/ButtonGroup';
 
 export default function BasicButtonGroup() {
   return (
-    <ButtonGroup variant="contained" aria-label="outlined primary button group">
+    <ButtonGroup variant="contained" aria-label="Basic button group">
       <Button>One</Button>
       <Button>Two</Button>
       <Button>Three</Button>

--- a/docs/data/material/components/button-group/BasicButtonGroup.tsx
+++ b/docs/data/material/components/button-group/BasicButtonGroup.tsx
@@ -4,7 +4,7 @@ import ButtonGroup from '@mui/material/ButtonGroup';
 
 export default function BasicButtonGroup() {
   return (
-    <ButtonGroup variant="contained" aria-label="outlined primary button group">
+    <ButtonGroup variant="contained" aria-label="Basic button group">
       <Button>One</Button>
       <Button>Two</Button>
       <Button>Three</Button>

--- a/docs/data/material/components/button-group/BasicButtonGroup.tsx.preview
+++ b/docs/data/material/components/button-group/BasicButtonGroup.tsx.preview
@@ -1,4 +1,4 @@
-<ButtonGroup variant="contained" aria-label="outlined primary button group">
+<ButtonGroup variant="contained" aria-label="Basic button group">
   <Button>One</Button>
   <Button>Two</Button>
   <Button>Three</Button>

--- a/docs/data/material/components/button-group/ButtonGroupMaterialYouPlayground.js
+++ b/docs/data/material/components/button-group/ButtonGroupMaterialYouPlayground.js
@@ -40,7 +40,7 @@ export default function ButtonGroupMaterialYouPlayground() {
         },
       ]}
       renderDemo={(props) => (
-        <ButtonGroup {...props}>
+        <ButtonGroup {...props} aria-label="Basic button group">
           <Button>One</Button>
           <Button>Two</Button>
           <Button startIcon={<FavoriteBorder />}>Three</Button>

--- a/docs/data/material/components/button-group/DisableElevation.js
+++ b/docs/data/material/components/button-group/DisableElevation.js
@@ -7,7 +7,7 @@ export default function DisableElevation() {
     <ButtonGroup
       disableElevation
       variant="contained"
-      aria-label="Disabled elevation buttons"
+      aria-label="Basic button group"
     >
       <Button>One</Button>
       <Button>Two</Button>

--- a/docs/data/material/components/button-group/DisableElevation.js
+++ b/docs/data/material/components/button-group/DisableElevation.js
@@ -7,7 +7,7 @@ export default function DisableElevation() {
     <ButtonGroup
       disableElevation
       variant="contained"
-      aria-label="Basic button group"
+      aria-label="Disabled button group"
     >
       <Button>One</Button>
       <Button>Two</Button>

--- a/docs/data/material/components/button-group/DisableElevation.tsx
+++ b/docs/data/material/components/button-group/DisableElevation.tsx
@@ -7,7 +7,7 @@ export default function DisableElevation() {
     <ButtonGroup
       disableElevation
       variant="contained"
-      aria-label="Disabled elevation buttons"
+      aria-label="Basic button group"
     >
       <Button>One</Button>
       <Button>Two</Button>

--- a/docs/data/material/components/button-group/DisableElevation.tsx
+++ b/docs/data/material/components/button-group/DisableElevation.tsx
@@ -7,7 +7,7 @@ export default function DisableElevation() {
     <ButtonGroup
       disableElevation
       variant="contained"
-      aria-label="Basic button group"
+      aria-label="Disabled button group"
     >
       <Button>One</Button>
       <Button>Two</Button>

--- a/docs/data/material/components/button-group/DisableElevation.tsx.preview
+++ b/docs/data/material/components/button-group/DisableElevation.tsx.preview
@@ -1,7 +1,7 @@
 <ButtonGroup
   disableElevation
   variant="contained"
-  aria-label="Disabled elevation buttons"
+  aria-label="Basic button group"
 >
   <Button>One</Button>
   <Button>Two</Button>

--- a/docs/data/material/components/button-group/DisableElevation.tsx.preview
+++ b/docs/data/material/components/button-group/DisableElevation.tsx.preview
@@ -1,7 +1,7 @@
 <ButtonGroup
   disableElevation
   variant="contained"
-  aria-label="Basic button group"
+  aria-label="Disabled button group"
 >
   <Button>One</Button>
   <Button>Two</Button>

--- a/docs/data/material/components/button-group/GroupOrientation.js
+++ b/docs/data/material/components/button-group/GroupOrientation.js
@@ -9,8 +9,6 @@ const buttons = [
   <Button key="three">Three</Button>,
 ];
 
-const ariaLabel = 'Vertical button group';
-
 export default function GroupOrientation() {
   return (
     <Box
@@ -21,13 +19,21 @@ export default function GroupOrientation() {
         },
       }}
     >
-      <ButtonGroup orientation="vertical" aria-label={ariaLabel}>
+      <ButtonGroup orientation="vertical" aria-label="Vertical button group">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="contained">
+      <ButtonGroup
+        orientation="vertical"
+        aria-label="Vertical button group"
+        variant="contained"
+      >
         {buttons}
       </ButtonGroup>
-      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="text">
+      <ButtonGroup
+        orientation="vertical"
+        aria-label="Vertical button group"
+        variant="text"
+      >
         {buttons}
       </ButtonGroup>
     </Box>

--- a/docs/data/material/components/button-group/GroupOrientation.js
+++ b/docs/data/material/components/button-group/GroupOrientation.js
@@ -9,6 +9,8 @@ const buttons = [
   <Button key="three">Three</Button>,
 ];
 
+const ariaLabel = 'Vertical button group';
+
 export default function GroupOrientation() {
   return (
     <Box
@@ -19,24 +21,13 @@ export default function GroupOrientation() {
         },
       }}
     >
-      <ButtonGroup
-        orientation="vertical"
-        aria-label="vertical outlined button group"
-      >
+      <ButtonGroup orientation="vertical" aria-label={ariaLabel}>
         {buttons}
       </ButtonGroup>
-      <ButtonGroup
-        orientation="vertical"
-        aria-label="vertical contained button group"
-        variant="contained"
-      >
+      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="contained">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup
-        orientation="vertical"
-        aria-label="vertical contained button group"
-        variant="text"
-      >
+      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="text">
         {buttons}
       </ButtonGroup>
     </Box>

--- a/docs/data/material/components/button-group/GroupOrientation.tsx
+++ b/docs/data/material/components/button-group/GroupOrientation.tsx
@@ -9,8 +9,6 @@ const buttons = [
   <Button key="three">Three</Button>,
 ];
 
-const ariaLabel = 'Vertical button group';
-
 export default function GroupOrientation() {
   return (
     <Box
@@ -21,13 +19,21 @@ export default function GroupOrientation() {
         },
       }}
     >
-      <ButtonGroup orientation="vertical" aria-label={ariaLabel}>
+      <ButtonGroup orientation="vertical" aria-label="Vertical button group">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="contained">
+      <ButtonGroup
+        orientation="vertical"
+        aria-label="Vertical button group"
+        variant="contained"
+      >
         {buttons}
       </ButtonGroup>
-      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="text">
+      <ButtonGroup
+        orientation="vertical"
+        aria-label="Vertical button group"
+        variant="text"
+      >
         {buttons}
       </ButtonGroup>
     </Box>

--- a/docs/data/material/components/button-group/GroupOrientation.tsx
+++ b/docs/data/material/components/button-group/GroupOrientation.tsx
@@ -9,6 +9,8 @@ const buttons = [
   <Button key="three">Three</Button>,
 ];
 
+const ariaLabel = 'Vertical button group';
+
 export default function GroupOrientation() {
   return (
     <Box
@@ -19,24 +21,13 @@ export default function GroupOrientation() {
         },
       }}
     >
-      <ButtonGroup
-        orientation="vertical"
-        aria-label="vertical outlined button group"
-      >
+      <ButtonGroup orientation="vertical" aria-label={ariaLabel}>
         {buttons}
       </ButtonGroup>
-      <ButtonGroup
-        orientation="vertical"
-        aria-label="vertical contained button group"
-        variant="contained"
-      >
+      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="contained">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup
-        orientation="vertical"
-        aria-label="vertical contained button group"
-        variant="text"
-      >
+      <ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="text">
         {buttons}
       </ButtonGroup>
     </Box>

--- a/docs/data/material/components/button-group/GroupOrientation.tsx.preview
+++ b/docs/data/material/components/button-group/GroupOrientation.tsx.preview
@@ -1,9 +1,0 @@
-<ButtonGroup orientation="vertical" aria-label={ariaLabel}>
-  {buttons}
-</ButtonGroup>
-<ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="contained">
-  {buttons}
-</ButtonGroup>
-<ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="text">
-  {buttons}
-</ButtonGroup>

--- a/docs/data/material/components/button-group/GroupOrientation.tsx.preview
+++ b/docs/data/material/components/button-group/GroupOrientation.tsx.preview
@@ -1,0 +1,9 @@
+<ButtonGroup orientation="vertical" aria-label={ariaLabel}>
+  {buttons}
+</ButtonGroup>
+<ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="contained">
+  {buttons}
+</ButtonGroup>
+<ButtonGroup orientation="vertical" aria-label={ariaLabel} variant="text">
+  {buttons}
+</ButtonGroup>

--- a/docs/data/material/components/button-group/GroupSizesColors.js
+++ b/docs/data/material/components/button-group/GroupSizesColors.js
@@ -21,13 +21,13 @@ export default function GroupSizesColors() {
         },
       }}
     >
-      <ButtonGroup size="small" aria-label="small button group">
+      <ButtonGroup size="small" aria-label="Small button group">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup color="secondary" aria-label="medium secondary button group">
+      <ButtonGroup color="secondary" aria-label="Medium-sized button group">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup size="large" aria-label="large button group">
+      <ButtonGroup size="large" aria-label="Large button group">
         {buttons}
       </ButtonGroup>
     </Box>

--- a/docs/data/material/components/button-group/GroupSizesColors.tsx
+++ b/docs/data/material/components/button-group/GroupSizesColors.tsx
@@ -21,13 +21,13 @@ export default function GroupSizesColors() {
         },
       }}
     >
-      <ButtonGroup size="small" aria-label="small button group">
+      <ButtonGroup size="small" aria-label="Small button group">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup color="secondary" aria-label="medium secondary button group">
+      <ButtonGroup color="secondary" aria-label="Medium-sized button group">
         {buttons}
       </ButtonGroup>
-      <ButtonGroup size="large" aria-label="large button group">
+      <ButtonGroup size="large" aria-label="Large button group">
         {buttons}
       </ButtonGroup>
     </Box>

--- a/docs/data/material/components/button-group/GroupSizesColors.tsx.preview
+++ b/docs/data/material/components/button-group/GroupSizesColors.tsx.preview
@@ -1,9 +1,9 @@
-<ButtonGroup size="small" aria-label="small button group">
+<ButtonGroup size="small" aria-label="Small button group">
   {buttons}
 </ButtonGroup>
-<ButtonGroup color="secondary" aria-label="medium secondary button group">
+<ButtonGroup color="secondary" aria-label="Medium-sized button group">
   {buttons}
 </ButtonGroup>
-<ButtonGroup size="large" aria-label="large button group">
+<ButtonGroup size="large" aria-label="Large button group">
   {buttons}
 </ButtonGroup>

--- a/docs/data/material/components/button-group/LoadingButtonGroup.js
+++ b/docs/data/material/components/button-group/LoadingButtonGroup.js
@@ -6,7 +6,7 @@ import SaveIcon from '@mui/icons-material/Save';
 
 export default function LoadingButtonGroup() {
   return (
-    <ButtonGroup variant="outlined" aria-label="loading button group">
+    <ButtonGroup variant="outlined" aria-label="Loading button group">
       <Button>Submit</Button>
       <LoadingButton>Fetch data</LoadingButton>
       <LoadingButton loading loadingPosition="start" startIcon={<SaveIcon />}>

--- a/docs/data/material/components/button-group/LoadingButtonGroup.tsx
+++ b/docs/data/material/components/button-group/LoadingButtonGroup.tsx
@@ -6,7 +6,7 @@ import SaveIcon from '@mui/icons-material/Save';
 
 export default function LoadingButtonGroup() {
   return (
-    <ButtonGroup variant="outlined" aria-label="loading button group">
+    <ButtonGroup variant="outlined" aria-label="Loading button group">
       <Button>Submit</Button>
       <LoadingButton>Fetch data</LoadingButton>
       <LoadingButton loading loadingPosition="start" startIcon={<SaveIcon />}>

--- a/docs/data/material/components/button-group/LoadingButtonGroup.tsx.preview
+++ b/docs/data/material/components/button-group/LoadingButtonGroup.tsx.preview
@@ -1,4 +1,4 @@
-<ButtonGroup variant="outlined" aria-label="loading button group">
+<ButtonGroup variant="outlined" aria-label="Loading button group">
   <Button>Submit</Button>
   <LoadingButton>Fetch data</LoadingButton>
   <LoadingButton loading loadingPosition="start" startIcon={<SaveIcon />}>

--- a/docs/data/material/components/button-group/SplitButton.js
+++ b/docs/data/material/components/button-group/SplitButton.js
@@ -39,7 +39,11 @@ export default function SplitButton() {
 
   return (
     <React.Fragment>
-      <ButtonGroup variant="contained" ref={anchorRef} aria-label="split button">
+      <ButtonGroup
+        variant="contained"
+        ref={anchorRef}
+        aria-label="Button group with a nested menu"
+      >
         <Button onClick={handleClick}>{options[selectedIndex]}</Button>
         <Button
           size="small"

--- a/docs/data/material/components/button-group/SplitButton.tsx
+++ b/docs/data/material/components/button-group/SplitButton.tsx
@@ -45,7 +45,11 @@ export default function SplitButton() {
 
   return (
     <React.Fragment>
-      <ButtonGroup variant="contained" ref={anchorRef} aria-label="split button">
+      <ButtonGroup
+        variant="contained"
+        ref={anchorRef}
+        aria-label="Button group with a nested menu"
+      >
         <Button onClick={handleClick}>{options[selectedIndex]}</Button>
         <Button
           size="small"

--- a/docs/data/material/components/button-group/VariantButtonGroup.js
+++ b/docs/data/material/components/button-group/VariantButtonGroup.js
@@ -3,6 +3,8 @@ import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import Box from '@mui/material/Box';
 
+const ariaLabel = 'Basic button group';
+
 export default function VariantButtonGroup() {
   return (
     <Box
@@ -15,12 +17,12 @@ export default function VariantButtonGroup() {
         },
       }}
     >
-      <ButtonGroup variant="outlined" aria-label="outlined button group">
+      <ButtonGroup variant="outlined" aria-label={ariaLabel}>
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>
       </ButtonGroup>
-      <ButtonGroup variant="text" aria-label="text button group">
+      <ButtonGroup variant="text" aria-label={ariaLabel}>
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>

--- a/docs/data/material/components/button-group/VariantButtonGroup.js
+++ b/docs/data/material/components/button-group/VariantButtonGroup.js
@@ -3,8 +3,6 @@ import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import Box from '@mui/material/Box';
 
-const ariaLabel = 'Basic button group';
-
 export default function VariantButtonGroup() {
   return (
     <Box
@@ -17,12 +15,12 @@ export default function VariantButtonGroup() {
         },
       }}
     >
-      <ButtonGroup variant="outlined" aria-label={ariaLabel}>
+      <ButtonGroup variant="outlined" aria-label="Basic button group">
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>
       </ButtonGroup>
-      <ButtonGroup variant="text" aria-label={ariaLabel}>
+      <ButtonGroup variant="text" aria-label="Basic button group">
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>

--- a/docs/data/material/components/button-group/VariantButtonGroup.tsx
+++ b/docs/data/material/components/button-group/VariantButtonGroup.tsx
@@ -3,6 +3,8 @@ import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import Box from '@mui/material/Box';
 
+const ariaLabel = 'Basic button group';
+
 export default function VariantButtonGroup() {
   return (
     <Box
@@ -15,12 +17,12 @@ export default function VariantButtonGroup() {
         },
       }}
     >
-      <ButtonGroup variant="outlined" aria-label="outlined button group">
+      <ButtonGroup variant="outlined" aria-label={ariaLabel}>
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>
       </ButtonGroup>
-      <ButtonGroup variant="text" aria-label="text button group">
+      <ButtonGroup variant="text" aria-label={ariaLabel}>
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>

--- a/docs/data/material/components/button-group/VariantButtonGroup.tsx
+++ b/docs/data/material/components/button-group/VariantButtonGroup.tsx
@@ -3,8 +3,6 @@ import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
 import Box from '@mui/material/Box';
 
-const ariaLabel = 'Basic button group';
-
 export default function VariantButtonGroup() {
   return (
     <Box
@@ -17,12 +15,12 @@ export default function VariantButtonGroup() {
         },
       }}
     >
-      <ButtonGroup variant="outlined" aria-label={ariaLabel}>
+      <ButtonGroup variant="outlined" aria-label="Basic button group">
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>
       </ButtonGroup>
-      <ButtonGroup variant="text" aria-label={ariaLabel}>
+      <ButtonGroup variant="text" aria-label="Basic button group">
         <Button>One</Button>
         <Button>Two</Button>
         <Button>Three</Button>

--- a/docs/data/material/components/button-group/VariantButtonGroup.tsx.preview
+++ b/docs/data/material/components/button-group/VariantButtonGroup.tsx.preview
@@ -1,9 +1,9 @@
-<ButtonGroup variant="outlined" aria-label="outlined button group">
+<ButtonGroup variant="outlined" aria-label={ariaLabel}>
   <Button>One</Button>
   <Button>Two</Button>
   <Button>Three</Button>
 </ButtonGroup>
-<ButtonGroup variant="text" aria-label="text button group">
+<ButtonGroup variant="text" aria-label={ariaLabel}>
   <Button>One</Button>
   <Button>Two</Button>
   <Button>Three</Button>

--- a/docs/data/material/components/button-group/VariantButtonGroup.tsx.preview
+++ b/docs/data/material/components/button-group/VariantButtonGroup.tsx.preview
@@ -1,9 +1,9 @@
-<ButtonGroup variant="outlined" aria-label={ariaLabel}>
+<ButtonGroup variant="outlined" aria-label="Basic button group">
   <Button>One</Button>
   <Button>Two</Button>
   <Button>Three</Button>
 </ButtonGroup>
-<ButtonGroup variant="text" aria-label={ariaLabel}>
+<ButtonGroup variant="text" aria-label="Basic button group">
   <Button>One</Button>
   <Button>Two</Button>
   <Button>Three</Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Following recent docs-feedback — some aria labels were really not great and could use some basic polish. Also, we should probably confirm whether it's necessary to add `role=group"` to these containers; it makes sense to me, and it's what [Bootstrap also recommends](https://getbootstrap.com/docs/4.0/components/button-group/#basic-example) folks doing. Unlike aria-labels, though, that role attribute feels like something that should come out of the box, as it will always be needed in this Button Group context.

https://deploy-preview-40892--material-ui.netlify.app/material-ui/react-button-group/