### PR TITLE
[docs][material-icons] Add option to search for all icon styles

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -5,7 +5,6 @@ import copy from 'clipboard-copy';
 import InputBase from '@mui/material/InputBase';
 import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
-import { debounce } from '@mui/material/utils';
 import Grid from '@mui/material/Grid';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -486,7 +485,7 @@ export default function SearchIcons() {
   const lazyKeys = React.useDeferredValue(keys);
   const [theme, setTheme] = useQueryParameterState('theme', 'All');
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
-  const [query, setQuery] = useQueryParameterState('query', '');
+  const [query, setQuery] = useQueryParameterState('query', '', 0);
   const lazyQuery = React.useDeferredValue(query);
   const [minIcons, setMinIcons] = React.useState(49);
 
@@ -528,8 +527,6 @@ export default function SearchIcons() {
       ).filter((icon) => theme === 'All' || theme === icon.theme),
     [theme, lazyKeys],
   );
-
-  const totalNumIcons = icons.length;
 
   const dialogSelectedIcon = useLatest(
     selectedIcon ? allIconsMap[selectedIcon] : null,
@@ -573,20 +570,20 @@ export default function SearchIcons() {
             autoFocus
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder={`Search over ${formatNumber(totalNumIcons)} available icons...`}
+            placeholder={`Search icons...`}
             inputProps={{ 'aria-label': 'search icons' }}
           />
         </Paper>
         <Typography variant="subtitle1" sx={{ mb: 1 }}>
-          {`${formatNumber(totalNumIcons)} matching results`}
+          {`${formatNumber(icons.length)} matching results`}
         </Typography>
         <Stack spacing={4} sx={{ height: '100%' }}>
           <Icons
             icons={icons.slice(0, minIcons)}
             handleOpenClick={handleOpenClick}
-            data={{ total: totalNumIcons, length: minIcons }}
+            data={{ total: icons.length, length: minIcons }}
           />
-          {totalNumIcons > minIcons && (
+          {icons.length > minIcons && (
             <Button
               size="small"
               color="primary"

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -51,7 +51,7 @@ import synonyms from './synonyms';
 
 const FlexSearchIndex = flexsearch.default.Index;
 
-const UPDATE_SEARCH_INDEX_WAIT_MS = 150;
+const UPDATE_SEARCH_INDEX_WAIT_MS = 220;
 
 // const mui = {
 //   ExitToApp,
@@ -175,7 +175,8 @@ const Icons = React.memo(
       </div>
     );
   },
-  (prev, next) => prev.total === next.total,
+  (prev, next) =>
+    prev.data.total === next.data.total && prev.data.length === next.data.length,
 );
 
 Icons.propTypes = {
@@ -487,8 +488,8 @@ export default function SearchIcons() {
   const [theme, setTheme] = useQueryParameterState('theme', 'All');
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
   const [query, setQuery] = useQueryParameterState('query', '');
-  const [_, startUpdateSearchTransition] = React.useTransition();
-  const [minIcons, setMinIcons] = React.useState(99);
+  const [isPending, startUpdateSearchTransition] = React.useTransition();
+  const [minIcons, setMinIcons] = React.useState(49);
 
   const handleOpenClick = React.useCallback(
     (event) => {
@@ -526,7 +527,7 @@ export default function SearchIcons() {
   React.useEffect(() => {
     startUpdateSearchTransition(() => updateSearchResults(query));
     if (query === '') {
-      setMinIcons(99);
+      setMinIcons(49);
     }
 
     return () => updateSearchResults.clear();
@@ -595,7 +596,7 @@ export default function SearchIcons() {
           <Icons
             icons={icons.slice(0, minIcons)}
             handleOpenClick={handleOpenClick}
-            total={totalNumIcons}
+            data={{ total: totalNumIcons, length: minIcons }}
           />
           {totalNumIcons > minIcons && (
             <Button

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -480,7 +480,7 @@ function useLatest(value) {
 
 export default function SearchIcons() {
   const [keys, setKeys] = React.useState(null);
-  const [theme, setTheme] = useQueryParameterState('theme', 'Filled');
+  const [theme, setTheme] = useQueryParameterState('theme', 'All');
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
   const [query, setQuery] = useQueryParameterState('query', '');
 
@@ -527,7 +527,7 @@ export default function SearchIcons() {
   const icons = React.useMemo(
     () =>
       (keys === null ? allIcons : keys.map((key) => allIconsMap[key])).filter(
-        (icon) => theme === icon.theme,
+        (icon) => theme === 'All' || theme === icon.theme,
       ),
     [theme, keys],
   );
@@ -544,7 +544,7 @@ export default function SearchIcons() {
             Filter the style
           </Typography>
           <RadioGroup>
-            {['Filled', 'Outlined', 'Rounded', 'Two tone', 'Sharp'].map(
+            {['All', 'Filled', 'Outlined', 'Rounded', 'Two tone', 'Sharp'].map(
               (currentTheme) => {
                 return (
                   <FormControlLabel

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -486,7 +486,7 @@ export default function SearchIcons() {
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
   const [query, setQuery] = useQueryParameterState('query', '');
   const [isPending, startUpdateSearchTransition] = React.useTransition();
-  const [minIcons, setMinIcons] = React.useState(49);
+  const [minIcons, setMinIcons] = React.useState(99);
 
   const handleOpenClick = React.useCallback(
     (event) => {
@@ -523,7 +523,7 @@ export default function SearchIcons() {
 
   React.useEffect(() => {
     startUpdateSearchTransition(() => updateSearchResults(query));
-    setMinIcons(49);
+    setMinIcons(99);
 
     return () => updateSearchResults.clear();
   }, [query, updateSearchResults]);
@@ -603,7 +603,7 @@ export default function SearchIcons() {
                 color="primary"
                 variant="outlined"
                 sx={{ mt: 'auto' }}
-                onClick={() => setMinIcons((m) => (m += 49))}
+                onClick={() => setMinIcons((m) => (m += 99))}
               >
                 View more
               </Button>

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -51,7 +51,7 @@ import synonyms from './synonyms';
 
 const FlexSearchIndex = flexsearch.default.Index;
 
-const UPDATE_SEARCH_INDEX_WAIT_MS = 220;
+const UPDATE_SEARCH_INDEX_WAIT_MS = 50;
 
 // const mui = {
 //   ExitToApp,
@@ -485,6 +485,7 @@ function useLatest(value) {
 
 export default function SearchIcons() {
   const [keys, setKeys] = React.useState(null);
+  const defferedKeys = React.useDeferredValue(keys);
   const [theme, setTheme] = useQueryParameterState('theme', 'All');
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
   const [query, setQuery] = useQueryParameterState('query', '');
@@ -535,10 +536,11 @@ export default function SearchIcons() {
 
   const icons = React.useMemo(
     () =>
-      (keys === null ? allIcons : keys.map((key) => allIconsMap[key])).filter(
-        (icon) => theme === 'All' || theme === icon.theme,
-      ),
-    [theme, keys],
+      (defferedKeys === null
+        ? allIcons
+        : defferedKeys.map((key) => allIconsMap[key])
+      ).filter((icon) => theme === 'All' || theme === icon.theme),
+    [theme, defferedKeys],
   );
 
   const totalNumIcons = icons.length;

--- a/docs/src/modules/utils/useQueryParameterState.ts
+++ b/docs/src/modules/utils/useQueryParameterState.ts
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { useRouter } from 'next/router';
 import { debounce } from '@mui/material/utils';
 
-const QUERY_UPDATE_WAIT_MS = 220;
-
 /**
  * Similar to `React.useState`, but it syncs back the current state to a query
  * parameter in the url, therefore it only supports strings. Wrap the result with
@@ -14,6 +12,7 @@ const QUERY_UPDATE_WAIT_MS = 220;
 export default function useQueryParameterState(
   name: string,
   initialValue = '',
+  waitMs = 220,
 ): [string, (newValue: string) => void] {
   const initialValueRef = React.useRef(initialValue);
 
@@ -50,7 +49,7 @@ export default function useQueryParameterState(
             },
           );
         }
-      }, QUERY_UPDATE_WAIT_MS),
+      }, waitMs),
     [name, router],
   );
 


### PR DESCRIPTION
Previously, the icon search selects the 'filled' style by default. This could lead to missing icons that existed in other styles but weren't shown in the search results unless you manually checked each style individually.

I've added an 'All' option to the search. With this new option, the search will include icons from all available styles, ensuring that no icons are missed due to being in a different style. Having the 'All' option available from the start makes it easier to find the desired icon without having to iterate through each style separately.

https://deploy-preview-41415--material-ui.netlify.app/material-ui/material-icons/