### PR TITLE
[material-ui][Breadcrumbs] Convert to support CSS extraction

### DIFF
--- a/apps/pigment-css-next-app/src/app/material-ui/react-breadcrumbs/page.tsx
+++ b/apps/pigment-css-next-app/src/app/material-ui/react-breadcrumbs/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+import * as React from 'react';
+import ActiveLastBreadcrumb from '../../../../../../docs/data/material/components/breadcrumbs/ActiveLastBreadcrumb';
+import BasicBreadcrumbs from '../../../../../../docs/data/material/components/breadcrumbs/BasicBreadcrumbs';
+import CollapsedBreadcrumbs from '../../../../../../docs/data/material/components/breadcrumbs/CollapsedBreadcrumbs';
+import CustomSeparator from '../../../../../../docs/data/material/components/breadcrumbs/CustomSeparator';
+import CustomizedBreadcrumbs from '../../../../../../docs/data/material/components/breadcrumbs/CustomizedBreadcrumbs';
+import IconBreadcrumbs from '../../../../../../docs/data/material/components/breadcrumbs/IconBreadcrumbs';
+import RouterBreadcrumbs from '../../../../../../docs/data/material/components/breadcrumbs/RouterBreadcrumbs';
+
+export default function Breadcrumbs() {
+  return (
+    <React.Fragment>
+      <section>
+        <h2> Active Last Breadcrumb</h2>
+        <div className="demo-container">
+          <ActiveLastBreadcrumb />
+        </div>
+      </section>
+      <section>
+        <h2> Basic Breadcrumbs</h2>
+        <div className="demo-container">
+          <BasicBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Collapsed Breadcrumbs</h2>
+        <div className="demo-container">
+          <CollapsedBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Custom Separator</h2>
+        <div className="demo-container">
+          <CustomSeparator />
+        </div>
+      </section>
+      <section>
+        <h2> Customized Breadcrumbs</h2>
+        <div className="demo-container">
+          <CustomizedBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Icon Breadcrumbs</h2>
+        <div className="demo-container">
+          <IconBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Router Breadcrumbs</h2>
+        <div className="demo-container">
+          <RouterBreadcrumbs />
+        </div>
+      </section>
+    </React.Fragment>
+  );
+}

--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-breadcrumbs.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-breadcrumbs.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import MaterialUILayout from '../../Layout';
+import ActiveLastBreadcrumb from '../../../../../docs/data/material/components/breadcrumbs/ActiveLastBreadcrumb.tsx';
+import BasicBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/BasicBreadcrumbs.tsx';
+import CollapsedBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/CollapsedBreadcrumbs.tsx';
+import CustomSeparator from '../../../../../docs/data/material/components/breadcrumbs/CustomSeparator.tsx';
+import CustomizedBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/CustomizedBreadcrumbs.tsx';
+import IconBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/IconBreadcrumbs.tsx';
+import RouterBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/RouterBreadcrumbs.tsx';
+
+export default function Breadcrumbs() {
+  return (
+    <MaterialUILayout>
+      <h1>Breadcrumbs</h1>
+      <section>
+        <h2> Active Last Breadcrumb</h2>
+        <div className="demo-container">
+          <ActiveLastBreadcrumb />
+        </div>
+      </section>
+      <section>
+        <h2> Basic Breadcrumbs</h2>
+        <div className="demo-container">
+          <BasicBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Collapsed Breadcrumbs</h2>
+        <div className="demo-container">
+          <CollapsedBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Custom Separator</h2>
+        <div className="demo-container">
+          <CustomSeparator />
+        </div>
+      </section>
+      <section>
+        <h2> Customized Breadcrumbs</h2>
+        <div className="demo-container">
+          <CustomizedBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Icon Breadcrumbs</h2>
+        <div className="demo-container">
+          <IconBreadcrumbs />
+        </div>
+      </section>
+      <section>
+        <h2> Router Breadcrumbs</h2>
+        <div className="demo-container">
+          <RouterBreadcrumbs />
+        </div>
+      </section>
+    </MaterialUILayout>
+  );
+}

