### PR TITLE
[docs][autocomplete] Fix duplicate autocomplete id

### DIFF
--- a/docs/data/joy/components/autocomplete/CountrySelect.js
+++ b/docs/data/joy/components/autocomplete/CountrySelect.js
@@ -8,7 +8,6 @@ import Typography from '@mui/joy/Typography';
 export default function CountrySelect() {
   return (
     <Autocomplete
-      id="country-select-demo"
       placeholder="Choose a country"
       slotProps={{
         input: {

--- a/docs/data/joy/components/autocomplete/CountrySelect.tsx
+++ b/docs/data/joy/components/autocomplete/CountrySelect.tsx
@@ -8,7 +8,6 @@ import Typography from '@mui/joy/Typography';
 export default function CountrySelect() {
   return (
     <Autocomplete
-      id="country-select-demo"
       placeholder="Choose a country"
       slotProps={{
         input: {

--- a/docs/data/joy/components/autocomplete/CustomTags.js
+++ b/docs/data/joy/components/autocomplete/CustomTags.js
@@ -6,7 +6,6 @@ import Close from '@mui/icons-material/Close';
 export default function CustomTags() {
   return (
     <Autocomplete
-      id="tags-default"
       multiple
       placeholder="Favorites"
       options={top100Films}

--- a/docs/data/joy/components/autocomplete/CustomTags.tsx
+++ b/docs/data/joy/components/autocomplete/CustomTags.tsx
@@ -6,7 +6,6 @@ import Close from '@mui/icons-material/Close';
 export default function CustomTags() {
   return (
     <Autocomplete
-      id="tags-default"
       multiple
       placeholder="Favorites"
       options={top100Films}

--- a/docs/data/material/components/autocomplete/Asynchronous.js
+++ b/docs/data/material/components/autocomplete/Asynchronous.js
@@ -44,7 +44,6 @@ export default function Asynchronous() {
 
   return (
     <Autocomplete
-      id="asynchronous-demo"
       sx={{ width: 300 }}
       open={open}
       onOpen={() => {

--- a/docs/data/material/components/autocomplete/Asynchronous.tsx
+++ b/docs/data/material/components/autocomplete/Asynchronous.tsx
@@ -49,7 +49,6 @@ export default function Asynchronous() {
 
   return (
     <Autocomplete
-      id="asynchronous-demo"
       sx={{ width: 300 }}
       open={open}
       onOpen={() => {

--- a/docs/data/material/components/autocomplete/ComboBox.js
+++ b/docs/data/material/components/autocomplete/ComboBox.js
@@ -7,7 +7,6 @@ export default function ComboBox() {
   return (
     <Autocomplete
       disablePortal
-      id="combo-box-demo"
       options={top100Films}
       sx={{ width: 300 }}
       renderInput={(params) => <TextField {...params} label="Movie" />}

--- a/docs/data/material/components/autocomplete/ComboBox.tsx
+++ b/docs/data/material/components/autocomplete/ComboBox.tsx
@@ -7,7 +7,6 @@ export default function ComboBox() {
   return (
     <Autocomplete
       disablePortal
-      id="combo-box-demo"
       options={top100Films}
       sx={{ width: 300 }}
       renderInput={(params) => <TextField {...params} label="Movie" />}

--- a/docs/data/material/components/autocomplete/ComboBox.tsx.preview
+++ b/docs/data/material/components/autocomplete/ComboBox.tsx.preview
@@ -1,6 +1,5 @@
 <Autocomplete
   disablePortal
-  id="combo-box-demo"
   options={top100Films}
   sx={{ width: 300 }}
   renderInput={(params) => <TextField {...params} label="Movie" />}

--- a/docs/data/material/components/autocomplete/DisabledOptions.js
+++ b/docs/data/material/components/autocomplete/DisabledOptions.js
@@ -5,7 +5,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 export default function DisabledOptions() {
   return (
     <Autocomplete
-      id="disabled-options-demo"
       options={timeSlots}
       getOptionDisabled={(option) =>
         option === timeSlots[0] || option === timeSlots[2]

--- a/docs/data/material/components/autocomplete/DisabledOptions.tsx
+++ b/docs/data/material/components/autocomplete/DisabledOptions.tsx
@@ -5,7 +5,6 @@ import Autocomplete from '@mui/material/Autocomplete';
 export default function DisabledOptions() {
   return (
     <Autocomplete
-      id="disabled-options-demo"
       options={timeSlots}
       getOptionDisabled={(option) =>
         option === timeSlots[0] || option === timeSlots[2]

--- a/docs/data/material/components/autocomplete/DisabledOptions.tsx.preview
+++ b/docs/data/material/components/autocomplete/DisabledOptions.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="disabled-options-demo"
   options={timeSlots}
   getOptionDisabled={(option) =>
     option === timeSlots[0] || option === timeSlots[2]

--- a/docs/data/material/components/autocomplete/Filter.js
+++ b/docs/data/material/components/autocomplete/Filter.js
@@ -10,7 +10,6 @@ const filterOptions = createFilterOptions({
 export default function Filter() {
   return (
     <Autocomplete
-      id="filter-demo"
       options={top100Films}
       getOptionLabel={(option) => option.title}
       filterOptions={filterOptions}

--- a/docs/data/material/components/autocomplete/Filter.tsx
+++ b/docs/data/material/components/autocomplete/Filter.tsx
@@ -10,7 +10,6 @@ const filterOptions = createFilterOptions({
 export default function Filter() {
   return (
     <Autocomplete
-      id="filter-demo"
       options={top100Films}
       getOptionLabel={(option) => option.title}
       filterOptions={filterOptions}

--- a/docs/data/material/components/autocomplete/Filter.tsx.preview
+++ b/docs/data/material/components/autocomplete/Filter.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="filter-demo"
   options={top100Films}
   getOptionLabel={(option) => option.title}
   filterOptions={filterOptions}

--- a/docs/data/material/components/autocomplete/GloballyCustomizedOptions.js
+++ b/docs/data/material/components/autocomplete/GloballyCustomizedOptions.js
@@ -65,7 +65,6 @@ function MovieSelect() {
 function CountrySelect() {
   return (
     <Autocomplete
-      id="country-customized-option-demo"
       options={countries}
       disableCloseOnSelect
       getOptionLabel={(option) =>

--- a/docs/data/material/components/autocomplete/GloballyCustomizedOptions.tsx
+++ b/docs/data/material/components/autocomplete/GloballyCustomizedOptions.tsx
@@ -65,7 +65,6 @@ function MovieSelect() {
 function CountrySelect() {
   return (
     <Autocomplete
-      id="country-customized-option-demo"
       options={countries}
       disableCloseOnSelect
       getOptionLabel={(option: CountryType) =>

--- a/docs/data/material/components/autocomplete/GoogleMaps.js
+++ b/docs/data/material/components/autocomplete/GoogleMaps.js
@@ -91,7 +91,6 @@ export default function GoogleMaps() {
 
   return (
     <Autocomplete
-      id="google-map-demo"
       sx={{ width: 300 }}
       getOptionLabel={(option) =>
         typeof option === 'string' ? option : option.description

--- a/docs/data/material/components/autocomplete/GoogleMaps.tsx
+++ b/docs/data/material/components/autocomplete/GoogleMaps.tsx
@@ -115,7 +115,6 @@ export default function GoogleMaps() {
 
   return (
     <Autocomplete
-      id="google-map-demo"
       sx={{ width: 300 }}
       getOptionLabel={(option) =>
         typeof option === 'string' ? option : option.description

--- a/docs/data/material/components/autocomplete/Grouped.js
+++ b/docs/data/material/components/autocomplete/Grouped.js
@@ -13,7 +13,6 @@ export default function Grouped() {
 
   return (
     <Autocomplete
-      id="grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/Grouped.tsx
+++ b/docs/data/material/components/autocomplete/Grouped.tsx
@@ -13,7 +13,6 @@ export default function Grouped() {
 
   return (
     <Autocomplete
-      id="grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/Grouped.tsx.preview
+++ b/docs/data/material/components/autocomplete/Grouped.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="grouped-demo"
   options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
   groupBy={(option) => option.firstLetter}
   getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/Highlights.js
+++ b/docs/data/material/components/autocomplete/Highlights.js
@@ -7,7 +7,6 @@ import match from 'autosuggest-highlight/match';
 export default function Highlights() {
   return (
     <Autocomplete
-      id="highlights-demo"
       sx={{ width: 300 }}
       options={top100Films}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/Highlights.tsx
+++ b/docs/data/material/components/autocomplete/Highlights.tsx
@@ -7,7 +7,6 @@ import match from 'autosuggest-highlight/match';
 export default function Highlights() {
   return (
     <Autocomplete
-      id="highlights-demo"
       sx={{ width: 300 }}
       options={top100Films}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/RenderGroup.js
+++ b/docs/data/material/components/autocomplete/RenderGroup.js
@@ -29,7 +29,7 @@ export default function RenderGroup() {
 
   return (
     <Autocomplete
-      id="grouped-demo"
+      id="render-grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/RenderGroup.js
+++ b/docs/data/material/components/autocomplete/RenderGroup.js
@@ -29,7 +29,6 @@ export default function RenderGroup() {
 
   return (
     <Autocomplete
-      id="render-grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/RenderGroup.tsx
+++ b/docs/data/material/components/autocomplete/RenderGroup.tsx
@@ -29,7 +29,7 @@ export default function RenderGroup() {
 
   return (
     <Autocomplete
-      id="grouped-demo"
+      id="render-grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/RenderGroup.tsx
+++ b/docs/data/material/components/autocomplete/RenderGroup.tsx
@@ -29,7 +29,6 @@ export default function RenderGroup() {
 
   return (
     <Autocomplete
-      id="render-grouped-demo"
       options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
       groupBy={(option) => option.firstLetter}
       getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/RenderGroup.tsx.preview
+++ b/docs/data/material/components/autocomplete/RenderGroup.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="render-grouped-demo"
   options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
   groupBy={(option) => option.firstLetter}
   getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/RenderGroup.tsx.preview
+++ b/docs/data/material/components/autocomplete/RenderGroup.tsx.preview
@@ -1,5 +1,5 @@
 <Autocomplete
-  id="grouped-demo"
+  id="render-grouped-demo"
   options={options.sort((a, b) => -b.firstLetter.localeCompare(a.firstLetter))}
   groupBy={(option) => option.firstLetter}
   getOptionLabel={(option) => option.title}

--- a/docs/data/material/components/autocomplete/Virtualize.js
+++ b/docs/data/material/components/autocomplete/Virtualize.js
@@ -138,7 +138,6 @@ const OPTIONS = Array.from(new Array(10000))
 export default function Virtualize() {
   return (
     <Autocomplete
-      id="virtualize-demo"
       sx={{ width: 300 }}
       disableListWrap
       PopperComponent={StyledPopper}

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -138,7 +138,6 @@ const OPTIONS = Array.from(new Array(10000))
 export default function Virtualize() {
   return (
     <Autocomplete
-      id="virtualize-demo"
       sx={{ width: 300 }}
       disableListWrap
       PopperComponent={StyledPopper}

--- a/docs/data/material/components/autocomplete/Virtualize.tsx.preview
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx.preview
@@ -1,5 +1,4 @@
 <Autocomplete
-  id="virtualize-demo"
   sx={{ width: 300 }}
   disableListWrap
   PopperComponent={StyledPopper}


### PR DESCRIPTION
We can't have duplicated id on a page. I noticed this in #42085. Part of the value of solving these errors, the more we have, the harder its to quickly spot regressions

<img width="622" alt="SCR-20240501-pstw" src="https://github.com/mui/material-ui/assets/3165635/76f1583d-59e7-41f4-a08f-5e6b3db27ffc">

https://validator.w3.org/nu/?doc=https%3A%2F%2Fdeploy-preview-39603--material-ui.netlify.app%2Fmaterial-ui%2Freact-autocomplete%2F

A regression from #34066

After: https://deploy-preview-42086--material-ui.netlify.app/material-ui/react-autocomplete/
