### PR TITLE
[code-infra] Fix `release:publish:dry-run` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:build": "lerna run --concurrency 8 --no-private build --skip-nx-cache",
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "release:publish": "pnpm publish --recursive --tag next",
-    "release:publish:dry-run": "pnpm publish --recursive --tag next --registry=\"http://localhost:4873/\"",
+    "release:publish:dry-run": "pnpm publish --recursive --tag next --dry-run",
     "release:tag": "node scripts/releaseTag.mjs",
     "docs:api": "rimraf --glob ./docs/pages/**/api-docs ./docs/pages/**/api && pnpm docs:api:build",
     "docs:api:build": "tsx ./scripts/buidApiDocs/index.ts",


### PR DESCRIPTION
The `--registry` argument was available when `lerna` was used. `pnpm` does not support it, but it does have the same `--[dry-run` attribute](https://pnpm.io/cli/publish#--dry-run) as `npm`.

I noticed this when working on https://github.com/mui/mui-x/pull/11875.