### PR TITLE
[docs][material-ui] Fix typo in composition docs

### DIFF
--- a/docs/data/material/guides/composition/composition.md
+++ b/docs/data/material/guides/composition/composition.md
@@ -123,7 +123,7 @@ import { Link } from 'react-router-dom';
 
 :::warning
 However, this strategy suffers from a limitation: prop name collisions.
-The component receiving the `component` prop (for example ListItem) might intercept the prop (for example to) that is destined to the leave element (for example Link).
+The component receiving the `component` prop (for example ListItem) might intercept the prop (for example to) that is destined to the leaf element (for example Link).
 :::
 
 ### With TypeScript


### PR DESCRIPTION
"destined to the ~leave~ **leaf** element"