### PR TITLE
[core] Remove `WyW-in-JS` from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,6 @@
       "matchPackagePatterns": "@emotion/*"
     },
     {
-      "groupName": "WyW-in-JS",
-      "matchPackagePatterns": ["@wyw-in-js/*"]
-    },
-    {
       "groupName": "Font awesome SVG icons",
       "matchPackagePatterns": "@fortawesome/*"
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

It is used by Pigment CSS.
