### PR TITLE
[material-ui][TextField] Fix ownerState silent propagation

### DIFF
--- a/packages/mui-material/src/FilledInput/FilledInput.js
+++ b/packages/mui-material/src/FilledInput/FilledInput.js
@@ -287,6 +287,9 @@ const FilledInput = React.forwardRef(function FilledInput(inProps, ref) {
     type,
   };
 
+  // https://github.com/mui/material-ui/issues/42184
+  delete ownerState.ownerState;
+
   const classes = useUtilityClasses(props);
   const filledInputComponentsProps = { root: { ownerState }, input: { ownerState } };
 

--- a/packages/mui-material/src/InputBase/InputBase.js
+++ b/packages/mui-material/src/InputBase/InputBase.js
@@ -525,6 +525,9 @@ const InputBase = React.forwardRef(function InputBase(inProps, ref) {
     type,
   };
 
+  // https://github.com/mui/material-ui/issues/42184
+  delete ownerState.ownerState;
+
   const classes = useUtilityClasses(ownerState);
 
   const Root = slots.root || components.Root || InputBaseRoot;

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -206,6 +206,9 @@ const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {
     focused: fcs.focused,
   };
 
+  // https://github.com/mui/material-ui/issues/42184
+  delete ownerState.ownerState;
+
   const classes = useUtilityClasses(ownerState);
 
   return (


### PR DESCRIPTION
This is a symptom of https://github.com/mui/material-ui/issues/42184. Fixes #42391

Introduced due to https://github.com/mui/material-ui/pull/42001 and https://github.com/mui/material-ui/pull/42062 being merged in parallel without testing them together. I think this is why Argos didn't catch it.

## Bug
https://next.mui.com/material-ui/react-text-field/

<img width="400" alt="Screenshot 2024-05-22 at 15 48 41" src="https://github.com/mui/material-ui/assets/16889233/d97cb69d-5c79-4e9c-8ce5-9294d837ff36">

<img width="400" alt="Screenshot 2024-05-22 at 15 48 22" src="https://github.com/mui/material-ui/assets/16889233/74cc2b03-a09f-4b49-9272-aedd33c6be37">

## Fix

**PR preview**: Waiting for PR deploy

**Benchmark**: https://mui.com/material-ui/react-text-field/

## Notes

The TextField's intricate `ownerState` scheme is hard to track and maintain. There are probably bugs similar to these that we didn't catch.

