### PR TITLE
[button][material-ui] Fix 'File upload' demo a11y

### DIFF
--- a/docs/data/material/components/buttons/InputFileUpload.js
+++ b/docs/data/material/components/buttons/InputFileUpload.js
@@ -17,7 +17,13 @@ const VisuallyHiddenInput = styled('input')({
 
 export default function InputFileUpload() {
   return (
-    <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>
+    <Button
+      component="label"
+      role={undefined}
+      variant="contained"
+      tabIndex={-1}
+      startIcon={<CloudUploadIcon />}
+    >
       Upload file
       <VisuallyHiddenInput type="file" />
     </Button>

--- a/docs/data/material/components/buttons/InputFileUpload.tsx
+++ b/docs/data/material/components/buttons/InputFileUpload.tsx
@@ -17,7 +17,13 @@ const VisuallyHiddenInput = styled('input')({
 
 export default function InputFileUpload() {
   return (
-    <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>
+    <Button
+      component="label"
+      role={undefined}
+      variant="contained"
+      tabIndex={-1}
+      startIcon={<CloudUploadIcon />}
+    >
       Upload file
       <VisuallyHiddenInput type="file" />
     </Button>

--- a/docs/data/material/components/buttons/InputFileUpload.tsx.preview
+++ b/docs/data/material/components/buttons/InputFileUpload.tsx.preview
@@ -1,4 +1,10 @@
-<Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>
+<Button
+  component="label"
+  role={undefined}
+  variant="contained"
+  tabIndex={-1}
+  startIcon={<CloudUploadIcon />}
+>
   Upload file
   <VisuallyHiddenInput type="file" />
 </Button>


### PR DESCRIPTION
This is a follow-up on #38823. The demo in https://mui.com/material-ui/react-button/#file-upload has two bugs that https://mui.com/joy-ui/react-button/#file-upload doesn't, so copied the solution Jun used. The bugs:

- Double tab
- [Axe](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) complaining about nested 

![Screenshot 2024-02-05 at 03 11 06](https://github.com/mui/material-ui/assets/3165635/d249cdb4-13c0-444f-8a17-d128eef6e288)

I noticed this in #40446