### PR TITLE
[docs-infra] Improve Twitter OG:image

### DIFF
--- a/docs/src/modules/components/AppLayoutDocs.js
+++ b/docs/src/modules/components/AppLayoutDocs.js
@@ -149,12 +149,7 @@ export default function AppLayoutDocs(props) {
         }}
       />
       <AdManager {...(hasTabs && { classSelector: '.component-tabs' })}>
-        <Head
-          title={`${title} - ${productName}`}
-          description={description}
-          largeCard={false}
-          card={card}
-        />
+        <Head title={`${title} - ${productName}`} description={description} card={card} />
         <Main disableToc={disableToc}>
           {/*
             Render the TOCs first to avoid layout shift when the HTML is streamed.


### PR DESCRIPTION
Revert https://github.com/mui/material-ui/pull/32536, since we have #41188 now 👌. I wanted to tweet to celebrate this change as it's a nice DX improvement, but got blocked by this.

Before
<img width="575" alt="SCR-20240411-pgxo" src="https://github.com/mui/material-ui/assets/3165635/1edd80bf-da02-4d55-88c2-6368fad9b1aa">