### PR TITLE
 [joy-ui][Accordion][AccordionGroup] Using css pseudo selectors for accordion group styles

### DIFF
--- a/packages/mui-joy/src/Accordion/Accordion.tsx
+++ b/packages/mui-joy/src/Accordion/Accordion.tsx
@@ -38,10 +38,10 @@ const AccordionRoot = styled(StyledListItem as unknown as 'div', {
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: AccordionOwnerState }>({
   borderBottom: 'var(--Accordion-borderBottom)',
-  '&[data-first-child]': {
+  ':first-child': {
     '--ListItem-radius': 'var(--unstable_List-childRadius) var(--unstable_List-childRadius) 0 0',
   },
-  '&[data-last-child]': {
+  ':last-child': {
     '--ListItem-radius': '0 0 var(--unstable_List-childRadius) var(--unstable_List-childRadius)',
     '& [aria-expanded="true"]': {
       '--ListItem-radius': '0',
@@ -51,7 +51,7 @@ const AccordionRoot = styled(StyledListItem as unknown as 'div', {
         '0 0 var(--unstable_List-childRadius) var(--unstable_List-childRadius)',
     },
   },
-  '&:not([data-first-child]):not([data-last-child])': {
+  '&:not(:first-child):not(:last-child)': {
     '--ListItem-radius': '0',
   },
 });

--- a/packages/mui-joy/src/AccordionGroup/AccordionGroup.tsx
+++ b/packages/mui-joy/src/AccordionGroup/AccordionGroup.tsx
@@ -58,7 +58,7 @@ const AccordionGroupRoot = styled(StyledList as unknown as 'div', {
     '--ListDivider-gap': '0px',
     ...transition,
     ...(!ownerState.disableDivider && {
-      [`& .${accordionClasses.root}:not([data-last-child])`]: {
+      [`& .${accordionClasses.root}:not(:last-child)`]: {
         '--Accordion-borderBottom': `1px solid ${theme.vars.palette.divider}`,
       },
     }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Related issues: https://github.com/mui/material-ui/issues/40548

Using pseudo selectors seems to be fixing the issue here, I have opened one more PR for the ButtonGroup. If this implementation is fine, I will update the tests.