### PR TITLE
[material-ui][docs] Update the Checkboxes Group demo to use 'correct' pattern of updating state

### DIFF
--- a/docs/data/material/components/checkboxes/CheckboxesGroup.js
+++ b/docs/data/material/components/checkboxes/CheckboxesGroup.js
@@ -15,10 +15,10 @@ export default function CheckboxesGroup() {
   });
 
   const handleChange = (event) => {
-    setState({
-      ...state,
-      [event.target.name]: event.target.checked,
-    });
+    setState((prevState) => ({
+			...prevState,
+			[event.target.name]: event.target.checked,
+		}));
   };
 
   const { gilad, jason, antoine } = state;

--- a/docs/data/material/components/checkboxes/CheckboxesGroup.tsx
+++ b/docs/data/material/components/checkboxes/CheckboxesGroup.tsx
@@ -15,10 +15,10 @@ export default function CheckboxesGroup() {
   });
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      [event.target.name]: event.target.checked,
-    });
+    setState((prevState) => ({
+			...prevState,
+			[event.target.name]: event.target.checked,
+		}));
   };
 
   const { gilad, jason, antoine } = state;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


While working on a checkbox component, I noticed that the demo code spreads the `...state`, to set a new state without using the updater function. I figured, might as well create a PR request for a simple fix.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
