### PR TITLE
[docs-infra] Fix search icon issue

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -31,10 +31,10 @@ const nProgressStart = debounce(() => {
   NProgress.start();
 }, 200);
 
-const nProgressDone = () => {
+function nProgressDone() {
   nProgressStart.clear();
   NProgress.done();
-};
+}
 
 export function NextNProgressBar() {
   const router = useRouter();
@@ -67,6 +67,7 @@ export function NextNProgressBar() {
 const sx = { minWidth: { sm: 160 } };
 
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
+
 export function DeferredAppSearch() {
   const [mounted, setMounted] = React.useState(false);
   React.useEffect(() => {

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -80,12 +80,10 @@ const SearchButton = styled('button')(({ theme }) => [
   }),
 ]);
 
-const SearchLabel = styled('span')(({ theme }) => {
-  return {
-    marginLeft: theme.spacing(1),
-    marginRight: 'auto',
-  };
-});
+const SearchLabel = styled('span')(({ theme }) => ({
+  marginLeft: theme.spacing(1),
+  marginRight: 'auto',
+}));
 
 const Shortcut = styled('div')(({ theme }) => {
   return {
@@ -108,7 +106,7 @@ function NewStartScreen() {
   const startScreenOptions = [
     {
       category: {
-        name: 'Material UI',
+        name: 'Material UI',
       },
       items: [
         {
@@ -135,7 +133,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'Base UI',
+        name: 'Base UI',
       },
       items: [
         {
@@ -206,7 +204,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'MUI Toolpad',
+        name: 'MUI Toolpad',
       },
       items: [
         {
@@ -228,7 +226,7 @@ function NewStartScreen() {
     },
     {
       category: {
-        name: 'MUI System',
+        name: 'MUI System',
       },
       items: [
         {
@@ -556,6 +554,15 @@ export default function AppSearch(props) {
               color: (theme.vars || theme).palette.primary[500],
               marginRight: theme.spacing(1.5),
               opacity: 0.6,
+              // Redefine SvgIcon-root style as ReactDOMServer.renderToStaticMarkup doesn't
+              // Generate the CSS.
+              // TODO v6: This hack should no longer be needed with static CSS rendering.
+              userSelect: 'none',
+              width: '1em',
+              height: '1em',
+              display: 'inline-block',
+              flexShrink: 0,
+              fill: 'currentColor',
             },
             '& .DocSearch-NewStartScreenItem': {
               display: 'flex',


### PR DESCRIPTION
Fix #33731

The problem is that https://docsearch.algolia.com/docs/api/ doesn't allow us to customize the home dialog, so we have to use: https://github.com/mui/material-ui/blob/3c445c68d6098841eff7c6b7b021965905d0b078/docs/src/modules/components/AppSearch.js#L391

to be able to render what we want. Because of the way Emotion works, this doesn't inject any styles.

The workaround I used is to redefine these styles, only using the SVG path.

In the future, the static extraction should provide stable CSS class names, and I also think that we should do #37599, removing the need to use `renderToStaticMarkup`.

Before: https://deploy-preview-40953--material-ui.netlify.app/blog/aggregation-functions/
After: https://deploy-preview-40957--material-ui.netlify.app/blog/aggregation-functions/