### PR TITLE
[material-ui][ListItemSecondaryAction] Deprecate component

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -991,6 +991,30 @@ The FormControlLabel's `componentsProps` prop was deprecated in favor of `slotPr
  />
 ```
 
+## ListItemSecondaryAction
+
+### Deprecated component
+
+The ListItemSecondaryAction component was deprecated in favor of the `secondaryAction` prop in the ListItem component.
+
+```diff
+ <ListItem
++  secondaryAction={
++    <IconButton aria-label="Leave a comment">
++      <CommentIcon />
++    </IconButton>
++  }
+   disablePadding
+ >
+   <ListItemText primary="John Doe" />
+-  <ListItemSecondaryAction>
+-    <IconButton aria-label="Leave a comment">
+-      <CommentIcon />
+-    </IconButton>
+-  </ListItemSecondaryAction>
+ </ListItem>
+```
+
 ## PaginationItem
 
 Use the [codemod](https://github.com/mui/material-ui/tree/HEAD/packages/mui-codemod#pagination-item-classes) below to migrate the code as described in the following sections:

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -255,7 +255,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
 
   const children = React.Children.toArray(childrenProp);
 
-  // v4 implementation, deprecated in v5, will be removed in v6
+  // v4 implementation, deprecated in v6, will be removed in v7
   const hasSecondaryAction =
     children.length && isMuiElement(children[children.length - 1], ['ListItemSecondaryAction']);
 
@@ -298,7 +298,7 @@ const ListItem = React.forwardRef(function ListItem(inProps, ref) {
     Component = ButtonBase;
   }
 
-  // v4 implementation, deprecated in v5, will be removed in v6
+  // v4 implementation, deprecated in v6, will be removed in v7
   if (hasSecondaryAction) {
     // Use div by default.
     Component = !componentProps.component && !componentProp ? 'div' : Component;

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -29,6 +29,8 @@ export interface ListItemSecondaryActionProps
  * API:
  *
  * - [ListItemSecondaryAction API](https://mui.com/material-ui/api/list-item-secondary-action/)
+ *
+ * @deprecated Use the `secondaryAction` prop in the `ListItem` component instead. This component will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
  */
 declare const ListItemSecondaryAction: ((props: ListItemSecondaryActionProps) => JSX.Element) & {
   muiName: string;

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -44,6 +44,8 @@ const ListItemSecondaryActionRoot = styled('div', {
 
 /**
  * Must be used as the last child of ListItem to function properly.
+ *
+ * @deprecated Use the `secondaryAction` prop in the `ListItem` component instead. This component will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
  */
 const ListItemSecondaryAction = React.forwardRef(function ListItemSecondaryAction(inProps, ref) {
   const props = useThemeProps({ props: inProps, name: 'MuiListItemSecondaryAction' });


### PR DESCRIPTION
We intended to deprecate `ListItemSecondaryAction` in v5 in favor of the `secondaryAction` prop in `ListItem`, but we forgot to do it officially so we can't remove it in v6. This PR adds a new `ListItemSecondaryAction` deprecation entry in the docs for v6 so we can remove it in v7. See https://github.com/mui/material-ui/pull/26446 for context.

Preview link: https://deploy-preview-42251--material-ui.netlify.app/material-ui/migration/migrating-from-deprecated-apis/#listitemsecondaryaction

<img width="550" alt="image" src="https://github.com/mui/material-ui/assets/7225802/c82f030b-8e99-499a-8136-79e16c6d1dda">
