### PR TITLE
[material-ui][Select] SelectProps fix variant

### DIFF
--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -156,7 +156,7 @@ export interface FilledSelectProps extends Omit<FilledInputProps, 'value' | 'onC
    * The variant to use.
    * @default 'outlined'
    */
-  variant: 'filled';
+  variant?: 'filled';
 }
 
 export interface StandardSelectProps extends Omit<InputProps, 'value' | 'onChange'> {
@@ -164,7 +164,7 @@ export interface StandardSelectProps extends Omit<InputProps, 'value' | 'onChang
    * The variant to use.
    * @default 'outlined'
    */
-  variant: 'standard';
+  variant?: 'standard';
 }
 
 export interface OutlinedSelectProps extends Omit<OutlinedInputProps, 'value' | 'onChange'> {
@@ -172,7 +172,7 @@ export interface OutlinedSelectProps extends Omit<OutlinedInputProps, 'value' | 
    * The variant to use.
    * @default 'outlined'
    */
-  variant: 'outlined';
+  variant?: 'outlined';
 }
 
 export type SelectVariants = 'outlined' | 'standard' | 'filled';


### PR DESCRIPTION
closes #41356 not sure about other side effects since this was our only case where it didn't build anymore. Also im stumbled why typing errors are not shown in MUI's pipeline...

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

_The fix still makes sure the intention of the previous PR (which introduced the bug) stays working correctly (choosing props that are only optional with the chosen variant)._

So when setting a prop not belonging to the variant it shows the error:

<img width="1049" alt="Screenshot 2024-03-04 at 21 49 16" src="https://github.com/mui/material-ui/assets/25961356/5d62d6a1-cb1b-45af-a0fc-0525be4f383a">

And when the prop is an option it allows it correctly:

<img width="1041" alt="Screenshot 2024-03-04 at 21 49 28" src="https://github.com/mui/material-ui/assets/25961356/80781cf9-6719-4d8d-814f-d23eafd18300">

fixes https://github.com/mui/material-ui/pull/39137#discussion_r1501919356

blamed #39137

What i still can do is to also change `export type SelectProps` back to `export interface SelectProps` because in general also this can be breaking ...
