### PR TITLE
[docs-infra] Move CPU to shared config

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -30,10 +30,6 @@ const pkgContent = fs.readFileSync(path.resolve(workspaceRoot, 'package.json'), 
 const pkg = JSON.parse(pkgContent);
 
 export default withDocsInfra({
-  experimental: {
-    workerThreads: true,
-    cpus: 3,
-  },
   webpack: (config, options) => {
     const plugins = config.plugins.slice();
 

--- a/docs/nextConfigDocsInfra.js
+++ b/docs/nextConfigDocsInfra.js
@@ -75,6 +75,8 @@ function withDocsInfra(nextConfig) {
     experimental: {
       scrollRestoration: true,
       esmExternals: false,
+      workerThreads: true,
+      cpus: 3,
       ...nextConfig.experimental,
     },
     eslint: {


### PR DESCRIPTION
I don't understand why we didn't make this a default in https://github.com/mui/material-ui/pull/41132 shared with the other docs. I'm trying this here.