### PR TITLE
[docs-infra] Skip loading source for non-editable modules

### DIFF
--- a/packages/markdown/loader.js
+++ b/packages/markdown/loader.js
@@ -164,9 +164,12 @@ module.exports = async function demoLoader() {
         raw: await fs.readFile(moduleFilepath, { encoding: 'utf8' }),
       };
       demoModuleIDs.add(moduleID);
-      extractImports(demos[demoName].raw).forEach((importModuleID) =>
-        importedModuleIDs.add(importModuleID),
-      );
+      // Skip non-editable demos
+      if (!nonEditableDemos.has(demoName)) {
+        extractImports(demos[demoName].raw).forEach((importModuleID) =>
+          importedModuleIDs.add(importModuleID),
+        );
+      }
 
       if (multipleDemoVersionsUsed) {
         // Add Tailwind demo data

--- a/packages/markdown/loader.js
+++ b/packages/markdown/loader.js
@@ -154,11 +154,6 @@ module.exports = async function demoLoader() {
         '',
       )}`;
 
-      // Skip non-editable demos
-      if (nonEditableDemos.has(demoName)) {
-        return;
-      }
-
       if (multipleDemoVersionsUsed) {
         moduleID = `${moduleID}/system/index.js`;
       }

--- a/packages/markdown/loader.js
+++ b/packages/markdown/loader.js
@@ -126,6 +126,7 @@ module.exports = async function demoLoader() {
   const components = {};
   const demoModuleIDs = new Set();
   const componentModuleIDs = new Set();
+  const nonEditableDemos = new Set();
   const demoNames = Array.from(
     new Set(
       docs.en.rendered
@@ -133,6 +134,9 @@ module.exports = async function demoLoader() {
           return typeof markdownOrComponentConfig !== 'string' && markdownOrComponentConfig.demo;
         })
         .map((demoConfig) => {
+          if (demoConfig.hideToolbar) {
+            nonEditableDemos.add(demoConfig.demo);
+          }
           return demoConfig.demo;
         }),
     ),
@@ -149,6 +153,11 @@ module.exports = async function demoLoader() {
         `pages/${fileRelativeContext.replace(/^docs\/src\/pages\//, '')}/`,
         '',
       )}`;
+
+      // Skip non-editable demos
+      if (nonEditableDemos.has(demoName)) {
+        return;
+      }
 
       if (multipleDemoVersionsUsed) {
         moduleID = `${moduleID}/system/index.js`;


### PR DESCRIPTION
- Skips extracting imports for modules which are not editable demos
- Relies on `hideToolbar` being `true` as the configuration property to detect the above
- Fixes #41585 

Before:
After: 