### PR TITLE
[code-infra] Reduce concurrency of typescript:ci further

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}'",
     "test:argos": "node ./scripts/pushArgos.mjs",
     "typescript": "lerna run --no-bail --parallel typescript",
-    "typescript:ci": "lerna run --concurrency 4 --no-bail --no-sort typescript",
+    "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
     "validate-declarations": "tsx scripts/validateTypescriptDeclarations.mts",
     "generate-codeowners": "node scripts/generateCodeowners.mjs",
     "watch:zero": "nx run-many -t watch --projects=\"@pigmentcss/*\" --parallel"


### PR DESCRIPTION
We're still hitting [OOM issues](https://app.circleci.com/pipelines/github/mui/material-ui/123266/workflows/26ec58df-c569-47d3-ac60-07f55195b152/jobs/664207/resources) after https://github.com/mui/material-ui/pull/41385

perhaps a different permutation of nx jobs running simultaneously on each run? This PR reduces concurrency once more.

Still peaks at almost 100% but it got through.

<img width="1100" alt="Screenshot 2024-03-07 at 09 08 21" src="https://github.com/mui/material-ui/assets/2109932/c46f2f97-59f0-46d8-90ac-5313efa73cce">

We can merge and reduce even further if the problem persists.