### PR TITLE
[docs][material-ui] Fix broken link

### DIFF
--- a/docs/data/material/design-resources/material-ui-for-figma/material-ui-for-figma.md
+++ b/docs/data/material/design-resources/material-ui-for-figma/material-ui-for-figma.md
@@ -91,4 +91,4 @@ If you need to replace a single component that's been updated, there are a coupl
 
 1. Add the new version of the design kit as a library and use [the new Figma library swap feature](https://www.youtube.com/watch?v=GQ2jztKpxLk). The components must have the same names in both libraries.
 2. Observe the new component and re-apply the changes to the existing projects. This is the recommended approach when you need to update multiple projects.
-3. Copy and paste the new component into your existing project, give it a different temporary name, then re-link tokens to the new component. When using [Select Similar plugins](www.figma.com/community/plugin/792767780551514994/select-similar) this shouldn't take more than five minutes. Then you can remove the old component and update the new component name.
+3. Copy and paste the new component into your existing project, give it a different temporary name, then re-link tokens to the new component. When using [Select Similar plugins](https://www.figma.com/community/plugin/792767780551514994/select-similar) this shouldn't take more than five minutes. Then you can remove the old component and update the new component name.


### PR DESCRIPTION
Although the link works on the [docs page](https://github.com/mui/material-ui/pull/42142), the links linter started to [fail](https://app.circleci.com/pipelines/github/mui/material-ui/128534/workflows/d58472c0-2995-4dba-9cbd-d6c69340e492/jobs/693026) due to the link missing "https://"

