### PR TITLE
[material-ui][Modal] ModalCloseReason type splitted

### DIFF
--- a/docs/data/base/components/modal/UseModal.tsx
+++ b/docs/data/base/components/modal/UseModal.tsx
@@ -7,6 +7,7 @@ import { FocusTrap } from '@mui/base/FocusTrap';
 import { Button } from '@mui/base/Button';
 import { unstable_useModal as useModal } from '@mui/base/unstable_useModal';
 import Fade from '@mui/material/Fade';
+import { ModalCloseReason } from '@mui/material';
 
 export default function UseModal() {
   const [open, setOpen] = React.useState(false);
@@ -50,7 +51,7 @@ interface ModalProps {
   disableScrollLock?: boolean;
   hideBackdrop?: boolean;
   keepMounted?: boolean;
-  onClose?: (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => void;
+  onClose?: (event: {}, reason: ModalCloseReason) => void;
   onTransitionEnter?: () => void;
   onTransitionExited?: () => void;
   open: boolean;

--- a/packages/mui-base/src/Modal/Modal.types.ts
+++ b/packages/mui-base/src/Modal/Modal.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Simplify } from '@mui/types';
+import { ModalCloseReason } from '@mui/material';
 import { PortalProps } from '../Portal';
 import { PolymorphicProps, SlotComponentProps } from '../utils';
 
@@ -91,7 +92,7 @@ export interface ModalOwnProps {
    * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`.
    */
   onClose?: {
-    bivarianceHack(event: {}, reason: 'backdropClick' | 'escapeKeyDown'): void;
+    bivarianceHack(event: {}, reason: ModalCloseReason): void;
   }['bivarianceHack'];
   /**
    * A function called when a transition enters.

--- a/packages/mui-base/src/unstable_useModal/useModal.types.ts
+++ b/packages/mui-base/src/unstable_useModal/useModal.types.ts
@@ -1,3 +1,4 @@
+import { ModalCloseReason } from '@mui/material';
 import { PortalProps } from '../Portal';
 import { EventHandlers } from '../utils';
 
@@ -57,7 +58,7 @@ export type UseModalParameters = {
    * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`.
    */
   onClose?: {
-    bivarianceHack(event: {}, reason: 'backdropClick' | 'escapeKeyDown'): void;
+    bivarianceHack(event: {}, reason: ModalCloseReason): void;
   }['bivarianceHack'];
   onKeyDown?: React.KeyboardEventHandler;
   /**

--- a/packages/mui-joy/src/Modal/ModalProps.ts
+++ b/packages/mui-joy/src/Modal/ModalProps.ts
@@ -3,6 +3,7 @@ import { ModalOwnProps as BaseModalOwnProps } from '@mui/base/Modal';
 import { OverrideProps } from '@mui/types';
 import { SxProps } from '../styles/types';
 import { CreateSlotsAndSlotProps, SlotProps } from '../utils/types';
+import { ModalCloseReason } from '@mui/material';
 
 export type ModalSlot = 'root' | 'backdrop';
 
@@ -49,7 +50,7 @@ export type ModalOwnProps = Pick<
    * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`, `"closeClick"`.
    */
   onClose?: {
-    bivarianceHack(event: {}, reason: 'backdropClick' | 'escapeKeyDown' | 'closeClick'): void;
+    bivarianceHack(event: {}, reason: ModalCloseReason | 'closeClick'): void;
   }['bivarianceHack'];
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.

--- a/packages/mui-material-next/src/Menu/Menu.types.ts
+++ b/packages/mui-material-next/src/Menu/Menu.types.ts
@@ -3,13 +3,15 @@ import * as React from 'react';
 import { SxProps } from '@mui/system';
 import { OverrideProps } from '@mui/types';
 import { SlotComponentProps, MenuActions } from '@mui/base';
-import { InternalStandardProps as StandardProps } from '@mui/material';
+import { InternalStandardProps as StandardProps, ModalCloseReason } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import Popover, { PopoverProps } from '@mui/material/Popover';
 import { MenuListProps } from '@mui/material/MenuList';
 import { Theme } from '@mui/material/styles';
 import { TransitionProps } from '@mui/material/transitions/transition';
 import { MenuClasses } from './menuClasses';
+
+export type MenuCloseReason = ModalCloseReason | 'tabKeyDown';
 
 export interface MenuTypeMap<AdditionalProps = {}, RootComponent extends React.ElementType = 'ul'> {
   props: AdditionalProps &
@@ -59,7 +61,7 @@ export interface MenuTypeMap<AdditionalProps = {}, RootComponent extends React.E
        * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`, `"tabKeyDown"`.
        */
       onClose?: {
-        bivarianceHack(event: {}, reason: 'backdropClick' | 'escapeKeyDown' | 'tabKeyDown'): void;
+        bivarianceHack(event: {}, reason: MenuCloseReason): void;
       }['bivarianceHack'];
       /**
        * If `true`, the component is shown.

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -14,6 +14,8 @@ export interface ModalOwnerState extends ModalProps {
   exited: boolean;
 }
 
+export type ModalCloseReason = 'backdropClick' | 'escapeKeyDown';
+
 export interface ModalSlots {
   /**
    * The component that renders the root.
@@ -164,7 +166,7 @@ export interface ModalOwnProps {
    * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`.
    */
   onClose?: {
-    bivarianceHack(event: {}, reason: 'backdropClick' | 'escapeKeyDown'): void;
+    bivarianceHack(event: {}, reason: ModalCloseReason): void;
   }['bivarianceHack'];
   /**
    * A function called when a transition enters.


### PR DESCRIPTION
## Changelog
- ModalCloseReason type has been isolated.
- Fixed the types of components affected by the Modal's onClose Prop.

## Reason
Currently, defining a CloseReason for a customized Modal requires a cumbersome type declaration. ex) `Parameters<ModalProps['onClose']>[0]`. Simplify this with something like SnackbarCloseReason. https://github.com/mui/material-ui/blob/a13dfe329d07541900f072c9e32d62d86a7529db/packages/mui-material/src/Snackbar/Snackbar.d.ts#L15

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
