### PR TITLE
[core] Remove Base UI mentions from issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -1,5 +1,5 @@
 name: Bug report 🐛
-description: Create a bug report for Material UI, Base UI, MUI System, or Joy UI.
+description: Create a bug report for Material UI, MUI System, or Joy UI.
 labels: ['status: waiting for maintainer']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -1,5 +1,5 @@
 name: Feature request 💄
-description: Suggest a new idea for Material UI, Base UI, MUI System, or Joy UI.
+description: Suggest a new idea for Material UI, MUI System, or Joy UI.
 labels: ['status: waiting for maintainer']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/4.docs-feedback.yml
@@ -1,5 +1,5 @@
 name: Docs feedback
-description: Improve documentation about Material UI, Base UI, MUI System, or Joy UI.
+description: Improve documentation about Material UI, MUI System, or Joy UI.
 labels: ['status: waiting for maintainer', 'support: docs-feedback']
 title: '[docs] '
 body:

--- a/.github/ISSUE_TEMPLATE/5.priority-support.yml
+++ b/.github/ISSUE_TEMPLATE/5.priority-support.yml
@@ -1,5 +1,5 @@
 name: 'Priority Support: SLA ⏰'
-description: I'm an MUI X Premium user and we have purchased the Priority Support add-on. I can't find a solution to my problem with Material UI, Base UI, MUI System, or Joy UI.
+description: I'm an MUI X Premium user and we have purchased the Priority Support add-on. I can't find a solution to my problem with Material UI, MUI System, or Joy UI.
 title: '[question] '
 labels: ['status: waiting for maintainer', 'support: unknown']
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Support ❔
     url: https://mui.com/getting-started/support/
-    about: I need support with Material UI, Base UI, MUI System, or Joy UI.
+    about: I need support with Material UI, MUI System, or Joy UI.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This seems to make sense as we direct Base UI contributions to its own repo! Also, I have intentionally not added Pigment CSS yet, as we might also extract it to a dedicated repo.
