### PR TITLE
[material-ui][theme] Add documentation on migrating JSS's alternative, array-based syntax to syntax supported by Emotion

### DIFF
--- a/docs/data/material/migration/migration-v4/v5-style-changes.md
+++ b/docs/data/material/migration/migration-v4/v5-style-changes.md
@@ -29,12 +29,14 @@ All other changes must be handled manually.
 
 ## Migrate theme styleOverrides to Emotion
 
+### Refactor local rule references
+
 Although your style overrides defined in the theme may partially work, there is an important difference regarding how the nested elements are styled.
 
 The `$` syntax (local rule reference) used with JSS will not work with Emotion.
 You need to replace those selectors with a valid class selector.
 
-### Replace state class names
+#### Replace state class names
 
 ```diff
  const theme = createTheme({
@@ -53,7 +55,7 @@ You need to replace those selectors with a valid class selector.
  });
 ```
 
-### Replace nested classes selectors with global class names
+#### Replace nested classes selectors with global class names
 
 ```diff
  const theme = createTheme({
@@ -98,6 +100,48 @@ You can rely on this instead of hardcoding the classes.
 ```
 
 Take a look at the complete [list of global state classnames](/material-ui/customization/how-to-customize/#state-classes) available.
+
+### Refactor alternative syntax for space- and comma-separated values
+
+The alternative, array-based syntax JSS supports for space- and comma-separated values is not supported by Emotion.
+
+#### Replace array-based values with string-based values
+
+```diff
+ const theme = createTheme({
+   components: {
+     MuiBox: {
+      styleOverrides: {
+        root: {
+-         background: [
+-           ['url(image1.png)', 'no-repeat', 'top'],
+-           ['url(image2.png)', 'no-repeat', 'center'],
+-           '!important'
+-         ]
++         background: 'url(image1.png) no-repeat top, url(image2.png) no-repeat center !important'
+        }
+      }
+     }
+   }
+ });
+```
+
+Be sure to add units to numeric values as appropriate.
+
+```diff
+ const theme = createTheme({
+   components: {
+     MuiOutlinedInput: {
+       styleOverrides: {
+         root: {
+-          padding: [[5, 8, 6]]
++          padding: '5px 8px 6px'
+         }
+       }
+     },
+   }
+ });
+```
 
 ## ref
 


### PR DESCRIPTION
Added a section to the page on [breaking style and theme changes in v5](https://mui.com/material-ui/migration/v5-style-changes) about migrating the alternative, array-based syntax for space- and comma-separated values to string-based values necessary for use with Emotion.

Since everything under the heading "Migrate theme styleOverrides to Emotion" was about refactoring local rule references, I opted to take the content in that section and put it under a new sub-header (so the existing h3s became h4s), then I added a second sub-header for the new section about migrating the alternative, array-based syntax.

This is to resolve #41971 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
