### PR TITLE
[pigment-css][react] Fix sx prop transformation on Box

### DIFF
--- a/apps/pigment-css-next-app/src/app/material-ui/page.tsx
+++ b/apps/pigment-css-next-app/src/app/material-ui/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import fs from 'fs/promises';
 import path from 'path';
 import { css } from '@pigment-css/react';
+import Box from '@pigment-css/react/Box';
 
 export default async function MaterialUIPage() {
   const rootPaths = await fs.readdir(path.join(process.cwd(), `src/app/material-ui`));
@@ -11,8 +12,9 @@ export default async function MaterialUIPage() {
     <div>
       <h1>Material UI Components</h1>
       <nav>
-        <ul
-          className={css({
+        <Box
+          as="ul"
+          sx={{
             margin: 0,
             marginBlock: '1rem',
             padding: 0,
@@ -20,7 +22,7 @@ export default async function MaterialUIPage() {
             display: 'flex',
             flexDirection: 'column',
             gap: '0.5rem',
-          })}
+          }}
         >
           {rootPaths
             .filter((item) => !item.match(/\.(js|tsx)$/))
@@ -37,7 +39,7 @@ export default async function MaterialUIPage() {
                 </Link>
               </li>
             ))}
-        </ul>
+        </Box>
       </nav>
     </div>
   );

--- a/apps/pigment-css-vite-app/package.json
+++ b/apps/pigment-css-vite-app/package.json
@@ -42,6 +42,11 @@
         "dependsOn": [
           "^build"
         ]
+      },
+      "dev": {
+        "dependsOn": [
+          "^build"
+        ]
       }
     }
   }

--- a/apps/pigment-css-vite-app/src/main.tsx
+++ b/apps/pigment-css-vite-app/src/main.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CircularProgress from '@mui/material/CircularProgress';
 import CssBaseline from '@mui/material/CssBaseline';
 import { css } from '@pigment-css/react';
-import { Box } from '@pigment-css/react/Box';
+import Box from '@pigment-css/react/Box';
 import { ErrorBoundary } from 'react-error-boundary';
 import routes from '~react-pages';
 import '@pigment-css/react/styles.css';

--- a/apps/pigment-css-vite-app/src/pages/material-ui/index.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useLocation, matchRoutes, Link } from 'react-router-dom';
-import { css } from '@pigment-css/react';
+import Box from '@pigment-css/react/Box';
 import routes from '~react-pages';
 import Layout from '../../Layout';
 
@@ -17,8 +17,9 @@ export default function MaterialIndex() {
       <div>
         <h1>Material UI Components</h1>
         <nav>
-          <ul
-            className={css({
+          <Box
+            as="ul"
+            sx={{
               margin: 0,
               marginBlock: '1rem',
               padding: 0,
@@ -26,24 +27,25 @@ export default function MaterialIndex() {
               display: 'flex',
               flexDirection: 'column',
               gap: '0.5rem',
-            })}
+            }}
           >
             {childRoutes
               .filter((item) => !!item.path)
               .map((item) => (
                 <li key={item.path}>
-                  <Link
+                  <Box
+                    as={Link}
                     to={`/material-ui/${item.path}`}
-                    className={css({
+                    sx={{
                       textDecoration: 'underline',
                       fontSize: '17px',
-                    })}
+                    }}
                   >
                     {item.path}
-                  </Link>
+                  </Box>
                 </li>
               ))}
-          </ul>
+          </Box>
         </nav>
       </div>
     </Layout>

--- a/packages/pigment-css-react/src/Box.d.ts
+++ b/packages/pigment-css-react/src/Box.d.ts
@@ -23,4 +23,4 @@ export interface PolymorphicComponent<BaseProps extends BaseDefaultProps>
 
 declare const Box: PolymorphicComponent<{}>;
 
-export { Box };
+export default Box;

--- a/packages/pigment-css-react/src/Box.jsx
+++ b/packages/pigment-css-react/src/Box.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import * as React from 'react';
 
-export const Box = React.forwardRef(
+const Box = React.forwardRef(
   (
     {
       as = 'div',
@@ -50,3 +50,5 @@ export const Box = React.forwardRef(
     return <Component ref={ref} className={classes} style={styles} {...rest} />;
   },
 );
+
+export default Box;

--- a/packages/pigment-css-react/tests/Box/box.test.tsx
+++ b/packages/pigment-css-react/tests/Box/box.test.tsx
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { runTransformation, expect } from '../testUtils';
+
+describe('Pigment CSS - Box', () => {
+  it('should transform and render sx prop', async () => {
+    const { output, fixture } = await runTransformation(
+      path.join(__dirname, 'fixtures/box.input.js'),
+    );
+
+    expect(output.js).to.equal(fixture.js);
+    expect(output.css).to.equal(fixture.css);
+  });
+});

--- a/packages/pigment-css-react/tests/Box/fixtures/box.input.js
+++ b/packages/pigment-css-react/tests/Box/fixtures/box.input.js
@@ -1,0 +1,20 @@
+import Box from '@pigment-css/react/Box';
+
+export function App() {
+  return (
+    <Box
+      as="ul"
+      sx={{
+        margin: 0,
+        marginBlock: '1rem',
+        padding: 0,
+        paddingLeft: '1.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+      }}
+    >
+      Hello Box
+    </Box>
+  );
+}

--- a/packages/pigment-css-react/tests/Box/fixtures/box.output.css
+++ b/packages/pigment-css-react/tests/Box/fixtures/box.output.css
@@ -1,0 +1,9 @@
+.bc1d15y {
+  margin: 0;
+  margin-block: 1rem;
+  padding: 0;
+  padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/packages/pigment-css-react/tests/Box/fixtures/box.output.js
+++ b/packages/pigment-css-react/tests/Box/fixtures/box.output.js
@@ -1,0 +1,8 @@
+import Box from '@pigment-css/react/Box';
+export function App() {
+  return (
+    <Box as="ul" sx={'bc1d15y'}>
+      Hello Box
+    </Box>
+  );
+}


### PR DESCRIPTION
This current fix is very crude and does not handle the case when a user might have their own wrapper component over Box and they'll be passing sx prop through the component. We need to have a better option to customize the condition.

Also made `Box` as a default import instead of name import.

Fixes #41704

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
