### PR TITLE
[core] Automate cherry-pick of PRs from `next` -> `master`

### DIFF
--- a/.github/workflows/cherry-pick-next-to-master.yml
+++ b/.github/workflows/cherry-pick-next-to-master.yml
@@ -1,0 +1,34 @@
+name: Cherry pick next to master
+
+on:
+  pull_request_target:
+    branches:
+      - next
+    types: ['closed']
+
+permissions: {}
+
+jobs:
+  cherry_pick_to_master:
+    runs-on: ubuntu-latest
+    name: Cherry pick into master
+    permissions:
+      pull-requests: write
+      contents: write
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+      - name: Cherry pick and create the new PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: carloscastrojumo/github-cherry-pick-action@a145da1b8142e752d3cbc11aaaa46a535690f0c5 # v1.0.9
+        with:
+          branch: master
+          body: 'Cherry-pick of #{old_pull_request_id}'
+          cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
+          title: '{old_title} (@${{ github.event.pull_request.user.login }})'
+          labels: |
+            cherry-pick


### PR DESCRIPTION
As @oliviertassinari [suggested](https://github.com/mui/material-ui/pull/41736#issuecomment-2030383966), this PR adds a GitHub Action to automate cherry-picking PRs from `next` to `master` (see Olivier's comment to see how it works). The code is an exact copy from [MUI X](https://github.com/mui/mui-x/blob/master/.github/workflows/cherry-pick-next-to-master.yml) (thanks @MBilalShafi !).

cc @danilo-leal
