### PR TITLE
[code-infra] Load commonjs files in next.config.mjs with require

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -5,17 +5,18 @@ import * as fs from 'fs';
 // @ts-ignore
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { createRequire } from 'module';
-import withDocsInfra from './nextConfigDocsInfra.js';
 import { findPages } from './src/modules/utils/find.mjs';
-import {
+
+const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
+const require = createRequire(import.meta.url);
+
+const withDocsInfra = require('./nextConfigDocsInfra.js');
+const {
   LANGUAGES,
   LANGUAGES_SSR,
   LANGUAGES_IGNORE_PAGES,
   LANGUAGES_IN_PROGRESS,
-} from './config.js';
-
-const currentDirectory = url.fileURLToPath(new URL('.', import.meta.url));
-const require = createRequire(import.meta.url);
+} = require('./config.js');
 
 const workspaceRoot = path.join(currentDirectory, '../');
 


### PR DESCRIPTION
Noticed netlify build errors started happening the day I moved to next.config.mjs.
This PR aligns the method of loading commonjs modules using `createRequire` with the way Toolpad does it instead of relying on esm/cjs interop.