### PR TITLE
[docs-infra] Fix broken anchor links

### DIFF
--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -53,7 +53,7 @@
     "required": "Required",
     "optional": "Optional",
     "additional-info": {
-      "cssApi": "See <a href='#css'>CSS API</a> below for more details.",
+      "cssApi": "See <a href='#classes'>CSS classes API</a> below for more details.",
       "sx": "See the <a href='/system/getting-started/the-sx-prop/'>`sx` page</a> for more details.",
       "slotsApi": "See <a href='#slots'>Slots API</a> below for more details.",
       "joy-size": "To learn how to add custom sizes to the component, check out <a href='/joy-ui/customization/themed-components/#extend-sizes'>Themed components—Extend sizes</a>.",

--- a/packages/mui-material-next/src/ButtonBase/Ripple.tsx
+++ b/packages/mui-material-next/src/ButtonBase/Ripple.tsx
@@ -57,7 +57,7 @@ function Ripple(props: RippleProps) {
 Ripple.propTypes = {
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,

--- a/packages/mui-material-next/src/ButtonBase/Ripple.tsx
+++ b/packages/mui-material-next/src/ButtonBase/Ripple.tsx
@@ -57,7 +57,6 @@ function Ripple(props: RippleProps) {
 Ripple.propTypes = {
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,

--- a/packages/mui-material-next/src/ButtonBase/TouchRipple.tsx
+++ b/packages/mui-material-next/src/ButtonBase/TouchRipple.tsx
@@ -284,7 +284,6 @@ TouchRipple.propTypes = {
   center: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material-next/src/ButtonBase/TouchRipple.tsx
+++ b/packages/mui-material-next/src/ButtonBase/TouchRipple.tsx
@@ -284,7 +284,7 @@ TouchRipple.propTypes = {
   center: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material-next/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material-next/src/OutlinedInput/NotchedOutline.js
@@ -97,7 +97,6 @@ NotchedOutline.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material-next/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material-next/src/OutlinedInput/NotchedOutline.js
@@ -97,7 +97,7 @@ NotchedOutline.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material-next/src/Select/SelectInput.js
+++ b/packages/mui-material-next/src/Select/SelectInput.js
@@ -604,7 +604,6 @@ SelectInput.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material-next/src/Select/SelectInput.js
+++ b/packages/mui-material-next/src/Select/SelectInput.js
@@ -604,7 +604,7 @@ SelectInput.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/ButtonBase/Ripple.js
+++ b/packages/mui-material/src/ButtonBase/Ripple.js
@@ -60,7 +60,6 @@ function Ripple(props) {
 Ripple.propTypes = {
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,

--- a/packages/mui-material/src/ButtonBase/Ripple.js
+++ b/packages/mui-material/src/ButtonBase/Ripple.js
@@ -60,7 +60,7 @@ function Ripple(props) {
 Ripple.propTypes = {
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -324,7 +324,6 @@ TouchRipple.propTypes = {
   center: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/ButtonBase/TouchRipple.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.js
@@ -324,7 +324,7 @@ TouchRipple.propTypes = {
   center: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -168,7 +168,7 @@ NativeSelectInput.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.js
@@ -168,7 +168,6 @@ NativeSelectInput.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -97,7 +97,6 @@ NotchedOutline.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/OutlinedInput/NotchedOutline.js
+++ b/packages/mui-material/src/OutlinedInput/NotchedOutline.js
@@ -97,7 +97,7 @@ NotchedOutline.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/Radio/RadioButtonIcon.js
+++ b/packages/mui-material/src/Radio/RadioButtonIcon.js
@@ -59,7 +59,6 @@ RadioButtonIcon.propTypes = {
   checked: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/Radio/RadioButtonIcon.js
+++ b/packages/mui-material/src/Radio/RadioButtonIcon.js
@@ -59,7 +59,7 @@ RadioButtonIcon.propTypes = {
   checked: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -600,7 +600,7 @@ SelectInput.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -600,7 +600,6 @@ SelectInput.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -194,7 +194,6 @@ SwitchBase.propTypes = {
   checkedIcon: PropTypes.node.isRequired,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**

--- a/packages/mui-material/src/internal/SwitchBase.js
+++ b/packages/mui-material/src/internal/SwitchBase.js
@@ -194,7 +194,7 @@ SwitchBase.propTypes = {
   checkedIcon: PropTypes.node.isRequired,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
+   * See [CSS classes API](#classes) below for more details.
    */
   classes: PropTypes.object,
   /**


### PR DESCRIPTION
Open https://mui.com/material-ui/api/tooltip/#tooltip-prop-classes the link is broken. Same issue on https://next.mui.com/x/api/tree-view/tree-item/#tree-item-prop-classes.

Preview: https://deploy-preview-40908--material-ui.netlify.app/material-ui/api/tooltip/#tooltip-prop-classes