### PR TITLE
[docs] Add notification for mui x v7 beta

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -5,11 +5,6 @@
     "text": "Love Material UI, but don't need Material Design? Try Base UI, the new \"unstyled\" alternative. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"introducing-base-ui\" href=\"/blog/introducing-base-ui/\">Read more in this announcement</a>."
   },
   {
-    "id": 76,
-    "title": "<b>Unveiling Charts: Alpha release is live</b>",
-    "text": "We're starting with bars, lines, and scatter charts. <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-introduce-charts\" href=\"https://mui.com/x/react-charts/\">Try X Charts now</a>, and let us know what you need."
-  },
-  {
     "id": 78,
     "title": "<b>MUI X v6.18.x and the latest improvements before the next major</b>",
     "text": "New stable components, polished features, better performance and more. Check out the details in our <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-end-v6\" href=\"https://mui.com/blog/mui-x-end-v6-features/\">recent blog post</a>."
@@ -18,5 +13,10 @@
     "id": 79,
     "title": "<b>Influence the roadmap for 2024</b>",
     "text": "Take a few minutes to share your feedback and expectations in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-survey\" href=\"https://tally.so/r/3Ex4PN?source=docs-notification\">Developer Survey</a>."
+  },
+  {
+    "id": 80,
+    "title": "<b>MUI X v7 is now in beta</b>",
+    "text": "Featuring new components and multiple enhancements for both developers and end-users. Discover all the specifics in our <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v7-beta\" href=\"https://mui.com/blog/mui-x-v7-beta/\">announcement blog post</a>."
   }
 ]

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -11,12 +11,12 @@
   },
   {
     "id": 79,
-    "title": "<b>Influence the roadmap for 2024</b>",
+    "title": "<b>A new Developer Survey is open</b>",
     "text": "Take a few minutes to share your feedback and expectations in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-survey\" href=\"https://tally.so/r/3Ex4PN?source=docs-notification\">Developer Survey</a>."
   },
   {
     "id": 80,
-    "title": "<b>MUI X v7 is now in beta</b>",
+    "title": "<b>MUI X v7.0.0-beta.0</b>",
     "text": "Featuring new components and multiple enhancements for both developers and end-users. Discover all the specifics in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v7-beta\" href=\"https://mui.com/blog/mui-x-v7-beta/\">announcement blog post</a>."
   }
 ]

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -17,6 +17,6 @@
   {
     "id": 80,
     "title": "<b>MUI X v7 is now in beta</b>",
-    "text": "Featuring new components and multiple enhancements for both developers and end-users. Discover all the specifics in our <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v7-beta\" href=\"https://mui.com/blog/mui-x-v7-beta/\">announcement blog post</a>."
+    "text": "Featuring new components and multiple enhancements for both developers and end-users. Discover all the specifics in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v7-beta\" href=\"https://mui.com/blog/mui-x-v7-beta/\">announcement blog post</a>."
   }
 ]


### PR DESCRIPTION
# Summary

Add notification to promote the announcement of [MUI X v7 Beta](https://mui.com/blog/mui-x-v7-beta/).

<img width="330" alt="image" src="https://github.com/mui/material-ui/assets/550141/13a36206-c69f-4f60-b78c-351ca38ff336">

