### PR TITLE
[material-ui][docs] Inform about deprecated TablePagination SelectProps usage

### DIFF
--- a/docs/data/material/components/table/CustomPaginationActionsTable.js
+++ b/docs/data/material/components/table/CustomPaginationActionsTable.js
@@ -148,11 +148,13 @@ export default function CustomPaginationActionsTable() {
               count={rows.length}
               rowsPerPage={rowsPerPage}
               page={page}
-              SelectProps={{
-                inputProps: {
-                  'aria-label': 'rows per page',
+              slotProps={{
+                select: {
+                  inputProps: {
+                    'aria-label': 'rows per page',
+                  },
+                  native: true,
                 },
-                native: true,
               }}
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}

--- a/docs/data/material/components/table/CustomPaginationActionsTable.tsx
+++ b/docs/data/material/components/table/CustomPaginationActionsTable.tsx
@@ -163,7 +163,7 @@ export default function CustomPaginationActionsTable() {
                     'aria-label': 'rows per page',
                   },
                   native: true,
-                }
+                },
               }}
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}

--- a/docs/data/material/components/table/CustomPaginationActionsTable.tsx
+++ b/docs/data/material/components/table/CustomPaginationActionsTable.tsx
@@ -157,11 +157,13 @@ export default function CustomPaginationActionsTable() {
               count={rows.length}
               rowsPerPage={rowsPerPage}
               page={page}
-              SelectProps={{
-                inputProps: {
-                  'aria-label': 'rows per page',
-                },
-                native: true,
+              slotProps={{
+                select: {
+                  inputProps: {
+                    'aria-label': 'rows per page',
+                  },
+                  native: true,
+                }
               }}
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/issues/41062

## Description
Replace deprecated `SelectProps` property on `CustomPaginationActions` with `slotProps`

### Refs
[Loom Video](https://www.loom.com/share/d9855748b9104cc4824193e69f11d22f)

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.