### PR TITLE
[pigment-css][nextjs] Handle file references passed through imports

### DIFF
--- a/packages/pigment-css-unplugin/src/utils.ts
+++ b/packages/pigment-css-unplugin/src/utils.ts
@@ -27,12 +27,20 @@ export const handleUrlReplacement = async (
     const mainItem = match[3];
     // no need to handle data uris or absolute paths
     if (
-      mainItem[0] === '/' ||
       mainItem.startsWith('data:') ||
       mainItem.startsWith('http:') ||
       mainItem.startsWith('https:')
     ) {
       newCss += `url(${mainItem})`;
+    } else if (mainItem[0] === '/') {
+      const newPath = mainItem.replace(projectPath, '').split(path.sep).join('/');
+      if (newPath === mainItem) {
+        // absolute path unrelated to files in the project or in public directory
+        newCss += `url(${mainItem})`;
+      } else {
+        // absolute path to files in the project
+        newCss += `url(~${mainItem.replace(projectPath, '').split(path.sep).join('/')})`;
+      }
     } else {
       // eslint-disable-next-line no-await-in-loop
       const resolvedAbsolutePath = await asyncResolver(mainItem, filename, []);

--- a/packages/pigment-css-unplugin/tests/utils.test.ts
+++ b/packages/pigment-css-unplugin/tests/utils.test.ts
@@ -60,6 +60,7 @@ describe('utils', () => {
         background-image: url(${ABSOLUTE_PATH});
         background-image: url('../../assets/mui.svg');
         background-image: url('@/assets/mui.svg');
+        background-image: url('${projectPath}/src/assets/mui.svg');
         background-image: url('/assets/mui.svg');
         background-image: url('@/assets/mui.svg');
         display: flex;
@@ -71,6 +72,7 @@ describe('utils', () => {
         background-image: url(${DATA_URI});
         background-image: url(${HTML_LOGO_URL});
         background-image: url(${ABSOLUTE_PATH});
+        background-image: url(~/src/assets/mui.svg);
         background-image: url(~/src/assets/mui.svg);
         background-image: url(~/src/assets/mui.svg);
         background-image: url(/assets/mui.svg);


### PR DESCRIPTION
Followup PR to #41758 to handle file path passed to CSS after importing in source code

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
