### PR TITLE
[code-infra] Bump node image used by CI in docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ default-job: &default-job
     AWS_REGION_ARTIFACTS: eu-central-1
   working_directory: /tmp/material-ui
   docker:
-    - image: cimg/node:18.19
+    - image: cimg/node:18.20
 
 default-context: &default-context
   context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,9 @@ jobs:
             #!/bin/bash
             VALE_STR_CLI_VERSION=3.3.0
 
+            # set smart sudo
+            if [[ $EUID -eq 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
             mkdir /tmp/vale-extract
             cd /tmp/vale-extract
             GZIPPED_OUTPUT="vale.tar.gz"


### PR DESCRIPTION
Bumping to use the latest LTS (v18.x) version to benefit from updates and security fixes.

https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md

Replicate change done on https://github.com/mui/mui-x/pull/12961