### PR TITLE
[material-ui][FloatingActionButton] Convert to support CSS extraction

### DIFF
--- a/apps/pigment-css-next-app/src/app/material-ui/react-floating-action-button/page.tsx
+++ b/apps/pigment-css-next-app/src/app/material-ui/react-floating-action-button/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import * as React from 'react';
+import FloatingActionButtonExtendedSize from '../../../../../../docs/data/material/components/floating-action-button/FloatingActionButtonExtendedSize';
+import FloatingActionButtonSize from '../../../../../../docs/data/material/components/floating-action-button/FloatingActionButtonSize';
+import FloatingActionButtonZoom from '../../../../../../docs/data/material/components/floating-action-button/FloatingActionButtonZoom';
+import FloatingActionButtons from '../../../../../../docs/data/material/components/floating-action-button/FloatingActionButtons';
+
+export default function FloatingActionButton() {
+  return (
+    <React.Fragment>
+      <section>
+        <h2> Floating Action Button Extended Size</h2>
+        <div className="demo-container">
+          <FloatingActionButtonExtendedSize />
+        </div>
+      </section>
+      <section>
+        <h2> Floating Action Button Size</h2>
+        <div className="demo-container">
+          <FloatingActionButtonSize />
+        </div>
+      </section>
+      <section>
+        <h2> Floating Action Button Zoom</h2>
+        <div className="demo-container">
+          <FloatingActionButtonZoom />
+        </div>
+      </section>
+      <section>
+        <h2> Floating Action Buttons</h2>
+        <div className="demo-container">
+          <FloatingActionButtons />
+        </div>
+      </section>
+    </React.Fragment>
+  );
+}

--- a/apps/pigment-css-vite-app/src/pages/material-ui/react-floating-action-button.tsx
+++ b/apps/pigment-css-vite-app/src/pages/material-ui/react-floating-action-button.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import MaterialUILayout from '../../Layout';
+import FloatingActionButtonExtendedSize from '../../../../../docs/data/material/components/floating-action-button/FloatingActionButtonExtendedSize.tsx';
+import FloatingActionButtonSize from '../../../../../docs/data/material/components/floating-action-button/FloatingActionButtonSize.tsx';
+import FloatingActionButtonZoom from '../../../../../docs/data/material/components/floating-action-button/FloatingActionButtonZoom.tsx';
+import FloatingActionButtons from '../../../../../docs/data/material/components/floating-action-button/FloatingActionButtons.tsx';
+
+export default function FloatingActionButton() {
+  return (
+    <MaterialUILayout>
+      <h1>FloatingActionButton</h1>
+      <section>
+        <h2> Floating Action Button Extended Size</h2>
+        <div className="demo-container">
+          <FloatingActionButtonExtendedSize />
+        </div>
+      </section>
+      <section>
+        <h2> Floating Action Button Size</h2>
+        <div className="demo-container">
+          <FloatingActionButtonSize />
+        </div>
+      </section>
+      <section>
+        <h2> Floating Action Button Zoom</h2>
+        <div className="demo-container">
+          <FloatingActionButtonZoom />
+        </div>
+      </section>
+      <section>
+        <h2> Floating Action Buttons</h2>
+        <div className="demo-container">
+          <FloatingActionButtons />
+        </div>
+      </section>
+    </MaterialUILayout>
+  );
+}

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -5,9 +5,9 @@ import clsx from 'clsx';
 import composeClasses from '@mui/utils/composeClasses';
 import ButtonBase from '../ButtonBase';
 import capitalize from '../utils/capitalize';
-import useThemeProps from '../styles/useThemeProps';
 import fabClasses, { getFabUtilityClass } from './fabClasses';
