### PR TITLE
[material-ui][AvatarGroup] Convert to support CSS extraction

### DIFF
--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -1374,13 +1374,13 @@ importers:
         version: file:../packages/mui-base/build(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: file:../../packages/mui-icons-material/build
-        version: file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0)
+        version: file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0)
       '@mui/material':
         specifier: file:../../packages/mui-material/build
         version: file:../packages/mui-material/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/material-nextjs':
         specifier: file:../../packages/mui-material-nextjs/build
-        version: file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.12)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0)
+        version: file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.13)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0)
       '@mui/system':
         specifier: file:../../packages/mui-system/build
         version: file:../packages/mui-system/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react@18.2.0)
@@ -1432,7 +1432,7 @@ importers:
         version: file:../packages/mui-base/build(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: file:../../packages/mui-icons-material/build
-        version: file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0)
+        version: file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0)
       '@mui/material':
         specifier: file:../../packages/mui-material/build
         version: file:../packages/mui-material/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
@@ -8991,7 +8991,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0):
+  file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0):
     resolution: {directory: ../packages/mui-icons-material/build, type: directory}
     id: file:../packages/mui-icons-material/build
     name: '@mui/icons-material'
@@ -9010,7 +9010,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.12)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0):
+  file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.13)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0):
     resolution: {directory: ../packages/mui-material-nextjs/build, type: directory}
     id: file:../packages/mui-material-nextjs/build
     name: '@mui/material-nextjs'

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -9,6 +9,11 @@ import { styled, createUseThemeProps } from '../zero-styled';
 import Avatar, { avatarClasses } from '../Avatar';
 import avatarGroupClasses, { getAvatarGroupUtilityClass } from './avatarGroupClasses';
 
