### PR TITLE
[docs-infra] Fix product selector popup not closing on route change

### DIFF
--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -57,12 +57,14 @@ function ProductDrawerButton(props) {
 
   const handleEventDelegation = (e) => {
     // In case of key down events, and any key apart from `enter` is clicked then don't close the menu.
-    if (e?.type === 'keydown' && e.keyCode !== 13) {
+    if (e?.type === 'keydown' && e.key !== 'Enter') {
       return;
     }
 
+    // Assert whether an 'a' tag resides in the parent of the clicked element through which the event bubbles out.
+    const isLinkInParentTree = e?.target ? Boolean(e.target.closest('a')) : false;
     // If the element clicked is link or just inside of a link element then close the menu.
-    if (e?.target && (e.target?.parentElement?.localName === 'a' || e.target?.localName === 'a')) {
+    if (isLinkInParentTree) {
       handleClose();
     }
   };

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -46,6 +46,9 @@ const savedScrollTop = {};
 
 function ProductDrawerButton(props) {
   const [anchorEl, setAnchorEl] = React.useState(null);
+  const { activePage } = React.useContext(PageContext);
+  const [previousPath, setPreviousPath] = React.useState(activePage.pathname);
+
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -53,6 +56,12 @@ function ProductDrawerButton(props) {
   const handleClose = () => {
     setAnchorEl(null);
   };
+
+  // Handling for the ProductSelector to close on any kind of route changes.
+  if (previousPath !== activePage.pathname) {
+    handleClose();
+    setPreviousPath(activePage.pathname);
+  }
 
   return (
     <React.Fragment>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -46,8 +46,8 @@ const savedScrollTop = {};
 
 function ProductDrawerButton(props) {
   const [anchorEl, setAnchorEl] = React.useState(null);
-  const { activePage } = React.useContext(PageContext);
-  const [previousPath, setPreviousPath] = React.useState(activePage.pathname);
+  const { activePage = {} } = React.useContext(PageContext);
+  const [previousPath, setPreviousPath] = React.useState(activePage?.pathname || '');
 
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -58,7 +58,7 @@ function ProductDrawerButton(props) {
   };
 
   // Handling for the ProductSelector to close on any kind of route changes.
-  if (previousPath !== activePage.pathname) {
+  if (activePage?.pathname && previousPath !== activePage.pathname) {
     handleClose();
     setPreviousPath(activePage.pathname);
   }

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -46,8 +46,6 @@ const savedScrollTop = {};
 
 function ProductDrawerButton(props) {
   const [anchorEl, setAnchorEl] = React.useState(null);
-  const { activePage = {} } = React.useContext(PageContext);
-  const [previousPath, setPreviousPath] = React.useState(activePage?.pathname || '');
 
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -57,11 +55,17 @@ function ProductDrawerButton(props) {
     setAnchorEl(null);
   };
 
-  // Handling for the ProductSelector to close on any kind of route changes.
-  if (activePage?.pathname && previousPath !== activePage.pathname) {
-    handleClose();
-    setPreviousPath(activePage.pathname);
-  }
+  const handleEventDelegation = (e) => {
+    // In case of key down events, and any key apart from `enter` is clicked then don't close the menu.
+    if (e?.type === 'keydown' && e.keyCode !== 13) {
+      return;
+    }
+
+    // If the element clicked is link or just inside of a link element then close the menu.
+    if (e?.target && (e.target?.parentElement?.localName === 'a' || e.target?.localName === 'a')) {
+      handleClose();
+    }
+  };
 
   return (
     <React.Fragment>
@@ -106,6 +110,8 @@ function ProductDrawerButton(props) {
             width: { xs: 340, sm: 'auto' },
           },
         }}
+        onClick={handleEventDelegation}
+        onKeyDown={handleEventDelegation}
       >
         <MuiProductSelector />
       </Menu>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -55,9 +55,9 @@ function ProductDrawerButton(props) {
     setAnchorEl(null);
   };
 
-  const handleEventDelegation = (e) => {
+  const handleEventDelegation = (event) => {
     // Assert whether an 'a' tag resides in the parent of the clicked element through which the event bubbles out.
-    const isLinkInParentTree = e?.target ? Boolean(e.target.closest('a')) : false;
+    const isLinkInParentTree = Boolean(event.target.closest('a'));
     // If the element clicked is link or just inside of a link element then close the menu.
     if (isLinkInParentTree) {
       handleClose();

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -56,11 +56,6 @@ function ProductDrawerButton(props) {
   };
 
   const handleEventDelegation = (e) => {
-    // In case of key down events, and any key apart from `enter` is clicked then don't close the menu.
-    if (e?.type === 'keydown' && e.key !== 'Enter') {
-      return;
-    }
-
     // Assert whether an 'a' tag resides in the parent of the clicked element through which the event bubbles out.
     const isLinkInParentTree = e?.target ? Boolean(e.target.closest('a')) : false;
     // If the element clicked is link or just inside of a link element then close the menu.
@@ -113,7 +108,6 @@ function ProductDrawerButton(props) {
           },
         }}
         onClick={handleEventDelegation}
-        onKeyDown={handleEventDelegation}
       >
         <MuiProductSelector />
       </Menu>


### PR DESCRIPTION
fixes #41128

## Description
The issue arose from the fact that on route changes since the layout is not rendered but the content panel is, in some cases when previous route was cached the popper never closed on clicking a link in it. Now, we track for route changes in the component, another approach could've been to send `handleClose` through props but it would need special handling when new elements are added in the popper.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
