### PR TITLE
[material-ui] Use generic argument for `responsiveFontSizes`

### DIFF
--- a/packages/mui-material/src/styles/responsiveFontSizes.d.ts
+++ b/packages/mui-material/src/styles/responsiveFontSizes.d.ts
@@ -9,7 +9,7 @@ export interface ResponsiveFontSizesOptions {
   variants?: Array<keyof Typography>;
 }
 
-export default function responsiveFontSizes(
-  theme: Theme,
+export default function responsiveFontSizes<T extends Pick<Theme, 'typography' | 'breakpoints'>>(
+  theme: T,
   options?: ResponsiveFontSizesOptions,
-): Theme;
+): T;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #40516

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
