### PR TITLE
[utils] Fix GitHub-reported prototype pollution vulnerability in `deepmerge`

### DIFF
--- a/packages/mui-utils/src/deepmerge/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.test.ts
@@ -4,8 +4,30 @@ import deepmerge from './deepmerge';
 
 describe('deepmerge', () => {
   // https://snyk.io/blog/after-three-years-of-silence-a-new-jquery-prototype-pollution-vulnerability-emerges-once-again/
-  it('should not be subject to prototype pollution', () => {
+  it('should not be subject to prototype pollution via __proto__', () => {
     deepmerge({}, JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }'), {
+      clone: false,
+    });
+
+    expect({}).not.to.have.property('isAdmin');
+  });
+
+  // https://cwe.mitre.org/data/definitions/915.html
+  it('should not be subject to prototype pollution via constructor', () => {
+    deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "constructor" : { "prototype": { "isAdmin" : true } } }'),
+      {
+        clone: true,
+      },
+    );
+
+    expect({}).not.to.have.property('isAdmin');
+  });
+
+  // https://cwe.mitre.org/data/definitions/915.html
+  it('should not be subject to prototype pollution via prototype', () => {
+    deepmerge({}, JSON.parse('{ "myProperty": "a", "prototype": { "isAdmin" : true } }'), {
       clone: false,
     });
 

--- a/packages/mui-utils/src/deepmerge/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.test.ts
@@ -34,6 +34,18 @@ describe('deepmerge', () => {
     expect({}).not.to.have.property('isAdmin');
   });
 
+  it('should appropriately copy the fields without prototype pollution', () => {
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }'),
+    );
+
+    // @ts-expect-error __proto__ is not on this object type
+    // eslint-disable-next-line no-proto
+    expect(result.__proto__).to.have.property('isAdmin');
+    expect({}).not.to.have.property('isAdmin');
+  })
+
   it('should merge objects across realms', function test() {
     if (!/jsdom/.test(window.navigator.userAgent)) {
       // vm is only available in Node.js.

--- a/packages/mui-utils/src/deepmerge/deepmerge.test.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.test.ts
@@ -5,16 +5,23 @@ import deepmerge from './deepmerge';
 describe('deepmerge', () => {
   // https://snyk.io/blog/after-three-years-of-silence-a-new-jquery-prototype-pollution-vulnerability-emerges-once-again/
   it('should not be subject to prototype pollution via __proto__', () => {
-    deepmerge({}, JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }'), {
-      clone: false,
-    });
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "__proto__" : { "isAdmin" : true } }'),
+      {
+        clone: false,
+      },
+    );
 
+    // @ts-expect-error __proto__ is not on this object type
+    // eslint-disable-next-line no-proto
+    expect(result.__proto__).to.have.property('isAdmin');
     expect({}).not.to.have.property('isAdmin');
   });
 
   // https://cwe.mitre.org/data/definitions/915.html
   it('should not be subject to prototype pollution via constructor', () => {
-    deepmerge(
+    const result = deepmerge(
       {},
       JSON.parse('{ "myProperty": "a", "constructor" : { "prototype": { "isAdmin" : true } } }'),
       {
@@ -22,15 +29,22 @@ describe('deepmerge', () => {
       },
     );
 
+    expect(result.constructor.prototype).to.have.property('isAdmin');
     expect({}).not.to.have.property('isAdmin');
   });
 
   // https://cwe.mitre.org/data/definitions/915.html
   it('should not be subject to prototype pollution via prototype', () => {
-    deepmerge({}, JSON.parse('{ "myProperty": "a", "prototype": { "isAdmin" : true } }'), {
-      clone: false,
-    });
+    const result = deepmerge(
+      {},
+      JSON.parse('{ "myProperty": "a", "prototype": { "isAdmin" : true } }'),
+      {
+        clone: false,
+      },
+    );
 
+    // @ts-expect-error prototype is not on this object type
+    expect(result.prototype).to.have.property('isAdmin');
     expect({}).not.to.have.property('isAdmin');
   });
 
@@ -44,7 +58,7 @@ describe('deepmerge', () => {
     // eslint-disable-next-line no-proto
     expect(result.__proto__).to.have.property('isAdmin');
     expect({}).not.to.have.property('isAdmin');
-  })
+  });
 
   it('should merge objects across realms', function test() {
     if (!/jsdom/.test(window.navigator.userAgent)) {

--- a/packages/mui-utils/src/deepmerge/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.ts
@@ -42,7 +42,7 @@ export default function deepmerge<T>(
   if (isPlainObject(target) && isPlainObject(source)) {
     Object.keys(source).forEach((key) => {
       // Avoid prototype pollution
-      if (key === '__proto__') {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
         return;
       }
 

--- a/packages/mui-utils/src/deepmerge/deepmerge.ts
+++ b/packages/mui-utils/src/deepmerge/deepmerge.ts
@@ -41,12 +41,12 @@ export default function deepmerge<T>(
 
   if (isPlainObject(target) && isPlainObject(source)) {
     Object.keys(source).forEach((key) => {
-      // Avoid prototype pollution
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-        return;
-      }
-
-      if (isPlainObject(source[key]) && key in target && isPlainObject(target[key])) {
+      if (
+        isPlainObject(source[key]) &&
+        // Avoid prototype pollution
+        Object.prototype.hasOwnProperty.call(target, key) &&
+        isPlainObject(target[key])
+      ) {
         // Since `output` is a clone of `target` and we have narrowed `target` in this block we can cast to the same type.
         (output as Record<keyof any, unknown>)[key] = deepmerge(target[key], source[key], options);
       } else if (options.clone) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Added more checks for prototype pollution in `deepmerge` to abide by [GitHub's vulnerability report in another repo using MUI](https://github.com/paranext/paranext-core/security/code-scanning/41).

It was hard to figure out which library was contributing the code the reported vulnerability is in, but [this line](https://github.com/paranext/paranext-core/blob/ea96b20540f65c22e2ec32dec85e47ef599d001b/lib/platform-bible-react/dist/index.js#L1018) helped me to find `isPlainObject` exported from the same module which then led me to find `deepmerge`.

Thanks for all the hard work!