### PR TITLE
[code-infra] Build internal packages before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean:zero": "pnpm --filter \"@mui/zero-*\" clean",
     "build:codesandbox": "NODE_OPTIONS=\"--max_old_space_size=4096\" lerna run --concurrency 8 --scope \"@mui/*\" --scope \"@mui-internal/*\" --no-private build",
     "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --no-private --force-publish=@mui/core-downloads-tracker",
-    "release:build": "lerna run --concurrency 8 --scope \"@mui/*\" build --skip-nx-cache",
+    "release:build": "lerna run --concurrency 8 --no-private build --skip-nx-cache",
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "release:publish": "pnpm publish --recursive --tag latest",
     "release:publish:dry-run": "pnpm publish --recursive --tag latest --registry=\"http://localhost:4873/\"",

--- a/packages-internal/scripts/package.json
+++ b/packages-internal/scripts/package.json
@@ -19,8 +19,8 @@
   "scripts": {
     "prebuild": "rimraf ./build",
     "build": "tsc --build tsconfig.json",
-    "release:publish": "pnpm publish --tag latest",
-    "release:publish:dry-run": "pnpm publish --tag latest --registry=\"http://localhost:4873/\"",
+    "release:publish": "pnpm build && pnpm publish --tag latest",
+    "release:publish:dry-run": "pnpm build && pnpm publish --tag latest --registry=\"http://localhost:4873/\"",
     "test": "cd ../../ && cross-env NODE_ENV=test mocha --config packages-internal/scripts/typescript-to-proptypes/test/.mocharc.js 'packages-internal/scripts/typescript-to-proptypes/**/*.test.ts'",
     "typescript": "tsc --build tsconfig.typecheck.json"
   },

--- a/packages/docs-utils/CHANGELOG.md
+++ b/packages/docs-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+Fixed incorrectly released package.
+
 ## 1.0.0
 
 Initial release as an npm package.

--- a/packages/docs-utils/package.json
+++ b/packages/docs-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui-internal/docs-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "MUI Team",
   "description": "Utilities for MUI docs. This is an internal package not meant for general use.",
   "main": "./build/index.js",
@@ -17,8 +17,8 @@
     "prebuild": "rimraf ./build",
     "build": "tsc -b tsconfig.build.json",
     "typescript": "tsc -b tsconfig.json",
-    "release:publish": "pnpm publish --tag latest",
-    "release:publish:dry-run": "pnpm publish --tag latest --registry=\"http://localhost:4873/\""
+    "release:publish": "pnpm build && pnpm publish --tag latest",
+    "release:publish:dry-run": "pnpm build && pnpm publish --tag latest --registry=\"http://localhost:4873/\""
   },
   "dependencies": {
     "rimraf": "^5.0.5",


### PR DESCRIPTION
During the last Core release, the @mui-internal/docs-utilities package has not been built before publishing. This PR adds steps to ensure internal packages are built.

It also bumps the faulty package version (it'll be released manually).