### PR TITLE
[test] Update browser versions in karma config

### DIFF
--- a/packages/mui-material/src/Autocomplete/Autocomplete.test.js
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.test.js
@@ -1529,9 +1529,9 @@ describe('<Autocomplete />', () => {
       // <button> since it has "pointer-events: none"
       const popupIndicator = container.querySelector(`.${classes.endAdornment}`);
 
-      // TODO v6: refactor using userEvent.setup() which doesn't work until we drop
-      //  iOS Safari 12.x support, see: https://github.com/mui/material-ui/pull/38325
-      await userEvent.pointer([
+      const user = userEvent.setup();
+
+      await user.pointer([
         // this sequence does not work with fireEvent
         // 1. point the cursor somewhere in the textbox and hold down MouseLeft
         { keys: '[MouseLeft>]', target: textbox },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -222,28 +222,24 @@ module.exports = function setKarmaConfig(config) {
         chrome: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Monterey',
           browser: 'chrome',
-          // We support Chrome 90.x
-          // However, >=88 fails on seemingly all focus-related tests.
-          // TODO: Investigate why.
-          browser_version: '87.0',
+          // We support Chrome 109.x per .browserslistrc
+          browser_version: '109.0',
         },
         safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Monterey',
           browser: 'safari',
-          // We support 12.5 on iOS.
-          // However, 12.x is very flaky on desktop (mobile is always flaky).
-          browser_version: '13.0',
+          browser_version: '15.6',
         },
         edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'edge',
-          browser_version: '91.0',
+          browser_version: '120.0',
         },
       },
     };

--- a/test/karma.conf.profile.js
+++ b/test/karma.conf.profile.js
@@ -144,10 +144,8 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Catalina',
           browser: 'chrome',
-          // We support Chrome 90.x
-          // However, >=88 fails on seemingly all focus-related tests.
-          // TODO: Investigate why.
-          browser_version: '87.0',
+          // We support Chrome 109.x per .browserslistrc
+          browser_version: '109.0',
         },
         // No accurate performance timings (integer precision instead of double).
         firefox: {
@@ -155,24 +153,23 @@ module.exports = function setKarmaConfig(config) {
           os: 'Windows',
           os_version: '10',
           browser: 'firefox',
-          browser_version: '78.0',
+          // We support Firefox 115.x per .browserslistrc
+          browser_version: '115.0',
         },
         // No accurate performance timings (integer precision instead of double).
         safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Catalina',
+          os_version: 'Monterey',
           browser: 'safari',
-          // We support 12.5 on iOS.
-          // However, 12.x is very flaky on desktop (mobile is always flaky).
-          browser_version: '13.0',
+          browser_version: '15.6',
         },
         edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'edge',
-          browser_version: '91.0',
+          browser_version: '120.0',
         },
       },
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Similar to https://github.com/mui/base-ui/pull/179.

Since we've updated the list of supported browsers, we should also update the browser versions in the karma config for browser tests.

`browserstack-force` run : https://app.circleci.com/pipelines/github/mui/material-ui/127738/workflows/6dbb14d6-7afa-4d20-b0e5-f0cae483bcde/jobs/688724.

Also, resolved the `userEvent.setup()` TODO in the Autocomplete test since we now support the new Safari version. I considered refactoring other `userEvent.setup()` TODOs, but they all reside in Base UI, which is planned for removal in the near future.
