### PR TITLE
[utils] Fix visually hidden styles' margin unit

### DIFF
--- a/packages/mui-base/src/useSelect/useSelect.test.tsx
+++ b/packages/mui-base/src/useSelect/useSelect.test.tsx
@@ -44,7 +44,7 @@ describe('useSelect', () => {
           border: 0,
           clip: 'rect(0 0 0 0)',
           height: '1px',
-          margin: -1,
+          margin: '-1px',
           overflow: 'hidden',
           padding: 0,
           position: 'absolute',

--- a/packages/mui-utils/src/visuallyHidden/visuallyHidden.ts
+++ b/packages/mui-utils/src/visuallyHidden/visuallyHidden.ts
@@ -2,7 +2,7 @@ const visuallyHidden: import('react').CSSProperties = {
   border: 0,
   clip: 'rect(0 0 0 0)',
   height: '1px',
-  margin: -1,
+  margin: '-1px',
   overflow: 'hidden',
   padding: 0,
   position: 'absolute',


### PR DESCRIPTION
Added the `px` unit to the visuallyHidden styles margin definition, as per https://github.com/mui/base-ui/pull/135#issuecomment-1993956186
