### PR TITLE
[material-ui][docs] Fix credit comment typo

### DIFF
--- a/docs/data/material/components/icons/CreateSvgIcon.js
+++ b/docs/data/material/components/icons/CreateSvgIcon.js
@@ -8,7 +8,7 @@ const HomeIcon = createSvgIcon(
 );
 
 const PlusIcon = createSvgIcon(
-  // credit: plus icon from https://heroicons.com/
+  // credit: plus icon from https://heroicons.com
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/docs/data/material/components/icons/CreateSvgIcon.tsx
+++ b/docs/data/material/components/icons/CreateSvgIcon.tsx
@@ -8,7 +8,7 @@ const HomeIcon = createSvgIcon(
 );
 
 const PlusIcon = createSvgIcon(
-  // credit: plus icon from https://heroicons.com/
+  // credit: plus icon from https://heroicons.com
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/docs/data/material/components/icons/SvgIconChildren.js
+++ b/docs/data/material/components/icons/SvgIconChildren.js
@@ -4,7 +4,7 @@ import SvgIcon from '@mui/material/SvgIcon';
 export default function SvgIconChildren() {
   return (
     <SvgIcon>
-      {/* credit: plus icon from https://heroicons.com/ */}
+      {/* credit: cog icon from https://heroicons.com */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"

--- a/docs/data/material/components/icons/SvgIconChildren.tsx
+++ b/docs/data/material/components/icons/SvgIconChildren.tsx
@@ -4,7 +4,7 @@ import SvgIcon from '@mui/material/SvgIcon';
 export default function SvgIconChildren() {
   return (
     <SvgIcon>
-      {/* credit: plus icon from https://heroicons.com/ */}
+      {/* credit: cog icon from https://heroicons.com */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"

--- a/docs/data/material/components/icons/SvgIconChildren.tsx.preview
+++ b/docs/data/material/components/icons/SvgIconChildren.tsx.preview
@@ -1,5 +1,5 @@
 <SvgIcon>
-  {/* credit: plus icon from https://heroicons.com/ */}
+  {/* credit: cog icon from https://heroicons.com */}
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"


### PR DESCRIPTION
Fixes a tiny typo in a credit comment. The icon is a `cog`, not a `plus`.

<img width="845" alt="Screenshot 2024-04-12 at 14 44 37" src="https://github.com/mui/material-ui/assets/7225802/1fdf6210-a5fb-49d1-bf92-c6da04db6074">

