### PR TITLE
[material-ui][ToggleButtonGroup] Add missing `selected` class in ToggleButtonGroupClasses type

### DIFF
--- a/docs/pages/material-ui/api/toggle-button-group.json
+++ b/docs/pages/material-ui/api/toggle-button-group.json
@@ -108,6 +108,12 @@
       "isGlobal": false
     },
     {
+      "key": "selected",
+      "className": "Mui-selected",
+      "description": "State class applied to the root element if `selected={true}`.",
+      "isGlobal": true
+    },
+    {
       "key": "vertical",
       "className": "MuiToggleButtonGroup-vertical",
       "description": "Styles applied to the root element if `orientation=\"vertical\"`.",

--- a/docs/translations/api-docs/toggle-button-group/toggle-button-group.json
+++ b/docs/translations/api-docs/toggle-button-group/toggle-button-group.json
@@ -73,6 +73,11 @@
       "nodeName": "buttons in the middle of the toggle button group"
     },
     "root": { "description": "Styles applied to the root element." },
+    "selected": {
+      "description": "State class applied to {{nodeName}} if {{conditions}}.",
+      "nodeName": "the root element",
+      "conditions": "<code>selected={true}</code>"
+    },
     "vertical": {
       "description": "Styles applied to {{nodeName}} if {{conditions}}.",
       "nodeName": "the root element",

--- a/packages/mui-material/src/ToggleButtonGroup/toggleButtonGroupClasses.ts
+++ b/packages/mui-material/src/ToggleButtonGroup/toggleButtonGroupClasses.ts
@@ -4,6 +4,8 @@ import generateUtilityClass from '@mui/utils/generateUtilityClass';
 export interface ToggleButtonGroupClasses {
   /** Styles applied to the root element. */
   root: string;
+  /** State class applied to the root element if `selected={true}`. */
+  selected: string;
   /** Styles applied to the root element if `orientation="horizontal"`. */
   horizontal: string;
   /** Styles applied to the root element if `orientation="vertical"`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes: #42228
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
