### PR TITLE
 [material-ui][Backdrop] Deprecate components and componentProps props for v7

### DIFF
--- a/docs/pages/material-ui/api/backdrop.json
+++ b/docs/pages/material-ui/api/backdrop.json
@@ -6,7 +6,9 @@
     "component": { "type": { "name": "elementType" } },
     "components": {
       "type": { "name": "shape", "description": "{ Root?: elementType }" },
-      "default": "{}"
+      "default": "{}",
+      "deprecated": true,
+      "deprecationInfo": "use the <code>slots</code> prop instead. This prop will be removed in v7. <a href=\"material-ui/migration/migrating-from-deprecated-apis/\">How to migrate</a>"
     },
     "componentsProps": {
       "type": { "name": "shape", "description": "{ root?: object }" },

--- a/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/actual.js
+++ b/packages/mui-codemod/src/deprecations/backdrop-props/test-cases/actual.js
@@ -1,26 +1,26 @@
 import Backdrop from '@mui/material/Backdrop';
 import { Backdrop as MyBackdrop } from '@mui/material';
 
-<Backdrop TransitionComponent={CustomTransition} />;
-<MyBackdrop TransitionComponent={CustomTransition} />;
+<Backdrop slots={{
+  transition: CustomTransition
+}} />;
+<MyBackdrop slots={{
+  transition: CustomTransition
+}} />;
 <Backdrop
-  TransitionComponent={CustomTransition}
   slots={{
     root: 'div',
-  }}
-/>;
+    transition: CustomTransition
+  }} />;
 <MyBackdrop
-  TransitionComponent={CustomTransition}
   slots={{
     ...outerSlots,
-  }}
-/>;
+    transition: CustomTransition
+  }} />;
 <Backdrop
-  TransitionComponent={ComponentTransition}
   slots={{
     root: 'div',
     transition: SlotTransition
-  }}
-/>;
+  }} />;
 // should skip non MUI components
 <NonMuiBackdrop TransitionComponent={CustomTransition} />;

--- a/packages/mui-material/src/Backdrop/Backdrop.d.ts
+++ b/packages/mui-material/src/Backdrop/Backdrop.d.ts
@@ -52,8 +52,7 @@ export interface BackdropOwnProps
   /**
    * The components used for each slot inside.
    *
-   * This prop is an alias for the `slots` prop.
-   * It's recommended to use the `slots` prop instead.
+   * @deprecated use the `slots` prop instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/).
    *
    * @default {}
    */
@@ -64,8 +63,7 @@ export interface BackdropOwnProps
    * The extra props for the slot components.
    * You can override the existing props or add new ones.
    *
-   * This prop is an alias for the `slotProps` prop.
-   * It's recommended to use the `slotProps` prop instead, as `componentsProps` will be deprecated in the future.
+   * @deprecated use the `slots` prop instead. This prop will be removed in v7. [How to migrate](/material-ui/migration/migrating-from-deprecated-apis/).
    *
    * @default {}
    */


### PR DESCRIPTION
Issue: https://github.com/mui/material-ui/issues/41279

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

@DiegoAndai do I need to change something else?