### PR TITLE
[system][docs] Add "dynamic values" section to sx prop page

### DIFF
--- a/docs/data/system/getting-started/the-sx-prop/DynamicValues.js
+++ b/docs/data/system/getting-started/the-sx-prop/DynamicValues.js
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+export default function DynamicValues() {
+  const [color, setColor] = React.useState('#007fff');
+
+  return (
+    <Stack spacing={1} alignItems="center">
+      <Typography
+        component="label"
+        variant="body2"
+        sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}
+      >
+        Pick a color to see a live preview
+        <input type="color" onChange={(event) => setColor(event.target.value)} />
+      </Typography>
+      <Box
+        component="div"
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          width: 75,
+          height: 75,
+          borderRadius: 2,
+          backgroundColor: 'var(--bg)',
+        }}
+        style={{ '--bg': color }}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/system/getting-started/the-sx-prop/DynamicValues.js
+++ b/docs/data/system/getting-started/the-sx-prop/DynamicValues.js
@@ -14,7 +14,11 @@ export default function DynamicValues() {
         sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}
       >
         Pick a color to see a live preview
-        <input type="color" onChange={(event) => setColor(event.target.value)} />
+        <input
+          type="color"
+          value={color}
+          onChange={(event) => setColor(event.target.value)}
+        />
       </Typography>
       <Box
         component="div"

--- a/docs/data/system/getting-started/the-sx-prop/DynamicValues.tsx
+++ b/docs/data/system/getting-started/the-sx-prop/DynamicValues.tsx
@@ -14,7 +14,11 @@ export default function DynamicValues() {
         sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}
       >
         Pick a color to see a live preview
-        <input type="color" onChange={(event) => setColor(event.target.value)} />
+        <input
+          type="color"
+          value={color}
+          onChange={(event) => setColor(event.target.value)}
+        />
       </Typography>
       <Box
         component="div"

--- a/docs/data/system/getting-started/the-sx-prop/DynamicValues.tsx
+++ b/docs/data/system/getting-started/the-sx-prop/DynamicValues.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+export default function DynamicValues() {
+  const [color, setColor] = React.useState('#007fff');
+
+  return (
+    <Stack spacing={1} alignItems="center">
+      <Typography
+        component="label"
+        variant="body2"
+        sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}
+      >
+        Pick a color to see a live preview
+        <input type="color" onChange={(event) => setColor(event.target.value)} />
+      </Typography>
+      <Box
+        component="div"
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          width: 75,
+          height: 75,
+          borderRadius: 2,
+          backgroundColor: 'var(--bg)',
+        }}
+        style={{ '--bg': color } as React.CSSProperties}
+      />
+    </Stack>
+  );
+}

--- a/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
@@ -292,6 +292,12 @@ If you want to receive the `sx` prop from a custom component and pass it down to
 
 {{"demo": "PassingSxProp.js", "bg": true, "defaultCodeOpen": true}}
 
+## Dynamic values
+
+For highly dynamic CSS values, we recommend using inline CSS variables instead of passing an object with varying values to the `sx` prop on each render. This approach avoids inserting unnecessary `style` tags into the DOM, preventing potential performance issues when dealing with CSS properties that can hold a wide range of values that change frequently. For example, a color picker with live preview.
+
+{{"demo": "DynamicValues.js", "bg": true}}
+
 ## TypeScript usage
 
 A frequent source of confusion with the `sx` prop is TypeScript's [type widening](https://mariusschulz.com/blog/literal-type-widening-in-typescript), which causes this example not to work as expected:

--- a/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
@@ -288,16 +288,19 @@ Each index can be an object or a callback.
 
 ## Passing the sx prop
 
-If you want to receive the `sx` prop from a custom component and pass it down to another MUI System, we recommend this approach:
+If you want to receive the `sx` prop from a custom component and pass it down to another MUI System, we recommend this approach:\*\*\*\*
 
 {{"demo": "PassingSxProp.js", "bg": true, "defaultCodeOpen": true}}
 
 ## Dynamic values
 
