### PR TITLE
[docs-infra] Use CSS vars for API pages

### DIFF
--- a/docs/pages/joy-ui/api/accordion-details.js
+++ b/docs/pages/joy-ui/api/accordion-details.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion-details.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/accordion-group.js
+++ b/docs/pages/joy-ui/api/accordion-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/accordion-summary.js
+++ b/docs/pages/joy-ui/api/accordion-summary.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion-summary.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/accordion.js
+++ b/docs/pages/joy-ui/api/accordion.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/alert.js
+++ b/docs/pages/joy-ui/api/alert.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './alert.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/aspect-ratio.js
+++ b/docs/pages/joy-ui/api/aspect-ratio.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './aspect-ratio.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/autocomplete-listbox.js
+++ b/docs/pages/joy-ui/api/autocomplete-listbox.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './autocomplete-listbox.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/autocomplete-option.js
+++ b/docs/pages/joy-ui/api/autocomplete-option.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './autocomplete-option.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/autocomplete.js
+++ b/docs/pages/joy-ui/api/autocomplete.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './autocomplete.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/avatar-group.js
+++ b/docs/pages/joy-ui/api/avatar-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './avatar-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/avatar.js
+++ b/docs/pages/joy-ui/api/avatar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './avatar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/badge.js
+++ b/docs/pages/joy-ui/api/badge.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './badge.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/box.js
+++ b/docs/pages/joy-ui/api/box.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './box.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/breadcrumbs.js
+++ b/docs/pages/joy-ui/api/breadcrumbs.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './breadcrumbs.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/button-group.js
+++ b/docs/pages/joy-ui/api/button-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './button-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/button.js
+++ b/docs/pages/joy-ui/api/button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/card-actions.js
+++ b/docs/pages/joy-ui/api/card-actions.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-actions.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/card-content.js
+++ b/docs/pages/joy-ui/api/card-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/card-cover.js
+++ b/docs/pages/joy-ui/api/card-cover.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-cover.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/card-overflow.js
+++ b/docs/pages/joy-ui/api/card-overflow.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-overflow.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/card.js
+++ b/docs/pages/joy-ui/api/card.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/checkbox.js
+++ b/docs/pages/joy-ui/api/checkbox.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './checkbox.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/chip-delete.js
+++ b/docs/pages/joy-ui/api/chip-delete.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './chip-delete.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/chip.js
+++ b/docs/pages/joy-ui/api/chip.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './chip.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/circular-progress.js
+++ b/docs/pages/joy-ui/api/circular-progress.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './circular-progress.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/css-baseline.js
+++ b/docs/pages/joy-ui/api/css-baseline.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './css-baseline.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/dialog-actions.js
+++ b/docs/pages/joy-ui/api/dialog-actions.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-actions.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/dialog-content.js
+++ b/docs/pages/joy-ui/api/dialog-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/dialog-title.js
+++ b/docs/pages/joy-ui/api/dialog-title.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-title.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/divider.js
+++ b/docs/pages/joy-ui/api/divider.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './divider.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/drawer.js
+++ b/docs/pages/joy-ui/api/drawer.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './drawer.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/form-control.js
+++ b/docs/pages/joy-ui/api/form-control.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-control.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/form-helper-text.js
+++ b/docs/pages/joy-ui/api/form-helper-text.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-helper-text.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/form-label.js
+++ b/docs/pages/joy-ui/api/form-label.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-label.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/grid.js
+++ b/docs/pages/joy-ui/api/grid.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './grid.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/icon-button.js
+++ b/docs/pages/joy-ui/api/icon-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './icon-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/input.js
+++ b/docs/pages/joy-ui/api/input.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './input.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/linear-progress.js
+++ b/docs/pages/joy-ui/api/linear-progress.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './linear-progress.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/link.js
+++ b/docs/pages/joy-ui/api/link.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './link.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list-divider.js
+++ b/docs/pages/joy-ui/api/list-divider.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-divider.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list-item-button.js
+++ b/docs/pages/joy-ui/api/list-item-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list-item-content.js
+++ b/docs/pages/joy-ui/api/list-item-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list-item-decorator.js
+++ b/docs/pages/joy-ui/api/list-item-decorator.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-decorator.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list-item.js
+++ b/docs/pages/joy-ui/api/list-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list-subheader.js
+++ b/docs/pages/joy-ui/api/list-subheader.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-subheader.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/list.js
+++ b/docs/pages/joy-ui/api/list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/menu-button.js
+++ b/docs/pages/joy-ui/api/menu-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/menu-item.js
+++ b/docs/pages/joy-ui/api/menu-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/menu-list.js
+++ b/docs/pages/joy-ui/api/menu-list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu-list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/menu.js
+++ b/docs/pages/joy-ui/api/menu.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/modal-close.js
+++ b/docs/pages/joy-ui/api/modal-close.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './modal-close.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/modal-dialog.js
+++ b/docs/pages/joy-ui/api/modal-dialog.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './modal-dialog.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/modal-overflow.js
+++ b/docs/pages/joy-ui/api/modal-overflow.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './modal-overflow.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/modal.js
+++ b/docs/pages/joy-ui/api/modal.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './modal.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/option.js
+++ b/docs/pages/joy-ui/api/option.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './option.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/radio-group.js
+++ b/docs/pages/joy-ui/api/radio-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './radio-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/radio.js
+++ b/docs/pages/joy-ui/api/radio.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './radio.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/scoped-css-baseline.js
+++ b/docs/pages/joy-ui/api/scoped-css-baseline.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './scoped-css-baseline.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/select.js
+++ b/docs/pages/joy-ui/api/select.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './select.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/sheet.js
+++ b/docs/pages/joy-ui/api/sheet.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './sheet.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/skeleton.js
+++ b/docs/pages/joy-ui/api/skeleton.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './skeleton.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/slider.js
+++ b/docs/pages/joy-ui/api/slider.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './slider.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/snackbar.js
+++ b/docs/pages/joy-ui/api/snackbar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './snackbar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/stack.js
+++ b/docs/pages/joy-ui/api/stack.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './stack.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/step-button.js
+++ b/docs/pages/joy-ui/api/step-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/step-indicator.js
+++ b/docs/pages/joy-ui/api/step-indicator.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-indicator.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/step.js
+++ b/docs/pages/joy-ui/api/step.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/stepper.js
+++ b/docs/pages/joy-ui/api/stepper.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './stepper.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/svg-icon.js
+++ b/docs/pages/joy-ui/api/svg-icon.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './svg-icon.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/switch.js
+++ b/docs/pages/joy-ui/api/switch.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './switch.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/tab-list.js
+++ b/docs/pages/joy-ui/api/tab-list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab-list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/tab-panel.js
+++ b/docs/pages/joy-ui/api/tab-panel.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab-panel.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/tab.js
+++ b/docs/pages/joy-ui/api/tab.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/table.js
+++ b/docs/pages/joy-ui/api/table.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/tabs.js
+++ b/docs/pages/joy-ui/api/tabs.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tabs.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/textarea.js
+++ b/docs/pages/joy-ui/api/textarea.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './textarea.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/toggle-button-group.js
+++ b/docs/pages/joy-ui/api/toggle-button-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './toggle-button-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/tooltip.js
+++ b/docs/pages/joy-ui/api/tooltip.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tooltip.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/joy-ui/api/typography.js
+++ b/docs/pages/joy-ui/api/typography.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './typography.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/accordion-actions.js
+++ b/docs/pages/material-ui/api/accordion-actions.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion-actions.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/accordion-actions.js
+++ b/docs/pages/material-ui/api/accordion-actions.js
@@ -8,7 +8,7 @@ export default function Page(props) {
   const { descriptions, pageContent } = props;
   return (
     <BrandingCssVarsProvider>
-      <ApiPage descriptions={descriptions} pageContent={pageContent} />
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
     </BrandingCssVarsProvider>
   );
 }

