### PR TITLE
[docs-infra] Fix flex-shrink pro-plan

### DIFF
--- a/docs/data/docs-infra/pages.ts
+++ b/docs/data/docs-infra/pages.ts
@@ -7,7 +7,7 @@ const pages: readonly MuiPage[] = [
     children: [
       { pathname: '/experiments/docs/headers' },
       { pathname: '/experiments/docs/markdown' },
-      { pathname: '/experiments/docs/og-card' },
+      { pathname: '/experiments/docs/og-card', title: 'OG Image' },
     ],
   },
   {
@@ -22,7 +22,7 @@ const pages: readonly MuiPage[] = [
   },
   {
     pathname: '/experiments/docs/main-parent',
-    title: 'Main parent',
+    title: 'Test: pages.js',
     children: [
       {
         pathname: '/experiments/docs/first-level-child-1',
@@ -53,11 +53,46 @@ const pages: readonly MuiPage[] = [
           },
         ],
       },
+      {
+        pathname: '/experiments/docs/first-level-child-3',
+        title: 'Pro plan',
+        plan: 'pro',
+      },
+      {
+        pathname: '/experiments/docs/first-level-child-4',
+        title: 'New feature',
+        newFeature: true,
+      },
+      {
+        pathname: '/experiments/docs/first-level-child-5',
+        title: 'Planned feature',
+        planned: true,
+      },
+      {
+        pathname: '/experiments/docs/first-level-child-6',
+        title: 'Unstable feature',
+        unstable: true,
+      },
+      {
+        pathname: '/experiments/docs/first-level-child-7',
+        title: 'Beta feature',
+        beta: true,
+      },
+      {
+        pathname: '/experiments/docs/first-level-child-8',
+        title: 'Legacy feature',
+        legacy: true,
+      },
+      {
+        pathname: '/experiments/docs/first-level-child-9',
+        title: 'OverflowWithLongApiComponent',
+        plan: 'pro',
+      },
     ],
   },
   {
     pathname: '/x/react-data-grid-group',
-    title: 'Data Grid',
+    title: 'Test: Data Grid e2e',
     children: [
       { pathname: '/x/react-data-grid', title: 'Overview' },
       { pathname: '/x/react-data-grid/demo' },
@@ -169,7 +204,7 @@ const pages: readonly MuiPage[] = [
   },
   {
     pathname: '/x/migration-group',
-    title: 'Migration',
+    title: 'Test: Migration',
     children: [
       {
         pathname: '/x/migration-v6',

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -162,6 +162,7 @@ export default class MyDocument extends Document {
                 marginBottom: '0.08em',
                 backgroundSize: 'contain',
                 backgroundRepeat: 'no-repeat',
+                flexShrink: 0,
               },
               '.plan-pro': {
                 backgroundImage: 'url(/static/x/pro.svg)',

--- a/docs/pages/experiments/docs/og-card.md
+++ b/docs/pages/experiments/docs/og-card.md
@@ -1,11 +1,6 @@
----
-title: OG card generation
-cardDescription: A quick overview of available options.
----
+# OG Image
 
-# OG card
-
-<p class="description">How the docs platform generate Open Graph card images</p>
+<p class="description">How the docs platform generate Open Graph card images.</p>
 
 ## The edge function
 


### PR DESCRIPTION
I have noticed this small bug on the API pages of MUI X.

Before: https://mui.com/x/api/date-pickers/multi-input-date-time-range-field/

<img width="280" alt="SCR-20240421-ltti" src="https://github.com/mui/material-ui/assets/3165635/13cecb25-c1a2-46ac-9d0c-a9dbf8fc7546">

After: https://deploy-preview-41990--material-ui.netlify.app/experiments/docs/og-card/

<img width="292" alt="SCR-20240421-lucz" src="https://github.com/mui/material-ui/assets/3165635/92ba0692-a56b-486a-9c07-ab89423665a1">

I have also used the opportunity to improve https://master--material-ui.netlify.app/experiments/docs/og-card/ by isolating what's docs for docs-infra and test for sidenav, and by having more tests for sidenav. It looks like this now:

<img width="309" alt="SCR-20240421-luop" src="https://github.com/mui/material-ui/assets/3165635/ffa24cd3-792c-45b1-a07f-263f1c4b671a">


I'm unclear if we need both "Beta" and "Preview", it feels a bit like the same thing. I would remove Beta.