### PR TITLE
[docs-infra] Reduce scrollbar width on ROC

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -23,6 +23,7 @@ const Nav = styled('nav')(({ theme }) => ({
   paddingBottom: theme.spacing(7),
   paddingRight: theme.spacing(4), // We can't use `padding` as stylis-plugin-rtl doesn't swap it
   display: 'none',
+  scrollbarWidth: 'thin',
   [theme.breakpoints.up('md')]: {
     display: 'block',
   },


### PR DESCRIPTION
I saw this done in Docusaurus https://github.com/facebookincubator/infima/blob/aa1eebd35cdaee3348eb47315774882464cb522f/packages/core/styles/utilities/custom-scrollbar.pcss#L17 while I was browsing a docs of another project. They also do it for the side nav tab, but this feels wrong. So I opened a PR, quick-win.

One step closer to address #38710. A previous iteration was done in #37770.

Before
<img width="641" alt="SCR-20240217-ulre" src="https://github.com/mui/material-ui/assets/3165635/4be2a57a-903c-4cc7-b1af-2655b6ae6ab1">

After
<img width="545" alt="SCR-20240217-ulps" src="https://github.com/mui/material-ui/assets/3165635/a559fe51-9f8b-4c1c-ae91-04ab4c908971">

Ideally, we could have used https://stackoverflow.com/a/68860350/2801714 but Chrome is so buggy with it, it's not ready yet. 