### PR TITLE
[material-ui][docs] Improve descriptions for deprecated props

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -50,7 +50,7 @@ npx @mui/codemod@latest deprecations/accordion-props <path>
 
 ### TransitionComponent
 
-The Accordion's `TransitionComponent` was deprecated in favor of `slots.transition`:
+The Accordion's `TransitionComponent` prop was deprecated in favor of `slots.transition`:
 
 ```diff
  <Accordion
@@ -61,7 +61,7 @@ The Accordion's `TransitionComponent` was deprecated in favor of `slots.transiti
 
 ### TransitionProps
 
-The Accordion's `TransitionProps` was deprecated in favor of `slotProps.transition`:
+The Accordion's `TransitionProps` prop was deprecated in favor of `slotProps.transition`:
 
 ```diff
  <Accordion
@@ -115,7 +115,7 @@ npx @mui/codemod@latest deprecations/alert-classes <path>
 
 ### components
 
-The Alert's `components` was deprecated in favor of `slots`:
+The Alert's `components` prop was deprecated in favor of `slots`:
 
 ```diff
  <Alert
@@ -126,7 +126,7 @@ The Alert's `components` was deprecated in favor of `slots`:
 
 ### componentsProps
 
-The Alert's `componentsProps` was deprecated in favor of `slotProps`:
+The Alert's `componentsProps` prop was deprecated in favor of `slotProps`:
 
 ```diff
  <Alert
@@ -277,7 +277,7 @@ npx @mui/codemod@latest deprecations/avatar-props <path>
 
 ### imgProps
 
-The Avatar's `imgProps` was deprecated in favor of `slotProps.img`:
+The Avatar's `imgProps` prop was deprecated in favor of `slotProps.img`:
 
 ```diff
  <Avatar
@@ -321,7 +321,7 @@ npx @mui/codemod@next deprecations/badge-props <path>
 
 ### components
 
-The Badge's `components` was deprecated in favor of `slots`:
+The Badge's `components` prop was deprecated in favor of `slots`:
 
 ```diff
  <Badge
@@ -332,7 +332,7 @@ The Badge's `components` was deprecated in favor of `slots`:
 
 ### componentsProps
 
-The Badge's `componentsProps` was deprecated in favor of `slotProps`:
+The Badge's `componentsProps` prop was deprecated in favor of `slotProps`:
 
 ```diff
  <Badge
@@ -962,7 +962,7 @@ npx @mui/codemod@next deprecations/form-control-label-props <path>
 
 ### componentsProps
 
-The FormControlLabel's `componentsProps` was deprecated in favor of `slotProps`:
+The FormControlLabel's `componentsProps` prop was deprecated in favor of `slotProps`:
 
 ```diff
  <FormControlLabel
@@ -1025,7 +1025,7 @@ Here's how to migrate:
 
 ### components
 
-The PaginationItems's `components` was deprecated in favor of `slots`:
+The PaginationItems's `components` prop was deprecated in favor of `slots`:
 
 ```diff
  <PaginationItems
@@ -1044,7 +1044,7 @@ npx @mui/codemod@latest deprecations/slider-props <path>
 
 ### components
 
-The Slider's `components` was deprecated in favor of `slots`:
+The Slider's `components` prop was deprecated in favor of `slots`:
 
 ```diff
  <Slider
@@ -1055,7 +1055,7 @@ The Slider's `components` was deprecated in favor of `slots`:
 
 ### componentsProps
 
-The Slider's `componentsProps` was deprecated in favor of `slotProps`:
+The Slider's `componentsProps` prop was deprecated in favor of `slotProps`:
 
 ```diff
  <Slider
@@ -1114,7 +1114,7 @@ npx @mui/codemod@latest deprecations/step-label-props <path>
 
 ### componentsProps
 
-The StepLabel's `componentsProps` was deprecated in favor of `slotProps`:
+The StepLabel's `componentsProps` prop was deprecated in favor of `slotProps`:
 
 ```diff
  <StepLabel
@@ -1125,7 +1125,7 @@ The StepLabel's `componentsProps` was deprecated in favor of `slotProps`:
 
 ### StepIconComponent
 
-The StepLabel's `StepIconComponent` was deprecated in favor of `slots.stepIcon`:
+The StepLabel's `StepIconComponent` prop was deprecated in favor of `slots.stepIcon`:
 
 ```diff
  <StepLabel
@@ -1136,7 +1136,7 @@ The StepLabel's `StepIconComponent` was deprecated in favor of `slots.stepIcon`:
 
 ### StepIconProps
 
-The StepLabel's `StepIconProps` was deprecated in favor of `slotProps.stepIcon`:
+The StepLabel's `StepIconProps` prop was deprecated in favor of `slotProps.stepIcon`:
 
 ```diff
  <StepLabel
@@ -1205,7 +1205,7 @@ The SpeedDial's `TransitionComponent` prop was deprecated in favor of `slots.tra
 
 ### TransitionProps
 
-The SpeedDial's `TransitionProps` was deprecated in favor of `slotProps.transition`:
+The SpeedDial's `TransitionProps` prop was deprecated in favor of `slotProps.transition`:
 
 ```diff
  <SpeedDial


### PR DESCRIPTION
Wording tweaks in the "Migrating from deprecated APIs" [page](https://next.mui.com/material-ui/migration/migrating-from-deprecated-apis/).