### PR TITLE
[pigment-css][react] RTL Support

### DIFF
--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -14,13 +14,14 @@ Pigment CSS is a zero-runtime CSS-in-JS library that extracts the colocated sty
     - [Styled component as a CSS selector](#styled-component-as-a-css-selector)
     - [Typing props](#typing-props)
 - [Theming](#theming)
-  - [Accesing theme values](#accesing-theme-values)
+  - [Accessing theme values](#accessing-theme-values)
   - [CSS variables support](#css-variables-support)
   - [Color schemes](#color-schemes)
   - [Switching color schemes](#switching-color-schemes)
   - [TypeScript](#typescript)
 - [How-to guides](#how-to-guides)
   - [Coming from Emotion or styled-components](#coming-from-emotion-or-styled-components)
+- [RTL Support](#rtl-support)
 
 ## Getting started
 
@@ -765,3 +766,85 @@ function App() {
   )
 }
 ```
+
+## RTL Support
+
+Pigment CSS offers built-in mechanism to automatically output corresponding rtl or ltr CSS. If your app by default caters to ltr direction, you also have an option to configure the plugin to output the CSS for the other direction automatically. To configure Pigment CSS for this, update the bundler config.
+
+### Next.js
+
+```js
+const { withPigment } = require('@pigment-css/nextjs-plugin');
+
+// ...
+module.exports = withPigment(nextConfig, {
+  theme: yourCustomTheme,
+  // CSS output option
+  css: {
+    // Specify your default CSS authoring direction
+    defaultDirection: 'ltr',
+    // If you want to output CSS for the direction other than
+    // the `defaultDirection`. Default is `false`.
+    generateForBothDir: true,
+    // Pass this to customize the dir selector. Default is
+    // [dir="rtl"] or [dir="ltr"]
+    getDirSelector(dir: string) {
+      // return your own selector that you'd like to use.
+      return `:dir(${dir})`;
+    }
+  }
+})
+```
+
+### Vite
+
+The options are same for Vite.
+
+```js
+import { pigment } from '@pigment-css/vite-plugin';
+
+export default defineConfig({
+  plugins: [
+    pigment({
+      theme: yourTheme,
+      css: {
+        defaultDirection: 'ltr',
+        generateForBothDir: true,
+        getDirSelector(dir: string) {
+          return `:dir(${dir})`;
+        }
+      }
+    }),
+    // ... Your other plugins.
+  ],
+});
+```
+
+Coming back to the app code, if one of the authored CSS is:
+
+```js
+import { css } from '@pigment-css/react';
+
+const className = css`
+  margin-left: 10px,
+  margin-right: 20px,
+  padding: '0 10px 20px 30px'
+`;
+```
+
+The output CSS would be:
+
+```css
+.cmip3v5 {
+  margin-left: 10px;
+  margin-right: 20px;
+  padding: 0 10px 20px 30px;
+}
+[dir='rtl'] .cmip3v5 {
+  margin-right: 10px;
+  margin-left: 20px;
+  padding: 0 30px 20px 10px;
+}
+```
+
+Remember to also add the `dir` attribute on the `html` element or any relevant parent element as per your application logic or user preference.

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -786,19 +786,11 @@ module.exports = withPigment(nextConfig, {
     // If you want to output CSS for the direction other than
     // the `defaultDirection`. Default is `false`.
     generateForBothDir: true,
-    // Pass this to customize the dir selector. Default is
-    // [dir="rtl"] or [dir="ltr"]
-    getDirSelector(dir: string) {
-      // return your own selector that you'd like to use.
-      return `:dir(${dir})`;
-    }
-  }
-})
+  },
+});
 ```
 
 ### Vite
-
-The options are same for Vite.
 
 ```js
 import { pigment } from '@pigment-css/vite-plugin';
@@ -808,12 +800,12 @@ export default defineConfig({
     pigment({
       theme: yourTheme,
       css: {
+        // Specify your default CSS authoring direction
         defaultDirection: 'ltr',
+        // If you want to output CSS for the direction other than
+        // the `defaultDirection`. Default is `false`.
         generateForBothDir: true,
-        getDirSelector(dir: string) {
-          return `:dir(${dir})`;
-        }
-      }
+      },
     }),
     // ... Your other plugins.
   ],
@@ -848,3 +840,17 @@ The output CSS would be:
 ```
 
 Remember to also add the `dir` attribute on the `html` element or any relevant parent element as per your application logic or user preference.
+
+#### Custom dir selector
+
+The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize this selector by passing an optional `getDirSelector` method in the `css` property above:
+
+```js
+  // ...
+  css: {
+    getDirSelector(dir: string) {
+      // return your own selector that you'd like to use.
+      return `:dir(${dir})`;
+    }
+  }
+```

--- a/packages/pigment-css-react/package.json
+++ b/packages/pigment-css-react/package.json
@@ -48,7 +48,8 @@
     "cssesc": "^3.0.0",
     "csstype": "^3.1.3",
     "lodash": "^4.17.21",
-    "stylis": "^4.3.1"
+    "stylis": "^4.3.1",
+    "stylis-plugin-rtl": "^2.1.1"
   },
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.23.3",
@@ -138,6 +139,15 @@
       "import": "./build/Box.mjs",
       "require": "./build/Box.js",
       "default": "./build/Box.js"
+    },
+    "./RtlProvider": {
+      "types": "./build/RtlProvider.d.ts",
+      "import": {
+        "types": "./build/RtlProvider.d.mts",
+        "default": "./build/RtlProvider.mjs"
+      },
+      "require": "./build/RtlProvider.js",
+      "default": "./build/RtlProvider.js"
     }
   },
   "nx": {

--- a/packages/pigment-css-react/src/RtlProvider.tsx
+++ b/packages/pigment-css-react/src/RtlProvider.tsx
@@ -1,0 +1,25 @@
+'use client';
+/**
+ * This package has it's own version of RtlProvider to avoid including
+ * @mui/system in the bundle if someone is not using it.
+ */
+import * as React from 'react';
+
+type RtlContextType = boolean | undefined;
+
+type RtlProviderProps = {
+  value?: RtlContextType;
+};
+
+const RtlContext = React.createContext<RtlContextType>(false);
+
+function RtlProvider({ value, ...props }: RtlProviderProps) {
+  return <RtlContext.Provider value={value ?? true} {...props} />;
+}
+
+export const useRtl = () => {
+  const value = React.useContext(RtlContext);
+  return value ?? false;
+};
+
+export default RtlProvider;

--- a/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
+++ b/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
@@ -16,6 +16,28 @@ export type PluginCustomOptions = {
    * Object to pass as parameter to the styled css callback functions.
    */
   themeArgs?: { theme?: Theme };
+  /**
+   * Customize the output CSS. Mainly used for RTL support right now.
+   */
+  css?: {
+    /**
+     * To denote that whatever default css is being authored pertains to this
+     * direction so that when Pigment CSS generates the CSS for the other direction,
+     * it can revert the direction of the selector accordingly.
+     * @default 'ltr'
+     */
+    defaultDirection?: 'ltr' | 'rtl';
+    /**
+     * Pass this as true if you want to output the CSS for both ltr and rtl.
+     * The css of the non-default direction will be wrapped in a `dir` selector.
+     */
+    generateForBothDir?: boolean;
+    /**
+     * Pass this callback to customize the selector for the `dir` attribute. The default
+     * is [dir=ltr] or [dir=rtl].
+     */
+    getDirSelector?: (dir: 'ltr' | 'rtl') => string;
+  };
 };
 
 type CssFnValueToVariableParams = {
@@ -27,8 +49,6 @@ type CssFnValueToVariableParams = {
   includeThemeArg?: boolean;
   themeImportIdentifier?: string;
 };
-
-// const expressionCache = new WeakMap<ExpressionValue, Expression>();
 
 // @TODO - Implement default theme argument for non-theme config as well.
 function parseAndWrapExpression(

--- a/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
+++ b/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
@@ -22,7 +22,7 @@ export type PluginCustomOptions = {
   css?: {
     /**
      * To denote that whatever default css is being authored pertains to this
-     * direction so that when Pigment CSS generates the CSS for the other direction,
+     * direction so that when Pigment CSS generates the CSS for the other direction,
      * it can revert the direction of the selector accordingly.
      * @default 'ltr'
      */

--- a/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
+++ b/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
@@ -26,12 +26,12 @@ export type PluginCustomOptions = {
      * it can revert the direction of the selector accordingly.
      * @default 'ltr'
      */
-    defaultDirection?: 'ltr' | 'rtl';
+    defaultDirection: 'ltr' | 'rtl';
     /**
      * Pass this as true if you want to output the CSS for both ltr and rtl.
      * The css of the non-default direction will be wrapped in a `dir` selector.
      */
-    generateForBothDir?: boolean;
+    generateForBothDir: boolean;
     /**
      * Pass this callback to customize the selector for the `dir` attribute. The default
      * is [dir=ltr] or [dir=rtl].

--- a/packages/pigment-css-react/src/utils/preprocessor.ts
+++ b/packages/pigment-css-react/src/utils/preprocessor.ts
@@ -1,5 +1,7 @@
 import type { Element } from 'stylis';
 import { serialize, compile, stringify, middleware } from 'stylis';
+import rtlPlugin from 'stylis-plugin-rtl';
+import { type PluginCustomOptions } from './cssFnValueToVariable';
 
 function globalSelector(element: Element) {
   switch (element.type) {
@@ -17,13 +19,48 @@ function globalSelector(element: Element) {
   }
 }
 
-const serializer = middleware([globalSelector, stringify]);
-
-const stylis = (css: string) => serialize(compile(css), serializer);
-
-export function preprocessor(selector: string, cssText: string) {
-  if (cssText.startsWith('@keyframes')) {
-    return stylis(cssText.replace('@keyframes', `@keyframes ${selector}`));
+function getSerializer(includeRtl?: boolean) {
+  if (!includeRtl) {
+    return middleware([globalSelector, stringify]);
   }
-  return stylis(`${selector}{${cssText}}`);
+  return middleware([globalSelector, rtlPlugin, stringify]);
+}
+
+const serializer = getSerializer();
+const serializerRtl = getSerializer(true);
+
+const stylis = (css: string, serializerParam = serializer) =>
+  serialize(compile(css), serializerParam);
+
+const defaultGetDirSelector = (dir: 'ltr' | 'rtl') => `[dir=${dir}]`;
+
+export function preprocessor(
+  selector: string,
+  cssText: string,
+  options?: PluginCustomOptions['css'],
+) {
+  const {
+    defaultDirection = 'ltr',
+    generateForBothDir = false,
+    getDirSelector = defaultGetDirSelector,
+  } = options || {};
+  let css = '';
+  if (cssText.startsWith('@keyframes')) {
+    css += stylis(cssText.replace('@keyframes', `@keyframes ${selector}`));
+    return css;
+
+    // if (generateForBothDir) {
+    //   const css2 = stylis(cssText.replace('@keyframes', `@keyframes ${selector}`), serializerRtl);
+    //   console.log(css2);
+    // }
+  }
+  css += stylis(`${selector}{${cssText}}`);
+  if (generateForBothDir) {
+    css += stylis(
+      `${getDirSelector(defaultDirection === 'ltr' ? 'rtl' : 'ltr')} ${selector}{${cssText}}`,
+      serializerRtl,
+    );
+  }
+
+  return css;
 }

--- a/packages/pigment-css-react/src/utils/preprocessor.ts
+++ b/packages/pigment-css-react/src/utils/preprocessor.ts
@@ -48,11 +48,6 @@ export function preprocessor(
   if (cssText.startsWith('@keyframes')) {
     css += stylis(cssText.replace('@keyframes', `@keyframes ${selector}`));
     return css;
-
-    // if (generateForBothDir) {
-    //   const css2 = stylis(cssText.replace('@keyframes', `@keyframes ${selector}`), serializerRtl);
-    //   console.log(css2);
-    // }
   }
   css += stylis(`${selector}{${cssText}}`);
   if (generateForBothDir) {

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.input.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.input.js
@@ -1,0 +1,33 @@
+import { styled, keyframes } from '@pigment-css/react';
+
+const rotateKeyframe = keyframes({
+  from: {
+    transform: 'translateX(0%)',
+  },
+  to: {
+    transform: 'translateX(100%)',
+  },
+});
+
+const Component = styled.div(({ theme }) => ({
+  animation: `${rotateKeyframe} 2s ease-out 0s infinite`,
+  marginLeft: 10,
+}));
+
+export const SliderRail = styled('span', {
+  name: 'MuiSlider',
+  slot: 'Rail',
+})`
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  border-top-left-radius: 3px;
+`;
+
+const SliderRail2 = styled.span`
+  ${SliderRail} {
+    padding-inline-start: none;
+    margin: 0px 10px 10px 30px;
+  }
+`;

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.output.css
@@ -1,0 +1,44 @@
+@keyframes r14vlhb {
+  from {
+    transform: translateX(0%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+.c194j3ko {
+  animation: r14vlhb 2s ease-out 0s infinite;
+  margin-left: 10px;
+}
+:dir(rtl) .c194j3ko {
+  animation: r14vlhb 2s ease-out 0s infinite;
+  margin-right: 10px;
+}
+.sgip8u5 {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  border-top-left-radius: 3px;
+}
+:dir(rtl) .sgip8u5 {
+  display: block;
+  position: absolute;
+  right: 0;
+  top: 0;
+  border-top-right-radius: 3px;
+}
+.sgip8u5-1 {
+  font-size: 1.5rem;
+}
+:dir(rtl) .sgip8u5-1 {
+  font-size: 1.5rem;
+}
+.smip3v5 .sgip8u5 {
+  padding-inline-start: none;
+  margin: 0px 10px 10px 30px;
+}
+:dir(rtl) .smip3v5 .sgip8u5 {
+  padding-inline-start: none;
+  margin: 0px 30px 10px 10px;
+}

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.output.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.output.js
@@ -1,0 +1,16 @@
+import { styled as _styled3 } from '@pigment-css/react';
+import { styled as _styled2 } from '@pigment-css/react';
+import { styled as _styled } from '@pigment-css/react';
+import _theme from '@pigment-css/react/theme';
+const Component = /*#__PURE__*/ _styled('div')({
+  classes: ['c194j3ko'],
+});
+export const SliderRail = /*#__PURE__*/ _styled2('span', {
+  name: 'MuiSlider',
+  slot: 'Rail',
+})({
+  classes: ['sgip8u5', 'sgip8u5-1'],
+});
+const SliderRail2 = /*#__PURE__*/ _styled3('span')({
+  classes: ['smip3v5'],
+});

--- a/packages/pigment-css-react/tests/styled/styled.test.ts
+++ b/packages/pigment-css-react/tests/styled/styled.test.ts
@@ -1,6 +1,28 @@
 import path from 'node:path';
 import { runTransformation, expect } from '../testUtils';
 
+const theme = {
+  palette: {
+    primary: {
+      main: 'red',
+    },
+  },
+  size: {
+    font: {
+      h1: '3rem',
+    },
+  },
+  components: {
+    MuiSlider: {
+      styleOverrides: {
+        rail: {
+          fontSize: '1.5rem',
+        },
+      },
+    },
+  },
+};
+
 describe('Pigment CSS - styled', () => {
   it('basics', async () => {
     const { output, fixture } = await runTransformation(
@@ -16,26 +38,27 @@ describe('Pigment CSS - styled', () => {
       path.join(__dirname, 'fixtures/styled-theme.input.js'),
       {
         themeArgs: {
-          theme: {
-            palette: {
-              primary: {
-                main: 'red',
-              },
-            },
-            size: {
-              font: {
-                h1: '3rem',
-              },
-            },
-            components: {
-              MuiSlider: {
-                styleOverrides: {
-                  rail: {
-                    fontSize: '1.5rem',
-                  },
-                },
-              },
-            },
+          theme,
+        },
+      },
+    );
+
+    expect(output.js).to.equal(fixture.js);
+    expect(output.css).to.equal(fixture.css);
+  });
+
+  it('should work with theme and rtl', async () => {
+    const { output, fixture } = await runTransformation(
+      path.join(__dirname, 'fixtures/styled-rtl.input.js'),
+      {
+        themeArgs: {
+          theme,
+        },
+        css: {
+          defaultDirection: 'ltr',
+          generateForBothDir: true,
+          getDirSelector(dir) {
+            return `:dir(${dir})`;
           },
         },
       },

--- a/packages/pigment-css-react/tests/testUtils.ts
+++ b/packages/pigment-css-react/tests/testUtils.ts
@@ -8,7 +8,7 @@ import {
   transform as wywTransform,
   createFileReporter,
 } from '@wyw-in-js/transform';
-import { preprocessor } from '@pigment-css/react/utils';
+import { PluginCustomOptions, preprocessor } from '@pigment-css/react/utils';
 import * as prettier from 'prettier';
 
 import sxTransformPlugin from '../exports/sx-plugin';
@@ -26,7 +26,7 @@ function runSxTransform(code: string, filename: string) {
 
 export async function runTransformation(
   absolutePath: string,
-  options?: { themeArgs?: { theme?: any } },
+  options?: { themeArgs?: { theme?: any }; css?: PluginCustomOptions['css'] },
 ) {
   const cache = new TransformCacheCollection();
   const { emitter: eventEmitter } = createFileReporter(false);
@@ -60,7 +60,7 @@ export async function runTransformation(
     {
       options: {
         filename: inputFilePath,
-        preprocessor,
+        preprocessor: (selector, css) => preprocessor(selector, css, options?.css),
         pluginOptions,
       },
       cache,

--- a/packages/pigment-css-react/tsconfig.json
+++ b/packages/pigment-css-react/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "types": ["node", "mocha"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.tsx", "src/**/*.js"],
   "exclude": ["./tsup.config.ts"]
 }

--- a/packages/pigment-css-react/tsup.config.ts
+++ b/packages/pigment-css-react/tsup.config.ts
@@ -10,14 +10,16 @@ const baseConfig: Options = {
   external,
 };
 
+const BASE_FILES = ['index.ts', 'theme.ts', 'Box.jsx', 'RtlProvider.tsx'];
+
 export default defineConfig([
   {
     ...baseConfig,
-    entry: ['./src/index.ts', './src/theme.ts', './src/Box.jsx'],
+    entry: BASE_FILES.map((file) => `./src/${file}`),
   },
   {
     ...baseConfig,
-    entry: processors.map((fn) => `./src/processors/${fn}.ts`),
+    entry: processors.map((file) => `./src/processors/${file}.ts`),
     outDir: 'processors',
   },
   {

--- a/packages/pigment-css-vite-plugin/src/index.ts
+++ b/packages/pigment-css-vite-plugin/src/index.ts
@@ -45,9 +45,10 @@ export function pigment(options: PigmentOptions) {
   const {
     theme,
     babelOptions = {},
-    preprocessor = basePreprocessor,
+    preprocessor,
     transformLibraries = [],
     transformSx = true,
+    css,
     ...rest
   } = options ?? {};
 
@@ -104,11 +105,15 @@ export function pigment(options: PigmentOptions) {
     };
   }
 
+  const withRtl = (selector: string, cssText: string) => {
+    return basePreprocessor(selector, cssText, css);
+  };
+
   const zeroPlugin = baseWywPluginPlugin({
     themeArgs: {
       theme,
     },
-    preprocessor,
+    preprocessor: preprocessor ?? withRtl,
     babelOptions: {
       ...babelOptions,
       plugins: ['@babel/plugin-syntax-typescript', ...(babelOptions.plugins ?? [])],

--- a/packages/pigment-css-vite-plugin/src/vite-plugin.ts
+++ b/packages/pigment-css-vite-plugin/src/vite-plugin.ts
@@ -50,6 +50,7 @@ export default function wywVitePlugin({
   transformLibraries = [],
   overrideContext,
   tagResolver,
+  css: cssConfig,
   ...rest
 }: VitePluginOptions = {}): Plugin {
   const filter = createFilter(include, exclude);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2062,6 +2062,9 @@ importers:
       stylis:
         specifier: ^4.3.1
         version: 4.3.1
+      stylis-plugin-rtl:
+        specifier: ^2.1.1
+        version: 2.1.1(stylis@4.3.1)
     devDependencies:
       '@babel/plugin-syntax-jsx':
         specifier: ^7.23.3
@@ -20102,6 +20105,15 @@ packages:
     dependencies:
       cssjanus: 2.1.0
       stylis: 4.2.0
+
+  /stylis-plugin-rtl@2.1.1(stylis@4.3.1):
+    resolution: {integrity: sha512-q6xIkri6fBufIO/sV55md2CbgS5c6gg9EhSVATtHHCdOnbN/jcI0u3lYhNVeuI65c4lQPo67g8xmq5jrREvzlg==}
+    peerDependencies:
+      stylis: 4.x
+    dependencies:
+      cssjanus: 2.1.0
+      stylis: 4.3.1
+    dev: false
 
   /stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}


### PR DESCRIPTION
* Re-export `RtlProvider` from `@mui/system`
* Also implements built-in RTL support. See the added test files.

Note: There is one optimization that we can pick-up later is to only add properties that actually changed in the output from ltr to rtl, ie, for:

```css
.class {
  display: block;
  margin-left: 20px;
}
```

The output should not include the `display` property since it's common in both.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
