### PR TITLE
[docs] Fix use of deprecated React API

### DIFF
--- a/docs/data/material/guides/server-rendering/server-rendering.md
+++ b/docs/data/material/guides/server-rendering/server-rendering.md
@@ -2,7 +2,7 @@
 
 <p class="description">The most common use case for server-side rendering is to handle the initial render when a user (or search engine crawler) first requests your app.</p>
 
-When the server receives the request, it renders the required component(s) into an HTML string, and then sends it as a response to the client.
+When the server receives the request, it renders the required component(s) into an HTML string and then sends it as a response to the client.
 From that point on, the client takes over rendering duties.
 
 ## Material UI on the server
@@ -208,7 +208,7 @@ function Main() {
   );
 }
 
-ReactDOM.hydrate(<Main />, document.querySelector('#root'));
+ReactDOM.hydrateRoot(document.querySelector('#root'), <Main />);
 ```
 
 ## Reference implementations


### PR DESCRIPTION
It got fixed in #38117 in the reference implementation but not in the docs.