### PR TITLE
[autocomplete] Avoid spread operator

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -554,9 +554,9 @@ const Autocomplete = React.forwardRef(function Autocomplete(inProps, ref) {
 
   const renderGroup = renderGroupProp || defaultRenderGroup;
   const defaultRenderOption = (props2, option) => {
-    const { key, ...otherProps } = props2;
+    // Need to clearly apply key because of https://github.com/vercel/next.js/issues/55642
     return (
-      <li key={key} {...otherProps}>
+      <li {...props2} key={props2.key}>
         {getOptionLabel(option)}
       </li>
     );


### PR DESCRIPTION
A quick follow-up on https://github.com/mui/material-ui/pull/39795#discussion_r1390206320. Adding comments to people in the future can figure out if this logic is still needed. And tried to speed up a bit the rendering.

To be noted that the problem isn't completely solved, the demos we have in the docs are 🙃