### PR TITLE
[docs-infra] Fix display when the default props is undefined

### DIFF
--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -177,7 +177,11 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                   }
                 </td>
                 <td className="default-column">
-                  <span className="MuiApi-table-item-default">{propDefault}</span>
+                  {propDefault ? (
+                    <span className="MuiApi-table-item-default">{propDefault}</span>
+                  ) : (
+                    '-'
+                  )}
                 </td>
                 <td className="MuiPropTable-description-column">
                   {description && <PropDescription description={description} />}


### PR DESCRIPTION
This bug has been visible for a while, e.g. in https://github.com/mui/material-ui/pull/39689#pullrequestreview-1709217787. It feels like there is a bug in the way the data is displayed, it doesn't feel like I can 100% trust what's shown on the API page. I saw this in https://github.com/mui/mui-x/pull/11996.

Before https://deploy-preview-41113--material-ui.netlify.app/material-ui/api/app-bar/#props
<img width="798" alt="SCR-20240215-oxfi" src="https://github.com/mui/material-ui/assets/3165635/eb411784-a6b5-4338-bb96-61e3f6f2e63d">

After https://deploy-preview-41114--material-ui.netlify.app/material-ui/api/app-bar/#props
<img width="792" alt="SCR-20240215-szps" src="https://github.com/mui/material-ui/assets/3165635/81725391-0c11-4b20-ada8-5b8eca194c58">
