### PR TITLE
Fix highlighted index doesn't get reset if options length is unchange…

### DIFF
--- a/packages/mui-base/src/useAutocomplete/useAutocomplete.js
+++ b/packages/mui-base/src/useAutocomplete/useAutocomplete.js
@@ -567,7 +567,7 @@ export function useAutocomplete(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     // Only sync the highlighted index when the option switch between empty and not
-    filteredOptions.length,
+    filteredOptions,
     // Don't sync the highlighted index with the value when multiple
     // eslint-disable-next-line react-hooks/exhaustive-deps
     multiple ? false : value,


### PR DESCRIPTION
…d (mui#40184)

The bug was that when the box had a limit, after selecting an option and pressing enter if I used the down arrow key the selected option wouldn't be the first one as expected. The bug came from the "filteredOptions.length" dependency in "syncHighlightedIndex" because as the list had a limit smaller than the total number of options, when an option was selected the size of the list didn't change. For the same reason, the "syncHighlightedIndex" function wasn't called and the index wasn't reset. To solve the bug, I changed the "filteredOptions.length" dependency to "filteredOptions", so that whenever there is a change in the "filteredOptions" list, such as removing an element, the function will be called and the index reset.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
