### PR TITLE
[Menu][base-ui] Fix improperly merged tests

### DIFF
--- a/packages/mui-base/src/Menu/Menu.test.tsx
+++ b/packages/mui-base/src/Menu/Menu.test.tsx
@@ -87,7 +87,7 @@ describe('<Menu />', () => {
       });
     });
 
-    it('highlights first item when down arrow key opens the menu', () => {
+    it('highlights first item when down arrow key opens the menu', async () => {
       const context: DropdownContextValue = {
         ...testContext,
         state: {
@@ -99,7 +99,7 @@ describe('<Menu />', () => {
           } as React.KeyboardEvent,
         },
       };
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <DropdownContext.Provider value={context}>
           <Menu>
             <MenuItem>1</MenuItem>
@@ -116,7 +116,7 @@ describe('<Menu />', () => {
       });
     });
 
-    it('highlights last item when up arrow key opens the menu', () => {
+    it('highlights last item when up arrow key opens the menu', async () => {
       const context: DropdownContextValue = {
         ...testContext,
         state: {
@@ -128,7 +128,7 @@ describe('<Menu />', () => {
           } as React.KeyboardEvent,
         },
       };
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <DropdownContext.Provider value={context}>
           <Menu>
             <MenuItem>1</MenuItem>
@@ -146,7 +146,7 @@ describe('<Menu />', () => {
       });
     });
 
-    it('highlights last non-disabled item when disabledItemsFocusable is set to false', () => {
+    it('highlights last non-disabled item when disabledItemsFocusable is set to false', async () => {
       const CustomMenu = React.forwardRef(function CustomMenu(
         props: React.ComponentPropsWithoutRef<'ul'>,
         ref: React.Ref<HTMLUListElement>,
@@ -180,7 +180,7 @@ describe('<Menu />', () => {
           } as React.KeyboardEvent,
         },
       };
-      const { getAllByRole } = render(
+      const { getAllByRole } = await render(
         <DropdownContext.Provider value={context}>
           <CustomMenu>
             <MenuItem>1</MenuItem>


### PR DESCRIPTION
After merging #40731, Base UI tests became broken, as another PR that changed them landed in master first. This fixes the usage of the `render` function, making the CI green again.
