### PR TITLE
[material-ui][Tooltip] Remove incorrect code comment

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -56,7 +56,7 @@ const TooltipPopper = styled(Popper, {
   },
 })(({ theme, ownerState, open }) => ({
   zIndex: (theme.vars || theme).zIndex.tooltip,
-  pointerEvents: 'none', // disable jss-rtl plugin
+  pointerEvents: 'none',
   ...(!ownerState.disableInteractive && {
     pointerEvents: 'auto',
   }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Small change. Found this incorrect code comment while investigating a tooltip issue. It appears that the comment was mistakenly relocated to the `pointerEvents` property in pull request #20745 in v4, which involved removing the `flip` property of the jss-rtl plugin.