### PR TITLE
[zero] Move extendTheme to its own subpath

### DIFF
--- a/packages/zero-next-plugin/src/index.ts
+++ b/packages/zero-next-plugin/src/index.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 import { findPagesDir } from 'next/dist/lib/find-pages-dir';
 import {
   webpack as zeroWebpackPlugin,
+  extendTheme,
   type PluginOptions as BaseZeroPluginConfig,
 } from '@mui/zero-unplugin';
 
@@ -81,3 +82,5 @@ export function withZeroPlugin(nextConfig: NextConfig, zeroConfig: ZeroPluginCon
     webpack,
   };
 }
+
+export { extendTheme };

--- a/packages/zero-runtime/.gitignore
+++ b/packages/zero-runtime/.gitignore
@@ -1,2 +1,3 @@
 /processors/
 /utils/
+/extendTheme/

--- a/packages/zero-runtime/README.md
+++ b/packages/zero-runtime/README.md
@@ -319,7 +319,7 @@ const { withZeroPlugin, extendTheme } = require('@mui/zero-next-plugin');
 
 module.exports = withZeroPlugin(
   {
-    // ...other nextConfig
+    // ...nextConfig
   },
   {
     theme: extendTheme({

--- a/packages/zero-runtime/package.json
+++ b/packages/zero-runtime/package.json
@@ -68,7 +68,8 @@
     "utils",
     "package.json",
     "styles.css",
-    "theme"
+    "theme",
+    "extendTheme"
   ],
   "exports": {
     ".": {
@@ -82,6 +83,15 @@
       "import": "./theme/index.mjs",
       "require": "./theme/index.js",
       "default": "./theme/index.js"
+    },
+    "./extendTheme": {
+      "types": "./extendTheme/index.d.ts",
+      "import": {
+        "default": "./extendTheme/index.mjs",
+        "types": "./extendTheme/index.d.mts"
+      },
+      "require": "./extendTheme/index.js",
+      "default": "./extendTheme/index.js"
     },
     "./styles.css": {
       "default": "./styles.css"

--- a/packages/zero-runtime/src/extendTheme.ts
+++ b/packages/zero-runtime/src/extendTheme.ts
@@ -86,7 +86,7 @@ export type Theme = ExtendTheme;
 /**
  * A utility to tell zero-runtime to generate CSS variables for the theme.
  */
-export default function extendTheme<
+export function extendTheme<
   Options extends {
     colorScheme: string;
     tokens: Record<string, any>;

--- a/packages/zero-runtime/src/index.ts
+++ b/packages/zero-runtime/src/index.ts
@@ -4,5 +4,3 @@ export { default as keyframes } from './keyframes';
 export { generateAtomics, atomics } from './generateAtomics';
 export { default as css } from './css';
 export { default as createUseThemeProps } from './createUseThemeProps';
-export { default as extendTheme } from './extendTheme';
-export type { Theme, ExtendTheme } from './extendTheme';

--- a/packages/zero-runtime/tsup.config.ts
+++ b/packages/zero-runtime/tsup.config.ts
@@ -21,6 +21,13 @@ export default defineConfig([
   },
   {
     ...baseConfig,
+    entry: {
+      index: './src/extendTheme.ts',
+    },
+    outDir: 'extendTheme',
+  },
+  {
+    ...baseConfig,
     entry: processors.map((fn) => `./src/processors/${fn}.ts`),
     outDir: 'processors',
   },

--- a/packages/zero-unplugin/src/index.ts
+++ b/packages/zero-unplugin/src/index.ts
@@ -19,7 +19,8 @@ import {
   generateTokenCss,
   generateThemeTokens,
 } from '@mui/zero-runtime/utils';
-import type { Theme as BaseTheme } from '@mui/zero-runtime';
+import type { Theme as BaseTheme } from '@mui/zero-runtime/extendTheme';
+import { extendTheme } from '@mui/zero-runtime/extendTheme';
 
 type NextMeta = {
   type: 'next';
@@ -341,3 +342,5 @@ export const webpack = plugin.webpack as unknown as UnpluginFactoryOutput<
   PluginOptions,
   WebpackPluginInstance
 >;
+
+export { extendTheme };

--- a/packages/zero-vite-plugin/src/index.ts
+++ b/packages/zero-vite-plugin/src/index.ts
@@ -4,7 +4,7 @@ import {
   generateTokenCss,
   generateThemeTokens,
 } from '@mui/zero-runtime/utils';
-import type { Theme } from '@mui/zero-runtime';
+import type { Theme } from '@mui/zero-runtime/extendTheme';
 import { transformAsync } from '@babel/core';
 import baseZeroVitePlugin, { type VitePluginOptions } from './zero-vite-plugin';
 


### PR DESCRIPTION
fixing the size of runtime bundle

Context -

zero-runtime package has 2 different types of exports -

1. Package level, ie, `import {styled} from '@mui/zero-runtime';`
2. Subpaths, ie, `import {generateCss} from '@mui/zero-runtime/utils'`

package level exports should be what we want to end-up in the final bundle and subpaths is for sharing common logic across different bundle plugin implementation (ie, implement the common functionality in one place and import and use it it next/vite plugin).

When @siriwatknp implemented the `extendTheme` functionality, he added it directly to the package level export, ie, `import {extendTheme} from '@mui/zero-runtime';`. I think this was an oversight as without proper tree-shaking, `extendTheme` will also end-up being part of the bundle (which also includes `@mui/system`).
So I was mainly fixing that. So moved it to its own subpath (`@mui/zero-runtime/extendTheme`). While doing this, I also made the change to re-export these items from the bundle specific packages as well.
My thinking is that if users are configuring their bundler, they should only import stuff from the bundler package and think of `@mui/zero-runtime` as the runtime package. Rest of the context is [here](#discussion_r1496864278).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
