### PR TITLE
[mui-material] Remove Zero Runtime Dependency

### DIFF
--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -48,7 +48,6 @@
     "@mui/system": "workspace:^",
     "@mui/types": "workspace:^",
     "@mui/utils": "workspace:^",
-    "@mui/zero-runtime": "workspace:^",
     "@types/react-transition-group": "^4.4.10",
     "clsx": "^2.1.0",
     "csstype": "^3.1.3",


### PR DESCRIPTION
Trying to install the latest package fails since the zero runtime package is not published, from the looks of it, yet. I am guessing adding it was a small miss, since the package doesn't actually utilize it internally and it is option. Let me know if there is a better way to resolve.

It was added here: https://github.com/mui/material-ui/commit/2321cf66b5c8dec69dfa01cea6fa27e442971a80#diff-e8aab51875264930602fe69a653255da168e210066bd719da98486797f2e5adcR51

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
