### PR TITLE
[docs] Fix v4 docs <b> appearing in notifications

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -1,22 +1,22 @@
 [
   {
     "id": 68,
-    "title": "<b>Check out Base UI today</b> 💥",
+    "title": "Check out Base UI today 💥",
     "text": "Love Material UI, but don't need Material Design? Try Base UI, the new \"unstyled\" alternative. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"introducing-base-ui\" href=\"/blog/introducing-base-ui/\">Read more in this announcement</a>."
   },
   {
     "id": 78,
-    "title": "<b>MUI X v6.18.x and the latest improvements before the next major</b>",
+    "title": "MUI X v6.18.x and the latest improvements before the next major",
     "text": "New stable components, polished features, better performance and more. Check out the details in our <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-end-v6\" href=\"https://mui.com/blog/mui-x-end-v6-features/\">recent blog post</a>."
   },
   {
     "id": 79,
-    "title": "<b>A new Developer Survey is open</b>",
+    "title": "A new Developer Survey is open",
     "text": "Take a few minutes to share your feedback and expectations in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-survey\" href=\"https://tally.so/r/3Ex4PN?source=docs-notification\">Developer Survey</a>."
   },
   {
     "id": 80,
-    "title": "<b>MUI X v7.0.0-beta.0</b>",
+    "title": "MUI X v7.0.0-beta.0",
     "text": "Featuring new components and multiple enhancements for both developers and end-users. Discover all the specifics in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v7-beta\" href=\"https://mui.com/blog/mui-x-v7-beta/\">announcement blog post</a>."
   }
 ]

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -231,10 +231,7 @@ export default function Notifications() {
                       <React.Fragment key={message.id}>
                         <ListItem alignItems="flex-start">
                           <Typography gutterBottom>
-                            <span
-                              // eslint-disable-next-line react/no-danger
-                              dangerouslySetInnerHTML={{ __html: message.title }}
-                            />
+                            <b>{message.title}</b>
                           </Typography>
                           <Typography gutterBottom variant="body2" color="text.secondary">
                             <span


### PR DESCRIPTION
Looks like the `dangerouslySetInnerHTML` usage isn't necessary anymore now that the `<b>` tags wrap the entire title on all of the visible notifications. I'm assuming that removing the `<b>` from each title and instead wrapping the title in `<b>` tags in the JSX here will get rid of the `<b>` tags showing up in the v4 docs, as it looks like they are using the same `notifications.json` file to render the text for their notifications. If my assumption is incorrect, feel free to ignore my PR.

v5 docs
![image](https://github.com/mui/material-ui/assets/2318867/3b2d95ea-464d-4a77-b671-4e75665eea21)


v4 docs
![image](https://github.com/mui/material-ui/assets/2318867/db5cad7d-5bca-4ad2-b094-b49c7701c8f7)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
