### PR TITLE
[docs] Update the installation guides to use the next tag

### DIFF
--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -10,18 +10,20 @@ If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](
 
 `@mui/base` is completely standalone – run one of the following commands to add Base UI to your React project:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/base
+npm install @mui/base@next
 ```
 
 ```bash yarn
-yarn add @mui/base
+yarn add @mui/base@next
 ```
 
 ```bash pnpm
-pnpm add @mui/base
+pnpm add @mui/base@next
 ```
 
 </codeblock>

--- a/docs/data/base/getting-started/quickstart/quickstart.md
+++ b/docs/data/base/getting-started/quickstart/quickstart.md
@@ -10,6 +10,10 @@ If you're using Next.js 13.4 or later, check out the [Next.js App Router guide](
 
 `@mui/base` is completely standalone – run one of the following commands to add Base UI to your React project:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
@@ -31,8 +31,10 @@ We'll use [`create-react-app` with TypeScript](https://create-react-app.dev/docs
 After you have created the project, follow the instructions given on the [Tailwind CSS installation page](https://tailwindcss.com/docs/guides/create-react-app) in order to configure `tailwind`.
 Next, install `@mui/base` in the project:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/base
+npm install @mui/base@next
 ```
 
 ## Adding the player markup

--- a/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
+++ b/docs/data/base/guides/working-with-tailwind-css/working-with-tailwind-css.md
@@ -31,6 +31,10 @@ We'll use [`create-react-app` with TypeScript](https://create-react-app.dev/docs
 After you have created the project, follow the instructions given on the [Tailwind CSS installation page](https://tailwindcss.com/docs/guides/create-react-app) in order to configure `tailwind`.
 Next, install `@mui/base` in the project:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 ```bash

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -6,17 +6,19 @@
 
 Run one of the following commands to add Joy UI to your project:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 ```bash npm
-npm install @mui/joy @emotion/react @emotion/styled
+npm install @mui/joy@next @emotion/react @emotion/styled
 ```
 
 ```bash yarn
-yarn add @mui/joy @emotion/react @emotion/styled
+yarn add @mui/joy@next @emotion/react @emotion/styled
 ```
 
 ```bash pnpm
-pnpm add @mui/joy @emotion/react @emotion/styled
+pnpm add @mui/joy@next @emotion/react @emotion/styled
 ```
 
 </codeblock>

--- a/docs/data/joy/getting-started/installation/installation.md
+++ b/docs/data/joy/getting-started/installation/installation.md
@@ -6,6 +6,10 @@
 
 Run one of the following commands to add Joy UI to your project:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/joy/integrations/icon-libraries/icon-libraries.md
+++ b/docs/data/joy/integrations/icon-libraries/icon-libraries.md
@@ -39,8 +39,10 @@ You can keep track of the progress in [this issue](https://github.com/mui/materi
 
 #### npm
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/icons-material @mui/material
+npm install @mui/icons-material@next @mui/material@next
 ```
 
 :::warning

--- a/docs/data/joy/integrations/icon-libraries/icon-libraries.md
+++ b/docs/data/joy/integrations/icon-libraries/icon-libraries.md
@@ -13,8 +13,12 @@ This section assumes that you've already installed Joy UI in your app—see [In
 
 #### yarn
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 ```bash
-yarn add @mui/icons-material @mui/material
+yarn add @mui/icons-material@next @mui/material@next
 ```
 
 :::warning
@@ -38,6 +42,10 @@ You can keep track of the progress in [this issue](https://github.com/mui/materi
 :::
 
 #### npm
+
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
 
 <!-- #default-branch-switch -->
 

--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -19,6 +19,10 @@ For a component to be ready to move to the core, the following criteria are cons
 
 To install and save in your `package.json` dependencies, run one of the following commands:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/material/components/about-the-lab/about-the-lab.md
+++ b/docs/data/material/components/about-the-lab/about-the-lab.md
@@ -19,18 +19,20 @@ For a component to be ready to move to the core, the following criteria are cons
 
 To install and save in your `package.json` dependencies, run one of the following commands:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/lab @mui/material
+npm install @mui/lab@next @mui/material@next
 ```
 
 ```bash yarn
-yarn add @mui/lab @mui/material
+yarn add @mui/lab@next @mui/material@next
 ```
 
 ```bash pnpm
-pnpm add @mui/lab @mui/material
+pnpm add @mui/lab@next @mui/material@next
 ```
 
 </codeblock>

--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -26,6 +26,10 @@ You can [search the full list of these icons](/material-ui/material-icons/).
 
 Run one of the following commands to install it and save it to your `package.json` dependencies:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/material/components/icons/icons.md
+++ b/docs/data/material/components/icons/icons.md
@@ -26,17 +26,19 @@ You can [search the full list of these icons](/material-ui/material-icons/).
 
 Run one of the following commands to install it and save it to your `package.json` dependencies:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 ```bash npm
-npm install @mui/icons-material
+npm install @mui/icons-material@next
 ```
 
 ```bash yarn
-yarn add @mui/icons-material
+yarn add @mui/icons-material@next
 ```
 
 ```bash pnpm
-pnpm add @mui/icons-material
+pnpm add @mui/icons-material@next
 ```
 
 </codeblock>

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -18,6 +18,10 @@ includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?ico
 It depends on `@mui/material`, which requires Emotion packages.
 Use one of the following commands to install it:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -18,18 +18,20 @@ includes the 2,100+ official [Material Icons](https://fonts.google.com/icons?ico
 It depends on `@mui/material`, which requires Emotion packages.
 Use one of the following commands to install it:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/icons-material @mui/material @emotion/styled @emotion/react
+npm install @mui/icons-material@next @mui/material@next @emotion/styled @emotion/react
 ```
 
 ```bash yarn
-yarn add @mui/icons-material @mui/material @emotion/styled @emotion/react
+yarn add @mui/icons-material@next @mui/material@next @emotion/styled @emotion/react
 ```
 
 ```bash pnpm
-pnpm add @mui/icons-material @mui/material @emotion/styled @emotion/react
+pnpm add @mui/icons-material@next @mui/material@next @emotion/styled @emotion/react
 ```
 
 </codeblock>

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -6,6 +6,10 @@
 
 Run one of the following commands to add Material UI to your project:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -6,18 +6,20 @@
 
 Run one of the following commands to add Material UI to your project:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material @emotion/react @emotion/styled
+npm install @mui/material@next @emotion/react @emotion/styled
 ```
 
 ```bash yarn
-yarn add @mui/material @emotion/react @emotion/styled
+yarn add @mui/material@next @emotion/react @emotion/styled
 ```
 
 ```bash pnpm
-pnpm add @mui/material @emotion/react @emotion/styled
+pnpm add @mui/material@next @emotion/react @emotion/styled
 ```
 
 </codeblock>

--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -11,18 +11,20 @@ This section walks through the Material UI integration with the Next.js [App Ro
 Start by ensuring that you already have `@mui/material` and `next` installed.
 Then, run one of the following commands to install the dependencies:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material-nextjs @emotion/cache
+npm install @mui/material-nextjs@next @emotion/cache
 ```
 
 ```bash yarn
-yarn add @mui/material-nextjs @emotion/cache
+yarn add @mui/material-nextjs@next @emotion/cache
 ```
 
 ```bash pnpm
-pnpm add @mui/material-nextjs @emotion/cache
+pnpm add @mui/material-nextjs@next @emotion/cache
 ```
 
 </codeblock>

--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -11,6 +11,10 @@ This section walks through the Material UI integration with the Next.js [App Ro
 Start by ensuring that you already have `@mui/material` and `next` installed.
 Then, run one of the following commands to install the dependencies:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/styles/basics/basics.md
+++ b/docs/data/styles/basics/basics.md
@@ -20,7 +20,7 @@ To install and save in your `package.json` dependencies, run:
 <!-- #default-branch-switch -->
 
 ```bash
-npm install @mui/styles
+npm install @mui/styles@next
 ```
 
 ## Getting started

--- a/docs/data/styles/basics/basics.md
+++ b/docs/data/styles/basics/basics.md
@@ -17,6 +17,10 @@ Please use [`@mui/system`](/system/getting-started/) instead.
 
 To install and save in your `package.json` dependencies, run:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 ```bash

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -41,6 +41,10 @@ Please note that [react](https://www.npmjs.com/package/react) is a peer dependen
 MUI System uses [Emotion](https://emotion.sh/docs/introduction) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
+:::info
+The `next` tag is used to download the latest <b>pre-release</b>, v6 version. Remove it to get the current stable version.
+:::
+
 <!-- #default-branch-switch -->
 
 <codeblock storageKey="package-manager">

--- a/docs/data/system/getting-started/installation/installation.md
+++ b/docs/data/system/getting-started/installation/installation.md
@@ -6,18 +6,20 @@
 
 Run one of the following commands to add MUI System to your project:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/system @emotion/react @emotion/styled
+npm install @mui/system@next @emotion/react @emotion/styled
 ```
 
 ```bash yarn
-yarn add @mui/system @emotion/react @emotion/styled
+yarn add @mui/system@next @emotion/react @emotion/styled
 ```
 
 ```bash pnpm
-pnpm add @mui/system @emotion/react @emotion/styled
+pnpm add @mui/system@next @emotion/react @emotion/styled
 ```
 
 </codeblock>
@@ -39,18 +41,20 @@ Please note that [react](https://www.npmjs.com/package/react) is a peer dependen
 MUI System uses [Emotion](https://emotion.sh/docs/introduction) as its default styling engine.
 If you want to use [styled-components](https://styled-components.com/) instead, run one of the following commands:
 
+<!-- #default-branch-switch -->
+
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/system @mui/styled-engine-sc styled-components
+npm install @mui/system@next @mui/styled-engine-sc@next styled-components
 ```
 
 ```bash yarn
-yarn add @mui/system @mui/styled-engine-sc styled-components
+yarn add @mui/system@next @mui/styled-engine-sc@next styled-components
 ```
 
 ```bash pnpm
-pnpm add @mui/system @mui/styled-engine-sc styled-components
+pnpm add @mui/system@next @mui/styled-engine-sc@next styled-components
 ```
 
 </codeblock>

--- a/packages/mui-base/README.md
+++ b/packages/mui-base/README.md
@@ -11,8 +11,10 @@ Base UI is a library of headless ("unstyled") React components and low-level ho
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/base
+npm install @mui/base@next
 ```
 
 ## Documentation

--- a/packages/mui-docs/README.md
+++ b/packages/mui-docs/README.md
@@ -6,15 +6,19 @@ This package hosts the documentation building blocks.
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/docs
+npm install @mui/docs@next
 ```
 
 The docs has a peer dependency on the core components.
 If you are not already using Material UI in your project, you can add it with:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/material
+npm install @mui/material@next
 ```
 
 ## Documentation

--- a/packages/mui-joy/README.md
+++ b/packages/mui-joy/README.md
@@ -11,8 +11,10 @@ Joy UI is an open-source React component library that implements MUI's own desi
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/joy @emotion/react @emotion/styled
+npm install @mui/joy@next @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/mui-material/README.md
+++ b/packages/mui-material/README.md
@@ -11,8 +11,10 @@ Material UI is an open-source React component library that implements Google's 
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/material @emotion/react @emotion/styled
+npm install @mui/material@next @emotion/react @emotion/styled
 ```
 
 ## Documentation

--- a/packages/mui-styles/README.md
+++ b/packages/mui-styles/README.md
@@ -6,8 +6,10 @@ You can leverage our styling solution, even if you are not using our components.
 
 Install the package in your project directory with:
 
+<!-- #default-branch-switch -->
+
 ```bash
-npm install @mui/styles
+npm install @mui/styles@next
 ```
 
 ## Documentation


### PR DESCRIPTION
I noticed that we were missing the `<!-- #default-branch-switch -->` statement on the installation guides. I've udpated the readmes and the docs and added the comment.
