### PR TITLE
[joy-ui][docs] Fix LinearProgressWithLabel example

### DIFF
--- a/docs/data/joy/components/linear-progress/LinearProgressWithLabel.js
+++ b/docs/data/joy/components/linear-progress/LinearProgressWithLabel.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import LinearProgress from '@mui/joy/LinearProgress';
 import Typography from '@mui/joy/Typography';
+import Box from '@mui/joy/Box';
 
 export default function LinearProgressWithLabel() {
   const [progress, setProgress] = React.useState(0);
@@ -16,28 +17,35 @@ export default function LinearProgressWithLabel() {
   }, []);
 
   return (
-    <LinearProgress
-      determinate
-      variant="outlined"
-      color="neutral"
-      size="sm"
-      thickness={32}
-      value={progress}
+    <Box
       sx={{
-        '--LinearProgress-radius': '0px',
-        '--LinearProgress-progressThickness': '24px',
-        boxShadow: 'sm',
-        borderColor: 'neutral.500',
+        bgcolor: 'white',
+        width: '100%',
       }}
     >
-      <Typography
-        level="body-xs"
-        fontWeight="xl"
-        textColor="common.white"
-        sx={{ mixBlendMode: 'difference' }}
+      <LinearProgress
+        determinate
+        variant="outlined"
+        color="neutral"
+        size="sm"
+        thickness={32}
+        value={progress}
+        sx={{
+          '--LinearProgress-radius': '0px',
+          '--LinearProgress-progressThickness': '24px',
+          boxShadow: 'sm',
+          borderColor: 'neutral.500',
+        }}
       >
-        LOADING… {`${Math.round(progress)}%`}
-      </Typography>
-    </LinearProgress>
+        <Typography
+          level="body-xs"
+          fontWeight="xl"
+          textColor="common.white"
+          sx={{ mixBlendMode: 'difference' }}
+        >
+          LOADING… {`${Math.round(progress)}%`}
+        </Typography>
+      </LinearProgress>
+    </Box>
   );
 }

--- a/docs/data/joy/components/linear-progress/LinearProgressWithLabel.tsx
+++ b/docs/data/joy/components/linear-progress/LinearProgressWithLabel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import LinearProgress from '@mui/joy/LinearProgress';
 import Typography from '@mui/joy/Typography';
+import Box from '@mui/joy/Box';
 
 export default function LinearProgressWithLabel() {
   const [progress, setProgress] = React.useState(0);
@@ -16,28 +17,35 @@ export default function LinearProgressWithLabel() {
   }, []);
 
   return (
-    <LinearProgress
-      determinate
-      variant="outlined"
-      color="neutral"
-      size="sm"
-      thickness={32}
-      value={progress}
+    <Box
       sx={{
-        '--LinearProgress-radius': '0px',
-        '--LinearProgress-progressThickness': '24px',
-        boxShadow: 'sm',
-        borderColor: 'neutral.500',
+        bgcolor: 'white',
+        width: '100%',
       }}
     >
-      <Typography
-        level="body-xs"
-        fontWeight="xl"
-        textColor="common.white"
-        sx={{ mixBlendMode: 'difference' }}
+      <LinearProgress
+        determinate
+        variant="outlined"
+        color="neutral"
+        size="sm"
+        thickness={32}
+        value={progress}
+        sx={{
+          '--LinearProgress-radius': '0px',
+          '--LinearProgress-progressThickness': '24px',
+          boxShadow: 'sm',
+          borderColor: 'neutral.500',
+        }}
       >
-        LOADING… {`${Math.round(progress)}%`}
-      </Typography>
-    </LinearProgress>
+        <Typography
+          level="body-xs"
+          fontWeight="xl"
+          textColor="common.white"
+          sx={{ mixBlendMode: 'difference' }}
+        >
+          LOADING… {`${Math.round(progress)}%`}
+        </Typography>
+      </LinearProgress>
+    </Box>
   );
 }


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Closes [#40938](https://github.com/mui/material-ui/issues/40938) where a background is required for mixBlendMode to work properly.

Running the example code in StackBlitz or CodeSandbox should now match the behavior on the docs site.

https://deploy-preview-41194--material-ui.netlify.app/joy-ui/react-linear-progress/