### PR TITLE
[POC][docs] JSDoc comments as deprecation source of truth

### DIFF
--- a/docs/pages/material-ui/api/hidden.json
+++ b/docs/pages/material-ui/api/hidden.json
@@ -40,5 +40,7 @@
   "filename": "/packages/mui-material/src/Hidden/Hidden.js",
   "inheritance": null,
   "demos": "<ul><li><a href=\"/material-ui/react-hidden/\">Hidden</a></li></ul>",
-  "cssComponent": false
+  "cssComponent": false,
+  "deprecated": true,
+  "deprecationInfo": "The Hidden component was deprecated in Material UI v5. To learn more, see <a href=\"/material-ui/migration/v5-component-changes/#hidden\">the Hidden section</a> of the migration docs."
 }

--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import AdGuest from 'docs/src/modules/components/AdGuest';
 import Alert from '@mui/material/Alert';
 import VerifiedRoundedIcon from '@mui/icons-material/VerifiedRounded';
+import DangerousIcon from '@mui/icons-material/Dangerous';
 import { alpha } from '@mui/material/styles';
 import { useTranslate, useUserLanguage } from '@mui/docs/i18n';
 import { HighlightedCode } from '@mui/docs/HighlightedCode';
@@ -79,6 +80,8 @@ export default function ApiPage(props) {
     spread,
     slots: componentSlots,
     classes,
+    deprecated,
+    deprecationInfo,
   } = pageContent;
 
   const componentClasses = Array.isArray(classes)
