### PR TITLE
[docs] Drop IE 11 official support

### DIFF
--- a/docs/data/material/components/app-bar/app-bar.md
+++ b/docs/data/material/components/app-bar/app-bar.md
@@ -62,7 +62,7 @@ A prominent app bar.
 
 When you render the app bar position fixed, the dimension of the element doesn't impact the rest of the page. This can cause some part of your content to be invisible, behind the app bar. Here are 3 possible solutions:
 
-1. You can use `position="sticky"` instead of fixed. ⚠️ sticky is not supported by IE 11.
+1. You can use `position="sticky"` instead of fixed.
 2. You can render a second `<Toolbar />` component:
 
 ```jsx

--- a/docs/data/material/components/cards/cards.md
+++ b/docs/data/material/components/cards/cards.md
@@ -59,10 +59,6 @@ By default, we use the combination of a `<div>` element and a _background image_
 
 {{"demo": "ImgMediaCard.js", "bg": true}}
 
-:::warning
-When `component="img"`, CardMedia relies on `object-fit` for centering the image. It's not supported by IE 11.
-:::
-
 ## Primary action
 
 Often a card allow users to interact with the entirety of its surface to trigger its main action, be it an expansion, a link to another screen or some other behavior. The action area of the card can be specified by wrapping its contents in a `CardActionArea` component.

--- a/docs/data/material/components/lists/lists.md
+++ b/docs/data/material/components/lists/lists.md
@@ -97,7 +97,6 @@ The switch is the secondary action and a separate target.
 
 Upon scrolling, subheaders remain pinned to the top of the screen until pushed off screen by the next subheader.
 This feature relies on CSS sticky positioning.
-(⚠️ no IE 11 support)
 
 {{"demo": "PinnedSubheaderList.js", "bg": true}}
 

--- a/docs/data/material/components/progress/progress.md
+++ b/docs/data/material/components/progress/progress.md
@@ -127,26 +127,3 @@ If you need to perform 30 re-renders per second or more, we recommend disabling 
   transition: none;
 }
 ```
-
-### IE 11
-
-The circular progress component animation on IE 11 is degraded.
-The stroke dash animation is not working (equivalent to `disableShrink`) and the circular animation wobbles.
-You can solve the latter with:
-
-```css
-.MuiCircularProgress-indeterminate {
-  animation: circular-rotate 1.4s linear infinite;
-}
-
-@keyframes circular-rotate {
-  0% {
-    transform: rotate(0deg);
-    /* Fix IE 11 wobbly */
-    transform-origin: 50% 50%;
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-```

--- a/docs/data/material/components/slider/slider.md
+++ b/docs/data/material/components/slider/slider.md
@@ -151,17 +151,3 @@ However, you need to make sure that:
 - Each thumb has a user-friendly text for its current value.
   This is not required if the value matches the semantics of the label.
   You can change the name with the `getAriaValueText` or `aria-valuetext` prop.
-
-## Limitations
-
-### IE 11
-
-The slider's value label is not centered in IE 11.
-The alignment is not handled to make customizations easier with the latest browsers.
-You can solve the issue with:
-
-```css
-.MuiSlider-valueLabel {
-  left: calc(-50% - 4px);
-}
-```

--- a/docs/data/material/components/table/table.md
+++ b/docs/data/material/components/table/table.md
@@ -88,7 +88,6 @@ The `ActionsComponent` prop of the `TablePagination` component allows the implem
 
 Here is an example of a table with scrollable rows and fixed column headers.
 It leverages the `stickyHeader` prop.
-(⚠️ no IE 11 support)
 
 {{"demo": "StickyHeadTable.js", "bg": true}}
 

--- a/docs/data/material/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/data/material/getting-started/supported-platforms/supported-platforms.md
@@ -9,9 +9,9 @@ You don't need to provide any JavaScript polyfill as it manages unsupported brow
 
 <!-- #stable-snapshot -->
 
