### PR TITLE
[docs][material-ui][Slider] Remove `valueLabelFormat` from restricted values demo so that the tooltip thumb label displays the same as the value text

### DIFF
--- a/docs/data/material/components/slider/DiscreteSliderValues.js
+++ b/docs/data/material/components/slider/DiscreteSliderValues.js
@@ -25,17 +25,12 @@ function valuetext(value) {
   return `${value}°C`;
 }
 
-function valueLabelFormat(value) {
-  return marks.findIndex((mark) => mark.value === value) + 1;
-}
-
 export default function DiscreteSliderValues() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
         aria-label="Restricted values"
         defaultValue={20}
-        valueLabelFormat={valueLabelFormat}
         getAriaValueText={valuetext}
         step={null}
         valueLabelDisplay="auto"

--- a/docs/data/material/components/slider/DiscreteSliderValues.tsx
+++ b/docs/data/material/components/slider/DiscreteSliderValues.tsx
@@ -25,17 +25,12 @@ function valuetext(value: number) {
   return `${value}°C`;
 }
 
-function valueLabelFormat(value: number) {
-  return marks.findIndex((mark) => mark.value === value) + 1;
-}
-
 export default function DiscreteSliderValues() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
         aria-label="Restricted values"
         defaultValue={20}
-        valueLabelFormat={valueLabelFormat}
         getAriaValueText={valuetext}
         step={null}
         valueLabelDisplay="auto"

--- a/docs/data/material/components/slider/DiscreteSliderValues.tsx.preview
+++ b/docs/data/material/components/slider/DiscreteSliderValues.tsx.preview
@@ -1,7 +1,6 @@
 <Slider
   aria-label="Restricted values"
   defaultValue={20}
-  valueLabelFormat={valueLabelFormat}
   getAriaValueText={valuetext}
   step={null}
   valueLabelDisplay="auto"


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Preview: https://deploy-preview-41567--material-ui.netlify.app/material-ui/react-slider/#restricted-values

### Issue
Going through the Slider documentation, for all code examples that have value labels and tooltip thumb labels, these values match (see Custom marks and Label always visible examples) except for the Restricted values example.

<img width="772" alt="Screenshot 2024-03-19 at 10 35 33 PM" src="https://github.com/mui/material-ui/assets/565783/6f951f3c-b41b-4faf-ad1a-34e80cf5dbe1">


### Proposed Change
I'm proposing this change to have the tooltip thumb label match the value label by removing the `valueLabelFormat` prop from the example. Doing this will then make the example look like the below screenshot:
<img width="758" alt="Screenshot 2024-03-19 at 10 35 15 PM" src="https://github.com/mui/material-ui/assets/565783/4382b941-79f3-4db4-aa26-adbd69898204">
