### PR TITLE
[docs-infra] Simplify Algolia crawler config

### DIFF
--- a/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/ClassesTable.tsx
@@ -81,13 +81,13 @@ export default function ClassesTable(props: ClassesTableProps) {
 
             return (
               <tr key={className} id={getHash({ componentName, className: key })}>
-                <td>
+                <td className="algolia-lvl3">
                   <span className="class-name">.{className}</span>
                 </td>
                 {displayClassKeys && (
                   <td>{!isGlobal && <span className="class-key">{key}</span>}</td>
                 )}
-                <td>
+                <td className="algolia-content">
                   <span
                     dangerouslySetInnerHTML={{
                       __html: description || '',

--- a/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
+++ b/docs/src/modules/components/ApiPage/table/PropertiesTable.tsx
@@ -166,7 +166,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                 key={propName}
                 id={getHash({ componentName, propName, hooksParameters, hooksReturnValue })}
               >
-                <td className="MuiApi-table-item-title">
+                <td className="MuiApi-table-item-title algolia-lvl3">
                   {propName}
                   {isRequired ? '*' : ''}
                   {isOptional ? '?' : ''}
@@ -200,7 +200,7 @@ export default function PropertiesTable(props: PropertiesTableProps) {
                     )}
                   </td>
                 )}
-                <td className="MuiPropTable-description-column">
+                <td className="MuiPropTable-description-column algolia-content">
                   {description && <PropDescription description={description} />}
                   {seeMoreDescription && (
                     <p


### PR DESCRIPTION
See the last issue in https://groups.google.com/a/mui.com/g/docs-infra/c/81eISb5eXmA. Once MUI X sync with these changes, we should be able to simplify the crawler config:

```jsx
        const result = helpers.docsearch({
          recordVersion: "v3",
          recordProps: {
            lvl0: {
              selectors: ".this-selector-will-never-match",
              defaultValue: $(".algolia-lvl0")
                .map((index, element) => $(element).text())
                .get()
                .join(" > "),
            },
            lvl1: [".algolia-lvl1", ".markdown-body h1"],
            lvl2: [".algolia-lvl2", ".markdown-body h2"],
            lvl3: [
              ".algolia-lvl3",
              ".markdown-body h3",
              ".markdown-body td:first-of-type",
            ],
            lvl4: [".algolia-lvl4", ".markdown-body h4"],
            content:
              ".algolia-content, .markdown-body p, .markdown-body li, .markdown-body td:last-of-type",
          },
        });
```

Part of the value is to be able to change the DOM structure without breaking the crawler, especially when spread between different deployment units (Base UI, Material UI, MUI X almost never using the same version of docs-infra at any moment in time)