### PR TITLE
[code-infra] Allow customizing hooks imports in API docs generator

### DIFF
--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -482,7 +482,7 @@ const extractInfoFromType = async (
  * @param filename The filename where its defined (to infer the package)
  * @returns an array of import command
  */
-const getHookImports = (name: string, filename: string) => {
+const defaultGetHookImports = (name: string, filename: string) => {
   const githubPath = toGitHubPath(filename);
   const rootImportPath = githubPath.replace(
     /\/packages\/mui(?:-(.+?))?\/src\/.*/,
@@ -552,6 +552,8 @@ export default async function generateHookApi(
   if (annotatedDescriptionMatch !== null) {
     reactApi.description = reactApi.description.slice(0, annotatedDescriptionMatch.index).trim();
   }
+
+  const { getHookImports = defaultGetHookImports } = projectSettings;
   reactApi.filename = filename;
   reactApi.name = name;
   reactApi.imports = getHookImports(name, filename);

--- a/packages/api-docs-builder/ProjectSettings.ts
+++ b/packages/api-docs-builder/ProjectSettings.ts
@@ -74,9 +74,13 @@ export interface ProjectSettings {
    */
   importTranslationPagesDirectory?: string;
   /**
-   * Returns an array of import commands used for the API page header.
+   * Returns an array of import commands used for the component API page header.
    */
   getComponentImports?: (name: string, filename: string) => string[];
+  /**
+   * Returns an array of import commands used for the hook API page header.
+   */
+  getHookImports?: (name: string, filename: string) => string[];
   /**
    * Settings to configure props definition tests.
    */


### PR DESCRIPTION
Makes hooks' import statements customizable, similarly to components. Keeps the previous logic as default if the corresponding option isn't set.