### PR TITLE
[base-ui][useNumberInput] Hold stepper buttons to continuously change value

### DIFF
--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput2.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput2.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { createRenderer, screen, fireEvent } from '@mui-internal/test-utils';
+import { unstable_useNumberInput as useNumberInput } from '@mui/base/unstable_useNumberInput';
+
+describe('useNumberInput2', () => {
+  const { clock, render } = createRenderer();
+
+  describe('press and hold', () => {
+    clock.withFakeTimers();
+    it('should call onChange continuously', () => {
+      const handleChange = spy();
+      function NumberInput(props: { defaultValue: number }) {
+        const { getInputProps, getIncrementButtonProps } = useNumberInput({
+          ...props,
+          onChange: handleChange,
+        });
+
+        return (
+          <div role="group">
+            <button {...getIncrementButtonProps()} data-testid="incrementBtn" />
+            <input data-testid="test-input" {...getInputProps()} />
+          </div>
+        );
+      }
+      render(<NumberInput defaultValue={0} />);
+
+      const incrementBtn = screen.getByTestId('incrementBtn');
+
+      fireEvent.mouseDown(incrementBtn);
+
+      clock.tick(100);
+      clock.tick(100);
+      clock.runToLast();
+
+      expect(handleChange.callCount).to.equal(3);
+    });
+  });
+});

--- a/packages/mui-base/src/unstable_useNumberInput/useNumberInput2.test.tsx
+++ b/packages/mui-base/src/unstable_useNumberInput/useNumberInput2.test.tsx
@@ -28,13 +28,14 @@ describe('useNumberInput2', () => {
 
       const incrementBtn = screen.getByTestId('incrementBtn');
 
-      fireEvent.mouseDown(incrementBtn);
+      fireEvent.mouseDown(incrementBtn); // onChange x1
 
-      clock.tick(100);
-      clock.tick(100);
+      clock.tick(100); // onChange x2
+      clock.tick(100); // onChange x3
+      clock.tick(100); // onChange x4
       clock.runToLast();
 
-      expect(handleChange.callCount).to.equal(3);
+      expect(handleChange.callCount).to.equal(4);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/mui/base-ui/issues/74

Preview: https://deploy-preview-41245--material-ui.netlify.app/base-ui/react-number-input/

### TODO
- [ ] make sure the tests are correct
- [ ] longer delay between the first `onChange` on the first `mouseDown` and subsequent continuously-firing ones
- [ ] pointer instead of mouse?
- [ ] handle mouse/pointerOut