### PR TITLE
[website] Add Store API redirect for mui.com domain

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -513,6 +513,7 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 ## MUI Store
 /store-asset/* https://mui-store.netlify.app/:splat 200
 /store/* https://mui-store.netlify.app/store/:splat 200
+/api/store/* https://mui-store.netlify.app/api/store/:splat 200
 /r/store-* https://mui-store.netlify.app/r/store-:splat 200
 /legal/* https://mui-store.netlify.app/legal/:splat 200
 /r/legal-* https://mui-store.netlify.app/r/legal-:splat 200


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Changed in this PR:
- Added redirects from `/api/store/...` on `mui.com` to the `MUI Store` application

https://deploy-preview-41087--material-ui.netlify.app/api/store/test-redirect

- [ ] I expect that it will return the same as https://mui-store.netlify.app/api/store/test-redirect
