### PR TITLE
[pigment-css][demo] Add index page for material-ui

### DIFF
--- a/apps/pigment-css-vite-app/package.json
+++ b/apps/pigment-css-vite-app/package.json
@@ -19,6 +19,7 @@
     "local-ui-lib": "workspace:^",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-router": "^6.22.1",
     "react-router-dom": "^6.22.1"
   },

--- a/apps/pigment-css-vite-app/src/pages/material-ui/index.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/index.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { useLocation, matchRoutes, Link } from 'react-router-dom';
+import { css } from '@pigment-css/react';
+import routes from '~react-pages';
+import Layout from '../../Layout';
+
+export default function MaterialIndex() {
+  const location = useLocation();
+  const matchedRoute = React.useMemo(
+    () => matchRoutes(routes, location.pathname)?.[0],
+    [location.pathname],
+  );
+  const childRoutes = matchedRoute?.route.children ?? [];
+
+  return (
+    <Layout>
+      <div>
+        <h1>Material UI Components</h1>
+        <nav>
+          <ul
+            className={css({
+              margin: 0,
+              marginBlock: '1rem',
+              padding: 0,
+              paddingLeft: '1.5rem',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.5rem',
+            })}
+          >
+            {childRoutes
+              .filter((item) => !!item.path)
+              .map((item) => (
+                <li key={item.path}>
+                  <Link
+                    to={`/material-ui/${item.path}`}
+                    className={css({
+                      textDecoration: 'underline',
+                      fontSize: '17px',
+                    })}
+                  >
+                    {item.path}
+                  </Link>
+                </li>
+              ))}
+          </ul>
+        </nav>
+      </div>
+    </Layout>
+  );
+}

--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-breadcrumbs.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-breadcrumbs.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { css } from '@pigment-css/react';
+import Alert from '@mui/material/Alert';
+
 import MaterialUILayout from '../../Layout';
 import ActiveLastBreadcrumb from '../../../../../docs/data/material/components/breadcrumbs/ActiveLastBreadcrumb.tsx';
 import BasicBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/BasicBreadcrumbs.tsx';
@@ -7,6 +11,24 @@ import CustomSeparator from '../../../../../docs/data/material/components/breadc
 import CustomizedBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/CustomizedBreadcrumbs.tsx';
 import IconBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/IconBreadcrumbs.tsx';
 import RouterBreadcrumbs from '../../../../../docs/data/material/components/breadcrumbs/RouterBreadcrumbs.tsx';
+
+function ErrorBoundaryFallback({ error }: FallbackProps) {
+  const err = error as Error;
+  return (
+    <Alert severity="error" variant="outlined">
+      Error while rendering.
+      <pre
+        className={css({
+          border: '1px dotted #ccc',
+          padding: 4,
+          whiteSpace: 'pre-wrap',
+        })}
+      >
+        {err.message}
+      </pre>
+    </Alert>
+  );
+}
 
 export default function Breadcrumbs() {
   return (
@@ -51,7 +73,9 @@ export default function Breadcrumbs() {
       <section>
         <h2> Router Breadcrumbs</h2>
         <div className="demo-container">
-          <RouterBreadcrumbs />
+          <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>
+            <RouterBreadcrumbs />
+          </ErrorBoundary>
         </div>
       </section>
     </MaterialUILayout>

--- a/packages/pigment-css-nextjs-plugin/src/index.ts
+++ b/packages/pigment-css-nextjs-plugin/src/index.ts
@@ -55,6 +55,8 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
           placeholderCssFile: extractionFile,
         },
         async asyncResolve(what: string, importer: string, stack: string[]) {
+          // Using the same stub file as "next/font". Should be updated in future to
+          // use it's own stub depdending on the actual usage.
           if (what.startsWith('__barrel_optimize__')) {
             return require.resolve('../next-font');
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-error-boundary:
+        specifier: ^4.0.13
+        version: 4.0.13(react@18.2.0)
       react-router:
         specifier: ^6.22.1
         version: 6.22.1(react@18.2.0)
@@ -18359,6 +18362,15 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /react-error-boundary@4.0.13(react@18.2.0):
+    resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      react: 18.2.0
+    dev: false
+
   /react-event-listener@0.6.6(react@18.2.0):
     resolution: {integrity: sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==}
     peerDependencies:
@@ -22221,6 +22233,7 @@ packages:
       lodash: 4.17.21
       react: 18.2.0
       stylis: 4.3.1
+      stylis-plugin-rtl: 2.1.1(stylis@4.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color


### PR DESCRIPTION
components, similar to the one we have in the next.js demo

<img width="527" alt="Screenshot 2024-03-20 at 7 58 03 PM" src="https://github.com/mui/material-ui/assets/717550/baa55cd6-5b06-47b3-a8a6-d3fd638ba9cf">

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
