### PR TITLE
[docs-infra] Allows to remove edit button

### DIFF
--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -10,6 +10,12 @@ export default function EditPage(props) {
   const { sourceLocation } = props;
   const t = useTranslate();
   const userLanguage = useUserLanguage();
+
+  if (!sourceLocation) {
+    // An empty div such that the footer layout stays unchanged.
+    return <div />;
+  }
+
   const CROWDIN_ROOT_URL = 'https://crowdin.com/project/material-ui-docs/';
   const crowdInLocale = LOCALES[userLanguage] || userLanguage;
   const crowdInPath = sourceLocation.substring(0, sourceLocation.lastIndexOf('/'));


### PR DESCRIPTION
When documenting interfaces, their is no obvious file to point to, so the sourceCode is an empty string which will be supported by this PR

![Screenshot from 2024-03-29 10-20-01](https://github.com/mui/material-ui/assets/45398769/0db1c015-6880-4590-9668-ed082db372ea)
