### PR TITLE
[docs-infra] Allow JSDoc tags

### DIFF
--- a/docs/translations/api-docs/use-menu-item-context-stabilizer/use-menu-item-context-stabilizer.json
+++ b/docs/translations/api-docs/use-menu-item-context-stabilizer/use-menu-item-context-stabilizer.json
@@ -1,5 +1,5 @@
 {
-  "hookDescription": "Stabilizes the ListContext value for the MenuItem component, so it doesn't change when sibling items update.\n\n@param id The id of the MenuItem. If undefined, it will be generated with useId.\n@returns The stable ListContext value and the id of the MenuItem.",
+  "hookDescription": "Stabilizes the ListContext value for the MenuItem component, so it doesn't change when sibling items update.",
   "parametersDescriptions": {},
   "returnValueDescriptions": {}
 }

--- a/docs/translations/api-docs/use-option-context-stabilizer/use-option-context-stabilizer.json
+++ b/docs/translations/api-docs/use-option-context-stabilizer/use-option-context-stabilizer.json
@@ -1,5 +1,5 @@
 {
-  "hookDescription": "Stabilizes the ListContext value for the Option component, so it doesn't change when sibling Options update.\n\n@param value The value of the Option.\n@returns The stable ListContext value.",
+  "hookDescription": "Stabilizes the ListContext value for the Option component, so it doesn't change when sibling Options update.",
   "parametersDescriptions": {},
   "returnValueDescriptions": {}
 }

--- a/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
+++ b/packages/api-docs-builder/ApiBuilders/HookApiBuilder.ts
@@ -8,6 +8,7 @@ import traverse from '@babel/traverse';
 import { defaultHandlers, parse as docgenParse, ReactDocgenApi } from 'react-docgen';
 import kebabCase from 'lodash/kebabCase';
 import upperFirst from 'lodash/upperFirst';
+import { parse as parseDoctrine, Annotation } from 'doctrine';
 import { renderMarkdown } from '@mui/internal-markdown';
 import { ProjectSettings } from '../ProjectSettings';
 import { computeApiDescription } from './ComponentApiBuilder';
