### PR TITLE
[test] Remove `userAgent` override in `jsdom` env

### DIFF
--- a/packages/mui-material/src/Tabs/Tabs.test.js
+++ b/packages/mui-material/src/Tabs/Tabs.test.js
@@ -46,7 +46,7 @@ function hasRightScrollButton(container) {
 
 describe('<Tabs />', () => {
   // tests mocking getBoundingClientRect prevent mocha to exit
-  const isJSDOM = navigator.userAgent === 'node.js';
+  const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
   const { clock, render, renderToString } = createRenderer();
 

--- a/packages/mui-material/src/internal/animate.test.js
+++ b/packages/mui-material/src/internal/animate.test.js
@@ -6,7 +6,7 @@ describe('animate', () => {
 
   before(function beforeHook() {
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    const isJSDOM = navigator.userAgent === 'node.js';
+    const isJSDOM = /jsdom/.test(window.navigator.userAgent);
     if (isJSDOM || isSafari) {
       // The test fails on Safari with just:
       //

--- a/packages/test-utils/src/createDOM.js
+++ b/packages/test-utils/src/createDOM.js
@@ -54,10 +54,6 @@ function createDOM() {
   }
   global.window.Touch = Touch;
 
-  global.navigator = {
-    userAgent: 'node.js',
-  };
-
   Object.keys(dom.window)
     .filter((key) => !blacklist.includes(key))
     .concat(whitelist)


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/pull/13191/files#r1610484570

`window.navigator.userAgent` and `navigator.userAgent` should be equal.