### PR TITLE
[website] Fix home page slider's track position

### DIFF
--- a/docs/src/components/showcase/ThemeSlider.tsx
+++ b/docs/src/components/showcase/ThemeSlider.tsx
@@ -70,7 +70,6 @@ export default function ThemeSlider() {
                 fontWeight: 'semiBold',
               },
               [`& .${sliderClasses.thumb}`]: {
-                mx: -1,
                 width: 16,
                 height: 16,
                 '&::before': {


### PR DESCRIPTION
It looks like https://github.com/mui/material-ui/pull/41547 introduced a small visual glitch on the home page slider because the slider track ends are not centered within the slider thumbs.

|before|after|
|---|---|
|<img width="362" alt="Screenshot 2024-05-06 at 10 03 19" src="https://github.com/mui/material-ui/assets/7225802/765f02fc-48f6-4fe0-8e50-28be4f2dda57">|<img width="360" alt="Screenshot 2024-05-06 at 10 16 34" src="https://github.com/mui/material-ui/assets/7225802/6fdfffa9-a29b-4a54-8978-398e5845c5a9">|
|<img width="364" alt="Screenshot 2024-05-06 at 10 03 37" src="https://github.com/mui/material-ui/assets/7225802/9e26608c-41d5-4822-9424-dc0f49a7b794">|<img width="360" alt="Screenshot 2024-05-06 at 10 16 24" src="https://github.com/mui/material-ui/assets/7225802/14c2503e-c7bb-4418-a96e-508787edaf78">|