### PR TITLE
[website] Sync career roles

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -146,30 +146,17 @@ const openRolesData = [
   {
     title: 'Engineering',
     roles: [
-      // {
-      //   title: 'React Engineer — xCharts',
-      //   description:
-      //     'You will help form the xCharts team, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
-      //   url: '/careers/react-engineer-x-charts/',
-      // },
-      // {
-      //   title: 'React Engineer — X',
-      //   description:
-      //     'You will strengthen the MUI X product, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
-      //   url: '/careers/react-engineer-x/',
-      // },
+      {
+        title: 'React Engineer — X',
+        description:
+          'You will strengthen the MUI X product, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
+        url: '/careers/react-engineer-x/',
+      },
     ],
   },
   {
     title: 'Design',
-    roles: [
-      {
-        title: 'Design Engineer — xGrid',
-        description:
-          'You will design and implement a great user and developer experience for the MUI X Data Grid.',
-        url: '/careers/design-engineer-x-grid/',
-      },
-    ],
+    roles: [],
   },
   {
     title: 'Developer Experience',
@@ -201,12 +188,6 @@ const nextRolesData = [
         url: '/careers/fullstack-engineer/',
       },
       {
-        title: 'React Engineer — X',
-        description:
-          'You will strengthen the MUI X product, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
-        url: '/careers/react-engineer-x/',
-      },
-      {
         title: 'React Engineer — xCharts',
         description:
           'You will help form the xCharts team, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
@@ -219,26 +200,10 @@ const nextRolesData = [
         url: '/careers/react-tech-lead-core/',
       },
       {
-        title: 'React Engineer — Core',
-        description:
-          'You will strengthen the core components team by collaborating with the community to land contributions.',
-        url: '/careers/react-engineer-core/',
-      },
-      {
         title: 'React Community Engineer — X',
         description:
           'You will provide guidance to the community and solve their struggle, working primarily in the advanced components team.',
         url: '/careers/react-community-engineer/',
-      },
-    ],
-  },
-  {
-    title: 'Design',
-    roles: [
-      {
-        title: 'Design Engineer',
-        description: 'You will focus on design to implement great product experiences.',
-        url: '/careers/design-engineer/',
       },
     ],
   },
@@ -264,13 +229,7 @@ const nextRolesData = [
   },
   {
     title: 'Marketing',
-    roles: [
-      {
-        title: 'Product Marketing Manager',
-        description: 'You will own the marketing efforts at MUI.',
-        url: '/careers/product-marketing-manager/',
-      },
-    ],
+    roles: [],
   },
 ] as typeof openRolesData;
 
