### PR TITLE
[code-infra] Run corepack enable on all CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ commands:
             node scripts/useReactVersion.mjs
             # log a patch for maintainers who want to check out this change
             git --no-pager diff HEAD
+
       - when:
           condition: << parameters.browsers >>
           steps:
@@ -93,6 +94,13 @@ commands:
                 name: Restore playwright cache
                 keys:
                   - v6-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
+      - when:
+          condition:
+            not: << parameters.browsers >>
+          steps:
+            # See https://stackoverflow.com/a/73411601
+            - run: corepack enable --install-directory ~/bin
+
       - run:
           name: View install environment
           command: |

--- a/package.json
+++ b/package.json
@@ -184,6 +184,9 @@
     "yargs": "^17.7.2"
   },
   "packageManager": "pnpm@8.15.8",
+  "engines": {
+    "pnpm": "8.15.8"
+  },
   "resolutions": {
     "@babel/core": "^7.24.5",
     "@babel/code-frame": "^7.24.2",


### PR DESCRIPTION
Looks like circleci updated their images with pnpm 9. This seems to break the checkout as the lockfile changes:

* Run `corepack enable` every time
* Prevent installing with the wrong package manager