### PR TITLE
[dependencies] Do not update envinfo test dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -105,6 +105,12 @@
     {
       "groupName": "@definitelytyped tools",
       "matchPackagePatterns": ["@definitelytyped/*"]
+    },
+    {
+      "groupName": "envinfo tests",
+      "matchPaths": ["packages/mui-envinfo/test/package.json"],
+      "matchPackagePatterns": ["@mui/*"],
+      "enabled": false
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
The @mui packages in envinfo tests are not meant to be up to date. It's important that they reference an older version so they are downloaded from the registry instead of being linked to the workspace package.
The tests require them to be present and do not rely on any exported API, so the exact version does not matter.