### PR TITLE
[docs-infra] Limit the copy button to the visible code block

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -350,9 +350,6 @@ const DemoCodeViewer = styled(HighlightedCode)(() => ({
     borderBottomLeftRadius: 12,
     borderBottomRightRadius: 12,
   },
-  '& .MuiCode-copy': {
-    display: 'none',
-  },
 }));
 
 const AnchorLink = styled('div')({

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import copy from 'clipboard-copy';
 import { useRouter } from 'next/router';
 import { debounce } from '@mui/material/utils';
 import { alpha, styled } from '@mui/material/styles';
@@ -12,6 +13,8 @@ import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import NoSsr from '@mui/material/NoSsr';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
+import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
+import LibraryAddCheckRoundedIcon from '@mui/icons-material/LibraryAddCheckRounded';
 import DemoSandbox from 'docs/src/modules/components/DemoSandbox';
 import ReactRunner from 'docs/src/modules/components/ReactRunner';
 import DemoEditor from 'docs/src/modules/components/DemoEditor';
@@ -554,6 +557,21 @@ export default function Demo(props) {
     demoData.relativeModules,
   ]);
 
+  const [copiedContent, setCopiedContent] = React.useState(false);
+
+  const handleCopyClick = async () => {
+    try {
+      const activeTabData = tabs[activeTab];
+      await copy(activeTabData.raw);
+      setCopiedContent(true);
+      setTimeout(() => {
+        setCopiedContent(false);
+      }, 1000);
+    } catch (error) {
+      console.error('Code content not copied', error);
+    }
+  };
+
   return (
     <Root>
       <AnchorLink id={demoName} />
@@ -593,6 +611,10 @@ export default function Demo(props) {
                 <DemoToolbar
                   codeOpen={codeOpen}
                   codeVariant={codeVariant}
+                  copyIcon={
+                    copiedContent ? <LibraryAddCheckRoundedIcon /> : <ContentCopyRoundedIcon />
+                  }
+                  copyButtonOnClick={handleCopyClick}
                   hasNonSystemDemos={hasNonSystemDemos}
                   demo={demo}
                   demoData={demoData}
@@ -642,6 +664,11 @@ export default function Demo(props) {
                         'data-ga-event-category': codeOpen ? 'demo-expand' : 'demo',
                         'data-ga-event-label': demo.gaLabel,
                         'data-ga-event-action': 'copy-click',
+                      }}
+                      sx={{
+                        '& .MuiCode-copy': {
+                          display: 'none',
+                        },
                       }}
                     />
                   ) : (

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -38,9 +38,6 @@ const StyledMarkdownElement = styled(MarkdownElement)(({ theme }) => [
       maxWidth: 'initial',
       maxHeight: 'initial',
     },
-    '& .MuiCode-copy': {
-      display: 'none',
-    },
   },
 ]) as any;
 

--- a/docs/src/modules/components/DemoEditor.tsx
+++ b/docs/src/modules/components/DemoEditor.tsx
@@ -38,6 +38,9 @@ const StyledMarkdownElement = styled(MarkdownElement)(({ theme }) => [
       maxWidth: 'initial',
       maxHeight: 'initial',
     },
+    '& .MuiCode-copy': {
+      display: 'none',
+    },
   },
 ]) as any;
 

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -261,31 +261,6 @@ function useToolbar(controlRefs, options = {}) {
   };
 }
 
