### PR TITLE
[docs-infra] Fix keyboard navigation on page tabs

### DIFF
--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -69,7 +69,7 @@ export default function ComponentPageTabs(props) {
 
   const position = positionMap[activeTab];
 
-  const tabData = [
+  const linkTabData = [
     {
       key: '',
       label: t('api-docs.demos'),
@@ -120,16 +120,16 @@ export default function ComponentPageTabs(props) {
           },
         }}
       >
-        {tabData.map((tab) => (
+        {linkTabData.map((linkTab) => (
           <LinkTab
-            key={tab.key}
-            href={tab.href}
-            aria-current={activeTab === tab.key ? 'page' : undefined}
+            key={linkTab.key}
+            href={linkTab.href}
+            aria-current={activeTab === linkTab.key ? 'page' : undefined}
             sx={{
-              color: activeTab === tab.key ? 'primary.main' : 'inherit',
+              color: activeTab === linkTab.key ? 'primary.main' : 'inherit',
             }}
           >
-            {tab.label}
+            {linkTab.label}
           </LinkTab>
         ))}
       </Box>

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -73,21 +73,24 @@ export default function ComponentPageTabs(props) {
       label: t('api-docs.demos'),
       href: demosHref,
     },
-    ...(headers.components?.length > 0 && [
-      {
-        key: 'components-api',
-        label: t('api-docs.componentsApi'),
-        href: componentsHref,
-      },
-    ]),
-    ...(headers.hooks &&
-      headers.hooks.length > 0 && [
-        {
-          key: 'hooks-api',
-          label: t('api-docs.hooksApi'),
-          href: hooksHref,
-        },
-      ]),
+    ...(headers.components?.length > 0
+      ? [
+          {
+            key: 'components-api',
+            label: t('api-docs.componentsApi'),
+            href: componentsHref,
+          },
+        ]
+      : []),
+    ...(headers.hooks && headers.hooks.length > 0
+      ? [
+          {
+            key: 'hooks-api',
+            label: t('api-docs.hooksApi'),
+            href: hooksHref,
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -110,8 +113,8 @@ export default function ComponentPageTabs(props) {
             content: "''",
             position: 'absolute',
             bottom: 0,
-            width: width,
             left: position,
+            width: width,
             height: '2px',
             backgroundColor: 'primary.light',
           },

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -126,6 +126,7 @@ export default function ComponentPageTabs(props) {
             key={linkTab.key}
             href={linkTab.href}
             aria-current={activeTab === linkTab.key ? 'page' : undefined}
+            className={linkTab.key.includes('api') ? 'skip-algolia-crawler' : ''} // Details: https://github.com/mui/material-ui/pull/37539
             sx={{
               color: activeTab === linkTab.key ? 'primary.main' : 'inherit',
             }}

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -59,13 +59,13 @@ export default function ComponentPageTabs(props) {
 
   const width = widthMap[activeTab];
 
-  const positionMap = {
+  const leftMap = {
     '': '1px',
     'components-api': '67px',
     'hooks-api': '198px',
   };
 
-  const position = positionMap[activeTab];
+  const left = leftMap[activeTab];
 
   const linkTabData = [
     {
@@ -113,8 +113,8 @@ export default function ComponentPageTabs(props) {
             content: "''",
             position: 'absolute',
             bottom: 0,
-            left: position,
-            width: width,
+            left,
+            width,
             height: '2px',
             backgroundColor: 'primary.light',
           },

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -96,6 +96,7 @@ export default function ComponentPageTabs(props) {
   return (
     <Box className="component-tabs" sx={{ display: 'inline' }}>
       <Box
+        component="nav"
         className="component-tabs"
         sx={{
           position: 'sticky',

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -6,7 +6,7 @@ import Box from '@mui/material/Box';
 import Tabs, { tabsClasses } from '@mui/material/Tabs';
 import Tab, { tabClasses } from '@mui/material/Tab';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
-import { Link } from '@mui/docs/Link';
+import NextLink from 'next/link';
 
 export const HEIGHT = 50;
 
@@ -80,11 +80,11 @@ export default function ComponentPageTabs(props) {
           },
         }}
       >
-        <StyledTab component={Link} href={demosHref} label={t('api-docs.demos')} value="" />
+        <StyledTab component={NextLink} href={demosHref} label={t('api-docs.demos')} value="" />
         {headers.components?.length > 0 && (
           <StyledTab
             className="skip-algolia-crawler" // For more details, see https://github.com/mui/material-ui/pull/37539.
-            component={Link}
+            component={NextLink}
             href={componentsHref}
             label={t('api-docs.componentsApi')}
             value="components-api"
@@ -93,7 +93,7 @@ export default function ComponentPageTabs(props) {
         {headers.hooks && headers.hooks.length > 0 && (
           <StyledTab
             className="skip-algolia-crawler" // For more details, see https://github.com/mui/material-ui/pull/37539.
-            component={Link}
+            component={NextLink}
             href={hooksHref}
             label={t('api-docs.hooksApi')}
             value="hooks-api"

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
-import Tabs, { tabsClasses } from '@mui/material/Tabs';
-import Tab, { tabClasses } from '@mui/material/Tab';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
 import { Link } from '@mui/docs/Link';
 
@@ -62,7 +60,7 @@ export default function ComponentPageTabs(props) {
   const width = widthMap[activeTab];
 
   const positionMap = {
-    '': '1px', // Default width when no value is specified
+    '': '1px',
     'components-api': '67px',
     'hooks-api': '198px',
   };
@@ -95,7 +93,6 @@ export default function ComponentPageTabs(props) {
   return (
     <Box className="component-tabs" sx={{ display: 'inline' }}>
       <Box
-        role="toolbar"
         className="component-tabs"
         sx={{
           position: 'sticky',

--- a/docs/src/modules/components/ComponentPageTabs.js
+++ b/docs/src/modules/components/ComponentPageTabs.js
@@ -6,17 +6,20 @@ import Box from '@mui/material/Box';
 import Tabs, { tabsClasses } from '@mui/material/Tabs';
 import Tab, { tabClasses } from '@mui/material/Tab';
 import { useTranslate } from 'docs/src/modules/utils/i18n';
-import NextLink from 'next/link';
+import { Link } from '@mui/docs/Link';
 
 export const HEIGHT = 50;
 
-const StyledTab = styled(Tab)(({ theme }) => ({
-  padding: theme.spacing(0.5),
-  border: '1px solid',
-  borderColor: 'transparent',
-  fontWeight: theme.typography.fontWeightSemiBold,
+const LinkTab = styled(Link)(({ theme }) => ({
   minHeight: 30,
   minWidth: 0,
+  padding: theme.spacing(0.5, 1),
+  border: '1px solid',
+  borderColor: 'transparent',
+  fontFamily: theme.typography.fontFamily,
+  fontWeight: theme.typography.fontWeightSemiBold,
+  fontSize: theme.typography.pxToRem(14),
+  color: (theme.vars || theme).palette.text.secondary,
   borderRadius: '8px',
   '&:hover': {
     background: (theme.vars || theme).palette.grey[50],
@@ -50,56 +53,86 @@ export default function ComponentPageTabs(props) {
   const componentsHref = `${apiPathname}components-api`;
   const hooksHref = `${apiPathname}hooks-api`;
 
+  const widthMap = {
+    '': '62px',
+    'components-api': '127px',
+    'hooks-api': '86px',
+  };
+
+  const width = widthMap[activeTab];
+
+  const positionMap = {
+    '': '1px', // Default width when no value is specified
+    'components-api': '67px',
+    'hooks-api': '198px',
+  };
+
+  const position = positionMap[activeTab];
+
+  const tabData = [
+    {
+      key: '',
+      label: t('api-docs.demos'),
+      href: demosHref,
+    },
+    ...(headers.components?.length > 0 && [
+      {
+        key: 'components-api',
+        label: t('api-docs.componentsApi'),
+        href: componentsHref,
+      },
+    ]),
+    ...(headers.hooks &&
+      headers.hooks.length > 0 && [
+        {
+          key: 'hooks-api',
+          label: t('api-docs.hooksApi'),
+          href: hooksHref,
+        },
+      ]),
+  ];
+
   return (
     <Box className="component-tabs" sx={{ display: 'inline' }}>
-      <Tabs
-        value={activeTab}
+      <Box
+        role="toolbar"
+        className="component-tabs"
         sx={{
           position: 'sticky',
           top: 65, // to be positioned below the app bar
+          width: '100%',
           mt: 2,
-          mx: -1,
           backgroundColor: 'background.default',
           borderBottom: 1,
           borderColor: 'divider',
           zIndex: 1000,
-          [`& .${tabsClasses.flexContainer}`]: {
-            p: 1,
-            gap: 1,
-          },
-          [`& .${tabsClasses.indicator}`]: {
-            transition: 'none',
-          },
-          // Make server side styles closer to hydrated
-          [`& .${tabClasses.root}`]: {
-            overflow: 'visible',
-            [`& .${tabsClasses.indicator}`]: {
-              top: '39px',
-              borderRadius: 0,
-            },
+          display: 'inline-flex',
+          py: 1,
+          gap: 0.5,
+          '&::before': {
+            content: "''",
+            position: 'absolute',
+            bottom: 0,
+            width: width,
+            left: position,
+            height: '2px',
+            backgroundColor: 'primary.light',
           },
         }}
       >
-        <StyledTab component={NextLink} href={demosHref} label={t('api-docs.demos')} value="" />
-        {headers.components?.length > 0 && (
-          <StyledTab
-            className="skip-algolia-crawler" // For more details, see https://github.com/mui/material-ui/pull/37539.
-            component={NextLink}
-            href={componentsHref}
-            label={t('api-docs.componentsApi')}
-            value="components-api"
-          />
-        )}
-        {headers.hooks && headers.hooks.length > 0 && (
-          <StyledTab
-            className="skip-algolia-crawler" // For more details, see https://github.com/mui/material-ui/pull/37539.
-            component={NextLink}
-            href={hooksHref}
-            label={t('api-docs.hooksApi')}
-            value="hooks-api"
-          />
-        )}
-      </Tabs>
+        {tabData.map((tab) => (
+          <LinkTab
+            key={tab.key}
+            href={tab.href}
+            aria-current={activeTab === tab.key ? 'page' : undefined}
+            sx={{
+              color: activeTab === tab.key ? 'primary.main' : 'inherit',
+            }}
+          >
+            {tab.label}
+          </LinkTab>
+        ))}
+      </Box>
       {children}
     </Box>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<details>
  <summary>Old description</summary>
After multiple trials and errors + looking around, I realized that something (which I couldn't quite figure out) is preventing the `Link` component from `@mui/docs` from rendering with the `role="tab"` attribute. That's ultimately what's breaking the arrow keys keyboard navigation. My goal with this PR is purely to fix that rather than discuss just yet whether this is a desirable pattern (although I did find [a cool Ariakit example](https://ariakit.org/examples/tab-next-router) using it, which is reassuring!). 

So, just using the `Link` component straight from Next.js seems to nicely fix the issue — try focusing on the first active tab and pressing the right key to navigate; you should expect normal Tabs behavior now.
</details>

**Edit:** The merged version of this PR is different from its initial iteration, so I kept the original description stored up there. In any case, here's a run-down of what was ultimately pushed:
- Remove the Material UI tabs component and use a plain Link instead. The reasoning here is that the whole page is not set up for proper Tabs usage, particularly because we weren't toggling the content with Tab Panels, so the accessible pattern was not implemented correctly, and that resulted in the keyboard navigation getting broken
- Add styles and logic so that the design _looks_ like a Tab component (e.g., active indicator), even with a Link. The difference as far as keyboard navigation here is that you can circle around the different links via the tab key, as opposed to arrow keys, as you'd do in an actual Tab component
- Cross-off the last item in https://github.com/mui/material-ui/issues/41122 regarding `aria-selected="false"`—that's fixed here

https://deploy-preview-42152--material-ui.netlify.app/base-ui/react-button/
