### PR TITLE
[material-ui][ListItem] Document `*Component` and `*Props` props deprecations

### DIFF
--- a/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
+++ b/docs/data/material/migration/migrating-from-deprecated-apis/migrating-from-deprecated-apis.md
@@ -1021,6 +1021,14 @@ The ListItem's `componentsProps` prop was deprecated in favor of `slotProps`:
  />
 ```
 
+### ContainerComponent
+
+The ListItem's `ContainerComponent` prop was deprecated in favor of `slots.root` or `component` instead.
+
+### ContainerProps
+
+The ListItem's `ContainerProps` prop was deprecated in favor of `slotProps.root` instead.
+
 ## ListItemSecondaryAction
 
 ### Deprecated component

--- a/docs/pages/material-ui/api/list-item.json
+++ b/docs/pages/material-ui/api/list-item.json
@@ -34,9 +34,15 @@
     "ContainerComponent": {
       "type": { "name": "custom", "description": "element type" },
       "default": "'li'",
-      "deprecated": true
+      "deprecated": true,
+      "deprecationInfo": "Use the <code>component</code> or <code>slots.root</code> prop instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
     },
-    "ContainerProps": { "type": { "name": "object" }, "default": "{}", "deprecated": true },
+    "ContainerProps": {
+      "type": { "name": "object" },
+      "default": "{}",
+      "deprecated": true,
+      "deprecationInfo": "Use the <code>slotProps.root</code> prop instead. This prop will be removed in v7. See <a href=\"/material-ui/migration/migrating-from-deprecated-apis/\">Migrating from deprecated APIs</a> for more details."
+    },
     "dense": { "type": { "name": "bool" }, "default": "false" },
     "disabled": {
       "type": { "name": "bool" },

--- a/packages/mui-material/src/ListItem/ListItem.d.ts
+++ b/packages/mui-material/src/ListItem/ListItem.d.ts
@@ -35,13 +35,13 @@ export interface ListItemBaseProps {
   /**
    * The container component used when a `ListItemSecondaryAction` is the last child.
    * @default 'li'
-   * @deprecated
+   * @deprecated Use the `component` or `slots.root` prop instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ContainerComponent?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   /**
    * Props applied to the container component if used.
    * @default {}
-   * @deprecated
+   * @deprecated Use the `slotProps.root` prop instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ContainerProps?: React.HTMLAttributes<HTMLDivElement>;
   /**

--- a/packages/mui-material/src/ListItem/ListItem.js
+++ b/packages/mui-material/src/ListItem/ListItem.js
@@ -442,13 +442,13 @@ ListItem.propTypes /* remove-proptypes */ = {
   /**
    * The container component used when a `ListItemSecondaryAction` is the last child.
    * @default 'li'
-   * @deprecated
+   * @deprecated Use the `component` or `slots.root` prop instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ContainerComponent: elementTypeAcceptingRef,
   /**
    * Props applied to the container component if used.
    * @default {}
-   * @deprecated
+   * @deprecated Use the `slotProps.root` prop instead. This prop will be removed in v7. See [Migrating from deprecated APIs](/material-ui/migration/migrating-from-deprecated-apis/) for more details.
    */
   ContainerProps: PropTypes.object,
   /**


### PR DESCRIPTION
`ListItem`'s `ContainerComponent` and `ContainerProps` props [were deprecated 3 years ago](https://github.com/mui/material-ui/pull/26446/files#diff-5698698594d052380d3b810071d671941c607258ee79027c74ed2844f127f3b6R33-R39), but not officially in the docs. This PR just makes the deprecation official adding it to the docs.

This deprecation goes hand in hand with `ListItemSecondaryAction` deprecation, so we should probably wait for https://github.com/mui/material-ui/pull/42251 to be merged first.

Preview link: https://deploy-preview-42263--material-ui.netlify.app/material-ui/migration/migrating-from-deprecated-apis/#listitem