### PR TITLE
[blog] Remove the "News" tag

### DIFF
--- a/docs/lib/sourcing.ts
+++ b/docs/lib/sourcing.ts
@@ -40,7 +40,6 @@ const ALLOWED_TAGS = [
   'Joy UI',
   'MUI X',
   'Material UI',
-  'News',
   'Product',
 ];
 

--- a/docs/pages/blog.tsx
+++ b/docs/pages/blog.tsx
@@ -419,7 +419,7 @@ export default function Blog(props: InferGetStaticPropsType<typeof getStaticProp
                 Want to hear more from us?
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                Stay on the loop about everything MUI-related through our social media:
+                Get up to date with everything MUI-related through our social media:
               </Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, '* > svg': { mr: 1 } }}>
                 <Link href="https://github.com/mui" target="_blank" fontSize={14}>

--- a/docs/pages/blog/2023-toolpad-beta-announcement.md
+++ b/docs/pages/blog/2023-toolpad-beta-announcement.md
@@ -4,7 +4,7 @@ description: Assemble admin panels and internal tools faster than ever before wi
 date: 2023-07-24T00:00:00.000Z
 authors: ['prakhargupta']
 card: true
-tags: ['Product', ]
+tags: ['Product']
 ---
 
 It's been over a year since we released the first version of Toolpad. Today, we're excited to take the next step on that journey with the release of Toolpad Beta. If you aren't familiar with Toolpad yet, it's an admin panel builder catering to the internal tooling needs of an organization, designed for developers who want to build a functional application quickly. It harnesses the speed of a UI builder for the front-end and closely integrates into your back-end. If this excites you, then read on!

--- a/docs/pages/blog/2023-toolpad-beta-announcement.md
+++ b/docs/pages/blog/2023-toolpad-beta-announcement.md
@@ -4,7 +4,7 @@ description: Assemble admin panels and internal tools faster than ever before wi
 date: 2023-07-24T00:00:00.000Z
 authors: ['prakhargupta']
 card: true
-tags: ['Product', 'News']
+tags: ['Product', ]
 ---
 
 It's been over a year since we released the first version of Toolpad. Today, we're excited to take the next step on that journey with the release of Toolpad Beta. If you aren't familiar with Toolpad yet, it's an admin panel builder catering to the internal tooling needs of an organization, designed for developers who want to build a functional application quickly. It harnesses the speed of a UI builder for the front-end and closely integrates into your back-end. If this excites you, then read on!

--- a/docs/pages/blog/aggregation-functions.md
+++ b/docs/pages/blog/aggregation-functions.md
@@ -3,7 +3,7 @@ title: Aggregate data like in Excel, but easier!
 description: Aggregation functions and summary rows are now available in the MUI X Premium Data Grid.
 date: 2022-08-01T00:00:00.000Z
 authors: ['josefreitas', 'flaviendelangle', 'cherniavskii']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/date-pickers-stable-v5.md
+++ b/docs/pages/blog/date-pickers-stable-v5.md
@@ -3,7 +3,7 @@ title: The MUI X Date and Time Pickers get a stable v5 release
 description: Migrate to the latest version for improved DX, customizability, and API consistency.
 date: 2022-09-19T00:00:00.000Z
 authors: ['alexfauquette', 'josefreitas']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/discord-announcement.md
+++ b/docs/pages/blog/discord-announcement.md
@@ -3,7 +3,7 @@ title: 'MUI is now on Discord!'
 description: Come join our community to engage in lively discussions, share your projects, and interact with the MUI team.
 date: 2023-08-02T00:00:00.000Z
 authors: ['richbustos']
-tags: ['News']
+tags: ['Company']
 card: true
 ---
 

--- a/docs/pages/blog/docs-restructure-2022.md
+++ b/docs/pages/blog/docs-restructure-2022.md
@@ -3,7 +3,7 @@ title: 'Our docs just got a major upgrade—here's what that means for you'
 description: Each of MUI's products now has its own dedicated documentation, making it easier than ever to find exactly what you need.
 date: 2022-04-06T00:00:00.000Z
 authors: ['danilo-leal']
-tags: ['News', 'Product']
+tags: ['Product']
 card: true
 ---
 

--- a/docs/pages/blog/introducing-the-row-grouping-feature.md
+++ b/docs/pages/blog/introducing-the-row-grouping-feature.md
@@ -3,7 +3,7 @@ title: Give your users more freedom with Data Grid row grouping
 description: The new row grouping feature gives your users more customization options for organizing their data.
 date: 2022-01-20T00:00:00.000Z
 authors: ['alexfauquette']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/lab-date-pickers-to-mui-x.md
+++ b/docs/pages/blog/lab-date-pickers-to-mui-x.md
@@ -3,7 +3,7 @@ title: Date and Time Pickers are moving to MUI X
 description: Migrate to the new package to start building with our powerful Date and Time Pickers, now part of MUI X. Previously released MIT components will stay MIT.
 date: 2022-04-03T00:00:00.000Z
 authors: ['flaviendelangle']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/lab-tree-view-to-mui-x.md
