### PR TITLE
[code-infra] Use `experimental.cpus` to control amount of export workers in Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dweewf
+dwee
 
 <!-- markdownlint-disable-next-line -->
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dwee
+dweefew
 
 <!-- markdownlint-disable-next-line -->
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-dweefew
-
 <!-- markdownlint-disable-next-line -->
 <p align="center">
   <a href="https://mui.com/core/" rel="noopener" target="_blank"><img width="150" height="133" src="https://mui.com/static/logo.svg" alt="MUI Core logo"></a>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+dweewf
+
 <!-- markdownlint-disable-next-line -->
 <p align="center">
   <a href="https://mui.com/core/" rel="noopener" target="_blank"><img width="150" height="133" src="https://mui.com/static/logo.svg" alt="MUI Core logo"></a>

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -30,6 +30,10 @@ const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 
 const pkg = JSON.parse(pkgContent);
 
 export default withDocsInfra({
+  experimental: {
+    workerThreads: true,
+    cpus: 3,
+  },
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
 


### PR DESCRIPTION
See https://github.com/mui/material-ui/pull/40302/files#r1492165714