--- a/docs/pages/material-ui/api/accordion-details.js
+++ b/docs/pages/material-ui/api/accordion-details.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion-details.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/accordion-summary.js
+++ b/docs/pages/material-ui/api/accordion-summary.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion-summary.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/accordion.js
+++ b/docs/pages/material-ui/api/accordion.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './accordion.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/alert-title.js
+++ b/docs/pages/material-ui/api/alert-title.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './alert-title.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/alert.js
+++ b/docs/pages/material-ui/api/alert.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './alert.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/app-bar.js
+++ b/docs/pages/material-ui/api/app-bar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './app-bar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/autocomplete.js
+++ b/docs/pages/material-ui/api/autocomplete.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './autocomplete.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/avatar-group.js
+++ b/docs/pages/material-ui/api/avatar-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './avatar-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/avatar.js
+++ b/docs/pages/material-ui/api/avatar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './avatar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/backdrop.js
+++ b/docs/pages/material-ui/api/backdrop.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './backdrop.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/badge.js
+++ b/docs/pages/material-ui/api/badge.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './badge.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/bottom-navigation-action.js
+++ b/docs/pages/material-ui/api/bottom-navigation-action.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './bottom-navigation-action.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/bottom-navigation.js
+++ b/docs/pages/material-ui/api/bottom-navigation.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './bottom-navigation.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/box.js
+++ b/docs/pages/material-ui/api/box.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './box.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/breadcrumbs.js
+++ b/docs/pages/material-ui/api/breadcrumbs.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './breadcrumbs.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/button-base.js
+++ b/docs/pages/material-ui/api/button-base.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './button-base.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/button-group.js
+++ b/docs/pages/material-ui/api/button-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './button-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/button.js
+++ b/docs/pages/material-ui/api/button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/card-action-area.js
+++ b/docs/pages/material-ui/api/card-action-area.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-action-area.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/card-actions.js
+++ b/docs/pages/material-ui/api/card-actions.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-actions.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/card-content.js
+++ b/docs/pages/material-ui/api/card-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/card-header.js
+++ b/docs/pages/material-ui/api/card-header.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-header.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/card-media.js
+++ b/docs/pages/material-ui/api/card-media.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card-media.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/card.js
+++ b/docs/pages/material-ui/api/card.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './card.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/checkbox.js
+++ b/docs/pages/material-ui/api/checkbox.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './checkbox.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/chip.js
+++ b/docs/pages/material-ui/api/chip.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './chip.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/circular-progress.js
+++ b/docs/pages/material-ui/api/circular-progress.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './circular-progress.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/collapse.js
+++ b/docs/pages/material-ui/api/collapse.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './collapse.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/container.js
+++ b/docs/pages/material-ui/api/container.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './container.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/css-baseline.js
+++ b/docs/pages/material-ui/api/css-baseline.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './css-baseline.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/dialog-actions.js
+++ b/docs/pages/material-ui/api/dialog-actions.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-actions.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/dialog-content-text.js
+++ b/docs/pages/material-ui/api/dialog-content-text.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-content-text.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/dialog-content.js
+++ b/docs/pages/material-ui/api/dialog-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/dialog-title.js
+++ b/docs/pages/material-ui/api/dialog-title.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog-title.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/dialog.js
+++ b/docs/pages/material-ui/api/dialog.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './dialog.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/divider.js
+++ b/docs/pages/material-ui/api/divider.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './divider.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/drawer.js
+++ b/docs/pages/material-ui/api/drawer.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './drawer.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/fab.js
+++ b/docs/pages/material-ui/api/fab.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './fab.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/fade.js
+++ b/docs/pages/material-ui/api/fade.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './fade.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/filled-input.js
+++ b/docs/pages/material-ui/api/filled-input.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './filled-input.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/form-control-label.js
+++ b/docs/pages/material-ui/api/form-control-label.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-control-label.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/form-control.js
+++ b/docs/pages/material-ui/api/form-control.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-control.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/form-group.js
+++ b/docs/pages/material-ui/api/form-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/form-helper-text.js
+++ b/docs/pages/material-ui/api/form-helper-text.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-helper-text.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/form-label.js
+++ b/docs/pages/material-ui/api/form-label.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './form-label.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/global-styles.js
+++ b/docs/pages/material-ui/api/global-styles.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './global-styles.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/grid.js
+++ b/docs/pages/material-ui/api/grid.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './grid.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/grow.js
+++ b/docs/pages/material-ui/api/grow.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './grow.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/hidden.js
+++ b/docs/pages/material-ui/api/hidden.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './hidden.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/icon-button.js
+++ b/docs/pages/material-ui/api/icon-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './icon-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/icon.js
+++ b/docs/pages/material-ui/api/icon.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './icon.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/image-list-item-bar.js
+++ b/docs/pages/material-ui/api/image-list-item-bar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './image-list-item-bar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/image-list-item.js
+++ b/docs/pages/material-ui/api/image-list-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './image-list-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/image-list.js
+++ b/docs/pages/material-ui/api/image-list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './image-list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/input-adornment.js
+++ b/docs/pages/material-ui/api/input-adornment.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './input-adornment.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/input-base.js
+++ b/docs/pages/material-ui/api/input-base.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './input-base.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/input-label.js
+++ b/docs/pages/material-ui/api/input-label.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './input-label.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/input.js
+++ b/docs/pages/material-ui/api/input.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './input.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/linear-progress.js
+++ b/docs/pages/material-ui/api/linear-progress.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './linear-progress.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/link.js
+++ b/docs/pages/material-ui/api/link.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './link.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-item-avatar.js
+++ b/docs/pages/material-ui/api/list-item-avatar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-avatar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-item-button.js
+++ b/docs/pages/material-ui/api/list-item-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-item-icon.js
+++ b/docs/pages/material-ui/api/list-item-icon.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-icon.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-item-secondary-action.js
+++ b/docs/pages/material-ui/api/list-item-secondary-action.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-secondary-action.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-item-text.js
+++ b/docs/pages/material-ui/api/list-item-text.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item-text.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-item.js
+++ b/docs/pages/material-ui/api/list-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list-subheader.js
+++ b/docs/pages/material-ui/api/list-subheader.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list-subheader.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/list.js
+++ b/docs/pages/material-ui/api/list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/loading-button.js
+++ b/docs/pages/material-ui/api/loading-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './loading-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/masonry.js
+++ b/docs/pages/material-ui/api/masonry.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './masonry.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/menu-item.js
+++ b/docs/pages/material-ui/api/menu-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/menu-list.js
+++ b/docs/pages/material-ui/api/menu-list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu-list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/menu.js
+++ b/docs/pages/material-ui/api/menu.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './menu.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/mobile-stepper.js
+++ b/docs/pages/material-ui/api/mobile-stepper.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './mobile-stepper.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/modal.js
+++ b/docs/pages/material-ui/api/modal.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './modal.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/native-select.js
+++ b/docs/pages/material-ui/api/native-select.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './native-select.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/outlined-input.js
+++ b/docs/pages/material-ui/api/outlined-input.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './outlined-input.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/pagination-item.js
+++ b/docs/pages/material-ui/api/pagination-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './pagination-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/pagination.js
+++ b/docs/pages/material-ui/api/pagination.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './pagination.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/paper.js
+++ b/docs/pages/material-ui/api/paper.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './paper.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/popover.js
+++ b/docs/pages/material-ui/api/popover.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './popover.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/popper.js
+++ b/docs/pages/material-ui/api/popper.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './popper.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/radio-group.js
+++ b/docs/pages/material-ui/api/radio-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './radio-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/radio.js
+++ b/docs/pages/material-ui/api/radio.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './radio.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/rating.js
+++ b/docs/pages/material-ui/api/rating.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './rating.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/scoped-css-baseline.js
+++ b/docs/pages/material-ui/api/scoped-css-baseline.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './scoped-css-baseline.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/select.js
+++ b/docs/pages/material-ui/api/select.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './select.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/skeleton.js
+++ b/docs/pages/material-ui/api/skeleton.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './skeleton.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/slide.js
+++ b/docs/pages/material-ui/api/slide.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './slide.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/slider.js
+++ b/docs/pages/material-ui/api/slider.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './slider.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/snackbar-content.js
+++ b/docs/pages/material-ui/api/snackbar-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './snackbar-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/snackbar.js
+++ b/docs/pages/material-ui/api/snackbar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './snackbar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/speed-dial-action.js
+++ b/docs/pages/material-ui/api/speed-dial-action.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './speed-dial-action.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/speed-dial-icon.js
+++ b/docs/pages/material-ui/api/speed-dial-icon.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './speed-dial-icon.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/speed-dial.js
+++ b/docs/pages/material-ui/api/speed-dial.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './speed-dial.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/stack.js
+++ b/docs/pages/material-ui/api/stack.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './stack.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/step-button.js
+++ b/docs/pages/material-ui/api/step-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/step-connector.js
+++ b/docs/pages/material-ui/api/step-connector.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-connector.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/step-content.js
+++ b/docs/pages/material-ui/api/step-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/step-icon.js
+++ b/docs/pages/material-ui/api/step-icon.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-icon.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/step-label.js
+++ b/docs/pages/material-ui/api/step-label.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step-label.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/step.js
+++ b/docs/pages/material-ui/api/step.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './step.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/stepper.js
+++ b/docs/pages/material-ui/api/stepper.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './stepper.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/svg-icon.js
+++ b/docs/pages/material-ui/api/svg-icon.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './svg-icon.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/swipeable-drawer.js
+++ b/docs/pages/material-ui/api/swipeable-drawer.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './swipeable-drawer.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/switch.js
+++ b/docs/pages/material-ui/api/switch.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './switch.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tab-context.js
+++ b/docs/pages/material-ui/api/tab-context.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab-context.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tab-list.js
+++ b/docs/pages/material-ui/api/tab-list.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab-list.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tab-panel.js
+++ b/docs/pages/material-ui/api/tab-panel.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab-panel.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tab-scroll-button.js
+++ b/docs/pages/material-ui/api/tab-scroll-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab-scroll-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tab.js
+++ b/docs/pages/material-ui/api/tab.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tab.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-body.js
+++ b/docs/pages/material-ui/api/table-body.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-body.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-cell.js
+++ b/docs/pages/material-ui/api/table-cell.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-cell.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-container.js
+++ b/docs/pages/material-ui/api/table-container.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-container.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-footer.js
+++ b/docs/pages/material-ui/api/table-footer.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-footer.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-head.js
+++ b/docs/pages/material-ui/api/table-head.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-head.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-pagination.js
+++ b/docs/pages/material-ui/api/table-pagination.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-pagination.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-row.js
+++ b/docs/pages/material-ui/api/table-row.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-row.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table-sort-label.js
+++ b/docs/pages/material-ui/api/table-sort-label.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table-sort-label.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/table.js
+++ b/docs/pages/material-ui/api/table.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './table.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tabs.js
+++ b/docs/pages/material-ui/api/tabs.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tabs.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/text-field.js
+++ b/docs/pages/material-ui/api/text-field.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './text-field.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline-connector.js
+++ b/docs/pages/material-ui/api/timeline-connector.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline-connector.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline-content.js
+++ b/docs/pages/material-ui/api/timeline-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline-dot.js
+++ b/docs/pages/material-ui/api/timeline-dot.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline-dot.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline-item.js
+++ b/docs/pages/material-ui/api/timeline-item.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline-item.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline-opposite-content.js
+++ b/docs/pages/material-ui/api/timeline-opposite-content.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline-opposite-content.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline-separator.js
+++ b/docs/pages/material-ui/api/timeline-separator.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline-separator.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/timeline.js
+++ b/docs/pages/material-ui/api/timeline.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './timeline.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/toggle-button-group.js
+++ b/docs/pages/material-ui/api/toggle-button-group.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './toggle-button-group.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/toggle-button.js
+++ b/docs/pages/material-ui/api/toggle-button.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './toggle-button.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/toolbar.js
+++ b/docs/pages/material-ui/api/toolbar.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './toolbar.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/tooltip.js
+++ b/docs/pages/material-ui/api/tooltip.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './tooltip.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/typography.js
+++ b/docs/pages/material-ui/api/typography.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './typography.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/api/zoom.js
+++ b/docs/pages/material-ui/api/zoom.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './zoom.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/material-ui/getting-started/index.js
+++ b/docs/pages/material-ui/getting-started/index.js
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import * as pageProps from 'docs/data/material/getting-started/overview/overview.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} disableAd />;
+  return (
+    <BrandingCssVarsProvider>
+      <MarkdownDocs {...pageProps} disableAd />
+    </BrandingCssVarsProvider>
+  );
 }