@@ -507,28 +466,25 @@ export default function Careers() {
           />
           <Divider sx={{ borderStyle: 'dashed', my: { xs: 2, sm: 6 } }} />
           <Stack spacing={2} divider={<Divider />}>
-            {openRolesData.map((category) => {
-              const roles = category.roles;
-              return (
-                <React.Fragment key={category.title}>
-                  <Typography component="h3" variant="h5" fontWeight="semiBold">
-                    {category.title}
-                  </Typography>
-                  {roles.length > 0 ? (
-                    roles.map((role) => (
+            {openRolesData
+              .filter((category) => category.roles.length > 0)
+              .map((category) => {
+                return (
+                  <React.Fragment key={category.title}>
+                    <Typography component="h3" variant="h5" fontWeight="semiBold">
+                      {category.title}
+                    </Typography>
+                    {category.roles.map((role) => (
                       <Role
                         key={role.title}
                         title={role.title}
                         description={role.description}
                         url={role.url}
                       />
-                    ))
-                  ) : (
-                    <Typography color="text.secondary">No open roles.</Typography>
-                  )}
-                </React.Fragment>
-              );
-            })}
+                    ))}
+                  </React.Fragment>
+                );
+              })}
           </Stack>
         </Section>
         <Divider />
@@ -555,28 +511,25 @@ export default function Careers() {
               />
               <Divider sx={{ borderStyle: 'dashed', my: { xs: 2, sm: 6 } }} />
               <Stack spacing={2} divider={<Divider />}>
-                {nextRolesData.map((category) => {
-                  const roles = category.roles;
-                  return (
-                    <React.Fragment key={category.title}>
-                      <Typography component="h3" variant="h5" fontWeight="extraBold">
-                        {category.title}
-                      </Typography>
-                      {roles.length > 0 ? (
-                        roles.map((role) => (
+                {nextRolesData
+                  .filter((category) => category.roles.length > 0)
+                  .map((category) => {
+                    return (
+                      <React.Fragment key={category.title}>
+                        <Typography component="h3" variant="h5" fontWeight="extraBold">
+                          {category.title}
+                        </Typography>
+                        {category.roles.map((role) => (
                           <Role
                             key={role.title}
                             title={role.title}
                             description={role.description}
                             url={role.url}
                           />
-                        ))
-                      ) : (
-                        <Typography color="text.secondary">No plans yet.</Typography>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
+                        ))}
+                      </React.Fragment>
+                    );
+                  })}
               </Stack>
             </Section>
           </Box>

--- a/docs/pages/careers/design-engineer-x-grid.js
+++ b/docs/pages/careers/design-engineer-x-grid.js
@@ -1,7 +1,0 @@
-import * as React from 'react';
-import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
-import * as pageProps from 'docs/pages/careers/design-engineer-x-grid.md?muiMarkdown';
-
-export default function Page() {
-  return <TopLayoutCareers {...pageProps} />;
-}

--- a/docs/pages/careers/design-engineer.js
+++ b/docs/pages/careers/design-engineer.js
@@ -1,7 +1,0 @@
-import * as React from 'react';
-import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
-import * as pageProps from 'docs/pages/careers/design-engineer.md?muiMarkdown';
-
-export default function Page() {
-  return <TopLayoutCareers {...pageProps} />;
-}

--- a/docs/pages/careers/product-marketing-manager.js
+++ b/docs/pages/careers/product-marketing-manager.js
@@ -1,7 +1,0 @@
-import * as React from 'react';
-import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
-import * as pageProps from 'docs/pages/careers/product-marketing-manager.md?muiMarkdown';
-
-export default function Page() {
-  return <TopLayoutCareers {...pageProps} />;
-}

--- a/docs/pages/careers/react-engineer-core.js
+++ b/docs/pages/careers/react-engineer-core.js
@@ -1,7 +1,0 @@
-import * as React from 'react';
-import TopLayoutCareers from 'docs/src/modules/components/TopLayoutCareers';
-import * as pageProps from 'docs/pages/careers/react-engineer-core.md?muiMarkdown';
-
-export default function Page() {
-  return <TopLayoutCareers {...pageProps} />;
-}

--- a/docs/pages/careers/react-engineer-x.md
+++ b/docs/pages/careers/react-engineer-x.md
@@ -1,4 +1,4 @@
-# React Engineer — X (future role)
+# React Engineer — X
 
 <p class="description">You will strengthen the MUI X product, build ambitious and complex new features, work on strategic problems, and help grow adoption.</p>
 

--- a/docs/pages/careers/support-agent.md
+++ b/docs/pages/careers/support-agent.md
@@ -1,0 +1,104 @@
+# Customer Support Agent
+
+<p class="description">You will help MUI provide timely and efficient support to our customers and continue to streamline our customer operations across the board.</p>
+
+## Details of the role
+
+- **Location**: Remote (working hours are UTC 15:00 to UTC 23:00).
+- **Type of work**: Full-time (contractor or employee [depending on circumstances](https://mui-org.notion.site/Hiring-FAQ-64763b756ae44c37b47b081f98915501#494af1f358794028beb4b7697b5d3102)).
+- We're a **remote** company, operating mostly asynchronously.
+
+## The company
+
+MUI's story began in 2014 with Material UI, the most successful React implementation of Google's Material Design.
+Today, Material UI stands as one of the most popular open-source libraries on GitHub and has paved the way for the fully-fledged startup known as MUI (founded in 2019), which now boasts an ever-expanding ecosystem of React UI products.
+We're a company of 31+ people as of early 2024, and we're growing.
+
+## The products
+
+MUI is best known for our flagship product, Material UI—but this is just one of three core component libraries we maintain.
+Base UI is our headless component library, and Joy UI is a sister library to Material UI that implements our own in-house Joy Design system.
+We also host Design Kits and pre-built Templates.
+
+Beyond the core libraries, MUI X offers advanced components like the Data Grid, Date and Time Pickers, and Charts, for more complex user interactions and data visualization needs.
+
+We're also making ambitious moves to incorporate our full suite of components into Toolpad, a low-code admin builder tool for assembling full-stack apps faster than ever.
+
+Learn more about MUI's products in this blog post: [An introduction to the MUI ecosystem](https://mui.com/blog/mui-product-comparison/).
+
+## The culture
+
+MUI is a fully remote company with a team that spans the globe.
+The majority of our work is asynchronous, and we rely on written communication to collaborate.
+We're radically transparent: nearly all of our work happens in public.
+Each contributor has the freedom to decide how and when they work, and that work is primarily self-directed: it's your responsibility to define and complete your own tasks in a timely manner.
+
+For additional details about the culture, you can check our [careers](https://mui.com/careers/) and [about](https://mui.com/about/) pages and also our [public Handbook](https://mui-org.notion.site/Handbook-f086d47e10794d5e839aef9dc67f324b).
+
+## Why we're hiring
+
+One of MUI's company values is to [#putcommunityfirst](https://mui-org.notion.site/Values-behaviors-d3a1e1c60e2a4c0782f770cceada54bd?pvs=4#63393bde7da14f0698de0653f07a8dc7), and that includes high-quality and timely responses to customer support requests. While technical support for bugs and features is provided by our product and engineering teams, all sales and product inquiries are currently handled by a small team of two support and operations agents. We're looking to add a support-focused agent to this stellar team, to ensure our resources and bandwidth continue to match our customer needs.
+
+Overall, both our open-source community and our premium products are growing fast (x2 YoY).
+We need talented people to keep that going!
+
+### Why this is interesting
+
+This is an opportunity to work fully remotely with an agile, industry-leading company.
+We offer a dynamic work environment that is best suited to independent learners who are eager to proactively dig into customer requests and who enjoy problem-solving independently.
+
+Our products empower React developers to build awesome applications faster – we see millions of developers on MUI's docs every year, one million a month.
+
+## The role
+
+As a customer support agent, you will focus on delivering consistent, high-quality support to our customers, providing product information, sales quotes, and filling out compliance requests with the support of our Head of Operations.
+This could include handling requests that are not yet documented in our existing knowledge base and working with the team to create clear guidelines around common support requests and agreed-upon responses.
+While this is not a technical role, having a basic understanding of what a UI library is and how they work will be fundamental.
+
+Taking initiative, actively documenting, and being comfortable with new challenges are the main keys to success in the role.
+
+### What you'll do on a day-to-day basis
+
+Depending on the day, you'll:
+
+- Manage our queue of customer support tickets and execute associated tasks for resolution, including but not limited to processing refunds, deleting user accounts, processing quote requests, and answering FAQs
+- Contribute to our support request types and macros database, making sure it's detailed, clear, and up-to-date
+- Maintain our ticket database for analytics and historical reference by leveraging tags, internal comments, and creating canned responses where appropriate
+- Suggest and implement workflow improvements, including automation and helpful reports to stay on top of ticket volume
+- Moderate our store reviews and escalate important feedback to the relevant parties (internal or store contributors)
+- Respond to Paypal & Stripe disputes
+- Actively follow up on critical customer communications, such as overdue invoices
+- Collaborate with a Customer Success Engineer and a Product Engineer for our Store to find new solutions to recurring customer pain points (updating legal documents for clarity, creating new internal apps for frequent use cases, adding feature requests to GitHub)
+- Stay up to date on any major releases or changes to our product offerings by attending monthly company meetings and incorporating any changes to our [legal pages](https://mui.com/legal/) in your work
+- Create Notion pages to suggest opportunities to improve the quality and efficiency of our customer service operation overall
+
+## Who we're looking for
+
+### Required
+
+- **Independent learning skills:** we operate mainly on documentation training and feedback, so having someone who can learn by reading through Notion pages, previous tickets, and written instructions and then responding to async feedback is key.
+- **Excellent communication skills:** the bulk of the work will be interpreting and responding to customer inquiries, so clear writing skills are invaluable.
+- **Patience and curiosity:** support requests can be tedious and confusing sometimes! We need someone who knows how to follow up for clarification, and who is committed to resolving requests with kindness and knowledgeability.
+- **Organized thinking:** responding to tickets requires an ability to interpret an incoming ticket based on existing or new patterns (agreement terms, support types, product promises, etc) and to match requests with the appropriate responses (from macros, previous tickets, or templates).
+- **Self-management:** as a remote and async company, we firmly avoid micromanaging practices, relying on everyone to leverage their own strategies for productivity and focusing on output, not process.
+- **Organized documenter:** we thrive when using thorough documentation and categorization, meaning tickets are labeled, patterns become templates, and ideas for automation/improvement become entries in our project database.
+- **Comfortable around technical language:** engineering skills are absolutely not required, however, you will need some basic literacy around web development and digital product work (downloads, installs, upgrades, updates, bugs, etc).
+
+### Nice to have (but not required)
+
+Experience (1+ years) providing customer support for similar companies (developer tools, IT tools, digital products) will be considered a bonus.
+
+## Benefits and compensation
+
+**Compensation bands:** 20-30k USD, or equivalent in local currency, per year.
+You can find our perks & benefits on the [careers](https://mui.com/careers/#perks-and-benefits) page.
+
+## How to apply
+
+[Apply now for this position 📮](https://jobs.ashbyhq.com/MUI/79a9b5ec-6fb3-41ec-b48b-0a792ced7c19/application?utm_source=ZNRrPGBkqO)
+
+Don't meet every requirement?
+Apply anyway!
+Research shows that certain folks are less likely to apply for a role than others [unless they meet 100%](https://hbr.org/2014/08/why-women-dont-apply-for-jobs-unless-theyre-100-qualified) of the outlined qualifications.
+If this role excites you, we want to hear from you.
+We'd love for you to share the unique skills, passion, and experience you could bring to MUI.


### PR DESCRIPTION
A quick iteration to better sync career roles and Notion source of truth. There are a bunch of roles to add, but writing them will take time.

Preview: https://deploy-preview-42058--material-ui.netlify.app/careers/