### PR TITLE
[material-ui] Fix getOverlayAlpha type

### DIFF
--- a/packages/mui-material/src/styles/experimental_extendTheme.test.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.test.js
@@ -258,7 +258,7 @@ describe('experimental_extendTheme', () => {
 
       expect(theme.colorSchemes.dark.overlays[0]).to.equal(undefined);
       expect(theme.colorSchemes.dark.overlays[24]).to.equal(
-        'linear-gradient(rgba(255 255 255 / 0.16), rgba(255 255 255 / 0.16))',
+        'linear-gradient(rgba(255 255 255 / 0.165), rgba(255 255 255 / 0.165))',
       );
     });
 

--- a/packages/mui-material/src/styles/getOverlayAlpha.ts
+++ b/packages/mui-material/src/styles/getOverlayAlpha.ts
@@ -1,12 +1,10 @@
 // Inspired by https://github.com/material-components/material-components-ios/blob/bca36107405594d5b7b16265a5b0ed698f85a5ee/components/Elevation/src/UIColor%2BMaterialElevation.m#L61
-const getOverlayAlpha = (elevation: number) => {
+export default function getOverlayAlpha(elevation: number): number {
   let alphaValue;
   if (elevation < 1) {
     alphaValue = 5.11916 * elevation ** 2;
   } else {
     alphaValue = 4.5 * Math.log(elevation + 1) + 2;
   }
-  return (alphaValue / 100).toFixed(2);
-};
-
-export default getOverlayAlpha;
+  return Math.round(alphaValue * 10) / 1000;
+}


### PR DESCRIPTION
- getOverlayAlpha() is provided to alpha() who expects a number but it returns a string today
- getOverlayAlpha() return type is missing, breaking MUI's policy
- getOverlayAlpha() is not using a function(), breaking MUI's policy
- two digits seems a bit too light as an approximation, go for 3