### PR TITLE
[code-infra] Allow to customize what is considered as a component file

### DIFF
--- a/packages/api-docs-builder/ProjectSettings.ts
+++ b/packages/api-docs-builder/ProjectSettings.ts
@@ -57,6 +57,11 @@ export interface ProjectSettings {
    */
   skipComponent: (filename: string) => boolean;
   /**
+   * Fuction called to detemine whether a filename is a component or not.
+   * @default test regexp /^(Unstable_)?([A-Z][a-z]+)+2?\.(js|tsx)/;
+   */
+  isComponent: (filename: string) => boolean;
+  /**
    * Determine is the component definition should be updated.
    */
   skipAnnotatingComponentDefinition?: boolean | ((filename: string) => boolean);

--- a/packages/api-docs-builder/ProjectSettings.ts
+++ b/packages/api-docs-builder/ProjectSettings.ts
@@ -60,7 +60,7 @@ export interface ProjectSettings {
    * Fuction called to detemine whether a filename is a component or not.
    * @default test regexp /^(Unstable_)?([A-Z][a-z]+)+2?\.(js|tsx)/;
    */
-  isComponent: (filename: string) => boolean;
+  isComponent?: (filename: string) => boolean;
   /**
    * Determine is the component definition should be updated.
    */

--- a/packages/api-docs-builder/buildApi.ts
+++ b/packages/api-docs-builder/buildApi.ts
@@ -120,19 +120,21 @@ async function buildSingleProject(
   }
 
   const apiBuilds = tsProjects.flatMap((project) => {
-    const projectComponents = findComponents(path.join(project.rootPath, 'src')).filter(
-      (component) => {
-        if (projectSettings.skipComponent(component.filename)) {
-          return false;
-        }
+    const projectComponents = findComponents(
+      path.join(project.rootPath, 'src'),
+      [],
+      projectSettings.isComponent,
+    ).filter((component) => {
+      if (projectSettings.skipComponent(component.filename)) {
+        return false;
+      }
 
-        if (grep === null) {
-          return true;
-        }
+      if (grep === null) {
+        return true;
+      }
 
-        return grep.test(component.filename);
-      },
-    );
+      return grep.test(component.filename);
+    });
 
     const projectHooks = findHooks(path.join(project.rootPath, 'src')).filter((hook) => {
       if (grep === null) {

--- a/packages/api-docs-builder/utils/findComponents.ts
+++ b/packages/api-docs-builder/utils/findComponents.ts
@@ -4,14 +4,20 @@ import findIndexFile from './findIndexFile';
 
 const componentRegex = /^(Unstable_)?([A-Z][a-z]+)+2?\.(js|tsx)/;
 
+function defaultIsComponent(item: string) {
+  return componentRegex.test(item);
+}
+
 /**
  * Returns the component source in a flat array.
  * @param {string} directory
  * @param {Array<{ filename: string, indexFilename: string }>} components
+ * @param {(filename: string) => boolean} isComponent
  */
 export default function findComponents(
   directory: string,
   components: { filename: string; indexFilename: string | null }[] = [],
+  isComponent: (filename: string) => boolean = defaultIsComponent,
 ) {
   const items = fs.readdirSync(directory);
 
@@ -19,11 +25,11 @@ export default function findComponents(
     const itemPath = path.resolve(directory, item);
 
     if (fs.statSync(itemPath).isDirectory()) {
-      findComponents(itemPath, components);
+      findComponents(itemPath, components, isComponent);
       return;
     }
 
-    if (!componentRegex.test(item)) {
+    if (!isComponent(item)) {
       return;
     }
 


### PR DESCRIPTION
I realized my components `ChartsXAxis` and `ChartsYAxis` was not considered as component because they have two capital letters one after the other.

A solution could be to do the following update on the regexp, but not sure every body would like it, so I'm adding a setting option

```diff
- ^(Unstable_)?([A-Z][a-z]+)+2?\.(js|tsx)
+ ^(Unstable_)?([A-Z][a-z]*)+2?\.(js|tsx)
```