### PR TITLE
[core] Remove `@types/prettier` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "@types/lodash": "^4.17.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.19.33",
-    "@types/prettier": "^2.7.3",
     "@types/react": "^18.2.55",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/packages-internal/scripts/package.json
+++ b/packages-internal/scripts/package.json
@@ -43,7 +43,6 @@
     "@types/doctrine": "^0.0.9",
     "@types/lodash": "^4.17.4",
     "@types/node": "^18.19.33",
-    "@types/prettier": "^2.7.3",
     "@types/react": "^18.2.55",
     "@types/uuid": "^9.0.8",
     "chai": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,9 +125,6 @@ importers:
       '@types/node':
         specifier: ^18.19.33
         version: 18.19.33
-      '@types/prettier':
-        specifier: ^2.7.3
-        version: 2.7.3
       '@types/react':
         specifier: 18.2.55
         version: 18.2.55
@@ -966,9 +963,6 @@ importers:
       '@types/node':
         specifier: ^18.19.33
         version: 18.19.33
-      '@types/prettier':
-        specifier: ^2.7.3
-        version: 2.7.3
       '@types/react':
         specifier: 18.2.55
         version: 18.2.55
@@ -8103,10 +8097,6 @@ packages:
 
   /@types/parse-json@4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
-
-  /@types/prettier@2.7.3:
-    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
-    dev: true
 
   /@types/promise.allsettled@1.0.3:
     resolution: {integrity: sha512-b/IFHHTkYkTqu41IH9UtpICwqrpKj2oNlb4KHPzFQDMiz+h1BgAeATeO0/XTph4+UkH9W2U0E4B4j64KWOovag==}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Read [here](https://app.renovatebot.com/package-diff?name=@types%2fprettier&from=2.7.3&to=3.0.0) that prettier provides it's own type definitions in the new version.

Closes #42297