### PR TITLE
[code-infra] Copy translations.json to @mui/docs build folder

### DIFF
--- a/packages/mui-docs/package.json
+++ b/packages/mui-docs/package.json
@@ -29,7 +29,7 @@
     "build:node": "node ../../scripts/build.mjs node",
     "build:stable": "node ../../scripts/build.mjs stable",
     "build:types": "node ../../scripts/buildTypes.mjs",
-    "build:copy-files": "node ../../scripts/copyFiles.mjs",
+    "build:copy-files": "node ../../scripts/copyFiles.mjs ./src/translations/translations.json:./translations/translations.json",
     "prebuild": "rimraf build",
     "release": "pnpm build && pnpm publish",
     "test": "exit 0"

--- a/scripts/copyFiles.mjs
+++ b/scripts/copyFiles.mjs
@@ -52,9 +52,10 @@ async function run() {
     const packageData = await createPackageFile();
 
     await Promise.all(
-      ['./README.md', '../../CHANGELOG.md', '../../LICENSE', ...extraFiles].map((file) =>
-        includeFileInBuild(file),
-      ),
+      ['./README.md', '../../CHANGELOG.md', '../../LICENSE', ...extraFiles].map(async (file) => {
+        const [sourcePath, targetPath] = file.split(':');
+        await includeFileInBuild(sourcePath, targetPath);
+      }),
     );
 
     await addLicense(packageData);

--- a/scripts/copyFilesUtils.mjs
+++ b/scripts/copyFilesUtils.mjs
@@ -6,9 +6,17 @@ import glob from 'fast-glob';
 const packagePath = process.cwd();
 const buildPath = path.join(packagePath, './build');
 
-export async function includeFileInBuild(file) {
+/**
+ * Copies a file into the build directory. By default it copies it under the same
+ * base name in the root, but you can provide a second argument to specify a
+ * different subpath.
+ * @param {string} file source file path
+ * @param {string=} target target file path
+ * @returns {Promise<void>}
+ */
+export async function includeFileInBuild(file, target = path.basename(file)) {
   const sourcePath = path.resolve(packagePath, file);
-  const targetPath = path.resolve(buildPath, path.basename(file));
+  const targetPath = path.resolve(buildPath, target);
   await fse.copy(sourcePath, targetPath);
   console.log(`Copied ${sourcePath} to ${targetPath}`);
 }


### PR DESCRIPTION
Copy translation files into the build folder. These are unfortunately not automatically copied to the build folder as our build system only simply transpiles a set of source files and doesn't resolve imports correctly as a real bundler would.

Fixes https://github.com/mui/material-ui/pull/41246#issuecomment-1991571357