### PR TITLE
[infra] Adjusted issue search links

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       label: Search keywords
       description: |
-        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues).
+        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
         If your issue isn't a duplicate, great! Please list the keywords you used so people in the future can find this one more easily:
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       label: Search keywords
       description: |
-        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues).
+        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
         If your issue isn't a duplicate, great! Please list the keywords you used so people in the future can find this one more easily:
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
@@ -10,7 +10,7 @@ body:
     attributes:
       label: Search keywords
       description: |
-        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues).
+        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
         If your issue isn't a duplicate, great! Please list the keywords you used so people in the future can find this one more easily:
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: Search keywords
       description: |
-        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues).
+        Your issue may have already been reported! First search for duplicates among the [existing issues](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
         If your issue isn't a duplicate, great! Please list the keywords you used so people in the future can find this one more easily:
       required: true
   - type: checkboxes

--- a/docs/data/material/getting-started/faq/faq.md
+++ b/docs/data/material/getting-started/faq/faq.md
@@ -16,7 +16,7 @@ There are many ways to support us:
 - **Make changes happen**.
   - Edit the documentation. At the bottom of every page, you can find an "Edit this page" button.
   - Report bugs or missing features by [creating an issue](https://github.com/mui/material-ui/issues/new).
-  - Review and comment on existing [pull requests](https://github.com/mui/material-ui/pulls) and [issues](https://github.com/mui/material-ui/issues).
+  - Review and comment on existing [pull requests](https://github.com/mui/material-ui/pulls?q=is%3Apr) and [issues](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed).
   - [Improve our documentation](https://github.com/mui/material-ui/tree/HEAD/docs), fix bugs, or add features by [submitting a pull request](https://github.com/mui/material-ui/pulls).
 - **Support us financially on [Open Collective](https://opencollective.com/mui-org)**.
   If you use Material UI in a commercial project and would like to support its continued development by becoming a Sponsor, or in a side or hobby project and would like to become a Backer, you can do so through Open Collective.

--- a/docs/data/material/getting-started/supported-components/supported-components.md
+++ b/docs/data/material/getting-started/supported-components/supported-components.md
@@ -9,7 +9,7 @@ feature of every component, but rather to provide the building blocks to
 allow developers to create compelling user interfaces and experiences.
 
 If you wish to add support for a component or feature not highlighted
-here, please search for the relevant [GitHub Issue](https://github.com/mui/material-ui/issues), or create a new one
+here, please search for the relevant [GitHub Issue](https://github.com/mui/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed), or create a new one
 to discuss the approach before submitting a pull request.
 
 {{"demo": "MaterialUIComponents.js", "hideToolbar": true, "bg": true}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---

In accordance to https://github.com/mui/mui-x/pull/11995

Quote from the linked PR:

> I noticed that the link in the issues templates leads to the default issue search, which looks for is:issue and is:open. Since the solution could also be in a closed issue this should be adjusted.