### PR TITLE
[docs] Fix format git diff regression

### DIFF
--- a/docs/data/material/integrations/nextjs/nextjs.md
+++ b/docs/data/material/integrations/nextjs/nextjs.md
@@ -369,10 +369,9 @@ To learn more about theming, check out the [Theming guide](/material-ui/customiz
 
 If you want to use [CSS theme variables](/material-ui/experimental-api/css-theme-variables/overview/), use the `extendTheme` and `CssVarsProvider` instead:
 
-````diff title="pages/_app.tsx"
+```diff title="pages/_app.tsx"
 -import { ThemeProvider, createTheme } from '@mui/material/styles';
 +import { CssVarsProvider, extendTheme } from '@mui/material/styles';
 ```
 
 Learn more about [the advantages of CSS theme variables](/material-ui/experimental-api/css-theme-variables/overview/#advantages).
-````


### PR DESCRIPTION
Fixing a quick regression from #41508. I couldn't find other bugs of this class in the codebase.

Before https://mui.com/material-ui/integrations/nextjs/#theming-2
<img width="773" alt="SCR-20240414-bocb" src="https://github.com/mui/material-ui/assets/3165635/a4707f76-e660-4737-a23f-e3aa925a268e">

After https://deploy-preview-41882--material-ui.netlify.app/material-ui/integrations/nextjs/#theming-2
<img width="791" alt="SCR-20240414-boam" src="https://github.com/mui/material-ui/assets/3165635/0de1cdcc-8e36-404a-8aab-ba4207ef5ca2">