### PR TITLE
[docs-infra] Make the Algolia search input label invisible

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -618,6 +618,10 @@ export default function AppSearch(props) {
                 width: '18px',
                 height: '18px',
               },
+              '& .DocSearch-VisuallyHiddenForAccessibility': {
+                width: 0,
+                visibility: 'hidden',
+              },
             },
             '& .DocSearch-Cancel': {
               display: 'block',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I don't think this label existed in the Algolia search input before or I just recently noticed it was visible, even though its class name is `DocSearch-VisuallyHiddenForAccessibility`. I guess we indeed don't want that to be visible as it overlaps with the input's placeholder, but it should still be there for accessibility. So, in this PR, I'm just using the available class to add CSS that will visually hide it, as the class name suggests it should be :)

| Before | After |
|--------|--------|
| <img width="664" alt="Screenshot 2024-03-18 at 09 30 12" src="https://github.com/mui/material-ui/assets/67129314/a2e8b188-cf3d-4cfa-95be-8bb743641ebb"> | <img width="664" alt="Screenshot 2024-03-18 at 09 30 20" src="https://github.com/mui/material-ui/assets/67129314/dedd166a-9d15-4d55-8749-1eddcb9ebdd7"> | 