### PR TITLE
[core][base-ui] Remove `@mui/base` dev dependency from Base UI workspace

### DIFF
--- a/packages/mui-base/package.json
+++ b/packages/mui-base/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@mui-internal/babel-macros": "workspace:^",
     "@mui-internal/test-utils": "workspace:^",
-    "@mui/base": "workspace:*",
     "@mui/types": "workspace:^",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1232,9 +1232,6 @@ importers:
       '@mui-internal/test-utils':
         specifier: workspace:^
         version: link:../test-utils
-      '@mui/base':
-        specifier: workspace:*
-        version: link:build
       '@testing-library/react':
         specifier: ^14.2.1
         version: 14.2.1(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Also saw this comment: https://github.com/mui/material-ui/pull/36287#discussion_r1440211795 but the tests do pass. Other workspaces also don't refer itself. Or am I missing something?

----

Also, while going through the [workspace documentation](https://pnpm.io/workspaces), I came across [this example](https://pnpm.io/workspaces#usage-examples):

![pnpm workspace example](https://github.com/mui/material-ui/assets/20900032/53ca5318-e660-42eb-bdfe-295fa0746a23)

Should it be named MUI?