### PR TITLE
[website] Avoid duplicate simple vs. rich

### DIFF
--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -573,8 +573,7 @@ const rowHeaders: Record<string, React.ReactNode> = {
       href="/x/react-date-pickers/date-range-picker/"
     />
   ),
-
-  // -- charts - components --
+  // charts - components
   'charts/line': <ColumnHead label="Line chart" href="/x/react-charts/lines/" />,
   'charts/bar': <ColumnHead label="Bar chart" href="/x/react-charts/bars/" />,
   'charts/scatter': <ColumnHead label="Scatter chart" href="/x/react-charts/scatter/" />,
@@ -590,25 +589,18 @@ const rowHeaders: Record<string, React.ReactNode> = {
   'charts/gantt-advanced': <ColumnHead label="Advanced Gantt" />,
   'charts/candlestick': <ColumnHead label="Candlestick" />,
   'charts/large-dataset': <ColumnHead label="Large dataset with canvas" />,
-  // -- charts - features --
+  // charts - features
   'charts/legend': <ColumnHead label="Legend" href="/x/react-charts/legend/" />,
   'charts/tooltip': <ColumnHead label="Tooltip" href="/x/react-charts/tooltip/" />,
   'charts/mouse-zoom': <ColumnHead label="Zoom on mouse" />,
   'charts/export': <ColumnHead label="Export" />,
-  // -- charts - datagrid --
+  // charts - datagrid
   'charts/cell-with-charts': (
     <ColumnHead label="Cell with chart" href="/x/react-data-grid/custom-columns/#sparkline" />
   ),
   'charts/filter-interaction': <ColumnHead label="Row filtering" />,
   'charts/selection-interaction': <ColumnHead label="Range selection" />,
-
-  'tree-view/simple-tree-view': (
-    <ColumnHead label="Simple Tree View" href="/x/react-tree-view/#simple-tree-view" />
-  ),
-  'tree-view/rich-tree-view': (
-    <ColumnHead label="Rich Tree View" href="/x/react-tree-view/#rich-tree-view" />
-  ),
-
+  'tree-view/tree-view': <ColumnHead label="Tree View" href="/x/react-tree-view/" />,
   'mui-x-production': <ColumnHead label="Perpetual use in production" />,
   'mui-x-development': <ColumnHead label="Development license" tooltip="For active development" />,
   'mui-x-development-perpetual': (
@@ -706,20 +698,20 @@ const toBeDefined = (
 );
 
 const communityData: Record<string, React.ReactNode> = {
-  // MUI Core
+  // Core open-source libraries
   'Base UI': yes,
   'MUI System': yes,
   'Material UI': yes,
   'Joy UI': yes,
   // MUI X
-  // -- data grid - columns --
+  // data grid - columns
   'data-grid/column-groups': yes,
   'data-grid/column-spanning': yes,
   'data-grid/column-resizing': yes,
   'data-grid/column-autosizing': yes,
   'data-grid/column-reorder': no,
   'data-grid/column-pinning': no,
-  // -- data grid - rows --
+  // data grid - rows
   'data-grid/row-height': yes,
   'data-grid/row-spanning': pending,
   'data-grid/row-reordering': no,
@@ -727,7 +719,7 @@ const communityData: Record<string, React.ReactNode> = {
   'data-grid/row-selection': yes,
   'data-grid/row-multiselection': no,
   'data-grid/row-cell-selection': no,
-  // -- data grid - filter --
+  // data grid - filter
   'data-grid/filter-quick': yes,
   'data-grid/filter-column': yes,
   'data-grid/header-filters': no,
@@ -736,10 +728,10 @@ const communityData: Record<string, React.ReactNode> = {
   'data-grid/multi-column-sorting': no,
   'data-grid/pagination': yes,
   'data-grid/pagination-large': no,
-  // -- data grid - edit --
+  // data grid - edit
   'data-grid/edit-row': yes,
   'data-grid/edit-cell': yes,
-  // -- data grid - export --
+  // data grid - export
   'data-grid/file-csv': yes,
   'data-grid/file-print': yes,
   'data-grid/file-clipboard-copy': yes,
@@ -756,12 +748,10 @@ const communityData: Record<string, React.ReactNode> = {
   'data-grid/accessibility': yes,
   'data-grid/keyboard-nav': yes,
   'data-grid/localization': yes,
-
-  // -- picker --
+  // picker
   'date-picker/simple': yes,
   'date-picker/range': no,
-
-  // -- charts - components --
+  // charts - components
   'charts/line': yes,
   'charts/bar': yes,
   'charts/scatter': yes,
@@ -777,20 +767,18 @@ const communityData: Record<string, React.ReactNode> = {
   'charts/gantt-advanced': no,
   'charts/candlestick': no,
   'charts/large-dataset': no,
-  // -- charts - features --
+  // charts - features
   'charts/legend': yes,
   'charts/tooltip': yes,
   'charts/mouse-zoom': no,
   'charts/export': no,
-  // -- charts - datagrid --
+  // charts - datagrid
   'charts/cell-with-charts': yes,
   'charts/filter-interaction': no,
   'charts/selection-interaction': no,
-
-  'tree-view/simple-tree-view': yes,
-  'tree-view/rich-tree-view': yes,
-
-  // -- general --
+  // Tree View
+  'tree-view/tree-view': yes,
+  // general
   'mui-x-production': yes,
   'mui-x-updates': yes,
   'mui-x-development': yes,
@@ -807,20 +795,20 @@ const communityData: Record<string, React.ReactNode> = {
 };
 
 const proData: Record<string, React.ReactNode> = {
-  // MUI Core
+  // Core
   'Base UI': yes,
   'MUI System': yes,
   'Material UI': yes,
   'Joy UI': yes,
   // MUI X
-  // -- data grid - columns --
+  // data grid - columns
   'data-grid/column-groups': yes,
   'data-grid/column-spanning': yes,
   'data-grid/column-resizing': yes,
   'data-grid/column-autosizing': yes,
   'data-grid/column-reorder': yes,
   'data-grid/column-pinning': yes,
-  // -- data grid - rows --
+  // data grid - rows
   'data-grid/row-height': yes,
   'data-grid/row-spanning': pending,
   'data-grid/row-reordering': yes,
@@ -828,7 +816,7 @@ const proData: Record<string, React.ReactNode> = {
   'data-grid/row-selection': yes,
   'data-grid/row-multiselection': yes,
   'data-grid/row-cell-selection': no,
-  // -- data grid - filter --
+  // data grid - filter
   'data-grid/filter-quick': yes,
   'data-grid/filter-column': yes,
   'data-grid/header-filters': yes,
@@ -837,10 +825,10 @@ const proData: Record<string, React.ReactNode> = {
   'data-grid/multi-column-sorting': yes,
   'data-grid/pagination': yes,
   'data-grid/pagination-large': yes,
-  // -- data grid - edit --
+  // data grid - edit
   'data-grid/edit-row': yes,
   'data-grid/edit-cell': yes,
-  // -- data grid - export --
+  // data grid - export
   'data-grid/file-csv': yes,
   'data-grid/file-print': yes,
   'data-grid/file-clipboard-copy': yes,
@@ -860,7 +848,7 @@ const proData: Record<string, React.ReactNode> = {
   'date-picker/simple': yes,
   'date-picker/range': yes,
 
-  // -- charts - components --
+  // charts - components
   'charts/line': yes,
   'charts/bar': yes,
   'charts/scatter': yes,
@@ -876,20 +864,18 @@ const proData: Record<string, React.ReactNode> = {
   'charts/gantt-advanced': no,
   'charts/candlestick': no,
   'charts/large-dataset': no,
-  // -- charts - features --
+  // charts - features
   'charts/legend': yes,
   'charts/tooltip': yes,
   'charts/mouse-zoom': pending,
   'charts/export': pending,
-  // -- charts - datagrid --
+  // charts - datagrid
   'charts/cell-with-charts': yes,
   'charts/filter-interaction': pending,
   'charts/selection-interaction': no,
-
-  'tree-view/simple-tree-view': yes,
-  'tree-view/rich-tree-view': yes,
-
-  // -- general --
+  // Tree View
+  'tree-view/tree-view': yes,
+  // general
   'mui-x-production': yes,
   'mui-x-development': <Info value="1 year" />,
   'mui-x-development-perpetual': <Info value="Perpetual" />,
@@ -911,20 +897,20 @@ const proData: Record<string, React.ReactNode> = {
 };
 
 const premiumData: Record<string, React.ReactNode> = {
-  // MUI Core
+  // Core
   'Base UI': yes,
   'MUI System': yes,
   'Material UI': yes,
   'Joy UI': yes,
   // MUI X
-  // -- data grid - columns --
+  // data grid - columns
   'data-grid/column-groups': yes,
   'data-grid/column-spanning': yes,
   'data-grid/column-resizing': yes,
   'data-grid/column-autosizing': yes,
   'data-grid/column-reorder': yes,
   'data-grid/column-pinning': yes,
-  // -- data grid - rows --
+  // data grid - rows
   'data-grid/row-height': yes,
   'data-grid/row-spanning': pending,
   'data-grid/row-reordering': yes,
@@ -932,7 +918,7 @@ const premiumData: Record<string, React.ReactNode> = {
   'data-grid/row-selection': yes,
   'data-grid/row-multiselection': yes,
   'data-grid/row-cell-selection': yes,
-  // -- data grid - filter --
+  // data grid - filter
   'data-grid/filter-quick': yes,
   'data-grid/filter-column': yes,
   'data-grid/header-filters': yes,
@@ -941,10 +927,10 @@ const premiumData: Record<string, React.ReactNode> = {
   'data-grid/multi-column-sorting': yes,
   'data-grid/pagination': yes,
   'data-grid/pagination-large': yes,
-  // -- data grid - edit --
+  // data grid - edit
   'data-grid/edit-row': yes,
   'data-grid/edit-cell': yes,
-  // -- data grid - export --
+  // data grid - export
   'data-grid/file-csv': yes,
   'data-grid/file-print': yes,
   'data-grid/file-clipboard-copy': yes,
@@ -964,7 +950,7 @@ const premiumData: Record<string, React.ReactNode> = {
   'date-picker/simple': yes,
   'date-picker/range': yes,
 
-  // -- charts - components --
+  // charts - components
   'charts/line': yes,
   'charts/bar': yes,
   'charts/scatter': yes,
@@ -980,20 +966,18 @@ const premiumData: Record<string, React.ReactNode> = {
   'charts/gantt-advanced': toBeDefined,
   'charts/candlestick': toBeDefined,
   'charts/large-dataset': toBeDefined,
-  // -- charts - features --
+  // charts - features
   'charts/legend': yes,
   'charts/tooltip': yes,
   'charts/mouse-zoom': pending,
   'charts/export': pending,
-  // -- charts - datagrid --
+  // charts - datagrid
   'charts/cell-with-charts': yes,
   'charts/filter-interaction': pending,
   'charts/selection-interaction': pending,
-
-  'tree-view/simple-tree-view': yes,
-  'tree-view/rich-tree-view': yes,
-
-  // -- general --
+  // Tree View
+  'tree-view/tree-view': yes,
+  // general
   'mui-x-production': yes,
   'mui-x-development': <Info value="1 year" />,
   'mui-x-development-perpetual': <Info value="Perpetual" />,
@@ -1588,9 +1572,7 @@ export default function PricingTable({
         {renderNestedRow('charts/selection-interaction')}
       </StyledCollapse>
       {divider}
-      {renderRow('tree-view/simple-tree-view')}
-      {divider}
-      {renderRow('tree-view/rich-tree-view')}
+      {renderRow('tree-view/tree-view')}
       {divider}
       {renderRow('mui-x-production')}
       {divider}


### PR DESCRIPTION
I'm confused by:

<img width="1128" alt="SCR-20240502-tapg" src="https://github.com/mui/material-ui/assets/3165635/2046eb72-43ee-4901-a06b-1bb5838eabf6">

1. Simple tree view and Rich tree view are the same components (not in the React sense but UI sense), so do we need to show them twice? It makes me think that there are two, which is not the case.
2. It feels like the page promise that all tree view features are open-source, but we have https://github.com/mui/mui-x/issues?q=is%3Aopen+is%3Aissue+label%3A%22component%3A+tree+view%22+sort%3Areactions-%2B1-desc+label%3A%22plan%3A+Pro%22.

So I'm going after 1 in this PR.
For point 2. I think https://github.com/mui/material-ui/pull/41595#discussion_r1535365315 makes sense, but I kept this PR more focused.

After: https://deploy-preview-42100--material-ui.netlify.app/pricing/