### PR TITLE
[pigment-css] Fix propTypes removal during eval stage

### DIFF
--- a/packages/pigment-css-react/package.json
+++ b/packages/pigment-css-react/package.json
@@ -65,6 +65,7 @@
     "@types/stylis": "^4.2.5",
     "chai": "^4.4.1",
     "prettier": "^3.2.5",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0"
   },
   "peerDependencies": {

--- a/packages/pigment-css-react/src/utils/remove-prop-types-plugin.ts
+++ b/packages/pigment-css-react/src/utils/remove-prop-types-plugin.ts
@@ -14,8 +14,9 @@ export const removePropTypesPlugin = declare<{}>((api) => {
         if (!property.isIdentifier({ name: 'propTypes' })) {
           return;
         }
-        if (path.parentPath.isExpressionStatement()) {
-          path.parentPath.remove();
+        const parentExpression = path.findParent((p) => p.isExpressionStatement());
+        if (parentExpression) {
+          parentExpression.remove();
         }
       },
     },

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-theme.input.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-theme.input.js
@@ -1,4 +1,5 @@
 import { styled, keyframes } from '@pigment-css/react';
+import PropTypes from 'prop-types';
 
 const rotateKeyframe = keyframes({
   from: {
@@ -34,3 +35,18 @@ const SliderRail2 = styled.span`
     display: none;
   }
 `;
+
+export function App() {
+  return (
+    <Component>
+      <SliderRail />
+      <SliderRail2 />
+    </Component>
+  );
+}
+
+process.env.NODE_ENV !== 'production'
+  ? (App.propTypes = {
+      children: PropTypes.element,
+    })
+  : void 0;

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-theme.output.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-theme.output.js
@@ -1,8 +1,28 @@
 import { styled as _styled, styled as _styled2, styled as _styled3 } from '@pigment-css/react';
 import _theme from '@pigment-css/react/theme';
+import PropTypes from 'prop-types';
 const Component = /*#__PURE__*/ _styled('div')({
   classes: ['c1h7nuob'],
+});
+const SliderRail = /*#__PURE__*/ _styled2('span', {
+  name: 'MuiSlider',
+  slot: 'Rail',
+})({
+  classes: ['s13xim6i', 's13xim6i-1'],
 });
 const SliderRail2 = /*#__PURE__*/ _styled3('span')({
   classes: ['s1emg10t'],
 });
+export function App() {
+  return (
+    <Component>
+      <SliderRail />
+      <SliderRail2 />
+    </Component>
+  );
+}
+process.env.NODE_ENV !== 'production'
+  ? (App.propTypes = {
+      children: PropTypes.element,
+    })
+  : void 0;

--- a/packages/pigment-css-react/tests/styled/fixtures/styled.input.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled.input.js
@@ -1,4 +1,5 @@
 import { styled, keyframes } from '@pigment-css/react';
+import PropTypes from 'prop-types';
 
 const rotateKeyframe = keyframes({
   from: {
@@ -32,3 +33,16 @@ const SliderRail2 = styled.span`
     display: none;
   }
 `;
+
+export function App() {
+  return (
+    <Component>
+      <SliderRail />
+      <SliderRail2 />
+    </Component>
+  );
+}
+
+App.propTypes = {
+  children: PropTypes.element,
+};

--- a/packages/pigment-css-react/tests/styled/fixtures/styled.output.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled.output.js
@@ -1,5 +1,6 @@
 import { styled as _styled, styled as _styled2, styled as _styled3 } from '@pigment-css/react';
 import _theme from '@pigment-css/react/theme';
+import PropTypes from 'prop-types';
 const Component = /*#__PURE__*/ _styled('div')({
   classes: ['c1aiqtje'],
 });
@@ -12,3 +13,14 @@ export const SliderRail = /*#__PURE__*/ _styled2('span', {
 const SliderRail2 = /*#__PURE__*/ _styled3('span')({
   classes: ['shdkmm7'],
 });
+export function App() {
+  return (
+    <Component>
+      <SliderRail />
+      <SliderRail2 />
+    </Component>
+  );
+}
+App.propTypes = {
+  children: PropTypes.element,
+};

--- a/packages/pigment-css-react/tests/testUtils.ts
+++ b/packages/pigment-css-react/tests/testUtils.ts
@@ -51,7 +51,10 @@ export async function runTransformation(
       babelrc: false,
       plugins: ['@babel/plugin-syntax-jsx'],
     },
-    tagResolver(_source: string, tag: string) {
+    tagResolver(source: string, tag: string) {
+      if (source !== '@pigment-css/react') {
+        return null;
+      }
       return require.resolve(`../exports/${tag}`);
     },
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2245,6 +2245,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
+      prop-types:
+        specifier: ^15.8.1
+        version: 15.8.1
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
Conditional assignment of propTypes was not handled resulting in error while using prod builds of material-ui.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
