### PR TITLE
[core] Update peerDependencies ranges to include v6 packages

### DIFF
--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -68,7 +68,7 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "@mui/material": "workspace:*",
+    "@mui/material": "workspace:^",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0"
   },

--- a/packages/mui-icons-material/package.json
+++ b/packages/mui-icons-material/package.json
@@ -68,7 +68,7 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "@mui/material": "^5.0.0",
+    "@mui/material": "workspace:*",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0"
   },

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -50,6 +50,7 @@
     "prop-types": "^15.8.1"
   },
   "devDependencies": {
+    "@mui/material": "workspace:*",
     "@mui-internal/test-utils": "workspace:^",
     "@types/chai": "^4.3.12",
     "@types/prop-types": "^15.7.11",

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
-    "@mui/material": "workspace:*",
+    "@mui/material": "workspace:^",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/mui-lab/package.json
+++ b/packages/mui-lab/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
-    "@mui/material": ">=5.15.0",
+    "@mui/material": "workspace:*",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/server": "^11.11.0",
-    "@mui/material": "^5.0.0",
+    "@mui/material": "workspace:*",
     "@types/react": "^17.0.0 || ^18.0.0",
     "next": "^13.0.0 || ^14.0.0",
     "react": "^17.0.0 || ^18.0.0"

--- a/packages/mui-material-nextjs/package.json
+++ b/packages/mui-material-nextjs/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@emotion/cache": "^11.11.0",
     "@emotion/server": "^11.11.0",
-    "@mui/material": "workspace:*",
+    "@mui/material": "workspace:^",
     "@types/react": "^17.0.0 || ^18.0.0",
     "next": "^13.0.0 || ^14.0.0",
     "react": "^17.0.0 || ^18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1764,8 +1764,8 @@ importers:
         specifier: ^7.23.9
         version: 7.24.1
       '@mui/material':
-        specifier: ^5.0.0
-        version: 5.15.4(@emotion/react@11.11.4)(@emotion/styled@11.11.0)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+        specifier: workspace:*
+        version: link:../mui-material/build
     devDependencies:
       '@emotion/cache':
         specifier: ^11.11.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1576,9 +1576,6 @@ importers:
       '@mui/base':
         specifier: workspace:*
         version: link:../mui-base/build
-      '@mui/material':
-        specifier: '>=5.15.0'
-        version: link:../mui-material/build
       '@mui/system':
         specifier: workspace:^
         version: link:../mui-system/build
@@ -1598,6 +1595,9 @@ importers:
       '@mui-internal/test-utils':
         specifier: workspace:^
         version: link:../test-utils
+      '@mui/material':
+        specifier: workspace:*
+        version: link:../mui-material/build
       '@types/chai':
         specifier: ^4.3.12
         version: 4.3.12
@@ -1765,7 +1765,7 @@ importers:
         version: 7.24.1
       '@mui/material':
         specifier: ^5.0.0
-        version: link:../mui-material/build
+        version: 5.15.4(@emotion/react@11.11.4)(@emotion/styled@11.11.0)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@emotion/cache':
         specifier: ^11.11.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1764,7 +1764,7 @@ importers:
         specifier: ^7.23.9
         version: 7.24.1
       '@mui/material':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../mui-material/build
     devDependencies:
       '@emotion/cache':


### PR DESCRIPTION
- Adds a missing @mui/material dev dependency to @mui/lab
- Updates peer dep version ranges in @mui/material-nextjs and @mui/lab