### PR TITLE
[docs] Update broken URL hashes

### DIFF
--- a/docs/data/material/components/text-fields/text-fields.md
+++ b/docs/data/material/components/text-fields/text-fields.md
@@ -197,7 +197,7 @@ import { useFormControl } from '@mui/material/FormControl';
 ## Performance
 
 Global styles for the auto-fill keyframes are injected and removed on each mount and unmount, respectively.
-If you are loading a large number of Text Field components at once, it might be a good idea to change this default behavior by enabling [`disableInjectingGlobalStyles`](/material-ui/api/input-base/#InputBase-prop-disableInjectingGlobalStyles) in `MuiInputBase`.
+If you are loading a large number of Text Field components at once, it might be a good idea to change this default behavior by enabling [`disableInjectingGlobalStyles`](/material-ui/api/input-base/#input-base-prop-disableInjectingGlobalStyles) in `MuiInputBase`.
 Make sure to inject `GlobalStyles` for the auto-fill keyframes at the top of your application.
 
 ```jsx

--- a/docs/data/material/migration/migration-v4/v5-component-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-component-changes.md
@@ -991,7 +991,7 @@ prop `listItemClasses` is removed, use `classes` instead.
 +<MenuItem classes={{...}}>
 ```
 
-Read more about the [MenuItem CSS API](/material-ui/api/menu-item/#css).
+Read more about the [MenuItem CSS API](/material-ui/api/menu-item/#classes).
 
 ## Modal
 


### PR DESCRIPTION
Discovered these broken links while working on https://github.com/mui/mui-x/pull/12135.

Didn't check, but it could be that the API table hash generation changed between the initial implementation and the current state. 🤔 

@alexfauquette Could be an interesting idea to automate the discovery of broken API/generated links based on our known preconditions:
- how do we generate the API table hash
- what sections are possible inside of an `API` page (slots, classes, etc.)