-import styled, { rootShouldForwardProp } from '../styles/styled';
+import { rootShouldForwardProp } from '../styles/styled';
+import { styled, createUseThemeProps } from '../zero-styled';
 
 const useUtilityClasses = (ownerState) => {
   const { color, variant, classes, size } = ownerState;
@@ -46,7 +46,7 @@ const FabRoot = styled(ButtonBase, {
     ];
   },
 })(
-  ({ theme, ownerState }) => ({
+  ({ theme }) => ({
     ...theme.typography.button,
     minHeight: 36,
     transition: theme.transitions.create(['background-color', 'box-shadow', 'border-color'], {
@@ -77,56 +77,79 @@ const FabRoot = styled(ButtonBase, {
     [`&.${fabClasses.focusVisible}`]: {
       boxShadow: (theme.vars || theme).shadows[6],
     },
-    ...(ownerState.size === 'small' && {
-      width: 40,
-      height: 40,
-    }),
-    ...(ownerState.size === 'medium' && {
-      width: 48,
-      height: 48,
-    }),
-    ...(ownerState.variant === 'extended' && {
-      borderRadius: 48 / 2,
-      padding: '0 16px',
-      width: 'auto',
-      minHeight: 'auto',
-      minWidth: 48,
-      height: 48,
-    }),
-    ...(ownerState.variant === 'extended' &&
-      ownerState.size === 'small' && {
-        width: 'auto',
-        padding: '0 8px',
-        borderRadius: 34 / 2,
-        minWidth: 34,
-        height: 34,
-      }),
-    ...(ownerState.variant === 'extended' &&
-      ownerState.size === 'medium' && {
-        width: 'auto',
-        padding: '0 16px',
-        borderRadius: 40 / 2,
-        minWidth: 40,
-        height: 40,
-      }),
-    ...(ownerState.color === 'inherit' && {
-      color: 'inherit',
-    }),
-  }),
-  ({ theme, ownerState }) => ({
-    ...(ownerState.color !== 'inherit' &&
-      ownerState.color !== 'default' &&
-      (theme.vars || theme).palette[ownerState.color] != null && {
-        color: (theme.vars || theme).palette[ownerState.color].contrastText,
-        backgroundColor: (theme.vars || theme).palette[ownerState.color].main,
-        '&:hover': {
-          backgroundColor: (theme.vars || theme).palette[ownerState.color].dark,
-          // Reset on touch devices, it doesn't add specificity
-          '@media (hover: none)': {
-            backgroundColor: (theme.vars || theme).palette[ownerState.color].main,
-          },
+    variants: [
+      {
+        props: { size: 'small' },
+        style: {
+          width: 40,
+          height: 40,
         },
-      }),
+      },
+      {
+        props: { size: 'medium' },
+        style: {
+          width: 48,
+          height: 48,
+        },
+      },
+      {
+        props: { variant: 'extended' },
+        style: {
+          borderRadius: 48 / 2,
+          padding: '0 16px',
+          width: 'auto',
+          minHeight: 'auto',
+          minWidth: 48,
+          height: 48,
+        },
+      },
+      {
+        props: { variant: 'extended', size: 'small' },
+        style: {
+          width: 'auto',
+          padding: '0 8px',
+          borderRadius: 34 / 2,
+          minWidth: 34,
+          height: 34,
+        },
+      },
+      {
+        props: { variant: 'extended', size: 'medium' },
+        style: {
+          width: 'auto',
+          padding: '0 16px',
+          borderRadius: 40 / 2,
+          minWidth: 40,
+          height: 40,
+        },
+      },
+      {
+        props: { color: 'inherit' },
+        style: {
+          color: 'inherit',
+        },
+      },
+    ],
+  }),
+  ({ theme }) => ({
+    variants: [
+      ...Object.entries(theme.palette)
+        .filter(([, value]) => value.main && value.dark && value.contrastText) // check all the used fields in the style below
+        .map(([color]) => ({
+          props: { color },
+          style: {
+            color: (theme.vars || theme).palette[color].contrastText,
+            backgroundColor: (theme.vars || theme).palette[color].main,
+            '&:hover': {
+              backgroundColor: (theme.vars || theme).palette[color].dark,
+              // Reset on touch devices, it doesn't add specificity
+              '@media (hover: none)': {
+                backgroundColor: (theme.vars || theme).palette[color].main,
+              },
+            },
+          },
+        })),
+    ],
   }),
   ({ theme }) => ({
     [`&.${fabClasses.disabled}`]: {
@@ -138,6 +161,7 @@ const FabRoot = styled(ButtonBase, {
 );
 
 const Fab = React.forwardRef(function Fab(inProps, ref) {
+  const useThemeProps = createUseThemeProps('MuiFab');
   const props = useThemeProps({ props: inProps, name: 'MuiFab' });
   const {
     children,

--- a/packages/mui-material/src/Fab/Fab.js
+++ b/packages/mui-material/src/Fab/Fab.js
@@ -9,6 +9,8 @@ import fabClasses, { getFabUtilityClass } from './fabClasses';
 import { rootShouldForwardProp } from '../styles/styled';
 import { styled, createUseThemeProps } from '../zero-styled';
 
+const useThemeProps = createUseThemeProps('MuiFab');
+
 const useUtilityClasses = (ownerState) => {
   const { color, variant, classes, size } = ownerState;
 
@@ -161,7 +163,6 @@ const FabRoot = styled(ButtonBase, {
 );
 
 const Fab = React.forwardRef(function Fab(inProps, ref) {
-  const useThemeProps = createUseThemeProps('MuiFab');
   const props = useThemeProps({ props: inProps, name: 'MuiFab' });
   const {
     children,


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/41273

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

@siriwatknp 

I found 2 problems.

It seems the sx prop in the example doesn't work. I couldn't find how this should be fixed. This results in a gray left aligned Fab, instead of a right aligned green fab.
| Pigment | Current |
|--------|--------|
| <img width="808" alt="image" src="https://github.com/mui/material-ui/assets/7714133/ab0fcafa-be54-457b-b563-84a5fd8c09b1"> | <img width="652" alt="image" src="https://github.com/mui/material-ui/assets/7714133/3140c3ee-c8c5-4b48-b11e-f1f810a6d62e"> | 


In dark mode it also uses the css var for primary text to style the default button. This results in white text on the `grey[300]` background. without vars it uses the `getContrastText` function to determine a color.
```
color: theme.vars
      ? theme.vars.palette.text.primary
      : theme.palette.getContrastText?.(theme.palette.grey[300])
```
<img width="168" alt="image" src="https://github.com/mui/material-ui/assets/7714133/27482cce-1d1a-4159-89df-adf2376a8015">



### Full examples page
| light | dark |
|--------|--------|
| ![localhost_3000_material-ui_react-floating-action-button (1)](https://github.com/mui/material-ui/assets/7714133/ab5263e7-dca9-4e20-bb09-084a0145c3a7) | ![localhost_3000_material-ui_react-floating-action-button](https://github.com/mui/material-ui/assets/7714133/de4dc1cd-ed48-49ce-972c-edf1d7a33246) | 