@@ -180,6 +183,50 @@ export default function ApiPage(props) {
     >
       <MarkdownElement>
         <h1>{pageContent.name} API</h1>
+        {deprecated ? (
+          <Alert
+            severity="error"
+            variant="outlined"
+            icon={<DangerousIcon sx={{ fontSize: 20 }} />}
+            sx={(theme) => ({
+              mt: 1.5,
+              mb: 1.5,
+              fontSize: theme.typography.pxToRem(16),
+              backgroundColor: (theme.vars || theme).palette.error[50],
+              borderColor: (theme.vars || theme).palette.error[100],
+              '& .MuiAlert-message': {
+                '& * p': {
+                  color: (theme.vars || theme).palette.text.primary,
+                  mb: 1,
+                },
+                '& * a': {
+                  fontWeight: theme.typography.fontWeightMedium,
+                  color: (theme.vars || theme).palette.error[900],
+                  textDecorationColor: alpha(theme.palette.error[600], 0.3),
+                },
+              },
+              ...theme.applyDarkStyles({
+                backgroundColor: alpha(theme.palette.error[700], 0.12),
+                borderColor: alpha(theme.palette.error[400], 0.1),
+                '& .MuiAlert-message': {
+                  ul: {
+                    pl: 3,
+                  },
+                  '& * a': {
+                    color: (theme.vars || theme).palette.error[100],
+                    textDecorationColor: alpha(theme.palette.error[100], 0.3),
+                  },
+                },
+              }),
+            })}
+          >
+            <span
+              dangerouslySetInnerHTML={{
+                __html: deprecationInfo,
+              }}
+            />
+          </Alert>
+        ) : null}
         <Typography variant="h5" component="p" className="description" gutterBottom>
           {description}
           {disableAd ? null : (
@@ -195,41 +242,37 @@ export default function ApiPage(props) {
           severity="success"
           variant="outlined"
           icon={<VerifiedRoundedIcon sx={{ fontSize: 20 }} />}
-          sx={[
-            (theme) => ({
-              mt: 1.5,
-              pt: 1,
-              px: 2,
-              pb: 0,
-              fontSize: theme.typography.pxToRem(16),
-              backgroundColor: (theme.vars || theme).palette.success[50],
-              borderColor: (theme.vars || theme).palette.success[100],
+          sx={(theme) => ({
+            mt: 1.5,
+            pb: 0,
+            fontSize: theme.typography.pxToRem(16),
+            backgroundColor: (theme.vars || theme).palette.success[50],
+            borderColor: (theme.vars || theme).palette.success[100],
+            '& .MuiAlert-message': {
+              '& * p': {
+                color: (theme.vars || theme).palette.text.primary,
+                mb: 1,
+              },
+              '& * a': {
+                fontWeight: theme.typography.fontWeightMedium,
+                color: (theme.vars || theme).palette.success[900],
+                textDecorationColor: alpha(theme.palette.success[600], 0.3),
+              },
+            },
+            ...theme.applyDarkStyles({
+              backgroundColor: alpha(theme.palette.success[700], 0.12),
+              borderColor: alpha(theme.palette.success[400], 0.1),
               '& .MuiAlert-message': {
-                '& * p': {
-                  color: (theme.vars || theme).palette.text.primary,
-                  mb: 1,
+                ul: {
+                  pl: 3,
                 },
                 '& * a': {
-                  fontWeight: theme.typography.fontWeightMedium,
-                  color: (theme.vars || theme).palette.success[900],
-                  textDecorationColor: alpha(theme.palette.success[600], 0.3),
+                  color: (theme.vars || theme).palette.success[100],
+                  textDecorationColor: alpha(theme.palette.success[100], 0.3),
                 },
               },
-              ...theme.applyDarkStyles({
-                backgroundColor: alpha(theme.palette.success[700], 0.12),
-                borderColor: alpha(theme.palette.success[400], 0.1),
-                '& .MuiAlert-message': {
-                  ul: {
-                    pl: 3,
-                  },
-                  '& * a': {
-                    color: (theme.vars || theme).palette.success[100],
-                    textDecorationColor: alpha(theme.palette.success[100], 0.3),
-                  },
-                },
-              }),
             }),
-          ]}
+          })}
         >
           <span
             dangerouslySetInnerHTML={{

--- a/packages/mui-material/src/Hidden/Hidden.d.ts
+++ b/packages/mui-material/src/Hidden/Hidden.d.ts
@@ -90,6 +90,8 @@ export interface HiddenProps {
  * API:
  *
  * - [Hidden API](https://mui.com/material-ui/api/hidden/)
+ *
+ * @deprecated The Hidden component was deprecated in Material UI v5. To learn more, see [the Hidden section](/material-ui/migration/v5-component-changes/#hidden) of the migration docs.
  */
 declare const Hidden: React.JSXElementConstructor<HiddenProps>;
 

--- a/packages/mui-material/src/Hidden/Hidden.js
+++ b/packages/mui-material/src/Hidden/Hidden.js
@@ -6,6 +6,8 @@ import HiddenCss from './HiddenCss';
 
 /**
  * Responsively hides children based on the selected implementation.
+ *
+ * @deprecated The Hidden component was deprecated in Material UI v5. To learn more, see [the Hidden section](/material-ui/migration/v5-component-changes/#hidden) of the migration docs.
  */
 function Hidden(props) {
   const {


### PR DESCRIPTION
As of today, we don't show deprecation messages in component API pages. The general idea of this PR is to treat JSDoc comments as the source of truth to mark components as deprecated in the docs.

- Adds support for `@deprecated` JSDoc tags (and any other tag) in components.
  - Before these changes, we couldn't annotate components with JSDoc tags because tags would appear on API pages.
- The deprecation message from JSDoc appears automatically on API pages.
  - For now, it works in Material, Joy, and System component API pages. It doesn't work on markdown-based pages i.e. it doesn't work on Base pages, which combines usage and API on the same page and it's markdown-based.
    <img width="600" alt="image" src="https://github.com/mui/material-ui/assets/7225802/465e3776-7425-4d96-b1a4-38af6c81a6ea">
- JSDoc tags are properly copied from .js to .d.ts files (using the existing mechanism).
- Consumers will be able to see components as deprecated in their IDEs (although a long-standing TS [issue](https://github.com/microsoft/TypeScript/issues/39374) sometimes interferes with the strikethrough styles).

Preview link: https://deploy-preview-42280--material-ui.netlify.app/material-ui/api/hidden/

---

**Potential improvements:**
- [ ] Apply changes to hooks and other APIs.
- [ ] [_Unrelated_] We have two similar but different-looking alerts in the docs, one used in usage pages (markdown rendered) and the other one in API pages (Material UI's Alert with some customization on top).
  ![deploy-preview-42280--material-ui netlify app_material-ui_react-hidden_](https://github.com/mui/material-ui/assets/7225802/27fc53cb-f669-4f10-b4bd-7813dd6781a6)
  ![deploy-preview-42280--material-ui netlify app_material-ui_react-hidden_ (1)](https://github.com/mui/material-ui/assets/7225802/dd90ead1-4f1b-400b-a69e-0dd086316763)
- [ ] edit: discarded, not worth the complexity. ~Use JSDoc as the source of truth for the deprecation message in markdown-generated pages, too, so it would work in all markdown-based pages too, like Base pages.~
  - ~Right now, deprecation messages are hardcoded in .md files ([example](https://github.com/mui/material-ui/blob/c34468ef08ac8cd0c99b8ddf1ac1b6633b8c5e05/docs/data/material/components/hidden/hidden.md?plain=1#L11-L14)).~
  - ~It would require some work to include the deprecation alert in the middle of markdown-generated pages since the whole page is rendered as a single markdown block, but definitely doable.~