+const SPACINGS = {
+  small: -16,
+  medium: -8,
+};
+
 const useThemeProps = createUseThemeProps('MuiAlert');
 
 const useUtilityClasses = (ownerState) => {
@@ -40,16 +45,22 @@ const AvatarGroupRoot = styled('div', {
     {
       props: { spacing: 'small' },
       style: {
-        [`& .${avatarClasses.root}:not(:last-of-type)`]: {
-          marginLeft: -16,
+        [`& .${avatarClasses.root}:not(:last-child)`]: {
+          marginLeft: 'var(--AvatarGroup-spacing, -16px)',
+        },
+        [`& .${avatarClasses.root}:last-child`]: {
+          marginLeft: 0,
         },
       },
     },
     {
       props: { spacing: 'medium' },
       style: {
-        [`& .${avatarClasses.root}:not(:last-of-type)`]: {
-          marginLeft: -8,
+        [`& .${avatarClasses.root}:not(:last-child)`]: {
+          marginLeft: 'var(--AvatarGroup-spacing, -8px)',
+        },
+        [`& .${avatarClasses.root}:last-child`]: {
+          marginLeft: 0,
         },
       },
     },
@@ -116,6 +127,11 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
 
   const additionalAvatarSlotProps = slotProps.additionalAvatar ?? componentsProps.additionalAvatar;
 
+  const marginValue =
+    ownerState.spacing && SPACINGS[ownerState.spacing] !== undefined
+      ? SPACINGS[ownerState.spacing]
+      : -ownerState.spacing || -8;
+
   return (
     <AvatarGroupRoot
       as={component}
@@ -129,6 +145,10 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
           variant={variant}
           {...additionalAvatarSlotProps}
           className={clsx(classes.avatar, additionalAvatarSlotProps?.className)}
+          style={{
+            '--AvatarRoot-spacing': marginValue ? `${marginValue}px` : undefined,
+            ...other.style,
+          }}
         >
           {extraAvatarsElement}
         </Avatar>

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -239,6 +239,10 @@ AvatarGroup.propTypes /* remove-proptypes */ = {
    */
   spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
   /**
+   * @ignore
+   */
+  style: PropTypes.object,
+  /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */
   sx: PropTypes.oneOfType([

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -40,31 +40,11 @@ const AvatarGroupRoot = styled('div', {
   [`& .${avatarClasses.root}`]: {
     border: `2px solid ${(theme.vars || theme).palette.background.default}`,
     boxSizing: 'content-box',
+    marginLeft: 'var(--AvatarGroup-spacing, -8px)',
+    '&:last-child': {
+      marginLeft: 0,
+    },
   },
-  variants: [
-    {
-      props: { spacing: 'small' },
-      style: {
-        [`& .${avatarClasses.root}:not(:last-child)`]: {
-          marginLeft: 'var(--AvatarGroup-spacing, -16px)',
-        },
-        [`& .${avatarClasses.root}:last-child`]: {
-          marginLeft: 0,
-        },
-      },
-    },
-    {
-      props: { spacing: 'medium' },
-      style: {
-        [`& .${avatarClasses.root}:not(:last-child)`]: {
-          marginLeft: 'var(--AvatarGroup-spacing, -8px)',
-        },
-        [`& .${avatarClasses.root}:last-child`]: {
-          marginLeft: 0,
-        },
-      },
-    },
-  ],
 }));
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -5,10 +5,11 @@ import { isFragment } from 'react-is';
 import clsx from 'clsx';
 import chainPropTypes from '@mui/utils/chainPropTypes';
 import composeClasses from '@mui/utils/composeClasses';
-import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { styled, createUseThemeProps } from '../zero-styled';
 import Avatar, { avatarClasses } from '../Avatar';
 import avatarGroupClasses, { getAvatarGroupUtilityClass } from './avatarGroupClasses';
+
+const useThemeProps = createUseThemeProps('MuiAlert');
 
 const SPACINGS = {
   small: -16,
@@ -33,25 +34,38 @@ const AvatarGroupRoot = styled('div', {
     [`& .${avatarGroupClasses.avatar}`]: styles.avatar,
     ...styles.root,
   }),
-})(({ theme, ownerState }) => {
-  const marginValue =
-    ownerState.spacing && SPACINGS[ownerState.spacing] !== undefined
-      ? SPACINGS[ownerState.spacing]
-      : -ownerState.spacing;
-
-  return {
-    [`& .${avatarClasses.root}`]: {
-      border: `2px solid ${(theme.vars || theme).palette.background.default}`,
-      boxSizing: 'content-box',
-      marginLeft: marginValue ?? -8,
-      '&:last-child': {
-        marginLeft: 0,
+})(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row-reverse',
+  [`& .${avatarClasses.root}`]: {
+    border: `2px solid ${(theme.vars || theme).palette.background.default}`,
+    boxSizing: 'content-box',
+    '&:not(:first-of-type)': {
+      marginLeft: -8,
+    },
+    '&:last-child': {
+      marginLeft: 0,
+    },
+  },
+  variants: [
+    {
+      props: { spacing: 'small' },
+      style: {
+        [`& .${avatarClasses.root}:not(:first-of-type)`]: {
+          marginLeft: `${SPACINGS.small}px`,
+        },
       },
     },
-    display: 'flex',
-    flexDirection: 'row-reverse',
-  };
-});
+    {
+      props: { spacing: 'medium' },
+      style: {
+        [`& .${avatarClasses.root}:not(:first-of-type)`]: {
+          marginLeft: SPACINGS.medium ? `${SPACINGS.medium}px` : 0,
+        },
+      },
+    },
+  ],
+}));
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(inProps, ref) {
   const props = useThemeProps({

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.js
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.js
@@ -11,11 +11,6 @@ import avatarGroupClasses, { getAvatarGroupUtilityClass } from './avatarGroupCla
 
 const useThemeProps = createUseThemeProps('MuiAlert');
 
-const SPACINGS = {
-  small: -16,
-  medium: null,
-};
-
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;
 
@@ -40,27 +35,21 @@ const AvatarGroupRoot = styled('div', {
   [`& .${avatarClasses.root}`]: {
     border: `2px solid ${(theme.vars || theme).palette.background.default}`,
     boxSizing: 'content-box',
-    '&:not(:first-of-type)': {
-      marginLeft: -8,
-    },
-    '&:last-child': {
-      marginLeft: 0,
-    },
   },
   variants: [
     {
       props: { spacing: 'small' },
       style: {
-        [`& .${avatarClasses.root}:not(:first-of-type)`]: {
-          marginLeft: `${SPACINGS.small}px`,
+        [`& .${avatarClasses.root}:not(:last-of-type)`]: {
+          marginLeft: -16,
         },
       },
     },
     {
       props: { spacing: 'medium' },
       style: {
-        [`& .${avatarClasses.root}:not(:first-of-type)`]: {
-          marginLeft: SPACINGS.medium ? `${SPACINGS.medium}px` : 0,
+        [`& .${avatarClasses.root}:not(:last-of-type)`]: {
+          marginLeft: -8,
         },
       },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Part of https://github.com/mui/material-ui/issues/41273


<img width="450" alt="Screenshot 2024-03-13 at 16 54 12" src="https://github.com/mui/material-ui/assets/37222944/56637719-5ac5-4e81-8f08-bac134ac4f94">
<img width="450" alt="Screenshot 2024-03-13 at 16 54 06" src="https://github.com/mui/material-ui/assets/37222944/41f26924-eba6-4d6f-8e7d-04e307b54349">

