### PR TITLE
[docs][material-ui] Fix typo in CSS theme variables customization

### DIFF
--- a/docs/data/material/experimental-api/css-theme-variables/customization.md
+++ b/docs/data/material/experimental-api/css-theme-variables/customization.md
@@ -166,7 +166,7 @@ Then, you can access those variables from the `theme.vars` object:
 const Divider = styled('hr')(({ theme }) => ({
   height: 1,
   border: '1px solid',
-  borderColor: theme.vars.palette.border.subtile,
+  borderColor: theme.vars.palette.border.subtle,
   backgroundColor: theme.vars.palette.gradient,
 }));
 ```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Cherry-pick 0080b1bbeccf445962009e75a99df39c799e64ff.
