### PR TITLE
[examples] Update dependency in the dashboard template

### DIFF
--- a/docs/data/material/getting-started/templates/dashboard/README.md
+++ b/docs/data/material/getting-started/templates/dashboard/README.md
@@ -5,7 +5,7 @@
 <!-- #default-branch-switch -->
 
 1. Copy the files into your project, or one of the [example projects](https://github.com/mui/material-ui/tree/master/examples).
-2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react, recharts.
+2. Make sure your project has the required dependencies: @mui/material, @mui/icons-material, @emotion/styled, @emotion/react, @mui/x-charts.
 3. Import and use the `Dashboard` component.
 
 ## Demo


### PR DESCRIPTION
The provided dependency in the README for the Dashboard example/template is outdated, replaced with the correct one which is `@mui/x-charts`