### PR TITLE
[docs] Update accordion.md - TransitionProps={{ unmountOnExit: true }} resolves #41513

### DIFF
--- a/docs/data/material/components/accordion/accordion.md
+++ b/docs/data/material/components/accordion/accordion.md
@@ -92,7 +92,7 @@ This default behavior has server-side rendering and SEO in mind.
 If you render the Accordion Details with a big component tree nested inside, or if you have many Accordions, you may want to change this behavior by setting `unmountOnExit` to `true` inside the `slotProps.transition` prop to improve performance:
 
 ```jsx
-<Accordion slotProps={{ transition: { unmountOnExit: true } }} />
+<Accordion TransitionProps={{ unmountOnExit: true }} />
 ```
 
 ## Accessibility


### PR DESCRIPTION
The `slotProps={{ transition: { unmountOnExit: true } }}` prop on the Accordion seems to be outdated and the use of `TransitionProps={{ unmountOnExit: true }} `works.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [✅] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
