### PR TITLE
Add flag to suppress warning closes 41669

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -579,27 +579,32 @@ export function useAutocomplete(props) {
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
+      function logWarning(message) {
+        if (suppressTextareaWarning) return;
+        console.warn(message);
+      }
+
+      function logError(message) {
+        console.error(message);
+      }
+
       if (!inputRef.current || inputRef.current.nodeName !== 'INPUT') {
-        if (inputRef.current && inputRef.current.nodeName === 'TEXTAREA' && !suppressTextareaWarning) {
-          console.warn(
-            [
-              `A textarea element was provided to ${componentName} where input was expected.`,
-              `This is not a supported scenario but it may work under certain conditions.`,
-              `A textarea keyboard navigation may conflict with Autocomplete controls (for example enter and arrow keys).`,
-              `Make sure to test keyboard navigation and add custom event handlers if necessary.`,
-            ].join('\n'),
-          );
+        if (inputRef.current && inputRef.current.nodeName === 'TEXTAREA') {
+          logWarning([
+            `A textarea element was provided to ${componentName} where input was expected.`,
+            `This is not a supported scenario but it may work under certain conditions.`,
+            `A textarea keyboard navigation may conflict with Autocomplete controls (for example enter and arrow keys).`,
+            `Make sure to test keyboard navigation and add custom event handlers if necessary.`,
+          ].join('\n'));
         } else {
-          console.error(
-            [
-              `MUI: Unable to find the input element. It was resolved to ${inputRef.current} while an HTMLInputElement was expected.`,
-              `Instead, ${componentName} expects an input element.`,
-              '',
-              componentName === 'useAutocomplete'
-                ? 'Make sure you have bound getInputProps correctly and that the normal ref/effect resolutions order is guaranteed.'
-                : 'Make sure you have customized the input component correctly.',
-            ].join('\n'),
-          );
+          logError([
+            `MUI: Unable to find the input element. It was resolved to ${inputRef.current} while an HTMLInputElement was expected.`,
+            `Instead, ${componentName} expects an input element.`,
+            '',
+            componentName === 'useAutocomplete'
+              ? 'Make sure you have bound getInputProps correctly and that the normal ref/effect resolutions order is guaranteed.'
+              : 'Make sure you have customized the input component correctly.',
+          ].join('\n'));
         }
       }
     }, [componentName]);

--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -104,6 +104,7 @@ export function useAutocomplete(props) {
     readOnly = false,
     selectOnFocus = !props.freeSolo,
     value: valueProp,
+    suppressTextareaWarning = false,
   } = props;
 
   const id = useId(idProp);
@@ -579,7 +580,7 @@ export function useAutocomplete(props) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       if (!inputRef.current || inputRef.current.nodeName !== 'INPUT') {
-        if (inputRef.current && inputRef.current.nodeName === 'TEXTAREA') {
+        if (inputRef.current && inputRef.current.nodeName === 'TEXTAREA' && !suppressTextareaWarning) {
           console.warn(
             [
               `A textarea element was provided to ${componentName} where input was expected.`,


### PR DESCRIPTION

In React, when you add the contentEditable, you get a warning in the console that warns you about the problems you might encounter using that prop. To remove that warning you have to add another prop: suppressContentEditableWarning.

To remove the warning message add suppressTextareaWarning flag to the component.

```
<Autocomplete
  options={yourOptions}
  renderInput={(params) => <TextField {...params} multiline />}
  suppressTextareaWarning
/>

```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

#41669