### PR TITLE
[pigment-css] Update the vite plugin to not require the options arg

### DIFF
--- a/packages/pigment-css-vite-plugin/src/index.ts
+++ b/packages/pigment-css-vite-plugin/src/index.ts
@@ -41,9 +41,9 @@ function isZeroRuntimeProcessableFile(fileName: string, transformLibraries: stri
   );
 }
 
-export function pigment(options: PigmentOptions) {
+export function pigment(options?: PigmentOptions) {
   const {
-    theme,
+    theme = {},
     babelOptions = {},
     preprocessor,
     transformLibraries = [],


### PR DESCRIPTION
I guess it makes sense for the options to be optional, if not, I will update the guide https://github.com/mui/material-ui/tree/next/packages/pigment-css-react#start-with-vite as otherwise it throws TS issue.