### PR TITLE
[material-ui][Autocomplete] Caret transformation issue with font size change

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -214,8 +214,8 @@ const AutocompleteEndAdornment = styled('div', {
   // We use a position absolute to support wrapping tags.
   position: 'absolute',
   right: 0,
-  top: 50%,
-  transform: translate(0, -50%),
+  top: '50%',
+  transform: 'translate(0, -50%)',
 });
 
 const AutocompleteClearIndicator = styled(IconButton, {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -213,8 +213,6 @@ const AutocompleteEndAdornment = styled('div', {
 })({
   // We use a position absolute to support wrapping tags.
   position: 'absolute',
-  right: 0,
-  top: 'calc(50% - 14px)', // Center vertically
 });
 
 const AutocompleteClearIndicator = styled(IconButton, {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -213,6 +213,7 @@ const AutocompleteEndAdornment = styled('div', {
 })({
   // We use a position absolute to support wrapping tags.
   position: 'absolute',
+  right: 0,
 });
 
 const AutocompleteClearIndicator = styled(IconButton, {

--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -214,6 +214,8 @@ const AutocompleteEndAdornment = styled('div', {
   // We use a position absolute to support wrapping tags.
   position: 'absolute',
   right: 0,
+  top: 50%,
+  transform: translate(0, -50%),
 });
 
 const AutocompleteClearIndicator = styled(IconButton, {


### PR DESCRIPTION
The caret icon within the Autocomplete component was incorrectly positioned due to the following styles applied to the .css-1q60rmi-MuiAutocomplete-endAdornment class:
   - top: calc(50% - 14px);

This caused the caret icon to be misaligned when the font size was adjusted. Additionally, the 'right: 0;' style was redundant and was overridden by another class, so I removed it..

   **Bug Fix:**
   1. Removed the 'top' style to ensure that the caret icon remains vertically centered regardless of the font size. The caret icon is now positioned correctly within the Autocomplete component.
   2. Removed the 'right: 0;' style as it was overridden, because it is unnecessary and the code is cleaner. 

The caret icon's positioning is now consistent and follows the standard Material-UI styling.

Fix #40874