### PR TITLE
Fix dedupe check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
             - run:
                 name: Check for duplicated packages
                 command: |
+                  # #default-branch-switch
                   if [[ $(git diff --name-status next | grep -E 'pnpm-lock.yaml|package\.json') == "" ]];
                   then
                       echo "No changes to dependencies detected. Skipping..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
                 name: Check for duplicated packages
                 command: |
                   # #default-branch-switch
-                  if [[ $(git diff --name-status next | grep -E 'pnpm-lock.yaml|package\.json') == "" ]];
+                  if [[ $(git diff --name-status next | grep -E 'pnpm-workspace\.yaml|pnpm-lock.yaml|package\.json') == "" ]];
                   then
                       echo "No changes to dependencies detected. Skipping..."
                   else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
             - run:
                 name: Check for duplicated packages
                 command: |
-                  if [[ $(git diff --name-status master | grep pnpm.lock) == "" ]];
+                  if [[ $(git diff --name-status next | grep -E 'pnpm-lock.yaml|package\.json') == "" ]];
                   then
                       echo "No changes to dependencies detected. Skipping..."
                   else


### PR DESCRIPTION
* compare against the `next` branch
* include package.json
* fix lock file name

Note: the check is passing in this CI run because we're not editing any of these files. But it's currently broken on CI. Will fix in a separate PR