### PR TITLE
[material-ui][docs] Fix the Basic Tabs demo

### DIFF
--- a/docs/data/material/components/tabs/BasicTabs.js
+++ b/docs/data/material/components/tabs/BasicTabs.js
@@ -16,11 +16,7 @@ function CustomTabPanel(props) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-      {value === index && (
-        <Box sx={{ p: 3 }}>
-          <Typography component="span">{children}</Typography>
-        </Box>
-      )}
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
     </div>
   );
 }

--- a/docs/data/material/components/tabs/BasicTabs.js
+++ b/docs/data/material/components/tabs/BasicTabs.js
@@ -18,7 +18,7 @@ function CustomTabPanel(props) {
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography component={`span`}>{children}</Typography>
+          <Typography component="span">{children}</Typography>
         </Box>
       )}
     </div>

--- a/docs/data/material/components/tabs/BasicTabs.js
+++ b/docs/data/material/components/tabs/BasicTabs.js
@@ -18,7 +18,7 @@ function CustomTabPanel(props) {
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography>{children}</Typography>
+          <Typography component={`span`}>{children}</Typography>
         </Box>
       )}
     </div>


### PR DESCRIPTION
To avoid validateDOMNesting warning, we can use span as a component of Typography instead of p (default component). 


A p tag can only contain inline elements. That means putting a div tag inside it should be improper, since the div tag is a block element. Improper nesting might cause glitches like rendering extra tags, which can affect your javascript and css.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
