### PR TITLE
[code-infra] Unpin the version of docs-utils in scripts

### DIFF
--- a/packages-internal/scripts/CHANGELOG.md
+++ b/packages-internal/scripts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+* Unpinned version of the @mui-internal/docs-utils dependency.
+* Corrected the readme file.
+
 ## 1.0.0
 
 Initial release as an npm package.

--- a/packages-internal/scripts/README.md
+++ b/packages-internal/scripts/README.md
@@ -1,25 +1,12 @@
-# @mui-internal/typescript-to-proptypes
+# @mui/internal-scripts
 
-An API for converting [TypeScript](https://www.npmjs.com/package/typescript) definitions to [PropTypes](https://www.npmjs.com/package/prop-types) using the TypeScript Compiler API.
-
-This package has been adapted for MUI needs.
+Code infra scripts for MUI repositories
 It is not meant for general use.
 
-## Support
+## Scripts
 
-| Component type   |                    |
-| :--------------- | :----------------- |
-| Class            | :heavy_check_mark: |
-| Function         | :heavy_check_mark: |
-| Const functions  | :heavy_check_mark: |
-| React.memo       | :heavy_check_mark: |
-| React.ForwardRef | :heavy_check_mark: |
-
-## License
-
-This project is licensed under the terms of the [MIT license](/LICENSE).
-
-## Release
-
-1. Build the project: `pnpm build`
-2. Publish the build artifacts to npm: `pnpm release:publish`
+* `build` - transpiles TS files into the build directory.
+* `release:publish` - builds the project and publishes it in the npm registry.
+* `release:publish:dry-run` - builds the project and publishes it in a local registry accessible on port 4873 (this is the default port of Verdaccio private npm server).
+* `test` - runs all the tests.
+* `typescript` - checks validity of types.

--- a/packages-internal/scripts/package.json
+++ b/packages-internal/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-scripts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "MUI Team",
   "description": "Utilities supporting MUI libraries build and docs generation. This is an internal package not meant for general use.",
   "main": "build/index.js",
@@ -30,7 +30,7 @@
     "@babel/plugin-syntax-jsx": "^7.23.3",
     "@babel/plugin-syntax-typescript": "^7.23.3",
     "@babel/types": "^7.23.9",
-    "@mui-internal/docs-utils": "workspace:*",
+    "@mui-internal/docs-utils": "workspace:^",
     "doctrine": "^3.0.0",
     "lodash": "^4.17.21",
     "typescript": "^5.3.3",


### PR DESCRIPTION
Relaxed the allowed version range of @mui-internal/docs-utils.
With the previous setting, @mui/internal-scripts used docs-utils@1.0.1 which was incorrectly built.

Also corrected the internal-scripts readme.