### PR TITLE
[website] Componentize a few Careers page sections

### DIFF
--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -1,146 +1,22 @@
 import * as React from 'react';
-import { styled, alpha } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
-import Grid from '@mui/material/Unstable_Grid2';
 import Stack from '@mui/material/Stack';
-import Paper from '@mui/material/Paper';
-import Button from '@mui/material/Button';
 import Badge from '@mui/material/Badge';
 import Typography from '@mui/material/Typography';
-import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
-import KeyboardArrowDownRounded from '@mui/icons-material/KeyboardArrowDownRounded';
-import MuiAccordion from '@mui/material/Accordion';
-import MuiAccordionSummary from '@mui/material/AccordionSummary';
-import MuiAccordionDetail from '@mui/material/AccordionDetails';
-import OurValues from 'docs/src/components/about/OurValues';
 import { Link } from '@mui/docs/Link';
+import OurValues from 'docs/src/components/about/OurValues';
+import PerksBenefits from 'docs/src/components/careers/PerksBenefits';
+import CareersFaq from 'docs/src/components/careers/CareersFaq';
+import RoleEntry from 'docs/src/components/careers/RoleEntry';
 import AppHeader from 'docs/src/layouts/AppHeader';
 import AppFooter from 'docs/src/layouts/AppFooter';
 import GradientText from 'docs/src/components/typography/GradientText';
-import IconImage from 'docs/src/components/icon/IconImage';
 import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import Section from 'docs/src/layouts/Section';
 import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
 import Head from 'docs/src/modules/components/Head';
-import ROUTES from 'docs/src/route';
 import AppHeaderBanner from 'docs/src/components/banner/AppHeaderBanner';
-
-interface RoleProps {
-  description: string;
-  title: string;
-  url?: string;
-}
-
-function Role(props: RoleProps) {
-  if (props.url) {
-    return (
-      <Box
-        sx={{
-          py: 1,
-          display: 'flex',
-          flexDirection: { xs: 'column', lg: 'row' },
-          justifyContent: 'space-between',
-          alignItems: 'start',
-          gap: 2,
-        }}
-      >
-        <div>
-          <Typography variant="body1" color="text.primary" fontWeight="medium" gutterBottom>
-            {props.title}
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 550 }}>
-            {props.description}
-          </Typography>
-        </div>
-        <Button
-          component="a"
-          variant="outlined"
-          color="secondary"
-          size="small"
-          href={props.url}
-          endIcon={<KeyboardArrowRightRounded />}
-        >
-          More about this role
-        </Button>
-      </Box>
-    );
-  }
-
-  return (
-    <div>
-      <Typography variant="body1" color="text.primary" fontWeight="medium" gutterBottom>
-        {props.title}
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 650 }}>
-        {props.description}
-      </Typography>
-    </div>
-  );
-}
-
-const Accordion = styled(MuiAccordion)(({ theme }) => ({
-  padding: theme.spacing(2),
-  transition: theme.transitions.create('box-shadow'),
-  borderRadius: theme.shape.borderRadius,
-  '&:hover': {
-    borderColor: theme.palette.primary[300],
-    boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
-  },
-  '&:not(:last-of-type)': {
-    marginBottom: theme.spacing(2),
-  },
-  '&::before': {
-    display: 'none',
-  },
-  '&::after': {
-    display: 'none',
-  },
-  ...theme.applyDarkStyles({
-    '&:hover': {
-      borderColor: alpha(theme.palette.primary[600], 0.6),
-      boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.8)',
-    },
-  }),
-}));
-
-const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
-  padding: theme.spacing(2),
-  margin: theme.spacing(-2),
-  minHeight: 'auto',
-  '&.Mui-expanded': {
-    minHeight: 'auto',
-  },
-  '& .MuiAccordionSummary-content': {
-    margin: 0,
-    paddingRight: theme.spacing(2),
-    '&.Mui-expanded': {
-      margin: 0,
-    },
-  },
-}));
-
-const AccordionDetails = styled(MuiAccordionDetail)(({ theme }) => ({
-  marginTop: theme.spacing(1),
-  padding: 0,
-}));
-
-const faqData = [
-  {
-    summary: 'Are there application deadlines?',
-    detail: 'No. You can still apply if a position is visible on our careers page.',
-  },
-  {
-    summary: 'Does MUI do whiteboarding during interviews?',
-    detail:
-      'No. We ask applicants to complete challenges that are close to their future day-to-day contributions.',
-  },
-  {
-    summary: 'Does MUI offer contract job opportunities?',
-    detail:
-      'Yes. People outside of France can be hired as full-time contractors. (Benefits may vary.)',
-  },
-];
 
 const openRolesData = [
   {
@@ -151,6 +27,12 @@ const openRolesData = [
         description:
           'You will strengthen the MUI X product, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
         url: '/careers/react-engineer-x/',
+      },
+      {
+        title: 'React Engineer — Docs Infra',
+        description:
+          'You will drive the development of the documentation platform that powers all of MUI’s products, enabling it to grow and establish itself as a mature product.',
+        url: '/careers/react-engineer-docs-infra/',
       },
     ],
   },
