### PR TITLE
[material-ui][Button] remove negative button icon margin

### DIFF
--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -271,10 +271,6 @@ const ButtonStartIcon = styled('span', {
 })(({ ownerState }) => ({
   display: 'inherit',
   marginRight: 8,
-  marginLeft: -4,
-  ...(ownerState.size === 'small' && {
-    marginLeft: -2,
-  }),
   ...commonIconStyles(ownerState),
 }));
 
@@ -288,11 +284,7 @@ const ButtonEndIcon = styled('span', {
   },
 })(({ ownerState }) => ({
   display: 'inherit',
-  marginRight: -4,
   marginLeft: 8,
-  ...(ownerState.size === 'small' && {
-    marginRight: -2,
-  }),
   ...commonIconStyles(ownerState),
 }));
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In the current implementation of the `startIcon` and `endIcon` props there is use of negative margin. This causes the Icons used for props to be moved outside the parent container of the button. 

This problem causes an issue when using the button on the edge of a viewport as the icon can be cut off.
![image](https://github.com/mui/material-ui/assets/62110248/40c1e1d4-d818-489d-b6fa-ba352926aab2)
![image](https://github.com/mui/material-ui/assets/62110248/a2128374-79ad-4755-83e5-6336137f9044)
Mui docs example:
![image](https://github.com/mui/material-ui/assets/62110248/85067e5e-92f2-4422-ade6-aaf15bf638a8)


This pr removes the negative margin causing the issue resulting in this.
![image](https://github.com/mui/material-ui/assets/62110248/648bb986-d20a-4ccc-adcd-ba28b8b66202)
Mui docs example:
![image](https://github.com/mui/material-ui/assets/62110248/54d33edc-e510-4f10-a6d6-3e8e76a29807)

