### PR TITLE
Allow empty `options` in @pigment-css/vite-plugin init

### DIFF
--- a/packages/pigment-css-vite-plugin/src/index.ts
+++ b/packages/pigment-css-vite-plugin/src/index.ts
@@ -41,9 +41,9 @@ function isZeroRuntimeProcessableFile(fileName: string, transformLibraries: stri
   );
 }
 
-export function pigment(options: PigmentOptions) {
+export function pigment(options?: PigmentOptions) {
   const {
-    theme,
+    theme = extendTheme({}),
     babelOptions = {},
     preprocessor = basePreprocessor,
     transformLibraries = [],


### PR DESCRIPTION
While trying to follow the docs, the plugin was throwing because its init required a `theme` to be passed.

This change allows users to omit the options as-recommended by the docs, and uses a default empty theme when one is not provided.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
