### PR TITLE
[material-ui][docs] Update the installation commands to use @next

### DIFF
--- a/docs/data/material/getting-started/installation/installation.md
+++ b/docs/data/material/getting-started/installation/installation.md
@@ -49,15 +49,15 @@ If you want to use [styled-components](https://styled-components.com/) instead, 
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/material @mui/styled-engine-sc styled-components
+npm install @mui/material@next @mui/styled-engine-sc styled-components
 ```
 
 ```bash yarn
-yarn add @mui/material @mui/styled-engine-sc styled-components
+yarn add @mui/material@next @mui/styled-engine-sc styled-components
 ```
 
 ```bash pnpm
-pnpm add @mui/material @mui/styled-engine-sc styled-components
+pnpm add @mui/material@next @mui/styled-engine-sc styled-components
 ```
 
 </codeblock>
@@ -127,15 +127,15 @@ You can do so with npm, or with the Google Web Fonts CDN.
 <codeblock storageKey="package-manager">
 
 ```bash npm
-npm install @mui/icons-material
+npm install @mui/icons-material@next
 ```
 
 ```bash yarn
-yarn add @mui/icons-material
+yarn add @mui/icons-material@next
 ```
 
 ```bash pnpm
-pnpm add @mui/icons-material
+pnpm add @mui/icons-material@next
 ```
 
 </codeblock>


### PR DESCRIPTION
Use `@next` branch for `@mui/icons-material` package and for `@mui/material` with styled-components as well

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree

npm ERR! Found: @mui/material@6.0.0-alpha.3
npm ERR! node_modules/@mui/material
npm ERR!   @mui/material@"^6.0.0-alpha.3" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @mui/material@"^5.0.0" from @mui/icons-material@5.15.15
npm ERR! node_modules/@mui/icons-material
npm ERR!   @mui/icons-material@"*" from the root project
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
