### PR TITLE
[docs][material-ui] Fix typo in style interoperability with Tailwind CSS docs

### DIFF
--- a/docs/data/material/integrations/interoperability/interoperability.md
+++ b/docs/data/material/integrations/interoperability/interoperability.md
@@ -610,7 +610,7 @@ If you use a different framework, or already have set up your project, follow th
 
 ```
 
-Most of the CSS used by Material UI has as specificity of 1, hence this `important` property is unnecessary.
+Most of the CSS used by Material UI has a specificity of 1, hence this `important` property is unnecessary.
 However, in a few edge cases, Material UI uses nested CSS selectors that win over Tailwind CSS.
 Use this step to help ensure that the [deeper elements](#deeper-elements-5) can always be customized using Tailwind's utility classes.
 More details on this option can be found here https://tailwindcss.com/docs/configuration#selector-strategy


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

I found a typo in this section of the docs while investigating an issue.

Preview: https://deploy-preview-42279--material-ui.netlify.app/material-ui/integrations/interoperability/#tailwind-css
