### PR TITLE
[utils] Add small optimization: composeClasses

### DIFF
--- a/packages/mui-utils/src/composeClasses/composeClasses.test.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.test.ts
@@ -13,8 +13,8 @@ describe('composeClasses', () => {
         undefined,
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root MuiTest-standard',
-      slot: 'MuiTest-slot',
+      root: 'MuiTest-root MuiTest-standard ',
+      slot: 'MuiTest-slot ',
     });
   });
 
@@ -32,8 +32,8 @@ describe('composeClasses', () => {
         },
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root MuiTest-standard standardOverride',
-      slot: 'MuiTest-slot slotOverride',
+      root: 'MuiTest-root MuiTest-standard standardOverride ',
+      slot: 'MuiTest-slot slotOverride ',
     });
   });
 
@@ -51,8 +51,8 @@ describe('composeClasses', () => {
         },
       ),
     ).to.deep.equal({
-      root: 'MuiTest-root MuiTest-standard standardOverride',
-      slot: 'MuiTest-slot slotOverride',
+      root: 'MuiTest-root MuiTest-standard standardOverride ',
+      slot: 'MuiTest-slot slotOverride ',
     });
   });
 });

--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -23,7 +23,7 @@ export default function composeClasses<ClassKey extends string>(
           if (slotPart) {
             const utilityClass = getUtilityClass(slotPart);
             if (utilityClass) {
-              result += ' ' + utilityClass;
+              result += utilityClass + ' ';
             }
           }
         }
@@ -41,10 +41,10 @@ export default function composeClasses<ClassKey extends string>(
           if (slotPart) {
             const utilityClass = getUtilityClass(slotPart);
             if (utilityClass) {
-              result += ' ' + utilityClass;
+              result += utilityClass + ' ';
             }
             if (classes[slotPart]) {
-              result += ' ' + classes[slotPart];
+              result += classes[slotPart] + ' ';
             }
           }
         }

--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -1,7 +1,4 @@
-/* eslint
-     no-restricted-syntax: 0
-     prefer-template: 0
-     no-unreachable-loop: 0
+/* eslint no-restricted-syntax: 0, prefer-template: 0, no-unreachable-loop: 0
    ---
    These rules are preventing the performance optimizations below.
  */

--- a/packages/mui-utils/src/composeClasses/composeClasses.ts
+++ b/packages/mui-utils/src/composeClasses/composeClasses.ts
@@ -1,30 +1,72 @@
+/* eslint
+     no-restricted-syntax: 0
+     prefer-template: 0
+     no-unreachable-loop: 0
+   ---
+   These rules are preventing the performance optimizations below.
+ */
+
 export default function composeClasses<ClassKey extends string>(
   slots: Record<ClassKey, ReadonlyArray<string | false | undefined | null>>,
   getUtilityClass: (slot: string) => string,
   classes: Record<string, string> | undefined = undefined,
 ): Record<ClassKey, string> {
-  const output: Record<ClassKey, string> = {} as any;
+  const output = {} as Record<ClassKey, string>;
 
-  Object.keys(slots).forEach(
-    // `Object.keys(slots)` can't be wider than `T` because we infer `T` from `slots`.
-    // @ts-expect-error https://github.com/microsoft/TypeScript/pull/12253#issuecomment-263132208
-    (slot: ClassKey) => {
-      output[slot] = slots[slot]
-        .reduce((acc, key) => {
-          if (key) {
-            const utilityClass = getUtilityClass(key);
-            if (utilityClass !== '') {
-              acc.push(utilityClass);
-            }
-            if (classes && classes[key]) {
-              acc.push(classes[key]);
+  /* This is split in 2 loops for performance reasons, as it allows to avoid the `if (classes)`
+   * check in both of those cases. If `classes` is either `{}` or `undefined`, we consider it empty. */
+  if (isEmpty(classes)) {
+    for (const slotName in slots) {
+      if (Object.prototype.hasOwnProperty.call(slots, slotName)) {
+        const slotNames = slots[slotName];
+
+        let result = '';
+        for (let i = 0; i < slotNames.length; i += 1) {
+          const slotPart = slotNames[i];
+          if (slotPart) {
+            const utilityClass = getUtilityClass(slotPart);
+            if (utilityClass) {
+              result += ' ' + utilityClass;
             }
           }
-          return acc;
-        }, [] as string[])
-        .join(' ');
-    },
-  );
+        }
+        output[slotName] = result;
+      }
+    }
+  } else {
+    for (const slotName in slots) {
+      if (Object.prototype.hasOwnProperty.call(slots, slotName)) {
+        const slotNames = slots[slotName];
+
+        let result = '';
+        for (let i = 0; i < slotNames.length; i += 1) {
+          const slotPart = slotNames[i];
+          if (slotPart) {
+            const utilityClass = getUtilityClass(slotPart);
+            if (utilityClass) {
+              result += ' ' + utilityClass;
+            }
+            if (classes[slotPart]) {
+              result += ' ' + classes[slotPart];
+            }
+          }
+        }
+        output[slotName] = result;
+      }
+    }
+  }
 
   return output;
+}
+
+function isEmpty(value: object | undefined): value is undefined {
+  if (!value) {
+    return true;
+  }
+  for (const key in value) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
I have been doing some more benchmarking on the datagrid and I see that `composeClasses` makes up around 1.5% of the CPU time during scroll events, but also in general during any rendering-heavy code (e.g. initial mount). I have run the benchmarks with just MUI core components (e.g. 40 buttons, 40 text fields) and the results are the same, which makes sense as we use the same patterns in both codebases.

<details>
<summary> `composeClasses` profile </summary>

![composeClasses-profile](https://github.com/mui/material-ui/assets/1423607/d9bbdb15-e2dd-4420-b88d-02be5b145228)

</details>

I have applied different optimizations to the original implementation, and was able to get it to run about 3x faster. By using this implementation, we'd reduce our rendering runtime in general by around 1%, which is an interesting result for optimizing just one function.

<details>
<summary> optimization rounds results <a href="https://jsben.ch/ACdHo">(benchmark code)</a> </summary>

<img src="https://github.com/mui/material-ui/assets/1423607/69ea3547-9702-4378-9108-f8e5db8c4c24" width="450" />

</details>

The obvious downside is that performance-optimized code is less readable. The table above presents the optimization improvements for each successive step, if the code proposed here is too exotic, you could also propose which optimizations make sense to include. The most impactful by far is avoiding accumulating strings in an array.

