### PR TITLE
[material-ui][docs] Annotate props with `SlideProps` on the full-screen Dialog demo

### DIFF
--- a/docs/data/material/components/dialogs/AlertDialogSlide.tsx
+++ b/docs/data/material/components/dialogs/AlertDialogSlide.tsx
@@ -5,13 +5,10 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import Slide from '@mui/material/Slide';
-import { TransitionProps } from '@mui/material/transitions';
+import Slide, { SlideProps } from '@mui/material/Slide';
 
 const Transition = React.forwardRef(function Transition(
-  props: TransitionProps & {
-    children: React.ReactElement<any, any>;
-  },
+  props: SlideProps,
   ref: React.Ref<unknown>,
 ) {
   return <Slide direction="up" ref={ref} {...props} />;


### PR DESCRIPTION
Instead of the currently confusing and complex annotation.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
