### PR TITLE
[material-ui][types] Make slots partial in `CreateSlotsAndSlotProp`type

### DIFF
--- a/packages/mui-material/src/utils/types.ts
+++ b/packages/mui-material/src/utils/types.ts
@@ -22,7 +22,7 @@ export type CreateSlotsAndSlotProps<Slots, K extends Record<keyof Slots, any>> =
    * The components used for each slot inside.
    * @default {}
    */
-  slots?: Slots;
+  slots?: Partial<Slots>;
   /**
    * The props used for each slot inside.
    * @default {}


### PR DESCRIPTION
@DiegoAndai
As already discussed in #41875, here is the PR to make the slots in the CreateSlotsAndSlotProps help type partial to avoid possible errors.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
