### PR TITLE
[system] Merge props and ownerState in the variants props callback

### DIFF
--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -49,7 +49,7 @@ function defaultOverridesResolver(slot) {
 function processStyleArg(callableStyle, { ownerState, ...props }) {
   const resolvedStylesArg =
     typeof callableStyle === 'function'
-      ? callableStyle({ ownerState, ...props, ...ownerState })
+      ? callableStyle({ ownerState, ...props })
       : callableStyle;
 
   if (Array.isArray(resolvedStylesArg)) {

--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -48,7 +48,9 @@ function defaultOverridesResolver(slot) {
 
 function processStyleArg(callableStyle, { ownerState, ...props }) {
   const resolvedStylesArg =
-    typeof callableStyle === 'function' ? callableStyle({ ownerState, ...props }) : callableStyle;
+    typeof callableStyle === 'function'
+      ? callableStyle({ ownerState, ...props, ...ownerState })
+      : callableStyle;
 
   if (Array.isArray(resolvedStylesArg)) {
     return resolvedStylesArg.flatMap((resolvedStyle) =>
@@ -66,7 +68,7 @@ function processStyleArg(callableStyle, { ownerState, ...props }) {
     variants.forEach((variant) => {
       let isMatch = true;
       if (typeof variant.props === 'function') {
-        isMatch = variant.props({ ownerState, ...props });
+        isMatch = variant.props({ ownerState, ...props, ...ownerState });
       } else {
         Object.keys(variant.props).forEach((key) => {
           if (ownerState?.[key] !== variant.props[key] && props[key] !== variant.props[key]) {
@@ -80,7 +82,7 @@ function processStyleArg(callableStyle, { ownerState, ...props }) {
         }
         result.push(
           typeof variant.style === 'function'
-            ? variant.style({ ownerState, ...props })
+            ? variant.style({ ownerState, ...props, ...ownerState })
             : variant.style,
         );
       }

--- a/packages/mui-system/src/createStyled.js
+++ b/packages/mui-system/src/createStyled.js
@@ -48,9 +48,7 @@ function defaultOverridesResolver(slot) {
 
 function processStyleArg(callableStyle, { ownerState, ...props }) {
   const resolvedStylesArg =
-    typeof callableStyle === 'function'
-      ? callableStyle({ ownerState, ...props })
-      : callableStyle;
+    typeof callableStyle === 'function' ? callableStyle({ ownerState, ...props }) : callableStyle;
 
   if (Array.isArray(resolvedStylesArg)) {
     return resolvedStylesArg.flatMap((resolvedStyle) =>
@@ -68,7 +66,7 @@ function processStyleArg(callableStyle, { ownerState, ...props }) {
     variants.forEach((variant) => {
       let isMatch = true;
       if (typeof variant.props === 'function') {
-        isMatch = variant.props({ ownerState, ...props, ...ownerState });
+        isMatch = variant.props({ ownerState, ...props });
       } else {
         Object.keys(variant.props).forEach((key) => {
           if (ownerState?.[key] !== variant.props[key] && props[key] !== variant.props[key]) {
@@ -82,7 +80,7 @@ function processStyleArg(callableStyle, { ownerState, ...props }) {
         }
         result.push(
           typeof variant.style === 'function'
-            ? variant.style({ ownerState, ...props, ...ownerState })
+            ? variant.style({ ownerState, ...props })
             : variant.style,
         );
       }

--- a/test/integration/mui-system/createStyled.test.js
+++ b/test/integration/mui-system/createStyled.test.js
@@ -513,6 +513,38 @@ describe('createStyled', () => {
       expect(getByTestId('red')).toHaveComputedStyle({ backgroundColor: 'rgb(255, 0, 0)' });
     });
 
+    it('should merge props and ownerState in props callback', () => {
+      const styled = createStyled({
+        defaultTheme: {
+          colors: { blue: 'rgb(0, 0, 255)', red: 'rgb(255, 0, 0)', green: 'rgb(0, 255, 0)' },
+        },
+      });
+
+      const Test = styled('div')(({ theme, color }) => ({
+        variants: [
+          {
+            props: (props) => props.color === 'green' || props.color === 'red',
+            style: {
+              backgroundColor: theme.colors[color],
+            },
+          },
+        ],
+      }));
+
+      const { getByTestId } = render(
+        <React.Fragment>
+          <Test data-testid="red" ownerState={{ color: 'red' }}>
+            Red
+          </Test>
+          <Test data-testid="green" ownerState={{ color: 'green' }}>
+            Green
+          </Test>
+        </React.Fragment>,
+      );
+      expect(getByTestId('green')).toHaveComputedStyle({ backgroundColor: 'rgb(0, 255, 0)' });
+      expect(getByTestId('red')).toHaveComputedStyle({ backgroundColor: 'rgb(255, 0, 0)' });
+    });
+
     it('should accept variants in arrays', () => {
       const styled = createStyled({ defaultTheme: { colors: { blue: 'rgb(0, 0, 255)' } } });
 


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/41220

Consolidate the arguments for the variants' props callback between the @mui/system and the zero-runtime. The argument is now merging props and `ownerState`, so that developers can do:

```
variants: [{
  props: (props) => props.someState === 'some-value'
}]
```

instead of needing to do:

```
variants: [{
  props: (props) => props.ownerState.someState === 'some-value'
}]
```

Zero-runtime related code: https://github.com/mui/material-ui/blob/master/packages/zero-runtime/src/styled.jsx#L9