### PR TITLE
[Popup][base-ui] Fix the exit transitions when keepMounted=false

### DIFF
--- a/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
+++ b/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
@@ -388,7 +388,7 @@ describe('<Popup />', () => {
   describe('visibility', () => {
     clock.withFakeTimers();
 
-    it('should keep visibility:hidden when not toggled and transition/keepMounted/disablePortal props are set', async () => {
+    it('should keep visibility:hidden when not toggled and keepMounted/disablePortal props are set', async () => {
       const { getByRole, setProps } = render(
         <Popup {...defaultProps} open={false} keepMounted disablePortal>
           <FakeTransition>


### PR DESCRIPTION
The exit transition did not work when elements were unmounted from the DOM after exiting. This PR fixes this.

Closes #40894

Master (broken): https://mui.com/base-ui/react-transitions/
Preview: https://deploy-preview-41007--material-ui.netlify.app/base-ui/react-transitions/