### PR TITLE
[material-ui][Typography] Fix Typography inherit variant styles

### DIFF
--- a/packages/mui-material/src/Typography/Typography.js
+++ b/packages/mui-material/src/Typography/Typography.js
@@ -46,6 +46,8 @@ export const TypographyRoot = styled('span', {
   ...(ownerState.variant === 'inherit' && {
     // Some elements, like <button> on Chrome have default font that doesn't inherit, reset this.
     font: 'inherit',
+    lineHeight: 'inherit',
+    letterSpacing: 'inherit',
   }),
   ...(ownerState.variant !== 'inherit' && theme.typography[ownerState.variant]),
   ...(ownerState.align !== 'inherit' && {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In https://github.com/mui/material-ui/pull/38123 the styles were supposed to be moved from the theme into the styled component but `lineHeight` and `letterSpacing` styles were missed and it caused regressions when using `button`.

Styles that were not moved over: https://github.com/mui/material-ui/pull/38123/files#diff-48a50468b17f36e83faa75d3f1a78ba450b0c78d0cdc6ebfbe1cb27ec5130e1aR80-R81