### PR TITLE
[material-ui][typescript][InputBase] Fix correct type of `InputBaseComponentProps`

### DIFF
--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -245,7 +245,7 @@ export interface InputBaseProps
 }
 
 export interface InputBaseComponentProps
-  extends React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
+  extends React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   // Accommodate arbitrary additional props coming from the `inputProps` prop
   [arbitrary: string]: any;
 }


### PR DESCRIPTION
Added missing types to `InputBaseComponentProps` by extending from `React.InputHTMLAttributes` instead of `React.HTMLAttributes`.

Here's a [link to `React.InputHTMLAttributes`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6e457e3f9c23a6fcfe15df8a9b0cbc349330e0f9/types/react/ts5.0/index.d.ts#L3178) from `@types/react`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
