### PR TITLE
[material-ui][Popover] Convert to support CSS extraction

### DIFF
--- a/apps/pigment-css-next-app/src/app/material-ui/react-popover/page.tsx
+++ b/apps/pigment-css-next-app/src/app/material-ui/react-popover/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import * as React from 'react';
+import BasicPopover from '../../../../../../docs/data/material/components/popover/BasicPopover';
+import MouseOverPopover from '../../../../../../docs/data/material/components/popover/MouseOverPopover';
+import PopoverPopupState from '../../../../../../docs/data/material/components/popover/PopoverPopupState';
+import VirtualElementPopover from '../../../../../../docs/data/material/components/popover/VirtualElementPopover';
+
+export default function Popover() {
+  return (
+    <React.Fragment>
+      <section>
+        <h2> Basic Popover</h2>
+        <div className="demo-container">
+          <BasicPopover />
+        </div>
+      </section>
+      <section>
+        <h2> Mouse Over Popover</h2>
+        <div className="demo-container">
+          <MouseOverPopover />
+        </div>
+      </section>
+      <section>
+        <h2> Popover Popup State</h2>
+        <div className="demo-container">
+          <PopoverPopupState />
+        </div>
+      </section>
+      <section>
+        <h2> Virtual Element Popover</h2>
+        <div className="demo-container">
+          <VirtualElementPopover />
+        </div>
+      </section>
+    </React.Fragment>
+  );
+}

--- a/packages/mui-material/src/Popover/Popover.js
+++ b/packages/mui-material/src/Popover/Popover.js
@@ -9,8 +9,7 @@ import refType from '@mui/utils/refType';
 import elementTypeAcceptingRef from '@mui/utils/elementTypeAcceptingRef';
 import integerPropType from '@mui/utils/integerPropType';
 import chainPropTypes from '@mui/utils/chainPropTypes';
-import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { styled, createUseThemeProps } from '../zero-styled';
 import debounce from '../utils/debounce';
 import ownerDocument from '../utils/ownerDocument';
 import ownerWindow from '../utils/ownerWindow';
@@ -19,6 +18,8 @@ import Grow from '../Grow';
 import Modal from '../Modal';
 import PaperBase from '../Paper';
 import { getPopoverUtilityClass } from './popoverClasses';
+
+const useThemeProps = createUseThemeProps('MuiPopover');
 
 export function getOffsetTop(rect, vertical) {
   let offset = 0;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The reason the hover popover isn't working is because due to the `sx` not working, since it needs `pointerEvents: 'none'` for it to work on hover.

https://github.com/mui/material-ui/assets/44305048/0ec85b95-6198-4a0d-aa6d-9746d868ff21


@siriwatknp 