### PR TITLE
[docs] Remove the Base notification

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": 68,
-    "title": "Check out Base UI today 💥",
-    "text": "Love Material UI, but don't need Material Design? Try Base UI, the new \"unstyled\" alternative. <a style=\"color: inherit;\" data-ga-event-category=\"Blog\" data-ga-event-action=\"notification\" data-ga-event-label=\"introducing-base-ui\" href=\"/blog/introducing-base-ui/\">Read more in this announcement</a>."
-  },
-  {
     "id": 78,
     "title": "MUI X v6.18.x and the latest improvements before the next major",
     "text": "New stable components, polished features, better performance and more. Check out the details in our <a style=\"color: inherit;\" data-ga-event-category=\"Announcement\" data-ga-event-action=\"notification\" data-ga-event-label=\"mui-x-end-v6\" href=\"https://mui.com/blog/mui-x-end-v6-features/\">recent blog post</a>."


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Just realized this was still there. Not sure it makes sense to keep linking this blog post there with wording that could communicate that "Base is ready!" when we're in the midst of rewriting the whole thing and a few months away from being fully usable 😬 
