### PR TITLE
[material] Fix: remove zero-runtime peer dep

### DIFF
--- a/apps/zero-runtime-next-app/README.md
+++ b/apps/zero-runtime-next-app/README.md
@@ -20,6 +20,8 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+If you see and error like package `@mui/zero-runtime` not found, add it as a peer-dependency in `@mui/material`'s `package.json` file and run `pnpm build` and `pnpm install` again. Make sure to not push this change to git.
+
 ### Note
 
 If you are testing changes in zero-runtime packages itself while also running this demo app, start the watch command in a separate terminal to watch and build zero-runtime package files as they change -

--- a/apps/zero-runtime-vite-app/README.md
+++ b/apps/zero-runtime-vite-app/README.md
@@ -5,29 +5,23 @@ This project is not part of the workspace yet.
 
 ## How to run
 
-You can either run `yarn release:build` command to build all the packages, or you need to build, the the minimum -
+You can either run `pnpm build` command to build all the packages, or you need to build, the the minimum -
 
 1. `@mui/zero-runtime`
-2. `@mui/zero-tag-processor`
-3. `@mui/zero-vite-plugin`
+2. `@mui/zero-vite-plugin`
 
-Make sure you have also run `yarn release:build` at least once because we also use `@mui/material` and `@mui/system` packages. On subsequent runs, you can only build the above packages using -
+Make sure you have also run `pnpm release:build` at least once because we also use `@mui/material` and `@mui/system` packages. On subsequent runs, you can only build the above packages using -
 
 ```bash
-yarn build
+pnpm build
 ```
 
 After building, you can run the project by changing into the directory and then
 
-1. Install dependencies using `yarn install`
-2. Start the dev server using `yarn dev`
-3. Build the code using `yarn build`
+1. Install dependencies using `pnpm install`
+2. Start the dev server using `pnpm dev`
+3. Build the code using `pnpm build`
 
-Optionally, before running the dev server, you can run `yarn vite optimize --force` if it logged some error during `yarn vite`.
+Optionally, before running the dev server, you can run `pnpm vite optimize --force` if it logged some error during `pnpm vite`.
 
-### Testing
-
-This demo app has been configured to run tests using both vitest or jest.
-
-1. Vitest - You can run `yarn test` to run the tests using vitest
-2. Jest - You can run `yarn jest` to run the tests using jest
+If you see and error like package `@mui/zero-runtime` not found, add it as a peer-dependency in `@mui/material`'s `package.json` file and run `pnpm build` and `pnpm install` again. Make sure to not push this change to git.

--- a/packages/mui-material/package.json
+++ b/packages/mui-material/package.json
@@ -48,7 +48,6 @@
     "@mui/system": "workspace:^",
     "@mui/types": "workspace:^",
     "@mui/utils": "workspace:^",
-    "@mui/zero-runtime": "workspace:^",
     "@types/react-transition-group": "^4.4.10",
     "clsx": "^2.1.0",
     "csstype": "^3.1.3",
@@ -103,9 +102,6 @@
       "optional": true
     },
     "@emotion/styled": {
-      "optional": true
-    },
-    "@mui/zero-runtime": {
       "optional": true
     }
   },


### PR DESCRIPTION
It was added to facilitate testing locally via pnpm but it has created more issues. So removing it. We can test locally by temporarily adding it back but not committing it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
