### PR TITLE
[website] Fix pricing casing

### DIFF
--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -999,7 +999,7 @@ const premiumData: Record<string, React.ReactNode> = {
   'mui-x-development-perpetual': <Info value="Perpetual" />,
   'mui-x-updates': <Info value="1 year" />,
   // Support
-  'core-support': <Info value={pending} metadata="priority add-on only" />,
+  'core-support': <Info value={pending} metadata="Priority add-on only" />,
   'x-support': <Info value={yes} metadata="Priority over Pro" />,
   'tech-advisory': pending,
   'support-duration': <Info value="1 year" />,
@@ -1017,7 +1017,7 @@ const premiumData: Record<string, React.ReactNode> = {
     />
   ),
   'pre-screening': <Info value={pending} metadata="4 hours (priority add-on only)" />,
-  'issue-escalation': <Info value={pending} metadata="priority add-on only" />,
+  'issue-escalation': <Info value={pending} metadata="Priority add-on only" />,
   'security-questionnaire': <Info value="Available from 4+ devs" />,
 };
 


### PR DESCRIPTION
before
<img width="1169" alt="Screenshot 2024-05-09 at 12 53 54" src="https://github.com/mui/material-ui/assets/7225802/b92b4aae-4794-40e2-a145-ea5f885c6ee6">

after
<img width="1166" alt="Screenshot 2024-05-09 at 12 54 35" src="https://github.com/mui/material-ui/assets/7225802/c6b95140-56d9-4955-9cd2-86124bb0b0e5">