-| Edge   | Firefox | Chrome | Safari (macOS) | Safari (iOS) | IE                   |
-| :----- | :------ | :----- | :------------- | :----------- | :------------------- |
-| >= 121 | >= 115  | >= 109 | >= 15.4        | >= 15.4      | 11 (partial support) |
+| Edge   | Firefox | Chrome | Safari (macOS) | Safari (iOS) |
+| :----- | :------ | :----- | :------------- | :----------- |
+| >= 121 | >= 115  | >= 109 | >= 15.4        | >= 15.4      |
 
 <!-- #default-branch-switch -->
 
@@ -20,20 +20,6 @@ An extensive list can be found in our [.browserlistrc](https://github.com/mui/ma
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that Material UI supports it.
 [WRS regularly updates the rendering engine it uses](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).
 You can expect Material UI's components to render without major issues.
-
-### IE 11
-
-Material UI provides **partial** supports for IE 11. Be aware of the following:
-
-- Some of the components have no support. For instance, the new components, the data grid, the date picker.
-- Some of the components have degraded support. For instance, the outlined input border radius is missing, the combobox doesn't remove diacritics, the circular progress animation is wobbling.
-- The documentation itself might crash.
-- You need to install the [legacy bundle](/material-ui/guides/minimizing-bundle-size/#legacy-bundle).
-- You might need to install polyfills. For instance for the [popper.js transitive dependency](https://popper.js.org/docs/v2/browser-support/#ie11).
-
-Overall, the library doesn't prioritize the support of IE 11 if it harms the most common use cases. For instance, we will close new issues opened about IE 11 and might not merge pull requests that improve IE 11 support.
-
-v6 will completely remove the support of IE 11.
 
 ## Server
 

--- a/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/data/material/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -214,10 +214,7 @@ It will perform the following diffs:
 
 The packages published on npm are **transpiled** with [Babel](https://github.com/babel/babel), optimized for performance with the [supported platforms](/material-ui/getting-started/supported-platforms/).
 
-Custom bundles are also available:
-
-- [Modern bundle](#modern-bundle)
-- [Legacy bundle](#legacy-bundle)
+A [modern bundle](#modern-bundle) is also available.
 
 ### How to use custom bundles?
 
@@ -264,9 +261,3 @@ A great way to use these bundles is to configure bundler aliases, for example wi
 The modern bundle can be found under the [`/modern` folder](https://unpkg.com/@mui/material/modern/).
 It targets the latest released versions of evergreen browsers (Chrome, Firefox, Safari, Edge).
 This can be used to make separate bundles targeting different browsers.
-
-### Legacy bundle
-
-If you need to support IE 11 you cannot use the default or modern bundle without transpilation.
-However, you can use the legacy bundle found under the [`/legacy` folder](https://unpkg.com/@mui/material/legacy/).
-You don't need any additional polyfills.

--- a/docs/data/material/migration/migration-v4/migration-v4.md
+++ b/docs/data/material/migration/migration-v4/migration-v4.md
@@ -67,7 +67,7 @@ The default bundle supports the following minimum versions:
 - and more (see [.browserslistrc (`stable` entry)](https://github.com/mui/material-ui/blob/v5.0.0/.browserslistrc#L11))
 
 Material UI no longer supports IE 11.
-If you need to support IE 11, check out our [legacy bundle](/material-ui/guides/minimizing-bundle-size/#legacy-bundle).
+If you need to support IE 11, check out our [legacy bundle](https://v5.mui.com/material-ui/guides/minimizing-bundle-size/#legacy-bundle).
 
 ## Update React & TypeScript version
 

--- a/docs/data/material/migration/migration-v4/migration-v4.md
+++ b/docs/data/material/migration/migration-v4/migration-v4.md
@@ -67,7 +67,7 @@ The default bundle supports the following minimum versions:
 - and more (see [.browserslistrc (`stable` entry)](https://github.com/mui/material-ui/blob/v5.0.0/.browserslistrc#L11))
 
 Material UI no longer supports IE 11.
-If you need to support IE 11, check out our [legacy bundle](https://v5.mui.com/material-ui/guides/minimizing-bundle-size/#legacy-bundle).
+If you need to support IE 11, check out the [legacy bundle](https://v5.mui.com/material-ui/guides/minimizing-bundle-size/#legacy-bundle).
 
 ## Update React & TypeScript version
 

--- a/docs/translations/api-docs-joy/table/table.json
+++ b/docs/translations/api-docs-joy/table/table.json
@@ -19,10 +19,10 @@
     "slotProps": { "description": "The props used for each slot inside." },
     "slots": { "description": "The components used for each slot inside." },
     "stickyFooter": {
-      "description": "If <code>true</code>, the footer always appear at the bottom of the overflow table.<br>⚠️ It doesn&#39;t work with IE11."
+      "description": "If <code>true</code>, the footer always appear at the bottom of the overflow table."
     },
     "stickyHeader": {
-      "description": "If <code>true</code>, the header always appear at the top of the overflow table.<br>⚠️ It doesn&#39;t work with IE11."
+      "description": "If <code>true</code>, the header always appear at the top of the overflow table."
     },
     "stripe": {
       "description": "The odd or even row of the table body will have subtle background color."

--- a/docs/translations/api-docs/table/table.json
+++ b/docs/translations/api-docs/table/table.json
@@ -10,9 +10,7 @@
     },
     "padding": { "description": "Allows TableCells to inherit padding of the Table." },
     "size": { "description": "Allows TableCells to inherit size of the Table." },
-    "stickyHeader": {
-      "description": "Set the header sticky.<br>⚠️ It doesn&#39;t work with IE11."
-    },
+    "stickyHeader": { "description": "Set the header sticky." },
     "sx": {
       "description": "The system prop that allows defining system overrides as well as additional CSS styles."
     }

--- a/packages/mui-joy/src/Table/Table.tsx
+++ b/packages/mui-joy/src/Table/Table.tsx
@@ -418,15 +418,11 @@ Table.propTypes /* remove-proptypes */ = {
   }),
   /**
    * If `true`, the footer always appear at the bottom of the overflow table.
-   *
-   * ⚠️ It doesn't work with IE11.
    * @default false
    */
   stickyFooter: PropTypes.bool,
   /**
    * If `true`, the header always appear at the top of the overflow table.
-   *
-   * ⚠️ It doesn't work with IE11.
    * @default false
    */
   stickyHeader: PropTypes.bool,

--- a/packages/mui-joy/src/Table/TableProps.ts
+++ b/packages/mui-joy/src/Table/TableProps.ts
@@ -65,15 +65,11 @@ export interface TableTypeMap<P = {}, D extends React.ElementType = 'table'> {
     size?: OverridableStringUnion<'sm' | 'md' | 'lg', TablePropsSizeOverrides>;
     /**
      * If `true`, the header always appear at the top of the overflow table.
-     *
-     * ⚠️ It doesn't work with IE11.
      * @default false
      */
     stickyHeader?: boolean;
     /**
      * If `true`, the footer always appear at the bottom of the overflow table.
-     *
-     * ⚠️ It doesn't work with IE11.
      * @default false
      */
     stickyFooter?: boolean;

--- a/packages/mui-material/src/Table/Table.d.ts
+++ b/packages/mui-material/src/Table/Table.d.ts
@@ -28,8 +28,6 @@ export interface TableOwnProps {
   size?: OverridableStringUnion<'small' | 'medium', TablePropsSizeOverrides>;
   /**
    * Set the header sticky.
-   *
-   * ⚠️ It doesn't work with IE11.
    * @default false
    */
   stickyHeader?: boolean;

--- a/packages/mui-material/src/Table/Table.js
+++ b/packages/mui-material/src/Table/Table.js
@@ -122,8 +122,6 @@ Table.propTypes /* remove-proptypes */ = {
   ]),
   /**
    * Set the header sticky.
-   *
-   * ⚠️ It doesn't work with IE11.
    * @default false
    */
   stickyHeader: PropTypes.bool,


### PR DESCRIPTION
This is the first step towards #14420. This PR official communicates that IE 11 is no longer supported. This is a breaking change.

More changes will be required to close the issue, but they won't be breaking changes in theory as IE 11 is no longer supported https://github.com/mui/material-ui/pull/41611#issuecomment-2027080816.