### PR TITLE
[code-infra] Reduce concurrency for test_types ci job

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}'",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 5 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 4 --no-bail --no-sort typescript",
     "validate-declarations": "tsx scripts/validateTypescriptDeclarations.mts",
     "generate-codeowners": "node scripts/generateCodeowners.mjs",
     "watch:zero": "nx run-many -t watch --projects=\"@pigmentcss/*\" --parallel"


### PR DESCRIPTION
This job regularly gets killed because OOM. e.g. in https://app.circleci.com/pipelines/github/mui/material-ui/123209/workflows/fc80066e-8f76-4a04-a1a6-e1d61730bb69/jobs/663886/resources

before:
<img width="1115" alt="Screenshot 2024-03-06 at 14 12 32" src="https://github.com/mui/material-ui/assets/2109932/a222d946-f0e1-4571-abc5-9712d125df3e">


after:
<img width="1102" alt="Screenshot 2024-03-06 at 14 13 31" src="https://github.com/mui/material-ui/assets/2109932/9fee1b8b-ef28-4793-9053-a25399f779b7">



It doesn't seem to impact the runtime