--- a/docs/pages/material-ui/react-accordion.js
+++ b/docs/pages/material-ui/react-accordion.js
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocsV2';
 import AppFrame from 'docs/src/modules/components/AppFrame';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import * as pageProps from 'docs/data/material/components/accordion/accordion.md?muiMarkdown';
 
 export default function Page() {
-  return <MarkdownDocs {...pageProps} />;
+  return (
+    <BrandingCssVarsProvider>
+      <MarkdownDocs {...pageProps} />
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getLayout = (page) => {

--- a/docs/pages/system/api/box.js
+++ b/docs/pages/system/api/box.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './box.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/system/api/container.js
+++ b/docs/pages/system/api/container.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './container.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/system/api/grid.js
+++ b/docs/pages/system/api/grid.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './grid.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/pages/system/api/stack.js
+++ b/docs/pages/system/api/stack.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import ApiPage from 'docs/src/modules/components/ApiPage';
+import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';
 import jsonPageContent from './stack.json';
 
 export default function Page(props) {
   const { descriptions, pageContent } = props;
-  return <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+  return (
+    <BrandingCssVarsProvider>
+      <ApiPage descriptions={descriptions} pageContent={pageContent} />;
+    </BrandingCssVarsProvider>
+  );
 }
 
 Page.getInitialProps = () => {

--- a/docs/src/modules/components/AppLayoutDocsFooter.js
+++ b/docs/src/modules/components/AppLayoutDocsFooter.js
@@ -40,7 +40,7 @@ const FooterLink = styled(Typography)(({ theme }) => {
     display: 'flex',
     alignItems: 'center',
     gap: 4,
-    fontWeight: (theme.vars || theme).typography.fontWeightSemiBold,
+    fontWeight: theme.typography.fontWeightSemiBold,
     color: (theme.vars || theme).palette.primary[600],
     '& > svg': { transition: '0.2s' },
     '&:hover > svg': { transform: 'translateX(2px)' },

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { styled, useTheme } from '@mui/material/styles';
+import { styled, useTheme, useColorScheme } from '@mui/material/styles';
 import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -35,6 +35,72 @@ const IconToggleButton = styled(ToggleButton)({
     marginRight: '8px',
   },
 });
+
+function ToggleTheme(props) {
+  const { value, onChange } = props;
+  const t = useTranslate();
+  return (
+    <ToggleButtonGroup
+      exclusive
+      value={value}
+      onChange={onChange}
+      color="primary"
+      aria-labelledby="settings-mode"
+      fullWidth
+    >
+      <IconToggleButton
+        value="light"
+        aria-label={t('settings.light')}
+        data-ga-event-category="settings"
+        data-ga-event-action="light"
+      >
+        <LightModeIcon fontSize="small" />
+        {t('settings.light')}
+      </IconToggleButton>
+      <IconToggleButton
+        value="system"
+        aria-label={t('settings.system')}
+        data-ga-event-category="settings"
+        data-ga-event-action="system"
+      >
+        <SettingsBrightnessIcon fontSize="small" />
+        {t('settings.system')}
+      </IconToggleButton>
+      <IconToggleButton
+        value="dark"
+        aria-label={t('settings.dark')}
+        data-ga-event-category="settings"
+        data-ga-event-action="dark"
+      >
+        <DarkModeOutlinedIcon fontSize="small" />
+        {t('settings.dark')}
+      </IconToggleButton>
+    </ToggleButtonGroup>
+  );
+}
+
+function ToggleVarTheme(props) {
+  const { setMode } = useColorScheme();
+
+  const handleChangeThemeMode = (event, paletteMode) => {
+    if (paletteMode === null) {
+      return;
+    }
+    props.onChange(paletteMode);
+    setMode(paletteMode);
+  };
+  return <ToggleTheme value={props.value} onChange={handleChangeThemeMode} />;
+}
+
+ToggleTheme.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.oneOf(['light', 'system', 'dark']).isRequired,
+};
+
+ToggleVarTheme.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.oneOf(['light', 'system', 'dark']).isRequired,
+};
 
 export default function AppSettingsDrawer(props) {
   const { onClose, open = false, ...other } = props;
@@ -96,42 +162,11 @@ export default function AppSettingsDrawer(props) {
         <Heading gutterBottom id="settings-mode">
           {t('settings.mode')}
         </Heading>
-        <ToggleButtonGroup
-          exclusive
-          value={mode}
-          color="primary"
-          onChange={handleChangeThemeMode}
-          aria-labelledby="settings-mode"
-          fullWidth
-        >
-          <IconToggleButton
-            value="light"
-            aria-label={t('settings.light')}
-            data-ga-event-category="settings"
-            data-ga-event-action="light"
-          >
-            <LightModeIcon fontSize="small" />
-            {t('settings.light')}
-          </IconToggleButton>
-          <IconToggleButton
-            value="system"
-            aria-label={t('settings.system')}
-            data-ga-event-category="settings"
-            data-ga-event-action="system"
-          >
-            <SettingsBrightnessIcon fontSize="small" />
-            {t('settings.system')}
-          </IconToggleButton>
-          <IconToggleButton
-            value="dark"
-            aria-label={t('settings.dark')}
-            data-ga-event-category="settings"
-            data-ga-event-action="dark"
-          >
-            <DarkModeOutlinedIcon fontSize="small" />
-            {t('settings.dark')}
-          </IconToggleButton>
-        </ToggleButtonGroup>
+        {upperTheme.vars ? (
+          <ToggleVarTheme value={mode} onChange={handleChangeThemeMode} />
+        ) : (
+          <ToggleTheme value={mode} onChange={handleChangeThemeMode} />
+        )}
         <Heading gutterBottom id="settings-direction">
           {t('settings.direction')}
         </Heading>

--- a/docs/src/modules/components/AppSettingsDrawer.js
+++ b/docs/src/modules/components/AppSettingsDrawer.js
@@ -94,12 +94,12 @@ function ToggleVarTheme(props) {
 
 ToggleTheme.propTypes = {
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOf(['light', 'system', 'dark']).isRequired,
+  value: PropTypes.oneOf(['light', 'system', 'dark']),
 };
 
 ToggleVarTheme.propTypes = {
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOf(['light', 'system', 'dark']).isRequired,
+  value: PropTypes.oneOf(['light', 'system', 'dark']),
 };
 
 export default function AppSettingsDrawer(props) {

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -241,7 +241,9 @@ const DemoRootMaterial = styled('div', {
     borderLeftWidth: 0,
     borderRightWidth: 0,
     ...theme.applyDarkStyles({
-      backgroundColor: alpha(theme.palette.primaryDark[700], 0.1),
+      backgroundColor: theme.vars
+        ? `rgba(${theme.vars.palette.primaryDark[700]} / 0.1)`
+        : alpha(theme.palette.primaryDark[700], 0.1),
     }),
   }),
   /* Similar to the outlined one but without padding. Ideal for playground demos. */
@@ -253,10 +255,14 @@ const DemoRootMaterial = styled('div', {
   /* Prepare the background to display an inner elevation. */
   ...(bg === true && {
     padding: theme.spacing(3),
-    backgroundColor: alpha((theme.vars || theme).palette.grey[50], 0.5),
+    backgroundColor: theme.vars
+      ? `rgba(${theme.vars.palette.grey[50]} / 0.5)`
+      : alpha(theme.palette.grey[50], 0.5),
     border: `1px solid ${(theme.vars || theme).palette.divider}`,
     ...theme.applyDarkStyles({
-      backgroundColor: alpha((theme.vars || theme).palette.primaryDark[700], 0.4),
+      backgroundColor: theme.vars
+        ? `rgba(${theme.vars.palette.primaryDark[700]} / 0.4)`
+        : alpha(theme.palette.primaryDark[700], 0.4),
     }),
   }),
   /* Mostly meant for introduction demos. */
@@ -267,11 +273,21 @@ const DemoRootMaterial = styled('div', {
     borderLeftWidth: 0,
     borderRightWidth: 0,
     backgroundClip: 'padding-box',
-    backgroundColor: alpha(theme.palette.primary[50], 0.2),
-    backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 40%, ${alpha((theme.vars || theme).palette.primary[100], 0.2)} 70%)`,
+    backgroundColor: theme.vars
+      ? `rgba(${theme.vars.palette.primary[50]} / 0.2)`
+      : alpha(theme.palette.primary[50], 0.2),
+    backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 40%, ${
+      theme.vars
+        ? `rgba(${theme.vars.palette.primary[100]} / 0.2)`
+        : alpha(theme.palette.primary[100], 0.2)
+    } 70%)`,
     ...theme.applyDarkStyles({
       backgroundColor: (theme.vars || theme).palette.primaryDark[900],
-      backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 30%, ${alpha((theme.vars || theme).palette.primary[900], 0.3)} 80%)`,
+      backgroundImage: `radial-gradient(120% 140% at 50% 10%, transparent 30%, ${
+        theme.vars
+          ? `rgba(${theme.vars.palette.primary[900]} / 0.3)`
+          : alpha(theme.palette.primary[900], 0.3)
+      } 80%)`,
     }),
   }),
 }));
@@ -304,7 +320,9 @@ const DemoRootJoy = joyStyled('div', {
     backgroundColor: 'transparent',
     ...theme.applyDarkStyles({
       borderColor: alpha(blueDark[500], 0.3),
-      backgroundColor: alpha(theme.palette.neutral[900], 0.8),
+      backgroundColor: theme.vars
+        ? `rgba(${theme.vars.palette.neutral[900]} / 0.8)`
+        : alpha(theme.palette.neutral[900], 0.8),
     }),
   }),
   /* Prepare the background to display an inner elevation. */

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -20,10 +20,10 @@ const StyledMarkdownElement = styled(MarkdownElement)(({ theme }) => [
       border: 0,
       colorScheme: 'dark',
       '&:hover': {
-        boxShadow: `0 0 0 3px ${alpha((theme.vars || theme).palette.primary[500], 0.5)}`,
+        boxShadow: `0 0 0 3px ${theme.vars ? `rgba(${theme.vars.palette.primary[500]} / 0.5)` : alpha(theme.palette.primary[500], 0.5)}`,
       },
       '&:focus-within': {
-        boxShadow: `0 0 0 3px ${alpha((theme.vars || theme).palette.primary[500], 0.8)}`,
+        boxShadow: `0 0 0 3px ${theme.vars ? `rgba(${theme.vars.palette.primary[500]} / 0.8)` : alpha(theme.palette.primary[500], 0.8)}`,
       },
       [theme.breakpoints.up('sm')]: {
         borderRadius: '0 0 12px 12px',

--- a/docs/src/modules/components/DiamondSponsors.js
+++ b/docs/src/modules/components/DiamondSponsors.js
@@ -17,19 +17,19 @@ const NativeLink = styled('a')(({ theme }) => ({
   border: '1px solid',
   borderColor: (theme.vars || theme).palette.divider,
   transition: theme.transitions.create(['color', 'border-color']),
-  boxShadow: `${alpha(theme.palette.grey[100], 0.3)} 0 -2px 0 inset`,
+  boxShadow: `${theme.vars ? `rgba(${theme.vars.palette.grey[100].mainChannel} / 0.3)` : alpha(theme.palette.grey[100], 0.3)} 0 -2px 0 inset`,
   '&:hover': {
     backgroundColor: (theme.vars || theme).palette.grey[50],
   },
   '&:focus-visible': {
-    outline: `3px solid ${alpha((theme.vars || theme).palette.primary[500], 0.5)}`,
+    outline: `3px solid ${theme.vars ? `rgba(${theme.vars.palette.primary.mainChannel} / 0.5)` : alpha(theme.palette.primary[500], 0.5)}`,
     outlineOffset: '2px',
   },
   '& img': {
     display: 'inline-block',
   },
   ...theme.applyDarkStyles({
-    boxShadow: `${alpha(theme.palette.primaryDark[600], 0.1)} 0 2px 0 inset, ${(theme.vars || theme).palette.common.black} 0 -2px 0 inset`,
+    boxShadow: `${theme.vars ? `rgba(${theme.vars.palette.primaryDark.mainChannel} / 0.1)` : alpha(theme.palette.primaryDark[600], 0.1)} 0 2px 0 inset, ${(theme.vars || theme).palette.common.black} 0 -2px 0 inset`,
     '&:hover': {
       backgroundColor: (theme.vars || theme).palette.primaryDark[800],
       borderColor: (theme.vars || theme).palette.primary[900],

--- a/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/ComponentApiBuilder.ts
@@ -435,6 +435,7 @@ const generateApiPage = async (
       path.resolve(apiPagesDirectory, `${kebabCase(reactApi.name)}.js`),
       `import * as React from 'react';
   import ApiPage from 'docs/src/modules/components/ApiPage';
+  import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
   import mapApiPageTranslations from 'docs/src/modules/utils/mapApiPageTranslations';${
     layoutConfigPath === ''
       ? ''
@@ -445,7 +446,11 @@ const generateApiPage = async (
 
   export default function Page(props) {
     const { descriptions, pageContent } = props;
-    return <ApiPage ${layoutConfigPath === '' ? '' : '{...layoutConfig} '}descriptions={descriptions} pageContent={pageContent} />;
+    return (
+      <BrandingCssVarsProvider>
+        <ApiPage ${layoutConfigPath === '' ? '' : '{...layoutConfig} '}descriptions={descriptions} pageContent={pageContent} />;
+      </BrandingCssVarsProvider>
+    );
   }
 
   Page.getInitialProps = () => {

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -480,7 +480,11 @@ export function getThemedComponents(): ThemeOptions {
               '& * a': {
                 // !important is used here to override the anchor tag color coming from MarkdownElement
                 color: `${(theme.vars || theme).palette.success[900]} !important`,
-                textDecorationColor: `${alpha(theme.palette.success.main, 0.4)} !important`,
+                textDecorationColor: `${
+                  theme.vars
+                    ? `rgba(${theme.vars.palette.success.mainChannel} / 0.4)`
+                    : alpha(theme.palette.success.main, 0.4)
+                } !important`,
                 '&:hover': {
                   textDecorationColor: `${(theme.vars || theme).palette.success[900]} !important`,
                 },

--- a/packages/mui-material/src/Paper/Paper.js
+++ b/packages/mui-material/src/Paper/Paper.js
@@ -117,7 +117,7 @@ const Paper = React.forwardRef(function Paper(inProps, ref) {
         ...(variant === 'elevation' && {
           '--Paper-shadow': (theme.vars || theme).shadows[elevation],
           ...(theme.vars && {
-            '--Paper-overlay': theme.overlays?.[elevation],
+            '--Paper-overlay': theme.vars.overlays?.[elevation],
           }),
           ...(!theme.vars &&
             theme.palette.mode === 'dark' && {


### PR DESCRIPTION
Now you can reload an API page in dark mode without having the light mode blinking
:tada:

I modified all the API pages at once because they are generated by a script

- now: https://deploy-preview-41911--material-ui.netlify.app/material-ui/api/accordion-actions/
- before: https://mui.com/material-ui/api/accordion-actions/

Those modification leads to an error message in the API pages but I've no idea about why

```
Warning: Prop `style` did not match. Server: "--Paper-shadow:var(--muidocs-shadows-4)" Client: "--Paper-shadow:var(--muidocs-shadows-4);--Paper-overlay:linear-gradient(rgba(255 255 255 / 0.092), rgba(255 255 255 / 0.092))"
```

Can be fixed by this diff, but not sure it's a misusage on our side or an error in the vars support

```diff
diff --git a/packages/mui-material/src/Paper/Paper.js b/packages/mui-material/src/Paper/Paper.js
index fbb7d90343..53c63403f7 100644
--- a/packages/mui-material/src/Paper/Paper.js
+++ b/packages/mui-material/src/Paper/Paper.js
@@ -117,7 +117,7 @@ const Paper = React.forwardRef(function Paper(inProps, ref) {
         ...(variant === 'elevation' && {
           '--Paper-shadow': (theme.vars || theme).shadows[elevation],
           ...(theme.vars && {
-            '--Paper-overlay': theme.overlays?.[elevation],
+            '--Paper-overlay': theme.vars.overlays?.[elevation],
           }),
           ...(!theme.vars &&
             theme.palette.mode === 'dark' && {
```