### PR TITLE
[templates][checkout] fix checkbox visibility when checked in AddressForm and PaymentForm

### DIFF
--- a/docs/data/material/getting-started/templates/checkout/AddressForm.tsx
+++ b/docs/data/material/getting-started/templates/checkout/AddressForm.tsx
@@ -99,7 +99,7 @@ export default function AddressForm() {
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel
-            control={<Checkbox color="secondary" name="saveAddress" value="yes" />}
+            control={<Checkbox color="default" name="saveAddress" value="yes" />}
             label="Use this address for payment details"
           />
         </Grid>

--- a/docs/data/material/getting-started/templates/checkout/PaymentForm.tsx
+++ b/docs/data/material/getting-started/templates/checkout/PaymentForm.tsx
@@ -55,7 +55,7 @@ export default function PaymentForm() {
         </Grid>
         <Grid item xs={12}>
           <FormControlLabel
-            control={<Checkbox color="secondary" name="saveCard" value="yes" />}
+            control={<Checkbox color="default" name="saveCard" value="yes" />}
             label="Remember credit card details for next time"
           />
         </Grid>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

**Fixed #41098**  checkbox visibility issue when checked at both Shipping address and Payment details section in checkout template

![fixed](https://github.com/mui/material-ui/assets/101316289/d8eea77e-3bde-47b2-a99e-d0e59deb6f52)