--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -1374,13 +1374,13 @@ importers:
         version: file:../packages/mui-base/build(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: file:../../packages/mui-icons-material/build
-        version: file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0)
+        version: file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0)
       '@mui/material':
         specifier: file:../../packages/mui-material/build
         version: file:../packages/mui-material/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/material-nextjs':
         specifier: file:../../packages/mui-material-nextjs/build
-        version: file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.12)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0)
+        version: file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.13)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0)
       '@mui/system':
         specifier: file:../../packages/mui-system/build
         version: file:../packages/mui-system/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react@18.2.0)
@@ -1432,7 +1432,7 @@ importers:
         version: file:../packages/mui-base/build(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: file:../../packages/mui-icons-material/build
-        version: file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0)
+        version: file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0)
       '@mui/material':
         specifier: file:../../packages/mui-material/build
         version: file:../packages/mui-material/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
@@ -8991,7 +8991,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0):
+  file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0):
     resolution: {directory: ../packages/mui-icons-material/build, type: directory}
     id: file:../packages/mui-icons-material/build
     name: '@mui/icons-material'
@@ -9010,7 +9010,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.12)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0):
+  file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.13)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0):
     resolution: {directory: ../packages/mui-material-nextjs/build, type: directory}
     id: file:../packages/mui-material-nextjs/build
     name: '@mui/material-nextjs'

--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -1374,13 +1374,13 @@ importers:
         version: file:../packages/mui-base/build(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: file:../../packages/mui-icons-material/build
-        version: file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0)
+        version: file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0)
       '@mui/material':
         specifier: file:../../packages/mui-material/build
         version: file:../packages/mui-material/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/material-nextjs':
         specifier: file:../../packages/mui-material-nextjs/build
-        version: file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.13)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0)
+        version: file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.12)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0)
       '@mui/system':
         specifier: file:../../packages/mui-system/build
         version: file:../packages/mui-system/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react@18.2.0)
@@ -1432,7 +1432,7 @@ importers:
         version: file:../packages/mui-base/build(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mui/icons-material':
         specifier: file:../../packages/mui-icons-material/build
-        version: file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0)
+        version: file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0)
       '@mui/material':
         specifier: file:../../packages/mui-material/build
         version: file:../packages/mui-material/build(@emotion/react@11.11.4)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
@@ -8991,7 +8991,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  file:../packages/mui-icons-material/build(@mui/material@5.15.13)(@types/react@18.2.55)(react@18.2.0):
+  file:../packages/mui-icons-material/build(@mui/material@5.15.12)(@types/react@18.2.55)(react@18.2.0):
     resolution: {directory: ../packages/mui-icons-material/build, type: directory}
     id: file:../packages/mui-icons-material/build
     name: '@mui/icons-material'
@@ -9010,7 +9010,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.13)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0):
+  file:../packages/mui-material-nextjs/build(@emotion/cache@11.11.0)(@mui/material@5.15.12)(@types/react@18.2.55)(next@14.1.3)(react@18.2.0):
     resolution: {directory: ../packages/mui-material-nextjs/build, type: directory}
     id: file:../packages/mui-material-nextjs/build
     name: '@mui/material-nextjs'

--- a/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/mui-material/src/Breadcrumbs/Breadcrumbs.js
@@ -6,11 +6,12 @@ import clsx from 'clsx';
 import integerPropType from '@mui/utils/integerPropType';
 import { useSlotProps } from '@mui/base/utils';
 import composeClasses from '@mui/utils/composeClasses';
-import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { styled, createUseThemeProps } from '../zero-styled';
 import Typography from '../Typography';
 import BreadcrumbCollapsed from './BreadcrumbCollapsed';
 import breadcrumbsClasses, { getBreadcrumbsUtilityClass } from './breadcrumbsClasses';
+
+const useThemeProps = createUseThemeProps('MuiBreadcrumbs');
 
 const useUtilityClasses = (ownerState) => {
   const { classes } = ownerState;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

These steps were not needed for this component AFAIK, correct me if I'm wrong.
- **Move `ownerState` from the root style argument callback to variants**
- **Use `Object.entries(theme.palette)` to populate colors**

https://github.com/mui/material-ui/assets/44305048/6e15d842-add6-4303-93e5-fdff74d928fb

@siriwatknp 