### PR TITLE
[material-ui][Box] Add basic demo to Box

### DIFF
--- a/docs/data/material/components/box/BoxSx.js
+++ b/docs/data/material/components/box/BoxSx.js
@@ -7,10 +7,10 @@ export default function BoxSx() {
       sx={{
         width: 300,
         height: 300,
-        backgroundColor: 'primary.dark',
+        borderRadius: '4px',
+        backgroundColor: 'primary.main',
         '&:hover': {
-          backgroundColor: 'primary.main',
-          opacity: [0.9, 0.8, 0.7],
+          backgroundColor: 'primary.dark',
         },
       }}
     />

--- a/docs/data/material/components/box/BoxSx.tsx
+++ b/docs/data/material/components/box/BoxSx.tsx
@@ -7,10 +7,10 @@ export default function BoxSx() {
       sx={{
         width: 300,
         height: 300,
-        backgroundColor: 'primary.dark',
+        borderRadius: '4px',
+        backgroundColor: 'primary.main',
         '&:hover': {
-          backgroundColor: 'primary.main',
-          opacity: [0.9, 0.8, 0.7],
+          backgroundColor: 'primary.dark',
         },
       }}
     />

--- a/docs/data/material/components/box/BoxSx.tsx.preview
+++ b/docs/data/material/components/box/BoxSx.tsx.preview
@@ -2,10 +2,10 @@
   sx={{
     width: 300,
     height: 300,
-    backgroundColor: 'primary.dark',
+    borderRadius: '4px',
+    backgroundColor: 'primary.main',
     '&:hover': {
-      backgroundColor: 'primary.main',
-      opacity: [0.9, 0.8, 0.7],
+      backgroundColor: 'primary.dark',
     },
   }}
 />

--- a/docs/data/material/components/box/box.md
+++ b/docs/data/material/components/box/box.md
@@ -9,9 +9,17 @@ githubLabel: 'component: Box'
 
 <p class="description">The Box component is a generic, theme-aware container with access to CSS utilities from MUI System.</p>
 
-:::warning
-Please refer to the [Box](/system/react-box/) component page in the MUI System docs for demos and details on usage.
+## Introduction
 
 The Box component is a part of the standalone [MUI System](/system/getting-started/) utility library.
 It is re-exported from `@mui/material` for your convenience.
-:::
+
+Please refer to the [Box](/system/react-box/) component page in the MUI System docs for more demos and details on usage.
+
+## Basics
+
+The Box component renders as a `<div>` by default, but you can swap in any other valid HTML tag or React component using the `component` prop.
+
+The demo below replaces the `<div>` with a `<Box>` element:
+
+{{"demo": "BoxSx.js", "defaultCodeOpen": true }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR aims to add a basic demo to the Box component. Even though it's a MUI System component, I believe we could have at least one simple demos for it, since we re-export this component from `mui/material`.

I also changed the warning callout for an introduction text. I believe this way the link to `Box` on MUI System docs will stand out more. 