### PR TITLE
[system] Fix createSpacing return type

### DIFF
--- a/packages/mui-system/src/createTheme/createSpacing.ts
+++ b/packages/mui-system/src/createTheme/createSpacing.ts
@@ -13,7 +13,7 @@ export type SpacingArgument = number | string;
 // We express the difference with variable names.
 export interface Spacing {
   (): string;
-  (value: number | string): string;
+  (value: SpacingArgument): string;
   (topBottom: SpacingArgument, rightLeft: SpacingArgument): string;
   (top: SpacingArgument, rightLeft: SpacingArgument, bottom: SpacingArgument): string;
   (

--- a/packages/mui-system/src/createTheme/createSpacing.ts
+++ b/packages/mui-system/src/createTheme/createSpacing.ts
@@ -13,7 +13,7 @@ export type SpacingArgument = number | string;
 // We express the difference with variable names.
 export interface Spacing {
   (): string;
-  (value: number): string;
+  (value: number | string): string;
   (topBottom: SpacingArgument, rightLeft: SpacingArgument): string;
   (top: SpacingArgument, rightLeft: SpacingArgument, bottom: SpacingArgument): string;
   (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

PR  #23224 added the ability to pass string arguments to `theme.spacing`, but did not change the `Spacing` interface, which still expects the unary value argument to be a `number` rather than the `number | string`