### PR TITLE
[mui-material][Drawer] Fix unrecognized slotProps on DOM with permanent/persistent variant

### DIFF
--- a/packages/mui-material/src/Drawer/Drawer.js
+++ b/packages/mui-material/src/Drawer/Drawer.js
@@ -168,6 +168,8 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
     PaperProps = {},
     SlideProps,
     // eslint-disable-next-line react/prop-types
+    slotProps,
+    // eslint-disable-next-line react/prop-types
     TransitionComponent = Slide,
     transitionDuration = defaultTransitionDuration,
     variant = 'temporary',
@@ -191,6 +193,7 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
     elevation,
     open,
     variant,
+    slotProps,
     ...other,
   };
 
@@ -259,6 +262,7 @@ const Drawer = React.forwardRef(function Drawer(inProps, ref) {
       ownerState={ownerState}
       onClose={onClose}
       hideBackdrop={hideBackdrop}
+      slotProps={slotProps}
       ref={ref}
       {...other}
       {...ModalProps}


### PR DESCRIPTION
…
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This pull request fixes issue when `slotProps` passed alongside with `variant='permanent' | 'persistent'`

![image](https://github.com/mui/material-ui/assets/28603752/28164970-6fb5-4e03-818f-cf938f8a5f7f)

```
   <Drawer
      open={true}
      variant='permanent'
      slotProps={{}}
    >
      {children}
    </Drawer>
```

or when overrides are present in theme 
```
export default {
  defaultProps: {
    slotProps: {
      backdrop: { invisible: true }
    }
  },
} as Components<Theme>['MuiDrawer'];
```

