### PR TITLE
[JoyUI][sign in template] Clean up wrong lines from the sign in template

### DIFF
--- a/docs/data/joy/getting-started/templates/sign-in-side/App.tsx
+++ b/docs/data/joy/getting-started/templates/sign-in-side/App.tsx
@@ -106,7 +106,6 @@ export default function JoySignInSideTemplate() {
             sx={{
               py: 3,
               display: 'flex',
-              alignItems: 'left',
               justifyContent: 'space-between',
             }}
           >


### PR DESCRIPTION
Hi, there's no such thing as `alignItems: "left"`, and aligning across the cross axis isn't needed here at all, because there's no extra height.

We can safely remove it.

