### PR TITLE
[docs-infra] Fix HTML structure violations

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -55,11 +55,11 @@ function Heading(props) {
     <Level id={hash}>
       <a aria-labelledby={hash} className="title-link-to-anchor" href={`#${hash}`} tabIndex={-1}>
         {getTranslatedHeader(t, hash)}
-        <div className="anchor-icon">
+        <span className="anchor-icon">
           <svg>
             <use xlinkHref="#anchor-link-icon" />
           </svg>
-        </div>
+        </span>
       </a>
     </Level>
   );

--- a/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ClassesSection.tsx
@@ -100,11 +100,11 @@ export default function ClassesSection(props: ClassesSectionProps) {
             tabIndex={-1}
           >
             {t(title)}
-            <div className="anchor-icon">
+            <span className="anchor-icon">
               <svg>
                 <use xlinkHref="#anchor-link-icon" />
               </svg>
-            </div>
+            </span>
           </a>
         </Level>
         <ToggleDisplayOption

--- a/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
+++ b/docs/src/modules/components/ApiPage/sections/PropertiesSection.js
@@ -129,11 +129,11 @@ export default function PropertiesSection(props) {
             tabIndex={-1}
           >
             {t(title)}
-            <div className="anchor-icon">
+            <span className="anchor-icon">
               <svg>
                 <use xlinkHref="#anchor-link-icon" />
               </svg>
-            </div>
+            </span>
           </a>
         </Level>
         <ToggleDisplayOption

--- a/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
+++ b/docs/src/modules/components/ApiPage/sections/SlotsSection.tsx
@@ -61,12 +61,12 @@ export default function SlotsSection(props: SlotsSectionProps) {
             href={`#${titleHash}`}
             tabIndex={-1}
           >
-            <div className="anchor-icon">
+            <span className="anchor-icon">
               {t(title)}
               <svg>
                 <use xlinkHref="#anchor-link-icon" />
               </svg>
-            </div>
+            </span>
           </a>
         </Level>
         <ToggleDisplayOption

--- a/docs/src/modules/components/ComponentsApiContent.js
+++ b/docs/src/modules/components/ComponentsApiContent.js
@@ -35,11 +35,11 @@ function Heading(props) {
     <Level id={hash}>
       <a aria-labelledby={hash} className="title-link-to-anchor" href={`#${hash}`} tabIndex={-1}>
         {getTranslatedHeader(t, hash, text)}
-        <div className="anchor-icon">
+        <span className="anchor-icon">
           <svg>
             <use xlinkHref="#anchor-link-icon" />
           </svg>
-        </div>
+        </span>
       </a>
     </Level>
   );

--- a/docs/src/modules/components/HooksApiContent.js
+++ b/docs/src/modules/components/HooksApiContent.js
@@ -29,11 +29,11 @@ function Heading(props) {
     <Level id={hash}>
       <a aria-labelledby={hash} className="title-link-to-anchor" href={`#${hash}`} tabIndex={-1}>
         {getTranslatedHeader(t, hash, text)}
-        <div className="anchor-icon">
+        <span className="anchor-icon">
           <svg>
             <use xlinkHref="#anchor-link-icon" />
           </svg>
-        </div>
+        </span>
       </a>
     </Level>
   );

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -364,7 +364,7 @@ function createRender(context) {
       }
 
       return [
-        `<h${level} id="${hash}"><a href="#${hash}" class="title-link-to-anchor">${headingHtml}<div class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></div></a>`,
+        `<h${level} id="${hash}"><a href="#${hash}" class="title-link-to-anchor">${headingHtml}<span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a>`,
         `<button title="Post a comment" class="comment-link" data-feedback-hash="${hash}">`,
         '<svg><use xlink:href="#comment-link-icon" /></svg>',
         `</button>`,

--- a/packages/markdown/parseMarkdown.test.js
+++ b/packages/markdown/parseMarkdown.test.js
@@ -295,9 +295,9 @@ authors:
       ).to.equal(
         [
           `<h1>Accordion</h1>`,
-          `<h2 id="basic-features"><a href="#basic-features" class="title-link-to-anchor">Basic features 🧪<div class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></div></a><button title="Post a comment" class="comment-link" data-feedback-hash="basic-features"><svg><use xlink:href="#comment-link-icon" /></svg></button></h2>`,
-          `<h2 id="using-slots-and-slotprops"><a href="#using-slots-and-slotprops" class="title-link-to-anchor">Using <code>slots</code> and <code>slotProps</code><div class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></div></a><button title="Post a comment" class="comment-link" data-feedback-hash="using-slots-and-slotprops"><svg><use xlink:href="#comment-link-icon" /></svg></button></h2>`,
-          `<h3 id="specific-example"><a href="#specific-example" class="title-link-to-anchor">Specific example<div class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></div></a><button title="Post a comment" class="comment-link" data-feedback-hash="specific-example"><svg><use xlink:href="#comment-link-icon" /></svg></button></h3>`,
+          `<h2 id="basic-features"><a href="#basic-features" class="title-link-to-anchor">Basic features 🧪<span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a><button title="Post a comment" class="comment-link" data-feedback-hash="basic-features"><svg><use xlink:href="#comment-link-icon" /></svg></button></h2>`,
+          `<h2 id="using-slots-and-slotprops"><a href="#using-slots-and-slotprops" class="title-link-to-anchor">Using <code>slots</code> and <code>slotProps</code><span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a><button title="Post a comment" class="comment-link" data-feedback-hash="using-slots-and-slotprops"><svg><use xlink:href="#comment-link-icon" /></svg></button></h2>`,
+          `<h3 id="specific-example"><a href="#specific-example" class="title-link-to-anchor">Specific example<span class="anchor-icon"><svg><use xlink:href="#anchor-link-icon" /></svg></span></a><button title="Post a comment" class="comment-link" data-feedback-hash="specific-example"><svg><use xlink:href="#comment-link-icon" /></svg></button></h3>`,
         ].join(''),
       );
 


### PR DESCRIPTION
A quick iteration to fix a regression introduced by #39603. 

<img width="467" alt="SCR-20240501-prlt" src="https://github.com/mui/material-ui/assets/3165635/63e5a217-08fa-4764-9359-5e7a2b53f907">