+++ b/docs/pages/blog/lab-tree-view-to-mui-x.md
@@ -3,7 +3,7 @@ title: The Tree View is moving to MUI X
 description: Migrate to the new package to start building with our powerful Tree View, now part of MUI X. Previously released MIT components will stay MIT.
 date: 2023-08-21T00:00:00.000Z
 authors: ['flaviendelangle']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/mui-core-v5.md
+++ b/docs/pages/blog/mui-core-v5.md
@@ -13,7 +13,7 @@ authors:
     'mbrookes',
   ]
 card: true
-tags: ['News']
+tags: ['Product', 'Material UI']
 ---
 
 After over 400 days of development and over 40 canary releases, we are excited to introduce [MUI Core v5.0.0](https://github.com/mui/material-ui/releases/tag/v5.0.0)!

--- a/docs/pages/blog/mui-next-js-app-router.md
+++ b/docs/pages/blog/mui-next-js-app-router.md
@@ -4,7 +4,7 @@ description: Material UI, Base UI, and Joy UI are now compatible with the App 
 date: 2023-07-18T00:00:00.000Z
 authors: ['samuelsycamore']
 card: true
-tags: ['News']
+tags: ['Product']
 ---
 
 With [v5.14.0](https://github.com/mui/material-ui/releases/tag/v5.14.0), MUI's Core component libraries—Material UI, Base UI, and Joy UI—are now compatible with the Next.js App Router. 🚀

--- a/docs/pages/blog/mui-x-end-v6-features.md
+++ b/docs/pages/blog/mui-x-end-v6-features.md
@@ -4,7 +4,7 @@ description: New components, polished features, better performance and more.
 date: 2023-11-13T00:00:00.000Z
 authors: ['josefreitas']
 card: true
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 ---
 
 <div style="max-width: 692px; width: 100%; height: 230px; overflow: hidden; margin-bottom: 16px;">

--- a/docs/pages/blog/mui-x-mid-v6-features.md
+++ b/docs/pages/blog/mui-x-mid-v6-features.md
@@ -4,7 +4,7 @@ description: Support for time zones, Charts in alpha, Data Grid filtering, and m
 date: 2023-08-14T00:00:00.000Z
 authors: ['richbustos', 'josefreitas']
 card: true
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 ---
 
 <a href="https://github.com/mui/mui-x/releases/tag/v6.11.0">

--- a/docs/pages/blog/mui-x-v5.md
+++ b/docs/pages/blog/mui-x-v5.md
@@ -5,7 +5,7 @@ date: 2021-11-22T00:00:00.000Z
 authors:
   ['oliviertassinari', 'm4theushw', 'flaviendelangle', 'DanailH', 'alexfauquette']
 card: true
-tags: ['News']
+tags: ['MUI X', 'Product']
 ---
 
 We are excited to introduce [MUI X v5.0.0](https://github.com/mui/mui-x/releases/tag/v5.0.0)!

--- a/docs/pages/blog/mui-x-v6-alpha-zero.md
+++ b/docs/pages/blog/mui-x-v6-alpha-zero.md
@@ -3,7 +3,7 @@ title: A major update is coming for MUI X—and you can get involved
 description: Let us know what you want to see in MUI X v6 as we begin the alpha phase of development.
 date: 2022-09-30T00:00:00.000Z
 authors: ['josefreitas']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/mui-x-v6.md
+++ b/docs/pages/blog/mui-x-v6.md
@@ -4,7 +4,7 @@ description: Introducing the new major version of the advanced components.
 date: 2023-03-06T00:00:00.000Z
 authors: ['josefreitas']
 card: true
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 ---
 
 <img src="/static/blog/mui-x-v6/card.png" alt="" style="margin-bottom: 16px;" width="2400" height="559" />

--- a/docs/pages/blog/mui-x-v7-beta.md
+++ b/docs/pages/blog/mui-x-v7-beta.md
@@ -3,7 +3,7 @@ title: MUI X v7 is now in beta
 description: Check out what's new and what's next for v7 stable.
 date: 2024-01-29T00:00:00.000Z
 authors: ['josefreitas']
-tags: ['MUI X', 'Product', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/premium-plan-release.md
+++ b/docs/pages/blog/premium-plan-release.md
@@ -3,7 +3,7 @@ title: Premium passengers, please proceed to the boarding gate 🚀
 description: Introducing the MUI X Premium plan, and a new licensing model.
 date: 2022-05-12T00:00:00.000Z
 authors: ['josefreitas', 'alexfauquette']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 

--- a/docs/pages/blog/v6-beta-pickers.md
+++ b/docs/pages/blog/v6-beta-pickers.md
@@ -3,7 +3,7 @@ title: Date and Time Pickers revamped
 description: Check out the new features coming in v6 beta.
 date: 2023-01-22T00:00:00.000Z
 authors: ['josefreitas']
-tags: ['MUI X', 'News']
+tags: ['MUI X', 'Product']
 card: true
 ---
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR is a follow-up to another one of mine https://github.com/mui/material-ui/pull/41193. I'll quote @samuelsycamore here, as that's pretty much it :)

> Everything we post is "news" when it's "new" and then not news when it's older.

I added "Product" to most of the posts that were using it.

https://deploy-preview-41208--material-ui.netlify.app/blog/