### PR TITLE
[material-ui][slider] Move palette styles to the bottom

### DIFF
--- a/packages/mui-material/src/Slider/Slider.js
+++ b/packages/mui-material/src/Slider/Slider.js
@@ -277,6 +277,30 @@ export const SliderThumb = styled('span', {
     },
   },
   variants: [
+    {
+      props: { size: 'small' },
+      style: {
+        width: 12,
+        height: 12,
+        '&::before': {
+          boxShadow: 'none',
+        },
+      },
+    },
+    {
+      props: { orientation: 'horizontal' },
+      style: {
+        top: '50%',
+        transform: 'translate(-50%, -50%)',
+      },
+    },
+    {
+      props: { orientation: 'vertical' },
+      style: {
+        left: '50%',
+        transform: 'translate(-50%, 50%)',
+      },
+    },
     ...Object.keys((theme.vars ?? theme).palette)
       .filter((key) => (theme.vars ?? theme).palette[key].main)
       .map((color) => ({
@@ -305,30 +329,6 @@ export const SliderThumb = styled('span', {
           },
         },
       })),
-    {
-      props: { size: 'small' },
-      style: {
-        width: 12,
-        height: 12,
-        '&::before': {
-          boxShadow: 'none',
-        },
-      },
-    },
-    {
-      props: { orientation: 'horizontal' },
-      style: {
-        top: '50%',
-        transform: 'translate(-50%, -50%)',
-      },
-    },
-    {
-      props: { orientation: 'vertical' },
-      style: {
-        left: '50%',
-        transform: 'translate(-50%, 50%)',
-      },
-    },
   ],
 }));
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Issue: https://mui.com/material-ui/.

<img width="1514" alt="image" src="https://github.com/mui/material-ui/assets/18292247/85bee2a8-005f-4cb8-a944-876dded5c8fd">

I don't have time to dig down to the root cause at the moment. This is a quick fix to get rid of the styles generation error.

**After**: https://deploy-preview-41676--material-ui.netlify.app/material-ui/

<img width="1511" alt="image" src="https://github.com/mui/material-ui/assets/18292247/6afca741-a502-497d-8776-7cc3a7a45348">

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
