### PR TITLE
[website] Improve job og image

### DIFF
--- a/docs/src/modules/components/TopLayoutCareers.js
+++ b/docs/src/modules/components/TopLayoutCareers.js
@@ -29,7 +29,11 @@ export default function TopLayoutCareers(props) {
   return (
     <BrandingCssVarsProvider>
       <AppHeader />
-      <Head title={`${title} - MUI`} description={description}>
+      <Head
+        title={`${title} - MUI`}
+        description={description}
+        card="/static/social-previews/careers-preview.jpg"
+      >
         <meta name="robots" content="noindex,nofollow" />
       </Head>
       <StyledDiv>


### PR DESCRIPTION
A continuation of #40793. The goal is for the subpages of https://mui.com/careers/ to have the same OG image. I needed this for https://twitter.com/olivtassinari/status/1772728620949139795. Instead, I had to add the image as an attachment but it's not a great UX, people can't click on the image, it's not a link.

Well, to be fair, ideally, it should be customized per role like in #41188. But this feels already a step forward, with less effort.