### PR TITLE
[material-ui][docs] Remove deleted page from the sidenav

### DIFF
--- a/docs/data/material/pages.ts
+++ b/docs/data/material/pages.ts
@@ -195,11 +195,6 @@ const pages: MuiPage[] = [
     pathname: '/material-ui/guides',
     title: 'How-to guides',
     children: [
-      {
-        pathname: '/material-ui/guides/material-3-components',
-        title: 'Material Design 3 components',
-        newFeature: true,
-      },
       { pathname: '/material-ui/guides/minimizing-bundle-size' },
       { pathname: '/material-ui/guides/server-rendering' },
       { pathname: '/material-ui/guides/responsive-ui', title: 'Responsive UI' },

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -237,7 +237,6 @@
     "/material-ui/customization/z-index": "z-index",
     "/material-ui/customization/transitions": "Transitions",
     "/material-ui/guides": "How-to guides",
-    "/material-ui/guides/material-3-components": "Material Design 3 components",
     "/material-ui/guides/minimizing-bundle-size": "Minimizing bundle size",
     "/material-ui/guides/server-rendering": "Server rendering",
     "/material-ui/guides/responsive-ui": "Responsive UI",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This PR removes the now non-existing "Material Design 3 components" page from the list of pages. I'm assuming we'll want to cherry-pick this one into master as well?
