### PR TITLE
[docs][material-ui][Slider] Remove valueLabelFormat from restricted values demo so that the tooltip thumb label displays the same as the value text

### DIFF
--- a/docs/data/material/components/slider/DiscreteSliderValues.js
+++ b/docs/data/material/components/slider/DiscreteSliderValues.js
@@ -25,17 +25,12 @@ function valuetext(value) {
   return `${value}°C`;
 }
 
-function valueLabelFormat(value) {
-  return marks.findIndex((mark) => mark.value === value) + 1;
-}
-
 export default function DiscreteSliderValues() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
         aria-label="Restricted values"
         defaultValue={20}
-        valueLabelFormat={valueLabelFormat}
         getAriaValueText={valuetext}
         step={null}
         valueLabelDisplay="auto"

--- a/docs/data/material/components/slider/DiscreteSliderValues.tsx
+++ b/docs/data/material/components/slider/DiscreteSliderValues.tsx
@@ -25,17 +25,12 @@ function valuetext(value: number) {
   return `${value}°C`;
 }
 
-function valueLabelFormat(value: number) {
-  return marks.findIndex((mark) => mark.value === value) + 1;
-}
-
 export default function DiscreteSliderValues() {
   return (
     <Box sx={{ width: 300 }}>
       <Slider
         aria-label="Restricted values"
         defaultValue={20}
-        valueLabelFormat={valueLabelFormat}
         getAriaValueText={valuetext}
         step={null}
         valueLabelDisplay="auto"

--- a/docs/data/material/components/slider/DiscreteSliderValues.tsx.preview
+++ b/docs/data/material/components/slider/DiscreteSliderValues.tsx.preview
@@ -1,7 +1,6 @@
 <Slider
   aria-label="Restricted values"
   defaultValue={20}
-  valueLabelFormat={valueLabelFormat}
   getAriaValueText={valuetext}
   step={null}
   valueLabelDisplay="auto"


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Cherry-pick b96215e09b600b68a5c03821c83ef12c3095943c. 