### PR TITLE
[docs-infra] Improve support for absolute locale URL

### DIFF
--- a/docs/pages/blog.tsx
+++ b/docs/pages/blog.tsx
@@ -81,7 +81,7 @@ function PostPreview(props: BlogPost) {
       >
         <Link
           aria-describedby={`describe-${props.slug}`}
-          href={`/blog/${props.slug}`}
+          href={`/blog/${props.slug}/`}
           sx={{
             color: 'text.primary',
             '&:hover': {

--- a/docs/src/modules/components/AppNavDrawerItem.js
+++ b/docs/src/modules/components/AppNavDrawerItem.js
@@ -273,7 +273,7 @@ export default function AppNavDrawerItem(props) {
   } = props;
   const [open, setOpen] = React.useState(initiallyExpanded);
   const handleClick = (event) => {
-    // Ignore the action if opening the link in a new tab
+    // Ignore click events meant for native link handling, e.g. open in new tab
     if (samePageLinkNavigation(event)) {
       return;
     }

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -204,7 +204,7 @@ export default function AppTableOfContents(props) {
   useThrottledOnScroll(items.length > 0 ? findActiveIndex : null, 166);
 
   const handleClick = (hash) => (event) => {
-    // Ignore click for new tab/new window behavior
+    // Ignore click events meant for native link handling, e.g. open in new tab
     if (samePageLinkNavigation(event)) {
       return;
     }

--- a/docs/src/modules/components/Link.tsx
+++ b/docs/src/modules/components/Link.tsx
@@ -96,17 +96,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     [activeClassName]: shouldBeActive && activeClassName,
   });
 
-  const isExternal =
-    typeof href === 'string' && (href.indexOf('http') === 0 || href.indexOf('mailto:') === 0);
   const userLanguage = useUserLanguage();
-
-  if (isExternal) {
-    if (noLinkStyle) {
-      return <Anchor className={className} href={href} ref={ref} {...other} />;
-    }
-
-    return <MuiLink className={className} href={href} ref={ref} {...other} />;
-  }
 
   let linkAs = linkAsProp || as || (href as string);
   if (

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -22,13 +22,13 @@ function isLink(event) {
     activeElement = activeElement.parentElement;
   }
 
-  // Ignore non internal link clicks
+  // Ignore non internal link clicks.
+  // Absolute URLs can be internal, we delegate this to Next.js's router
   if (
     activeElement === null ||
     activeElement.nodeName !== 'A' ||
     activeElement.getAttribute('target') === '_blank' ||
-    activeElement.getAttribute('data-no-markdown-link') === 'true' ||
-    activeElement.getAttribute('href').indexOf('/') !== 0
+    activeElement.getAttribute('data-no-markdown-link') === 'true'
   ) {
     return null;
   }
@@ -40,13 +40,13 @@ function isLink(event) {
  * @param {MouseEvent} event
  */
 function handleClick(event) {
-  const activeElement = isLink(event);
-  if (activeElement === null) {
+  // Ignore click events meant for native link handling, e.g. open in new tab
+  if (samePageLinkNavigation(event)) {
     return;
   }
 
-  // Ignore click meant for native link handling, e.g. open in new tab
-  if (samePageLinkNavigation(event)) {
+  const activeElement = isLink(event);
+  if (activeElement === null) {
     return;
   }
 

--- a/examples/material-ui-nextjs-pages-router-ts/src/Link.tsx
+++ b/examples/material-ui-nextjs-pages-router-ts/src/Link.tsx
@@ -82,17 +82,6 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(function Link(props,
     [activeClassName]: router.pathname === pathname && activeClassName,
   });
 
-  const isExternal =
-    typeof href === 'string' && (href.indexOf('http') === 0 || href.indexOf('mailto:') === 0);
-
-  if (isExternal) {
-    if (noLinkStyle) {
-      return <Anchor className={className} href={href} ref={ref} {...other} />;
-    }
-
-    return <MuiLink className={className} href={href} ref={ref} {...other} />;
-  }
-
   const linkAs = linkAsProp || as;
   const nextjsProps = {
     to: href,

--- a/examples/material-ui-nextjs-pages-router/src/Link.js
+++ b/examples/material-ui-nextjs-pages-router/src/Link.js
@@ -78,17 +78,6 @@ const Link = React.forwardRef(function Link(props, ref) {
     [activeClassName]: router.pathname === pathname && activeClassName,
   });
 
-  const isExternal =
-    typeof href === 'string' && (href.indexOf('http') === 0 || href.indexOf('mailto:') === 0);
-
-  if (isExternal) {
-    if (noLinkStyle) {
-      return <Anchor className={className} href={href} ref={ref} {...other} />;
-    }
-
-    return <MuiLink className={className} href={href} ref={ref} {...other} />;
-  }
-
   const linkAs = linkAsProp || as;
   const nextjsProps = {
     to: href,


### PR DESCRIPTION
I'm reverting a change we did in #18441 to support Next.js v9. The underlying issue has since been solved in https://github.com/vercel/next.js/pull/15792/files#diff-29e1b9bc8e17f47fa46cad2f0e0e54d5bbb268adee26051c21d929902a2a5c8cR69 by @Janpot

To get the value of this change see https://mui.com/careers/react-engineer-x-charts/#benefits-and-compensation how the `https://mui.com/careers/#perks-and-benefits` link triggers a full page navigation:

https://github.com/mui/material-ui/assets/3165635/54f66500-81da-4ff9-ac6a-b9908aea9c0d

I noticed this from https://github.com/mui/material-ui/pull/40890#discussion_r1477424397.