-function copyWithRelativeModules(raw, relativeModules) {
-  if (relativeModules) {
-    relativeModules.forEach(({ module, raw: content }) => {
-      // remove exports from relative module
-      content = content.replace(/export( )*(default)*( )*\w+;|export default|export/gm, '');
-      // replace import statement with relative module content
-      // the module might be imported with or without extension, so we need to cover all cases
-      // E.g.: /import .* from '(.\/top100Films.js|.\/top100Films)';/
-      const extensions = ['', '.js', '.jsx', '.ts', '.tsx', '.css', '.json'];
-      const patterns = extensions
-        .map((ext) => {
-          if (module.endsWith(ext)) {
-            return module.replace(ext, '');
-          }
-          return '';
-        })
-        .filter(Boolean)
-        .join('|');
-      const importPattern = new RegExp(`import .* from '(${patterns})';`);
-      raw = raw.replace(importPattern, content);
-    });
-  }
-  return copy(raw);
-}
-
 export default function DemoToolbar(props) {
   const {
     codeOpen,

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -19,7 +19,6 @@ import Tooltip from '@mui/material/Tooltip';
 import Divider from '@mui/material/Divider';
 import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded';
 import ResetFocusIcon from '@mui/icons-material/CenterFocusWeak';
-import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
 import { useRouter } from 'next/router';
 import { CODE_VARIANTS, CODE_STYLING } from 'docs/src/modules/constants';
 import { useSetCodeVariant } from 'docs/src/modules/utils/codeVariant';
@@ -339,16 +338,6 @@ export default function DemoToolbar(props) {
     setSnackbarOpen(false);
   };
 
-  const handleCopyClick = async () => {
-    try {
-      await copyWithRelativeModules(demoData.raw, demoData.relativeModules);
-      setSnackbarMessage(t('copiedSource'));
-      setSnackbarOpen(true);
-    } finally {
-      handleMoreClose();
-    }
-  };
-
   const createHandleCodeSourceLink = (anchor, codeVariantParam, stylingSolution) => async () => {
     try {
       await copy(
@@ -586,25 +575,13 @@ export default function DemoToolbar(props) {
               </DemoTooltip>
             </React.Fragment>
           )}
-          <DemoTooltip title={t('copySource')} placement="bottom">
-            <IconButton
-              data-ga-event-category="demo"
-              data-ga-event-label={demo.gaLabel}
-              data-ga-event-action="copy"
-              onClick={handleCopyClick}
-              {...getControlProps(6)}
-              sx={{ borderRadius: 1 }}
-            >
-              <ContentCopyRoundedIcon />
-            </IconButton>
-          </DemoTooltip>
           <DemoTooltip title={t('resetFocus')} placement="bottom">
             <IconButton
               data-ga-event-category="demo"
               data-ga-event-label={demo.gaLabel}
               data-ga-event-action="reset-focus"
               onClick={handleResetFocusClick}
-              {...getControlProps(7)}
+              {...getControlProps(6)}
               sx={{ borderRadius: 1 }}
             >
               <ResetFocusIcon />
@@ -617,7 +594,7 @@ export default function DemoToolbar(props) {
               data-ga-event-label={demo.gaLabel}
               data-ga-event-action="reset"
               onClick={onResetDemoClick}
-              {...getControlProps(8)}
+              {...getControlProps(7)}
               sx={{ borderRadius: 1 }}
             >
               <RefreshRoundedIcon />
@@ -628,7 +605,7 @@ export default function DemoToolbar(props) {
             aria-label={t('seeMore')}
             aria-owns={anchorEl ? 'demo-menu-more' : undefined}
             aria-haspopup="true"
-            {...getControlProps(9)}
+            {...getControlProps(8)}
             sx={{ borderRadius: 1 }}
           >
             <MoreVertIcon />

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -265,6 +265,8 @@ export default function DemoToolbar(props) {
   const {
     codeOpen,
     codeVariant,
+    copyIcon,
+    copyButtonOnClick,
     hasNonSystemDemos,
     demo,
     demoData,
@@ -550,6 +552,18 @@ export default function DemoToolbar(props) {
               </DemoTooltip>
             </React.Fragment>
           )}
+          <DemoTooltip title={t('copySource')} placement="bottom">
+            <IconButton
+              data-ga-event-category="demo"
+              data-ga-event-label={demo.gaLabel}
+              data-ga-event-action="copy"
+              onClick={copyButtonOnClick}
+              {...getControlProps(6)}
+              sx={{ borderRadius: 1 }}
+            >
+              {copyIcon}
+            </IconButton>
+          </DemoTooltip>
           <DemoTooltip title={t('resetFocus')} placement="bottom">
             <IconButton
               data-ga-event-category="demo"
@@ -693,6 +707,8 @@ export default function DemoToolbar(props) {
 DemoToolbar.propTypes = {
   codeOpen: PropTypes.bool.isRequired,
   codeVariant: PropTypes.string.isRequired,
+  copyIcon: PropTypes.object.isRequired,
+  copyButtonOnClick: PropTypes.object.isRequired,
   demo: PropTypes.object.isRequired,
   demoData: PropTypes.object.isRequired,
   demoId: PropTypes.string,

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -265,8 +265,8 @@ export default function DemoToolbar(props) {
   const {
     codeOpen,
     codeVariant,
-    copyIcon,
     copyButtonOnClick,
+    copyIcon,
     hasNonSystemDemos,
     demo,
     demoData,
@@ -707,8 +707,8 @@ export default function DemoToolbar(props) {
 DemoToolbar.propTypes = {
   codeOpen: PropTypes.bool.isRequired,
   codeVariant: PropTypes.string.isRequired,
-  copyIcon: PropTypes.object.isRequired,
   copyButtonOnClick: PropTypes.object.isRequired,
+  copyIcon: PropTypes.object.isRequired,
   demo: PropTypes.object.isRequired,
   demoData: PropTypes.object.isRequired,
   demoId: PropTypes.string,

--- a/docs/src/modules/components/DemoToolbar.js
+++ b/docs/src/modules/components/DemoToolbar.js
@@ -570,7 +570,7 @@ export default function DemoToolbar(props) {
               data-ga-event-label={demo.gaLabel}
               data-ga-event-action="reset-focus"
               onClick={handleResetFocusClick}
-              {...getControlProps(6)}
+              {...getControlProps(7)}
               sx={{ borderRadius: 1 }}
             >
               <ResetFocusIcon />
@@ -583,7 +583,7 @@ export default function DemoToolbar(props) {
               data-ga-event-label={demo.gaLabel}
               data-ga-event-action="reset"
               onClick={onResetDemoClick}
-              {...getControlProps(7)}
+              {...getControlProps(8)}
               sx={{ borderRadius: 1 }}
             >
               <RefreshRoundedIcon />
@@ -594,7 +594,7 @@ export default function DemoToolbar(props) {
             aria-label={t('seeMore')}
             aria-owns={anchorEl ? 'demo-menu-more' : undefined}
             aria-haspopup="true"
-            {...getControlProps(8)}
+            {...getControlProps(9)}
             sx={{ borderRadius: 1 }}
           >
             <MoreVertIcon />

--- a/packages/markdown/parseMarkdown.js
+++ b/packages/markdown/parseMarkdown.js
@@ -423,10 +423,8 @@ function createRender(context) {
         escaped ? code : escape(code, true)
       }</code></pre>${[
         '<button data-ga-event-category="code" data-ga-event-action="copy-click" aria-label="Copy the code" class="MuiCode-copy">',
-        '<svg focusable="false" aria-hidden="true" viewBox="0 0 24 24" data-testid="ContentCopyRoundedIcon">',
-        '<use class="MuiCode-copy-icon" xlink:href="#copy-icon" />',
-        '<use class="MuiCode-copied-icon" xlink:href="#copied-icon" />',
-        '</svg>',
+        '<span class="MuiCode-copy-label">Copy</span>',
+        '<span class="MuiCode-copied-label">Copied</span>',
         '<span class="MuiCode-copyKeypress"><span>(or</span> $keyC<span>)</span></span></button></div>',
       ].join('')}\n`;
     };

--- a/packages/mui-docs/src/CodeCopy/CodeCopyButton.tsx
+++ b/packages/mui-docs/src/CodeCopy/CodeCopyButton.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import ContentCopyRoundedIcon from '@mui/icons-material/ContentCopyRounded';
-import LibraryAddCheckRoundedIcon from '@mui/icons-material/LibraryAddCheckRounded';
 import useClipboardCopy from './useClipboardCopy';
 
 export interface CodeCopyButtonProps {
@@ -27,12 +25,8 @@ export function CodeCopyButton(props: CodeCopyButtonProps) {
         }}
       >
         {/* material-ui/no-hardcoded-labels */}
-        {isCopied ? (
-          <LibraryAddCheckRoundedIcon sx={{ fontSize: 18 }} />
-        ) : (
-          <ContentCopyRoundedIcon sx={{ fontSize: 18 }} />
-        )}
-        <span className="MuiCode-copyKeypress">
+        {isCopied ? 'Copied' : 'Copy'}
+        <span className="MuiCode-copyKeypress" style={{ opacity: isCopied ? 0 : 1 }}>
           <span>(or</span> {key}C<span>)</span>
         </span>
       </button>

--- a/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
+++ b/packages/mui-docs/src/MarkdownElement/MarkdownElement.tsx
@@ -532,44 +532,34 @@ const Root = styled('div')(
       top: 0,
     },
     '& .MuiCode-copy': {
-      display: 'inline-flex',
-      flexDirection: 'row-reverse',
-      alignItems: 'center',
-      width: 26,
-      height: 26,
       cursor: 'pointer',
       position: 'absolute',
       top: 12,
       right: 12,
+      display: 'inline-flex',
+      flexDirection: 'row-reverse',
+      alignItems: 'center',
+      height: 24,
       padding: theme.spacing(0.5),
-      fontFamily: 'inherit',
-      fontWeight: 500,
+      paddingBottom: '5px', // optical alignment
+      fontFamily: lightTheme.typography.fontFamily,
+      fontWeight: lightTheme.typography.fontWeightMedium,
+      fontSize: lightTheme.typography.pxToRem(12),
       borderRadius: 6,
-      border: 'none',
-      backgroundColor: 'hsl(210, 35%, 9%)', // using the code block one-off background color (defined in line 23)
-      color: '#FFF',
+      border: '1px solid',
+      borderColor: alpha(lightTheme.palette.primaryDark[600], 0.5),
+      backgroundColor: alpha(lightTheme.palette.primaryDark[800], 0.5),
+      color: `var(--muidocs-palette-grey-200, ${lightTheme.palette.grey[200]})`,
       transition: theme.transitions.create(['background', 'borderColor', 'display'], {
         duration: theme.transitions.duration.shortest,
       }),
-      '& svg': {
-        userSelect: 'none',
-        width: theme.typography.pxToRem(16),
-        height: theme.typography.pxToRem(16),
-        display: 'inline-block',
-        fill: 'currentcolor',
-        flexShrink: 0,
-        fontSize: '18px',
-        margin: 'auto',
-        opacity: 0.5,
-      },
-      '& .MuiCode-copied-icon': {
+      '& .MuiCode-copied-label': {
         display: 'none',
       },
       '&:hover, &:focus': {
-        backgroundColor: lightTheme.palette.primaryDark[600],
-        '& svg': {
-          opacity: 1,
-        },
+        borderColor: `var(--muidocs-palette-primaryDark-400, ${lightTheme.palette.primaryDark[400]})`,
+        backgroundColor: `var(--muidocs-palette-primaryDark-700, ${lightTheme.palette.primaryDark[700]})`,
+        color: '#FFF',
         '& .MuiCode-copyKeypress': {
           display: 'block',
           // Approximate no hover capabilities with no keyboard
@@ -582,17 +572,19 @@ const Root = styled('div')(
       '& .MuiCode-copyKeypress': {
         display: 'none',
         position: 'absolute',
-        right: 26,
+        right: 34,
       },
       '&[data-copied]': {
-        // style of the button when it is in copied state.
-        borderColor: lightTheme.palette.primary[700],
+        borderColor: `var(--muidocs-palette-primaryDark-400, ${lightTheme.palette.primaryDark[400]})`,
+        backgroundColor: `var(--muidocs-palette-primaryDark-700, ${lightTheme.palette.primaryDark[700]})`,
         color: '#fff',
-        backgroundColor: lightTheme.palette.primaryDark[600],
-        '& .MuiCode-copy-icon': {
+        '& .MuiCode-copyKeypress': {
+          opacity: 0,
+        },
+        '& .MuiCode-copy-label': {
           display: 'none',
         },
-        '& .MuiCode-copied-icon': {
+        '& .MuiCode-copied-label': {
           display: 'block',
         },
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<details>
  <summary>Old description</summary>
This PR is a follow-up to https://github.com/mui/material-ui/pull/41827. What motivated this one is a reflection around multi-tab demos where I initially thought that the demo toolbar's copy button copying the content from both tabs was a valuable thing to support. However, in discussing it with @colmtuite & @zanivan, I realized this is actually a non-intuitive UX. Here's why that is:

1. The PR I linked above introduced somewhat of an inconsistency: if there's a demo toolbar, the copy button will appear on it. If there's not, the copy button is inside the code block. A better approach for managing the user's expectations is for this button to always be in the same place.
2. It seems way more intuitive to have the copy button closer to the content it will copy (i.e., the code block). 
3. In the case of multi-tab demos, there's no affordance for users that lets them know the copy button on the toolbar will copy content from both tabs; this can get them surprised and create frustration, because we expect that, more often than not, you want to copy _only_  what you're seeing, and not what it's hidden in a separate tab.

On a more logistical note, I know we already have the code block copy button wired in GA, but I'm not sure if we want to do anything differently here if we're removing the button and its respective `eventAction` from the code. I considered swapping the `eventAction` from the remaining button to the toolbar's one, but I'm not sure — y'all let me know.
</details>

**Edit:** This PR has gone through quite the discussion, so this is the updated summary of what it is doing:

- Changes the plain code block copy button from icon-based to word-based
- When in multi-tab demo containers, the demo toolbar copy button just copies the active tab content, as opposed to concatenating and copying content from the two tabs

Preview:

- https://deploy-preview-42115--material-ui.netlify.app/experiments/docs/demos/
- https://deploy-preview-42115--material-ui.netlify.app/material-ui/react-autocomplete/#combo-box