### PR TITLE
updates useSlider to correct trackOffset and trackLeap values

### DIFF
--- a/packages/mui-base/src/useSlider/useSlider.ts
+++ b/packages/mui-base/src/useSlider/useSlider.ts
@@ -631,8 +631,8 @@ export function useSlider(parameters: UseSliderParameters): UseSliderReturnValue
       doc.addEventListener('mouseup', handleTouchEnd);
     };
 
-  const trackOffset = valueToPercent(range ? values[0] : min, min, max);
-  const trackLeap = valueToPercent(values[values.length - 1], min, max) - trackOffset;
+  const trackLeap = valueToPercent(range ? values[0] : min, min, max);
+  const trackOffset = valueToPercent(values[values.length - 1], min, max) - trackLeap;
 
   const getRootProps = <ExternalProps extends Record<string, unknown> = {}>(
     externalProps: ExternalProps = {} as ExternalProps,


### PR DESCRIPTION
The trackOffset and trackLeap variables were resulting in the following style for the track when the value is 33: 

{
    width: 0%;
    left: 32.3232%;
}

With the fix: 

{
    width: 32.3232%;
    left: 0%;
}


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
