### PR TITLE
[docs] Add notification about Toolpad internal usage

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -22,6 +22,6 @@
   {
     "id": 81,
     "title": "MUI dogfooded Toolpad. See how!",
-    "text": "Learn how we used Toolpad to build some of our internal tooling at MUI. <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"toolpad-use-cases\" href=\"https://mui.com/blog/toolpad-use-cases/\">Read the blog post</a> and learn how you can use it too."
+    "text": "Learn how we used Toolpad to build some of our internal tools at MUI. <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"toolpad-use-cases\" href=\"https://mui.com/blog/toolpad-use-cases/\">Read the blog post</a> and learn how you can use it too."
   }
 ]

--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -18,5 +18,10 @@
     "id": 80,
     "title": "MUI X v7.0.0-beta.0",
     "text": "Featuring new components and multiple enhancements for both developers and end-users. Discover all the specifics in the <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-v7-beta\" href=\"https://mui.com/blog/mui-x-v7-beta/\">announcement blog post</a>."
+  },
+  {
+    "id": 81,
+    "title": "MUI dogfooded Toolpad. See how!",
+    "text": "Learn how we used Toolpad to build some of our internal tooling at MUI. <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"toolpad-use-cases\" href=\"https://mui.com/blog/toolpad-use-cases/\">Read the blog post</a> and learn how you can use it too."
   }
 ]


### PR DESCRIPTION
<img width="392" alt="Screenshot 2024-03-11 at 11 48 44 AM" src="https://github.com/mui/material-ui/assets/92228082/172f403f-2355-49f2-a0ba-a87d7ea281c7">


Another option:
<img width="368" alt="Screenshot 2024-03-11 at 4 08 34 PM" src="https://github.com/mui/material-ui/assets/92228082/6c804f30-c60c-4264-8da5-cc4c61e48195">



<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
