### PR TITLE
[material-ui][FilledInput] Remove unapplied classes from filledInputClasses interface and add missing classes to root

### DIFF
--- a/docs/pages/material-ui/api/filled-input.json
+++ b/docs/pages/material-ui/api/filled-input.json
@@ -70,18 +70,6 @@
   ],
   "classes": [
     {
-      "key": "adornedEnd",
-      "className": "MuiFilledInput-adornedEnd",
-      "description": "Styles applied to the root element if `endAdornment` is provided.",
-      "isGlobal": false
-    },
-    {
-      "key": "adornedStart",
-      "className": "MuiFilledInput-adornedStart",
-      "description": "Styles applied to the root element if `startAdornment` is provided.",
-      "isGlobal": false
-    },
-    {
       "key": "colorSecondary",
       "className": "MuiFilledInput-colorSecondary",
       "description": "Styles applied to the root element if color secondary.",
@@ -118,57 +106,9 @@
       "isGlobal": false
     },
     {
-      "key": "inputAdornedEnd",
-      "className": "MuiFilledInput-inputAdornedEnd",
-      "description": "Styles applied to the input element if `endAdornment` is provided.",
-      "isGlobal": false
-    },
-    {
-      "key": "inputAdornedStart",
-      "className": "MuiFilledInput-inputAdornedStart",
-      "description": "Styles applied to the input element if `startAdornment` is provided.",
-      "isGlobal": false
-    },
-    {
-      "key": "inputHiddenLabel",
-      "className": "MuiFilledInput-inputHiddenLabel",
-      "description": "Styles applied to the `input` if in `<FormControl hiddenLabel />`.",
-      "isGlobal": false
-    },
-    {
-      "key": "inputMultiline",
-      "className": "MuiFilledInput-inputMultiline",
-      "description": "Styles applied to the input element if `multiline={true}`.",
-      "isGlobal": false
-    },
-    {
-      "key": "inputSizeSmall",
-      "className": "MuiFilledInput-inputSizeSmall",
-      "description": "Styles applied to the input element if `size=\"small\"`.",
-      "isGlobal": false
-    },
-    {
-      "key": "inputTypeSearch",
-      "className": "MuiFilledInput-inputTypeSearch",
-      "description": "Styles applied to the input element if `type=\"search\"`.",
-      "isGlobal": false
-    },
-    {
-      "key": "multiline",
-      "className": "MuiFilledInput-multiline",
-      "description": "Styles applied to the root element if `multiline={true}`.",
-      "isGlobal": false
-    },
-    {
       "key": "root",
       "className": "MuiFilledInput-root",
       "description": "Styles applied to the root element.",
-      "isGlobal": false
-    },
-    {
-      "key": "sizeSmall",
-      "className": "MuiFilledInput-sizeSmall",
-      "description": "Styles applied to the input element if `size=\"small\"`.",
       "isGlobal": false
     },
     {

--- a/docs/pages/material-ui/api/filled-input.json
+++ b/docs/pages/material-ui/api/filled-input.json
@@ -70,6 +70,18 @@
   ],
   "classes": [
     {
+      "key": "adornedEnd",
+      "className": "MuiFilledInput-adornedEnd",
+      "description": "Styles applied to the root element if `endAdornment` is provided.",
+      "isGlobal": false
+    },
+    {
+      "key": "adornedStart",
+      "className": "MuiFilledInput-adornedStart",
+      "description": "Styles applied to the root element if `startAdornment` is provided.",
+      "isGlobal": false
+    },
+    {
       "key": "colorSecondary",
       "className": "MuiFilledInput-colorSecondary",
       "description": "Styles applied to the root element if color secondary.",
@@ -106,9 +118,21 @@
       "isGlobal": false
     },
     {
+      "key": "multiline",
+      "className": "MuiFilledInput-multiline",
+      "description": "Styles applied to the root element if `multiline={true}`.",
+      "isGlobal": false
+    },
+    {
       "key": "root",
       "className": "MuiFilledInput-root",
       "description": "Styles applied to the root element.",
+      "isGlobal": false
+    },
+    {
+      "key": "sizeSmall",
+      "className": "MuiFilledInput-sizeSmall",
+      "description": "Styles applied to the root element if `size=\"small\"`.",
       "isGlobal": false
     },
     {

--- a/docs/translations/api-docs/filled-input/filled-input.json
+++ b/docs/translations/api-docs/filled-input/filled-input.json
@@ -91,6 +91,16 @@
     }
   },
   "classDescriptions": {
+    "adornedEnd": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>endAdornment</code> is provided"
+    },
+    "adornedStart": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>startAdornment</code> is provided"
+    },
     "colorSecondary": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -117,7 +127,17 @@
       "conditions": "<code>hiddenLabel={true}</code>"
     },
     "input": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the input element" },
