### PR TITLE
[zero] Move extendTheme to already existing @mui/zero-runtime/utils

### DIFF
--- a/packages/zero-runtime/.gitignore
+++ b/packages/zero-runtime/.gitignore
@@ -1,4 +1,3 @@
 /processors/
 /utils/
-/extendTheme/
 LICENSE

--- a/packages/zero-runtime/package.json
+++ b/packages/zero-runtime/package.json
@@ -21,7 +21,7 @@
     "url": "https://opencollective.com/mui-org"
   },
   "scripts": {
-    "clean": "rimraf build extendTheme types processors utils",
+    "clean": "rimraf build types processors utils",
     "watch": "tsup --watch --clean false",
     "copy-license": "node ../../scripts/zero-runtime-license.mjs",
     "build": "tsup",
@@ -82,7 +82,6 @@
   "files": [
     "build",
     "exports",
-    "extendTheme",
     "processors",
     "theme",
     "utils",
@@ -102,15 +101,6 @@
       "import": "./theme/index.mjs",
       "require": "./theme/index.js",
       "default": "./theme/index.js"
-    },
-    "./extendTheme": {
-      "types": "./extendTheme/index.d.ts",
-      "import": {
-        "default": "./extendTheme/index.mjs",
-        "types": "./extendTheme/index.d.mts"
-      },
-      "require": "./extendTheme/index.js",
-      "default": "./extendTheme/index.js"
     },
     "./styles.css": {
       "default": "./styles.css"
@@ -144,7 +134,6 @@
       "build": {
         "outputs": [
           "{projectRoot}/build",
-          "{projectRoot}/extendTheme",
           "{projectRoot}/processors",
           "{projectRoot}/utils"
         ]

--- a/packages/zero-runtime/src/theme.ts
+++ b/packages/zero-runtime/src/theme.ts
@@ -1,1 +1,2 @@
 export interface ThemeArgs {}
+export { ExtendTheme } from './utils/extendTheme';

--- a/packages/zero-runtime/src/utils/cssFnValueToVariable.ts
+++ b/packages/zero-runtime/src/utils/cssFnValueToVariable.ts
@@ -5,7 +5,7 @@ import * as t from '@babel/types';
 import type { Expression } from '@babel/types';
 import { isUnitLess } from './isUnitLess';
 import { cssFunctionTransformerPlugin } from './cssFunctionTransformerPlugin';
-import type { Theme } from '../extendTheme';
+import type { Theme } from './extendTheme';
 
 interface StyleObj {
   [key: string]: string | number | (() => void) | StyleObj;

--- a/packages/zero-runtime/src/utils/extendTheme.ts
+++ b/packages/zero-runtime/src/utils/extendTheme.ts
@@ -1,7 +1,7 @@
 import deepMerge from 'lodash/merge';
 import { prepareCssVars } from '@mui/system/cssVars';
 import type { SxConfig } from '@mui/system/styleFunctionSx';
-import type { CSSObject } from './base';
+import type { CSSObject } from '../base';
 
 export interface ThemeInput<ColorScheme extends string = string> {
   /**

--- a/packages/zero-runtime/src/utils/generateCss.ts
+++ b/packages/zero-runtime/src/utils/generateCss.ts
@@ -1,5 +1,5 @@
 import { serializeStyles } from '@emotion/serialize';
-import { Theme } from '../extendTheme';
+import { Theme } from './extendTheme';
 
 export function generateTokenCss(theme: Theme) {
   // create stylesheet as object

--- a/packages/zero-runtime/src/utils/index.ts
+++ b/packages/zero-runtime/src/utils/index.ts
@@ -1,3 +1,4 @@
 export type { PluginCustomOptions } from './cssFnValueToVariable';
 export * from './preprocessor';
 export * from './generateCss';
+export * from './extendTheme';

--- a/packages/zero-runtime/tsup.config.ts
+++ b/packages/zero-runtime/tsup.config.ts
@@ -21,13 +21,6 @@ export default defineConfig([
   },
   {
     ...baseConfig,
-    entry: {
-      index: './src/extendTheme.ts',
-    },
-    outDir: 'extendTheme',
-  },
-  {
-    ...baseConfig,
     entry: processors.map((fn) => `./src/processors/${fn}.ts`),
     outDir: 'processors',
   },

--- a/packages/zero-unplugin/src/index.ts
+++ b/packages/zero-unplugin/src/index.ts
@@ -18,8 +18,9 @@ import {
   preprocessor as basePreprocessor,
   generateTokenCss,
   generateThemeTokens,
+  extendTheme,
+  type Theme as BaseTheme,
 } from '@mui/zero-runtime/utils';
-import { extendTheme, type Theme as BaseTheme } from '@mui/zero-runtime/extendTheme';
 
 type NextMeta = {
   type: 'next';

--- a/packages/zero-vite-plugin/src/index.ts
+++ b/packages/zero-vite-plugin/src/index.ts
@@ -3,8 +3,9 @@ import {
   preprocessor as basePreprocessor,
   generateTokenCss,
   generateThemeTokens,
+  type Theme,
+  extendTheme,
 } from '@mui/zero-runtime/utils';
-import type { Theme } from '@mui/zero-runtime/extendTheme';
 import { transformAsync } from '@babel/core';
 import baseZeroVitePlugin, { type VitePluginOptions } from './zero-vite-plugin';
 
@@ -116,3 +117,5 @@ export function zeroVitePlugin(options: ZeroVitePluginOptions) {
 
   return [injectMUITokensPlugin(), intermediateBabelPlugin(), zeroPlugin];
 }
+
+export { extendTheme };


### PR DESCRIPTION
path. Doesn't make sense to have so many export subpaths since these utils are mostly there to be consumed by bundler packages.
Also add the missing export to the vite plugin.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
