### PR TITLE
[material-ui] Fix missing babel/runtime dependency in material-ui-nextjs

### DIFF
--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -36,6 +36,9 @@
     "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/mui-material-nextjs/**/*.test.{js,ts,tsx}'",
     "typescript": "tsc -p tsconfig.json"
   },
+  "dependencies": {
+    "@babel/runtime": "^7.23.9"
+  },
   "devDependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1740,6 +1740,9 @@ importers:
 
   packages/mui-material-nextjs:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.23.9
+        version: 7.23.9
       '@mui/material':
         specifier: ^5.0.0
         version: link:../mui-material/build


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #41071

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