-For highly dynamic CSS values, we recommend using inline CSS variables instead of passing an object with varying values to the `sx` prop on each render. This approach avoids inserting unnecessary `style` tags into the DOM, preventing potential performance issues when dealing with CSS properties that can hold a wide range of values that change frequently. For example, a color picker with live preview.
+For highly dynamic CSS values, we recommend using inline CSS variables instead of passing an object with varying values to the `sx` prop on each render.
+This approach avoids inserting unnecessary `style` tags into the DOM, preventing potential performance issues when dealing with CSS properties that can hold a wide range of values that change frequently.
+For example, a color picker with live preview.
 
 :::info
-If you're having problems with your CSP policy while using inline styles with the `style` attribute, make sure you've enabled the [`style-src-attr`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr) directive. Check [our guide](/material-ui/guides/content-security-policy/) on how to configure CSP.
+If you're having problems with your CSP policy while using inline styles with the `style` attribute, make sure you've enabled the [`style-src-attr`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr) directive.
+Check [our guide](/material-ui/guides/content-security-policy/) on how to configure CSP.
 :::
 
 {{"demo": "DynamicValues.js", "bg": true}}

--- a/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
@@ -296,6 +296,10 @@ If you want to receive the `sx` prop from a custom component and pass it down to
 
 For highly dynamic CSS values, we recommend using inline CSS variables instead of passing an object with varying values to the `sx` prop on each render. This approach avoids inserting unnecessary `style` tags into the DOM, preventing potential performance issues when dealing with CSS properties that can hold a wide range of values that change frequently. For example, a color picker with live preview.
 
+:::info
+If you're having problems with your CSP policy while using inline styles with the `style` attribute, make sure you've enabled the [`style-src-attr`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr) directive. Check [our guide](/material-ui/guides/content-security-policy/) on how to configure CSP.
+:::
+
 {{"demo": "DynamicValues.js", "bg": true}}
 
 ## TypeScript usage

--- a/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
@@ -288,7 +288,7 @@ Each index can be an object or a callback.
 
 ## Passing the sx prop
 
-If you want to receive the `sx` prop from a custom component and pass it down to another MUI System, we recommend this approach:\*\*\*\*
+If you want to receive the `sx` prop from a custom component and pass it down to another MUI System, we recommend this approach:
 
 {{"demo": "PassingSxProp.js", "bg": true, "defaultCodeOpen": true}}
 

--- a/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
+++ b/docs/data/system/getting-started/the-sx-prop/the-sx-prop.md
@@ -295,12 +295,11 @@ If you want to receive the `sx` prop from a custom component and pass it down to
 ## Dynamic values
 
 For highly dynamic CSS values, we recommend using inline CSS variables instead of passing an object with varying values to the `sx` prop on each render.
-This approach avoids inserting unnecessary `style` tags into the DOM, preventing potential performance issues when dealing with CSS properties that can hold a wide range of values that change frequently.
-For example, a color picker with live preview.
+This approach avoids inserting unnecessary `style` tags into the DOM, which prevents potential performance issues when dealing with CSS properties that can hold a wide range of values that change frequently—for example, a color picker with live preview.
 
 :::info
-If you're having problems with your CSP policy while using inline styles with the `style` attribute, make sure you've enabled the [`style-src-attr`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr) directive.
-Check [our guide](/material-ui/guides/content-security-policy/) on how to configure CSP.
+If you're having problems with your Content Security Policy while using inline styles with the `style` attribute, make sure you've enabled the [`style-src-attr` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr).
+Visit the [Content Security Policy guide](/material-ui/guides/content-security-policy/) for configuration details.
 :::
 
 {{"demo": "DynamicValues.js", "bg": true}}


### PR DESCRIPTION
Resolves https://github.com/mui/material-ui/issues/42164

Adds a new "Dynamic values" section in the `sx` prop [docs page](https://mui.com/system/getting-started/the-sx-prop/) with guidance on how to leverage CSS variables to handle highly dynamic values to avoid polluting the DOM with unnecessary `style` tags.

_This PR will be cherry-picked to master._

Preview link: https://deploy-preview-42239--material-ui.netlify.app/system/getting-started/the-sx-prop/#dynamic-values