### PR TITLE
[code-infra] Fix require.context with aliases

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -347,7 +347,7 @@ MyApp.propTypes = {
 MyApp.getInitialProps = async ({ ctx, Component }) => {
   let pageProps = {};
 
-  const req = require.context('docs/translations', false, /translations.*\.json$/);
+  const req = require.context('docs/translations', false, /\.\/translations.*\.json$/);
   const translations = mapTranslations(req);
 
   if (Component.getInitialProps) {


### PR DESCRIPTION
Noticed while working on https://github.com/mui/mui-x/pull/12232

`require.context` returns [all possible requests](https://github.com/webpack/webpack/issues/12087#issuecomment-737532578) that can be made. `req.keys()` returns 
```tsx
[ './translations.json', 'docs/translations/translations.json' ]
```
after the change it returns
```tsx
[ './translations.json' ]
```