### PR TITLE
[material-ui][Button] Add `onChange` event handler to file upload example

### DIFF
--- a/docs/data/material/components/buttons/InputFileUpload.js
+++ b/docs/data/material/components/buttons/InputFileUpload.js
@@ -24,8 +24,12 @@ export default function InputFileUpload() {
       tabIndex={-1}
       startIcon={<CloudUploadIcon />}
     >
-      Upload file
-      <VisuallyHiddenInput type="file" />
+      Upload files
+      <VisuallyHiddenInput
+        type="file"
+        onChange={(event) => console.log(event.target.files)}
+        multiple
+      />
     </Button>
   );
 }

--- a/docs/data/material/components/buttons/InputFileUpload.tsx
+++ b/docs/data/material/components/buttons/InputFileUpload.tsx
@@ -24,8 +24,12 @@ export default function InputFileUpload() {
       tabIndex={-1}
       startIcon={<CloudUploadIcon />}
     >
-      Upload file
-      <VisuallyHiddenInput type="file" />
+      Upload files
+      <VisuallyHiddenInput
+        type="file"
+        onChange={(event) => console.log(event.target.files)}
+        multiple
+      />
     </Button>
   );
 }

--- a/docs/data/material/components/buttons/InputFileUpload.tsx.preview
+++ b/docs/data/material/components/buttons/InputFileUpload.tsx.preview
@@ -5,6 +5,10 @@
   tabIndex={-1}
   startIcon={<CloudUploadIcon />}
 >
-  Upload file
-  <VisuallyHiddenInput type="file" />
+  Upload files
+  <VisuallyHiddenInput
+    type="file"
+    onChange={(event) => console.log(event.target.files)}
+    multiple
+  />
 </Button>


### PR DESCRIPTION
Adding an `onChange` event handler to the "File upload" Button [example](https://mui.com/material-ui/react-button/#file-upload) after receiving this feedback:

> For file upload example, there is no code that handles the upload event (i.e. doing something with the file.) I'm stuck on this at the moment.

Also making the input `multiple`.