### PR TITLE
[wip][system] Try reordering the presedence of variants over base styles

### DIFF
--- a/packages/mui-system/src/createStyled/createStyled.js
+++ b/packages/mui-system/src/createStyled/createStyled.js
@@ -5,6 +5,7 @@ import capitalize from '@mui/utils/capitalize';
 import getDisplayName from '@mui/utils/getDisplayName';
 import createTheme from '../createTheme';
 import styleFunctionSx from '../styleFunctionSx';
+import exp from 'constants';
 
 function isEmpty(obj) {
   return Object.keys(obj).length === 0;
@@ -46,13 +47,13 @@ function defaultOverridesResolver(slot) {
   return (props, styles) => styles[slot];
 }
 
-function processStyleArg(callableStyle, { ownerState, ...props }) {
+function processBaseStyleArg(callableStyle, { ownerState, ...props }) {
   const resolvedStylesArg =
     typeof callableStyle === 'function' ? callableStyle({ ownerState, ...props }) : callableStyle;
 
   if (Array.isArray(resolvedStylesArg)) {
     return resolvedStylesArg.flatMap((resolvedStyle) =>
-      processStyleArg(resolvedStyle, { ownerState, ...props }),
+      processBaseStyleArg(resolvedStyle, { ownerState, ...props }),
     );
   }
 
@@ -63,6 +64,28 @@ function processStyleArg(callableStyle, { ownerState, ...props }) {
   ) {
     const { variants = [], ...otherStyles } = resolvedStylesArg;
     let result = otherStyles;
+    return result;
+  }
+  return resolvedStylesArg;
+}
+
+function processVariantStyleArg(callableStyle, { ownerState, ...props }) {
+  const resolvedStylesArg =
+    typeof callableStyle === 'function' ? callableStyle({ ownerState, ...props }) : callableStyle;
+
+  if (Array.isArray(resolvedStylesArg)) {
+    return resolvedStylesArg.flatMap((resolvedStyle) =>
+      processVariantStyleArg(resolvedStyle, { ownerState, ...props }),
+    );
+  }
+
+  if (
+    !!resolvedStylesArg &&
+    typeof resolvedStylesArg === 'object' &&
+    Array.isArray(resolvedStylesArg.variants)
+  ) {
+    const { variants = [] } = resolvedStylesArg;
+    let result = [];
     variants.forEach((variant) => {
       let isMatch = true;
       if (typeof variant.props === 'function') {
@@ -87,7 +110,7 @@ function processStyleArg(callableStyle, { ownerState, ...props }) {
     });
     return result;
   }
-  return resolvedStylesArg;
+  return [];
 }
 
 export default function createStyled(input = {}) {
@@ -158,7 +181,7 @@ export default function createStyled(input = {}) {
       ...options,
     });
 
-    const transformStyleArg = (stylesArg) => {
+    const transformStyleArg = (stylesArg, stylePresedence = 'base') => {
       // On the server Emotion doesn't use React.forwardRef for creating components, so the created
       // component stays as a function. This condition makes sure that we do not interpolate functions
       // which are basically components used as a selectors.
@@ -166,18 +189,51 @@ export default function createStyled(input = {}) {
         (typeof stylesArg === 'function' && stylesArg.__emotion_real !== stylesArg) ||
         isPlainObject(stylesArg)
       ) {
-        return (props) =>
-          processStyleArg(stylesArg, {
+        return (props) => {
+          const fn = stylePresedence === 'base' ? processBaseStyleArg : processVariantStyleArg;
+          return fn(stylesArg, {
             ...props,
             theme: resolveTheme({ theme: props.theme, defaultTheme, themeId }),
           });
+        };
+      }
+
+      return stylesArg;
+    };
+
+    const transformVariantsStyleArg = (stylesArg, stylePresedence = 'base') => {
+      // On the server Emotion doesn't use React.forwardRef for creating components, so the created
+      // component stays as a function. This condition makes sure that we do not interpolate functions
+      // which are basically components used as a selectors.
+      if (
+        (typeof stylesArg === 'function' && stylesArg.__emotion_real !== stylesArg) ||
+        isPlainObject(stylesArg)
+      ) {
+        return (props) => {
+          const fn = stylePresedence === 'base' ? processBaseStyleArg : processVariantStyleArg;
+          return fn(stylesArg, {
+            ...props,
+            theme: resolveTheme({ theme: props.theme, defaultTheme, themeId }),
+          });
+        };
       }
       return stylesArg;
     };
     const muiStyledResolver = (styleArg, ...expressions) => {
       let transformedStyleArg = transformStyleArg(styleArg);
+      const trasfnormedVariantsStyleArg = transformStyleArg(styleArg, 'variants');
       const expressionsWithDefaultTheme = expressions ? expressions.map(transformStyleArg) : [];
 
+      const variantsExpressions = [];
+      // Collect variants from the styled variants definition
+      variantsExpressions.push(trasfnormedVariantsStyleArg);
+      if (expressionsWithDefaultTheme.length > 0) {
+        variantsExpressions.push(
+          ...(expressions ? expressions.map(transformVariantsStyleArg) : []),
+        );
+      }
+
+      // Collect base style overrides
       if (componentName && overridesResolver) {
         expressionsWithDefaultTheme.push((props) => {
           const theme = resolveTheme({ ...props, defaultTheme, themeId });
@@ -192,19 +248,46 @@ export default function createStyled(input = {}) {
           const resolvedStyleOverrides = {};
           // TODO: v7 remove iteration and use `resolveStyleArg(styleOverrides[slot])` directly
           Object.entries(styleOverrides).forEach(([slotKey, slotStyle]) => {
-            resolvedStyleOverrides[slotKey] = processStyleArg(slotStyle, { ...props, theme });
+            resolvedStyleOverrides[slotKey] = processBaseStyleArg(slotStyle, { ...props, theme });
+          });
+          return overridesResolver(props, resolvedStyleOverrides);
+        });
+      }
+
+      // Collect variant style overrides
+      if (componentName && overridesResolver) {
+        variantsExpressions.push((props) => {
+          const theme = resolveTheme({ ...props, defaultTheme, themeId });
+          if (
+            !theme.components ||
+            !theme.components[componentName] ||
+            !theme.components[componentName].styleOverrides
+          ) {
+            return null;
+          }
+          const styleOverrides = theme.components[componentName].styleOverrides;
+          const resolvedStyleOverrides = {};
+          // TODO: v7 remove iteration and use `resolveStyleArg(styleOverrides[slot])` directly
+          Object.entries(styleOverrides).forEach(([slotKey, slotStyle]) => {
+            resolvedStyleOverrides[slotKey] = processVariantStyleArg(slotStyle, {
+              ...props,
+              theme,
+            });
           });
           return overridesResolver(props, resolvedStyleOverrides);
         });
       }
 
       if (componentName && !skipVariantsResolver) {
-        expressionsWithDefaultTheme.push((props) => {
+        variantsExpressions.push((props) => {
           const theme = resolveTheme({ ...props, defaultTheme, themeId });
           const themeVariants = theme?.components?.[componentName]?.variants;
-          return processStyleArg({ variants: themeVariants }, { ...props, theme });
+          return processVariantStyleArg({ variants: themeVariants }, { ...props, theme });
         });
       }
+
+      // add all variants collected
+      expressionsWithDefaultTheme.push(...variantsExpressions);
 
       if (!skipSx) {
         expressionsWithDefaultTheme.push(systemSx);

--- a/packages/mui-system/src/createStyled/createStyled.js
+++ b/packages/mui-system/src/createStyled/createStyled.js
@@ -5,7 +5,6 @@ import capitalize from '@mui/utils/capitalize';
 import getDisplayName from '@mui/utils/getDisplayName';
 import createTheme from '../createTheme';
 import styleFunctionSx from '../styleFunctionSx';
-import exp from 'constants';
 
 function isEmpty(obj) {
   return Object.keys(obj).length === 0;

--- a/test/integration/mui-system/createStyled.test.js
+++ b/test/integration/mui-system/createStyled.test.js
@@ -730,4 +730,141 @@ describe('createStyled', () => {
       expect(getByTestId('text')).toHaveComputedStyle({ color: 'rgb(0, 0, 255)' });
     });
   });
+
+  // TODO: We need to figure out if it is possible to fix this
+  it.skip('styled() variants should have presedence over wrapper styled() base styles', () => {
+    const styled = createStyled();
+
+    const A = styled('div')({
+      paddingTop: '10px',
+      variants: [
+        {
+          props: { variant: 'filled' },
+          style: {
+            backgroundColor: 'rgb(255, 0, 0)',
+          },
+        },
+      ],
+    });
+
+    const B = styled(A)({
+      paddingTop: '20px',
+      // this should not override the one from A
+      backgroundColor: 'rgb(255, 255, 255)',
+    });
+
+    const C = styled(A)({
+      variants: [
+        {
+          props: { variant: 'filled' },
+          style: {
+            // this now overrides the one from A
+            backgroundColor: 'rgb(255, 255, 255)',
+          },
+        },
+      ],
+    });
+
+    const { getByTestId } = render(
+      <>
+        <B data-testid="b" variant="filled" />
+        {/*<C data-testid="c" variant="filled" />*/}
+      </>,
+    );
+    expect(getByTestId('b')).toHaveComputedStyle({ backgroundColor: 'rgb(255, 0, 0)' });
+    // expect(getByTestId('c')).toHaveComputedStyle({ backgroundColor: 'rgb(255, 255, 255)' });
+  });
+
+  it.only('styled() variant styles should take presedence over base style overrides', () => {
+    const styled = createStyled();
+
+    const A = styled('div', {
+      name: 'MuiA',
+      slot: 'root',
+    })({
+      paddingTop: '10px',
+      variants: [
+        {
+          props: { variant: 'filled' },
+          style: {
+            backgroundColor: 'rgb(255, 0, 0)',
+          },
+        },
+      ],
+    });
+
+    const { getByTestId } = render(
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiA: {
+              styleOverrides: {
+                root: {
+                  paddingTop: '20px',
+                  // this should not override the one from A
+                  backgroundColor: 'rgb(255, 255, 255)',
+                },
+              },
+            },
+          },
+        })}
+      >
+        <A data-testid="a" variant="filled" />
+      </ThemeProvider>,
+    );
+    expect(getByTestId('a')).toHaveComputedStyle({
+      paddingTop: '20px',
+      backgroundColor: 'rgb(255, 0, 0)',
+    });
+  });
+
+  it.only('styled() variant styles should not take presedence over variant style overrides', () => {
+    const styled = createStyled();
+
+    const A = styled('div', {
+      name: 'MuiA',
+      slot: 'root',
+    })({
+      paddingTop: '10px',
+      variants: [
+        {
+          props: { variant: 'filled' },
+          style: {
+            backgroundColor: 'rgb(255, 0, 0)',
+          },
+        },
+      ],
+    });
+
+    const { getByTestId } = render(
+      <ThemeProvider
+        theme={createTheme({
+          components: {
+            MuiA: {
+              styleOverrides: {
+                root: {
+                  paddingTop: '20px',
+                  variants: [
+                    {
+                      props: { variant: 'filled' },
+                      style: {
+                        // this should not override the one from A
+                        backgroundColor: 'rgb(255, 255, 255)',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        })}
+      >
+        <A data-testid="a" variant="filled" />
+      </ThemeProvider>,
+    );
+    expect(getByTestId('a')).toHaveComputedStyle({
+      paddingTop: '20px',
+      backgroundColor: 'rgb(255, 255, 255)',
+    });
+  });
 });


### PR DESCRIPTION
We discussed internally how the precedence of overrides should work with the new variants API (the discussion started around the Pigment CSS product, see more info [here](https://www.notion.so/mui-org/pigment-css-Overrides-precedence-6f9b22fd3e13405b855a6317942bdd67)).

From the initial investigation, it is possible for us to dictate how the order of the base styles/variants are handled along one instance of component, styled(), styleOverrides, variants, however, I didn't find a way how to augment the order of how they are added across components, for example using styled(Button). Check the tests for more details (I skipped the one that is not working).

Considering it is not possible to do it consistently between theme vs styled() overrides, I would lean toward not implementing any change and document this as a different behavior between Pigment CSS and MUI System and add instructions around best practices of how the overrides should be written so that people know how to not get into this kind of differences in behavior.