### PR TITLE
[material-ui][ButtonBase] Add button component as hyperlink always when have href prop

### DIFF
--- a/packages/mui-material/src/ButtonBase/ButtonBase.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.js
@@ -292,7 +292,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(inProps, ref) {
 
   let ComponentProp = component;
 
-  if (ComponentProp === 'button' && (other.href || other.to)) {
+  if (other.href || other.to) {
     ComponentProp = LinkComponent;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Minor improvement if considered by maintainer. 
Currently, if the Button component has prop `href` or `to` and the component is example as `span`, the button does not render a link. This happens only when the prop component is a button.
Thanks!
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
