### PR TITLE
[material-ui][Transitions] External ownerState is incorrectly forwarded to inner components

### DIFF
--- a/packages/mui-material/src/Accordion/Accordion.js
+++ b/packages/mui-material/src/Accordion/Accordion.js
@@ -180,8 +180,6 @@ const Accordion = React.forwardRef(function Accordion(inProps, ref) {
     ownerState,
   });
 
-  delete transitionProps.ownerState;
-
   return (
     <AccordionRoot
       className={clsx(classes.root, className)}

--- a/packages/mui-material/src/Collapse/Collapse.js
+++ b/packages/mui-material/src/Collapse/Collapse.js
@@ -290,7 +290,7 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
           ref={handleRef}
           {...childProps}
           // `ownerState` is set after `childProps` to override any existing `ownerState` property in `childProps`
-          // that might have been forwarded from the Transition component. 
+          // that might have been forwarded from the Transition component.
           ownerState={{ ...ownerState, state }}
         >
           <CollapseWrapper

--- a/packages/mui-material/src/Collapse/Collapse.js
+++ b/packages/mui-material/src/Collapse/Collapse.js
@@ -287,9 +287,11 @@ const Collapse = React.forwardRef(function Collapse(inProps, ref) {
             [isHorizontal ? 'minWidth' : 'minHeight']: collapsedSize,
             ...style,
           }}
-          ownerState={{ ...ownerState, state }}
           ref={handleRef}
           {...childProps}
+          // `ownerState` is set after `childProps` to override any existing `ownerState` property in `childProps`
+          // that might have been forwarded from the Transition component. 
+          ownerState={{ ...ownerState, state }}
         >
           <CollapseWrapper
             ownerState={{ ...ownerState, state }}


### PR DESCRIPTION
## Description
Fix forwarded `ownerState` from Transition component overriding component own's `ownerState`

https://www.loom.com/share/96131abf63ba48878bf3e8d02856cce3

closes https://github.com/mui/material-ui/issues/40653

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
