### PR TITLE
[pigment-css][docs] Update the RTL section on the readme

### DIFF
--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -19,9 +19,9 @@ Pigment CSS is a zero-runtime CSS-in-JS library that extracts the colocated sty
   - [Color schemes](#color-schemes)
   - [Switching color schemes](#switching-color-schemes)
   - [TypeScript](#typescript)
+- [Right-to-left support](#right-to-left-support)
 - [How-to guides](#how-to-guides)
   - [Coming from Emotion or styled-components](#coming-from-emotion-or-styled-components)
-- [RTL Support](#rtl-support)
 
 ## Getting started
 
@@ -663,6 +663,93 @@ declare module '@pigment-css/react/theme' {
 }
 ```
 
+## Right-to-left support
+
+Pigment CSS offers a built-in mechanism to support right-to-left (RTL) or left-to-right (LTR) CSS automatically. To turn it on, start by updating your bundler config:
+
+### Next.js
+
+```js
+const { withPigment } = require('@pigment-css/nextjs-plugin');
+
+// ...
+module.exports = withPigment(nextConfig, {
+  theme: yourCustomTheme,
+  // CSS output option
+  css: {
+    // Specify your default direction
+    defaultDirection: 'ltr',
+    // Use this prop if you want to output CSS for both directions. Default is `false`.
+    generateForBothDir: true,
+  },
+});
+```
+
+### Vite
+
+```js
+import { pigment } from '@pigment-css/vite-plugin';
+
+export default defineConfig({
+  plugins: [
+    pigment({
+      theme: yourTheme,
+      css: {
+        // Specify your default direction
+        defaultDirection: 'ltr',
+        // Use this prop if you want to output CSS for both directions. Default is `false`.
+        generateForBothDir: true,
+      },
+    }),
+    // ... Your other plugins.
+  ],
+});
+```
+
+So, with RTL turned on, if your authored CSS is:
+
+```js
+import { css } from '@pigment-css/react';
+
+const className = css`
+  margin-left: 10px,
+  margin-right: 20px,
+  padding: '0 10px 20px 30px'
+`;
+```
+
+The actual CSS output would be:
+
+```css
+.cmip3v5 {
+  margin-left: 10px;
+  margin-right: 20px;
+  padding: 0 10px 20px 30px;
+}
+
+[dir='rtl'] .cmip3v5 {
+  margin-right: 10px;
+  margin-left: 20px;
+  padding: 0 30px 20px 10px;
+}
+```
+
+Make sure to add the `dir` attribute on either the `html` element or any other equivalent parent element per your application logic or user preference.
+
+#### Custom dir selector
+
+The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize this selector by passing an optional `getDirSelector` method in the `css` property above:
+
+```js
+  // ...
+  css: {
+    getDirSelector(dir: string) {
+      // return your own selector that you'd like to use.
+      return `:dir(${dir})`;
+    }
+  }
+```
+
 ## How-to guides
 
 ### Coming from Emotion or styled-components
@@ -765,92 +852,4 @@ function App() {
     </div>
   )
 }
-```
-
-## RTL Support
-
-Pigment CSS offers built-in mechanism to automatically output corresponding rtl or ltr CSS. If your app by default caters to ltr direction, you also have an option to configure the plugin to output the CSS for the other direction automatically. To configure Pigment CSS for this, update the bundler config.
-
-### Next.js
-
-```js
-const { withPigment } = require('@pigment-css/nextjs-plugin');
-
-// ...
-module.exports = withPigment(nextConfig, {
-  theme: yourCustomTheme,
-  // CSS output option
-  css: {
-    // Specify your default CSS authoring direction
-    defaultDirection: 'ltr',
-    // If you want to output CSS for the direction other than
-    // the `defaultDirection`. Default is `false`.
-    generateForBothDir: true,
-  },
-});
-```
-
-### Vite
-
-```js
-import { pigment } from '@pigment-css/vite-plugin';
-
-export default defineConfig({
-  plugins: [
-    pigment({
-      theme: yourTheme,
-      css: {
-        // Specify your default CSS authoring direction
-        defaultDirection: 'ltr',
-        // If you want to output CSS for the direction other than
-        // the `defaultDirection`. Default is `false`.
-        generateForBothDir: true,
-      },
-    }),
-    // ... Your other plugins.
-  ],
-});
-```
-
-Coming back to the app code, if one of the authored CSS is:
-
-```js
-import { css } from '@pigment-css/react';
-
-const className = css`
-  margin-left: 10px,
-  margin-right: 20px,
-  padding: '0 10px 20px 30px'
-`;
-```
-
-The output CSS would be:
-
-```css
-.cmip3v5 {
-  margin-left: 10px;
-  margin-right: 20px;
-  padding: 0 10px 20px 30px;
-}
-[dir='rtl'] .cmip3v5 {
-  margin-right: 10px;
-  margin-left: 20px;
-  padding: 0 30px 20px 10px;
-}
-```
-
-Remember to also add the `dir` attribute on the `html` element or any relevant parent element as per your application logic or user preference.
-
-#### Custom dir selector
-
-The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize this selector by passing an optional `getDirSelector` method in the `css` property above:
-
-```js
-  // ...
-  css: {
-    getDirSelector(dir: string) {
-      // return your own selector that you'd like to use.
-      return `:dir(${dir})`;
-    }
-  }
 ```

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -678,9 +678,7 @@ module.exports = withPigment(nextConfig, {
   // CSS output option
   css: {
     // Specify your default direction
-    defaultDirection: 'ltr',
-    // Use this prop if you want to output CSS for both directions. Default is `false`.
-    generateForBothDir: true,
+    defaultDirection: 'rtl',
   },
 });
 ```
@@ -696,14 +694,25 @@ export default defineConfig({
       theme: yourTheme,
       css: {
         // Specify your default direction
-        defaultDirection: 'ltr',
-        // Use this prop if you want to output CSS for both directions. Default is `false`.
-        generateForBothDir: true,
+        defaultDirection: 'rtl',
       },
     }),
-    // ... Your other plugins.
+    // ... other plugins
   ],
 });
+```
+
+### Generate CSS for both directions
+
+Turn the `generateForBothDir` prop to true if you want to generate CSS for both directions. This would allow, for example, your user to toggle the app's direction, which would happen instantly, given the CSS is already available.
+
+```js
+  css: {
+    // Specify your default direction
+    defaultDirection: 'ltr',
+    // Default is `false`
+    generateForBothDir: true,
+  },
 ```
 
 For example, if you've specified `defaultDirection: 'ltr'` and `dir="rtl"`, and your authored CSS looks like this:

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -665,7 +665,7 @@ declare module '@pigment-css/react/theme' {
 
 ## Right-to-left support
 
-To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows:
+To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows to generate styles for both directions:
 
 ### Next.js
 
@@ -679,8 +679,8 @@ module.exports = withPigment(nextConfig, {
   css: {
     // Specify your default CSS authoring direction
     defaultDirection: 'ltr',
-    // To output CSS for the opposite direction to `defaultDirection`
-    // Default is `false`.
+    // Generate CSS for the opposite of the `defaultDirection`
+    // This is set to `false` by default
     generateForBothDir: true,
   },
 });
@@ -698,8 +698,8 @@ export default defineConfig({
       css: {
         // Specify your default CSS authoring direction
         defaultDirection: 'ltr',
-        // To output CSS for the opposite direction to `defaultDirection`
-        // Default is `false`.
+        // Generate CSS for the opposite of the `defaultDirection`
+        // This is set to `false` by default
         generateForBothDir: true,
       },
     }),

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -665,7 +665,7 @@ declare module '@pigment-css/react/theme' {
 
 ## Right-to-left support
 
-Pigment CSS offers a built-in mechanism to support right-to-left (RTL) or left-to-right (LTR) CSS automatically. To turn it on, start by updating your bundler config:
+Pigment CSS is designed for left-to-right (LTR) languages by default. To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows:
 
 ### Next.js
 
@@ -706,7 +706,7 @@ export default defineConfig({
 });
 ```
 
-So, with RTL turned on, if your authored CSS is:
+For example, if you've specified `'rtl'` as the direction and your authored CSS looks like this:
 
 ```js
 import { css } from '@pigment-css/react';
@@ -718,7 +718,7 @@ const className = css`
 `;
 ```
 
-The actual CSS output would be:
+Then the actual CSS output would be:
 
 ```css
 .cmip3v5 {
@@ -734,20 +734,22 @@ The actual CSS output would be:
 }
 ```
 
-Make sure to add the `dir` attribute on either the `html` element or any other equivalent parent element per your application logic or user preference.
-
 #### Custom dir selector
 
-The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize this selector by passing an optional `getDirSelector` method in the `css` property above:
+The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize this selector by passing an optional `getDirSelector` method to the `css` property in your bundler config:
 
 ```js
-  // ...
-  css: {
-    getDirSelector(dir: string) {
-      // return your own selector that you'd like to use.
-      return `:dir(${dir})`;
-    }
-  }
+  plugins: [
+    pigment({
+      theme: yourTheme,
+      css: {
+        getDirSelector(dir: string) {
+          // return a custom selector that you'd like to use
+          return `:dir(${dir})`;
+        },
+      },
+    }),
+  ]
 ```
 
 ## How-to guides

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -677,8 +677,11 @@ module.exports = withPigment(nextConfig, {
   theme: yourCustomTheme,
   // CSS output option
   css: {
-    // Specify your default direction
-    defaultDirection: 'rtl',
+    // Specify your default CSS authoring direction
+    defaultDirection: 'ltr',
+    // To output CSS for the opposite direction to `defaultDirection`
+    // Default is `false`.
+    generateForBothDir: true,
   },
 });
 ```
@@ -693,27 +696,19 @@ export default defineConfig({
     pigment({
       theme: yourTheme,
       css: {
-        // Specify your default direction
-        defaultDirection: 'rtl',
+        // Specify your default CSS authoring direction
+        defaultDirection: 'ltr',
+        // To output CSS for the opposite direction to `defaultDirection`
+        // Default is `false`.
+        generateForBothDir: true,
       },
     }),
-    // ... other plugins
+    // ... other plugins.
   ],
 });
 ```
 
-### Generate CSS for both directions
-
-Turn the `generateForBothDir` prop to true to generate CSS for both directions. This enables you to add a direction toggle on your app that would change it instantly given the CSS is already available.
-
-```js
-  css: {
-    // Specify your default direction
-    defaultDirection: 'ltr',
-    // Default is `false`
-    generateForBothDir: true,
-  },
-```
+### Generated CSS
 
 For example, if you've specified `defaultDirection: 'ltr'` and `dir="rtl"`, and your authored CSS looks like this:
 

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -665,7 +665,7 @@ declare module '@pigment-css/react/theme' {
 
 ## Right-to-left support
 
-Pigment CSS is designed for left-to-right (LTR) languages by default. To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows:
+Pigment CSS is designed for left-to-right (LTR) languages by default. To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows:
 
 ### Next.js
 
@@ -706,7 +706,7 @@ export default defineConfig({
 });
 ```
 
-For example, if you've specified `'rtl'` as the direction and your authored CSS looks like this:
+For example, if you've specified `defaultDirection: 'ltr'` and `dir="rtl"`, and your authored CSS looks like this:
 
 ```js
 import { css } from '@pigment-css/react';

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -665,7 +665,7 @@ declare module '@pigment-css/react/theme' {
 
 ## Right-to-left support
 
-Pigment CSS is designed for left-to-right (LTR) languages by default. To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows:
+To support right-to-left (RTL) languages, add the `dir="rtl"` attribute to your app's `<html>` element or any other equivalent top level container. Then, update your bundler config as follows:
 
 ### Next.js
 
@@ -704,7 +704,7 @@ export default defineConfig({
 
 ### Generate CSS for both directions
 
-Turn the `generateForBothDir` prop to true if you want to generate CSS for both directions. This would allow, for example, your user to toggle the app's direction, which would happen instantly, given the CSS is already available.
+Turn the `generateForBothDir` prop to true to generate CSS for both directions. This enables you to add a direction toggle on your app that would change it instantly given the CSS is already available.
 
 ```js
   css: {
@@ -743,9 +743,9 @@ Then the actual CSS output would be:
 }
 ```
 
-#### Custom dir selector
+### Custom dir selector
 
-The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize this selector by passing an optional `getDirSelector` method to the `css` property in your bundler config:
+The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize it by passing an optional `getDirSelector` method to the `css` property in your bundler config:
 
 ```js
   plugins: [
@@ -753,7 +753,7 @@ The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can cu
       theme: yourTheme,
       css: {
         getDirSelector(dir: string) {
-          // return a custom selector that you'd like to use
+          // return a custom selector you'd like to use
           return `:dir(${dir})`;
         },
       },

--- a/packages/pigment-css-react/README.md
+++ b/packages/pigment-css-react/README.md
@@ -743,17 +743,12 @@ Then the actual CSS output would be:
 The default selector in the output CSS is `[dir=rtl]` or `[dir=ltr]`. You can customize it by passing an optional `getDirSelector` method to the `css` property in your bundler config:
 
 ```js
-  plugins: [
-    pigment({
-      theme: yourTheme,
-      css: {
-        getDirSelector(dir: string) {
-          // return a custom selector you'd like to use
-          return `:dir(${dir})`;
-        },
+    css: {
+      getDirSelector(dir: string) {
+        // return a custom selector you'd like to use
+        return `:dir(${dir})`;
       },
-    }),
-  ]
+    },
 ```
 
 ## How-to guides


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just a few writing tweaks:

- "RTL" might be a well-known acronym, but I don't think it hurts to start first with what it means and then introduce the acronym later on _after_ we have mentioned its meaning.
- Moving this section above the "How-to guides". It feels like a feature that'd be a sibling to "Theming"?