### PR TITLE
[material-ui][docs] Add subtitle to icons search UI

### DIFF
--- a/docs/data/material/components/material-icons/material-icons.md
+++ b/docs/data/material/components/material-icons/material-icons.md
@@ -44,6 +44,8 @@ See the [Installation](/material-ui/getting-started/installation/) page for addi
 
 <hr/>
 
+## Search Material Icons
+
 Browse through the icons below to find the one you need.
 The search field supports synonyms—for example, try searching for "hamburger" or "logout."
 


### PR DESCRIPTION
Noticed recently on the weekly algolia email report that "icons" is the top search term, by a large margin. I find myself using this term most often to get to the icons search interface. Yet, the experience is not clear, the search box shows two pages for the "icons" term.

![Screenshot 2024-04-04 at 10 18 25](https://github.com/mui/material-ui/assets/2109932/4cf377fd-021b-4817-bb00-64bdfb180616)

Proposing to add a subtitle that can show up in this search box to help disambiguate which page contains the icon search experience.
