### PR TITLE
[base-ui][Switch] Add missing role attribute

### DIFF
--- a/packages/mui-base/src/Switch/Switch.tsx
+++ b/packages/mui-base/src/Switch/Switch.tsx
@@ -103,9 +103,6 @@ const Switch = React.forwardRef(function Switch<RootComponentType extends React.
     elementType: Input,
     getSlotProps: getInputProps,
     externalSlotProps: slotProps.input,
-    additionalProps: {
-      role: 'switch', // Switch component should have the role "switch" to meet a11y guidelines
-    },
     ownerState,
     className: classes.input,
   });

--- a/packages/mui-base/src/Switch/Switch.tsx
+++ b/packages/mui-base/src/Switch/Switch.tsx
@@ -103,6 +103,9 @@ const Switch = React.forwardRef(function Switch<RootComponentType extends React.
     elementType: Input,
     getSlotProps: getInputProps,
     externalSlotProps: slotProps.input,
+    additionalProps: {
+      role: 'switch', // Switch component should have the role "switch" to meet a11y guidelines
+    },
     ownerState,
     className: classes.input,
   });

--- a/packages/mui-base/src/useSwitch/useSwitch.test.tsx
+++ b/packages/mui-base/src/useSwitch/useSwitch.test.tsx
@@ -65,7 +65,7 @@ describe('useSwitch', () => {
       render(<Switch />);
 
       act(() => {
-        screen.getByRole('checkbox').click();
+        screen.getByRole('switch').click();
       });
 
       expect(handleChange.callCount).to.equal(1);
@@ -85,11 +85,11 @@ describe('useSwitch', () => {
         return <input {...getInputProps()} />;
       }
       render(<Switch />);
-      const checkbox = screen.getByRole('checkbox');
+      const switchElement = screen.getByRole('switch');
 
       simulatePointerDevice();
       act(() => {
-        checkbox.focus();
+        switchElement.focus();
       });
 
       expect(handleBlur.callCount).to.equal(0);
@@ -99,7 +99,7 @@ describe('useSwitch', () => {
       );
 
       act(() => {
-        checkbox.blur();
+        switchElement.blur();
       });
 
       expect(handleBlur.callCount).to.equal(1);
@@ -108,7 +108,7 @@ describe('useSwitch', () => {
         programmaticFocusTriggersFocusVisible() ? 1 : 0,
       );
 
-      focusVisible(checkbox);
+      focusVisible(switchElement);
 
       expect(handleBlur.callCount).to.equal(1);
       expect(handleFocus.callCount).to.equal(2);

--- a/packages/mui-base/src/useSwitch/useSwitch.test.tsx
+++ b/packages/mui-base/src/useSwitch/useSwitch.test.tsx
@@ -65,7 +65,7 @@ describe('useSwitch', () => {
       render(<Switch />);
 
       act(() => {
-        screen.getByRole('switch').click();
+        screen.getByRole('checkbox').click();
       });
 
       expect(handleChange.callCount).to.equal(1);
@@ -85,7 +85,7 @@ describe('useSwitch', () => {
         return <input {...getInputProps()} />;
       }
       render(<Switch />);
-      const checkbox = screen.getByRole('switch');
+      const checkbox = screen.getByRole('checkbox');
 
       simulatePointerDevice();
       act(() => {

--- a/packages/mui-base/src/useSwitch/useSwitch.test.tsx
+++ b/packages/mui-base/src/useSwitch/useSwitch.test.tsx
@@ -65,7 +65,7 @@ describe('useSwitch', () => {
       render(<Switch />);
 
       act(() => {
-        screen.getByRole('checkbox').click();
+        screen.getByRole('switch').click();
       });
 
       expect(handleChange.callCount).to.equal(1);
@@ -85,7 +85,7 @@ describe('useSwitch', () => {
         return <input {...getInputProps()} />;
       }
       render(<Switch />);
-      const checkbox = screen.getByRole('checkbox');
+      const checkbox = screen.getByRole('switch');
 
       simulatePointerDevice();
       act(() => {

--- a/packages/mui-base/src/useSwitch/useSwitch.ts
+++ b/packages/mui-base/src/useSwitch/useSwitch.ts
@@ -110,6 +110,8 @@ export function useSwitch(props: UseSwitchParameters): UseSwitchReturnValue {
     ref: handleInputRef,
     required,
     type: 'checkbox',
+    role: 'switch',
+    'aria-checked': checkedProp,
     ...otherProps,
     onChange: createHandleInputChange(otherProps),
     onFocus: createHandleFocus(otherProps),

--- a/packages/mui-base/src/useSwitch/useSwitch.ts
+++ b/packages/mui-base/src/useSwitch/useSwitch.ts
@@ -110,6 +110,7 @@ export function useSwitch(props: UseSwitchParameters): UseSwitchReturnValue {
     ref: handleInputRef,
     required,
     type: 'checkbox',
+    role: 'switch',
     'aria-checked': checkedProp,
     ...otherProps,
     onChange: createHandleInputChange(otherProps),

--- a/packages/mui-base/src/useSwitch/useSwitch.ts
+++ b/packages/mui-base/src/useSwitch/useSwitch.ts
@@ -110,7 +110,6 @@ export function useSwitch(props: UseSwitchParameters): UseSwitchReturnValue {
     ref: handleInputRef,
     required,
     type: 'checkbox',
-    role: 'switch',
     'aria-checked': checkedProp,
     ...otherProps,
     onChange: createHandleInputChange(otherProps),

--- a/packages/mui-joy/src/Checkbox/Checkbox.tsx
+++ b/packages/mui-joy/src/Checkbox/Checkbox.tsx
@@ -322,7 +322,7 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
       name,
       value,
       readOnly,
-      role: 'checkbox',
+      role: undefined,
       required: required ?? formControl?.required,
       'aria-describedby': formControl?.['aria-describedby'],
       ...(indeterminate && {

--- a/packages/mui-joy/src/Checkbox/Checkbox.tsx
+++ b/packages/mui-joy/src/Checkbox/Checkbox.tsx
@@ -322,6 +322,7 @@ const Checkbox = React.forwardRef(function Checkbox(inProps, ref) {
       name,
       value,
       readOnly,
+      role: 'checkbox',
       required: required ?? formControl?.required,
       'aria-describedby': formControl?.['aria-describedby'],
       ...(indeterminate && {

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -369,7 +369,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const [SlotInput, inputProps] = useSlot('input', {
     additionalProps: {
       type: 'radio',
-      role: 'radio',
+      role: undefined,
       id,
       name,
       readOnly,

--- a/packages/mui-joy/src/Radio/Radio.tsx
+++ b/packages/mui-joy/src/Radio/Radio.tsx
@@ -369,6 +369,7 @@ const Radio = React.forwardRef(function Radio(inProps, ref) {
   const [SlotInput, inputProps] = useSlot('input', {
     additionalProps: {
       type: 'radio',
+      role: 'radio',
       id,
       name,
       readOnly,

--- a/packages/mui-joy/src/Switch/Switch.test.tsx
+++ b/packages/mui-joy/src/Switch/Switch.test.tsx
@@ -72,28 +72,28 @@ describe('<Switch />', () => {
     expect(switchComponent.childNodes[0]).to.have.class(classes.track);
   });
 
-  it('renders a `role="checkbox"` with the Unchecked state by default', () => {
+  it('renders a `role="switch"` with the Off state by default', () => {
     const { getByRole } = render(<Switch />);
 
-    expect(getByRole('checkbox')).to.have.property('checked', false);
+    expect(getByRole('switch')).to.have.property('checked', false);
   });
 
-  it('renders a checkbox with the Checked state when checked', () => {
+  it('renders a switch with the Checked state when On', () => {
     const { getByRole } = render(<Switch defaultChecked />);
 
-    expect(getByRole('checkbox')).to.have.property('checked', true);
+    expect(getByRole('switch')).to.have.property('checked', true);
   });
 
   it('the switch can be disabled', () => {
     const { getByRole } = render(<Switch disabled />);
 
-    expect(getByRole('checkbox')).to.have.property('disabled', true);
+    expect(getByRole('switch')).to.have.property('disabled', true);
   });
 
   it('the switch can be readonly', () => {
     const { getByRole } = render(<Switch readOnly />);
 
-    expect(getByRole('checkbox')).to.have.property('readOnly', true);
+    expect(getByRole('switch')).to.have.property('readOnly', true);
   });
 
   it('the Checked state changes after change events', () => {
@@ -101,11 +101,11 @@ describe('<Switch />', () => {
 
     // how a user would trigger it
     act(() => {
-      getByRole('checkbox').click();
-      fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+      getByRole('switch').click();
+      fireEvent.change(getByRole('switch'), { target: { checked: '' } });
     });
 
-    expect(getByRole('checkbox')).to.have.property('checked', false);
+    expect(getByRole('switch')).to.have.property('checked', false);
   });
 
   describe('decorator', () => {
@@ -130,8 +130,8 @@ describe('<Switch />', () => {
 
       // how a user would trigger it
       act(() => {
-        getByRole('checkbox').click();
-        fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+        getByRole('switch').click();
+        fireEvent.change(getByRole('switch'), { target: { checked: '' } });
       });
 
       expect(getByText('On')).toBeVisible();
@@ -146,8 +146,8 @@ describe('<Switch />', () => {
 
       // how a user would trigger it
       act(() => {
-        getByRole('checkbox').click();
-        fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+        getByRole('switch').click();
+        fireEvent.change(getByRole('switch'), { target: { checked: '' } });
       });
 
       expect(getByText('On')).toBeVisible();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related to #40615

**Changes in this PR:**

Added the missing accessibility features for the `Switch` component and `useSwitch` hook:

- Root element's `role` should be `switch`
- Root element should have `aria-checked` attribute