### PR TITLE
[core] Add instructions to deploying docs guide

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,10 +65,10 @@ To do so, follow these steps:
    git remote add material-ui-docs https://github.com/mui/material-ui-docs.git
    ```
 
-2. Pull the latest changes from the `material-ui-docs` remote:
+2. Fetch the latest changes from the `material-ui-docs` remote:
 
    ```bash
-   git pull material-ui-docs latest
+   git fetch material-ui-docs latest
    ```
 
 3. Switch to the `latest` branch from `material-ui-docs` remote:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,13 +65,19 @@ To do so, follow these steps:
    git remote add material-ui-docs https://github.com/mui/material-ui-docs.git
    ```
 
-2. Switch to the `latest` branch from `material-ui-docs` remote:
+2. Pull the latest changes from the `material-ui-docs` remote:
+
+   ```bash
+   git pull material-ui-docs latest
+   ```
+
+3. Switch to the `latest` branch from `material-ui-docs` remote:
 
    ```bash
    git switch --detach material-ui-docs/latest
    ```
 
-3. Cherry-pick the commit(s) that you want to include in the new deployment:
+4. Cherry-pick the commit(s) that you want to include in the new deployment:
 
    ```bash
    git cherry-pick <commit>
@@ -81,13 +87,17 @@ To do so, follow these steps:
 
    In case of conflicts you will need to resolve them and commit the changes manually.
 
-4. Push the changes to the `material-ui-docs` remote:
+   If this command fails with the message 'bad revision', it means that the commit doesn't exist on your local repository.
+   The commit might have been created on a remote branch, probably when merging into `master` or `next`.
+   In this case, you'll have to fetch the latest changes of the corresponding remote branch and then try again.
+
+5. Push the changes to the `material-ui-docs` remote:
 
    ```bash
    git push material-ui-docs HEAD:latest
    ```
 
-5. Switch from detached `HEAD` back to your last checked out branch:
+6. Switch from detached `HEAD` back to your last checked out branch:
 
    ```bash
    git checkout -


### PR DESCRIPTION
Add instructions to the guide about deploying docs without a release to avoid the following pitfalls:

- The local `material-ui-docs/latest` branch isn't updated
- The cherry-picked commit doesn't exist on the local branch
