### PR TITLE
[material-ui][Autocomplete] Fix adding start adornment on small autocompletes causes text to wrap

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.js
@@ -101,7 +101,7 @@ const AutocompleteRoot = styled('div', {
     maxWidth: 'calc(100% - 6px)',
   },
   [`& .${autocompleteClasses.inputRoot}`]: {
-    flexWrap: 'wrap',
+    flexWrap: 'nowrap',
     [`.${autocompleteClasses.hasPopupIcon}&, .${autocompleteClasses.hasClearIcon}&`]: {
       paddingRight: 26 + 4,
     },


### PR DESCRIPTION
in this issue https://github.com/mui/material-ui/issues/41780 The startAdornment behavior used in an Autocomplete doesn't match that of a regular TextField. The Autocomplete wraps onto a new line when it gets too small. i think it is a simple fix just to change flexwrap from wrap to nowrap but i can't run the library locally on my computer to test it

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
