### PR TITLE
[joy-ui][Button] Fix `disabled` prop priority when inside button group

### DIFF
--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -219,7 +219,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   const size = inProps.size || buttonGroup.size || sizeProp;
   const color = inProps.color || buttonGroup.color || colorProp;
   const disabled =
-    (inProps.loading || inProps.disabled) ?? (buttonGroup.disabled || disabledProp || loading);
+    (inProps.loading || inProps.disabled) ?? (buttonGroup.disabled || loading || disabledProp);
 
   const buttonRef = React.useRef<HTMLElement>(null);
   const handleRef = useForkRef(buttonRef, ref);

--- a/packages/mui-joy/src/Button/Button.tsx
+++ b/packages/mui-joy/src/Button/Button.tsx
@@ -219,7 +219,7 @@ const Button = React.forwardRef(function Button(inProps, ref) {
   const size = inProps.size || buttonGroup.size || sizeProp;
   const color = inProps.color || buttonGroup.color || colorProp;
   const disabled =
-    (inProps.disabled || inProps.loading) ?? (buttonGroup.disabled || disabledProp || loading);
+    (inProps.loading || inProps.disabled) ?? (buttonGroup.disabled || disabledProp || loading);
 
   const buttonRef = React.useRef<HTMLElement>(null);
   const handleRef = useForkRef(buttonRef, ref);

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.test.tsx
@@ -195,7 +195,7 @@ describe('<ButtonGroup />', () => {
     expect(getAllByRole('button')[1]).to.have.property('disabled', true);
   });
 
-  it('pass disabled to buttons inless it is overriden', () => {
+  it('pass disabled to buttons unless it is overriden', () => {
     const { getAllByRole } = render(
       <ButtonGroup disabled>
         <Button disabled={false} />

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.test.tsx
@@ -194,4 +194,15 @@ describe('<ButtonGroup />', () => {
     expect(getAllByRole('button')[0]).to.have.property('disabled', true);
     expect(getAllByRole('button')[1]).to.have.property('disabled', true);
   });
+
+  it('pass disabled to buttons inless it is overriden', () => {
+    const { getAllByRole } = render(
+      <ButtonGroup disabled>
+        <Button disabled={false} />
+        <IconButton disabled={false} />
+      </ButtonGroup>,
+    );
+    expect(getAllByRole('button')[0]).not.to.have.property('disabled', true);
+    expect(getAllByRole('button')[1]).not.to.have.property('disabled', true);
+  });
 });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixed a bug in the Button component:

> <img width="859" alt="image" src="https://github.com/mui/material-ui/assets/1857117/92201fbf-b93e-4c03-b730-5fe5dd657319">

ButtonGroup's `disabled` prop wasn't overridden, because the first part of `(inProps.disabled || inProps.loading) ?? (buttonGroup.disabled || disabledProp || loading);` resulted in `(false || undefined)` which is `undefined`.

The correct order is `(inProps.loading || inProps.disabled)`, because if it's loading, we should always disable a button. If it's not (whether `false` or `undefined`), we should rely on `disabled` prop which could be `true`, `false` or `undefined` and make the whole construction work properly.