### PR TITLE
[docs][pigment-css] Fixing location of the ExtendTheme type in the docs

### DIFF
--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -598,7 +598,7 @@ To get the type checking for the theme, you need to augment the theme type:
 
 ```ts
 // any file that is included in your tsconfig.json
-import type { ExtendTheme } from '@pigment-css/react';
+import type { ExtendTheme } from '@pigment-css/react/theme';
 
 declare module '@pigment-css/react/theme' {
   interface ThemeTokens {


### PR DESCRIPTION
The docs around theme typing have the import from `@pigment-css/react` when it's actually exported from `@pigment-css/react/theme`. Fixing the docs.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
