### PR TITLE
[docs-infra] Simplify copy logic

### DIFF
--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -182,7 +182,7 @@ export function CodeCopyProvider({ children }: CodeCopyProviderProps) {
       }
 
       const copyBtn = rootNode.current.querySelector('.MuiCode-copy') as HTMLButtonElement;
-      const initialEventAction = copyBtn!.getAttribute('data-ga-event-action');
+      const initialEventAction = copyBtn.getAttribute('data-ga-event-action');
       // update the 'data-ga-event-action' on the button to track keyboard interaction
       copyBtn.dataset.gaEventAction =
         initialEventAction?.replace('click', 'keyboard') || 'copy-keyboard';

--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -181,13 +181,13 @@ export function CodeCopyProvider({ children }: CodeCopyProviderProps) {
         return;
       }
 
-      const copyBtn = rootNode.current.querySelector('.MuiCode-copy') as HTMLButtonElement | null;
+      const copyBtn = rootNode.current.querySelector('.MuiCode-copy') as HTMLButtonElement;
       const initialEventAction = copyBtn!.getAttribute('data-ga-event-action');
       // update the 'data-ga-event-action' on the button to track keyboard interaction
-      copyBtn!.dataset.gaEventAction =
+      copyBtn.dataset.gaEventAction =
         initialEventAction?.replace('click', 'keyboard') || 'copy-keyboard';
-      copyBtn!.click(); // let the GA setup in GoogleAnalytics.js do the job
-      copyBtn!.dataset.gaEventAction = initialEventAction!; // reset the 'data-ga-event-action' back to initial
+      copyBtn.click(); // let the GA setup in GoogleAnalytics.js do the job
+      copyBtn.dataset.gaEventAction = initialEventAction!; // reset the 'data-ga-event-action' back to initial
     });
   }, []);
   return (

--- a/docs/src/modules/utils/CodeCopy.tsx
+++ b/docs/src/modules/utils/CodeCopy.tsx
@@ -160,30 +160,34 @@ export function CodeCopyProvider({ children }: CodeCopyProviderProps) {
   const rootNode = React.useRef<HTMLDivElement | null>(null);
   React.useEffect(() => {
     document.addEventListener('keydown', (event) => {
-      if (hasNativeSelection(event.target as HTMLTextAreaElement)) {
-        // Skip if user is highlighting a text.
-        return;
-      }
-      // event.key === 'c' is not enough as alt+c can lead to ©, ç, or other characters on macOS.
-      // event.code === 'KeyC' is not enough as event.code assume a QWERTY keyboard layout which would
-      // be wrong with a Dvorak keyboard (as if pressing J).
-      const isModifierKeyPressed = event.ctrlKey || event.metaKey || event.altKey;
-      if (String.fromCharCode(event.keyCode) !== 'C' || !isModifierKeyPressed) {
-        return;
-      }
       if (!rootNode.current) {
         return;
       }
-      const copyBtn = rootNode.current.querySelector('.MuiCode-copy') as HTMLButtonElement | null;
-      if (!copyBtn) {
+
+      // Skip if user is highlighting a text.
+      if (hasNativeSelection(event.target as HTMLTextAreaElement)) {
         return;
       }
-      const initialEventAction = copyBtn.getAttribute('data-ga-event-action');
+
+      // Skip if it's not a copy keyboard event
+      if (
+        !(
+          (event.ctrlKey || event.metaKey) &&
+          event.key.toLowerCase() === 'c' &&
+          !event.shiftKey &&
+          !event.altKey
+        )
+      ) {
+        return;
+      }
+
+      const copyBtn = rootNode.current.querySelector('.MuiCode-copy') as HTMLButtonElement | null;
+      const initialEventAction = copyBtn!.getAttribute('data-ga-event-action');
       // update the 'data-ga-event-action' on the button to track keyboard interaction
-      copyBtn.dataset.gaEventAction =
+      copyBtn!.dataset.gaEventAction =
         initialEventAction?.replace('click', 'keyboard') || 'copy-keyboard';
-      copyBtn.click(); // let the GA setup in GoogleAnalytics.js do the job
-      copyBtn.dataset.gaEventAction = initialEventAction!; // reset the 'data-ga-event-action' back to initial
+      copyBtn!.click(); // let the GA setup in GoogleAnalytics.js do the job
+      copyBtn!.dataset.gaEventAction = initialEventAction!; // reset the 'data-ga-event-action' back to initial
     });
   }, []);
   return (


### PR DESCRIPTION
This is a follow-up on #32390. That logic is weird. We support Alt + C as a shortcut but it doesn't make sense. Instead, I copied the copy logic from https://github.com/mui/mui-x/pull/12121. 

I noticed this from https://github.com/mui/mui-x/pull/11965