### PR TITLE
[material-ui][docs] Change composition code snippet from `useMemo()` to `useCallback()`

### DIFF
--- a/docs/data/material/guides/composition/composition.md
+++ b/docs/data/material/guides/composition/composition.md
@@ -89,13 +89,12 @@ import { Link, LinkProps } from 'react-router-dom';
 function ListItemLink(props) {
   const { icon, primary, to } = props;
 
-  const CustomLink = React.useMemo(
-    () =>
-      React.forwardRef<HTMLAnchorElement, Omit<RouterLinkProps, 'to'>>(
-        function Link(linkProps, ref) {
-          return <Link ref={ref} to={to} {...linkProps} />;
-        },
-      ),
+  const CustomLink = React.useCallback(
+    React.forwardRef<HTMLAnchorElement, Omit<RouterLinkProps, 'to'>>(
+      function Link(linkProps, ref) {
+        return <Link ref={ref} to={to} {...linkProps} />;
+      },
+    ),
     [to],
   );
 


### PR DESCRIPTION
`useCallback(fn, deps)` is equivalent to `useMemo(() => fn, deps)` but more readable.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