+    "multiline": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>multiline={true}</code>"
+    },
     "root": { "description": "Styles applied to the root element." },
+    "sizeSmall": {
+      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>size=\"small\"</code>"
+    },
     "underline": {
       "description": "Styles applied to {{nodeName}} unless {{conditions}}.",
       "nodeName": "the root element",

--- a/docs/translations/api-docs/filled-input/filled-input.json
+++ b/docs/translations/api-docs/filled-input/filled-input.json
@@ -91,16 +91,6 @@
     }
   },
   "classDescriptions": {
-    "adornedEnd": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>endAdornment</code> is provided"
-    },
-    "adornedStart": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>startAdornment</code> is provided"
-    },
     "colorSecondary": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",
@@ -127,47 +117,7 @@
       "conditions": "<code>hiddenLabel={true}</code>"
     },
     "input": { "description": "Styles applied to {{nodeName}}.", "nodeName": "the input element" },
-    "inputAdornedEnd": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>endAdornment</code> is provided"
-    },
-    "inputAdornedStart": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>startAdornment</code> is provided"
-    },
-    "inputHiddenLabel": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the <code>input</code>",
-      "conditions": "in <code><FormControl hiddenLabel /></code>"
-    },
-    "inputMultiline": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>multiline={true}</code>"
-    },
-    "inputSizeSmall": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>size=\"small\"</code>"
-    },
-    "inputTypeSearch": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>type=\"search\"</code>"
-    },
-    "multiline": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the root element",
-      "conditions": "<code>multiline={true}</code>"
-    },
     "root": { "description": "Styles applied to the root element." },
-    "sizeSmall": {
-      "description": "Styles applied to {{nodeName}} if {{conditions}}.",
-      "nodeName": "the input element",
-      "conditions": "<code>size=\"small\"</code>"
-    },
     "underline": {
       "description": "Styles applied to {{nodeName}} unless {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -14,12 +14,22 @@ import {
   InputBaseRoot,
   InputBaseComponent as InputBaseInput,
 } from '../InputBase/InputBase';
+import { capitalize } from '../utils';
 
 const useUtilityClasses = (ownerState) => {
-  const { classes, disableUnderline } = ownerState;
+  const { classes, disableUnderline, startAdornment, endAdornment, size, hiddenLabel, multiline } =
+    ownerState;
 
   const slots = {
-    root: ['root', !disableUnderline && 'underline'],
+    root: [
+      'root',
+      !disableUnderline && 'underline',
+      startAdornment && 'adornedStart',
+      endAdornment && 'adornedEnd',
+      size === 'small' && `size${capitalize(size)}`,
+      hiddenLabel && 'hiddenLabel',
+      multiline && 'multiline',
+    ],
     input: ['input'],
   };
 

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -75,4 +75,26 @@ describe('<FilledInput />', () => {
     render(<FilledInput endAdornment={<Adornment />} slotProps={{}} />);
     render(<FilledInput startAdornment={<Adornment />} slotProps={{}} />);
   });
+
+  it('should not have following classes', () => {
+    render(
+      <FilledInput
+        size="small"
+        multiline
+        startAdornment="start"
+        endAdornment="end"
+        type="search"
+      />,
+    );
+
+    expect(document.querySelector('.MuiFilledInput-sizeSmall')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-multiline')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-adornedEnd')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-adornedStart')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-inputSizeSmall')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-inputMultiline')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-inputAdornedStart')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-inputAdornedEnd')).to.equal(null);
+    expect(document.querySelector('.MuiFilledInput-inputTypeSearch')).to.equal(null);
+  });
 });

--- a/packages/mui-material/src/FilledInput/FilledInput.test.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.test.js
@@ -87,14 +87,22 @@ describe('<FilledInput />', () => {
       />,
     );
 
-    expect(document.querySelector('.MuiFilledInput-sizeSmall')).to.equal(null);
-    expect(document.querySelector('.MuiFilledInput-multiline')).to.equal(null);
-    expect(document.querySelector('.MuiFilledInput-adornedEnd')).to.equal(null);
-    expect(document.querySelector('.MuiFilledInput-adornedStart')).to.equal(null);
     expect(document.querySelector('.MuiFilledInput-inputSizeSmall')).to.equal(null);
     expect(document.querySelector('.MuiFilledInput-inputMultiline')).to.equal(null);
     expect(document.querySelector('.MuiFilledInput-inputAdornedStart')).to.equal(null);
     expect(document.querySelector('.MuiFilledInput-inputAdornedEnd')).to.equal(null);
     expect(document.querySelector('.MuiFilledInput-inputTypeSearch')).to.equal(null);
+  });
+
+  it('should have following classes', () => {
+    const { container } = render(
+      <FilledInput hiddenLabel multiline size="small" startAdornment="start" endAdornment="end" />,
+    );
+    const root = container.firstChild;
+    expect(root).to.have.class(classes.hiddenLabel);
+    expect(root).to.have.class(classes.multiline);
+    expect(root).to.have.class(classes.sizeSmall);
+    expect(root).to.have.class(classes.adornedEnd);
+    expect(root).to.have.class(classes.adornedStart);
   });
 });

