### PR TITLE
[docs-infra] Add demo container design refinements

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -239,7 +239,6 @@ const DemoRootMaterial = styled('div', {
     borderRightWidth: 0,
     ...theme.applyDarkStyles({
       backgroundColor: alpha(theme.palette.primaryDark[700], 0.1),
-      borderBottom: 0,
     }),
   }),
   /* Similar to the outlined one but without padding. Ideal for playground demos. */

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -8,7 +8,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import Fade from '@mui/material/Fade';
 import MDButton from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import MDToggleButton, { toggleButtonClasses } from '@mui/material/ToggleButton';
+import MDToggleButton from '@mui/material/ToggleButton';
 import MDToggleButtonGroup, { toggleButtonGroupClasses } from '@mui/material/ToggleButtonGroup';
 import SvgIcon from '@mui/material/SvgIcon';
 import Snackbar from '@mui/material/Snackbar';

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -69,15 +69,10 @@ const ToggleButtonGroup = styled(MDToggleButtonGroup)(({ theme }) => [
   theme.unstable_sx({
     [`& .${toggleButtonGroupClasses.grouped}`]: {
       '&:not(:first-of-type)': {
-        marginLeft: 0.8,
-        borderLeft: '1px solid',
-        borderLeftColor: 'divider',
-        borderTopLeftRadius: 999,
-        borderBottomLeftRadius: 999,
+        pr: '2px', // a nudge for optical alignment
       },
       '&:not(:last-of-type)': {
-        borderTopRightRadius: 999,
-        borderBottomRightRadius: 999,
+        pl: '2px', // a nudge for optical alignment
       },
     },
   }),
@@ -85,7 +80,7 @@ const ToggleButtonGroup = styled(MDToggleButtonGroup)(({ theme }) => [
 
 const Button = styled(MDButton)(({ theme }) => ({
   height: 26,
-  padding: '6px 8px',
+  padding: '6px 8px 8px 8px',
   flexShrink: 0,
   borderRadius: 999,
   border: '1px solid',
@@ -131,29 +126,14 @@ const MenuItem = styled(MDMenuItem)(({ theme }) => ({
 const ToggleButton = styled(MDToggleButton)(({ theme }) => [
   theme.unstable_sx({
     height: 26,
-    padding: theme.spacing(0, 1, 0.1, 1),
+    width: 38,
+    p: 0,
     fontSize: theme.typography.pxToRem(13),
-    borderColor: 'grey.200',
     borderRadius: '999px',
     '&.Mui-disabled': {
-      opacity: 0.5,
+      opacity: 0.8,
+      cursor: 'not-allowed',
     },
-    [`&.${toggleButtonClasses.selected}:hover`]: {
-      backgroundColor: theme.vars
-        ? `rgba(${theme.vars.palette.primary.mainChannel} / calc(${theme.vars.palette.action.selectedOpacity} + ${theme.vars.palette.action.hoverOpacity}))`
-        : alpha(
-            theme.palette.primary.main,
-            theme.palette.action.selectedOpacity + theme.palette.action.hoverOpacity,
-          ),
-      '@media (hover: none)': {
-        backgroundColor: theme.vars
-          ? `rgba(${theme.vars.palette.primary.mainChannel} / ${theme.vars.palette.action.selectedOpacity})`
-          : alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
-      },
-    },
-  }),
-  theme.applyDarkStyles({
-    borderColor: theme.palette.primaryDark[700],
   }),
 ]);
 
@@ -526,7 +506,7 @@ export default function DemoToolbar(props) {
           </Button>
         )}
         <Fade in={codeOpen}>
-          <Box sx={{ display: 'flex', height: 40 }}>
+          <Box sx={{ display: 'flex' }}>
             {hasNonSystemDemos && (
               <Divider orientation="vertical" variant="middle" sx={{ mx: 1, height: '24px' }} />
             )}

--- a/docs/src/modules/components/DemoToolbarRoot.ts
+++ b/docs/src/modules/components/DemoToolbarRoot.ts
@@ -12,6 +12,7 @@ const DemoToolbarRoot = styled('div', {
     display: 'none',
     [theme.breakpoints.up('sm')]: {
       top: 0,
+      maxHeight: 50,
       display: 'block',
       marginTop: demoOptions.bg === 'inline' ? theme.spacing(1) : -1,
       padding: theme.spacing(0.5, 1),

--- a/docs/src/modules/components/HighlightedCodeWithTabs.tsx
+++ b/docs/src/modules/components/HighlightedCodeWithTabs.tsx
@@ -48,7 +48,7 @@ export const CodeTab = styled(TabBase)<{ ownerState: { mounted: boolean; contain
   ({ theme, ownerState }) =>
     theme.unstable_sx({
       height: 26,
-      p: '0 8px',
+      p: '0 8px 2px 8px',
       border: ownerState?.contained ? '1px solid transparent' : 'none',
       bgcolor: 'transparent',
       color: ownerState?.contained


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Little tweaks to fine-tune the demo container even more. The primary change here is making the JS/TS toggle button look more like a pill rather than separate-looking buttons so there's no confusion with the code tabs that have been recently introduced.

https://deploy-preview-41948--material-ui.netlify.app/experiments/docs/demos/