### PR TITLE
[material-ui][Switch] Add height styles on the input slot

### DIFF
--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -128,6 +128,7 @@ const SwitchSwitchBase = styled(SwitchBase, {
     [`& .${switchClasses.input}`]: {
       left: '-100%',
       width: '300%',
+      height': '100%',
     },
   }),
   ({ theme, ownerState }) => ({

--- a/packages/mui-material/src/Switch/Switch.js
+++ b/packages/mui-material/src/Switch/Switch.js
@@ -128,7 +128,7 @@ const SwitchSwitchBase = styled(SwitchBase, {
     [`& .${switchClasses.input}`]: {
       left: '-100%',
       width: '300%',
-      height': '100%',
+      height: '100%',
     },
   }),
   ({ theme, ownerState }) => ({


### PR DESCRIPTION
Input is not given propper heigth size. Making the Switch not hard and buggy to click on. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
