### PR TITLE
elements is Select multiple native interfering with input label

### DIFF
--- a/packages/mui-material/src/Select/SelectInput.js
+++ b/packages/mui-material/src/Select/SelectInput.js
@@ -566,6 +566,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
               ...(paperProps != null ? paperProps.style : null),
             },
           },
+          list: { mt: 1 },
         }}
       >
         {items}


### PR DESCRIPTION
i Think that this will add a margin between the Input label and the list elements in the select multiple native because as of now when scrolling the elements will interfere with the label
![image](https://github.com/mui/material-ui/assets/51023058/be13426a-e3bc-4d98-9c08-067b5df2086a)


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