--- a/packages/mui-material/src/FilledInput/filledInputClasses.ts
+++ b/packages/mui-material/src/FilledInput/filledInputClasses.ts
@@ -13,8 +13,16 @@ export interface FilledInputClasses {
   focused: string;
   /** State class applied to the root element if `disabled={true}`. */
   disabled: string;
+  /** Styles applied to the root element if `startAdornment` is provided. */
+  adornedStart: string;
+  /** Styles applied to the root element if `endAdornment` is provided. */
+  adornedEnd: string;
   /** State class applied to the root element if `error={true}`. */
   error: string;
+  /** Styles applied to the root element if `size="small"`. */
+  sizeSmall: string;
+  /** Styles applied to the root element if `multiline={true}`. */
+  multiline: string;
   /** Styles applied to the root element if `hiddenLabel={true}`. */
   hiddenLabel: string;
   /** Styles applied to the input element. */
@@ -29,7 +37,16 @@ export function getFilledInputUtilityClass(slot: string): string {
 
 const filledInputClasses: FilledInputClasses = {
   ...inputBaseClasses,
-  ...generateUtilityClasses('MuiFilledInput', ['root', 'underline', 'input']),
+  ...generateUtilityClasses('MuiFilledInput', [
+    'root',
+    'underline',
+    'input',
+    'adornedStart',
+    'adornedEnd',
+    'sizeSmall',
+    'multiline',
+    'hiddenLabel',
+  ]),
 };
 
 export default filledInputClasses;

--- a/packages/mui-material/src/FilledInput/filledInputClasses.ts
+++ b/packages/mui-material/src/FilledInput/filledInputClasses.ts
@@ -13,32 +13,12 @@ export interface FilledInputClasses {
   focused: string;
   /** State class applied to the root element if `disabled={true}`. */
   disabled: string;
-  /** Styles applied to the root element if `startAdornment` is provided. */
-  adornedStart: string;
-  /** Styles applied to the root element if `endAdornment` is provided. */
-  adornedEnd: string;
   /** State class applied to the root element if `error={true}`. */
   error: string;
-  /** Styles applied to the input element if `size="small"`. */
-  sizeSmall: string;
-  /** Styles applied to the root element if `multiline={true}`. */
-  multiline: string;
   /** Styles applied to the root element if `hiddenLabel={true}`. */
   hiddenLabel: string;
   /** Styles applied to the input element. */
   input: string;
-  /** Styles applied to the input element if `size="small"`. */
-  inputSizeSmall: string;
-  /** Styles applied to the `input` if in `<FormControl hiddenLabel />`. */
-  inputHiddenLabel: string;
-  /** Styles applied to the input element if `multiline={true}`. */
-  inputMultiline: string;
-  /** Styles applied to the input element if `startAdornment` is provided. */
-  inputAdornedStart: string;
-  /** Styles applied to the input element if `endAdornment` is provided. */
-  inputAdornedEnd: string;
-  /** Styles applied to the input element if `type="search"`. */
-  inputTypeSearch: string;
 }
 
 export type FilledInputClassKey = keyof FilledInputClasses;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

[Documentation says](https://mui.com/material-ui/api/filled-input/#classes) following classes are applied when necessary conditions are met but actually none of the classes are applied. I've written test case to validate same [here](https://github.com/mui/material-ui/pull/42082/files#diff-0c29a4032ec827ace42291c4c833c034250496dce6d3ea013bdc484918be4d33)

1.  .MuiFilledInput-sizeSmall
2.   .MuiFilledInput-multiline
3.   .MuiFilledInput-adornedEnd
4.   .MuiFilledInput-adornedStart
5.   .MuiFilledInput-inputSizeSmall
6.   .MuiFilledInput-inputMultiline
7.   .MuiFilledInput-inputAdornedStart
8.   .MuiFilledInput-inputAdornedEnd
9.   .MuiFilledInput-inputTypeSearch

we can do either of the following

1. to remove above classes from filledInputClasses interface and from docs. that's what this PR does
2. to add above classes to applicable elements and don't remove any classes from filledInputClasses interface

@DiegoAndai which approach you recommend 




- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
