### PR TITLE
[test] Generalize test utils

### DIFF
--- a/packages/mui-base/src/Badge/Badge.test.tsx
+++ b/packages/mui-base/src/Badge/Badge.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, createMount, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createRenderer, createMount } from '@mui-internal/test-utils';
 import { Badge, badgeClasses as classes } from '@mui/base/Badge';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Badge />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Button/Button.test.tsx
+++ b/packages/mui-base/src/Button/Button.test.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
-import {
-  act,
-  createMount,
-  createRenderer,
-  describeConformanceUnstyled,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { act, createMount, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { Button, buttonClasses } from '@mui/base/Button';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Button />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/FormControl/FormControl.test.tsx
+++ b/packages/mui-base/src/FormControl/FormControl.test.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  createMount,
-  createRenderer,
-  describeConformanceUnstyled,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { createMount, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { FormControl, formControlClasses, useFormControlContext } from '@mui/base/FormControl';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<FormControl />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/Input/Input.test.tsx
+++ b/packages/mui-base/src/Input/Input.test.tsx
@@ -1,16 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {
-  createMount,
-  createRenderer,
-  describeConformanceUnstyled,
-  fireEvent,
-  screen,
-  act,
-} from '@mui-internal/test-utils';
+import { createMount, createRenderer, fireEvent, screen, act } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { Input, inputClasses, InputOwnerState } from '@mui/base/Input';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Input />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/Menu/Menu.test.tsx
+++ b/packages/mui-base/src/Menu/Menu.test.tsx
@@ -4,7 +4,6 @@ import { spy } from 'sinon';
 import {
   createMount,
   createRenderer,
-  describeConformanceUnstyled,
   fireEvent,
   act,
   MuiRenderResult,
@@ -16,6 +15,7 @@ import { MenuItem, MenuItemRootSlotProps } from '@mui/base/MenuItem';
 import { DropdownContext, DropdownContextValue } from '@mui/base/useDropdown';
 import { Popper } from '@mui/base/Popper';
 import { MenuProvider, useMenu } from '@mui/base/useMenu';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 const testContext: DropdownContextValue = {
   dispatch: () => {},

--- a/packages/mui-base/src/MenuButton/MenuButton.test.tsx
+++ b/packages/mui-base/src/MenuButton/MenuButton.test.tsx
@@ -2,14 +2,10 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import userEvent from '@testing-library/user-event';
-import {
-  act,
-  createMount,
-  createRenderer,
-  describeConformanceUnstyled,
-} from '@mui-internal/test-utils';
+import { act, createMount, createRenderer } from '@mui-internal/test-utils';
 import { MenuButton, menuButtonClasses } from '@mui/base/MenuButton';
 import { DropdownContext, DropdownContextValue, DropdownActionTypes } from '@mui/base/useDropdown';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 // TODO v6: initialize @testing-library/user-event using userEvent.setup() instead of directly calling methods e.g. userEvent.click() for all related tests in this file
 // currently the setup() method uses the ClipboardEvent constructor which is incompatible with our lowest supported version of iOS Safari (12.2) https://github.com/mui/material-ui/blob/master/.browserslistrc#L44

--- a/packages/mui-base/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-base/src/MenuItem/MenuItem.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { MenuItem, menuItemClasses } from '@mui/base/MenuItem';
 import { MenuProvider } from '@mui/base/useMenu';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 const dummyGetItemState = () => ({
   disabled: false,

--- a/packages/mui-base/src/Modal/Modal.test.tsx
+++ b/packages/mui-base/src/Modal/Modal.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { Modal, modalClasses as classes, ModalRootSlotProps } from '@mui/base/Modal';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Modal />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/Option/Option.test.tsx
+++ b/packages/mui-base/src/Option/Option.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { Option, optionClasses } from '@mui/base/Option';
 import { SelectProvider } from '../useSelect/SelectProvider';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 const dummyGetItemState = () => ({
   highlighted: false,

--- a/packages/mui-base/src/OptionGroup/OptionGroup.test.tsx
+++ b/packages/mui-base/src/OptionGroup/OptionGroup.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { OptionGroup, optionGroupClasses } from '@mui/base/OptionGroup';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<OptionGroup />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/Popper/Popper.test.tsx
+++ b/packages/mui-base/src/Popper/Popper.test.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  createRenderer,
-  createMount,
-  describeConformanceUnstyled,
-  screen,
-} from '@mui-internal/test-utils';
+import { createRenderer, createMount, screen } from '@mui-internal/test-utils';
 import { Popper, popperClasses } from '@mui/base/Popper';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Popper />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/Select/Select.test.tsx
+++ b/packages/mui-base/src/Select/Select.test.tsx
@@ -4,7 +4,6 @@ import { spy } from 'sinon';
 import {
   createMount,
   createRenderer,
-  describeConformanceUnstyled,
   fireEvent,
   act,
   screen,
@@ -17,6 +16,7 @@ import { Select, SelectListboxSlotProps, selectClasses } from '@mui/base/Select'
 import { SelectOption } from '@mui/base/useOption';
 import { Option, OptionProps, OptionRootSlotProps, optionClasses } from '@mui/base/Option';
 import { OptionGroup } from '@mui/base/OptionGroup';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 // TODO v6: initialize @testing-library/user-event using userEvent.setup() instead of directly calling methods e.g. userEvent.click() for all related tests in this file
 // currently the setup() method uses the ClipboardEvent constructor which is incompatible with our lowest supported version of iOS Safari (12.2) https://github.com/mui/material-ui/blob/master/.browserslistrc#L44

--- a/packages/mui-base/src/Slider/Slider.test.tsx
+++ b/packages/mui-base/src/Slider/Slider.test.tsx
@@ -1,20 +1,14 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import { spy, stub } from 'sinon';
-import {
-  act,
-  createRenderer,
-  createMount,
-  describeConformanceUnstyled,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, createMount, fireEvent, screen } from '@mui-internal/test-utils';
 import {
   Slider,
   sliderClasses as classes,
   SliderRootSlotProps,
   SliderValueLabelSlotProps,
 } from '@mui/base/Slider';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 type Touches = Array<Pick<Touch, 'identifier' | 'clientX' | 'clientY'>>;
 

--- a/packages/mui-base/src/Snackbar/Snackbar.test.tsx
+++ b/packages/mui-base/src/Snackbar/Snackbar.test.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  act,
-  createRenderer,
-  createMount,
-  describeConformanceUnstyled,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, createMount, fireEvent } from '@mui-internal/test-utils';
 import { Snackbar, snackbarClasses as classes } from '@mui/base/Snackbar';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Snackbar />', () => {
   const { clock, render: clientRender } = createRenderer({ clock: 'fake' });

--- a/packages/mui-base/src/Switch/Switch.test.tsx
+++ b/packages/mui-base/src/Switch/Switch.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { Switch, SwitchOwnerState, switchClasses } from '@mui/base/Switch';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Switch />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/Tab/Tab.test.tsx
+++ b/packages/mui-base/src/Tab/Tab.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { Tab, tabClasses } from '@mui/base/Tab';
 import { TabsListProvider, TabsListProviderValue } from '../useTabsList';
 import { TabsContext } from '../Tabs';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Tab />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-base/src/TabPanel/TabPanel.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createMount, createRenderer, describeConformanceUnstyled } from '@mui-internal/test-utils';
+import { createMount, createRenderer } from '@mui-internal/test-utils';
 import { TabPanel, tabPanelClasses } from '@mui/base/TabPanel';
 import { TabsProvider, TabsProviderValue } from '../useTabs';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<TabPanel />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/TablePagination/TablePagination.test.tsx
+++ b/packages/mui-base/src/TablePagination/TablePagination.test.tsx
@@ -2,17 +2,13 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import {
-  describeConformanceUnstyled,
-  fireEvent,
-  createRenderer,
-  createMount,
-} from '@mui-internal/test-utils';
+import { fireEvent, createRenderer, createMount } from '@mui-internal/test-utils';
 import {
   TablePagination,
   tablePaginationClasses as classes,
   LabelDisplayedRowsArgs,
 } from '@mui/base/TablePagination';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 interface WithClassName {
   className: string;

--- a/packages/mui-base/src/Tabs/Tabs.test.tsx
+++ b/packages/mui-base/src/Tabs/Tabs.test.tsx
@@ -1,18 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformanceUnstyled,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-  createMount,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen, createMount } from '@mui-internal/test-utils';
 import { Tab } from '@mui/base/Tab';
 import { Tabs, tabsClasses as classes, TabsProps } from '@mui/base/Tabs';
 import { TabsList } from '@mui/base/TabsList';
 import { TabPanel } from '@mui/base/TabPanel';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<Tabs />', () => {
   const mount = createMount();

--- a/packages/mui-base/src/TabsList/TabsList.test.tsx
+++ b/packages/mui-base/src/TabsList/TabsList.test.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
-import {
-  act,
-  createMount,
-  createRenderer,
-  describeConformanceUnstyled,
-} from '@mui-internal/test-utils';
+import { act, createMount, createRenderer } from '@mui-internal/test-utils';
 import { Tab } from '@mui/base/Tab';
 import { Tabs, TabsContext } from '@mui/base/Tabs';
 import { TabsList, tabsListClasses } from '@mui/base/TabsList';
 import { expect } from 'chai';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 describe('<TabsList />', () => {
   const { render } = createRenderer();

--- a/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
+++ b/packages/mui-base/src/TextareaAutosize/TextareaAutosize.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import sinon, { spy, stub } from 'sinon';
 import {
-  describeConformanceUnstyled,
   act,
   screen,
   waitFor,
@@ -11,6 +10,7 @@ import {
   fireEvent,
 } from '@mui-internal/test-utils';
 import { TextareaAutosize } from '@mui/base/TextareaAutosize';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 function getStyleValue(value: string) {
   return parseInt(value, 10) || 0;

--- a/packages/mui-base/src/Unstable_NumberInput/NumberInput.test.tsx
+++ b/packages/mui-base/src/Unstable_NumberInput/NumberInput.test.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import userEvent from '@testing-library/user-event';
-import {
-  act,
-  createMount,
-  createRenderer,
-  describeConformanceUnstyled,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { act, createMount, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import {
   Unstable_NumberInput as NumberInput,
   numberInputClasses,
@@ -16,6 +10,7 @@ import {
   NumberInputIncrementButtonSlotProps,
   NumberInputDecrementButtonSlotProps,
 } from '@mui/base/Unstable_NumberInput';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 // TODO v6: initialize @testing-library/user-event using userEvent.setup() instead of directly calling methods e.g. userEvent.click() for all related tests in this file
 // currently the setup() method uses the ClipboardEvent constructor which is incompatible with our lowest supported version of iOS Safari (12.2) https://github.com/mui/material-ui/blob/master/.browserslistrc#L44

--- a/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
+++ b/packages/mui-base/src/Unstable_Popup/Popup.test.tsx
@@ -1,16 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  act,
-  createRenderer,
-  createMount,
-  describeConformanceUnstyled,
-  screen,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, createMount, screen, fireEvent } from '@mui-internal/test-utils';
 import { Unstable_Popup as Popup, popupClasses, PopupProps } from '@mui/base/Unstable_Popup';
 import { PopupContext } from './PopupContext';
 import { useTransitionStateManager } from '../useTransition';
+import { describeConformanceUnstyled } from '../../test/describeConformanceUnstyled';
 
 const TRANSITION_DURATION = 100;
 

--- a/packages/mui-base/test/describeConformanceUnstyled.tsx
+++ b/packages/mui-base/test/describeConformanceUnstyled.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { ClassNameConfigurator } from '@mui/base/utils';
-import { MuiRenderResult, RenderOptions, screen } from './createRenderer';
-import createDescribe from './createDescribe';
 import {
+  MuiRenderResult,
+  RenderOptions,
+  screen,
+  createDescribe,
   ConformanceOptions,
   SlotTestingOptions,
   describeRef,
@@ -11,7 +12,8 @@ import {
   testClassName,
   testComponentProp,
   testReactTestRenderer,
-} from './describeConformance';
+} from '@mui-internal/test-utils';
+import { ClassNameConfigurator } from '@mui/base/utils';
 
 export interface UnstyledConformanceOptions
   extends Omit<Partial<ConformanceOptions>, 'render' | 'skip' | 'classes'> {
@@ -391,7 +393,7 @@ const fullSuite = {
   disableClassGeneration: testDisablingClassGeneration,
 };
 
-function describeConformanceUnstyled(
+function describeConformance(
   minimalElement: React.ReactElement,
   getOptions: () => UnstyledConformanceOptions,
 ) {
@@ -410,4 +412,6 @@ function describeConformanceUnstyled(
   });
 }
 
-export default createDescribe('MUI unstyled component API', describeConformanceUnstyled);
+const describeConformanceUnstyled = createDescribe('Base UI component API', describeConformance);
+
+export { describeConformanceUnstyled };

--- a/packages/mui-joy/src/Accordion/Accordion.test.tsx
+++ b/packages/mui-joy/src/Accordion/Accordion.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Accordion, { accordionClasses as classes } from '@mui/joy/Accordion';
 import AccordionSummary from '@mui/joy/AccordionSummary';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Accordion />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/AccordionDetails/AccordionDetails.test.tsx
+++ b/packages/mui-joy/src/AccordionDetails/AccordionDetails.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, fireEvent, screen } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Accordion from '@mui/joy/Accordion';
 import AccordionSummary from '@mui/joy/AccordionSummary';
 import AccordionDetails, { accordionDetailsClasses as classes } from '@mui/joy/AccordionDetails';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionDetails />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/AccordionGroup/AccordionGroup.test.tsx
+++ b/packages/mui-joy/src/AccordionGroup/AccordionGroup.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import AccordionGroup, { accordionGroupClasses as classes } from '@mui/joy/AccordionGroup';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/AccordionSummary/AccordionSummary.test.tsx
+++ b/packages/mui-joy/src/AccordionSummary/AccordionSummary.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import AccordionSummary, { accordionSummaryClasses as classes } from '@mui/joy/AccordionSummary';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionSummary />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Alert/Alert.test.tsx
+++ b/packages/mui-joy/src/Alert/Alert.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Alert, { AlertClassKey, alertClasses as classes } from '@mui/joy/Alert';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Alert />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/AspectRatio/AspectRatio.test.tsx
+++ b/packages/mui-joy/src/AspectRatio/AspectRatio.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import AspectRatio, {
   AspectRatioClassKey,
   aspectRatioClasses as classes,
 } from '@mui/joy/AspectRatio';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AspectRatio />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.test.tsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
-  describeConformance,
   createRenderer,
   screen,
   act,
@@ -20,6 +19,7 @@ import ChipDelete from '@mui/joy/ChipDelete';
 import Select from '@mui/joy/Select';
 import Option from '@mui/joy/Option';
 import { ThemeProvider, styled } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 function checkHighlightIs(listbox: HTMLElement, expected: string | null) {
   const focused = listbox.querySelector(`.${classes.focused}`);

--- a/packages/mui-joy/src/AutocompleteListbox/AutocompleteListbox.test.tsx
+++ b/packages/mui-joy/src/AutocompleteListbox/AutocompleteListbox.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import AutocompleteListbox, {
   autocompleteListboxClasses as classes,
 } from '@mui/joy/AutocompleteListbox';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <AutocompleteListbox />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/AutocompleteOption/AutocompleteOption.test.tsx
+++ b/packages/mui-joy/src/AutocompleteOption/AutocompleteOption.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import AutocompleteOption, {
   autocompleteOptionClasses as classes,
 } from '@mui/joy/AutocompleteOption';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <AutocompleteOption />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Avatar/Avatar.test.tsx
+++ b/packages/mui-joy/src/Avatar/Avatar.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Avatar, { AvatarClassKey, avatarClasses as classes } from '@mui/joy/Avatar';
 import PersonIcon from '../internal/svg-icons/Person';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Avatar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/mui-joy/src/AvatarGroup/AvatarGroup.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import AvatarGroup, { avatarGroupClasses as classes } from '@mui/joy/AvatarGroup';
 import Avatar, { avatarClasses } from '@mui/joy/Avatar';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AvatarGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Badge/Badge.test.tsx
+++ b/packages/mui-joy/src/Badge/Badge.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Badge, { BadgeClassKey, BadgeOrigin, badgeClasses as classes } from '@mui/joy/Badge';
+import describeConformance from '../../test/describeConformance';
 
 function findBadge(container: HTMLElement) {
   return (container?.firstChild as HTMLElement)?.querySelector('span') ?? null;

--- a/packages/mui-joy/src/Box/Box.test.tsx
+++ b/packages/mui-joy/src/Box/Box.test.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable material-ui/no-empty-box */
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider, CssVarsProvider, extendTheme, PalettePrimary } from '@mui/joy/styles';
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/joy/className';
 import Box from '@mui/joy/Box';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Box />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Breadcrumbs, {
   BreadcrumbsClassKey,
   breadcrumbsClasses as classes,
 } from '@mui/joy/Breadcrumbs';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Breadcrumbs />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Button/Button.test.tsx
+++ b/packages/mui-joy/src/Button/Button.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Button, { buttonClasses as classes } from '@mui/joy/Button';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Button />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ButtonGroup, {
@@ -9,6 +9,7 @@ import ButtonGroup, {
 } from '@mui/joy/ButtonGroup';
 import Button, { buttonClasses, ButtonClassKey } from '@mui/joy/Button';
 import IconButton, { iconButtonClasses, IconButtonClassKey } from '@mui/joy/IconButton';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ButtonGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Card/Card.test.tsx
+++ b/packages/mui-joy/src/Card/Card.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Card, { cardClasses as classes, CardClassKey } from '@mui/joy/Card';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Card />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/CardActions/CardActions.test.tsx
+++ b/packages/mui-joy/src/CardActions/CardActions.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import CardActions, { cardActionsClasses as classes } from '@mui/joy/CardActions';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardActions />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/CardContent/CardContent.test.tsx
+++ b/packages/mui-joy/src/CardContent/CardContent.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import CardContent, { cardContentClasses as classes } from '@mui/joy/CardContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/CardCover/CardCover.test.tsx
+++ b/packages/mui-joy/src/CardCover/CardCover.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import CardCover, { cardCoverClasses as classes } from '@mui/joy/CardCover';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardCover />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/CardOverflow/CardOverflow.test.tsx
+++ b/packages/mui-joy/src/CardOverflow/CardOverflow.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import CardOverflow, {
   CardOverflowClassKey,
   cardOverflowClasses as classes,
 } from '@mui/joy/CardOverflow';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardOverflow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Checkbox/Checkbox.test.tsx
+++ b/packages/mui-joy/src/Checkbox/Checkbox.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Checkbox, { checkboxClasses as classes } from '@mui/joy/Checkbox';
 import { ThemeProvider } from '@mui/joy/styles';
 import CloseIcon from '../internal/svg-icons/Close';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Checkbox />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Chip/Chip.test.tsx
+++ b/packages/mui-joy/src/Chip/Chip.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Chip, { ChipClassKey, chipClasses as classes } from '@mui/joy/Chip';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Chip />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ChipDelete/ChipDelete.test.tsx
+++ b/packages/mui-joy/src/ChipDelete/ChipDelete.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, act, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, act, fireEvent } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Chip from '@mui/joy/Chip';
 import ChipDelete, { chipDeleteClasses as classes } from '@mui/joy/ChipDelete';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ChipDelete />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/CircularProgress/CircularProgress.test.tsx
+++ b/packages/mui-joy/src/CircularProgress/CircularProgress.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import CircularProgress, { circularProgressClasses as classes } from '@mui/joy/CircularProgress';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CircularProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Container/Container.test.tsx
+++ b/packages/mui-joy/src/Container/Container.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Container, { containerClasses as classes } from '@mui/joy/Container';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Container />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/DialogActions/DialogActions.test.tsx
+++ b/packages/mui-joy/src/DialogActions/DialogActions.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import DialogActions, { dialogActionsClasses as classes } from '@mui/joy/DialogActions';
+import describeConformance from '../../test/describeConformance';
 
 describe('<DialogActions />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/DialogContent/DialogContent.test.tsx
+++ b/packages/mui-joy/src/DialogContent/DialogContent.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import DialogContent, { dialogContentClasses as classes } from '@mui/joy/DialogContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<DialogContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/DialogTitle/DialogTitle.test.tsx
+++ b/packages/mui-joy/src/DialogTitle/DialogTitle.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import CardContent, { cardContentClasses as classes } from '@mui/joy/CardContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Divider/Divider.test.tsx
+++ b/packages/mui-joy/src/Divider/Divider.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Divider, { dividerClasses as classes } from '@mui/joy/Divider';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Divider />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Drawer/Drawer.test.tsx
+++ b/packages/mui-joy/src/Drawer/Drawer.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider, CssVarsProvider, extendTheme } from '@mui/joy/styles';
 import Drawer, { drawerClasses as classes } from '@mui/joy/Drawer';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Drawer />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/FormControl/FormControl.test.tsx
+++ b/packages/mui-joy/src/FormControl/FormControl.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import FormControl, { formControlClasses as classes } from '@mui/joy/FormControl';
@@ -14,6 +14,7 @@ import RadioGroup from '@mui/joy/RadioGroup';
 import Radio, { radioClasses } from '@mui/joy/Radio';
 import Switch, { switchClasses } from '@mui/joy/Switch';
 import Autocomplete, { autocompleteClasses } from '@mui/joy/Autocomplete';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormControl />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/FormHelperText/FormHelperText.test.tsx
+++ b/packages/mui-joy/src/FormHelperText/FormHelperText.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import FormHelperText, { formHelperTextClasses as classes } from '@mui/joy/FormHelperText';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <FormHelperText />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/FormLabel/FormLabel.test.tsx
+++ b/packages/mui-joy/src/FormLabel/FormLabel.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import FormLabel, { formLabelClasses as classes } from '@mui/joy/FormLabel';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <FormLabel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Grid/Grid.test.tsx
+++ b/packages/mui-joy/src/Grid/Grid.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Grid, { gridClasses as classes } from '@mui/joy/Grid';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy UI <Grid />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/IconButton/IconButton.test.tsx
+++ b/packages/mui-joy/src/IconButton/IconButton.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import IconButton, { iconButtonClasses as classes } from '@mui/joy/IconButton';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <IconButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Input/Input.test.tsx
+++ b/packages/mui-joy/src/Input/Input.test.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  createRenderer,
-  screen,
-  act,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { createRenderer, screen, act, fireEvent } from '@mui-internal/test-utils';
 import Input, { inputClasses as classes } from '@mui/joy/Input';
 import { ThemeProvider, extendTheme } from '@mui/joy/styles';
 import FormControl from '@mui/joy/FormControl';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Input />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/LinearProgress/LinearProgress.test.tsx
+++ b/packages/mui-joy/src/LinearProgress/LinearProgress.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import LinearProgress, { linearProgressClasses as classes } from '@mui/joy/LinearProgress';
+import describeConformance from '../../test/describeConformance';
 
 describe('<LinearProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Link/Link.test.tsx
+++ b/packages/mui-joy/src/Link/Link.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { SinonSpy, spy } from 'sinon';
-import { act, createRenderer, fireEvent, describeConformance } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import Link, { LinkClassKey, linkClasses as classes } from '@mui/joy/Link';
 import Typography from '@mui/joy/Typography';
 import { ThemeProvider, TypographySystem } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 function focusVisible(element: HTMLAnchorElement | null) {
   act(() => {

--- a/packages/mui-joy/src/List/List.test.tsx
+++ b/packages/mui-joy/src/List/List.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import List, { listClasses as classes } from '@mui/joy/List';
 import ListItem from '@mui/joy/ListItem';
@@ -8,6 +8,7 @@ import MenuList from '@mui/joy/MenuList';
 import Menu from '@mui/joy/Menu';
 import Select from '@mui/joy/Select';
 import RadioGroup from '@mui/joy/RadioGroup';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <List />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ListDivider/ListDivider.test.tsx
+++ b/packages/mui-joy/src/ListDivider/ListDivider.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import List from '@mui/joy/List';
 import ListDivider, { listDividerClasses as classes } from '@mui/joy/ListDivider';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <ListDivider />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ListItem/ListItem.test.tsx
+++ b/packages/mui-joy/src/ListItem/ListItem.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import MenuList from '@mui/joy/MenuList';
 import List from '@mui/joy/List';
 import ListItem, { listItemClasses as classes } from '@mui/joy/ListItem';
 import ListSubheader from '@mui/joy/ListSubheader';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <ListItem />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ListItemButton/ListItemButton.test.tsx
+++ b/packages/mui-joy/src/ListItemButton/ListItemButton.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, act, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, act, fireEvent } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ListItemButton, { listItemButtonClasses as classes } from '@mui/joy/ListItemButton';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <ListItemButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ListItemContent/ListItemContent.test.tsx
+++ b/packages/mui-joy/src/ListItemContent/ListItemContent.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ListItemContent, { listItemContentClasses as classes } from '@mui/joy/ListItemContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <ListItemContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.test.tsx
+++ b/packages/mui-joy/src/ListItemDecorator/ListItemDecorator.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ListItemDecorator, { listItemDecoratorClasses as classes } from '@mui/joy/ListItemDecorator';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <ListItemDecorator />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ListSubheader/ListSubheader.test.tsx
+++ b/packages/mui-joy/src/ListSubheader/ListSubheader.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ListSubheader, { listSubheaderClasses as classes } from '@mui/joy/ListSubheader';
 import ListSubheaderDispatch from './ListSubheaderContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <ListSubheader />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Menu/Menu.test.tsx
+++ b/packages/mui-joy/src/Menu/Menu.test.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import {
-  act,
-  createRenderer,
-  describeConformance,
-  screen,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
 import { Popper as PopperUnstyled } from '@mui/base/Popper';
 import { DropdownContext, DropdownContextValue } from '@mui/base/useDropdown';
 import { ThemeProvider } from '@mui/joy/styles';
@@ -15,6 +9,7 @@ import Menu, { menuClasses as classes } from '@mui/joy/Menu';
 import Dropdown from '@mui/joy/Dropdown';
 import MenuItem from '@mui/joy/MenuItem';
 import MenuButton from '@mui/joy/MenuButton';
+import describeConformance from '../../test/describeConformance';
 
 const testContext: DropdownContextValue = {
   dispatch: () => {},

--- a/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { DropdownContext, DropdownContextValue } from '@mui/base/useDropdown';
 import { ThemeProvider } from '@mui/joy/styles';
 import MenuButton, { menuButtonClasses as classes } from '@mui/joy/MenuButton';
+import describeConformance from '../../test/describeConformance';
 
 const testContext: DropdownContextValue = {
   dispatch: () => {},

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -1,17 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  act,
-  describeConformance,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { MenuProvider, MenuProviderValue } from '@mui/base/useMenu';
 import { ThemeProvider } from '@mui/joy/styles';
 import MenuItem, { menuItemClasses as classes } from '@mui/joy/MenuItem';
 import ListItemButton from '@mui/joy/ListItemButton';
+import describeConformance from '../../test/describeConformance';
 
 const testContext: MenuProviderValue = {
   registerItem: () => ({ id: '0', deregister: () => {} }),

--- a/packages/mui-joy/src/MenuList/MenuList.test.tsx
+++ b/packages/mui-joy/src/MenuList/MenuList.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import MenuList, { menuListClasses as classes } from '@mui/joy/MenuList';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <MenuList />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Modal/Modal.test.tsx
+++ b/packages/mui-joy/src/Modal/Modal.test.tsx
@@ -2,15 +2,10 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { spy } from 'sinon';
 import { expect } from 'chai';
-import {
-  createRenderer,
-  describeConformance,
-  act,
-  fireEvent,
-  within,
-} from '@mui-internal/test-utils';
+import { createRenderer, act, fireEvent, within } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Modal, { modalClasses as classes, ModalProps } from '@mui/joy/Modal';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Modal />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-joy/src/ModalClose/ModalClose.test.tsx
+++ b/packages/mui-joy/src/ModalClose/ModalClose.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Modal from '@mui/joy/Modal';
 import ModalDialog from '@mui/joy/ModalDialog';
 import ModalClose, { modalCloseClasses as classes } from '@mui/joy/ModalClose';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ModalClose />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ModalDialog/ModalDialog.test.tsx
+++ b/packages/mui-joy/src/ModalDialog/ModalDialog.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ModalDialog, { modalDialogClasses as classes } from '@mui/joy/ModalDialog';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ModalDialog />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ModalOverflow/ModalOverflow.test.tsx
+++ b/packages/mui-joy/src/ModalOverflow/ModalOverflow.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ModalOverflow, { modalOverflowClasses as classes } from '@mui/joy/ModalOverflow';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ModalOverflow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Radio/Radio.test.tsx
+++ b/packages/mui-joy/src/Radio/Radio.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Radio, { radioClasses as classes } from '@mui/joy/Radio';
 import { ThemeProvider, extendTheme } from '@mui/joy/styles';
 import FormControl from '@mui/joy/FormControl';
 import RadioGroup from '@mui/joy/RadioGroup';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Radio />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/mui-joy/src/RadioGroup/RadioGroup.test.tsx
@@ -2,16 +2,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import RadioGroup, { radioGroupClasses as classes, RadioGroupProps } from '@mui/joy/RadioGroup';
 import Radio from '@mui/joy/Radio';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<RadioGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.test.tsx
+++ b/packages/mui-joy/src/ScopedCssBaseline/ScopedCssBaseline.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ScopedCssBaseline, { scopedCssBaselineClasses as classes } from '@mui/joy/ScopedCssBaseline';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ScopedCssBaseline />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Select/Select.test.tsx
+++ b/packages/mui-joy/src/Select/Select.test.tsx
@@ -1,19 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Select, { selectClasses as classes, SelectOption } from '@mui/joy/Select';
 import Option from '@mui/joy/Option';
 import List from '@mui/joy/List';
 import ListItem from '@mui/joy/ListItem';
 import ListDivider from '@mui/joy/ListDivider';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Select />', () => {
   const { render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-joy/src/Sheet/Sheet.test.tsx
+++ b/packages/mui-joy/src/Sheet/Sheet.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Sheet, { sheetClasses as classes, SheetClassKey } from '@mui/joy/Sheet';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Sheet />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Skeleton/Skeleton.test.tsx
+++ b/packages/mui-joy/src/Skeleton/Skeleton.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Skeleton, { skeletonClasses as classes } from '@mui/joy/Skeleton';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Skeleton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Slider/Slider.test.tsx
+++ b/packages/mui-joy/src/Slider/Slider.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Slider, { sliderClasses as classes } from '@mui/joy/Slider';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Slider />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Snackbar/Snackbar.test.tsx
+++ b/packages/mui-joy/src/Snackbar/Snackbar.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, fireEvent, act } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent, act } from '@mui-internal/test-utils';
 import Snackbar, { snackbarClasses as classes } from '@mui/joy/Snackbar';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Snackbar />', () => {
   const { render: clientRender, clock } = createRenderer({ clock: 'fake' });

--- a/packages/mui-joy/src/Stack/Stack.test.tsx
+++ b/packages/mui-joy/src/Stack/Stack.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Stack, { stackClasses as classes } from '@mui/joy/Stack';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Stack />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Step/Step.test.tsx
+++ b/packages/mui-joy/src/Step/Step.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Step, { stepClasses as classes } from '@mui/joy/Step';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Step />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/StepButton/StepButton.test.tsx
+++ b/packages/mui-joy/src/StepButton/StepButton.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import StepButton, { stepButtonClasses as classes } from '@mui/joy/StepButton';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/StepIndicator/StepIndicator.test.tsx
+++ b/packages/mui-joy/src/StepIndicator/StepIndicator.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { unstable_capitalize as capitalize } from '@mui/utils';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import StepIndicator, { stepIndicatorClasses as classes } from '@mui/joy/StepIndicator';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepIndicator />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Stepper/Stepper.test.tsx
+++ b/packages/mui-joy/src/Stepper/Stepper.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Stepper, { stepperClasses as classes } from '@mui/joy/Stepper';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Stepper />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/SvgIcon/SvgIcon.test.tsx
+++ b/packages/mui-joy/src/SvgIcon/SvgIcon.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import SvgIcon, {
   svgIconClasses as classes,
@@ -8,6 +8,7 @@ import SvgIcon, {
   SvgIconProps,
 } from '@mui/joy/SvgIcon';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SvgIcon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Switch/Switch.test.tsx
+++ b/packages/mui-joy/src/Switch/Switch.test.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import Switch, { switchClasses as classes } from '@mui/joy/Switch';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Switch />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Tab/Tab.test.tsx
+++ b/packages/mui-joy/src/Tab/Tab.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { TabsProps } from '@mui/base/Tabs';
 import { useTabs, TabsProvider as BaseTabsProvider } from '@mui/base/useTabs';
 import { useTabsList, TabsListProvider as BaseTabsListProvider } from '@mui/base/useTabsList';
 import { ThemeProvider } from '@mui/joy/styles';
 import Tab, { tabClasses as classes } from '@mui/joy/Tab';
+import describeConformance from '../../test/describeConformance';
 
 function TabsListProvider({ children }: React.PropsWithChildren<{}>) {
   const { contextValue: tabsListContextValue } = useTabsList({

--- a/packages/mui-joy/src/TabList/TabList.test.tsx
+++ b/packages/mui-joy/src/TabList/TabList.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { TabsProps } from '@mui/base/Tabs';
 import { useTabs, TabsProvider as BaseTabsProvider } from '@mui/base/useTabs';
 import { ThemeProvider } from '@mui/joy/styles';
 import Tabs from '@mui/joy/Tabs';
 import TabList, { tabListClasses as classes } from '@mui/joy/TabList';
 import RowListContext from '../List/RowListContext';
+import describeConformance from '../../test/describeConformance';
 
 function TabsProvider({ children, ...props }: TabsProps) {
   const { contextValue } = useTabs(props);

--- a/packages/mui-joy/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-joy/src/TabPanel/TabPanel.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { TabsProps } from '@mui/base/Tabs';
 import { useTabs, TabsProvider as BaseTabsProvider } from '@mui/base/useTabs';
 import { ThemeProvider } from '@mui/joy/styles';
 import Tabs from '@mui/joy/Tabs';
 import TabPanel, { tabPanelClasses as classes } from '@mui/joy/TabPanel';
+import describeConformance from '../../test/describeConformance';
 
 function TabsProvider({ children, ...props }: TabsProps) {
   const { contextValue } = useTabs(props);

--- a/packages/mui-joy/src/Table/Table.test.tsx
+++ b/packages/mui-joy/src/Table/Table.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Table, { tableClasses as classes } from '@mui/joy/Table';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Table />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Tabs/Tabs.test.tsx
+++ b/packages/mui-joy/src/Tabs/Tabs.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import Tabs, { tabsClasses as classes } from '@mui/joy/Tabs';
 import SizeTabsContext from './SizeTabsContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Tabs />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Textarea/Textarea.test.tsx
+++ b/packages/mui-joy/src/Textarea/Textarea.test.tsx
@@ -1,15 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  createRenderer,
-  screen,
-  act,
-  fireEvent,
-} from '@mui-internal/test-utils';
+import { createRenderer, screen, act, fireEvent } from '@mui-internal/test-utils';
 import Textarea, { textareaClasses as classes } from '@mui/joy/Textarea';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('Joy <Textarea />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.test.tsx
+++ b/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { act, createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/joy/styles';
 import ToggleButtonGroup, { toggleButtonGroupClasses as classes } from '@mui/joy/ToggleButtonGroup';
 import Button from '@mui/joy/Button';
 import IconButton from '@mui/joy/IconButton';
 import Tooltip from '@mui/joy/Tooltip';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ToggleButtonGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import { PopperProps } from '@mui/base';
 import { ThemeProvider } from '@mui/joy/styles';
 import Tooltip, { tooltipClasses as classes, TooltipClassKey } from '@mui/joy/Tooltip';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Tooltip />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/src/Typography/Typography.test.tsx
+++ b/packages/mui-joy/src/Typography/Typography.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography, { typographyClasses as classes, TypographyProps } from '@mui/joy/Typography';
 import { ThemeProvider } from '@mui/joy/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Typography />', () => {
   const { render } = createRenderer();

--- a/packages/mui-joy/test/describeConformance.ts
+++ b/packages/mui-joy/test/describeConformance.ts
@@ -1,0 +1,21 @@
+import {
+  describeConformance as baseDescribeConformance,
+  ConformanceOptions,
+} from '@mui-internal/test-utils';
+import { ThemeProvider } from '@mui/joy/styles';
+import { createTheme } from '@mui/system';
+
+export default function describeConformance(
+  minimalElement: React.ReactElement,
+  getOptions: () => ConformanceOptions,
+) {
+  function getOptionsWithDefaults() {
+    return {
+      ThemeProvider,
+      createTheme,
+      ...getOptions(),
+    };
+  }
+
+  return baseDescribeConformance(minimalElement, getOptionsWithDefaults);
+}

--- a/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
+++ b/packages/mui-lab/src/LoadingButton/LoadingButton.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { createRenderer, describeConformance, screen, within } from '@mui-internal/test-utils';
+import { createRenderer, screen, within } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import Button, { buttonClasses } from '@mui/material/Button';
 import LoadingButton, { loadingButtonClasses as classes } from '@mui/lab/LoadingButton';
 import ButtonGroup, { buttonGroupClasses } from '@mui/material/ButtonGroup';
+import describeConformance from '../../test/describeConformance';
 
 describe('<LoadingButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/Masonry/Masonry.test.js
+++ b/packages/mui-lab/src/Masonry/Masonry.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { expect } from 'chai';
 import { createTheme } from '@mui/material/styles';
 import defaultTheme from '@mui/material/styles/defaultTheme';
 import Masonry, { masonryClasses as classes } from '@mui/lab/Masonry';
 import { getStyle, parseToNumber } from './Masonry';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Masonry />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TabList/TabList.test.js
+++ b/packages/mui-lab/src/TabList/TabList.test.js
@@ -1,11 +1,12 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Tab from '@mui/material/Tab';
 import Tabs, { tabsClasses as classes } from '@mui/material/Tabs';
 import TabList from './TabList';
 import TabContext from '../TabContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TabList />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TabPanel, { tabPanelClasses as classes } from '@mui/lab/TabPanel';
 import TabContext from '../TabContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TabPanel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/Timeline/Timeline.test.tsx
+++ b/packages/mui-lab/src/Timeline/Timeline.test.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import Timeline, { timelineClasses as classes } from '@mui/lab/Timeline';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Timeline />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.test.js
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TimelineConnector, { timelineConnectorClasses as classes } from '@mui/lab/TimelineConnector';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineConnector />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.test.js
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography from '@mui/material/Typography';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineContent, { timelineContentClasses as classes } from '@mui/lab/TimelineContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.test.js
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TimelineDot, { timelineDotClasses as classes } from '@mui/lab/TimelineDot';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineDot />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TimelineItem, { timelineItemClasses as classes } from '@mui/lab/TimelineItem';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineItem />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography from '@mui/material/Typography';
 import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineOppositeContent, {
   timelineOppositeContentClasses as classes,
 } from '@mui/lab/TimelineOppositeContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineOppositeContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.test.js
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TimelineSeparator, { timelineSeparatorClasses as classes } from '@mui/lab/TimelineSeparator';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TimelineSeparator />', () => {
   const { render } = createRenderer();

--- a/packages/mui-lab/test/describeConformance.ts
+++ b/packages/mui-lab/test/describeConformance.ts
@@ -1,0 +1,20 @@
+import {
+  describeConformance as baseDescribeConformance,
+  ConformanceOptions,
+} from '@mui-internal/test-utils';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export default function describeConformance(
+  minimalElement: React.ReactElement,
+  getOptions: () => ConformanceOptions,
+) {
+  function getOptionsWithDefaults() {
+    return {
+      ThemeProvider,
+      createTheme,
+      ...getOptions(),
+    };
+  }
+
+  return baseDescribeConformance(minimalElement, getOptionsWithDefaults);
+}

--- a/packages/mui-material-next/src/Badge/Badge.test.tsx
+++ b/packages/mui-material-next/src/Badge/Badge.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Badge, { badgeClasses as classes } from '@mui/material-next/Badge';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
+import describeConformance from '../../test/describeConformance';
 
 function findBadgeRoot(container: HTMLElement) {
   return container?.firstChild;

--- a/packages/mui-material-next/src/Button/Button.test.js
+++ b/packages/mui-material-next/src/Button/Button.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, fireEvent, act } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent, act } from '@mui-internal/test-utils';
 import { camelCase } from 'lodash';
 import Button, { buttonClasses as classes } from '@mui/material-next/Button';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Button />', () => {
   const { render, renderToString } = createRenderer();

--- a/packages/mui-material-next/src/ButtonBase/ButtonBase.test.tsx
+++ b/packages/mui-material-next/src/ButtonBase/ButtonBase.test.tsx
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import userEvent from '@testing-library/user-event';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -19,6 +18,7 @@ import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 import ButtonBase, { buttonBaseClasses as classes } from '@mui/material-next/ButtonBase';
 import { ButtonBaseActions } from './ButtonBase.types';
 import { TouchRippleActions } from './TouchRipple.types';
+import describeConformance from '../../test/describeConformance';
 
 // TODO v6: initialize @testing-library/user-event using userEvent.setup() instead of directly calling methods e.g. userEvent.click() for all related tests in this file
 // currently the setup() method uses the ClipboardEvent constructor which is incompatible with our lowest supported version of iOS Safari (12.2) https://github.com/mui/material-ui/blob/master/.browserslistrc#L44

--- a/packages/mui-material-next/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material-next/src/ButtonBase/TouchRipple.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
+import describeConformance from '../../test/describeConformance';
 
 const cb = () => {};
 

--- a/packages/mui-material-next/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/mui-material-next/src/ButtonGroup/ButtonGroup.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import ButtonGroup, { buttonGroupClasses as classes } from '@mui/material-next/ButtonGroup';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 import Button, { buttonClasses } from '@mui/material-next/Button';
 import ButtonGroupContext, { ButtonGroupContextType } from './ButtonGroupContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ButtonGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Chip/Chip.test.tsx
+++ b/packages/mui-material-next/src/Chip/Chip.test.tsx
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import userEvent from '@testing-library/user-event';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -19,6 +18,7 @@ import Chip, { chipClasses as classes } from '@mui/material-next/Chip';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 import CheckBox from '../internal/svg-icons/CheckBox';
 import { ChipProps } from './Chip.types';
+import describeConformance from '../../test/describeConformance';
 
 // TODO: remove after migrating SvgIcon to support Material Design 3 colors
 const MaterialV5DefaultTheme = createTheme();

--- a/packages/mui-material-next/src/CircularProgress/CircularProgress.test.tsx
+++ b/packages/mui-material-next/src/CircularProgress/CircularProgress.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import CircularProgress, {
   circularProgressClasses as classes,
 } from '@mui/material-next/CircularProgress';
 import { CssVarsProvider, extendTheme } from '../styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CircularProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Divider/Divider.test.tsx
+++ b/packages/mui-material-next/src/Divider/Divider.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Divider, { dividerClasses as classes } from '@mui/material-next/Divider';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Divider />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/FilledInput/FilledInput.test.tsx
+++ b/packages/mui-material-next/src/FilledInput/FilledInput.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { ClassNames } from '@emotion/react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 import FilledInput, { filledInputClasses as classes } from '@mui/material-next/FilledInput';
 import InputBase from '@mui/material-next/InputBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FilledInput />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/FormControl/FormControl.test.tsx
+++ b/packages/mui-material-next/src/FormControl/FormControl.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { ClassNames } from '@emotion/react';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import FormControl, { formControlClasses as classes } from '@mui/material-next/FormControl';
 import FilledInput from '@mui/material-next/FilledInput';
 import InputBase from '@mui/material-next/InputBase';
@@ -10,6 +10,7 @@ import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 // TODO v6: replace with material-next/Select
 import Select from '@mui/material/Select';
 import useFormControl from './useFormControl';
+import describeConformance from '../../test/describeConformance';
 
 type TestFormControlledComponent = {
   onFilled: () => {};

--- a/packages/mui-material-next/src/FormHelperText/FormHelperText.test.tsx
+++ b/packages/mui-material-next/src/FormHelperText/FormHelperText.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import FormHelperText, {
   formHelperTextClasses as classes,
   FormHelperTextClasses,
 } from '@mui/material-next/FormHelperText';
 import FormControl from '@mui/material-next/FormControl';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormHelperText />', () => {
   let originalMatchmedia: typeof window.matchMedia;

--- a/packages/mui-material-next/src/FormLabel/FormLabel.test.tsx
+++ b/packages/mui-material-next/src/FormLabel/FormLabel.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import FormLabel, { formLabelClasses as classes } from '@mui/material-next/FormLabel';
 import FormControl, { useFormControl } from '@mui/material-next/FormControl';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormLabel />', () => {
   let originalMatchmedia: typeof window.matchMedia;

--- a/packages/mui-material-next/src/IconButton/IconButton.test.js
+++ b/packages/mui-material-next/src/IconButton/IconButton.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import Icon from '@mui/material/Icon';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ButtonBase from '@mui/material/ButtonBase';
 import { iconButtonClasses as classes } from '@mui/material/IconButton';
 import IconButton from '.';
+import describeConformance from '../../test/describeConformance';
 
 describe('<IconButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/InputAdornment/InputAdornment.test.js
+++ b/packages/mui-material-next/src/InputAdornment/InputAdornment.test.js
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  createRenderer,
-  describeConformance,
-  strictModeDoubleLoggingSuppressed,
-} from '@mui-internal/test-utils';
+import { createRenderer, strictModeDoubleLoggingSuppressed } from '@mui-internal/test-utils';
 import { typographyClasses } from '@mui/material/Typography';
 import InputAdornment, { inputAdornmentClasses as classes } from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 import FormControl from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
+import describeConformance from '../../test/describeConformance';
 
 describe('<InputAdornment />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/InputBase/InputBase.test.tsx
+++ b/packages/mui-material-next/src/InputBase/InputBase.test.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import FormControl, { useFormControl } from '@mui/material-next/FormControl';
 // TODO v6: replace with material-next/InputAdornment
 import InputAdornment from '@mui/material/InputAdornment';
@@ -23,6 +17,7 @@ import {
   InputBaseOwnerState,
   InputBaseProps,
 } from './InputBase.types';
+import describeConformance from '../../test/describeConformance';
 
 describe('<InputBase />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/InputLabel/InputLabel.test.tsx
+++ b/packages/mui-material-next/src/InputLabel/InputLabel.test.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import { ClassNames } from '@emotion/react';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 import FormControl from '@mui/material-next/FormControl';
 import FilledInput from '@mui/material-next/FilledInput';
 import FormLabel from '@mui/material-next/FormLabel';
 import InputLabel, { inputLabelClasses as classes } from '@mui/material-next/InputLabel';
+import describeConformance from '../../test/describeConformance';
 
 describe('<InputLabel />', () => {
   let originalMatchmedia: typeof window.matchMedia;

--- a/packages/mui-material-next/src/LinearProgress/LinearProgress.test.tsx
+++ b/packages/mui-material-next/src/LinearProgress/LinearProgress.test.tsx
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import {
   createRenderer,
   screen,
-  describeConformance,
   strictModeDoubleLoggingSuppressed,
   MuiRenderResult,
 } from '@mui-internal/test-utils';
@@ -11,6 +10,7 @@ import LinearProgress, {
   linearProgressClasses as classes,
 } from '@mui/material-next/LinearProgress';
 import { CssVarsProvider, extendTheme } from '../styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<LinearProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/List/List.test.js
+++ b/packages/mui-material-next/src/List/List.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListSubheader, { listSubheaderClasses } from '@mui/material-next/ListSubheader';
 import ListItem, { listItemClasses } from '@mui/material-next/ListItem';
 import List, { listClasses as classes } from '@mui/material-next/List';
+import describeConformance from '../../test/describeConformance';
 
 describe('<List />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/ListItem/ListItem.test.js
+++ b/packages/mui-material-next/src/ListItem/ListItem.test.js
@@ -1,18 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  queries,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, queries } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ListItemText from '@mui/material-next/ListItemText';
 import ListItemSecondaryAction from '@mui/material-next/ListItemSecondaryAction';
 import ListItem, { listItemClasses as classes } from '@mui/material-next/ListItem';
 import ListContext from '../List/ListContext';
+import describeConformance from '../../test/describeConformance';
 
 const NoContent = React.forwardRef(() => {
   return null;

--- a/packages/mui-material-next/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/mui-material-next/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListItemAvatar, {
   listItemAvatarClasses as classes,
 } from '@mui/material-next/ListItemAvatar';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemAvatar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material-next/src/ListItemButton/ListItemButton.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import ListItemButton, {
   listItemButtonClasses as classes,
 } from '@mui/material-next/ListItemButton';
 import ButtonBase from '@mui/material-next/ButtonBase';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ListContext from '../List/ListContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/mui-material-next/src/ListItemIcon/ListItemIcon.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListItemIcon, { listItemIconClasses as classes } from '@mui/material-next/ListItemIcon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemIcon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/mui-material-next/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListItem from '@mui/material-next/ListItem';
 import ListItemSecondaryAction, {
   listItemSecondaryActionClasses as classes,
 } from '@mui/material-next/ListItemSecondaryAction';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemSecondaryAction />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/ListItemText/ListItemText.test.js
+++ b/packages/mui-material-next/src/ListItemText/ListItemText.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 /* TODO: change @mui/material/Typography to @mui/material-next/Typography once Typograpghy is available in @mui/material-next */
 import Typography, { typographyClasses } from '@mui/material/Typography';
 import ListItemText, { listItemTextClasses as classes } from '@mui/material-next/ListItemText';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemText />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/ListSubheader/ListSubheader.test.js
+++ b/packages/mui-material-next/src/ListSubheader/ListSubheader.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListSubheader, { listSubheaderClasses as classes } from '@mui/material-next/ListSubheader';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListSubheader />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Menu/Menu.test.tsx
+++ b/packages/mui-material-next/src/Menu/Menu.test.tsx
@@ -5,7 +5,6 @@ import {
   act,
   createRenderer,
   createMount,
-  describeConformance,
   screen,
   fireEvent,
   strictModeDoubleLoggingSuppressed,
@@ -17,6 +16,7 @@ import Menu, { menuClasses as classes, MenuProps } from '@mui/material-next/Menu
 import Popover from '@mui/material/Popover';
 import { extendTheme, CssVarsProvider } from '@mui/material-next/styles';
 import { MenuPaper } from './Menu';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Menu />', () => {
   const { render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material-next/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-material-next/src/MenuItem/MenuItem.test.tsx
@@ -1,17 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  act,
-  describeConformance,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { MenuProvider } from '@mui/base/useMenu';
 import MenuItem, { menuItemClasses as classes } from '@mui/material-next/MenuItem';
 import Menu from '@mui/material-next/Menu';
 import ButtonBase from '@mui/material-next/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 const dummyGetItemState = () => ({
   disabled: false,

--- a/packages/mui-material-next/src/Option/Option.test.tsx
+++ b/packages/mui-material-next/src/Option/Option.test.tsx
@@ -1,17 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  act,
-  describeConformance,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { MenuProvider } from '@mui/base/useMenu';
 import Option, { optionClasses as classes } from '@mui/material-next/Option';
 import Menu from '@mui/material-next/Menu';
 import ButtonBase from '@mui/material-next/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 const dummyGetItemState = () => ({
   disabled: false,

--- a/packages/mui-material-next/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material-next/src/OutlinedInput/OutlinedInput.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import OutlinedInput, { outlinedInputClasses as classes } from '@mui/material/OutlinedInput';
 import InputBase from '@mui/material/InputBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<OutlinedInput />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Select/Select.test.js
+++ b/packages/mui-material-next/src/Select/Select.test.js
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import {
-  describeConformance,
-  ErrorBoundary,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { ErrorBoundary, act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { nativeSelectClasses } from '@mui/material/NativeSelect';
 // TODO v6: replace with material-next's extendTheme and provider when implementing Material Design 3
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -24,6 +17,7 @@ import InputLabel from '@mui/material/InputLabel';
 import Divider from '@mui/material/Divider';
 import Select from '@mui/material-next/Select';
 import classes from './selectClasses';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Select />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material-next/src/Slider/Slider.test.js
+++ b/packages/mui-material-next/src/Slider/Slider.test.js
@@ -2,16 +2,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';
 import { expect } from 'chai';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { Slider as BaseSlider } from '@mui/base/Slider';
 import { CssVarsProvider, extendTheme } from '@mui/material-next/styles';
 import Slider, { sliderClasses as classes } from '@mui/material-next/Slider';
+import describeConformance from '../../test/describeConformance';
 
 function createTouches(touches) {
   return {

--- a/packages/mui-material-next/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material-next/src/Snackbar/Snackbar.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Snackbar, { snackbarClasses as classes } from '@mui/material-next/Snackbar';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Snackbar />', () => {
   const { clock, render: clientRender } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material-next/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material-next/src/SnackbarContent/SnackbarContent.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Paper from '@mui/material/Paper';
 import SnackbarContent, {
   snackbarContentClasses as classes,
 } from '@mui/material-next/SnackbarContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SnackbarContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Switch/Switch.test.tsx
+++ b/packages/mui-material-next/src/Switch/Switch.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Switch, { switchClasses as classes } from '@mui/material-next/Switch';
 import FormControl from '@mui/material/FormControl';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Switch />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/Tab/Tab.test.js
+++ b/packages/mui-material-next/src/Tab/Tab.test.js
@@ -3,7 +3,8 @@ import Tab, { tabClasses as classes } from '@mui/material/Tab';
 import { expect } from 'chai';
 import * as React from 'react';
 import { spy } from 'sinon';
-import { act, createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Tab />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material-next/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/mui-material-next/src/TabScrollButton/TabScrollButton.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TabScrollButton, {
   tabScrollButtonClasses as classes,
 } from '@mui/material-next/TabScrollButton';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TabScrollButton />', () => {
   const defaultProps = {

--- a/packages/mui-material-next/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material-next/src/TablePagination/TablePagination.test.js
@@ -2,13 +2,14 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { describeConformance, fireEvent, createRenderer } from '@mui-internal/test-utils';
+import { fireEvent, createRenderer } from '@mui-internal/test-utils';
 import TableFooter from '@mui/material/TableFooter';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import TablePagination, {
   tablePaginationClasses as classes,
 } from '@mui/material-next/TablePagination';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TablePagination />', () => {
   const noop = () => {};

--- a/packages/mui-material-next/src/Tabs/Tabs.test.js
+++ b/packages/mui-material-next/src/Tabs/Tabs.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -13,6 +12,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { unstable_capitalize as capitalize } from '@mui/utils';
 import Tab from '@mui/material-next/Tab';
 import Tabs, { tabsClasses as classes } from '@mui/material-next/Tabs';
+import describeConformance from '../../test/describeConformance';
 
 function findScrollButton(container, direction) {
   return container.querySelector(`svg[data-testid="KeyboardArrow${capitalize(direction)}Icon"]`);

--- a/packages/mui-material-next/test/describeConformance.ts
+++ b/packages/mui-material-next/test/describeConformance.ts
@@ -1,0 +1,20 @@
+import {
+  describeConformance as baseDescribeConformance,
+  ConformanceOptions,
+} from '@mui-internal/test-utils';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export default function describeConformance(
+  minimalElement: React.ReactElement,
+  getOptions: () => ConformanceOptions,
+) {
+  function getOptionsWithDefaults() {
+    return {
+      ThemeProvider,
+      createTheme,
+      ...getOptions(),
+    };
+  }
+
+  return baseDescribeConformance(minimalElement, getOptionsWithDefaults);
+}

--- a/packages/mui-material/src/Accordion/Accordion.test.js
+++ b/packages/mui-material/src/Accordion/Accordion.test.js
@@ -2,10 +2,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Accordion, { accordionClasses as classes } from '@mui/material/Accordion';
 import Paper from '@mui/material/Paper';
 import AccordionSummary from '@mui/material/AccordionSummary';
+import describeConformance from '../../test/describeConformance';
 
 function NoTransition(props) {
   const { children, in: inProp } = props;

--- a/packages/mui-material/src/AccordionActions/AccordionActions.test.js
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import AccordionActions, {
   accordionActionsClasses as classes,
 } from '@mui/material/AccordionActions';
 import Button from '@mui/material/Button';
 import { expect } from 'chai';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionActions />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.test.js
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import AccordionDetails, {
   accordionDetailsClasses as classes,
 } from '@mui/material/AccordionDetails';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionDetails />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
+++ b/packages/mui-material/src/AccordionSummary/AccordionSummary.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import AccordionSummary, {
   accordionSummaryClasses as classes,
 } from '@mui/material/AccordionSummary';
 import Accordion from '@mui/material/Accordion';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AccordionSummary />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Alert/Alert.test.js
+++ b/packages/mui-material/src/Alert/Alert.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Alert, { alertClasses as classes } from '@mui/material/Alert';
 import Paper, { paperClasses } from '@mui/material/Paper';
 import { iconButtonClasses } from '@mui/material/IconButton';
 import { svgIconClasses } from '@mui/material/SvgIcon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Alert />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/AlertTitle/AlertTitle.test.js
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import AlertTitle, { alertTitleClasses as classes } from '@mui/material/AlertTitle';
 import Typography from '@mui/material/Typography';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AlertTitle />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/AppBar/AppBar.test.js
+++ b/packages/mui-material/src/AppBar/AppBar.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import AppBar, { appBarClasses as classes } from '@mui/material/AppBar';
 import Paper from '@mui/material/Paper';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AppBar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -23,6 +22,7 @@ import { paperClasses } from '@mui/material/Paper';
 import { iconButtonClasses } from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import Tooltip from '@mui/material/Tooltip';
+import describeConformance from '../../test/describeConformance';
 
 function checkHighlightIs(listbox, expected) {
   const focused = listbox.querySelector(`.${classes.focused}`);

--- a/packages/mui-material/src/Avatar/Avatar.test.js
+++ b/packages/mui-material/src/Avatar/Avatar.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, fireEvent, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { spy } from 'sinon';
 import Avatar, { avatarClasses as classes } from '@mui/material/Avatar';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CancelIcon from '../internal/svg-icons/Cancel';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Avatar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Avatar from '@mui/material/Avatar';
 import AvatarGroup, { avatarGroupClasses as classes } from '@mui/material/AvatarGroup';
+import describeConformance from '../../test/describeConformance';
 
 describe('<AvatarGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Backdrop/Backdrop.test.js
+++ b/packages/mui-material/src/Backdrop/Backdrop.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Backdrop, { backdropClasses as classes } from '@mui/material/Backdrop';
 import Fade from '@mui/material/Fade';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Backdrop />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/Badge/Badge.test.js
+++ b/packages/mui-material/src/Badge/Badge.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Badge, { badgeClasses as classes } from '@mui/material/Badge';
+import describeConformance from '../../test/describeConformance';
 
 function findBadgeRoot(container) {
   return container.firstChild;

--- a/packages/mui-material/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/mui-material/src/BottomNavigation/BottomNavigation.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import BottomNavigation, {
   bottomNavigationClasses as classes,
 } from '@mui/material/BottomNavigation';
@@ -9,6 +9,7 @@ import BottomNavigationAction, {
   bottomNavigationActionClasses as actionClasses,
 } from '@mui/material/BottomNavigationAction';
 import Icon from '@mui/material/Icon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<BottomNavigation />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/mui-material/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, within } from '@mui-internal/test-utils';
+import { createRenderer, within } from '@mui-internal/test-utils';
 import BottomNavigationAction, {
   bottomNavigationActionClasses as classes,
 } from '@mui/material/BottomNavigationAction';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<BottomNavigationAction />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Box/Box.test.js
+++ b/packages/mui-material/src/Box/Box.test.js
@@ -1,10 +1,11 @@
 /* eslint-disable material-ui/no-empty-box */
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Box />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import {
   act,
-  describeConformance,
   createRenderer,
   screen,
   strictModeDoubleLoggingSuppressed,
@@ -10,6 +9,7 @@ import {
 import Breadcrumbs, { breadcrumbsClasses as classes } from '@mui/material/Breadcrumbs';
 import Typography from '@mui/material/Typography';
 import FirstPageIcon from '../internal/svg-icons/FirstPage';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Breadcrumbs />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Button/Button.test.js
+++ b/packages/mui-material/src/Button/Button.test.js
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { ClassNames } from '@emotion/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button, { buttonClasses as classes } from '@mui/material/Button';
 import ButtonBase, { touchRippleClasses } from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Button />', () => {
   const { render, renderToString } = createRenderer();

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -15,6 +14,7 @@ import {
 import PropTypes from 'prop-types';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ButtonBase, { buttonBaseClasses as classes } from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ButtonBase />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ButtonBase/TouchRipple.test.js
+++ b/packages/mui-material/src/ButtonBase/TouchRipple.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
+import describeConformance from '../../test/describeConformance';
 
 const cb = () => {};
 

--- a/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
+++ b/packages/mui-material/src/ButtonGroup/ButtonGroup.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import ButtonGroup, { buttonGroupClasses as classes } from '@mui/material/ButtonGroup';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Button, { buttonClasses } from '@mui/material/Button';
 import ButtonGroupContext from './ButtonGroupContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ButtonGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Card/Card.test.tsx
+++ b/packages/mui-material/src/Card/Card.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Card, { cardClasses as classes } from '@mui/material/Card';
 import Paper from '@mui/material/Paper';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Card />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/CardActionArea/CardActionArea.test.js
+++ b/packages/mui-material/src/CardActionArea/CardActionArea.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import CardActionArea, { cardActionAreaClasses as classes } from '@mui/material/CardActionArea';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardActionArea />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/CardActions/CardActions.test.js
+++ b/packages/mui-material/src/CardActions/CardActions.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import CardActions, { cardActionsClasses as classes } from '@mui/material/CardActions';
 import Button from '@mui/material/Button';
 import { expect } from 'chai';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardActions />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/CardContent/CardContent.test.js
+++ b/packages/mui-material/src/CardContent/CardContent.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import CardContent, { cardContentClasses as classes } from '@mui/material/CardContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/CardHeader/CardHeader.test.js
+++ b/packages/mui-material/src/CardHeader/CardHeader.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { typographyClasses } from '@mui/material/Typography';
 import CardHeader, { cardHeaderClasses as classes } from '@mui/material/CardHeader';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardHeader />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/CardMedia/CardMedia.test.js
+++ b/packages/mui-material/src/CardMedia/CardMedia.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import CardMedia, { cardMediaClasses as classes } from '@mui/material/CardMedia';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CardMedia />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Checkbox/Checkbox.test.js
+++ b/packages/mui-material/src/Checkbox/Checkbox.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import Checkbox, { checkboxClasses as classes } from '@mui/material/Checkbox';
 import FormControl from '@mui/material/FormControl';
 import ButtonBase from '@mui/material/ButtonBase';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Checkbox />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Chip/Chip.test.js
+++ b/packages/mui-material/src/Chip/Chip.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -20,6 +19,7 @@ import {
 } from '@mui/material/styles';
 import CheckBox from '../internal/svg-icons/CheckBox';
 import defaultTheme from '../styles/defaultTheme';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Chip />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/CircularProgress/CircularProgress.test.js
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import CircularProgress, {
   circularProgressClasses as classes,
 } from '@mui/material/CircularProgress';
+import describeConformance from '../../test/describeConformance';
 
 describe('<CircularProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Collapse/Collapse.test.js
+++ b/packages/mui-material/src/Collapse/Collapse.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import { act, createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import { Transition } from 'react-transition-group';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Collapse, { collapseClasses as classes } from '@mui/material/Collapse';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Collapse />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/Container/Container.test.js
+++ b/packages/mui-material/src/Container/Container.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Container, { containerClasses as classes } from '@mui/material/Container';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Container />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Dialog/Dialog.test.js
+++ b/packages/mui-material/src/Dialog/Dialog.test.js
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import Modal from '@mui/material/Modal';
 import Dialog, { dialogClasses as classes } from '@mui/material/Dialog';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 /**
  * more comprehensive simulation of a user click (mousedown + click)

--- a/packages/mui-material/src/DialogActions/DialogActions.test.js
+++ b/packages/mui-material/src/DialogActions/DialogActions.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import DialogActions, { dialogActionsClasses as classes } from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import { expect } from 'chai';
+import describeConformance from '../../test/describeConformance';
 
 describe('<DialogActions />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/DialogContent/DialogContent.test.js
+++ b/packages/mui-material/src/DialogContent/DialogContent.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import DialogContent, { dialogContentClasses as classes } from '@mui/material/DialogContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<DialogContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/DialogContentText/DialogContentText.test.js
+++ b/packages/mui-material/src/DialogContentText/DialogContentText.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography from '@mui/material/Typography';
 import DialogContentText, {
   dialogContentTextClasses as classes,
 } from '@mui/material/DialogContentText';
+import describeConformance from '../../test/describeConformance';
 
 describe('<DialogContentText />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/DialogTitle/DialogTitle.test.js
+++ b/packages/mui-material/src/DialogTitle/DialogTitle.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography from '@mui/material/Typography';
 import DialogTitle, { dialogTitleClasses as classes } from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
+import describeConformance from '../../test/describeConformance';
 
 describe('<DialogTitle />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Divider/Divider.test.js
+++ b/packages/mui-material/src/Divider/Divider.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Divider, { dividerClasses as classes } from '@mui/material/Divider';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Divider />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Drawer/Drawer.test.js
+++ b/packages/mui-material/src/Drawer/Drawer.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Drawer, { drawerClasses as classes } from '@mui/material/Drawer';
 import { getAnchor, isHorizontal } from './Drawer';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Drawer />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/Fab/Fab.test.js
+++ b/packages/mui-material/src/Fab/Fab.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, act, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, act, fireEvent } from '@mui-internal/test-utils';
 import Fab, { fabClasses as classes } from '@mui/material/Fab';
 import ButtonBase, { touchRippleClasses } from '@mui/material/ButtonBase';
 import Icon from '@mui/material/Icon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Fab />', () => {
   const { render, renderToString } = createRenderer();

--- a/packages/mui-material/src/Fade/Fade.test.js
+++ b/packages/mui-material/src/Fade/Fade.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { Transition } from 'react-transition-group';
 import Fade from '@mui/material/Fade';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Fade />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { styled } from '@mui/material/styles';
 import FilledInput, { filledInputClasses as classes } from '@mui/material/FilledInput';
 import InputBase from '@mui/material/InputBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FilledInput />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/FormControl/FormControl.test.js
+++ b/packages/mui-material/src/FormControl/FormControl.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import FormControl, { formControlClasses as classes } from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
 import Select from '@mui/material/Select';
 import useFormControl from './useFormControl';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormControl />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import FormControlLabel, {
   formControlLabelClasses as classes,
 } from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 import FormControl from '@mui/material/FormControl';
 import Typography from '@mui/material/Typography';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormControlLabel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/FormGroup/FormGroup.test.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import FormGroup, { formGroupClasses as classes } from '@mui/material/FormGroup';
 import FormControl from '@mui/material/FormControl';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/FormHelperText/FormHelperText.test.js
+++ b/packages/mui-material/src/FormHelperText/FormHelperText.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import FormHelperText, { formHelperTextClasses as classes } from '@mui/material/FormHelperText';
 import FormControl from '@mui/material/FormControl';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormHelperText />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/FormLabel/FormLabel.test.js
+++ b/packages/mui-material/src/FormLabel/FormLabel.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import FormLabel, { formLabelClasses as classes } from '@mui/material/FormLabel';
 import FormControl, { useFormControl } from '@mui/material/FormControl';
 import { hexToRgb } from '@mui/material/styles';
 import defaultTheme from '../styles/defaultTheme';
+import describeConformance from '../../test/describeConformance';
 
 describe('<FormLabel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Grid/Grid.test.js
+++ b/packages/mui-material/src/Grid/Grid.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import defaultTheme from '@mui/material/styles/defaultTheme';
 import Grid, { gridClasses as classes } from '@mui/material/Grid';
 import { generateGrid, generateRowGap, generateColumnGap, generateDirection } from './Grid';
+import describeConformance from '../../test/describeConformance';
 
 describe('Material UI <Grid />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { Transition } from 'react-transition-group';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Grow from '@mui/material/Grow';
 import useForkRef from '../utils/useForkRef';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Grow />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/Icon/Icon.test.js
+++ b/packages/mui-material/src/Icon/Icon.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Icon, { iconClasses as classes } from '@mui/material/Icon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Icon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/IconButton/IconButton.test.js
+++ b/packages/mui-material/src/IconButton/IconButton.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import capitalize from '@mui/utils/capitalize';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import IconButton, { iconButtonClasses as classes } from '@mui/material/IconButton';
 import Icon from '@mui/material/Icon';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<IconButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ImageList/ImageList.test.js
+++ b/packages/mui-material/src/ImageList/ImageList.test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ImageList, { imageListClasses as classes } from '@mui/material/ImageList';
+import describeConformance from '../../test/describeConformance';
 
 const itemsData = [
   {

--- a/packages/mui-material/src/ImageListItem/ImageListItem.test.js
+++ b/packages/mui-material/src/ImageListItem/ImageListItem.test.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ImageList from '@mui/material/ImageList';
 import ImageListItem, { imageListItemClasses as classes } from '@mui/material/ImageListItem';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ImageListItem />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.test.js
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.test.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ImageListItemBar, {
   imageListItemBarClasses as classes,
 } from '@mui/material/ImageListItemBar';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ImageListItemBar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Input/Input.test.js
+++ b/packages/mui-material/src/Input/Input.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import InputBase from '@mui/material/InputBase';
 import Input, { inputClasses as classes } from '@mui/material/Input';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Input />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/InputAdornment/InputAdornment.test.js
+++ b/packages/mui-material/src/InputAdornment/InputAdornment.test.js
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  createRenderer,
-  describeConformance,
-  strictModeDoubleLoggingSuppressed,
-} from '@mui-internal/test-utils';
+import { createRenderer, strictModeDoubleLoggingSuppressed } from '@mui-internal/test-utils';
 import { typographyClasses } from '@mui/material/Typography';
 import InputAdornment, { inputAdornmentClasses as classes } from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
 import FormControl from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
+import describeConformance from '../../test/describeConformance';
 
 describe('<InputAdornment />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/InputBase/InputBase.test.js
+++ b/packages/mui-material/src/InputBase/InputBase.test.js
@@ -2,13 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@emotion/react';
 import FormControl, { useFormControl } from '@mui/material/FormControl';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -16,6 +10,7 @@ import TextField from '@mui/material/TextField';
 import Select from '@mui/material/Select';
 import InputBase, { inputBaseClasses as classes } from '@mui/material/InputBase';
 import { createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<InputBase />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/InputLabel/InputLabel.test.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import { ClassNames } from '@emotion/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import FormControl from '@mui/material/FormControl';
 import Input from '@mui/material/Input';
 import FormLabel from '@mui/material/FormLabel';
 import InputLabel, { inputLabelClasses as classes } from '@mui/material/InputLabel';
+import describeConformance from '../../test/describeConformance';
 
 describe('<InputLabel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/LinearProgress/LinearProgress.test.js
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.test.js
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import {
   createRenderer,
   screen,
-  describeConformance,
   strictModeDoubleLoggingSuppressed,
 } from '@mui-internal/test-utils';
 import LinearProgress, { linearProgressClasses as classes } from '@mui/material/LinearProgress';
+import describeConformance from '../../test/describeConformance';
 
 describe('<LinearProgress />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Link/Link.test.js
+++ b/packages/mui-material/src/Link/Link.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { act, createRenderer, fireEvent, describeConformance } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Link, { linkClasses as classes } from '@mui/material/Link';
 import Typography, { typographyClasses } from '@mui/material/Typography';
+import describeConformance from '../../test/describeConformance';
 
 function focusVisible(element) {
   act(() => {

--- a/packages/mui-material/src/List/List.test.js
+++ b/packages/mui-material/src/List/List.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListSubheader, { listSubheaderClasses } from '@mui/material/ListSubheader';
 import ListItem, { listItemClasses } from '@mui/material/ListItem';
 import List, { listClasses as classes } from '@mui/material/List';
+import describeConformance from '../../test/describeConformance';
 
 describe('<List />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ListItem/ListItem.test.js
+++ b/packages/mui-material/src/ListItem/ListItem.test.js
@@ -1,18 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  queries,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, queries } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction';
 import ListItem, { listItemClasses as classes } from '@mui/material/ListItem';
 import ListContext from '../List/ListContext';
+import describeConformance from '../../test/describeConformance';
 
 const NoContent = React.forwardRef(() => {
   return null;

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListItemAvatar, { listItemAvatarClasses as classes } from '@mui/material/ListItemAvatar';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemAvatar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ListItemButton/ListItemButton.test.js
+++ b/packages/mui-material/src/ListItemButton/ListItemButton.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import ListItemButton, { listItemButtonClasses as classes } from '@mui/material/ListItemButton';
 import ButtonBase from '@mui/material/ButtonBase';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import ListContext from '../List/ListContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListItemIcon, { listItemIconClasses as classes } from '@mui/material/ListItemIcon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemIcon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListItem from '@mui/material/ListItem';
 import ListItemSecondaryAction, {
   listItemSecondaryActionClasses as classes,
 } from '@mui/material/ListItemSecondaryAction';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemSecondaryAction />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ListItemText/ListItemText.test.js
+++ b/packages/mui-material/src/ListItemText/ListItemText.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography, { typographyClasses } from '@mui/material/Typography';
 import ListItemText, { listItemTextClasses as classes } from '@mui/material/ListItemText';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListItemText />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ListSubheader/ListSubheader.test.js
+++ b/packages/mui-material/src/ListSubheader/ListSubheader.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ListSubheader, { listSubheaderClasses as classes } from '@mui/material/ListSubheader';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ListSubheader />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Menu/Menu.test.js
+++ b/packages/mui-material/src/Menu/Menu.test.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import {
   createRenderer,
   createMount,
-  describeConformance,
   screen,
   fireEvent,
   strictModeDoubleLoggingSuppressed,
@@ -13,6 +12,7 @@ import Menu, { menuClasses as classes } from '@mui/material/Menu';
 import Popover from '@mui/material/Popover';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { MenuPaper } from './Menu';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Menu />', () => {
   const { render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/MenuItem/MenuItem.test.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.test.js
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {
-  act,
-  describeConformance,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import MenuItem, { menuItemClasses as classes } from '@mui/material/MenuItem';
 import ButtonBase from '@mui/material/ButtonBase';
 import ListContext from '../List/ListContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<MenuItem />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/MenuList/MenuList.test.js
+++ b/packages/mui-material/src/MenuList/MenuList.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub } from 'sinon';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Divider from '@mui/material/Divider';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
 import List from '@mui/material/List';
 import getScrollbarSize from '../utils/getScrollbarSize';
+import describeConformance from '../../test/describeConformance';
 
 function setStyleWidthForJsdomOrBrowser(style, width) {
   style.width = '';

--- a/packages/mui-material/src/MobileStepper/MobileStepper.test.js
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance, fireEvent, screen } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import Paper, { paperClasses } from '@mui/material/Paper';
 import Button from '@mui/material/Button';
 import MobileStepper, { mobileStepperClasses as classes } from '@mui/material/MobileStepper';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
+import describeConformance from '../../test/describeConformance';
 
 describe('<MobileStepper />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Modal/Modal.test.js
+++ b/packages/mui-material/src/Modal/Modal.test.js
@@ -3,17 +3,11 @@ import * as ReactDOM from 'react-dom';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import {
-  act,
-  createRenderer,
-  fireEvent,
-  within,
-  describeConformance,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, within, screen } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Fade from '@mui/material/Fade';
 import Modal, { modalClasses as classes } from '@mui/material/Modal';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Modal />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/NativeSelect/NativeSelect.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider, styled } from '@mui/material/styles';
 import NativeSelect, { nativeSelectClasses as classes } from '@mui/material/NativeSelect';
 import Input, { inputClasses } from '@mui/material/Input';
+import describeConformance from '../../test/describeConformance';
 
 describe('<NativeSelect />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import NativeSelectInput from './NativeSelectInput';
 import nativeSelectClasses from './nativeSelectClasses';
+import describeConformance from '../../test/describeConformance';
 
 describe('<NativeSelectInput />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import OutlinedInput, { outlinedInputClasses as classes } from '@mui/material/OutlinedInput';
 import InputBase from '@mui/material/InputBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<OutlinedInput />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Pagination/Pagination.test.js
+++ b/packages/mui-material/src/Pagination/Pagination.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Pagination, { paginationClasses as classes } from '@mui/material/Pagination';
 import { paginationItemClasses } from '@mui/material/PaginationItem';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Pagination />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/PaginationItem/PaginationItem.test.js
+++ b/packages/mui-material/src/PaginationItem/PaginationItem.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import PaginationItem, { paginationItemClasses as classes } from '@mui/material/PaginationItem';
+import describeConformance from '../../test/describeConformance';
 
 describe('<PaginationItem />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Paper/Paper.test.js
+++ b/packages/mui-material/src/Paper/Paper.test.js
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
-import {
-  createRenderer,
-  describeConformance,
-  strictModeDoubleLoggingSuppressed,
-} from '@mui-internal/test-utils';
+import { createRenderer, strictModeDoubleLoggingSuppressed } from '@mui-internal/test-utils';
 import Paper, { paperClasses as classes } from '@mui/material/Paper';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Paper />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Popover/Popover.test.js
+++ b/packages/mui-material/src/Popover/Popover.test.js
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub, match } from 'sinon';
-import {
-  act,
-  createMount,
-  createRenderer,
-  describeConformance,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createMount, createRenderer, screen } from '@mui-internal/test-utils';
 import PropTypes from 'prop-types';
 import Grow from '@mui/material/Grow';
 import Modal from '@mui/material/Modal';
@@ -17,6 +11,7 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { getOffsetLeft, getOffsetTop } from './Popover';
 import useForkRef from '../utils/useForkRef';
 import styled from '../styles/styled';
+import describeConformance from '../../test/describeConformance';
 
 const FakePaper = React.forwardRef(function FakeWidthPaper(props, ref) {
   const handleMocks = React.useCallback((paperInstance) => {

--- a/packages/mui-material/src/Popper/Popper.test.js
+++ b/packages/mui-material/src/Popper/Popper.test.js
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/system';
 import createTheme from '@mui/system/createTheme';
 import Grow from '@mui/material/Grow';
 import Popper from '@mui/material/Popper';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Popper />', () => {
   let rtlTheme;

--- a/packages/mui-material/src/Radio/Radio.test.js
+++ b/packages/mui-material/src/Radio/Radio.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Radio, { radioClasses as classes } from '@mui/material/Radio';
 import FormControl from '@mui/material/FormControl';
 import ButtonBase from '@mui/material/ButtonBase';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Radio />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -2,16 +2,11 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import FormGroup from '@mui/material/FormGroup';
 import Radio from '@mui/material/Radio';
 import RadioGroup, { useRadioGroup } from '@mui/material/RadioGroup';
+import describeConformance from '../../test/describeConformance';
 
 describe('<RadioGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Rating/Rating.test.js
+++ b/packages/mui-material/src/Rating/Rating.test.js
@@ -1,15 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { stub, spy } from 'sinon';
-import {
-  act,
-  describeConformance,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import Rating, { ratingClasses as classes } from '@mui/material/Rating';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Rating />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.test.js
+++ b/packages/mui-material/src/ScopedCssBaseline/ScopedCssBaseline.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ScopedCssBaseline, {
   scopedCssBaselineClasses as classes,
 } from '@mui/material/ScopedCssBaseline';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ScopedCssBaseline />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Select/Select.test.js
+++ b/packages/mui-material/src/Select/Select.test.js
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import {
-  describeConformance,
-  ErrorBoundary,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { ErrorBoundary, act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import MenuItem, { menuItemClasses } from '@mui/material/MenuItem';
 import ListSubheader from '@mui/material/ListSubheader';
@@ -19,6 +12,7 @@ import Select from '@mui/material/Select';
 import Divider from '@mui/material/Divider';
 import classes from './selectClasses';
 import { nativeSelectClasses } from '../NativeSelect';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Select />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/Skeleton/Skeleton.test.js
+++ b/packages/mui-material/src/Skeleton/Skeleton.test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Skeleton, { skeletonClasses as classes } from '@mui/material/Skeleton';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Skeleton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import { act, createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import { Transition } from 'react-transition-group';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import Slide from '@mui/material/Slide';
 import { setTranslateValue } from './Slide';
 import { useForkRef } from '../utils';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Slide />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/Slider/Slider.test.js
+++ b/packages/mui-material/src/Slider/Slider.test.js
@@ -2,16 +2,11 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { spy, stub } from 'sinon';
 import { expect } from 'chai';
-import {
-  describeConformance,
-  act,
-  createRenderer,
-  fireEvent,
-  screen,
-} from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui-internal/test-utils';
 import { Slider as BaseSlider } from '@mui/base/Slider';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Slider, { sliderClasses as classes } from '@mui/material/Slider';
+import describeConformance from '../../test/describeConformance';
 
 function createTouches(touches) {
   return {

--- a/packages/mui-material/src/Snackbar/Snackbar.test.js
+++ b/packages/mui-material/src/Snackbar/Snackbar.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Snackbar, { snackbarClasses as classes } from '@mui/material/Snackbar';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Snackbar />', () => {
   const { clock, render: clientRender } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Paper from '@mui/material/Paper';
 import SnackbarContent, { snackbarContentClasses as classes } from '@mui/material/SnackbarContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SnackbarContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/SpeedDial/SpeedDial.test.js
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.test.js
@@ -7,13 +7,13 @@ import {
   fireEvent,
   fireDiscreteEvent,
   screen,
-  describeConformance,
 } from '@mui-internal/test-utils';
 import Icon from '@mui/material/Icon';
 import SpeedDial, { speedDialClasses as classes } from '@mui/material/SpeedDial';
 import SpeedDialAction from '@mui/material/SpeedDialAction';
 import { tooltipClasses } from '@mui/material/Tooltip';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SpeedDial />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Icon from '@mui/material/Icon';
 import Tooltip from '@mui/material/Tooltip';
 import { fabClasses } from '@mui/material/Fab';
 import SpeedDialAction, { speedDialActionClasses as classes } from '@mui/material/SpeedDialAction';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SpeedDialAction />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Icon from '@mui/material/Icon';
 import SpeedDialIcon, { speedDialIconClasses as classes } from '@mui/material/SpeedDialIcon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SpeedDialIcon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Stack/Stack.test.js
+++ b/packages/mui-material/src/Stack/Stack.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Stack, { stackClasses as classes } from '@mui/material/Stack';
+import describeConformance from '../../test/describeConformance';
 
 // The main tests are in mui-system Stack folder
 describe('<Stack />', () => {

--- a/packages/mui-material/src/Step/Step.test.js
+++ b/packages/mui-material/src/Step/Step.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Step, { stepClasses as classes } from '@mui/material/Step';
 import Stepper from '@mui/material/Stepper';
 import StepLabel, { stepLabelClasses } from '@mui/material/StepLabel';
 import StepButton, { stepButtonClasses } from '@mui/material/StepButton';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Step />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/StepButton/StepButton.test.js
+++ b/packages/mui-material/src/StepButton/StepButton.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { fireEvent } from '@testing-library/dom';
 import StepButton, { stepButtonClasses as classes } from '@mui/material/StepButton';
 import Step from '@mui/material/Step';
 import StepLabel, { stepLabelClasses } from '@mui/material/StepLabel';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepButton />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/StepConnector/StepConnector.test.js
+++ b/packages/mui-material/src/StepConnector/StepConnector.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepConnector, { stepConnectorClasses as classes } from '@mui/material/StepConnector';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepConnector />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/StepContent/StepContent.test.js
+++ b/packages/mui-material/src/StepContent/StepContent.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { collapseClasses } from '@mui/material/Collapse';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepContent, { stepContentClasses as classes } from '@mui/material/StepContent';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepContent />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/StepIcon/StepIcon.test.js
+++ b/packages/mui-material/src/StepIcon/StepIcon.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import StepIcon, { stepIconClasses as classes } from '@mui/material/StepIcon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepIcon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/StepLabel/StepLabel.test.js
+++ b/packages/mui-material/src/StepLabel/StepLabel.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography from '@mui/material/Typography';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import { stepIconClasses as iconClasses } from '@mui/material/StepIcon';
 import StepLabel, { stepLabelClasses as classes } from '@mui/material/StepLabel';
+import describeConformance from '../../test/describeConformance';
 
 describe('<StepLabel />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Stepper/Stepper.test.tsx
+++ b/packages/mui-material/src/Stepper/Stepper.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Step, { StepProps, stepClasses } from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import StepConnector, { stepConnectorClasses } from '@mui/material/StepConnector';
 import StepContent, { stepContentClasses } from '@mui/material/StepContent';
 import Stepper, { stepperClasses as classes } from '@mui/material/Stepper';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Stepper />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import SvgIcon, { svgIconClasses as classes } from '@mui/material/SvgIcon';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SvgIcon />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { fireEvent, createRenderer, describeConformance, screen } from '@mui-internal/test-utils';
+import { fireEvent, createRenderer, screen } from '@mui-internal/test-utils';
 import PropTypes, { checkPropTypes } from 'prop-types';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import Drawer, { drawerClasses } from '@mui/material/Drawer';
 import { backdropClasses } from '@mui/material/Backdrop';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import useForkRef from '../utils/useForkRef';
+import describeConformance from '../../test/describeConformance';
 
 const FakePaper = React.forwardRef(function FakeWidthPaper(props, ref) {
   const { style, ...other } = props;

--- a/packages/mui-material/src/Switch/Switch.test.js
+++ b/packages/mui-material/src/Switch/Switch.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, act, createRenderer, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Switch, { switchClasses as classes } from '@mui/material/Switch';
 import FormControl from '@mui/material/FormControl';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Switch />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Tab/Tab.test.js
+++ b/packages/mui-material/src/Tab/Tab.test.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 import * as React from 'react';
 import { spy } from 'sinon';
-import { act, createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { act, createRenderer, fireEvent } from '@mui-internal/test-utils';
 import Tab, { tabClasses as classes } from '@mui/material/Tab';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Tab />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TabScrollButton, { tabScrollButtonClasses as classes } from '@mui/material/TabScrollButton';
 import { createSvgIcon } from '@mui/material/utils';
+import describeConformance from '../../test/describeConformance';
 
 const ArrowBackIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowBack');
 const ArrowForwardIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowForward');

--- a/packages/mui-material/src/Table/Table.test.js
+++ b/packages/mui-material/src/Table/Table.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Table, { tableClasses as classes } from '@mui/material/Table';
 import TableContext from './TableContext';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Table />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TableBody/TableBody.test.js
+++ b/packages/mui-material/src/TableBody/TableBody.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableBody, { tableBodyClasses as classes } from '@mui/material/TableBody';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TableBody />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableCell, { tableCellClasses as classes } from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Table from '@mui/material/Table';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TableCell />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TableContainer/TableContainer.test.js
+++ b/packages/mui-material/src/TableContainer/TableContainer.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableContainer, { tableContainerClasses as classes } from '@mui/material/TableContainer';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TableContainer />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TableFooter/TableFooter.test.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableFooter, { tableFooterClasses as classes } from '@mui/material/TableFooter';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TableFooter />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TableHead/TableHead.test.js
+++ b/packages/mui-material/src/TableHead/TableHead.test.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableHead, { tableHeadClasses as classes } from '@mui/material/TableHead';
 import Tablelvl2Context from '../Table/Tablelvl2Context';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TableHead />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { describeConformance, fireEvent, createRenderer } from '@mui-internal/test-utils';
+import { fireEvent, createRenderer } from '@mui-internal/test-utils';
 import TableFooter from '@mui/material/TableFooter';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
@@ -13,6 +13,7 @@ import { filledInputClasses } from '@mui/material/FilledInput';
 import IconButton, { iconButtonClasses } from '@mui/material/IconButton';
 import { svgIconClasses } from '@mui/material/SvgIcon';
 import { createSvgIcon } from '@mui/material/utils';
+import describeConformance from '../../test/describeConformance';
 
 const ArrowBackIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowBack');
 const ArrowForwardIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowForward');

--- a/packages/mui-material/src/TableRow/TableRow.test.js
+++ b/packages/mui-material/src/TableRow/TableRow.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableRow, { tableRowClasses as classes } from '@mui/material/TableRow';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TableRow />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/mui-material/src/TableSortLabel/TableSortLabel.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import TableSortLabel, { tableSortLabelClasses as classes } from '@mui/material/TableSortLabel';
 import ButtonBase from '@mui/material/ButtonBase';
 import { createSvgIcon } from '@mui/material/utils';
+import describeConformance from '../../test/describeConformance';
 
 const SortIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'Sort');
 

--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -16,6 +15,7 @@ import { svgIconClasses } from '@mui/material/SvgIcon';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { createSvgIcon } from '@mui/material/utils';
 import capitalize from '../utils/capitalize';
+import describeConformance from '../../test/describeConformance';
 
 const ArrowBackIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowBack');
 const ArrowForwardIcon = createSvgIcon(<path d="M3 3h18v18H3z" />, 'ArrowForward');

--- a/packages/mui-material/src/TextField/TextField.test.js
+++ b/packages/mui-material/src/TextField/TextField.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance, fireEvent } from '@mui-internal/test-utils';
+import { createRenderer, fireEvent } from '@mui-internal/test-utils';
 import FormControl from '@mui/material/FormControl';
 import { inputBaseClasses } from '@mui/material/InputBase';
 import MenuItem from '@mui/material/MenuItem';
 import { outlinedInputClasses } from '@mui/material/OutlinedInput';
 import TextField, { textFieldClasses as classes } from '@mui/material/TextField';
+import describeConformance from '../../test/describeConformance';
 
 describe('<TextField />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/ToggleButton/ToggleButton.test.js
+++ b/packages/mui-material/src/ToggleButton/ToggleButton.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import ToggleButton, { toggleButtonClasses as classes } from '@mui/material/ToggleButton';
 import ButtonBase from '@mui/material/ButtonBase';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ToggleButton />', () => {
   const { render, renderToString } = createRenderer();

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import ToggleButtonGroup, {
   toggleButtonGroupClasses as classes,
 } from '@mui/material/ToggleButtonGroup';
 import ToggleButton, { toggleButtonClasses } from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
+import describeConformance from '../../test/describeConformance';
 
 describe('<ToggleButtonGroup />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Toolbar/Toolbar.test.js
+++ b/packages/mui-material/src/Toolbar/Toolbar.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Toolbar, { toolbarClasses as classes } from '@mui/material/Toolbar';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Toolbar />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Tooltip/Tooltip.test.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
-  describeConformance,
   act,
   createRenderer,
   fireEvent,
@@ -14,6 +13,7 @@ import {
 import { camelCase } from 'lodash/string';
 import Tooltip, { tooltipClasses as classes } from '@mui/material/Tooltip';
 import { testReset } from './Tooltip';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Tooltip />', () => {
   const { clock, render } = createRenderer({ clock: 'fake' });

--- a/packages/mui-material/src/Typography/Typography.test.js
+++ b/packages/mui-material/src/Typography/Typography.test.js
@@ -1,8 +1,9 @@
 // @ts-check
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Typography, { typographyClasses as classes } from '@mui/material/Typography';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Typography />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/src/Unstable_Grid2/Grid2.test.js
+++ b/packages/mui-material/src/Unstable_Grid2/Grid2.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Grid2, { grid2Classes as classes } from '@mui/material/Unstable_Grid2';
+import describeConformance from '../../test/describeConformance';
 
 // The main tests are in mui-system Unstable_Grid folder
 describe('<Grid2 />', () => {

--- a/packages/mui-material/src/Zoom/Zoom.test.js
+++ b/packages/mui-material/src/Zoom/Zoom.test.js
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { Transition } from 'react-transition-group';
 import Zoom from '@mui/material/Zoom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Zoom />', () => {
   const { clock, render } = createRenderer();

--- a/packages/mui-material/src/internal/SwitchBase.test.js
+++ b/packages/mui-material/src/internal/SwitchBase.test.js
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { describeConformance, act, createRenderer } from '@mui-internal/test-utils';
+import { act, createRenderer } from '@mui-internal/test-utils';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import ButtonBase from '../ButtonBase';
 import classes from './switchBaseClasses';
+import describeConformance from '../../test/describeConformance';
 
 describe('<SwitchBase />', () => {
   const { render } = createRenderer();

--- a/packages/mui-material/test/describeConformance.ts
+++ b/packages/mui-material/test/describeConformance.ts
@@ -1,0 +1,18 @@
+import { describeConformance as baseDescribeConformance } from '@mui-internal/test-utils';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { InputConformanceOptions } from 'packages/test-utils/src/describeConformance';
+
+export default function describeConformance(
+  minimalElement: React.ReactElement,
+  getOptions: () => InputConformanceOptions,
+) {
+  function getOptionsWithDefaults() {
+    return {
+      ThemeProvider,
+      createTheme,
+      ...getOptions(),
+    };
+  }
+
+  return baseDescribeConformance(minimalElement, getOptionsWithDefaults);
+}

--- a/packages/mui-material/test/describeConformance.ts
+++ b/packages/mui-material/test/describeConformance.ts
@@ -1,10 +1,12 @@
-import { describeConformance as baseDescribeConformance } from '@mui-internal/test-utils';
+import {
+  describeConformance as baseDescribeConformance,
+  ConformanceOptions,
+} from '@mui-internal/test-utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
-import { InputConformanceOptions } from 'packages/test-utils/src/describeConformance';
 
 export default function describeConformance(
   minimalElement: React.ReactElement,
-  getOptions: () => InputConformanceOptions,
+  getOptions: () => ConformanceOptions,
 ) {
   function getOptionsWithDefaults() {
     return {

--- a/packages/mui-system/src/Box/Box.test.js
+++ b/packages/mui-system/src/Box/Box.test.js
@@ -1,10 +1,10 @@
 /* eslint-disable material-ui/no-empty-box */
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { Box, ThemeProvider, boxClasses as classes } from '@mui/system';
-
 import createTheme from '@mui/system/createTheme';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Box />', () => {
   const { render } = createRenderer();

--- a/packages/mui-system/src/Container/Container.test.js
+++ b/packages/mui-system/src/Container/Container.test.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import { Container, containerClasses as classes } from '@mui/system';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Container />', () => {
   const { render } = createRenderer();

--- a/packages/mui-system/src/Stack/Stack.test.js
+++ b/packages/mui-system/src/Stack/Stack.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createRenderer, describeConformance } from '@mui-internal/test-utils';
+import { createRenderer } from '@mui-internal/test-utils';
 import Stack from '@mui/system/Stack';
 import createTheme from '@mui/system/createTheme';
 import { style } from './createStack';
+import describeConformance from '../../test/describeConformance';
 
 describe('<Stack />', () => {
   const { render } = createRenderer();

--- a/packages/mui-system/src/Unstable_Grid/Grid.test.js
+++ b/packages/mui-system/src/Unstable_Grid/Grid.test.js
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { describeConformance, createRenderer, screen } from '@mui-internal/test-utils';
+import { createRenderer, screen } from '@mui-internal/test-utils';
 import { ThemeProvider } from '@mui/system';
 import createTheme from '@mui/system/createTheme';
 import Grid, { gridClasses as classes } from '@mui/system/Unstable_Grid';
+import describeConformance from '../../test/describeConformance';
 
 describe('System <Grid />', () => {
   const { render } = createRenderer();

--- a/packages/mui-system/test/describeConformance.ts
+++ b/packages/mui-system/test/describeConformance.ts
@@ -1,0 +1,20 @@
+import {
+  describeConformance as baseDescribeConformance,
+  ConformanceOptions,
+} from '@mui-internal/test-utils';
+import { ThemeProvider, createTheme } from '@mui/system';
+
+export default function describeConformance(
+  minimalElement: React.ReactElement,
+  getOptions: () => ConformanceOptions,
+) {
+  function getOptionsWithDefaults() {
+    return {
+      ThemeProvider,
+      createTheme,
+      ...getOptions(),
+    };
+  }
+
+  return baseDescribeConformance(minimalElement, getOptionsWithDefaults);
+}

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -2,16 +2,15 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { ReactWrapper } from 'enzyme';
-import {
-  ThemeProvider as MDThemeProvider,
-  createTheme as mdCreateTheme,
-} from '@mui/material/styles';
-import { unstable_capitalize as capitalize } from '@mui/utils';
 import ReactTestRenderer from 'react-test-renderer';
 import createMount from './createMount';
 import createDescribe from './createDescribe';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 import { MuiRenderResult } from './createRenderer';
+
+function capitalize(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
 
 export interface SlotTestingOptions {
   /**
@@ -117,7 +116,7 @@ export function randomStringValue() {
   return `s${Math.random().toString(36).slice(2)}`;
 }
 
-function throwMissingPropError(field: string) {
+function throwMissingPropError(field: string): never {
   throw new Error(`missing "${field}" in options
 
   > describeConformance(element, () => options)
@@ -576,12 +575,7 @@ function testThemeDefaultProps(element: React.ReactElement, getOptions: () => Co
   describe('theme default components:', () => {
     it("respect theme's defaultProps", () => {
       const testProp = 'data-id';
-      const {
-        muiName,
-        render,
-        ThemeProvider = MDThemeProvider,
-        createTheme = mdCreateTheme,
-      } = getOptions();
+      const { muiName, render, ThemeProvider, createTheme } = getOptions();
 
       if (!muiName) {
         throwMissingPropError('muiName');
@@ -589,6 +583,14 @@ function testThemeDefaultProps(element: React.ReactElement, getOptions: () => Co
 
       if (!render) {
         throwMissingPropError('render');
+      }
+
+      if (!ThemeProvider) {
+        throwMissingPropError('ThemeProvider');
+      }
+
+      if (!createTheme) {
+        throwMissingPropError('createTheme');
       }
 
       const theme = createTheme({
@@ -621,13 +623,7 @@ function testThemeStyleOverrides(
       if (/jsdom/.test(window.navigator.userAgent)) {
         this.skip();
       }
-      const {
-        muiName,
-        testStateOverrides,
-        render,
-        ThemeProvider = MDThemeProvider,
-        createTheme = mdCreateTheme,
-      } = getOptions();
+      const { muiName, testStateOverrides, render, ThemeProvider, createTheme } = getOptions();
 
       if (!testStateOverrides) {
         return;
@@ -639,6 +635,14 @@ function testThemeStyleOverrides(
 
       if (!render) {
         throwMissingPropError('render');
+      }
+
+      if (!ThemeProvider) {
+        throwMissingPropError('ThemeProvider');
+      }
+
+      if (!createTheme) {
+        throwMissingPropError('createTheme');
       }
 
       const testStyle = {
@@ -680,9 +684,17 @@ function testThemeStyleOverrides(
         testDeepOverrides,
         testRootOverrides = { slotName: 'root' },
         render,
-        ThemeProvider = MDThemeProvider,
-        createTheme = mdCreateTheme,
+        ThemeProvider,
+        createTheme,
       } = getOptions();
+
+      if (!ThemeProvider) {
+        throwMissingPropError('ThemeProvider');
+      }
+
+      if (!createTheme) {
+        throwMissingPropError('createTheme');
+      }
 
       const testStyle = {
         mixBlendMode: 'darken',
@@ -778,14 +790,16 @@ function testThemeStyleOverrides(
         this.skip();
       }
 
-      const {
-        muiName,
-        classes,
-        testStateOverrides,
-        render,
-        ThemeProvider = MDThemeProvider,
-        createTheme = mdCreateTheme,
-      } = getOptions();
+      const { muiName, classes, testStateOverrides, render, ThemeProvider, createTheme } =
+        getOptions();
+
+      if (!ThemeProvider) {
+        throwMissingPropError('ThemeProvider');
+      }
+
+      if (!createTheme) {
+        throwMissingPropError('createTheme');
+      }
 
       const classKeys = Object.keys(classes);
 
@@ -854,13 +868,7 @@ function testThemeVariants(element: React.ReactElement, getOptions: () => Confor
         this.skip();
       }
 
-      const {
-        muiName,
-        testVariantProps,
-        render,
-        ThemeProvider = MDThemeProvider,
-        createTheme = mdCreateTheme,
-      } = getOptions();
+      const { muiName, testVariantProps, render, ThemeProvider, createTheme } = getOptions();
 
       if (!testVariantProps) {
         throw new Error('missing testVariantProps');
@@ -872,6 +880,14 @@ function testThemeVariants(element: React.ReactElement, getOptions: () => Confor
 
       if (!render) {
         throwMissingPropError('render');
+      }
+
+      if (!ThemeProvider) {
+        throwMissingPropError('ThemeProvider');
+      }
+
+      if (!createTheme) {
+        throwMissingPropError('createTheme');
       }
 
       const testStyle = {
@@ -907,13 +923,15 @@ function testThemeVariants(element: React.ReactElement, getOptions: () => Confor
         this.skip();
       }
 
-      const {
-        muiName,
-        testCustomVariant,
-        render,
-        ThemeProvider = MDThemeProvider,
-        createTheme = mdCreateTheme,
-      } = getOptions();
+      const { muiName, testCustomVariant, render, ThemeProvider, createTheme } = getOptions();
+
+      if (!ThemeProvider) {
+        throwMissingPropError('ThemeProvider');
+      }
+
+      if (!createTheme) {
+        throwMissingPropError('createTheme');
+      }
 
       if (!testCustomVariant) {
         return;

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export * from './components';
-export { default as describeConformance } from './describeConformance';
+export { default as describeConformance, ConformanceOptions } from './describeConformance';
 export { default as describeConformanceUnstyled } from './describeConformanceUnstyled';
 export { default as createDescribe } from './createDescribe';
 export * from './createRenderer';

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 export * from './components';
-export { default as describeConformance, ConformanceOptions } from './describeConformance';
-export { default as describeConformanceUnstyled } from './describeConformanceUnstyled';
+export { default as describeConformance } from './describeConformance';
+export * from './describeConformance';
 export { default as createDescribe } from './createDescribe';
 export * from './createRenderer';
 export { default as createMount } from './createMount';


### PR DESCRIPTION
Removed @mui/material, @mui/base, and @mui/utils dependencies from @mui-internal/test-utils to break dependency cycles and allow the package to be published to npm.
Created wrappers in individual projects to maintain the old behavior.

This requires changes in MUI X. Integration PR: https://github.com/mui/mui-x/pull/12130