### PR TITLE
[material-ui][FormGroup] Convert to support CSS extraction

### DIFF
--- a/packages/mui-material/src/FormGroup/FormGroup.js
+++ b/packages/mui-material/src/FormGroup/FormGroup.js
@@ -3,11 +3,12 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
-import styled from '../styles/styled';
-import useThemeProps from '../styles/useThemeProps';
+import { styled, createUseThemeProps } from '../zero-styled';
 import { getFormGroupUtilityClass } from './formGroupClasses';
 import useFormControl from '../FormControl/useFormControl';
 import formControlState from '../FormControl/formControlState';
+
+const useThemeProps = createUseThemeProps('MuiFormGroup');
 
 const useUtilityClasses = (ownerState) => {
   const { classes, row, error } = ownerState;
@@ -27,14 +28,19 @@ const FormGroupRoot = styled('div', {
 
     return [styles.root, ownerState.row && styles.row];
   },
-})(({ ownerState }) => ({
+})({
   display: 'flex',
   flexDirection: 'column',
   flexWrap: 'wrap',
-  ...(ownerState.row && {
-    flexDirection: 'row',
-  }),
-}));
+  variants: [
+    {
+      props: { row: true },
+      style: {
+        flexDirection: 'row',
+      },
+    },
+  ],
+});
 
 /**
  * `FormGroup` wraps controls such as `Checkbox` and `Switch`.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).


https://github.com/mui/material-ui/assets/44305048/174d7913-06ec-4136-9d0d-1013d63ce952

@siriwatknp just like FormControl, I used the Switch demo to showcase the FormGroup.