### PR TITLE
[material-ui][docs] Fix Material Icon search lag (alternative to 41330)

### DIFF
--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -480,7 +480,6 @@ function useLatest(value) {
 
 export default function SearchIcons() {
   const [keys, setKeys] = React.useState(null);
-  const [, startTransition] = React.useTransition();
   const [theme, setTheme] = useQueryParameterState('theme', 'Filled');
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
   const [query, setQuery] = useQueryParameterState('query', '');
@@ -574,7 +573,7 @@ export default function SearchIcons() {
           <Input
             autoFocus
             value={query}
-            onChange={(event) => startTransition(() => setQuery(event.target.value))}
+            onChange={(event) => setQuery(event.target.value)}
             placeholder="Search icons…"
             inputProps={{ 'aria-label': 'search icons' }}
           />

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -10,6 +10,8 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import CircularProgress from '@mui/material/CircularProgress';
+import InputAdornment from '@mui/material/InputAdornment';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Button from '@mui/material/Button';
@@ -45,7 +47,6 @@ import useQueryParameterState from 'docs/src/modules/utils/useQueryParameterStat
 // import DeleteForeverTwoTone from '@mui/icons-material/DeleteForeverTwoTone';
 // import DeleteForeverSharp from '@mui/icons-material/DeleteForeverSharp';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
-import { CircularProgress, InputAdornment, LinearProgress } from '@mui/material';
 import synonyms from './synonyms';
 
 const FlexSearchIndex = flexsearch.Index;

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -492,22 +492,17 @@ export default function SearchIcons() {
   }, [setSelectedIcon]);
 
   const deferredQuery = React.useDeferredValue(query);
+  const deferredTheme = React.useDeferredValue(theme);
 
-  const keys = React.useMemo(
-    () =>
+  const icons = React.useMemo(() => {
+    const keys =
       deferredQuery === ''
         ? null
-        : searchIndex.search(deferredQuery, { limit: 3000 }),
-    [deferredQuery],
-  );
-
-  const icons = React.useMemo(
-    () =>
-      (keys === null ? allIcons : keys.map((key) => allIconsMap[key])).filter(
-        (icon) => theme === icon.theme,
-      ),
-    [theme, keys],
-  );
+        : searchIndex.search(deferredQuery, { limit: 3000 });
+    return (keys === null ? allIcons : keys.map((key) => allIconsMap[key])).filter(
+      (icon) => deferredTheme === icon.theme,
+    );
+  }, [deferredQuery, deferredTheme]);
 
   const dialogSelectedIcon = useLatest(
     selectedIcon ? allIconsMap[selectedIcon] : null,

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -496,6 +496,8 @@ export default function SearchIcons() {
   const deferredQuery = React.useDeferredValue(query);
   const deferredTheme = React.useDeferredValue(theme);
 
+  const isPending = query !== deferredQuery || theme !== deferredTheme;
+
   const icons = React.useMemo(() => {
     const keys =
       deferredQuery === ''
@@ -527,20 +529,17 @@ export default function SearchIcons() {
           <Typography fontWeight={500} sx={{ mb: 1 }}>
             Filter the style
           </Typography>
-          <RadioGroup>
+          <RadioGroup
+            value={theme}
+            onChange={(event) => setTheme(event.target.value)}
+          >
             {['Filled', 'Outlined', 'Rounded', 'Two tone', 'Sharp'].map(
               (currentTheme) => {
                 return (
                   <FormControlLabel
                     key={currentTheme}
-                    control={
-                      <Radio
-                        size="small"
-                        checked={theme === currentTheme}
-                        onChange={() => setTheme(currentTheme)}
-                        value={currentTheme}
-                      />
-                    }
+                    value={currentTheme}
+                    control={<Radio size="small" />}
                     label={currentTheme}
                   />
                 );
@@ -561,11 +560,11 @@ export default function SearchIcons() {
             placeholder="Search icons…"
             inputProps={{ 'aria-label': 'search icons' }}
             endAdornment={
-              query === deferredQuery ? null : (
+              isPending ? (
                 <InputAdornment position="end">
                   <CircularProgress size={16} sx={{ mr: 2 }} />
                 </InputAdornment>
-              )
+              ) : null
             }
           />
         </Paper>

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -45,6 +45,7 @@ import useQueryParameterState from 'docs/src/modules/utils/useQueryParameterStat
 // import DeleteForeverTwoTone from '@mui/icons-material/DeleteForeverTwoTone';
 // import DeleteForeverSharp from '@mui/icons-material/DeleteForeverSharp';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
+import { CircularProgress, InputAdornment, LinearProgress } from '@mui/material';
 import synonyms from './synonyms';
 
 const FlexSearchIndex = flexsearch.Index;
@@ -558,6 +559,13 @@ export default function SearchIcons() {
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search icons…"
             inputProps={{ 'aria-label': 'search icons' }}
+            endAdornment={
+              query === deferredQuery ? null : (
+                <InputAdornment position="end">
+                  <CircularProgress size={16} sx={{ mr: 2 }} />
+                </InputAdornment>
+              )
+            }
           />
         </Paper>
         <Typography sx={{ mb: 1 }}>{`${formatNumber(

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -504,6 +504,16 @@ export default function SearchIcons() {
     );
   }, [deferredQuery, deferredTheme]);
 
+  React.useEffect(() => {
+    // Keep track of the no results so we can add synonyms in the future.
+    if (deferredQuery.length >= 4 && icons.length === 0) {
+      window.gtag('event', 'material-icons', {
+        eventAction: 'no-results',
+        eventLabel: deferredQuery,
+      });
+    }
+  }, [deferredQuery, icons]);
+
   const dialogSelectedIcon = useLatest(
     selectedIcon ? allIconsMap[selectedIcon] : null,
   );

--- a/docs/data/material/components/material-icons/SearchIcons.js
+++ b/docs/data/material/components/material-icons/SearchIcons.js
@@ -480,6 +480,7 @@ function useLatest(value) {
 
 export default function SearchIcons() {
   const [keys, setKeys] = React.useState(null);
+  const [, startTransition] = React.useTransition();
   const [theme, setTheme] = useQueryParameterState('theme', 'Filled');
   const [selectedIcon, setSelectedIcon] = useQueryParameterState('selected', '');
   const [query, setQuery] = useQueryParameterState('query', '');
@@ -573,7 +574,7 @@ export default function SearchIcons() {
           <Input
             autoFocus
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => startTransition(() => setQuery(event.target.value))}
             placeholder="Search icons…"
             inputProps={{ 'aria-label': 'search icons' }}
           />

--- a/docs/src/modules/utils/useQueryParameterState.ts
+++ b/docs/src/modules/utils/useQueryParameterState.ts
@@ -63,8 +63,8 @@ export default function useQueryParameterState(
 
   const setUserState = React.useCallback(
     (newValue: string) => {
-      setState(newValue);
       setUrlValue(newValue);
+      setState(newValue);
     },
     [setUrlValue],
   );

--- a/docs/src/modules/utils/useQueryParameterState.ts
+++ b/docs/src/modules/utils/useQueryParameterState.ts
@@ -61,10 +61,11 @@ export default function useQueryParameterState(
     [setUrlValue],
   );
 
+  const [, startTransition] = React.useTransition();
   const setUserState = React.useCallback(
     (newValue: string) => {
-      setUrlValue(newValue);
       setState(newValue);
+      startTransition(() => setUrlValue(newValue));
     },
     [setUrlValue],
   );

--- a/docs/src/modules/utils/useQueryParameterState.ts
+++ b/docs/src/modules/utils/useQueryParameterState.ts
@@ -61,11 +61,10 @@ export default function useQueryParameterState(
     [setUrlValue],
   );
 
-  const [, startTransition] = React.useTransition();
   const setUserState = React.useCallback(
     (newValue: string) => {
       setState(newValue);
-      startTransition(() => setUrlValue(newValue));
+      setUrlValue(newValue);
     },
     [setUrlValue],
   );


### PR DESCRIPTION
Testing out the solution I suggested in https://github.com/mui/material-ui/pull/41330#issuecomment-1997454243

Few other fixes in this PR:
* Fix `flexsearch` import to get correct typing
* Show feedback when the UI is rendering in the background
* Fix `RadioGroup` controlled props
* Remove index search debounce.