### PR TITLE
[docs] Update the versions dropdown to show v6

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -166,6 +166,10 @@ function AppWrapper(props) {
         metadata: 'MUI Core',
         name: 'Material UI',
         versions: [
+          {
+            text: 'v6 (next)',
+            href: `https://next.mui.com${languagePrefix}/material-ui/getting-started/`,
+          },
           { text: `v${materialPkgJson.version}`, current: true },
           {
             text: 'v4',
@@ -192,6 +196,10 @@ function AppWrapper(props) {
         metadata: 'MUI Core',
         name: 'MUI System',
         versions: [
+          {
+            text: 'v6 (next)',
+            href: `https://next.mui.com${languagePrefix}/system/getting-started/`,
+          },
           { text: `v${systemPkgJson.version}`, current: true },
           { text: 'v4', href: `https://v4.mui.com${languagePrefix}/system/basics/` },
           {


### PR DESCRIPTION
We need to be able to link the next docs from the main one.

<img width="348" alt="Screenshot 2024-03-19 at 13 02 38" src="https://github.com/mui/material-ui/assets/4512430/80903e7d-f115-41dd-ad93-45aad6181214">
