### PR TITLE
[joy-ui][docs] Update Case Studies Chip Background Color

### DIFF
--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.js
@@ -91,7 +91,7 @@ export default function ColorInversionHeader() {
                 sx={{
                   ml: 'auto',
                   bgcolor: (theme) =>
-                    `rgba(${theme.vars.palette.primary.mainChannel} / 0.1)`,
+                    `rgba(${theme.vars.palette[color].mainChannel} / 0.4)`,
                 }}
               >
                 Beta

--- a/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionHeader.tsx
@@ -96,7 +96,7 @@ export default function ColorInversionHeader() {
                 sx={{
                   ml: 'auto',
                   bgcolor: (theme) =>
-                    `rgba(${theme.vars.palette.primary.mainChannel} / 0.1)`,
+                    `rgba(${theme.vars.palette[color].mainChannel} / 0.4)`,
                 }}
               >
                 Beta


### PR DESCRIPTION
Changes were made to the “Beta” Chip to ensure it looks consistent and nice across various color schemes. Now, instead of using a fixed background color, we’re dynamically setting it based on the theme’s palette color.

Also increased the opacity value from 0.1 to 0.4. This change makes the background color more noticeable and prominent. 


### Before
![Screenshot Capture - 2024-03-09 - 10-16-49](https://github.com/mui/material-ui/assets/73669345/3891b189-5e80-4279-8e7f-2145c172b4ab)
![Screenshot Capture - 2024-03-09 - 10-16-29](https://github.com/mui/material-ui/assets/73669345/3313f351-45c9-4c96-aa05-30465543be9d)

### After
![Screenshot Capture - 2024-03-09 - 10-17-28](https://github.com/mui/material-ui/assets/73669345/fa7784f8-5f96-4a95-bb41-f33b5adeb077)
![Screenshot Capture - 2024-03-09 - 10-17-16](https://github.com/mui/material-ui/assets/73669345/e2e5d5c8-4772-4c32-86a4-9343b85dbe59)
![Screenshot Capture - 2024-03-09 - 10-17-06](https://github.com/mui/material-ui/assets/73669345/75060505-56cc-4bde-b833-483f5ba478f1)
