### PR TITLE
[joy-ui][ButtonGroup] Using css pseudo selectors for button group styles

### DIFF
--- a/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/mui-joy/src/ButtonGroup/ButtonGroup.tsx
@@ -84,7 +84,7 @@ export const StyledButtonGroup = styled('div')<{ ownerState: ButtonGroupOwnerSta
       borderRadius: 'var(--ButtonGroup-radius)',
       flexDirection: ownerState.orientation === 'vertical' ? 'column' : 'row',
       // first Button or IconButton
-      [`& > [data-first-child]`]: {
+      [`& > :first-child`]: {
         '--Button-radius': firstChildRadius,
         '--IconButton-radius': firstChildRadius,
         ...(ownerState.orientation === 'horizontal' && {
@@ -95,7 +95,7 @@ export const StyledButtonGroup = styled('div')<{ ownerState: ButtonGroupOwnerSta
         }),
       },
       // middle Buttons or IconButtons
-      [`& > :not([data-first-child]):not([data-last-child]):not(:only-child)`]: {
+      [`& > :not(:first-child):not(:last-child)`]: {
         '--Button-radius': 'var(--unstable_childRadius)',
         '--IconButton-radius': 'var(--unstable_childRadius)',
         borderRadius: 'var(--unstable_childRadius)',
@@ -109,7 +109,7 @@ export const StyledButtonGroup = styled('div')<{ ownerState: ButtonGroupOwnerSta
         }),
       },
       // last Button or IconButton
-      [`& > [data-last-child]`]: {
+      [`& > :last-child`]: {
         '--Button-radius': lastChildRadius,
         '--IconButton-radius': lastChildRadius,
         ...(ownerState.orientation === 'horizontal' && {
@@ -124,7 +124,7 @@ export const StyledButtonGroup = styled('div')<{ ownerState: ButtonGroupOwnerSta
         '--Button-radius': 'var(--ButtonGroup-radius)',
         '--IconButton-radius': 'var(--ButtonGroup-radius)',
       },
-      [`& > :not([data-first-child]):not(:only-child)`]: {
+      [`& > :not(:first-child):not(:only-child)`]: {
         '--Button-margin': margin,
         '--IconButton-margin': margin,
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related issues: #39372 #40021

This is a proposal pull request which works and fixes the mentioned issues, using pseudo selectors works fine.

However is there a reason we use data-ids instead of pseudo selectors? If this is good, I will also update the tests.

