### PR TITLE
[zero] Add support for styled tagged-template literals

### DIFF
--- a/packages/zero-runtime/src/keyframes.d.ts
+++ b/packages/zero-runtime/src/keyframes.d.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from './base';
 import type { ThemeArgs } from './theme';
 
-type Primitve = string | null | undefined | boolean | number;
+export type Primitve = string | null | undefined | boolean | number;
 
 interface KeyframesObject {
   [key: string]: {

--- a/packages/zero-runtime/src/styled.d.ts
+++ b/packages/zero-runtime/src/styled.d.ts
@@ -2,6 +2,7 @@ import type * as React from 'react';
 import type { CSSObject } from './base';
 import type { ThemeArgs } from './theme';
 import type { SxProp } from './sx';
+import { Primitve } from './keyframes';
 
 type Falsy = false | 0 | '' | null | undefined;
 
@@ -58,6 +59,11 @@ export interface CreateStyledComponent<
   Component extends React.ElementType,
   OuterProps extends object,
 > {
+  (
+    styles: TemplateStringsArray,
+    ...args: Array<(options: ThemeArgs) => Primitve | Primitve | React.ComponentClass>
+  ): StyledComponent<OuterProps> & (Component extends string ? BaseDefaultProps : Component);
+
   /**
    * @typeparam Props: Additional props to add to the styled component
    */

--- a/packages/zero-runtime/tests/fixtures/styled.input.js
+++ b/packages/zero-runtime/tests/fixtures/styled.input.js
@@ -1,4 +1,4 @@
-import { styled, keyframes } from '@mui/zero-runtime';
+import { styled, keyframes, css } from '@mui/zero-runtime';
 
 const rotateKeyframe = keyframes({
   from: {
@@ -13,3 +13,26 @@ const Component = styled.div(({ theme }) => ({
   color: theme.palette.primary.main,
   animation: `${rotateKeyframe} 2s ease-out 0s infinite`,
 }));
+
+const cls1 = css`
+  color: ${({ theme }) => theme.palette.primary.main};
+  font-size: ${({ theme }) => theme.size.font.h1};
+`;
+
+const SliderRail = styled('span', {
+  name: 'MuiSlider',
+  slot: 'Rail',
+})`
+  display: block;
+  position: absolute;
+  border-radius: inherit;
+  background-color: currentColor;
+  opacity: 0.38;
+  font-size: ${({ theme }) => theme.size.font.h1};
+`;
+
+const SliderRail2 = styled.span`
+  display: block;
+  opacity: 0.38;
+  font-size: ${({ theme }) => theme.size.font.h1};
+`;

--- a/packages/zero-runtime/tests/fixtures/styled.output.css
+++ b/packages/zero-runtime/tests/fixtures/styled.output.css
@@ -1,2 +1,6 @@
 @keyframes r1yjyf7p{from{transform:rotate(360deg);}to{transform:rotate(0deg);}}
 .cir471u{color:red;animation:r1yjyf7p 2s ease-out 0s infinite;}
+.c1xj10ek{color:red;font-size:3rem;}
+.sefdpty{display:block;position:absolute;border-radius:inherit;background-color:currentColor;opacity:0.38;font-size:3rem;}
+.sefdpty-1{font-size:3rem;}
+.s13fhnbp{display:block;opacity:0.38;font-size:3rem;}

--- a/packages/zero-runtime/tests/fixtures/styled.output.js
+++ b/packages/zero-runtime/tests/fixtures/styled.output.js
@@ -1,5 +1,17 @@
+import { styled as _styled3 } from "@mui/zero-runtime";
+import { styled as _styled2 } from "@mui/zero-runtime";
 import { styled as _styled } from "@mui/zero-runtime";
 import _theme from "@mui/zero-runtime/theme";
 const Component = /*#__PURE__*/_styled("div")({
   classes: ["cir471u"]
+});
+const cls1 = "c1xj10ek";
+const SliderRail = /*#__PURE__*/_styled2("span", {
+  name: 'MuiSlider',
+  slot: 'Rail'
+})({
+  classes: ["sefdpty", "sefdpty-1"]
+});
+const SliderRail2 = /*#__PURE__*/_styled3("span")({
+  classes: ["s13fhnbp"]
 });

--- a/packages/zero-runtime/tests/zero-runtime.test.js
+++ b/packages/zero-runtime/tests/zero-runtime.test.js
@@ -13,6 +13,20 @@ const theme = {
       main: 'red',
     },
   },
+  size: {
+    font: {
+      h1: '3rem',
+    },
+  },
+  components: {
+    MuiSlider: {
+      styleOverrides: {
+        rail: {
+          fontSize: '3rem',
+        },
+      },
+    },
+  },
 };
 
 describe('zero-runtime', () => {
@@ -59,8 +73,8 @@ describe('zero-runtime', () => {
         asyncResolveFallback,
       );
 
-      expect(result.code.trim()).to.equal(outputContent.trim());
       expect(result.cssText).to.equal(outputCssContent);
+      expect(result.code.trim()).to.equal(outputContent.trim());
     });
   });
 });


### PR DESCRIPTION
This PR brings support for:

```jsx
const cls1 = css`
  color: ${({ theme }) => theme.palette.primary.main};
  font-size: ${({ theme }) => theme.size.font.h1};
`;
```

```jsx
const SliderRail = styled('span')`
  display: block;
  position: absolute;
  border-radius: inherit;
  background-color: currentColor;
  opacity: 0.38;
  font-size: ${({ theme }) => theme.size.font.h1};
`;
```