### PR TITLE
changed-SelectProps-to-slotProps-in-docs

### DIFF
--- a/docs/data/material/components/table/CustomPaginationActionsTable.js
+++ b/docs/data/material/components/table/CustomPaginationActionsTable.js
@@ -148,11 +148,13 @@ export default function CustomPaginationActionsTable() {
               count={rows.length}
               rowsPerPage={rowsPerPage}
               page={page}
-              SelectProps={{
-                inputProps: {
-                  'aria-label': 'rows per page',
+              slotProps={{
+                select: {
+                  label: 'Rows per page',
+                  inputProps: {
+                    'aria-label': 'rows per page',
+                  },
                 },
-                native: true,
               }}
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}

--- a/docs/data/material/components/table/CustomPaginationActionsTable.tsx
+++ b/docs/data/material/components/table/CustomPaginationActionsTable.tsx
@@ -157,11 +157,13 @@ export default function CustomPaginationActionsTable() {
               count={rows.length}
               rowsPerPage={rowsPerPage}
               page={page}
-              SelectProps={{
-                inputProps: {
-                  'aria-label': 'rows per page',
+              slotProps={{
+                select: {
+                  label: 'Rows per page',
+                  inputProps: {
+                    'aria-label': 'rows per page',
+                  },
                 },
-                native: true,
               }}
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}


### PR DESCRIPTION
Fixes issue #41062
# What does this PR do?
changes the deprecated TablePagination SelectProps to slotProps in docs

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
