### PR TITLE
[material-ui][joy-ui] Move typography CSS variables to `font`

### DIFF
--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -53,7 +53,7 @@ export default function AppFooter(props: AppFooterProps) {
           <Link prefetch={false} href="/" aria-label="Go to homepage" sx={{ mb: 2 }}>
             <SvgMuiLogotype height={28} width={91} />
           </Link>
-          <Typography variant="body2" fontWeight="600" gutterBottom>
+          <Typography variant="body2" fontWeight="semiBold" gutterBottom>
             Keep up to date
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
@@ -70,7 +70,7 @@ export default function AppFooter(props: AppFooterProps) {
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
               Products
             </Typography>
             <Link prefetch={false} href={ROUTES.productMaterial}>
@@ -93,7 +93,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
               Resources
             </Typography>
             <Link prefetch={false} href={ROUTES.materialIcons}>
@@ -113,7 +113,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
               Explore
             </Typography>
             <Link prefetch={false} href={ROUTES.documentation}>
@@ -133,7 +133,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
               Company
             </Typography>
             <Link prefetch={false} href={ROUTES.about}>

--- a/docs/src/layouts/AppFooter.tsx
+++ b/docs/src/layouts/AppFooter.tsx
@@ -53,7 +53,7 @@ export default function AppFooter(props: AppFooterProps) {
           <Link prefetch={false} href="/" aria-label="Go to homepage" sx={{ mb: 2 }}>
             <SvgMuiLogotype height={28} width={91} />
           </Link>
-          <Typography variant="body2" fontWeight="semiBold" gutterBottom>
+          <Typography variant="body2" fontWeight="600" gutterBottom>
             Keep up to date
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
@@ -70,7 +70,7 @@ export default function AppFooter(props: AppFooterProps) {
           }}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
               Products
             </Typography>
             <Link prefetch={false} href={ROUTES.productMaterial}>
@@ -93,7 +93,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
               Resources
             </Typography>
             <Link prefetch={false} href={ROUTES.materialIcons}>
@@ -113,7 +113,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
               Explore
             </Typography>
             <Link prefetch={false} href={ROUTES.documentation}>
@@ -133,7 +133,7 @@ export default function AppFooter(props: AppFooterProps) {
             </Link>
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography fontWeight="semiBold" variant="body2" sx={{ mb: 0.5 }}>
+            <Typography fontWeight="600" variant="body2" sx={{ mb: 0.5 }}>
               Company
             </Typography>
             <Link prefetch={false} href={ROUTES.about}>

--- a/packages/mui-joy/src/styles/defaultTheme.test.js
+++ b/packages/mui-joy/src/styles/defaultTheme.test.js
@@ -13,6 +13,7 @@ describe('defaultTheme', () => {
         'components',
         'colorSchemes',
         'focus',
+        'font',
         'fontSize',
         'fontFamily',
         'fontWeight',

--- a/packages/mui-joy/src/styles/extendTheme.test.js
+++ b/packages/mui-joy/src/styles/extendTheme.test.js
@@ -16,6 +16,7 @@ describe('extendTheme', () => {
         'colorSchemes',
         'defaultColorScheme',
         'focus',
+        'font',
         'fontSize',
         'fontFamily',
         'fontWeight',
@@ -51,6 +52,7 @@ describe('extendTheme', () => {
       'radius',
       'shadow',
       'focus',
+      'font',
       'fontFamily',
       'fontSize',
       'fontWeight',
@@ -156,7 +158,7 @@ describe('extendTheme', () => {
   describe('typography', () => {
     it('produce typography token by default', () => {
       const theme = extendTheme();
-      expect(Object.keys(theme.vars.typography)).to.deep.equal([
+      expect(Object.keys(theme.vars.font)).to.deep.equal([
         'h1',
         'h2',
         'h3',
@@ -169,6 +171,28 @@ describe('extendTheme', () => {
         'body-sm',
         'body-xs',
       ]);
+    });
+
+    it('access font vars', () => {
+      const theme = extendTheme();
+      expect(
+        theme.unstable_sx({
+          font: 'h1',
+        }),
+      ).to.deep.equal({
+        font: 'var(--joy-font-h1, var(--joy-fontWeight-xl, 700) var(--joy-fontSize-xl4, 2.25rem)/var(--joy-lineHeight-xs, 1.33334) var(--joy-fontFamily-display, "Inter", var(--joy-fontFamily-fallback, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol")))',
+      });
+    });
+
+    it('use provided value if no font', () => {
+      const theme = extendTheme();
+      expect(
+        theme.unstable_sx({
+          font: 'var(--custom-font)',
+        }),
+      ).to.deep.equal({
+        font: 'var(--custom-font)',
+      });
     });
   });
 

--- a/packages/mui-joy/src/styles/extendTheme.ts
+++ b/packages/mui-joy/src/styles/extendTheme.ts
@@ -385,6 +385,7 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
       light: lightColorSystem,
       dark: darkColorSystem,
     },
+    font: {},
     fontSize,
     fontFamily,
     fontWeight,
@@ -606,7 +607,7 @@ export default function extendTheme(themeOptions?: CssVarsThemeOptions): Theme {
     cssVarPrefix,
     getCssVar,
     spacing: getSpacingVal(spacing),
-    typography: prepareTypographyVars(mergedScales.typography),
+    font: { ...prepareTypographyVars(mergedScales.typography), ...mergedScales.font },
   } as unknown as Theme & { attribute: string; colorSchemeSelector: string }; // Need type casting due to module augmentation inside the repo
   theme = cssContainerQueries(theme);
 

--- a/packages/mui-joy/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-joy/src/styles/shouldSkipGeneratingVar.ts
@@ -1,6 +1,6 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
   return (
-    !!keys[0].match(/^(variants|breakpoints)$/) ||
+    !!keys[0].match(/^(typography|variants|breakpoints)$/) ||
     !!keys[0].match(/sxConfig$/) || // ends with sxConfig
     (keys[0] === 'palette' && !!keys[1]?.match(/^(mode)$/)) ||
     (keys[0] === 'focus' && keys[1] !== 'thickness')

--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -86,6 +86,7 @@ interface ColorSystemVars extends Omit<ColorSystem, 'palette'> {
 }
 export interface ThemeVars extends ThemeScales, ColorSystemVars {
   typography: ExtractTypographyTokens<TypographySystem>;
+  font: ExtractTypographyTokens<TypographySystem>;
 }
 
 export interface ThemeCssVarOverrides {}

--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -85,7 +85,6 @@ interface ColorSystemVars extends Omit<ColorSystem, 'palette'> {
   palette: Omit<ColorSystem['palette'], 'mode'>;
 }
 export interface ThemeVars extends ThemeScales, ColorSystemVars {
-  typography: ExtractTypographyTokens<TypographySystem>;
   font: ExtractTypographyTokens<TypographySystem>;
 }
 

--- a/packages/mui-material/src/styles/experimental_extendTheme.d.ts
+++ b/packages/mui-material/src/styles/experimental_extendTheme.d.ts
@@ -322,6 +322,7 @@ export interface CssVarsThemeOptions extends Omit<ThemeOptions, 'palette' | 'com
 
 // should not include keys defined in `shouldSkipGeneratingVar` and have value typeof function
 export interface ThemeVars {
+  font: ExtractTypographyTokens<Theme['typography']>;
   palette: Omit<
     ColorSystem['palette'],
     | 'colorScheme'
@@ -337,7 +338,6 @@ export interface ThemeVars {
   shape: Theme['shape'];
   spacing: string;
   zIndex: ZIndex;
-  typography: ExtractTypographyTokens<Theme['typography']>;
 }
 
 type Split<T, K extends keyof T = keyof T> = K extends string | number

--- a/packages/mui-material/src/styles/experimental_extendTheme.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.js
@@ -139,7 +139,7 @@ export default function extendTheme(options = {}, ...args) {
         overlays: colorSchemesInput.dark?.overlays || defaultDarkOverlays,
       },
     },
-    typography: prepareTypographyVars(muiTheme.typography),
+    font: { ...prepareTypographyVars(muiTheme.typography), ...muiTheme.font },
     spacing: getSpacingVal(input.spacing),
   };
 
@@ -437,7 +437,6 @@ export default function extendTheme(options = {}, ...args) {
   theme.getColorSchemeSelector = (colorScheme) => `[${theme.attribute}="${colorScheme}"] &`;
   theme.spacing = theme.generateSpacing();
   theme.shouldSkipGeneratingVar = shouldSkipGeneratingVar;
-  theme.typography = muiTheme.typography;
   theme.unstable_sxConfig = {
     ...defaultSxConfig,
     ...input?.unstable_sxConfig,

--- a/packages/mui-material/src/styles/experimental_extendTheme.test.js
+++ b/packages/mui-material/src/styles/experimental_extendTheme.test.js
@@ -411,7 +411,7 @@ describe('experimental_extendTheme', () => {
   describe('typography', () => {
     it('produce typography token by default', () => {
       const theme = extendTheme();
-      expect(Object.keys(theme.vars.typography)).to.deep.equal([
+      expect(Object.keys(theme.vars.font)).to.deep.equal([
         'h1',
         'h2',
         'h3',
@@ -427,6 +427,28 @@ describe('experimental_extendTheme', () => {
         'overline',
         'inherit',
       ]);
+    });
+
+    it('access font vars', () => {
+      const theme = extendTheme();
+      expect(
+        theme.unstable_sx({
+          font: 'h1',
+        }),
+      ).to.deep.equal({
+        font: 'var(--mui-font-h1, 300 6rem/1.167 "Roboto", "Helvetica", "Arial", sans-serif)',
+      });
+    });
+
+    it('use provided value if no font', () => {
+      const theme = extendTheme();
+      expect(
+        theme.unstable_sx({
+          font: 'var(--custom-font)',
+        }),
+      ).to.deep.equal({
+        font: 'var(--custom-font)',
+      });
     });
   });
 

--- a/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-material/src/styles/shouldSkipGeneratingVar.ts
@@ -1,6 +1,6 @@
 export default function shouldSkipGeneratingVar(keys: string[]) {
   return (
-    !!keys[0].match(/(cssVarPrefix|mixins|breakpoints|direction|transitions)/) ||
+    !!keys[0].match(/(cssVarPrefix|typography|mixins|breakpoints|direction|transitions)/) ||
     !!keys[0].match(/sxConfig$/) || // ends with sxConfig
     (keys[0] === 'palette' && !!keys[1]?.match(/(mode|contrastThreshold|tonalOffset)/))
   );

--- a/packages/mui-system/src/cssVars/prepareTypographyVars.test.ts
+++ b/packages/mui-system/src/cssVars/prepareTypographyVars.test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { createTheme } from '@mui/material/styles';
-import prepareTypographyTokens from './prepareTypographyVars';
+import prepareTypographyVars from './prepareTypographyVars';
 
 describe('prepareTypographyVars', () => {
   it('should prepare typography vars', () => {
     const theme = createTheme();
-    expect(prepareTypographyTokens(theme.typography)).to.deep.equal({
+    expect(prepareTypographyVars(theme.typography)).to.deep.equal({
       body1: '400 1rem/1.5 "Roboto", "Helvetica", "Arial", sans-serif',
       body2: '400 0.875rem/1.43 "Roboto", "Helvetica", "Arial", sans-serif',
       button: '500 0.875rem/1.75 "Roboto", "Helvetica", "Arial", sans-serif',

--- a/packages/mui-system/src/cssVars/prepareTypographyVars.ts
+++ b/packages/mui-system/src/cssVars/prepareTypographyVars.ts
@@ -4,7 +4,7 @@ type RecordPropertyNames<T> = {
 
 export type ExtractTypographyTokens<T> = { [K in RecordPropertyNames<T>]: string };
 
-export default function prepareTypographyTokens<T extends Record<string, any>>(typography: T) {
+export default function prepareTypographyVars<T extends Record<string, any>>(typography: T) {
   const vars: Record<string, string | number> = {};
   const entries = Object.entries(typography);
   entries.forEach((entry) => {

--- a/packages/mui-system/src/styleFunctionSx/defaultSxConfig.js
+++ b/packages/mui-system/src/styleFunctionSx/defaultSxConfig.js
@@ -290,6 +290,9 @@ const defaultSxConfig = {
   boxSizing: {},
 
   // typography
+  font: {
+    themeKey: 'font',
+  },
   fontFamily: {
     themeKey: 'typography',
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Regression from #41703

Changes related to `typography` in #41703 have been reverted. A new field, `font`, is created to store typography token.

**usage**:

```js
<Box sx={{ font: 'h1' }} />
```

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
