### PR TITLE
[joy-ui][docs] Add UI improvements to the side navigation demo

### DIFF
--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -31,7 +31,6 @@ export default function ColorInversionNavigation() {
     <Box sx={{ display: 'flex', borderRadius: 'sm', overflow: 'auto' }}>
       <Sheet
         variant="solid"
-        color="neutral"
         invertedColors
         sx={{
           p: 2,

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -139,7 +139,7 @@ export default function ColorInversionNavigation() {
       <Sheet
         variant="solid"
         invertedColors
-        sx={(theme) => ({
+        sx={{
           p: 2,
           display: 'flex',
           flexDirection: 'column',
@@ -154,7 +154,7 @@ export default function ColorInversionNavigation() {
             padding: 0,
             '--IconButton-size': '3rem',
           },
-        })}
+        }}
       >
         <Badge badgeContent="7" badgeInset="15%" size="sm">
           <IconButton size="lg">

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -89,8 +89,8 @@ export default function ColorInversionNavigation() {
             <Chip
               data-skip-inverted-colors
               size="sm"
-              color="warning"
               variant="soft"
+              color={color}
               sx={{ ml: 'auto' }}
             >
               5

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -17,6 +17,7 @@ import Typography from '@mui/joy/Typography';
 import Select from '@mui/joy/Select';
 import Option from '@mui/joy/Option';
 import Stack from '@mui/joy/Stack';
+import Tooltip from '@mui/joy/Tooltip';
 import Sheet from '@mui/joy/Sheet';
 import PieChart from '@mui/icons-material/PieChart';
 import SmsIcon from '@mui/icons-material/Sms';
@@ -167,9 +168,11 @@ export default function ColorInversionNavigation() {
             <Avatar src="/static/images/avatar/4.jpg" />
           </IconButton>
         </Badge>
-        <IconButton aria-label="Add another chat" sx={{color: "text.tertiary"}}>
-          <AddIcon />
-        </IconButton>
+        <Tooltip title="Add another chat" variant="soft">
+          <IconButton sx={{ color: 'text.tertiary' }}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
         <IconButton
           onClick={() => {
             const colors = ['primary', 'neutral', 'danger', 'success', 'warning'];
@@ -177,7 +180,7 @@ export default function ColorInversionNavigation() {
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto', color: "text.tertiary"}}
+          sx={{ mt: 'auto', color: 'text.tertiary' }}
         >
           <ColorLensRoundedIcon />
         </IconButton>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -16,6 +16,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Typography from '@mui/joy/Typography';
 import Select from '@mui/joy/Select';
 import Option from '@mui/joy/Option';
+import Stack from '@mui/joy/Stack';
 import Sheet from '@mui/joy/Sheet';
 import PieChart from '@mui/icons-material/PieChart';
 import SmsIcon from '@mui/icons-material/Sms';
@@ -44,10 +45,10 @@ export default function ColorInversionNavigation() {
           defaultValue="1"
           size="sm"
           placeholder={
-            <div>
-              <Typography level="inherit">Saleshouse</Typography>
+            <Stack alignItems="start">
+              <Typography level="title-lg">Saleshouse</Typography>
               <Typography level="body-md">general team</Typography>
-            </div>
+            </Stack>
           }
           startDecorator={
             <Sheet

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -41,9 +41,9 @@ export default function ColorInversionNavigation() {
         }}
       >
         <Select
-          variant="outlined"
-          defaultValue="1"
+          variant="soft"
           size="sm"
+          defaultValue="1"
           placeholder={
             <Stack alignItems="start">
               <Typography level="title-lg">Saleshouse</Typography>
@@ -63,7 +63,8 @@ export default function ColorInversionNavigation() {
               <BubbleChartIcon sx={{ m: 0 }} />
             </Sheet>
           }
-          sx={{ py: 1 }}
+          color={color}
+          sx={{py: 1, bgcolor: "transparent", border: "1px solid", borderColor: "divider"}}
         >
           <Option value="1">General team</Option>
           <Option value="2">Engineering team</Option>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -138,14 +138,14 @@ export default function ColorInversionNavigation() {
           p: 2,
           display: 'flex',
           flexDirection: 'column',
+          alignItems: "center",
           gap: 2,
           bgcolor: `${color}.900`,
+
           '& button': {
             borderRadius: '50%',
             padding: 0,
-            '&:hover': {
-              boxShadow: theme.shadow.md,
-            },
+            "--IconButton-size": "3rem",
           },
         })}
       >
@@ -170,8 +170,6 @@ export default function ColorInversionNavigation() {
           <AddIcon />
         </IconButton>
         <IconButton
-          variant="plain"
-          size="sm"
           onClick={() => {
             const colors = ['primary', 'neutral', 'danger', 'success', 'warning'];
 

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Avatar from '@mui/joy/Avatar';
-import Badge, { badgeClasses } from '@mui/joy/Badge';
+import Badge from '@mui/joy/Badge';
 import Box from '@mui/joy/Box';
 import Card from '@mui/joy/Card';
 import CardContent from '@mui/joy/CardContent';
@@ -132,7 +132,6 @@ export default function ColorInversionNavigation() {
       </Sheet>
       <Sheet
         variant="solid"
-        color="neutral"
         invertedColors
         sx={(theme) => ({
           p: 2,
@@ -143,6 +142,7 @@ export default function ColorInversionNavigation() {
           bgcolor: `${color}.900`,
 
           "& .MuiBadge-root": {"--Badge-ringColor": "unset"},
+          "& .MuiBadge-colorSuccess": { bgcolor: "success.400" },
           '& button': {
             borderRadius: '50%',
             padding: 0,
@@ -161,7 +161,7 @@ export default function ColorInversionNavigation() {
             horizontal: 'right',
           }}
           badgeInset="20%"
-          sx={{ [`& .${badgeClasses.badge}`]: { bgcolor: 'success.300' } }}
+          color="success"
         >
           <IconButton size="lg">
             <Avatar src="/static/images/avatar/4.jpg" />

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -142,6 +142,7 @@ export default function ColorInversionNavigation() {
           gap: 2,
           bgcolor: `${color}.900`,
 
+          "& .MuiBadge-root": {"--Badge-ringColor": "unset"},
           '& button': {
             borderRadius: '50%',
             padding: 0,
@@ -149,7 +150,7 @@ export default function ColorInversionNavigation() {
           },
         })}
       >
-        <Badge badgeContent="7" size="sm">
+        <Badge badgeContent="7" badgeInset="15%" size="sm">
           <IconButton size="lg">
             <Avatar src="/static/images/avatar/3.jpg" />
           </IconButton>
@@ -159,7 +160,7 @@ export default function ColorInversionNavigation() {
             vertical: 'bottom',
             horizontal: 'right',
           }}
-          badgeInset="14%"
+          badgeInset="20%"
           sx={{ [`& .${badgeClasses.badge}`]: { bgcolor: 'success.300' } }}
         >
           <IconButton size="lg">

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -43,12 +43,6 @@ export default function ColorInversionNavigation() {
           variant="soft"
           size="sm"
           defaultValue="1"
-          placeholder={
-            <Stack alignItems="start">
-              <Typography level="title-lg">Saleshouse</Typography>
-              <Typography level="body-md">general team</Typography>
-            </Stack>
-          }
           startDecorator={
             <Sheet
               variant="solid"
@@ -145,9 +139,9 @@ export default function ColorInversionNavigation() {
           flexDirection: 'column',
           alignItems: 'center',
           gap: 2,
-          bgcolor: `${color}.900`,
+          bgcolor: `${color}.800`,
 
-          '& .MuiBadge-root': { '--Badge-ringColor': 'unset' },
+          '& .MuiBadge-root': { '--Badge-ringColor': '#FFF' },
           '& .MuiBadge-colorSuccess': { bgcolor: 'success.400' },
           '& button': {
             borderRadius: '50%',
@@ -156,8 +150,8 @@ export default function ColorInversionNavigation() {
           },
         }}
       >
-        <Badge badgeContent="7" badgeInset="15%" size="sm">
-          <IconButton size="lg">
+        <Badge badgeContent="7" badgeInset="10%" size="sm">
+          <IconButton>
             <Avatar src="/static/images/avatar/3.jpg" />
           </IconButton>
         </Badge>
@@ -166,25 +160,24 @@ export default function ColorInversionNavigation() {
             vertical: 'bottom',
             horizontal: 'right',
           }}
-          badgeInset="20%"
+          badgeInset="15%"
           color="success"
         >
-          <IconButton size="lg">
+          <IconButton>
             <Avatar src="/static/images/avatar/4.jpg" />
           </IconButton>
         </Badge>
-        <IconButton size="lg" aria-label="Add another chat">
+        <IconButton aria-label="Add another chat" sx={{color: "text.tertiary"}}>
           <AddIcon />
         </IconButton>
         <IconButton
-          size="lg"
           onClick={() => {
             const colors = ['primary', 'neutral', 'danger', 'success', 'warning'];
 
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto' }}
+          sx={{ mt: 'auto', color: "text.tertiary"}}
         >
           <ColorLensRoundedIcon />
         </IconButton>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -15,9 +15,8 @@ import ListItemButton from '@mui/joy/ListItemButton';
 import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Typography from '@mui/joy/Typography';
 import Select from '@mui/joy/Select';
-import Option from '@mui/joy/Option';
-import Stack from '@mui/joy/Stack';
 import Tooltip from '@mui/joy/Tooltip';
+import Option from '@mui/joy/Option';
 import Sheet from '@mui/joy/Sheet';
 import PieChart from '@mui/icons-material/PieChart';
 import SmsIcon from '@mui/icons-material/Sms';
@@ -42,8 +41,9 @@ export default function ColorInversionNavigation() {
       >
         <Select
           variant="soft"
-          size="sm"
           defaultValue="1"
+          size="sm"
+          color={color}
           startDecorator={
             <Sheet
               variant="solid"
@@ -54,10 +54,9 @@ export default function ColorInversionNavigation() {
                 alignSelf: 'center',
               }}
             >
-              <BubbleChartIcon sx={{ m: 0 }} />
+              <BubbleChartIcon fontSize="small" sx={{ m: 0 }} />
             </Sheet>
           }
-          color={color}
           sx={{
             py: 1,
             bgcolor: 'transparent',
@@ -141,7 +140,6 @@ export default function ColorInversionNavigation() {
           alignItems: 'center',
           gap: 2,
           bgcolor: `${color}.800`,
-
           '& .MuiBadge-root': { '--Badge-ringColor': '#FFF' },
           '& .MuiBadge-colorSuccess': { bgcolor: 'success.400' },
           '& button': {

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -150,7 +150,7 @@ export default function ColorInversionNavigation() {
         })}
       >
         <Badge badgeContent="7" size="sm">
-          <IconButton>
+          <IconButton size="lg">
             <Avatar src="/static/images/avatar/3.jpg" />
           </IconButton>
         </Badge>
@@ -162,23 +162,24 @@ export default function ColorInversionNavigation() {
           badgeInset="14%"
           sx={{ [`& .${badgeClasses.badge}`]: { bgcolor: 'success.300' } }}
         >
-          <IconButton>
+          <IconButton size="lg">
             <Avatar src="/static/images/avatar/4.jpg" />
           </IconButton>
         </Badge>
-        <IconButton variant="soft" aria-label="Add another chat">
+        <IconButton size="lg" aria-label="Add another chat">
           <AddIcon />
         </IconButton>
         <IconButton
+          size="lg"
           onClick={() => {
             const colors = ['primary', 'neutral', 'danger', 'success', 'warning'];
 
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto', height: '40px' }}
+          sx={{ mt: 'auto'}}
         >
-          <ColorLensRoundedIcon fontSize="small" />
+          <ColorLensRoundedIcon />
         </IconButton>
       </Sheet>
     </Box>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -63,7 +63,12 @@ export default function ColorInversionNavigation() {
             </Sheet>
           }
           color={color}
-          sx={{py: 1, bgcolor: "transparent", border: "1px solid", borderColor: "divider"}}
+          sx={{
+            py: 1,
+            bgcolor: 'transparent',
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
         >
           <Option value="1">General team</Option>
           <Option value="2">Engineering team</Option>
@@ -138,16 +143,16 @@ export default function ColorInversionNavigation() {
           p: 2,
           display: 'flex',
           flexDirection: 'column',
-          alignItems: "center",
+          alignItems: 'center',
           gap: 2,
           bgcolor: `${color}.900`,
 
-          "& .MuiBadge-root": {"--Badge-ringColor": "unset"},
-          "& .MuiBadge-colorSuccess": { bgcolor: "success.400" },
+          '& .MuiBadge-root': { '--Badge-ringColor': 'unset' },
+          '& .MuiBadge-colorSuccess': { bgcolor: 'success.400' },
           '& button': {
             borderRadius: '50%',
             padding: 0,
-            "--IconButton-size": "3rem",
+            '--IconButton-size': '3rem',
           },
         })}
       >
@@ -179,7 +184,7 @@ export default function ColorInversionNavigation() {
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto'}}
+          sx={{ mt: 'auto' }}
         >
           <ColorLensRoundedIcon />
         </IconButton>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.js
@@ -35,7 +35,7 @@ export default function ColorInversionNavigation() {
         sx={{
           p: 2,
           ...(color !== 'neutral' && {
-            bgcolor: `${color}.800`,
+            bgcolor: `${color}.700`,
           }),
         }}
       >
@@ -131,7 +131,7 @@ export default function ColorInversionNavigation() {
         </Card>
       </Sheet>
       <Sheet
-        variant="soft"
+        variant="solid"
         color="neutral"
         invertedColors
         sx={(theme) => ({
@@ -139,9 +139,7 @@ export default function ColorInversionNavigation() {
           display: 'flex',
           flexDirection: 'column',
           gap: 2,
-          ...(color !== 'neutral' && {
-            bgcolor: `${color}.900`,
-          }),
+          bgcolor: `${color}.900`,
           '& button': {
             borderRadius: '50%',
             padding: 0,

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -31,7 +31,6 @@ export default function ColorInversionNavigation() {
     <Box sx={{ display: 'flex', borderRadius: 'sm', overflow: 'auto' }}>
       <Sheet
         variant="solid"
-        color="neutral"
         invertedColors
         sx={{
           p: 2,

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -63,7 +63,12 @@ export default function ColorInversionNavigation() {
             </Sheet>
           }
           color={color}
-          sx={{py: 1, bgcolor: "transparent", border: "1px solid", borderColor: "divider"}}
+          sx={{
+            py: 1,
+            bgcolor: 'transparent',
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
         >
           <Option value="1">General team</Option>
           <Option value="2">Engineering team</Option>
@@ -138,16 +143,16 @@ export default function ColorInversionNavigation() {
           p: 2,
           display: 'flex',
           flexDirection: 'column',
-          alignItems: "center",
+          alignItems: 'center',
           gap: 2,
           bgcolor: `${color}.900`,
 
-          "& .MuiBadge-root": {"--Badge-ringColor": "unset"},
-          "& .MuiBadge-colorSuccess": {bgcolor: "success.400"},
+          '& .MuiBadge-root': { '--Badge-ringColor': 'unset' },
+          '& .MuiBadge-colorSuccess': { bgcolor: 'success.400' },
           '& button': {
             borderRadius: '50%',
             padding: 0,
-            "--IconButton-size": "3rem",
+            '--IconButton-size': '3rem',
           },
         })}
       >
@@ -184,7 +189,7 @@ export default function ColorInversionNavigation() {
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto'}}
+          sx={{ mt: 'auto' }}
         >
           <ColorLensRoundedIcon />
         </IconButton>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -16,6 +16,7 @@ import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Typography from '@mui/joy/Typography';
 import Select from '@mui/joy/Select';
 import Stack from '@mui/joy/Stack';
+import Tooltip from '@mui/joy/Tooltip';
 import Option from '@mui/joy/Option';
 import Sheet from '@mui/joy/Sheet';
 import PieChart from '@mui/icons-material/PieChart';
@@ -167,9 +168,11 @@ export default function ColorInversionNavigation() {
             <Avatar src="/static/images/avatar/4.jpg" />
           </IconButton>
         </Badge>
-        <IconButton aria-label="Add another chat" sx={{color: "text.tertiary"}}>
-          <AddIcon />
-        </IconButton>
+        <Tooltip title="Add another chat" variant="soft">
+          <IconButton sx={{ color: 'text.tertiary' }}>
+            <AddIcon />
+          </IconButton>
+        </Tooltip>
         <IconButton
           onClick={() => {
             const colors: ColorPaletteProp[] = [
@@ -182,7 +185,7 @@ export default function ColorInversionNavigation() {
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto', color: "text.tertiary" }}
+          sx={{ mt: 'auto', color: 'text.tertiary' }}
         >
           <ColorLensRoundedIcon />
         </IconButton>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -15,6 +15,7 @@ import ListItemButton from '@mui/joy/ListItemButton';
 import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Typography from '@mui/joy/Typography';
 import Select from '@mui/joy/Select';
+import Stack from '@mui/joy/Stack';
 import Option from '@mui/joy/Option';
 import Sheet from '@mui/joy/Sheet';
 import PieChart from '@mui/icons-material/PieChart';
@@ -44,10 +45,10 @@ export default function ColorInversionNavigation() {
           defaultValue="1"
           size="sm"
           placeholder={
-            <div>
-              <Typography level="inherit">Saleshouse</Typography>
+            <Stack alignItems="start">
+              <Typography level="title-lg">Saleshouse</Typography>
               <Typography level="body-md">general team</Typography>
-            </div>
+            </Stack>
           }
           startDecorator={
             <Sheet

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -139,7 +139,7 @@ export default function ColorInversionNavigation() {
       <Sheet
         variant="solid"
         invertedColors
-        sx={(theme) => ({
+        sx={{
           p: 2,
           display: 'flex',
           flexDirection: 'column',
@@ -154,7 +154,7 @@ export default function ColorInversionNavigation() {
             padding: 0,
             '--IconButton-size': '3rem',
           },
-        })}
+        }}
       >
         <Badge badgeContent="7" badgeInset="15%" size="sm">
           <IconButton size="lg">

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -89,8 +89,8 @@ export default function ColorInversionNavigation() {
             <Chip
               data-skip-inverted-colors
               size="sm"
-              color="warning"
               variant="soft"
+              color={color}
               sx={{ ml: 'auto' }}
             >
               5

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -41,7 +41,7 @@ export default function ColorInversionNavigation() {
         }}
       >
         <Select
-          variant="outlined"
+          variant="soft"
           defaultValue="1"
           size="sm"
           placeholder={
@@ -63,7 +63,8 @@ export default function ColorInversionNavigation() {
               <BubbleChartIcon sx={{ m: 0 }} />
             </Sheet>
           }
-          sx={{ py: 1 }}
+          color={color}
+          sx={{py: 1, bgcolor: "transparent", border: "1px solid", borderColor: "divider"}}
         >
           <Option value="1">General team</Option>
           <Option value="2">Engineering team</Option>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -35,7 +35,7 @@ export default function ColorInversionNavigation() {
         sx={{
           p: 2,
           ...(color !== 'neutral' && {
-            bgcolor: `${color}.800`,
+            bgcolor: `${color}.700`,
           }),
         }}
       >
@@ -139,9 +139,7 @@ export default function ColorInversionNavigation() {
           display: 'flex',
           flexDirection: 'column',
           gap: 2,
-          ...(color !== 'neutral' && {
-            bgcolor: `${color}.900`,
-          }),
+          bgcolor: `${color}.900`,
           '& button': {
             borderRadius: '50%',
             padding: 0,

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -15,7 +15,6 @@ import ListItemButton from '@mui/joy/ListItemButton';
 import ListItemDecorator from '@mui/joy/ListItemDecorator';
 import Typography from '@mui/joy/Typography';
 import Select from '@mui/joy/Select';
-import Stack from '@mui/joy/Stack';
 import Tooltip from '@mui/joy/Tooltip';
 import Option from '@mui/joy/Option';
 import Sheet from '@mui/joy/Sheet';
@@ -44,6 +43,7 @@ export default function ColorInversionNavigation() {
           variant="soft"
           defaultValue="1"
           size="sm"
+          color={color}
           startDecorator={
             <Sheet
               variant="solid"
@@ -54,10 +54,9 @@ export default function ColorInversionNavigation() {
                 alignSelf: 'center',
               }}
             >
-              <BubbleChartIcon sx={{ m: 0 }} />
+              <BubbleChartIcon fontSize="small" sx={{ m: 0 }} />
             </Sheet>
           }
-          color={color}
           sx={{
             py: 1,
             bgcolor: 'transparent',
@@ -141,7 +140,6 @@ export default function ColorInversionNavigation() {
           alignItems: 'center',
           gap: 2,
           bgcolor: `${color}.800`,
-
           '& .MuiBadge-root': { '--Badge-ringColor': '#FFF' },
           '& .MuiBadge-colorSuccess': { bgcolor: 'success.400' },
           '& button': {

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -131,21 +131,20 @@ export default function ColorInversionNavigation() {
         </Card>
       </Sheet>
       <Sheet
-        variant="soft"
+        variant="solid"
         color="neutral"
         invertedColors
         sx={(theme) => ({
           p: 2,
           display: 'flex',
           flexDirection: 'column',
+          alignItems: "center",
           gap: 2,
           bgcolor: `${color}.900`,
           '& button': {
             borderRadius: '50%',
             padding: 0,
-            '&:hover': {
-              boxShadow: theme.shadow.md,
-            },
+            "--IconButton-size": "3rem",
           },
         })}
       >
@@ -170,8 +169,6 @@ export default function ColorInversionNavigation() {
           <AddIcon />
         </IconButton>
         <IconButton
-          variant="plain"
-          size="sm"
           onClick={() => {
             const colors: ColorPaletteProp[] = [
               'primary',

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ColorPaletteProp } from '@mui/joy/styles';
 import Avatar from '@mui/joy/Avatar';
-import Badge, { badgeClasses } from '@mui/joy/Badge';
+import Badge from '@mui/joy/Badge';
 import Box from '@mui/joy/Box';
 import Card from '@mui/joy/Card';
 import CardContent from '@mui/joy/CardContent';
@@ -132,7 +132,6 @@ export default function ColorInversionNavigation() {
       </Sheet>
       <Sheet
         variant="solid"
-        color="neutral"
         invertedColors
         sx={(theme) => ({
           p: 2,
@@ -143,6 +142,7 @@ export default function ColorInversionNavigation() {
           bgcolor: `${color}.900`,
 
           "& .MuiBadge-root": {"--Badge-ringColor": "unset"},
+          "& .MuiBadge-colorSuccess": {bgcolor: "success.400"},
           '& button': {
             borderRadius: '50%',
             padding: 0,
@@ -161,7 +161,7 @@ export default function ColorInversionNavigation() {
             horizontal: 'right',
           }}
           badgeInset="20%"
-          sx={{ [`& .${badgeClasses.badge}`]: { bgcolor: 'success.300' } }}
+          color="success"
         >
           <IconButton size="lg">
             <Avatar src="/static/images/avatar/4.jpg" />

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -43,12 +43,6 @@ export default function ColorInversionNavigation() {
           variant="soft"
           defaultValue="1"
           size="sm"
-          placeholder={
-            <Stack alignItems="start">
-              <Typography level="title-lg">Saleshouse</Typography>
-              <Typography level="body-md">general team</Typography>
-            </Stack>
-          }
           startDecorator={
             <Sheet
               variant="solid"
@@ -145,9 +139,9 @@ export default function ColorInversionNavigation() {
           flexDirection: 'column',
           alignItems: 'center',
           gap: 2,
-          bgcolor: `${color}.900`,
+          bgcolor: `${color}.800`,
 
-          '& .MuiBadge-root': { '--Badge-ringColor': 'unset' },
+          '& .MuiBadge-root': { '--Badge-ringColor': '#FFF' },
           '& .MuiBadge-colorSuccess': { bgcolor: 'success.400' },
           '& button': {
             borderRadius: '50%',
@@ -156,8 +150,8 @@ export default function ColorInversionNavigation() {
           },
         }}
       >
-        <Badge badgeContent="7" badgeInset="15%" size="sm">
-          <IconButton size="lg">
+        <Badge badgeContent="7" badgeInset="10%" size="sm">
+          <IconButton>
             <Avatar src="/static/images/avatar/3.jpg" />
           </IconButton>
         </Badge>
@@ -166,18 +160,17 @@ export default function ColorInversionNavigation() {
             vertical: 'bottom',
             horizontal: 'right',
           }}
-          badgeInset="20%"
+          badgeInset="15%"
           color="success"
         >
-          <IconButton size="lg">
+          <IconButton>
             <Avatar src="/static/images/avatar/4.jpg" />
           </IconButton>
         </Badge>
-        <IconButton size="lg" aria-label="Add another chat">
+        <IconButton aria-label="Add another chat" sx={{color: "text.tertiary"}}>
           <AddIcon />
         </IconButton>
         <IconButton
-          size="lg"
           onClick={() => {
             const colors: ColorPaletteProp[] = [
               'primary',
@@ -189,7 +182,7 @@ export default function ColorInversionNavigation() {
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto' }}
+          sx={{ mt: 'auto', color: "text.tertiary" }}
         >
           <ColorLensRoundedIcon />
         </IconButton>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -149,7 +149,7 @@ export default function ColorInversionNavigation() {
         })}
       >
         <Badge badgeContent="7" size="sm">
-          <IconButton>
+          <IconButton size="lg">
             <Avatar src="/static/images/avatar/3.jpg" />
           </IconButton>
         </Badge>
@@ -161,14 +161,15 @@ export default function ColorInversionNavigation() {
           badgeInset="14%"
           sx={{ [`& .${badgeClasses.badge}`]: { bgcolor: 'success.300' } }}
         >
-          <IconButton>
+          <IconButton size="lg">
             <Avatar src="/static/images/avatar/4.jpg" />
           </IconButton>
         </Badge>
-        <IconButton variant="soft" aria-label="Add another chat">
+        <IconButton size="lg" aria-label="Add another chat">
           <AddIcon />
         </IconButton>
         <IconButton
+          size="lg"
           onClick={() => {
             const colors: ColorPaletteProp[] = [
               'primary',
@@ -180,9 +181,9 @@ export default function ColorInversionNavigation() {
             const nextColorIndex = colors.indexOf(color) + 1;
             setColor(colors[nextColorIndex] ?? colors[0]);
           }}
-          sx={{ mt: 'auto', height: '40px' }}
+          sx={{ mt: 'auto'}}
         >
-          <ColorLensRoundedIcon fontSize="small" />
+          <ColorLensRoundedIcon />
         </IconButton>
       </Sheet>
     </Box>

--- a/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
+++ b/docs/data/joy/main-features/color-inversion/ColorInversionNavigation.tsx
@@ -141,6 +141,8 @@ export default function ColorInversionNavigation() {
           alignItems: "center",
           gap: 2,
           bgcolor: `${color}.900`,
+
+          "& .MuiBadge-root": {"--Badge-ringColor": "unset"},
           '& button': {
             borderRadius: '50%',
             padding: 0,
@@ -148,7 +150,7 @@ export default function ColorInversionNavigation() {
           },
         })}
       >
-        <Badge badgeContent="7" size="sm">
+        <Badge badgeContent="7" badgeInset="15%" size="sm">
           <IconButton size="lg">
             <Avatar src="/static/images/avatar/3.jpg" />
           </IconButton>
@@ -158,7 +160,7 @@ export default function ColorInversionNavigation() {
             vertical: 'bottom',
             horizontal: 'right',
           }}
-          badgeInset="14%"
+          badgeInset="20%"
           sx={{ [`& .${badgeClasses.badge}`]: { bgcolor: 'success.300' } }}
         >
           <IconButton size="lg">


### PR DESCRIPTION
Several enhancements to the [side navigation](https://mui.com/joy-ui/main-features/color-inversion/#side-navigation) in this pull request. 

https://deploy-preview-41461--material-ui.netlify.app/joy-ui/main-features/color-inversion/#side-navigation

Here’s a concise overview:

### 1. Fixing IconButton Interactions:
+ Resolved issues related to light and dark mode interactions.
+ Improved consistency across both color schemes.

### 2. Avatar Interaction Enhancement:
+ When an Avatar contains a picture, all icon button properties are now accessible.
+ Before the only remaining visual cue is the cursor pointer, which indicates that the avatar is clickable, now all iconbutton behaviour is inherited.

### 3. Specific Fixes and Modifications:
+ Corrected distortion in the plus icon button.

![Screenshot Capture - 2024-03-12 - 11-16-40](https://github.com/mui/material-ui/assets/73669345/3ffac2bb-7c04-4df9-989d-ed63939f5ed4)

+ Enhanced visual separation between the right and left sidebars, especially noticeable when switching color schemes.

**Before** 
![Screenshot Capture - 2024-03-11 - 21-59-14](https://github.com/mui/material-ui/assets/73669345/0b410fce-db36-4052-ba1f-df4425b16223)

**After**
![Screenshot Capture - 2024-03-11 - 21-59-47](https://github.com/mui/material-ui/assets/73669345/d2f671ba-2252-4b3f-b7ab-b4bc98d4bfb3)


+ Ensured consistency in the select menu colors.
**Before**

![Screenshot Capture - 2024-03-12 - 11-18-14](https://github.com/mui/material-ui/assets/73669345/0d3c983d-d8e8-4ff7-8506-bebe96b72b1c)

**After**
![Screenshot Capture - 2024-03-12 - 11-18-45](https://github.com/mui/material-ui/assets/73669345/cce01b51-b3f5-4b03-abdb-5faded8f5ea0)



Other changes are explained withing each commit message.