### PR TITLE
[pigment-css] Example fix leading spaces

### DIFF
--- a/examples/pigment-css-nextjs-ts/src/app/page.tsx
+++ b/examples/pigment-css-nextjs-ts/src/app/page.tsx
@@ -71,8 +71,7 @@ export default function Home() {
       })}
     >
       <h1
-        className={`
-        ${css(({ theme }) => ({
+        className={`my-custom-class ${css(({ theme }) => ({
           fontFamily: 'system-ui, sans-serif',
           fontSize: '4rem',
           fontWeight: 500,
@@ -153,17 +152,15 @@ export default function Home() {
         </span>
       </h1>
       <div
-        className={`
-          ${css({
-            fontFamily: 'system-ui, sans-serif',
-            letterSpacing: '2px',
-            fontWeight: 500,
-            opacity: 0.5,
-            lineHeight: 2,
-            textAlign: 'center',
-            textWrap: 'balance',
-          })}
-        `}
+        className={css({
+          fontFamily: 'system-ui, sans-serif',
+          letterSpacing: '2px',
+          fontWeight: 500,
+          opacity: 0.5,
+          lineHeight: 2,
+          textAlign: 'center',
+          textWrap: 'balance',
+        })}
       >
         CSS-in-JS library with static extraction
       </div>

--- a/examples/pigment-css-vite-ts/src/App.tsx
+++ b/examples/pigment-css-vite-ts/src/App.tsx
@@ -76,8 +76,7 @@ export default function Home() {
       })}
     >
       <h1
-        className={`
-        ${css(({ theme }) => ({
+        className={`my-custom-class ${css(({ theme }) => ({
           fontFamily: 'system-ui, sans-serif',
           fontSize: '4rem',
           fontWeight: 500,


### PR DESCRIPTION
Fix this strange line break:

<img width="347" alt="SCR-20240310-dlfe" src="https://github.com/mui/material-ui/assets/3165635/a250e482-9342-4b52-b068-14e65a67539a">
