### PR TITLE
[material-ui][Tooltip] Fix text that cannot be selected inside of a dialog

### DIFF
--- a/packages/mui-material/src/Tooltip/Tooltip.js
+++ b/packages/mui-material/src/Tooltip/Tooltip.js
@@ -667,6 +667,7 @@ const Tooltip = React.forwardRef(function Tooltip(inProps, ref) {
       <PopperComponent
         as={PopperComponentProp ?? Popper}
         placement={placement}
+        disablePortal={true}
         anchorEl={
           followCursor
             ? {


### PR DESCRIPTION
The bug is that when you create a Tooltip inside of a Dialog and then open the Dialog, the Tooltip's content text cannot be selected in the normal way (mouse hold and drag). The bug came from the Tooltip's content component, the Popper. By default, the Popper is not rendered inside the Dialog, and so eventhough the text is visible, it is not inside the focus reach of the Dialog, making it unable to be interacted with and thus selectable. To solve the bug, I added "disablePortal = {true}" to the list of Popper props, upon creating the Popper in Tooltip.js. This makes sure the Popper is rendered inside the Dialog, and so the text is selectable.

Fixes #40870 

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