@@ -108,7 +109,7 @@ export interface ReactApi extends ReactDocgenApi {
  * *
  * * - [useButton API](https://mui.com/base-ui/api/use-button/)
  */
-async function annotateHookDefinition(api: ReactApi) {
+async function annotateHookDefinition(api: ReactApi, hookJsdoc: Annotation) {
   const HOST = 'https://mui.com';
 
   const typesFilename = api.filename.replace(/\.js$/, '.d.ts');
@@ -284,6 +285,14 @@ async function annotateHookDefinition(api: ReactApi) {
       api.apiPathname.startsWith('http') ? api.apiPathname : `${HOST}${api.apiPathname}`
     })`,
   );
+
+  if (hookJsdoc.tags.length > 0) {
+    markdownLines.push('');
+  }
+
+  hookJsdoc.tags.forEach((tag) => {
+    markdownLines.push(`@${tag.title}${tag.name ? ` ${tag.name} -` : ''} ${tag.description}`);
+  });
 
   const jsdoc = `/**\n${markdownLines
     .map((line) => (line.length > 0 ? ` * ${line}` : ` *`))
@@ -546,6 +555,11 @@ export default async function generateHookApi(
 
   const parameters = await extractInfoFromType(`${upperFirst(name)}Parameters`, project);
   const returnValue = await extractInfoFromType(`${upperFirst(name)}ReturnValue`, project);
+  const hookJsdoc = parseDoctrine(reactApi.description);
+
+  // We override `reactApi.description` with `hookJsdoc.description` because
+  // the former can include JSDoc tags that we don't want to render in the docs.
+  reactApi.description = hookJsdoc.description;
 
   // Ignore what we might have generated in `annotateHookDefinition`
   const annotatedDescriptionMatch = reactApi.description.match(/(Demos|API):\r?\n\r?\n/);
@@ -588,7 +602,7 @@ export default async function generateHookApi(
     await generateApiJson(apiPagesDirectory, reactApi);
 
     // Add comment about demo & api links to the component hook file
-    await annotateHookDefinition(reactApi);
+    await annotateHookDefinition(reactApi, hookJsdoc);
   }
 
   return reactApi;

--- a/packages/mui-base/src/useMenuItem/useMenuItemContextStabilizer.ts
+++ b/packages/mui-base/src/useMenuItem/useMenuItemContextStabilizer.ts
@@ -6,9 +6,6 @@ import { ListContext, ListContextValue, ListItemState } from '../useList';
 /**
  * Stabilizes the ListContext value for the MenuItem component, so it doesn't change when sibling items update.
  *
- * @param id The id of the MenuItem. If undefined, it will be generated with useId.
- * @returns The stable ListContext value and the id of the MenuItem.
- *
  * Demos:
  *
  * - [Menu](https://mui.com/base-ui/react-menu/#hooks)
@@ -16,6 +13,9 @@ import { ListContext, ListContextValue, ListItemState } from '../useList';
  * API:
  *
  * - [useMenuItemContextStabilizer API](https://mui.com/base-ui/react-menu/hooks-api/#use-menu-item-context-stabilizer)
+ *
+ * @param id - The id of the MenuItem. If undefined, it will be generated with useId.
+ * @returns The stable ListContext value and the id of the MenuItem.
  */
 export function useMenuItemContextStabilizer(id: string | undefined) {
   const listContext = React.useContext(ListContext as React.Context<ListContextValue<string>>);

--- a/packages/mui-base/src/useOption/useOptionContextStabilizer.ts
+++ b/packages/mui-base/src/useOption/useOptionContextStabilizer.ts
@@ -5,9 +5,6 @@ import { ListContext, ListContextValue } from '../useList';
 /**
  * Stabilizes the ListContext value for the Option component, so it doesn't change when sibling Options update.
  *
- * @param value The value of the Option.
- * @returns The stable ListContext value.
- *
  * Demos:
  *
  * - [Select](https://mui.com/base-ui/react-select/#hooks)
@@ -15,6 +12,9 @@ import { ListContext, ListContextValue } from '../useList';
  * API:
  *
  * - [useOptionContextStabilizer API](https://mui.com/base-ui/react-select/hooks-api/#use-option-context-stabilizer)
+ *
+ * @param value - The value of the Option.
+ * @returns The stable ListContext value.
  */
 export function useOptionContextStabilizer<OptionValue>(value: OptionValue) {
   const listContext = React.useContext(ListContext as React.Context<ListContextValue<OptionValue>>);

--- a/packages/mui-material/src/Hidden/Hidden.d.ts
+++ b/packages/mui-material/src/Hidden/Hidden.d.ts
@@ -90,6 +90,8 @@ export interface HiddenProps {
  * API:
  *
  * - [Hidden API](https://mui.com/material-ui/api/hidden/)
+ *
+ * @deprecated The Hidden component was deprecated in Material UI v5. To learn more, see [the Hidden section](/material-ui/migration/v5-component-changes/#hidden) of the migration docs.
  */
 declare const Hidden: React.JSXElementConstructor<HiddenProps>;
 

--- a/packages/mui-material/src/Hidden/Hidden.js
+++ b/packages/mui-material/src/Hidden/Hidden.js
@@ -6,6 +6,8 @@ import HiddenCss from './HiddenCss';
 
 /**
  * Responsively hides children based on the selected implementation.
+ *
+ * @deprecated The Hidden component was deprecated in Material UI v5. To learn more, see [the Hidden section](/material-ui/migration/v5-component-changes/#hidden) of the migration docs.
  */
 function Hidden(props) {
   const {


### PR DESCRIPTION
These changes allow JSDoc tags like `@deprecated` to be present in components and hook JSDoc comments without them being displayed in the docs. Before these changes, JSDoc tags would be displayed in the docs.

The benefits to allow JSDoc tags are:
- Consumers get the info right in their IDE e.g. strikethrough styles and info in the popover when using a `@deprecated` API.
  <img width="640" alt="Screenshot 2024-05-22 at 10 12 27" src="https://github.com/mui/material-ui/assets/7225802/f0609db8-bbb6-48b5-a6b9-43d21feadc38">
- We'll be able to use JSDoc tags like `@deprecated` as the source of truth to display deprecation alerts in API pages. Further context [#42280](https://github.com/mui/material-ui/pull/42280)
- We'll be able to use standard JSDoc syntax for things like links to doc pages.