@@ -233,99 +115,6 @@ const nextRolesData = [
   },
 ] as typeof openRolesData;
 
-const companyInfo = [
-  {
-    title: 'About us',
-    description: 'Meet the team and a little bit of our history.',
-    routeUrl: ROUTES.about,
-  },
-  {
-    title: 'Handbook',
-    description: 'Learn everything about how MUI as a company is run.',
-    routeUrl: ROUTES.handbook,
-  },
-  {
-    title: 'Blog',
-    description: 'Check behind-the-scenes and news about the company.',
-    routeUrl: ROUTES.blog,
-  },
-];
-
-function renderFAQItem(index: number, defaultExpanded?: boolean) {
-  const faq = faqData[index];
-  return (
-    <Accordion variant="outlined" defaultExpanded={defaultExpanded}>
-      <AccordionSummary
-        expandIcon={<KeyboardArrowDownRounded sx={{ fontSize: 20, color: 'primary.main' }} />}
-      >
-        <Typography variant="body2" fontWeight="bold" component="h3">
-          {faq.summary}
-        </Typography>
-      </AccordionSummary>
-      <AccordionDetails>
-        <Typography
-          component="div"
-          variant="body2"
-          color="text.secondary"
-          sx={{ '& ul': { pl: 2 } }}
-        >
-          {faq.detail}
-        </Typography>
-      </AccordionDetails>
-    </Accordion>
-  );
-}
-
-function RemoteAwardCard() {
-  return (
-    <Paper
-      component={Link}
-      href="/blog/remote-award-win-2024/"
-      noLinkStyle
-      variant="outlined"
-      sx={{ p: 2 }}
-    >
-      <Box
-        sx={{
-          mb: 2,
-          maxWidth: { xs: 315, sm: 325 },
-          maxHeight: 315,
-          border: '1px solid',
-          borderColor: 'divider',
-          borderRadius: '6px',
-          overflow: 'clip',
-        }}
-      >
-        <Box
-          component="img"
-          src="/static/branding/careers/remote-award-light.png"
-          alt="MUI is the winner of the Remote Excellence Awards in the Small and Mighty for SMEs category."
-          height="1200px"
-          width="1200px"
-          sx={(theme) => ({
-            width: '100%',
-            height: '100%',
-            ...theme.applyDarkStyles({
-              content: `url(/static/branding/careers/remote-award-dark.png)`,
-            }),
-          })}
-        />
-      </Box>
-      <div>
-        <Typography component="h2" variant="body2" fontWeight="semiBold">
-          Remote Excellence Awards
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-          Winners in the first-ever Remote Excellence Awards, in the Small & Mighty category! 🎉
-        </Typography>
-        <Typography variant="body2" fontWeight="bold" color="primary">
-          Learn more <KeyboardArrowRightRounded fontSize="small" sx={{ verticalAlign: 'middle' }} />
-        </Typography>
-      </div>
-    </Paper>
-  );
-}
-
 export default function Careers() {
   return (
     <BrandingCssVarsProvider>
@@ -353,100 +142,7 @@ export default function Careers() {
         <Divider />
         <OurValues />
         <Divider />
-        {/* Perks & benefits */}
-        <Section bg="gradient" cozy>
-          <Grid container spacing={5} alignItems="center">
-            <Grid md={6}>
-              <SectionHeadline
-                overline="Working at MUI"
-                title={
-                  <Typography variant="h2" id="perks-and-benefits">
-                    Perks & benefits
-                  </Typography>
-                }
-                description="To help you go above and beyond with us, we provide:"
-              />
-              <Box sx={{ maxWidth: 500 }}>
-                {[
-                  ['100% remote work', 'Our entire company is globally distributed.'],
-                  [
-                    'Retreats',
-                    'We meet up every 8 months for a week of working & having fun together!',
-                  ],
-                  [
-                    'Equipment',
-                    'We provide the hardware of your choice (initial grant of $2,500 USD).',
-                  ],
-                  ['Time off', 'We provide 33 days of paid time off globally.'],
-                ].map((textArray) => (
-                  <Box
-                    key={textArray[0]}
-                    sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1, py: 0.5 }}
-                  >
-                    <IconImage name="pricing/yes" />
-                    <div>
-                      <Typography variant="body2" color="text.primary" fontWeight="semiBold">
-                        {textArray[0]}
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary">
-                        {textArray[1]}
-                      </Typography>
-                    </div>
-                  </Box>
-                ))}
-              </Box>
-            </Grid>
-            <Grid
-              xs={12}
-              md={6}
-              sx={{
-                p: { xs: 2, sm: 0 },
-                display: 'flex',
-                flexDirection: { xs: 'column', sm: 'row' },
-                gap: 2,
-              }}
-            >
-              <RemoteAwardCard />
-              <Stack spacing={2} useFlexGap>
-                {companyInfo.map(({ title, description, routeUrl }) => (
-                  <Paper
-                    key={title}
-                    component={Link}
-                    href={routeUrl}
-                    noLinkStyle
-                    variant="outlined"
-                    sx={{
-                      p: 2,
-                      width: '100%',
-                      flexGrow: 1,
-                      display: 'flex',
-                      flexDirection: 'column',
-                    }}
-                  >
-                    <Typography variant="body2" fontWeight="bold" sx={{ mb: 0.5 }}>
-                      {title}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                      {description}
-                    </Typography>
-                    <Typography
-                      variant="body2"
-                      fontWeight="bold"
-                      color="primary"
-                      sx={{ mt: 'auto' }}
-                    >
-                      Learn more{' '}
-                      <KeyboardArrowRightRounded
-                        fontSize="small"
-                        sx={{ verticalAlign: 'middle' }}
-                      />
-                    </Typography>
-                  </Paper>
-                ))}
-              </Stack>
-            </Grid>
-          </Grid>
-        </Section>
+        <PerksBenefits />
         <Divider />
         {/* Open roles */}
         <Section cozy>
@@ -475,7 +171,7 @@ export default function Careers() {
                       {category.title}
                     </Typography>
                     {category.roles.map((role) => (
-                      <Role
+                      <RoleEntry
                         key={role.title}
                         title={role.title}
                         description={role.description}
@@ -520,7 +216,7 @@ export default function Careers() {
                           {category.title}
                         </Typography>
                         {category.roles.map((role) => (
-                          <Role
+                          <RoleEntry
                             key={role.title}
                             title={role.title}
                             description={role.description}
@@ -535,50 +231,7 @@ export default function Careers() {
           </Box>
         )}
         <Divider />
-        {/* Frequently asked questions */}
-        <Section bg="transparent" cozy>
-          <Typography variant="h2" sx={{ mb: { xs: 2, sm: 4 } }}>
-            Frequently asked questions
-          </Typography>
-          <Grid container spacing={2}>
-            <Grid xs={12} md={6}>
-              {renderFAQItem(0, true)}
-              {renderFAQItem(1)}
-            </Grid>
-            <Grid xs={12} md={6}>
-              {renderFAQItem(2)}
-              <Paper
-                variant="outlined"
-                sx={(theme) => ({
-                  p: 2,
-                  borderStyle: 'dashed',
-                  borderColor: 'divider',
-                  bgcolor: 'white',
-                  ...theme.applyDarkStyles({
-                    bgcolor: 'primaryDark.800',
-                  }),
-                })}
-              >
-                <Box sx={{ textAlign: 'left' }}>
-                  <Typography variant="body2" color="text.primary" fontWeight="bold">
-                    Got any questions unanswered or need more help?
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ my: 1, textAlign: 'left' }}
-                >
-                  We&apos;re here to help you with any other question you have about our hiring
-                  process.
-                </Typography>
-                <Link href="mailto:job@mui.com" variant="body2">
-                  Contact us <KeyboardArrowRightRounded fontSize="small" />
-                </Link>
-              </Paper>
-            </Grid>
-          </Grid>
-        </Section>
+        <CareersFaq />
       </main>
       <Divider />
       <AppFooter />

--- a/docs/pages/careers.tsx
+++ b/docs/pages/careers.tsx
@@ -28,12 +28,6 @@ const openRolesData = [
           'You will strengthen the MUI X product, build ambitious and complex new features, work on strategic problems, and help grow adoption.',
         url: '/careers/react-engineer-x/',
       },
-      {
-        title: 'React Engineer — Docs Infra',
-        description:
-          'You will drive the development of the documentation platform that powers all of MUI’s products, enabling it to grow and establish itself as a mature product.',
-        url: '/careers/react-engineer-docs-infra/',
-      },
     ],
   },
   {

--- a/docs/src/components/careers/CareersFaq.tsx
+++ b/docs/src/components/careers/CareersFaq.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { styled, alpha } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+import KeyboardArrowDownRounded from '@mui/icons-material/KeyboardArrowDownRounded';
+import MuiAccordion from '@mui/material/Accordion';
+import MuiAccordionSummary from '@mui/material/AccordionSummary';
+import MuiAccordionDetail from '@mui/material/AccordionDetails';
+import { Link } from '@mui/docs/Link';
+import Section from 'docs/src/layouts/Section';
+
+const Accordion = styled(MuiAccordion)(({ theme }) => ({
+  padding: theme.spacing(2),
+  transition: theme.transitions.create('box-shadow'),
+  borderRadius: theme.shape.borderRadius,
+  '&:hover': {
+    borderColor: theme.palette.primary[300],
+    boxShadow: `0px 4px 8px ${alpha(theme.palette.grey[200], 0.6)}`,
+  },
+  '&:not(:last-of-type)': {
+    marginBottom: theme.spacing(2),
+  },
+  '&::before': {
+    display: 'none',
+  },
+  '&::after': {
+    display: 'none',
+  },
+  ...theme.applyDarkStyles({
+    '&:hover': {
+      borderColor: alpha(theme.palette.primary[600], 0.6),
+      boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.8)',
+    },
+  }),
+}));
+
+const AccordionSummary = styled(MuiAccordionSummary)(({ theme }) => ({
+  padding: theme.spacing(2),
+  margin: theme.spacing(-2),
+  minHeight: 'auto',
+  '&.Mui-expanded': {
+    minHeight: 'auto',
+  },
+  '& .MuiAccordionSummary-content': {
+    margin: 0,
+    paddingRight: theme.spacing(2),
+    '&.Mui-expanded': {
+      margin: 0,
+    },
+  },
+}));
+
+const AccordionDetails = styled(MuiAccordionDetail)(({ theme }) => ({
+  marginTop: theme.spacing(1),
+  padding: 0,
+}));
+
+const faqData = [
+  {
+    summary: 'Are there application deadlines?',
+    detail: 'No. You can still apply if a position is visible on our careers page.',
+  },
+  {
+    summary: 'Does MUI do whiteboarding during interviews?',
+    detail:
+      'No. We ask applicants to complete challenges that are close to their future day-to-day contributions.',
+  },
+  {
+    summary: 'Does MUI offer contract job opportunities?',
+    detail:
+      'Yes. People outside of France can be hired as full-time contractors. (Benefits may vary.)',
+  },
+];
+
+function renderFAQItem(index: number, defaultExpanded?: boolean) {
+  const faq = faqData[index];
+  return (
+    <Accordion variant="outlined" defaultExpanded={defaultExpanded}>
+      <AccordionSummary
+        expandIcon={<KeyboardArrowDownRounded sx={{ fontSize: 20, color: 'primary.main' }} />}
+      >
+        <Typography variant="body2" fontWeight="bold" component="h3">
+          {faq.summary}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Typography
+          component="div"
+          variant="body2"
+          color="text.secondary"
+          sx={{ '& ul': { pl: 2 } }}
+        >
+          {faq.detail}
+        </Typography>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+export default function CareersFaq() {
+  return (
+    <Section bg="transparent" cozy>
+      <Typography variant="h2" sx={{ mb: { xs: 2, sm: 4 } }}>
+        Frequently asked questions
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid xs={12} md={6}>
+          {renderFAQItem(0, true)}
+          {renderFAQItem(1)}
+        </Grid>
+        <Grid xs={12} md={6}>
+          {renderFAQItem(2)}
+          <Paper
+            variant="outlined"
+            sx={(theme) => ({
+              p: 2,
+              borderStyle: 'dashed',
+              borderColor: 'divider',
+              bgcolor: 'white',
+              ...theme.applyDarkStyles({
+                bgcolor: 'primaryDark.800',
+              }),
+            })}
+          >
+            <Box sx={{ textAlign: 'left' }}>
+              <Typography variant="body2" color="text.primary" fontWeight="bold">
+                Got any questions unanswered or need more help?
+              </Typography>
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ my: 1, textAlign: 'left' }}>
+              We&apos;re here to help you with any other question you have about our hiring process.
+            </Typography>
+            <Link href="mailto:job@mui.com" variant="body2">
+              Contact us <KeyboardArrowRightRounded fontSize="small" />
+            </Link>
+          </Paper>
+        </Grid>
+      </Grid>
+    </Section>
+  );
+}

--- a/docs/src/components/careers/PerksBenefits.tsx
+++ b/docs/src/components/careers/PerksBenefits.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Unstable_Grid2';
+import Stack from '@mui/material/Stack';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+import { Link } from '@mui/docs/Link';
+import IconImage from 'docs/src/components/icon/IconImage';
+import Section from 'docs/src/layouts/Section';
+import SectionHeadline from 'docs/src/components/typography/SectionHeadline';
+import ROUTES from 'docs/src/route';
+
+const companyInfo = [
+  {
+    title: 'About us',
+    description: 'Meet the team and a little bit of our history.',
+    routeUrl: ROUTES.about,
+  },
+  {
+    title: 'Handbook',
+    description: 'Learn everything about how MUI as a company is run.',
+    routeUrl: ROUTES.handbook,
+  },
+  {
+    title: 'Blog',
+    description: 'Check behind-the-scenes and news about the company.',
+    routeUrl: ROUTES.blog,
+  },
+];
+
+function RemoteAwardCard() {
+  return (
+    <Paper
+      component={Link}
+      href="/blog/remote-award-win-2024/"
+      noLinkStyle
+      variant="outlined"
+      sx={{ p: 2 }}
+    >
+      <Box
+        sx={{
+          mb: 2,
+          maxWidth: { xs: 315, sm: 325 },
+          maxHeight: 315,
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: '6px',
+          overflow: 'clip',
+        }}
+      >
+        <Box
+          component="img"
+          src="/static/branding/careers/remote-award-light.png"
+          alt="MUI is the winner of the Remote Excellence Awards in the Small and Mighty for SMEs category."
+          height="1200px"
+          width="1200px"
+          sx={(theme) => ({
+            width: '100%',
+            height: '100%',
+            ...theme.applyDarkStyles({
+              content: `url(/static/branding/careers/remote-award-dark.png)`,
+            }),
+          })}
+        />
+      </Box>
+      <div>
+        <Typography component="h2" variant="body2" fontWeight="semiBold">
+          Remote Excellence Awards
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Winners in the first-ever Remote Excellence Awards, in the Small & Mighty category! 🎉
+        </Typography>
+        <Typography variant="body2" fontWeight="bold" color="primary">
+          Learn more <KeyboardArrowRightRounded fontSize="small" sx={{ verticalAlign: 'middle' }} />
+        </Typography>
+      </div>
+    </Paper>
+  );
+}
+
+export default function PerksBenefits() {
+  return (
+    <Section bg="gradient" cozy>
+      <Grid container spacing={5} alignItems="center">
+        <Grid md={6}>
+          <SectionHeadline
+            overline="Working at MUI"
+            title={
+              <Typography variant="h2" id="perks-and-benefits">
+                Perks & benefits
+              </Typography>
+            }
+            description="To help you go above and beyond with us, we provide:"
+          />
+          <Box sx={{ maxWidth: 500 }}>
+            {[
+              ['100% remote work', 'Our entire company is globally distributed.'],
+              [
+                'Retreats',
+                'We meet up every 8 months for a week of working & having fun together!',
+              ],
+              [
+                'Equipment',
+                'We provide the hardware of your choice (initial grant of $2,500 USD).',
+              ],
+              ['Time off', 'We provide 33 days of paid time off globally.'],
+            ].map((textArray) => (
+              <Box
+                key={textArray[0]}
+                sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1, py: 0.5 }}
+              >
+                <IconImage name="pricing/yes" />
+                <div>
+                  <Typography variant="body2" color="text.primary" fontWeight="semiBold">
+                    {textArray[0]}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {textArray[1]}
+                  </Typography>
+                </div>
+              </Box>
+            ))}
+          </Box>
+        </Grid>
+        <Grid
+          xs={12}
+          md={6}
+          sx={{
+            p: { xs: 2, sm: 0 },
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            gap: 2,
+          }}
+        >
+          <RemoteAwardCard />
+          <Stack spacing={2} useFlexGap>
+            {companyInfo.map(({ title, description, routeUrl }) => (
+              <Paper
+                key={title}
+                component={Link}
+                href={routeUrl}
+                noLinkStyle
+                variant="outlined"
+                sx={{
+                  p: 2,
+                  width: '100%',
+                  flexGrow: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Typography variant="body2" fontWeight="bold" sx={{ mb: 0.5 }}>
+                  {title}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  {description}
+                </Typography>
+                <Typography variant="body2" fontWeight="bold" color="primary" sx={{ mt: 'auto' }}>
+                  Learn more{' '}
+                  <KeyboardArrowRightRounded fontSize="small" sx={{ verticalAlign: 'middle' }} />
+                </Typography>
+              </Paper>
+            ))}
+          </Stack>
+        </Grid>
+      </Grid>
+    </Section>
+  );
+}

--- a/docs/src/components/careers/RoleEntry.tsx
+++ b/docs/src/components/careers/RoleEntry.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import KeyboardArrowRightRounded from '@mui/icons-material/KeyboardArrowRightRounded';
+
+interface RoleProps {
+  description: string;
+  title: string;
+  url?: string;
+}
+
+export default function RoleEntry(props: RoleProps) {
+  if (props.url) {
+    return (
+      <Box
+        sx={{
+          py: 1,
+          display: 'flex',
+          flexDirection: { xs: 'column', lg: 'row' },
+          justifyContent: 'space-between',
+          alignItems: 'start',
+          gap: 2,
+        }}
+      >
+        <div>
+          <Typography variant="body1" color="text.primary" fontWeight="medium" gutterBottom>
+            {props.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 550 }}>
+            {props.description}
+          </Typography>
+        </div>
+        <Button
+          component="a"
+          variant="outlined"
+          color="secondary"
+          size="small"
+          href={props.url}
+          endIcon={<KeyboardArrowRightRounded />}
+        >
+          More about this role
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <div>
+      <Typography variant="body1" color="text.primary" fontWeight="medium" gutterBottom>
+        {props.title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 650 }}>
+        {props.description}
+      </Typography>
+    </div>
+  );
+}

--- a/docs/src/modules/components/TopLayoutCareers.js
+++ b/docs/src/modules/components/TopLayoutCareers.js
@@ -10,6 +10,7 @@ import AppHeader from 'docs/src/layouts/AppHeader';
 import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { Link } from '@mui/docs/Link';
+import { useTranslate } from 'docs/src/modules/utils/i18n';
 
 const StyledDiv = styled('div')(({ theme }) => ({
   flex: '1 0 100%',
@@ -34,6 +35,7 @@ const StyledAppContainer = styled(AppContainer)(({ theme }) => ({
 export default function TopLayoutCareers(props) {
   const { docs } = props;
   const { description, rendered, title } = docs.en;
+  const t = useTranslate();
 
   return (
     <BrandingCssVarsProvider>
@@ -51,11 +53,10 @@ export default function TopLayoutCareers(props) {
             href="/careers/#open-roles"
             rel="nofollow"
             variant="body2"
-            sx={{ display: 'flex', gap: 0.5, alignItems: 'center', mb: 2 }}
+            sx={{ display: 'flex', gap: 0.5, alignItems: 'center', mb: 4 }}
           >
             <KeyboardArrowLeftIcon fontSize="small" />
-            {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-            {'Back to open roles'}
+            {t('backToOpenRoles')}
           </Link>
           {rendered.map((chunk, index) => {
             return <MarkdownElement key={index} renderedMarkdown={chunk} />;

--- a/docs/src/modules/components/TopLayoutCareers.js
+++ b/docs/src/modules/components/TopLayoutCareers.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { styled } from '@mui/material/styles';
+import { styled, alpha } from '@mui/material/styles';
 import Divider from '@mui/material/Divider';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import Head from 'docs/src/modules/components/Head';
 import AppContainer from 'docs/src/modules/components/AppContainer';
 import AppFooter from 'docs/src/layouts/AppFooter';
@@ -10,9 +11,17 @@ import BrandingCssVarsProvider from 'docs/src/BrandingCssVarsProvider';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { Link } from '@mui/docs/Link';
 
-const StyledDiv = styled('div')({
+const StyledDiv = styled('div')(({ theme }) => ({
   flex: '1 0 100%',
-});
+  background: `linear-gradient(180deg, ${(theme.vars || theme).palette.grey[50]} 0%, #FFFFFF 100%)`,
+  backgroundSize: '100% 500px',
+  backgroundRepeat: 'no-repeat',
+  ...theme.applyDarkStyles({
+    background: `linear-gradient(180deg, ${alpha(theme.palette.primary[900], 0.15)} 0%, ${(theme.vars || theme).palette.primaryDark[900]} 100%)`,
+    backgroundSize: '100% 500px',
+    backgroundRepeat: 'no-repeat',
+  }),
+}));
 
 const StyledAppContainer = styled(AppContainer)(({ theme }) => ({
   '& .markdownElement': {
@@ -42,10 +51,11 @@ export default function TopLayoutCareers(props) {
             href="/careers/#open-roles"
             rel="nofollow"
             variant="body2"
-            sx={{ display: 'block', mb: 2 }}
+            sx={{ display: 'flex', gap: 0.5, alignItems: 'center', mb: 2 }}
           >
+            <KeyboardArrowLeftIcon fontSize="small" />
             {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-            {'< Back to open roles'}
+            {'Back to open roles'}
           </Link>
           {rendered.map((chunk, index) => {
             return <MarkdownElement key={index} renderedMarkdown={chunk} />;

--- a/packages/mui-docs/src/translations/translations.json
+++ b/packages/mui-docs/src/translations/translations.json
@@ -75,6 +75,7 @@
     "toggleSettings": "Toggle settings drawer"
   },
   "backToTop": "Scroll back to top",
+  "backToOpenRoles": "Back to open roles",
   "blogDescr": "A polished blog page layout. Markdown support is courtesy of markdown-to-jsx.",
   "blogTitle": "Blog",
   "bundleSize": "Bundle size",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

All of the Careers page sections were defined in the `careers.tsx` component/file. Given that we're somewhat frequently touching this page to add and remove roles, I figured we could simplify it by extracting a few sections to their own dedicated file. Aside from that, I also added small design improvements (e.g., we _can't_ use Unicode for icons as a UI-focused company 😅 we need to be polished).

https://deploy-preview-42102--material-ui.netlify.app/careers