### PR TITLE
[website] Fix hero spacing changes applying at the wrong breakpoint

### DIFF
--- a/docs/src/layouts/HeroContainer.tsx
+++ b/docs/src/layouts/HeroContainer.tsx
@@ -138,8 +138,8 @@ export default function HeroContainer(props: HeroContainerProps) {
     <Box sx={{ overflow: 'hidden' }}>
       <Container
         sx={{
-          pt: { xs: 8, sm: 0 },
-          minHeight: { xs: 'auto', sm: 500 },
+          pt: { xs: 8, md: 0 },
+          minHeight: { xs: 'auto', md: 500 },
           height: { md: 'calc(100vh - 120px)' },
           maxHeight: { md: 700, xl: 850 },
           transition: '0.3s',


### PR DESCRIPTION
Looks like the min-height and padding-top were supposed to be applied at the `md` breakpoint instead of `sm`. 

| Before | After |
| --- | --- |
| ![mui com_](https://github.com/mui/material-ui/assets/9557798/c414df45-9b21-4bde-b3ff-bed0aa0feb66) | ![localhost_3000_](https://github.com/mui/material-ui/assets/9557798/61d84527-805e-4578-bec4-b7395f4281cc) |

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
