### PR TITLE
[core] Apply React 19 type changes that don't require upcoming `@types/` packages

### DIFF
--- a/apps/local-ui-lib/index.d.ts
+++ b/apps/local-ui-lib/index.d.ts
@@ -1,6 +1,8 @@
+import * as React from "react";
+
 export const bounceAnim: string;
 export const Button: React.ComponentType<
-  JSX.IntrinsicElements['button'] & {
+  React.JSX.IntrinsicElements['button'] & {
     isRed?: boolean;
     sx?: unknown;
   }

--- a/apps/local-ui-lib/index.d.ts
+++ b/apps/local-ui-lib/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 
 export const bounceAnim: string;
 export const Button: React.ComponentType<

--- a/docs/data/base/components/modal/SpringModal.tsx
+++ b/docs/data/base/components/modal/SpringModal.tsx
@@ -37,7 +37,7 @@ export default function SpringModal() {
 
 const Backdrop = React.forwardRef<
   HTMLDivElement,
-  { children: React.ReactElement; open: boolean }
+  { children: React.ReactElement<any>; open: boolean }
 >((props, ref) => {
   const { open, ...other } = props;
   return <Fade ref={ref} in={open} {...other} />;
@@ -61,7 +61,7 @@ const StyledBackdrop = styled(Backdrop)`
 `;
 
 interface FadeProps {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   in?: boolean;
   onClick?: any;
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void;

--- a/docs/data/base/components/modal/UseModal.tsx
+++ b/docs/data/base/components/modal/UseModal.tsx
@@ -39,7 +39,7 @@ export default function UseModal() {
 }
 
 interface ModalProps {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   closeAfterTransition?: boolean;
   container?: Element | (() => Element | null) | null;
   disableAutoFocus?: boolean;

--- a/docs/data/base/components/popper/PlacementPopper.tsx
+++ b/docs/data/base/components/popper/PlacementPopper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Popper, PopperPlacementType } from '@mui/base/Popper';
 
-function Radio({ value, ...props }: JSX.IntrinsicElements['input']) {
+function Radio({ value, ...props }: React.JSX.IntrinsicElements['input']) {
   return (
     <span>
       <input

--- a/docs/data/base/components/popup/Placement.tsx
+++ b/docs/data/base/components/popup/Placement.tsx
@@ -5,7 +5,7 @@ import {
 } from '@mui/base/Unstable_Popup';
 import { styled, css, Theme } from '@mui/system';
 
-function Radio({ value, ...props }: JSX.IntrinsicElements['input']) {
+function Radio({ value, ...props }: React.JSX.IntrinsicElements['input']) {
   return (
     <span>
       <input

--- a/docs/data/base/components/select/UnstyledSelectBasic/system/index.tsx
+++ b/docs/data/base/components/select/UnstyledSelectBasic/system/index.tsx
@@ -23,7 +23,7 @@ const Select = React.forwardRef(function Select<
   return <BaseSelect {...props} ref={ref} slots={slots} />;
 }) as <TValue extends {}, Multiple extends boolean>(
   props: SelectProps<TValue, Multiple> & React.RefAttributes<HTMLButtonElement>,
-) => JSX.Element;
+) => React.JSX.Element;
 
 export default function UnstyledSelectBasic() {
   return (

--- a/docs/data/base/components/select/UnstyledSelectForm.tsx
+++ b/docs/data/base/components/select/UnstyledSelectForm.tsx
@@ -47,7 +47,7 @@ const Select = React.forwardRef(function CustomSelect<
   return <BaseSelect {...props} ref={ref} slots={slots} />;
 }) as <TValue extends {}, Multiple extends boolean>(
   props: SelectProps<TValue, Multiple> & React.RefAttributes<HTMLButtonElement>,
-) => JSX.Element;
+) => React.JSX.Element;
 
 const blue = {
   100: '#DAECFF',

--- a/docs/data/base/components/slider/DiscreteSlider.tsx
+++ b/docs/data/base/components/slider/DiscreteSlider.tsx
@@ -21,7 +21,7 @@ export default function DiscreteSlider() {
 }
 
 interface SliderValueLabelProps {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
 }
 
 function SliderValueLabel({ children }: SliderValueLabelProps) {

--- a/docs/data/base/components/slider/LabeledValuesSlider.tsx
+++ b/docs/data/base/components/slider/LabeledValuesSlider.tsx
@@ -11,7 +11,7 @@ export default function LabeledValuesSlider() {
 }
 
 interface SliderValueLabelProps {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
 }
 
 function SliderValueLabel({ children }: SliderValueLabelProps) {

--- a/docs/data/base/components/transitions/ReactTransitionGroup.tsx
+++ b/docs/data/base/components/transitions/ReactTransitionGroup.tsx
@@ -115,7 +115,7 @@ function PopupWithTrigger(props: PopupProps) {
   );
 }
 
-function MaterialUITransitionAdapter(props: { children: React.ReactElement }) {
+function MaterialUITransitionAdapter(props: { children: React.ReactElement<any> }) {
   const { requestedEnter, onExited } = useTransitionStateManager();
   const { children } = props;
 

--- a/docs/data/base/getting-started/accessibility/KeyboardNavigation.tsx
+++ b/docs/data/base/getting-started/accessibility/KeyboardNavigation.tsx
@@ -54,7 +54,7 @@ const Select = React.forwardRef(function Select<
   return <BaseSelect {...props} ref={ref} slots={slots} />;
 }) as <TValue extends {}, Multiple extends boolean>(
   props: SelectProps<TValue, Multiple> & React.RefAttributes<HTMLButtonElement>,
-) => JSX.Element;
+) => React.JSX.Element;
 
 const SelectButton = React.forwardRef(function SelectButton<
   TValue extends {},

--- a/docs/data/joy/components/alert/AlertVariousStates.tsx
+++ b/docs/data/joy/components/alert/AlertVariousStates.tsx
@@ -14,7 +14,7 @@ export default function AlertVariousStates() {
   const items: {
     title: string;
     color: ColorPaletteProp;
-    icon: React.ReactElement;
+    icon: React.ReactElement<any>;
   }[] = [
     { title: 'Success', color: 'success', icon: <CheckCircleIcon /> },
     { title: 'Warning', color: 'warning', icon: <WarningIcon /> },

--- a/docs/data/joy/components/autocomplete/AutocompleteHint.tsx
+++ b/docs/data/joy/components/autocomplete/AutocompleteHint.tsx
@@ -12,7 +12,7 @@ const StyledDiv = styled('div')({
 });
 
 type WrapperProps = {
-  children: JSX.Element;
+  children: React.JSX.Element;
   hint: string;
 };
 

--- a/docs/data/joy/components/autocomplete/Virtualize.tsx
+++ b/docs/data/joy/components/autocomplete/Virtualize.tsx
@@ -66,7 +66,7 @@ const ListboxComponent = React.forwardRef<
   const { children, anchorEl, open, modifiers, ...other } = props;
   const itemData: Array<any> = [];
   (
-    children as [Array<{ children: Array<React.ReactElement> | undefined }>]
+    children as [Array<{ children: Array<React.ReactElement<any>> | undefined }>]
   )[0].forEach((item) => {
     if (item) {
       itemData.push(item);

--- a/docs/data/joy/components/input/FloatingLabelInput.tsx
+++ b/docs/data/joy/components/input/FloatingLabelInput.tsx
@@ -56,7 +56,7 @@ const StyledLabel = styled('label')(({ theme }) => ({
 
 const InnerInput = React.forwardRef<
   HTMLInputElement,
-  JSX.IntrinsicElements['input']
+  React.JSX.IntrinsicElements['input']
 >(function InnerInput(props, ref) {
   const id = React.useId();
   return (

--- a/docs/data/joy/components/menu/MenuIconSideNavExample.tsx
+++ b/docs/data/joy/components/menu/MenuIconSideNavExample.tsx
@@ -15,7 +15,7 @@ import MenuButton from '@mui/joy/MenuButton';
 // https://popper.js.org/docs/v2/modifiers/offset/
 interface MenuButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  menu: React.ReactElement;
+  menu: React.ReactElement<any>;
   open: boolean;
   onOpen: (
     event?:

--- a/docs/data/joy/components/menu/MenuToolbarExample.tsx
+++ b/docs/data/joy/components/menu/MenuToolbarExample.tsx
@@ -13,7 +13,7 @@ import { Theme } from '@mui/joy';
 type MenuBarButtonProps = Pick<DropdownProps, 'children' | 'open'> & {
   onOpen: DropdownProps['onOpenChange'];
   onKeyDown: React.KeyboardEventHandler;
-  menu: JSX.Element;
+  menu: React.JSX.Element;
   onMouseEnter: React.MouseEventHandler;
 };
 

--- a/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx
+++ b/docs/data/joy/components/textarea/FloatingLabelTextarea.tsx
@@ -48,7 +48,7 @@ const StyledLabel = styled('label')(({ theme }) => ({
 
 const InnerTextarea = React.forwardRef<
   HTMLTextAreaElement,
-  JSX.IntrinsicElements['textarea']
+  React.JSX.IntrinsicElements['textarea']
 >(function InnerTextarea(props, ref) {
   const id = React.useId();
   return (

--- a/docs/data/joy/getting-started/templates/files/components/Menu.tsx
+++ b/docs/data/joy/getting-started/templates/files/components/Menu.tsx
@@ -4,7 +4,7 @@ import MenuItem from '@mui/joy/MenuItem';
 import { ListActionTypes } from '@mui/base/useList';
 
 export default function Menu(props: {
-  control: React.ReactElement;
+  control: React.ReactElement<any>;
   id: string;
   menus: Array<{ label: string } & { [k: string]: any }>;
 }) {

--- a/docs/data/joy/getting-started/templates/profile-dashboard/components/DropZone.tsx
+++ b/docs/data/joy/getting-started/templates/profile-dashboard/components/DropZone.tsx
@@ -7,7 +7,9 @@ import AspectRatio from '@mui/joy/AspectRatio';
 
 import FileUploadRoundedIcon from '@mui/icons-material/FileUploadRounded';
 
-export default function DropZone(props: CardProps & { icon?: React.ReactElement }) {
+export default function DropZone(
+  props: CardProps & { icon?: React.ReactElement<any> },
+) {
   const { icon, sx, ...other } = props;
   return (
     <Card

--- a/docs/data/joy/getting-started/templates/profile-dashboard/components/FileUpload.tsx
+++ b/docs/data/joy/getting-started/templates/profile-dashboard/components/FileUpload.tsx
@@ -13,7 +13,7 @@ import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutl
 
 export default function FileUpload(
   props: CardProps & {
-    icon?: React.ReactElement;
+    icon?: React.ReactElement<any>;
     fileName: string;
     fileSize: string;
     progress: number;

--- a/docs/data/material/components/app-bar/BackToTop.tsx
+++ b/docs/data/material/components/app-bar/BackToTop.tsx
@@ -16,7 +16,7 @@ interface Props {
    * You won't need it on your project.
    */
   window?: () => Window;
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
 }
 
 function ScrollTop(props: Props) {

--- a/docs/data/material/components/app-bar/ElevateAppBar.tsx
+++ b/docs/data/material/components/app-bar/ElevateAppBar.tsx
@@ -13,7 +13,7 @@ interface Props {
    * You won't need it on your project.
    */
   window?: () => Window;
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
 }
 
 function ElevationScroll(props: Props) {

--- a/docs/data/material/components/app-bar/HideAppBar.tsx
+++ b/docs/data/material/components/app-bar/HideAppBar.tsx
@@ -14,7 +14,7 @@ interface Props {
    * You won't need it on your project.
    */
   window?: () => Window;
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
 }
 
 function HideOnScroll(props: Props) {

--- a/docs/data/material/components/autocomplete/Virtualize.tsx
+++ b/docs/data/material/components/autocomplete/Virtualize.tsx
@@ -56,9 +56,9 @@ const ListboxComponent = React.forwardRef<
   React.HTMLAttributes<HTMLElement>
 >(function ListboxComponent(props, ref) {
   const { children, ...other } = props;
-  const itemData: React.ReactElement[] = [];
-  (children as React.ReactElement[]).forEach(
-    (item: React.ReactElement & { children?: React.ReactElement[] }) => {
+  const itemData: React.ReactElement<any>[] = [];
+  (children as React.ReactElement<any>[]).forEach(
+    (item: React.ReactElement<any> & { children?: React.ReactElement<any>[] }) => {
       itemData.push(item);
       itemData.push(...(item.children || []));
     },
@@ -71,7 +71,7 @@ const ListboxComponent = React.forwardRef<
   const itemCount = itemData.length;
   const itemSize = smUp ? 36 : 48;
 
-  const getChildSize = (child: React.ReactElement) => {
+  const getChildSize = (child: React.ReactElement<any>) => {
     if (child.hasOwnProperty('group')) {
       return 48;
     }

--- a/docs/data/material/components/dialogs/FullScreenDialog.tsx
+++ b/docs/data/material/components/dialogs/FullScreenDialog.tsx
@@ -15,7 +15,7 @@ import { TransitionProps } from '@mui/material/transitions';
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
-    children: React.ReactElement;
+    children: React.ReactElement<any>;
   },
   ref: React.Ref<unknown>,
 ) {

--- a/docs/data/material/components/lists/InteractiveList.tsx
+++ b/docs/data/material/components/lists/InteractiveList.tsx
@@ -16,7 +16,7 @@ import Typography from '@mui/material/Typography';
 import FolderIcon from '@mui/icons-material/Folder';
 import DeleteIcon from '@mui/icons-material/Delete';
 
-function generate(element: React.ReactElement) {
+function generate(element: React.ReactElement<any>) {
   return [0, 1, 2].map((value) =>
     React.cloneElement(element, {
       key: value,

--- a/docs/data/material/components/modal/SpringModal.tsx
+++ b/docs/data/material/components/modal/SpringModal.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography';
 import { useSpring, animated } from '@react-spring/web';
 
 interface FadeProps {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   in?: boolean;
   onClick?: any;
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void;

--- a/docs/data/material/components/popper/SpringPopper.tsx
+++ b/docs/data/material/components/popper/SpringPopper.tsx
@@ -4,7 +4,7 @@ import Popper from '@mui/material/Popper';
 import { useSpring, animated } from '@react-spring/web';
 
 interface FadeProps {
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
   in?: boolean;
   onEnter?: () => void;
   onExited?: () => void;

--- a/docs/data/material/components/rating/RadioGroupRating.tsx
+++ b/docs/data/material/components/rating/RadioGroupRating.tsx
@@ -15,7 +15,7 @@ const StyledRating = styled(Rating)(({ theme }) => ({
 
 const customIcons: {
   [index: string]: {
-    icon: React.ReactElement;
+    icon: React.ReactElement<any>;
     label: string;
   };
 } = {

--- a/docs/data/material/components/steppers/CustomizedSteppers.tsx
+++ b/docs/data/material/components/steppers/CustomizedSteppers.tsx
@@ -122,7 +122,7 @@ const ColorlibStepIconRoot = styled('div')<{
 function ColorlibStepIcon(props: StepIconProps) {
   const { active, completed, className } = props;
 
-  const icons: { [index: string]: React.ReactElement } = {
+  const icons: { [index: string]: React.ReactElement<any> } = {
     1: <SettingsIcon />,
     2: <GroupAddIcon />,
     3: <VideoLabelIcon />,

--- a/docs/data/material/integrations/routing/ListRouter.tsx
+++ b/docs/data/material/integrations/routing/ListRouter.tsx
@@ -33,7 +33,7 @@ function Router(props: { children?: React.ReactNode }) {
 }
 
 interface ListItemLinkProps {
-  icon?: React.ReactElement;
+  icon?: React.ReactElement<any>;
   primary: string;
   to: string;
 }

--- a/docs/pages/base-ui/api/use-modal.json
+++ b/docs/pages/base-ui/api/use-modal.json
@@ -2,8 +2,8 @@
   "parameters": {
     "children": {
       "type": {
-        "name": "React.ReactElement | undefined | null",
-        "description": "React.ReactElement | undefined | null"
+        "name": "React.ReactElement&lt;any&gt; | undefined | null",
+        "description": "React.ReactElement&lt;any&gt; | undefined | null"
       },
       "required": true
     },

--- a/docs/src/components/about/HowToSupport.tsx
+++ b/docs/src/components/about/HowToSupport.tsx
@@ -21,7 +21,7 @@ function Widget({
 }: {
   children: React.ReactNode;
   title: string;
-  icon: React.ReactElement;
+  icon: React.ReactElement<any>;
 }) {
   return (
     <Paper

--- a/docs/src/components/action/StylingInfo.tsx
+++ b/docs/src/components/action/StylingInfo.tsx
@@ -12,7 +12,7 @@ export default function StylingInfo({
   appeared,
   stylingContent,
   ...props
-}: { appeared: boolean; stylingContent?: React.ReactElement } & BoxProps) {
+}: { appeared: boolean; stylingContent?: React.ReactElement<any> } & BoxProps) {
   const [hidden, setHidden] = React.useState(false);
   const defaultContent = (
     <React.Fragment>

--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -75,7 +75,7 @@ const PRODUCT_IDS = [
 ];
 
 type ProductSubMenuProps = {
-  icon: React.ReactElement;
+  icon: React.ReactElement<any>;
   name: React.ReactNode;
   description: React.ReactNode;
   chip?: React.ReactNode;

--- a/docs/src/components/header/HeaderNavBar.tsx
+++ b/docs/src/components/header/HeaderNavBar.tsx
@@ -80,7 +80,7 @@ type ProductSubMenuProps = {
   description: React.ReactNode;
   chip?: React.ReactNode;
   href: string;
-} & Omit<JSX.IntrinsicElements['a'], 'ref'>;
+} & Omit<React.JSX.IntrinsicElements['a'], 'ref'>;
 
 const ProductSubMenu = React.forwardRef<HTMLAnchorElement, ProductSubMenuProps>(
   function ProductSubMenu({ icon, name, description, chip, href, ...props }, ref) {

--- a/docs/src/components/home/MaterialDesignComponents.tsx
+++ b/docs/src/components/home/MaterialDesignComponents.tsx
@@ -125,7 +125,7 @@ function Demo({
 }: {
   name: string;
   theme: Theme | undefined;
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   control?: { prop: string; values: Array<string>; defaultValue?: string };
 }) {
   const [propValue, setPropValue] = React.useState(

--- a/docs/src/components/home/StoreTemplatesBanner.tsx
+++ b/docs/src/components/home/StoreTemplatesBanner.tsx
@@ -100,7 +100,7 @@ const StoreTemplateLink = React.forwardRef<
 
 const StoreTemplateImage = React.forwardRef<
   HTMLImageElement,
-  { brand: TemplateBrand } & Omit<JSX.IntrinsicElements['img'], 'ref'>
+  { brand: TemplateBrand } & Omit<React.JSX.IntrinsicElements['img'], 'ref'>
 >(function StoreTemplateImage({ brand, ...props }, ref) {
   return (
     <Image

--- a/docs/src/components/home/UserFeedbacks.tsx
+++ b/docs/src/components/home/UserFeedbacks.tsx
@@ -95,7 +95,7 @@ function Feedback({
     avatarSrcSet: string;
     name: string;
     role: string;
-    company?: React.ReactElement;
+    company?: React.ReactElement<any>;
   };
 }) {
   return (

--- a/docs/src/components/icon/IconImage.tsx
+++ b/docs/src/components/icon/IconImage.tsx
@@ -40,7 +40,7 @@ export type IconImageProps = {
   mode?: '' | 'light' | 'dark';
   sx?: SxProps<Theme>;
   width?: number;
-} & Omit<JSX.IntrinsicElements['img'], 'ref'>;
+} & Omit<React.JSX.IntrinsicElements['img'], 'ref'>;
 
 const Img = styled('img')({ display: 'inline-block', verticalAlign: 'bottom' });
 

--- a/docs/src/components/pricing/PricingTable.tsx
+++ b/docs/src/components/pricing/PricingTable.tsx
@@ -382,7 +382,11 @@ function Cell({ highlighted = false, ...props }: BoxProps & { highlighted?: bool
   );
 }
 
-function RowHead({ children, startIcon, ...props }: BoxProps & { startIcon?: React.ReactElement }) {
+function RowHead({
+  children,
+  startIcon,
+  ...props
+}: BoxProps & { startIcon?: React.ReactElement<any> }) {
   return (
     <Box
       {...props}

--- a/docs/src/components/productBaseUI/components/BaseInputDemo.tsx
+++ b/docs/src/components/productBaseUI/components/BaseInputDemo.tsx
@@ -95,17 +95,18 @@ const CSS = `.base-Input-root {${fieldStyles}}
 
 .base-Input-input {${inputStyles}}`;
 
-const StyledFloatingLabelInput = React.forwardRef<HTMLInputElement, React.JSX.IntrinsicElements['input']>(
-  function StyledFloatingLabelInput(props, ref) {
-    const id = unstable_useId(props.id);
-    return (
-      <React.Fragment>
-        <StyledInput ref={ref} {...props} id={id} />
-        <label htmlFor={id}>Floating label</label>
-      </React.Fragment>
-    );
-  },
-);
+const StyledFloatingLabelInput = React.forwardRef<
+  HTMLInputElement,
+  React.JSX.IntrinsicElements['input']
+>(function StyledFloatingLabelInput(props, ref) {
+  const id = unstable_useId(props.id);
+  return (
+    <React.Fragment>
+      <StyledInput ref={ref} {...props} id={id} />
+      <label htmlFor={id}>Floating label</label>
+    </React.Fragment>
+  );
+});
 
 const FloatingLabelInput = React.forwardRef<HTMLInputElement, React.JSX.IntrinsicElements['input']>(
   function FloatingLabelInput(props, ref) {

--- a/docs/src/components/productBaseUI/components/BaseInputDemo.tsx
+++ b/docs/src/components/productBaseUI/components/BaseInputDemo.tsx
@@ -95,7 +95,7 @@ const CSS = `.base-Input-root {${fieldStyles}}
 
 .base-Input-input {${inputStyles}}`;
 
-const StyledFloatingLabelInput = React.forwardRef<HTMLInputElement, JSX.IntrinsicElements['input']>(
+const StyledFloatingLabelInput = React.forwardRef<HTMLInputElement, React.JSX.IntrinsicElements['input']>(
   function StyledFloatingLabelInput(props, ref) {
     const id = unstable_useId(props.id);
     return (
@@ -107,7 +107,7 @@ const StyledFloatingLabelInput = React.forwardRef<HTMLInputElement, JSX.Intrinsi
   },
 );
 
-const FloatingLabelInput = React.forwardRef<HTMLInputElement, JSX.IntrinsicElements['input']>(
+const FloatingLabelInput = React.forwardRef<HTMLInputElement, React.JSX.IntrinsicElements['input']>(
   function FloatingLabelInput(props, ref) {
     const id = unstable_useId(props.id);
     return (
@@ -121,7 +121,7 @@ const FloatingLabelInput = React.forwardRef<HTMLInputElement, JSX.IntrinsicEleme
 
 const TailwindFloatingLabelInput = React.forwardRef<
   HTMLInputElement,
-  JSX.IntrinsicElements['input']
+  React.JSX.IntrinsicElements['input']
   // @ts-ignore
 >(function TailwindFloatingLabelInput({ ownerState, ...props }, ref) {
   const id = unstable_useId(props.id);
@@ -192,7 +192,7 @@ const Field = styled('div')\`${fieldStyles}\`;
 const StyledInput = styled('input')\`${inputStyles}/\`;
 
 const FloatingLabelInput = React.forwardRef<
-  HTMLInputElement, JSX.IntrinsicElements['input']
+  HTMLInputElement, React.JSX.IntrinsicElements['input']
 >(
   function FloatingLabelInput(props, ref) {
     const id = unstable_useId(props.id);
@@ -219,7 +219,7 @@ const FloatingLabelInput = React.forwardRef<
 import './styles.css';
 
 const FloatingLabelInput = React.forwardRef<
-  HTMLInputElement, JSX.IntrinsicElements['input']
+  HTMLInputElement, React.JSX.IntrinsicElements['input']
 >(
   function FloatingLabelInput(props, ref) {
     const id = unstable_useId(props.id);

--- a/docs/src/components/productX/XRoadmap.tsx
+++ b/docs/src/components/productX/XRoadmap.tsx
@@ -41,7 +41,7 @@ function RoadmapStatusDot({ color }: RoadmapStatusDotProps) {
 }
 
 export default function XRoadmap() {
-  function renderList(content: React.ReactElement, nested?: boolean) {
+  function renderList(content: React.ReactElement<any>, nested?: boolean) {
     return (
       <Box
         sx={{

--- a/docs/src/components/showcase/ViewToggleButton.tsx
+++ b/docs/src/components/showcase/ViewToggleButton.tsx
@@ -11,7 +11,7 @@ const views = ['quilt', 'module', 'agenda', 'week', 'sidebar'] as const;
 
 type View = (typeof views)[number];
 
-const viewIcons: Record<View, React.ReactElement> = {
+const viewIcons: Record<View, React.ReactElement<any>> = {
   quilt: <ViewQuiltRounded />,
   module: <ViewModuleRounded />,
   agenda: <ViewAgendaRounded />,

--- a/docs/src/components/typography/SectionHeadline.tsx
+++ b/docs/src/components/typography/SectionHeadline.tsx
@@ -11,7 +11,7 @@ interface SectionHeadlineProps {
    */
   inverted?: boolean;
   overline?: React.ReactNode;
-  title: string | React.ReactElement;
+  title: string | React.ReactElement<any>;
 }
 
 export default function SectionHeadline(props: SectionHeadlineProps) {

--- a/docs/src/layouts/HeroContainer.tsx
+++ b/docs/src/layouts/HeroContainer.tsx
@@ -8,9 +8,9 @@ import { alpha } from '@mui/material/styles';
 interface HeroContainerProps {
   disableMobileHidden?: boolean;
   disableTabExclusion?: boolean;
-  left: React.ReactElement;
+  left: React.ReactElement<any>;
   linearGradient?: boolean;
-  right: React.ReactElement;
+  right: React.ReactElement<any>;
   rightSx?: BoxProps['sx'];
 }
 

--- a/docs/src/modules/components/JoyThemeBuilder.tsx
+++ b/docs/src/modules/components/JoyThemeBuilder.tsx
@@ -1037,7 +1037,6 @@ function GlobalVariantForm({
         Pick the specific primitive color, now in CSS variables form already, to correspond to a
         semantic global variant token.
       </Typography>
-
       <Sheet
         variant="outlined"
         sx={{
@@ -1273,7 +1272,7 @@ function getAvailableTokens(colorSchemes: any, colorMode: 'light' | 'dark') {
   return tokens;
 }
 
-function TemplatesDialog({ children, data }: { children: React.ReactElement; data: any }) {
+function TemplatesDialog({ children, data }: { children: React.ReactElement<any>; data: any }) {
   const [open, setOpen] = React.useState(false);
   const { map: templateMap } = sourceJoyTemplates();
   const renderItem = (name: string, item: TemplateData) => {

--- a/docs/src/modules/components/JoyUsageDemo.tsx
+++ b/docs/src/modules/components/JoyUsageDemo.tsx
@@ -165,7 +165,7 @@ interface JoyUsageDemoProps<ComponentProps> {
    * A function to override the code block result.
    */
   getCodeBlock?: (code: string, props: ComponentProps) => string;
-  renderDemo: (props: ComponentProps) => React.ReactElement;
+  renderDemo: (props: ComponentProps) => React.ReactElement<any>;
 }
 
 export default function JoyUsageDemo<T extends { [k: string]: any } = {}>({

--- a/docs/src/modules/components/JoyVariablesDemo.tsx
+++ b/docs/src/modules/components/JoyVariablesDemo.tsx
@@ -33,7 +33,7 @@ function formatSx(sx: { [k: string]: string | number }) {
 interface SlotVariablesProps {
   slot: string;
   data: Array<DataItem>;
-  renderField: (item: DataItem) => React.ReactElement;
+  renderField: (item: DataItem) => React.ReactElement<any>;
   defaultOpen?: boolean;
 }
 
@@ -88,7 +88,7 @@ export default function JoyVariablesDemo(props: {
   componentName: string;
   childrenAccepted?: boolean;
   data: Array<DataItem | [string, Array<DataItem>, { defaultOpen?: boolean } | undefined]>;
-  renderDemo: (sx: { [k: string]: string | number }) => React.ReactElement;
+  renderDemo: (sx: { [k: string]: string | number }) => React.ReactElement<any>;
   renderCode?: (formattedSx: string) => string;
 }) {
   const { componentName, data = [], childrenAccepted = false, renderCode } = props;

--- a/docs/src/pages/premium-themes/onepirate/modules/withRoot.tsx
+++ b/docs/src/pages/premium-themes/onepirate/modules/withRoot.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from './theme';
 
-export default function withRoot<P extends JSX.IntrinsicAttributes>(
+export default function withRoot<P extends React.JSX.IntrinsicAttributes>(
   Component: React.ComponentType<P>,
 ) {
   function WithRoot(props: P) {

--- a/docs/types/docs.d.ts
+++ b/docs/types/docs.d.ts
@@ -10,7 +10,7 @@ declare module 'docs/src/modules/components/HighlightedCode' {
      */
     code: string;
     copyButtonHidden?: boolean;
-    copyButtonProps?: JSX.IntrinsicElements['button'];
+    copyButtonProps?: React.JSX.IntrinsicElements['button'];
     /**
      * short identifier of the code language
      * see @mui/internal-markdown/prism for possible languages

--- a/docs/types/docs.d.ts
+++ b/docs/types/docs.d.ts
@@ -23,7 +23,7 @@ declare module 'docs/src/modules/components/HighlightedCode' {
     component?: React.ElementType;
     sx?: object;
   }
-  export default function HighlightedCode(props: Props): React.ReactElement;
+  export default function HighlightedCode(props: Props): React.ReactElement<any>;
 }
 
 declare module 'react-imask';

--- a/packages-internal/scripts/typescript-to-proptypes/test/boolean-values/optional/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/boolean-values/optional/input.d.ts
@@ -4,4 +4,4 @@ type Props = {
   baz?: false;
 };
 
-export default function Foo(props: Props): JSX.Element;
+export default function Foo(props: Props): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/boolean-values/required/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/boolean-values/required/input.d.ts
@@ -4,4 +4,4 @@ type Props = {
   baz: false;
 };
 
-export default function Foo(props: Props): JSX.Element;
+export default function Foo(props: Props): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/code-order/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/code-order/input.d.ts
@@ -4,4 +4,4 @@ export interface Props {
   value: unknown;
 }
 
-export default function Component(props: Props): JSX.Element;
+export default function Component(props: Props): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/default-value/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/default-value/input.d.ts
@@ -6,4 +6,4 @@ interface Props {
   type?: 'button' | 'reset' | 'submit';
 }
 
-export function Foo(props: Props): JSX.Element;
+export function Foo(props: Props): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/generator/html-elements/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/generator/html-elements/input.d.ts
@@ -3,4 +3,4 @@ export function Foo(props: {
   optional?: Element;
   htmlElement: HTMLElement;
   bothTypes: Element | HTMLElement;
-}): JSX.Element;
+}): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/generic/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/generic/input.d.ts
@@ -7,4 +7,4 @@ interface ParentProps<T extends Type> {
 
 interface ChildProps extends ParentProps<'one' | 'two'> {}
 
-export function Foo(props: ChildProps): JSX.Element;
+export function Foo(props: ChildProps): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/getThemeProps/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/getThemeProps/input.d.ts
@@ -1,3 +1,3 @@
 import * as React from 'react';
 
-export default function Modal(props: React.HTMLAttributes<HTMLDivElement>): JSX.Element;
+export default function Modal(props: React.HTMLAttributes<HTMLDivElement>): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/omit-conditional/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/omit-conditional/input.d.ts
@@ -2,4 +2,4 @@ type TextFieldProps<A extends boolean> = A extends true ? { testProp: string } :
 
 type Props<A extends boolean = false> = Omit<TextFieldProps<A>, 'b'>
 
-export function Foo<A extends boolean = false>(props: Props<A>): JSX.Element;
+export function Foo<A extends boolean = false>(props: Props<A>): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/overloaded-function-component/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/overloaded-function-component/input.d.ts
@@ -5,9 +5,9 @@ interface ButtonProps {
 }
 
 interface Component<C extends React.ElementType = 'div'> {
-  (props: ButtonProps): JSX.Element;
-  (props: { component: C } & ButtonProps): JSX.Element;
+  (props: ButtonProps): React.JSX.Element;
+  (props: { component: C } & ButtonProps): React.JSX.Element;
 }
 
 // a component using overloading and intersection of function signature
-declare const ButtonBase: Component & ((props: { href: string } & ButtonProps) => JSX.Element);
+declare const ButtonBase: Component & ((props: { href: string } & ButtonProps) => React.JSX.Element);

--- a/packages-internal/scripts/typescript-to-proptypes/test/partial-any-props/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/partial-any-props/input.d.ts
@@ -2,4 +2,4 @@ type Props = {
   foo: any;
 };
 
-export default function Foo(props: Partial<Props>): JSX.Element;
+export default function Foo(props: Partial<Props>): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/propTypes-casting/input.tsx
+++ b/packages-internal/scripts/typescript-to-proptypes/test/propTypes-casting/input.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 // empty props are likely a mistake.
 // We want to make sure we catch this instead of keeping .propTypes
-export default function Component(props: {}): JSX.Element {
+export default function Component(props: {}): React.JSX.Element {
   return <div />;
 }
 

--- a/packages-internal/scripts/typescript-to-proptypes/test/reconcile-prop-types/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/reconcile-prop-types/input.d.ts
@@ -4,4 +4,4 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export default function Component(props: Props): JSX.Element;
+export default function Component(props: Props): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/sort-unions/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/sort-unions/input.d.ts
@@ -11,4 +11,4 @@ export interface Props {
   only?: Breakpoint | Breakpoint[];
 }
 
-export default function Hidden(props: Props): JSX.Element;
+export default function Hidden(props: Props): React.JSX.Element;

--- a/packages-internal/scripts/typescript-to-proptypes/test/union-props/input.d.ts
+++ b/packages-internal/scripts/typescript-to-proptypes/test/union-props/input.d.ts
@@ -16,4 +16,4 @@ export interface FilledProps extends BaseProps {
 
 export type TextFieldProps = StandardProps | OutlinedProps | FilledProps;
 
-export default function TextField(props: TextFieldProps): JSX.Element;
+export default function TextField(props: TextFieldProps): React.JSX.Element;

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
@@ -70,7 +70,7 @@ export interface ClickAwayListenerProps {
  *
  * - [ClickAwayListener API](https://mui.com/base-ui/react-click-away-listener/components-api/#click-away-listener)
  */
-function ClickAwayListener(props: ClickAwayListenerProps): JSX.Element {
+function ClickAwayListener(props: ClickAwayListenerProps): React.JSX.Element {
   const {
     children,
     disableReactTree = false,

--- a/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/mui-base/src/ClickAwayListener/ClickAwayListener.tsx
@@ -35,7 +35,7 @@ export interface ClickAwayListenerProps {
   /**
    * The wrapped element.
    */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /**
    * If `true`, the React tree is ignored and only the DOM tree is considered.
    * This prop changes how portaled elements are handled.

--- a/packages/mui-base/src/FocusTrap/FocusTrap.tsx
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.tsx
@@ -132,7 +132,7 @@ function defaultIsEnabled(): boolean {
  *
  * - [FocusTrap API](https://mui.com/base-ui/react-focus-trap/components-api/#focus-trap)
  */
-function FocusTrap(props: FocusTrapProps): JSX.Element {
+function FocusTrap(props: FocusTrapProps): React.JSX.Element {
   const {
     children,
     disableAutoFocus = false,

--- a/packages/mui-base/src/FocusTrap/FocusTrap.types.ts
+++ b/packages/mui-base/src/FocusTrap/FocusTrap.types.ts
@@ -24,7 +24,7 @@ export interface FocusTrapProps {
   /**
    * A single child content element.
    */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /**
    * If `true`, the focus trap will not automatically shift focus to itself when it opens, and
    * replace it to the last focused element when it closes.

--- a/packages/mui-base/src/Modal/Modal.types.ts
+++ b/packages/mui-base/src/Modal/Modal.types.ts
@@ -10,7 +10,7 @@ export interface ModalOwnProps {
   /**
    * A single child content element.
    */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /**
    * When set to true the Modal waits until a nested Transition is completed before closing.
    * @default false

--- a/packages/mui-base/src/NoSsr/NoSsr.tsx
+++ b/packages/mui-base/src/NoSsr/NoSsr.tsx
@@ -22,7 +22,7 @@ import { NoSsrProps } from './NoSsr.types';
  *
  * - [NoSsr API](https://mui.com/base-ui/react-no-ssr/components-api/#no-ssr)
  */
-function NoSsr(props: NoSsrProps): JSX.Element {
+function NoSsr(props: NoSsrProps): React.JSX.Element {
   const { children, defer = false, fallback = null } = props;
   const [mountedState, setMountedState] = React.useState(false);
 

--- a/packages/mui-base/src/Option/Option.types.ts
+++ b/packages/mui-base/src/Option/Option.types.ts
@@ -65,7 +65,7 @@ export interface OptionType {
     RootComponentType extends React.ElementType = OptionTypeMap<OptionValue>['defaultComponent'],
   >(
     props: PolymorphicProps<OptionTypeMap<OptionValue>, RootComponentType>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   propTypes?: any;
   displayName?: string | undefined;
 }

--- a/packages/mui-base/src/Select/Select.types.ts
+++ b/packages/mui-base/src/Select/Select.types.ts
@@ -191,7 +191,7 @@ export interface SelectType {
     >['defaultComponent'],
   >(
     props: PolymorphicProps<SelectTypeMap<OptionValue, Multiple>, RootComponentType>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   propTypes?: any;
   displayName?: string | undefined;
 }

--- a/packages/mui-base/src/Snackbar/Snackbar.test.tsx
+++ b/packages/mui-base/src/Snackbar/Snackbar.test.tsx
@@ -17,7 +17,7 @@ describe('<Snackbar />', () => {
    * We have to defer the effect manually like `useEffect` would so we have to flush the effect manually instead of relying on `act()`.
    * React bug: https://github.com/facebook/react/issues/20074
    */
-  function render(...args: [React.ReactElement]) {
+  function render(...args: [React.ReactElement<any>]) {
     const result = clientRender(...args);
     clock.tick(0);
     return result;

--- a/packages/mui-base/src/unstable_useModal/useModal.types.ts
+++ b/packages/mui-base/src/unstable_useModal/useModal.types.ts
@@ -22,7 +22,7 @@ export type UseModalParameters = {
   /**
    * A single child content element.
    */
-  children: React.ReactElement | undefined | null;
+  children: React.ReactElement<any> | undefined | null;
   /**
    * When set to true the Modal waits until a nested Transition is completed before closing.
    * @default false

--- a/packages/mui-base/src/utils/PolymorphicComponent.ts
+++ b/packages/mui-base/src/utils/PolymorphicComponent.ts
@@ -10,7 +10,7 @@ import { DistributiveOmit, OverridableTypeMap } from '@mui/types';
 export type PolymorphicComponent<TypeMap extends OverridableTypeMap> = {
   <RootComponent extends React.ElementType = TypeMap['defaultComponent']>(
     props: PolymorphicProps<TypeMap, RootComponent>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   propTypes?: any;
   displayName?: string | undefined;
 };

--- a/packages/mui-base/src/utils/appendOwnerState.ts
+++ b/packages/mui-base/src/utils/appendOwnerState.ts
@@ -10,7 +10,7 @@ import { isHostComponent } from './isHostComponent';
 type OwnerStateWhenApplicable<ElementType extends React.ElementType, OwnerState> =
   ElementType extends React.ComponentType<any>
     ? OwnerState
-    : ElementType extends keyof JSX.IntrinsicElements
+    : ElementType extends keyof React.JSX.IntrinsicElements
       ? undefined
       : OwnerState | undefined;
 

--- a/packages/mui-base/test/describeConformanceUnstyled.tsx
+++ b/packages/mui-base/test/describeConformanceUnstyled.tsx
@@ -60,7 +60,7 @@ function forEachSlot(
 }
 
 function testPropForwarding(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => UnstyledConformanceOptions,
 ) {
   const {
@@ -110,7 +110,10 @@ function testPropForwarding(
   });
 }
 
-function testSlotsProp(element: React.ReactElement, getOptions: () => UnstyledConformanceOptions) {
+function testSlotsProp(
+  element: React.ReactElement<any>,
+  getOptions: () => UnstyledConformanceOptions,
+) {
   const {
     render,
     slots,
@@ -224,7 +227,7 @@ function testSlotsProp(element: React.ReactElement, getOptions: () => UnstyledCo
 }
 
 function testSlotPropsProp(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => UnstyledConformanceOptions,
 ) {
   const { render, slots } = getOptions();
@@ -271,7 +274,7 @@ interface TestOwnerState {
 }
 
 function testSlotPropsCallbacks(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => UnstyledConformanceOptions,
 ) {
   const { render, slots } = getOptions();
@@ -307,7 +310,7 @@ function testSlotPropsCallbacks(
 }
 
 function testOwnerStatePropagation(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => UnstyledConformanceOptions,
 ) {
   const {
@@ -359,7 +362,7 @@ function testOwnerStatePropagation(
 }
 
 function testDisablingClassGeneration(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => UnstyledConformanceOptions,
 ) {
   const { render } = getOptions();
@@ -394,7 +397,7 @@ const fullSuite = {
 };
 
 function describeConformance(
-  minimalElement: React.ReactElement,
+  minimalElement: React.ReactElement<any>,
   getOptions: () => UnstyledConformanceOptions,
 ) {
   const { after: runAfterHook = () => {}, only = Object.keys(fullSuite), skip = [] } = getOptions();

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -735,7 +735,7 @@ interface AutocompleteComponent {
     FreeSolo extends boolean | undefined = undefined,
   >(
     props: AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
-  ): JSX.Element;
+  ): React.JSX.Element;
   propTypes?: any;
 }
 

--- a/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/mui-joy/src/Breadcrumbs/Breadcrumbs.tsx
@@ -154,7 +154,7 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(inProps, ref) {
   const allItems = (
     React.Children.toArray(children).filter((child) => {
       return React.isValidElement(child);
-    }) as Array<React.ReactElement>
+    }) as Array<React.ReactElement<any>>
   ).map((child, index) => (
     <SlotLi key={`child-${index}`} {...liProps}>
       {isMuiElement(child, ['Typography'])

--- a/packages/mui-joy/src/Button/Button.spec.tsx
+++ b/packages/mui-joy/src/Button/Button.spec.tsx
@@ -47,7 +47,7 @@ function CustomLink({
   children,
   to,
   ...props
-}: React.PropsWithChildren<{ to: string } & Omit<JSX.IntrinsicElements['a'], 'href'>>) {
+}: React.PropsWithChildren<{ to: string } & Omit<React.JSX.IntrinsicElements['a'], 'href'>>) {
   return (
     <a href={to} {...props}>
       {children}

--- a/packages/mui-joy/src/Button/ButtonProps.ts
+++ b/packages/mui-joy/src/Button/ButtonProps.ts
@@ -147,5 +147,5 @@ export interface ButtonOwnerState extends ApplyColorInversion<ButtonProps> {
 
 export type ExtendButton<M extends OverridableTypeMap> = ((
   props: OverrideProps<ExtendButtonTypeMap<M>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendButtonTypeMap<M>>;

--- a/packages/mui-joy/src/IconButton/IconButtonProps.ts
+++ b/packages/mui-joy/src/IconButton/IconButtonProps.ts
@@ -120,5 +120,5 @@ export interface IconButtonOwnerState extends ApplyColorInversion<IconButtonProp
 
 export type ExtendIconButton<M extends OverridableTypeMap> = ((
   props: OverrideProps<ExtendIconButtonTypeMap<M>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendIconButtonTypeMap<M>>;

--- a/packages/mui-joy/src/Link/Link.tsx
+++ b/packages/mui-joy/src/Link/Link.tsx
@@ -292,8 +292,8 @@ const Link = React.forwardRef(function Link(inProps, ref) {
         )}
 
         {isMuiElement(children, ['Skeleton'])
-          ? React.cloneElement(children as React.ReactElement, {
-              variant: (children as React.ReactElement).props.variant || 'inline',
+          ? React.cloneElement(children as React.ReactElement<any>, {
+              variant: (children as React.ReactElement<any>).props.variant || 'inline',
             })
           : children}
         {endDecorator && <SlotEndDecorator {...endDecoratorProps}>{endDecorator}</SlotEndDecorator>}

--- a/packages/mui-joy/src/ListItemButton/ListItemButtonProps.ts
+++ b/packages/mui-joy/src/ListItemButton/ListItemButtonProps.ts
@@ -123,5 +123,5 @@ export interface ListItemButtonOwnerState extends ApplyColorInversion<ListItemBu
 
 export type ExtendListItemButton<M extends OverridableTypeMap> = ((
   props: OverrideProps<ExtendListItemButtonTypeMap<M>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendListItemButtonTypeMap<M>>;

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -26,7 +26,7 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 
 describe('Joy <MenuItem />', () => {
   const { render: baseRender } = createRenderer();
-  const render = (element: JSX.Element, options = {}) =>
+  const render = (element: React.JSX.Element, options = {}) =>
     baseRender(element, {
       wrapper: Wrapper as React.JSXElementConstructor<{ children?: React.ReactNode }>,
       ...options,

--- a/packages/mui-joy/src/MenuItem/MenuItemProps.ts
+++ b/packages/mui-joy/src/MenuItem/MenuItemProps.ts
@@ -50,5 +50,5 @@ export interface MenuItemOwnerState extends ApplyColorInversion<MenuItemProps> {
 
 export type ExtendMenuItem<M extends OverridableTypeMap> = ((
   props: OverrideProps<ExtendMenuItemTypeMap<M>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendMenuItemTypeMap<M>>;

--- a/packages/mui-joy/src/Option/OptionProps.ts
+++ b/packages/mui-joy/src/Option/OptionProps.ts
@@ -48,7 +48,7 @@ export interface OptionTypeMap<P = {}, D extends React.ElementType = 'li'> {
      * A text representation of the option's content.
      * Used for keyboard text navigation matching.
      */
-    label?: string | React.ReactElement;
+    label?: string | React.ReactElement<any>;
     /**
      * The [global variant](https://mui.com/joy-ui/main-features/global-variants/) to use.
      * @default 'plain'

--- a/packages/mui-joy/src/Option/OptionProps.ts
+++ b/packages/mui-joy/src/Option/OptionProps.ts
@@ -100,5 +100,5 @@ export interface OptionOwnerState extends ApplyColorInversion<Omit<OptionProps, 
 
 export type ExtendOption<M extends OverridableTypeMap> = ((
   props: OverrideProps<ExtendOptionTypeMap<M>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendOptionTypeMap<M>>;

--- a/packages/mui-joy/src/Select/Select.tsx
+++ b/packages/mui-joy/src/Select/Select.tsx
@@ -626,12 +626,12 @@ interface SelectComponent {
       component: C;
       multiple?: Multiple;
     } & OverrideProps<SelectTypeMap<OptionValue, Multiple>, C>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   <OptionValue extends {}, Multiple extends boolean = false>(
     props: {
       multiple?: Multiple;
     } & DefaultComponentProps<SelectTypeMap<OptionValue, Multiple>>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   propTypes?: any;
 }
 

--- a/packages/mui-joy/src/Snackbar/Snackbar.test.tsx
+++ b/packages/mui-joy/src/Snackbar/Snackbar.test.tsx
@@ -19,7 +19,7 @@ describe('Joy <Snackbar />', () => {
    * We have to defer the effect manually like `useEffect` would so we have to flush the effect manually instead of relying on `act()`.
    * React bug: https://github.com/facebook/react/issues/20074
    */
-  function render(...args: [React.ReactElement]) {
+  function render(...args: [React.ReactElement<any>]) {
     const result = clientRender(...args);
     clock.tick(0);
     return result;

--- a/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/mui-joy/src/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -193,10 +193,10 @@ interface ToggleButtonGroupComponent {
        */
       component: C;
     } & OverrideProps<ToggleButtonGroupTypeMap<TValue>, C>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   <TValue extends SupportedValue>(
     props: DefaultComponentProps<ToggleButtonGroupTypeMap<TValue>>,
-  ): JSX.Element | null;
+  ): React.JSX.Element | null;
   propTypes?: any;
 }
 

--- a/packages/mui-joy/src/Tooltip/TooltipProps.ts
+++ b/packages/mui-joy/src/Tooltip/TooltipProps.ts
@@ -47,7 +47,7 @@ export interface TooltipTypeMap<P = {}, D extends React.ElementType = 'div'> {
       /**
        * Tooltip reference element.
        */
-      children: React.ReactElement;
+      children: React.ReactElement<any>;
       /**
        * The color of the component. It supports those theme colors that make sense for this component.
        * @default 'neutral'

--- a/packages/mui-joy/src/Typography/Typography.spec.tsx
+++ b/packages/mui-joy/src/Typography/Typography.spec.tsx
@@ -6,7 +6,7 @@ import Typography, { TypographyOwnerState } from '@mui/joy/Typography';
   Text
 </Typography>;
 
-function Link(props: JSX.IntrinsicElements['a']) {
+function Link(props: React.JSX.IntrinsicElements['a']) {
   return <a {...props} />;
 }
 <Typography component={Link} href="/">

--- a/packages/mui-joy/src/Typography/Typography.tsx
+++ b/packages/mui-joy/src/Typography/Typography.tsx
@@ -250,8 +250,8 @@ const Typography = React.forwardRef(function Typography(inProps, ref) {
         )}
 
         {hasSkeleton
-          ? React.cloneElement(children as React.ReactElement, {
-              variant: (children as React.ReactElement).props.variant || 'inline',
+          ? React.cloneElement(children as React.ReactElement<any>, {
+              variant: (children as React.ReactElement<any>).props.variant || 'inline',
             })
           : children}
         {endDecorator && <SlotEndDecorator {...endDecoratorProps}>{endDecorator}</SlotEndDecorator>}

--- a/packages/mui-joy/test/describeConformance.ts
+++ b/packages/mui-joy/test/describeConformance.ts
@@ -6,7 +6,7 @@ import { ThemeProvider } from '@mui/joy/styles';
 import { createTheme } from '@mui/system';
 
 export default function describeConformance(
-  minimalElement: React.ReactElement,
+  minimalElement: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   function getOptionsWithDefaults() {

--- a/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
+++ b/packages/mui-lab/src/CalendarPicker/CalendarPicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type CalendarPickerComponent = (<TDate>(
   props: CalendarPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The CalendarPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
+++ b/packages/mui-lab/src/CalendarPickerSkeleton/CalendarPickerSkeleton.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type CalendarPickerSkeletonComponent = ((
   props: CalendarPickerSkeletonProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The CalendarPickerSkeleton component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
+++ b/packages/mui-lab/src/ClockPicker/ClockPicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type ClockPickerComponent = (<TDate>(
   props: ClockPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The ClockPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/mui-lab/src/DatePicker/DatePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DatePickerComponent = (<TDate>(
   props: DatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @ignore - do not document.

--- a/packages/mui-lab/src/DateRangePicker/DateRangePicker.ts
+++ b/packages/mui-lab/src/DateRangePicker/DateRangePicker.ts
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DateRangePickerComponent = (<TDate>(
   props: DateRangePickerProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DateRangePicker component was moved from `@mui/lab` to `@mui/x-date-pickers-pro`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.ts
+++ b/packages/mui-lab/src/DateRangePickerDay/DateRangePickerDay.ts
@@ -22,7 +22,7 @@ const warn = () => {
 
 type DateRangePickerDayComponent = (<TDate>(
   props: DateRangePickerDayProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DateRangePickerDay component was moved from `@mui/lab` to `@mui/x-date-pickers-pro`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/mui-lab/src/DateTimePicker/DateTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DateTimePickerComponent = (<TDate>(
   props: DateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
+++ b/packages/mui-lab/src/DesktopDatePicker/DesktopDatePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DesktopDatePickerComponent = (<TDate>(
   props: DesktopDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DesktopDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.ts
+++ b/packages/mui-lab/src/DesktopDateRangePicker/DesktopDateRangePicker.ts
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DesktopDateRangePickerComponent = (<TDate>(
   props: DesktopDateRangePickerProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DesktopDateRangePicker component was moved from `@mui/lab` to `@mui/x-date-pickers-pro`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopDateTimePicker/DesktopDateTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DesktopDateTimePickerComponent = (<TDate>(
   props: DesktopDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DesktopDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/mui-lab/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type DesktopTimePickerComponent = (<TDate>(
   props: DesktopTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The DesktopTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers-pro`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
+++ b/packages/mui-lab/src/LocalizationProvider/LocalizationProvider.tsx
@@ -22,7 +22,7 @@ const warn = () => {
 
 type LocalizationProviderComponent = ((
   props: LocalizationProviderProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The LocalizationProvider component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
+++ b/packages/mui-lab/src/MobileDatePicker/MobileDatePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type MobileDatePickerComponent = (<TDate>(
   props: MobileDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The MobileDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.ts
+++ b/packages/mui-lab/src/MobileDateRangePicker/MobileDateRangePicker.ts
@@ -23,7 +23,7 @@ const warn = () => {
 
 type MobileDateRangePickerComponent = (<TDate>(
   props: MobileDateRangePickerProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The MobileDateRangePicker component was moved from `@mui/lab` to `@mui/x-date-pickers-pro`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
+++ b/packages/mui-lab/src/MobileDateTimePicker/MobileDateTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type MobileDateTimePickerComponent = (<TDate>(
   props: MobileDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The MobileDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
+++ b/packages/mui-lab/src/MobileTimePicker/MobileTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type MobileTimePickerComponent = (<TDate>(
   props: MobileTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The MobileTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
+++ b/packages/mui-lab/src/MonthPicker/MonthPicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type MonthPickerComponent = (<TDate>(
   props: MonthPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The MonthPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/PickersDay/PickersDay.tsx
+++ b/packages/mui-lab/src/PickersDay/PickersDay.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type PickersDayComponent = (<TDate>(
   props: PickersDayProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The PickersDay component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
+++ b/packages/mui-lab/src/StaticDatePicker/StaticDatePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type StaticDatePickerComponent = (<TDate>(
   props: StaticDatePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The StaticDatePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.ts
+++ b/packages/mui-lab/src/StaticDateRangePicker/StaticDateRangePicker.ts
@@ -23,7 +23,7 @@ const warn = () => {
 
 type StaticDateRangePickerComponent = (<TDate>(
   props: StaticDateRangePickerProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The StaticDateRangePicker component was moved from `@mui/lab` to `@mui/x-date-pickers-pro`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
+++ b/packages/mui-lab/src/StaticDateTimePicker/StaticDateTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type StaticDateTimePickerComponent = (<TDate>(
   props: StaticDateTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The StaticDateTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
+++ b/packages/mui-lab/src/StaticTimePicker/StaticTimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type StaticTimePickerComponent = (<TDate>(
   props: StaticTimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The StaticTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/TabContext/TabContext.d.ts
+++ b/packages/mui-lab/src/TabContext/TabContext.d.ts
@@ -25,7 +25,7 @@ export interface TabContextProps {
  *
  * - [TabContext API](https://mui.com/material-ui/api/tab-context/)
  */
-export default function TabContext(props: TabContextProps): JSX.Element;
+export default function TabContext(props: TabContextProps): React.JSX.Element;
 export function useTabContext(): TabContextValue | null;
 export function getPanelId(context: TabContextValue, tabValue: string): string;
 export function getTabId(context: TabContextValue, tabValue: string): string;

--- a/packages/mui-lab/src/TabPanel/TabPanel.d.ts
+++ b/packages/mui-lab/src/TabPanel/TabPanel.d.ts
@@ -39,4 +39,4 @@ export interface TabPanelProps extends StandardProps<React.HTMLAttributes<HTMLDi
  *
  * - [TabPanel API](https://mui.com/material-ui/api/tab-panel/)
  */
-export default function TabPanel(props: TabPanelProps): JSX.Element;
+export default function TabPanel(props: TabPanelProps): React.JSX.Element;

--- a/packages/mui-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/mui-lab/src/TimePicker/TimePicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type TimePickerComponent = (<TDate>(
   props: TimePickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The StaticTimePicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/src/TimelineConnector/TimelineConnector.d.ts
+++ b/packages/mui-lab/src/TimelineConnector/TimelineConnector.d.ts
@@ -30,4 +30,4 @@ export interface TimelineConnectorProps
  *
  * - [TimelineConnector API](https://mui.com/material-ui/api/timeline-connector/)
  */
-export default function TimelineConnector(props: TimelineConnectorProps): JSX.Element;
+export default function TimelineConnector(props: TimelineConnectorProps): React.JSX.Element;

--- a/packages/mui-lab/src/TimelineContent/TimelineContent.d.ts
+++ b/packages/mui-lab/src/TimelineContent/TimelineContent.d.ts
@@ -30,4 +30,4 @@ export interface TimelineContentProps extends StandardProps<TypographyProps> {
  * - [TimelineContent API](https://mui.com/material-ui/api/timeline-content/)
  * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
-export default function TimelineContent(props: TimelineContentProps): JSX.Element;
+export default function TimelineContent(props: TimelineContentProps): React.JSX.Element;

--- a/packages/mui-lab/src/TimelineDot/TimelineDot.d.ts
+++ b/packages/mui-lab/src/TimelineDot/TimelineDot.d.ts
@@ -47,4 +47,4 @@ export interface TimelineDotProps extends StandardProps<React.HTMLAttributes<HTM
  *
  * - [TimelineDot API](https://mui.com/material-ui/api/timeline-dot/)
  */
-export default function TimelineDot(props: TimelineDotProps): JSX.Element;
+export default function TimelineDot(props: TimelineDotProps): React.JSX.Element;

--- a/packages/mui-lab/src/TimelineItem/TimelineItem.d.ts
+++ b/packages/mui-lab/src/TimelineItem/TimelineItem.d.ts
@@ -33,4 +33,4 @@ export interface TimelineItemProps extends StandardProps<React.HTMLAttributes<HT
  *
  * - [TimelineItem API](https://mui.com/material-ui/api/timeline-item/)
  */
-export default function TimelineItem(props: TimelineItemProps): JSX.Element;
+export default function TimelineItem(props: TimelineItemProps): React.JSX.Element;

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.d.ts
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.d.ts
@@ -30,7 +30,7 @@ export interface TimelineOppositeContentProps extends StandardProps<TypographyPr
  * - [TimelineOppositeContent API](https://mui.com/material-ui/api/timeline-opposite-content/)
  * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
-declare const TimelineOppositeContent: ((props: TimelineOppositeContentProps) => JSX.Element) & {
+declare const TimelineOppositeContent: ((props: TimelineOppositeContentProps) => React.JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.d.ts
+++ b/packages/mui-lab/src/TimelineOppositeContent/TimelineOppositeContent.d.ts
@@ -30,7 +30,9 @@ export interface TimelineOppositeContentProps extends StandardProps<TypographyPr
  * - [TimelineOppositeContent API](https://mui.com/material-ui/api/timeline-opposite-content/)
  * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
-declare const TimelineOppositeContent: ((props: TimelineOppositeContentProps) => React.JSX.Element) & {
+declare const TimelineOppositeContent: ((
+  props: TimelineOppositeContentProps,
+) => React.JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.d.ts
+++ b/packages/mui-lab/src/TimelineSeparator/TimelineSeparator.d.ts
@@ -30,4 +30,4 @@ export interface TimelineSeparatorProps
  *
  * - [TimelineSeparator API](https://mui.com/material-ui/api/timeline-separator/)
  */
-export default function TimelineSeparator(props: TimelineSeparatorProps): JSX.Element;
+export default function TimelineSeparator(props: TimelineSeparatorProps): React.JSX.Element;

--- a/packages/mui-lab/src/TreeItem/TreeItem.tsx
+++ b/packages/mui-lab/src/TreeItem/TreeItem.tsx
@@ -22,7 +22,7 @@ const warn = () => {
 
 type TreeItemComponent = ((
   props: TreeItemProps & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The TreeItem component was moved from `@mui/lab` to `@mui/x-tree-view`. More information about this migration on our blog: https://mui.com/blog/lab-tree-view-to-mui-x/.

--- a/packages/mui-lab/src/TreeView/TreeView.tsx
+++ b/packages/mui-lab/src/TreeView/TreeView.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type TreeViewComponent<Multiple extends boolean | undefined = undefined> = ((
   props: TreeViewProps<Multiple> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The TreeView component was moved from `@mui/lab` to `@mui/x-tree-view`. More information about this migration on our blog: https://mui.com/blog/lab-tree-view-to-mui-x/.

--- a/packages/mui-lab/src/YearPicker/YearPicker.tsx
+++ b/packages/mui-lab/src/YearPicker/YearPicker.tsx
@@ -23,7 +23,7 @@ const warn = () => {
 
 type YearPickerComponent = (<TDate>(
   props: YearPickerProps<TDate> & React.RefAttributes<HTMLDivElement>,
-) => JSX.Element) & { propTypes?: any };
+) => React.JSX.Element) & { propTypes?: any };
 
 /**
  * @deprecated The YearPicker component was moved from `@mui/lab` to `@mui/x-date-pickers`. More information about this migration on our blog: https://mui.com/blog/lab-date-pickers-to-mui-x/.

--- a/packages/mui-lab/test/describeConformance.ts
+++ b/packages/mui-lab/test/describeConformance.ts
@@ -5,7 +5,7 @@ import {
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 export default function describeConformance(
-  minimalElement: React.ReactElement,
+  minimalElement: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   function getOptionsWithDefaults() {

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -9,7 +9,7 @@ import createEmotionCache from './createCache';
 interface Plugin {
   enhanceApp: (
     App: React.ComponentType<React.ComponentProps<AppType>>,
-  ) => (props: any) => JSX.Element;
+  ) => (props: any) => React.JSX.Element;
   resolveProps: (initialProps: DocumentInitialProps) => Promise<DocumentInitialProps>;
 }
 

--- a/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
+++ b/packages/mui-material-nextjs/src/v13-pagesRouter/pagesRouterV13Document.tsx
@@ -37,7 +37,7 @@ export function createGetInitialProps(plugins: Plugin[]) {
 }
 
 export interface DocumentHeadTagsProps {
-  emotionStyleTags: React.ReactElement[];
+  emotionStyleTags: React.ReactElement<any>[];
 }
 
 export function DocumentHeadTags(props: DocumentHeadTagsProps) {

--- a/packages/mui-material/src/AccordionActions/AccordionActions.d.ts
+++ b/packages/mui-material/src/AccordionActions/AccordionActions.d.ts
@@ -33,4 +33,4 @@ export interface AccordionActionsProps extends StandardProps<React.HTMLAttribute
  *
  * - [AccordionActions API](https://mui.com/material-ui/api/accordion-actions/)
  */
-export default function AccordionActions(props: AccordionActionsProps): JSX.Element;
+export default function AccordionActions(props: AccordionActionsProps): React.JSX.Element;

--- a/packages/mui-material/src/AccordionDetails/AccordionDetails.d.ts
+++ b/packages/mui-material/src/AccordionDetails/AccordionDetails.d.ts
@@ -28,4 +28,4 @@ export interface AccordionDetailsProps extends StandardProps<React.HTMLAttribute
  *
  * - [AccordionDetails API](https://mui.com/material-ui/api/accordion-details/)
  */
-export default function AccordionDetails(props: AccordionDetailsProps): JSX.Element;
+export default function AccordionDetails(props: AccordionDetailsProps): React.JSX.Element;

--- a/packages/mui-material/src/Alert/Alert.d.ts
+++ b/packages/mui-material/src/Alert/Alert.d.ts
@@ -133,4 +133,4 @@ export interface AlertOwnerState extends AlertProps {}
  * - [Alert API](https://mui.com/material-ui/api/alert/)
  * - inherits [Paper API](https://mui.com/material-ui/api/paper/)
  */
-export default function Alert(props: AlertProps): JSX.Element;
+export default function Alert(props: AlertProps): React.JSX.Element;

--- a/packages/mui-material/src/AlertTitle/AlertTitle.d.ts
+++ b/packages/mui-material/src/AlertTitle/AlertTitle.d.ts
@@ -29,4 +29,4 @@ export interface AlertTitleProps extends TypographyProps<'div'> {
  * - [AlertTitle API](https://mui.com/material-ui/api/alert-title/)
  * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
-export default function AlertTitle(props: AlertTitleProps): JSX.Element;
+export default function AlertTitle(props: AlertTitleProps): React.JSX.Element;

--- a/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/mui-material/src/Autocomplete/Autocomplete.d.ts
@@ -372,4 +372,4 @@ export default function Autocomplete<
   ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent'],
 >(
   props: AutocompleteProps<Value, Multiple, DisableClearable, FreeSolo, ChipComponent>,
-): JSX.Element;
+): React.JSX.Element;

--- a/packages/mui-material/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/mui-material/src/AvatarGroup/AvatarGroup.d.ts
@@ -92,4 +92,4 @@ export interface AvatarGroupProps extends StandardProps<React.HTMLAttributes<HTM
  *
  * - [AvatarGroup API](https://mui.com/material-ui/api/avatar-group/)
  */
-export default function AvatarGroup(props: AvatarGroupProps): JSX.Element;
+export default function AvatarGroup(props: AvatarGroupProps): React.JSX.Element;

--- a/packages/mui-material/src/Button/Button.d.ts
+++ b/packages/mui-material/src/Button/Button.d.ts
@@ -104,7 +104,7 @@ export interface ExtendButtonTypeMap<TypeMap extends OverridableTypeMap> {
 
 export type ExtendButton<TypeMap extends OverridableTypeMap> = ((
   props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<TypeMap>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendButtonBaseTypeMap<TypeMap>>;
 
 /**

--- a/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.d.ts
@@ -105,7 +105,7 @@ export interface ExtendButtonBaseTypeMap<TypeMap extends OverridableTypeMap> {
 
 export type ExtendButtonBase<TypeMap extends OverridableTypeMap> = ((
   props: { href: string } & OverrideProps<ExtendButtonBaseTypeMap<TypeMap>, 'a'>,
-) => JSX.Element) &
+) => React.JSX.Element) &
   OverridableComponent<ExtendButtonBaseTypeMap<TypeMap>>;
 
 /**

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -1127,7 +1127,7 @@ describe('<ButtonBase />', () => {
   describe('prop: action', () => {
     it('should be able to focus visible the button', () => {
       /**
-       * @type {React.RefObject<import('./ButtonBase').ButtonBaseActions | null>}
+       * @type {React.RefObject<import('./ButtonBase').ButtonBaseActions>}
        */
       const buttonActionsRef = React.createRef();
       const { getByText } = render(

--- a/packages/mui-material/src/ButtonBase/ButtonBase.test.js
+++ b/packages/mui-material/src/ButtonBase/ButtonBase.test.js
@@ -1127,7 +1127,7 @@ describe('<ButtonBase />', () => {
   describe('prop: action', () => {
     it('should be able to focus visible the button', () => {
       /**
-       * @type {React.RefObject<import('./ButtonBase').ButtonBaseActions>}
+       * @type {React.RefObject<import('./ButtonBase').ButtonBaseActions | null>}
        */
       const buttonActionsRef = React.createRef();
       const { getByText } = render(

--- a/packages/mui-material/src/CardActions/CardActions.d.ts
+++ b/packages/mui-material/src/CardActions/CardActions.d.ts
@@ -33,4 +33,4 @@ export interface CardActionsProps extends StandardProps<React.HTMLAttributes<HTM
  *
  * - [CardActions API](https://mui.com/material-ui/api/card-actions/)
  */
-export default function CardActions(props: CardActionsProps): JSX.Element;
+export default function CardActions(props: CardActionsProps): React.JSX.Element;

--- a/packages/mui-material/src/CardHeader/CardHeader.d.ts
+++ b/packages/mui-material/src/CardHeader/CardHeader.d.ts
@@ -98,7 +98,7 @@ export interface OverridableCardHeader extends OverridableComponent<CardHeaderTy
       TitleTypographyComponent,
       SubheaderTypographyComponent
     >,
-  ): JSX.Element;
+  ): React.JSX.Element;
 }
 
 export type CardHeaderProps<

--- a/packages/mui-material/src/Checkbox/Checkbox.d.ts
+++ b/packages/mui-material/src/Checkbox/Checkbox.d.ts
@@ -115,4 +115,4 @@ export interface CheckboxProps
  * - [Checkbox API](https://mui.com/material-ui/api/checkbox/)
  * - inherits [ButtonBase API](https://mui.com/material-ui/api/button-base/)
  */
-export default function Checkbox(props: CheckboxProps): JSX.Element;
+export default function Checkbox(props: CheckboxProps): React.JSX.Element;

--- a/packages/mui-material/src/Chip/Chip.d.ts
+++ b/packages/mui-material/src/Chip/Chip.d.ts
@@ -15,7 +15,7 @@ export interface ChipOwnProps {
   /**
    * The Avatar element to display.
    */
-  avatar?: React.ReactElement;
+  avatar?: React.ReactElement<any>;
   /**
    * This prop isn't supported.
    * Use the `component` prop if you need to change the children structure.
@@ -47,7 +47,7 @@ export interface ChipOwnProps {
   /**
    * Override the default delete icon element. Shown only if `onDelete` is set.
    */
-  deleteIcon?: React.ReactElement;
+  deleteIcon?: React.ReactElement<any>;
   /**
    * If `true`, the component is disabled.
    * @default false
@@ -56,7 +56,7 @@ export interface ChipOwnProps {
   /**
    * Icon element.
    */
-  icon?: React.ReactElement;
+  icon?: React.ReactElement<any>;
   /**
    * The content of the component.
    */

--- a/packages/mui-material/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/mui-material/src/CircularProgress/CircularProgress.d.ts
@@ -73,4 +73,4 @@ export interface CircularProgressProps
  *
  * - [CircularProgress API](https://mui.com/material-ui/api/circular-progress/)
  */
-export default function CircularProgress(props: CircularProgressProps): JSX.Element;
+export default function CircularProgress(props: CircularProgressProps): React.JSX.Element;

--- a/packages/mui-material/src/Collapse/Collapse.d.ts
+++ b/packages/mui-material/src/Collapse/Collapse.d.ts
@@ -69,4 +69,4 @@ export interface CollapseProps extends StandardProps<TransitionProps, 'timeout'>
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition/#Transition-props)
  */
 
-export default function Collapse(props: CollapseProps): JSX.Element;
+export default function Collapse(props: CollapseProps): React.JSX.Element;

--- a/packages/mui-material/src/CssBaseline/CssBaseline.d.ts
+++ b/packages/mui-material/src/CssBaseline/CssBaseline.d.ts
@@ -26,4 +26,4 @@ export interface CssBaselineProps extends StyledComponentProps<never> {
  *
  * - [CssBaseline API](https://mui.com/material-ui/api/css-baseline/)
  */
-export default function CssBaseline(props: CssBaselineProps): JSX.Element;
+export default function CssBaseline(props: CssBaselineProps): React.JSX.Element;

--- a/packages/mui-material/src/Dialog/Dialog.d.ts
+++ b/packages/mui-material/src/Dialog/Dialog.d.ts
@@ -118,4 +118,4 @@ export interface DialogProps extends StandardProps<ModalProps, 'children'> {
  * - [Dialog API](https://mui.com/material-ui/api/dialog/)
  * - inherits [Modal API](https://mui.com/material-ui/api/modal/)
  */
-export default function Dialog(props: DialogProps): JSX.Element;
+export default function Dialog(props: DialogProps): React.JSX.Element;

--- a/packages/mui-material/src/DialogActions/DialogActions.d.ts
+++ b/packages/mui-material/src/DialogActions/DialogActions.d.ts
@@ -33,4 +33,4 @@ export interface DialogActionsProps extends StandardProps<React.HTMLAttributes<H
  *
  * - [DialogActions API](https://mui.com/material-ui/api/dialog-actions/)
  */
-export default function DialogActions(props: DialogActionsProps): JSX.Element;
+export default function DialogActions(props: DialogActionsProps): React.JSX.Element;

--- a/packages/mui-material/src/DialogContent/DialogContent.d.ts
+++ b/packages/mui-material/src/DialogContent/DialogContent.d.ts
@@ -33,4 +33,4 @@ export interface DialogContentProps extends StandardProps<React.HTMLAttributes<H
  *
  * - [DialogContent API](https://mui.com/material-ui/api/dialog-content/)
  */
-export default function DialogContent(props: DialogContentProps): JSX.Element;
+export default function DialogContent(props: DialogContentProps): React.JSX.Element;

--- a/packages/mui-material/src/Drawer/Drawer.d.ts
+++ b/packages/mui-material/src/Drawer/Drawer.d.ts
@@ -85,4 +85,4 @@ export interface DrawerProps extends StandardProps<ModalProps, 'open' | 'childre
  *
  * - [Drawer API](https://mui.com/material-ui/api/drawer/)
  */
-export default function Drawer(props: DrawerProps): JSX.Element;
+export default function Drawer(props: DrawerProps): React.JSX.Element;

--- a/packages/mui-material/src/Fade/Fade.d.ts
+++ b/packages/mui-material/src/Fade/Fade.d.ts
@@ -46,4 +46,4 @@ export interface FadeProps extends Omit<TransitionProps, 'children'> {
  * - [Fade API](https://mui.com/material-ui/api/fade/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition/#Transition-props)
  */
-export default function Fade(props: FadeProps): JSX.Element;
+export default function Fade(props: FadeProps): React.JSX.Element;

--- a/packages/mui-material/src/FilledInput/FilledInput.d.ts
+++ b/packages/mui-material/src/FilledInput/FilledInput.d.ts
@@ -37,6 +37,6 @@ export interface FilledInputProps extends StandardProps<InputBaseProps> {
  * - [FilledInput API](https://mui.com/material-ui/api/filled-input/)
  * - inherits [InputBase API](https://mui.com/material-ui/api/input-base/)
  */
-declare const FilledInput: ((props: FilledInputProps) => JSX.Element) & { muiName: string };
+declare const FilledInput: ((props: FilledInputProps) => React.JSX.Element) & { muiName: string };
 
 export default FilledInput;

--- a/packages/mui-material/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/mui-material/src/FormControlLabel/FormControlLabel.d.ts
@@ -106,4 +106,4 @@ export interface FormControlLabelProps
  *
  * - [FormControlLabel API](https://mui.com/material-ui/api/form-control-label/)
  */
-export default function FormControlLabel(props: FormControlLabelProps): JSX.Element;
+export default function FormControlLabel(props: FormControlLabelProps): React.JSX.Element;

--- a/packages/mui-material/src/FormGroup/FormGroup.d.ts
+++ b/packages/mui-material/src/FormGroup/FormGroup.d.ts
@@ -37,4 +37,4 @@ export interface FormGroupProps extends StandardProps<React.HTMLAttributes<HTMLD
  *
  * - [FormGroup API](https://mui.com/material-ui/api/form-group/)
  */
-export default function FormGroup(props: FormGroupProps): JSX.Element;
+export default function FormGroup(props: FormGroupProps): React.JSX.Element;

--- a/packages/mui-material/src/GlobalStyles/GlobalStyles.d.ts
+++ b/packages/mui-material/src/GlobalStyles/GlobalStyles.d.ts
@@ -18,4 +18,4 @@ export interface GlobalStylesProps {
  *
  * - [GlobalStyles API](https://mui.com/material-ui/api/global-styles/)
  */
-export default function GlobalStyles(props: GlobalStylesProps): React.ReactElement;
+export default function GlobalStyles(props: GlobalStylesProps): React.ReactElement<any>;

--- a/packages/mui-material/src/Grow/Grow.d.ts
+++ b/packages/mui-material/src/Grow/Grow.d.ts
@@ -47,4 +47,4 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
  * - [Grow API](https://mui.com/material-ui/api/grow/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition/#Transition-props)
  */
-export default function Grow(props: GrowProps): JSX.Element;
+export default function Grow(props: GrowProps): React.JSX.Element;

--- a/packages/mui-material/src/ImageListItemBar/ImageListItemBar.d.ts
+++ b/packages/mui-material/src/ImageListItemBar/ImageListItemBar.d.ts
@@ -48,4 +48,4 @@ export interface ImageListItemBarProps
  *
  * - [ImageListItemBar API](https://mui.com/material-ui/api/image-list-item-bar/)
  */
-export default function ImageListItemBar(props: ImageListItemBarProps): JSX.Element;
+export default function ImageListItemBar(props: ImageListItemBarProps): React.JSX.Element;

--- a/packages/mui-material/src/Input/Input.d.ts
+++ b/packages/mui-material/src/Input/Input.d.ts
@@ -30,6 +30,6 @@ export interface InputProps extends StandardProps<InputBaseProps> {
  * - [Input API](https://mui.com/material-ui/api/input/)
  * - inherits [InputBase API](https://mui.com/material-ui/api/input-base/)
  */
-declare const Input: ((props: InputProps) => JSX.Element) & { muiName: string };
+declare const Input: ((props: InputProps) => React.JSX.Element) & { muiName: string };
 
 export default Input;

--- a/packages/mui-material/src/InputBase/InputBase.d.ts
+++ b/packages/mui-material/src/InputBase/InputBase.d.ts
@@ -263,4 +263,4 @@ export interface InputBaseComponentProps
  *
  * - [InputBase API](https://mui.com/material-ui/api/input-base/)
  */
-export default function InputBase(props: InputBaseProps): JSX.Element;
+export default function InputBase(props: InputBaseProps): React.JSX.Element;

--- a/packages/mui-material/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/mui-material/src/LinearProgress/LinearProgress.d.ts
@@ -59,4 +59,4 @@ export interface LinearProgressProps
  *
  * - [LinearProgress API](https://mui.com/material-ui/api/linear-progress/)
  */
-export default function LinearProgress(props: LinearProgressProps): JSX.Element;
+export default function LinearProgress(props: LinearProgressProps): React.JSX.Element;

--- a/packages/mui-material/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/mui-material/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -28,4 +28,4 @@ export interface ListItemAvatarProps extends StandardProps<React.HTMLAttributes<
  *
  * - [ListItemAvatar API](https://mui.com/material-ui/api/list-item-avatar/)
  */
-export default function ListItemAvatar(props: ListItemAvatarProps): JSX.Element;
+export default function ListItemAvatar(props: ListItemAvatarProps): React.JSX.Element;

--- a/packages/mui-material/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/mui-material/src/ListItemIcon/ListItemIcon.d.ts
@@ -30,4 +30,4 @@ export interface ListItemIconProps extends StandardProps<React.HTMLAttributes<HT
  *
  * - [ListItemIcon API](https://mui.com/material-ui/api/list-item-icon/)
  */
-export default function ListItemIcon(props: ListItemIconProps): JSX.Element;
+export default function ListItemIcon(props: ListItemIconProps): React.JSX.Element;

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -30,7 +30,7 @@ export interface ListItemSecondaryActionProps
  *
  * - [ListItemSecondaryAction API](https://mui.com/material-ui/api/list-item-secondary-action/)
  */
-declare const ListItemSecondaryAction: ((props: ListItemSecondaryActionProps) => JSX.Element) & {
+declare const ListItemSecondaryAction: ((props: ListItemSecondaryActionProps) => React.JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/mui-material/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -30,7 +30,9 @@ export interface ListItemSecondaryActionProps
  *
  * - [ListItemSecondaryAction API](https://mui.com/material-ui/api/list-item-secondary-action/)
  */
-declare const ListItemSecondaryAction: ((props: ListItemSecondaryActionProps) => React.JSX.Element) & {
+declare const ListItemSecondaryAction: ((
+  props: ListItemSecondaryActionProps,
+) => React.JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-material/src/ListItemText/ListItemText.d.ts
+++ b/packages/mui-material/src/ListItemText/ListItemText.d.ts
@@ -73,4 +73,6 @@ export interface ListItemTextProps<
 export default function ListItemText<
   PrimaryTypographyComponent extends React.ElementType = 'span',
   SecondaryTypographyComponent extends React.ElementType = 'p',
->(props: ListItemTextProps<PrimaryTypographyComponent, SecondaryTypographyComponent>): React.JSX.Element;
+>(
+  props: ListItemTextProps<PrimaryTypographyComponent, SecondaryTypographyComponent>,
+): React.JSX.Element;

--- a/packages/mui-material/src/ListItemText/ListItemText.d.ts
+++ b/packages/mui-material/src/ListItemText/ListItemText.d.ts
@@ -73,4 +73,4 @@ export interface ListItemTextProps<
 export default function ListItemText<
   PrimaryTypographyComponent extends React.ElementType = 'span',
   SecondaryTypographyComponent extends React.ElementType = 'p',
->(props: ListItemTextProps<PrimaryTypographyComponent, SecondaryTypographyComponent>): JSX.Element;
+>(props: ListItemTextProps<PrimaryTypographyComponent, SecondaryTypographyComponent>): React.JSX.Element;

--- a/packages/mui-material/src/Menu/Menu.d.ts
+++ b/packages/mui-material/src/Menu/Menu.d.ts
@@ -94,4 +94,4 @@ export declare const MenuPaper: React.FC<PaperProps>;
  * - [Menu API](https://mui.com/material-ui/api/menu/)
  * - inherits [Popover API](https://mui.com/material-ui/api/popover/)
  */
-export default function Menu(props: MenuProps): JSX.Element;
+export default function Menu(props: MenuProps): React.JSX.Element;

--- a/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/mui-material/src/MobileStepper/MobileStepper.d.ts
@@ -59,4 +59,4 @@ export interface MobileStepperProps extends StandardProps<PaperProps, 'children'
  * - [MobileStepper API](https://mui.com/material-ui/api/mobile-stepper/)
  * - inherits [Paper API](https://mui.com/material-ui/api/paper/)
  */
-export default function MobileStepper(props: MobileStepperProps): JSX.Element;
+export default function MobileStepper(props: MobileStepperProps): React.JSX.Element;

--- a/packages/mui-material/src/Modal/Modal.d.ts
+++ b/packages/mui-material/src/Modal/Modal.d.ts
@@ -50,7 +50,7 @@ export interface ModalOwnProps {
   /**
    * A single child content element.
    */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /**
    * Override or extend the styles applied to the component.
    */

--- a/packages/mui-material/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/mui-material/src/NativeSelect/NativeSelect.d.ts
@@ -64,6 +64,6 @@ export interface NativeSelectProps
  * - [NativeSelect API](https://mui.com/material-ui/api/native-select/)
  * - inherits [Input API](https://mui.com/material-ui/api/input/)
  */
-declare const NativeSelect: ((props: NativeSelectProps) => JSX.Element) & { muiName: string };
+declare const NativeSelect: ((props: NativeSelectProps) => React.JSX.Element) & { muiName: string };
 
 export default NativeSelect;

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.d.ts
@@ -35,6 +35,6 @@ export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
  * - [OutlinedInput API](https://mui.com/material-ui/api/outlined-input/)
  * - inherits [InputBase API](https://mui.com/material-ui/api/input-base/)
  */
-declare const OutlinedInput: ((props: OutlinedInputProps) => JSX.Element) & { muiName: string };
+declare const OutlinedInput: ((props: OutlinedInputProps) => React.JSX.Element) & { muiName: string };
 
 export default OutlinedInput;

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.d.ts
@@ -35,6 +35,8 @@ export interface OutlinedInputProps extends StandardProps<InputBaseProps> {
  * - [OutlinedInput API](https://mui.com/material-ui/api/outlined-input/)
  * - inherits [InputBase API](https://mui.com/material-ui/api/input-base/)
  */
-declare const OutlinedInput: ((props: OutlinedInputProps) => React.JSX.Element) & { muiName: string };
+declare const OutlinedInput: ((props: OutlinedInputProps) => React.JSX.Element) & {
+  muiName: string;
+};
 
 export default OutlinedInput;

--- a/packages/mui-material/src/OverridableComponent.d.ts
+++ b/packages/mui-material/src/OverridableComponent.d.ts
@@ -20,8 +20,8 @@ export interface OverridableComponent<TypeMap extends OverridableTypeMap> {
        */
       component: RootComponent;
     } & OverrideProps<TypeMap, RootComponent>,
-  ): JSX.Element | null;
-  (props: DefaultComponentProps<TypeMap>): JSX.Element | null;
+  ): React.JSX.Element | null;
+  (props: DefaultComponentProps<TypeMap>): React.JSX.Element | null;
 }
 
 /**

--- a/packages/mui-material/src/Pagination/Pagination.d.ts
+++ b/packages/mui-material/src/Pagination/Pagination.d.ts
@@ -86,4 +86,4 @@ export interface PaginationProps
  *
  * - [Pagination API](https://mui.com/material-ui/api/pagination/)
  */
-export default function Pagination(props: PaginationProps): JSX.Element;
+export default function Pagination(props: PaginationProps): React.JSX.Element;

--- a/packages/mui-material/src/Popover/Popover.d.ts
+++ b/packages/mui-material/src/Popover/Popover.d.ts
@@ -195,4 +195,4 @@ export declare const PopoverPaper: React.FC<PopoverPaperProps>;
  * - [Popover API](https://mui.com/material-ui/api/popover/)
  * - inherits [Modal API](https://mui.com/material-ui/api/modal/)
  */
-export default function Popover(props: PopoverProps): JSX.Element;
+export default function Popover(props: PopoverProps): React.JSX.Element;

--- a/packages/mui-material/src/Popper/Popper.spec.tsx
+++ b/packages/mui-material/src/Popper/Popper.spec.tsx
@@ -3,7 +3,7 @@ import { Instance } from '@popperjs/core';
 import Tooltip from '@mui/material/Tooltip';
 
 interface Props {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   value: number;
 }
 

--- a/packages/mui-material/src/Radio/Radio.d.ts
+++ b/packages/mui-material/src/Radio/Radio.d.ts
@@ -62,4 +62,4 @@ export interface RadioProps
  * - [Radio API](https://mui.com/material-ui/api/radio/)
  * - inherits [ButtonBase API](https://mui.com/material-ui/api/button-base/)
  */
-export default function Radio(props: RadioProps): JSX.Element;
+export default function Radio(props: RadioProps): React.JSX.Element;

--- a/packages/mui-material/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.d.ts
@@ -36,4 +36,4 @@ export interface RadioGroupProps extends Omit<FormGroupProps, 'onChange'> {
  * - [RadioGroup API](https://mui.com/material-ui/api/radio-group/)
  * - inherits [FormGroup API](https://mui.com/material-ui/api/form-group/)
  */
-export default function RadioGroup(props: RadioGroupProps): JSX.Element;
+export default function RadioGroup(props: RadioGroupProps): React.JSX.Element;

--- a/packages/mui-material/src/Rating/Rating.d.ts
+++ b/packages/mui-material/src/Rating/Rating.d.ts
@@ -124,4 +124,4 @@ export interface RatingProps
  *
  * - [Rating API](https://mui.com/material-ui/api/rating/)
  */
-export default function Rating(props: RatingProps): JSX.Element;
+export default function Rating(props: RatingProps): React.JSX.Element;

--- a/packages/mui-material/src/Select/Select.d.ts
+++ b/packages/mui-material/src/Select/Select.d.ts
@@ -196,7 +196,7 @@ export type SelectProps<Value = unknown> =
  * - [Select API](https://mui.com/material-ui/api/select/)
  * - inherits [OutlinedInput API](https://mui.com/material-ui/api/outlined-input/)
  */
-declare const Select: (<Value = unknown>(props: SelectProps<Value>) => JSX.Element) & {
+declare const Select: (<Value = unknown>(props: SelectProps<Value>) => React.JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-material/src/Slide/Slide.d.ts
+++ b/packages/mui-material/src/Slide/Slide.d.ts
@@ -61,4 +61,4 @@ export interface SlideProps extends TransitionProps {
  * - [Slide API](https://mui.com/material-ui/api/slide/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition/#Transition-props)
  */
-export default function Slide(props: SlideProps): JSX.Element;
+export default function Slide(props: SlideProps): React.JSX.Element;

--- a/packages/mui-material/src/Slider/Slider.d.ts
+++ b/packages/mui-material/src/Slider/Slider.d.ts
@@ -281,7 +281,7 @@ export interface SliderTypeMap<
 }
 
 export interface SliderValueLabelProps extends React.HTMLAttributes<HTMLSpanElement> {
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   index: number;
   open: boolean;
   value: number;

--- a/packages/mui-material/src/Slider/SliderValueLabel.types.ts
+++ b/packages/mui-material/src/Slider/SliderValueLabel.types.ts
@@ -1,5 +1,5 @@
 export interface SliderValueLabelProps {
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
   className?: string;
   style?: React.CSSProperties;
   /**

--- a/packages/mui-material/src/Snackbar/Snackbar.d.ts
+++ b/packages/mui-material/src/Snackbar/Snackbar.d.ts
@@ -127,4 +127,4 @@ export interface SnackbarProps extends StandardProps<React.HTMLAttributes<HTMLDi
  *
  * - [Snackbar API](https://mui.com/material-ui/api/snackbar/)
  */
-export default function Snackbar(props: SnackbarProps): JSX.Element;
+export default function Snackbar(props: SnackbarProps): React.JSX.Element;

--- a/packages/mui-material/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/mui-material/src/SnackbarContent/SnackbarContent.d.ts
@@ -40,4 +40,4 @@ export interface SnackbarContentProps extends StandardProps<PaperProps, 'childre
  * - [SnackbarContent API](https://mui.com/material-ui/api/snackbar-content/)
  * - inherits [Paper API](https://mui.com/material-ui/api/paper/)
  */
-export default function SnackbarContent(props: SnackbarContentProps): JSX.Element;
+export default function SnackbarContent(props: SnackbarContentProps): React.JSX.Element;

--- a/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/mui-material/src/SpeedDial/SpeedDial.d.ts
@@ -129,4 +129,4 @@ export interface SpeedDialOwnerState extends SpeedDialProps {}
  *
  * - [SpeedDial API](https://mui.com/material-ui/api/speed-dial/)
  */
-export default function SpeedDial(props: SpeedDialProps): JSX.Element;
+export default function SpeedDial(props: SpeedDialProps): React.JSX.Element;

--- a/packages/mui-material/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/mui-material/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -60,4 +60,4 @@ export interface SpeedDialActionProps extends StandardProps<Partial<TooltipProps
  * - [SpeedDialAction API](https://mui.com/material-ui/api/speed-dial-action/)
  * - inherits [Tooltip API](https://mui.com/material-ui/api/tooltip/)
  */
-export default function SpeedDialAction(props: SpeedDialActionProps): JSX.Element;
+export default function SpeedDialAction(props: SpeedDialActionProps): React.JSX.Element;

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -39,6 +39,8 @@ export interface SpeedDialIconProps
  *
  * - [SpeedDialIcon API](https://mui.com/material-ui/api/speed-dial-icon/)
  */
-declare const SpeedDialIcon: ((props: SpeedDialIconProps) => React.JSX.Element) & { muiName: string };
+declare const SpeedDialIcon: ((props: SpeedDialIconProps) => React.JSX.Element) & {
+  muiName: string;
+};
 
 export default SpeedDialIcon;

--- a/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/mui-material/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -39,6 +39,6 @@ export interface SpeedDialIconProps
  *
  * - [SpeedDialIcon API](https://mui.com/material-ui/api/speed-dial-icon/)
  */
-declare const SpeedDialIcon: ((props: SpeedDialIconProps) => JSX.Element) & { muiName: string };
+declare const SpeedDialIcon: ((props: SpeedDialIconProps) => React.JSX.Element) & { muiName: string };
 
 export default SpeedDialIcon;

--- a/packages/mui-material/src/StepConnector/StepConnector.d.ts
+++ b/packages/mui-material/src/StepConnector/StepConnector.d.ts
@@ -30,4 +30,4 @@ export type StepConnectorClasskey = keyof NonNullable<StepConnectorProps['classe
  *
  * - [StepConnector API](https://mui.com/material-ui/api/step-connector/)
  */
-export default function StepConnector(props: StepConnectorProps): JSX.Element;
+export default function StepConnector(props: StepConnectorProps): React.JSX.Element;

--- a/packages/mui-material/src/StepConnector/StepConnector.d.ts
+++ b/packages/mui-material/src/StepConnector/StepConnector.d.ts
@@ -4,7 +4,7 @@ import { InternalStandardProps as StandardProps } from '..';
 import { Theme } from '../styles';
 import { StepConnectorClasses } from './stepConnectorClasses';
 
-export type StepConnectorIcon = React.ReactElement | string | number;
+export type StepConnectorIcon = React.ReactElement<any> | string | number;
 
 export interface StepConnectorProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, 'children'> {

--- a/packages/mui-material/src/StepContent/StepContent.d.ts
+++ b/packages/mui-material/src/StepContent/StepContent.d.ts
@@ -53,4 +53,4 @@ export type StepContentClasskey = keyof NonNullable<StepContentProps['classes']>
  *
  * - [StepContent API](https://mui.com/material-ui/api/step-content/)
  */
-export default function StepContent(props: StepContentProps): JSX.Element;
+export default function StepContent(props: StepContentProps): React.JSX.Element;

--- a/packages/mui-material/src/StepIcon/StepIcon.d.ts
+++ b/packages/mui-material/src/StepIcon/StepIcon.d.ts
@@ -47,4 +47,4 @@ export type StepIconClasskey = keyof NonNullable<StepIconProps['classes']>;
  *
  * - [StepIcon API](https://mui.com/material-ui/api/step-icon/)
  */
-export default function StepIcon(props: StepIconProps): JSX.Element;
+export default function StepIcon(props: StepIconProps): React.JSX.Element;

--- a/packages/mui-material/src/StepLabel/StepLabel.d.ts
+++ b/packages/mui-material/src/StepLabel/StepLabel.d.ts
@@ -92,7 +92,7 @@ export type StepLabelClasskey = keyof NonNullable<StepLabelProps['classes']>;
  *
  * - [StepLabel API](https://mui.com/material-ui/api/step-label/)
  */
-declare const StepLabel: ((props: StepLabelProps) => JSX.Element) & {
+declare const StepLabel: ((props: StepLabelProps) => React.JSX.Element) & {
   muiName: string;
 };
 

--- a/packages/mui-material/src/Switch/Switch.d.ts
+++ b/packages/mui-material/src/Switch/Switch.d.ts
@@ -66,4 +66,4 @@ export interface SwitchProps
  * - [Switch API](https://mui.com/material-ui/api/switch/)
  * - inherits [IconButton API](https://mui.com/material-ui/api/icon-button/)
  */
-export default function Switch(props: SwitchProps): JSX.Element;
+export default function Switch(props: SwitchProps): React.JSX.Element;

--- a/packages/mui-material/src/Tab/Tab.d.ts
+++ b/packages/mui-material/src/Tab/Tab.d.ts
@@ -28,7 +28,7 @@ export interface TabOwnProps {
   /**
    * The icon to display.
    */
-  icon?: string | React.ReactElement;
+  icon?: string | React.ReactElement<any>;
   /**
    * The position of the icon relative to the label.
    * @default 'top'

--- a/packages/mui-material/src/TabScrollButton/TabScrollButton.d.ts
+++ b/packages/mui-material/src/TabScrollButton/TabScrollButton.d.ts
@@ -75,4 +75,4 @@ export interface TabScrollButtonProps extends ButtonBaseProps {
  *
  * - [TabScrollButton API](https://mui.com/material-ui/api/tab-scroll-button/)
  */
-export default function TabScrollButton(props: TabScrollButtonProps): JSX.Element;
+export default function TabScrollButton(props: TabScrollButtonProps): React.JSX.Element;

--- a/packages/mui-material/src/TableCell/TableCell.d.ts
+++ b/packages/mui-material/src/TableCell/TableCell.d.ts
@@ -83,4 +83,4 @@ export type SortDirection = 'asc' | 'desc' | false;
  *
  * - [TableCell API](https://mui.com/material-ui/api/table-cell/)
  */
-export default function TableCell(props: TableCellProps): JSX.Element;
+export default function TableCell(props: TableCellProps): React.JSX.Element;

--- a/packages/mui-material/src/TextField/TextField.d.ts
+++ b/packages/mui-material/src/TextField/TextField.d.ts
@@ -340,4 +340,4 @@ export default function TextField<Variant extends TextFieldVariants>(
      */
     variant?: Variant;
   } & Omit<TextFieldProps, 'variant'>,
-): JSX.Element;
+): React.JSX.Element;

--- a/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/mui-material/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -86,4 +86,4 @@ export interface ToggleButtonGroupProps
  *
  * - [ToggleButtonGroup API](https://mui.com/material-ui/api/toggle-button-group/)
  */
-export default function ToggleButtonGroup(props: ToggleButtonGroupProps): JSX.Element;
+export default function ToggleButtonGroup(props: ToggleButtonGroupProps): React.JSX.Element;

--- a/packages/mui-material/src/Tooltip/Tooltip.d.ts
+++ b/packages/mui-material/src/Tooltip/Tooltip.d.ts
@@ -225,4 +225,4 @@ export interface TooltipProps extends StandardProps<React.HTMLAttributes<HTMLDiv
  *
  * - [Tooltip API](https://mui.com/material-ui/api/tooltip/)
  */
-export default function Tooltip(props: TooltipProps): JSX.Element;
+export default function Tooltip(props: TooltipProps): React.JSX.Element;

--- a/packages/mui-material/src/Typography/typography.spec.tsx
+++ b/packages/mui-material/src/Typography/typography.spec.tsx
@@ -11,7 +11,7 @@ const typographyTest = () => {
     ...props
   }: TypographyProps & {
     maxLines?: number;
-  }): JSX.Element => {
+  }): React.JSX.Element => {
     return (
       <Typography
         {...props}

--- a/packages/mui-material/src/Zoom/Zoom.d.ts
+++ b/packages/mui-material/src/Zoom/Zoom.d.ts
@@ -47,4 +47,4 @@ export interface ZoomProps extends TransitionProps {
  * - [Zoom API](https://mui.com/material-ui/api/zoom/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition/#Transition-props)
  */
-export default function Zoom(props: ZoomProps): JSX.Element;
+export default function Zoom(props: ZoomProps): React.JSX.Element;

--- a/packages/mui-material/src/types/OverridableComponentAugmentation.ts
+++ b/packages/mui-material/src/types/OverridableComponentAugmentation.ts
@@ -16,8 +16,8 @@ declare module '@mui/material/OverridableComponent' {
          */
         component: DefaultComponent;
       } & OverridePropsVer2<TypeMap, DefaultComponent>,
-    ): JSX.Element;
-    (props: DefaultComponentPropsVer2<TypeMap>): JSX.Element;
+    ): React.JSX.Element;
+    (props: DefaultComponentPropsVer2<TypeMap>): React.JSX.Element;
   }
 
   /**

--- a/packages/mui-material/test/describeConformance.ts
+++ b/packages/mui-material/test/describeConformance.ts
@@ -5,7 +5,7 @@ import {
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 export default function describeConformance(
-  minimalElement: React.ReactElement,
+  minimalElement: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   function getOptionsWithDefaults() {

--- a/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.d.ts
+++ b/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.d.ts
@@ -8,4 +8,4 @@ export interface GlobalStylesProps<Theme extends object = {}> {
 
 export default function Global<Theme extends object = {}>(
   props: GlobalStylesProps<Theme>,
-): React.ReactElement;
+): React.ReactElement<any>;

--- a/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.spec.tsx
+++ b/packages/mui-styled-engine-sc/src/GlobalStyles/GlobalStyles.spec.tsx
@@ -25,7 +25,7 @@ export interface GlobalStylesProps {
   styles: SCGlobalStylesProps<Theme>['styles'];
 }
 
-function GlobalStyles(props: GlobalStylesProps): React.ReactElement {
+function GlobalStyles(props: GlobalStylesProps): React.ReactElement<any> {
   return <SCGlobalStyles {...props} defaultTheme={defaultTheme} />;
 }
 

--- a/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.d.ts
+++ b/packages/mui-styled-engine-sc/src/StyledEngineProvider/StyledEngineProvider.d.ts
@@ -5,4 +5,4 @@ export interface StyledEngineProviderProps {
   injectFirst?: boolean;
 }
 
-export default function StyledEngineProvider(props: StyledEngineProviderProps): JSX.Element;
+export default function StyledEngineProvider(props: StyledEngineProviderProps): React.JSX.Element;

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -23,7 +23,7 @@ type Defaultize<P, D> = P extends any
         Partial<PickU<D, Exclude<keyof D, keyof P>>>
   : never;
 
-export type IntrinsicElementsKeys = keyof JSX.IntrinsicElements;
+export type IntrinsicElementsKeys = keyof React.JSX.IntrinsicElements;
 type ReactDefaultizedProps<C, P> = C extends { defaultProps: infer D } ? Defaultize<P, D> : P;
 
 type MakeAttrsOptional<
@@ -156,7 +156,7 @@ type StyledComponentPropsWithAs<
 };
 
 export type StyledComponent<
-  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  C extends keyof React.JSX.IntrinsicElements | React.ComponentType<any>,
   T extends object = {},
   O extends object = {},
   A extends keyof any = never,
@@ -217,7 +217,7 @@ export interface StyledComponentBase<
     O & StyledComponentInnerOtherProps<WithC>,
     A | StyledComponentInnerAttrs<WithC>
   >;
-  withComponent<WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+  withComponent<WithC extends keyof React.JSX.IntrinsicElements | React.ComponentType<any>>(
     component: WithC,
   ): StyledComponent<WithC, T, O, A>;
 }
@@ -232,18 +232,18 @@ type StyledComponentInterpolation =
 type AnyIfEmpty<T extends object> = keyof T extends never ? any : T;
 
 type ThemedStyledComponentFactories<T extends object> = {
-  [TTag in keyof JSX.IntrinsicElements]: ThemedStyledFunctionBase<TTag, T>;
+  [TTag in keyof React.JSX.IntrinsicElements]: ThemedStyledFunctionBase<TTag, T>;
 };
 
 export type StyledComponentPropsWithRef<
-  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  C extends keyof React.JSX.IntrinsicElements | React.ComponentType<any>,
 > = C extends AnyStyledComponent
   ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
   : React.ComponentPropsWithRef<C>;
 
 // Same as in styled-components, but copied here so that it would use the Interpolation & CSS typings from above
 export interface ThemedStyledFunctionBase<
-  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  C extends keyof React.JSX.IntrinsicElements | React.ComponentType<any>,
   T extends object,
   O extends object = {},
   A extends keyof any = never,
@@ -267,7 +267,7 @@ export interface ThemedStyledFunctionBase<
 
 // same as ThemedStyledFunction in styled-components, but without attrs, and withConfig
 export interface ThemedStyledFunction<
-  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  C extends keyof React.JSX.IntrinsicElements | React.ComponentType<any>,
   T extends object,
   O extends object = {},
   A extends keyof any = never,
@@ -348,22 +348,22 @@ export interface ThemedBaseStyledInterface<
   ): CreateStyledComponent<PropsOf<C> & MUIStyledCommonProps, {}, {}, Theme>;
 
   <
-    Tag extends keyof JSX.IntrinsicElements,
-    ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
+    Tag extends keyof React.JSX.IntrinsicElements,
+    ForwardedProps extends keyof React.JSX.IntrinsicElements[Tag] = keyof React.JSX.IntrinsicElements[Tag],
   >(
     tag: Tag,
-    options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<React.JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
   ): CreateStyledComponent<
     MUIStyledCommonProps,
-    Pick<JSX.IntrinsicElements[Tag], ForwardedProps>,
+    Pick<React.JSX.IntrinsicElements[Tag], ForwardedProps>,
     {},
     Theme
   >;
 
-  <Tag extends keyof JSX.IntrinsicElements>(
+  <Tag extends keyof React.JSX.IntrinsicElements>(
     tag: Tag,
     options?: StyledConfig<MUIStyledCommonProps> & MuiStyledOptions,
-  ): CreateStyledComponent<MUIStyledCommonProps, JSX.IntrinsicElements[Tag], {}, Theme>;
+  ): CreateStyledComponent<MUIStyledCommonProps, React.JSX.IntrinsicElements[Tag], {}, Theme>;
 }
 
 export type CreateMUIStyled<
@@ -372,8 +372,8 @@ export type CreateMUIStyled<
   T extends object = {},
 > = ThemedBaseStyledInterface<MUIStyledCommonProps, MuiStyledOptions, AnyIfEmpty<T>>;
 
-export type PropsOf<C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>> =
-  JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>;
+export type PropsOf<C extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>> =
+  React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>;
 
 export interface MUIStyledComponent<
   ComponentProps extends {},
@@ -386,7 +386,7 @@ export interface MUIStyledComponent<
   withComponent<C extends React.ComponentType<React.ComponentProps<C>>>(
     component: C,
   ): MUIStyledComponent<ComponentProps & PropsOf<C>>;
-  withComponent<Tag extends keyof JSX.IntrinsicElements>(
+  withComponent<Tag extends keyof React.JSX.IntrinsicElements>(
     tag: Tag,
-  ): MUIStyledComponent<ComponentProps, JSX.IntrinsicElements[Tag]>;
+  ): MUIStyledComponent<ComponentProps, React.JSX.IntrinsicElements[Tag]>;
 }

--- a/packages/mui-styled-engine-sc/src/index.d.ts
+++ b/packages/mui-styled-engine-sc/src/index.d.ts
@@ -349,10 +349,12 @@ export interface ThemedBaseStyledInterface<
 
   <
     Tag extends keyof React.JSX.IntrinsicElements,
-    ForwardedProps extends keyof React.JSX.IntrinsicElements[Tag] = keyof React.JSX.IntrinsicElements[Tag],
+    ForwardedProps extends
+      keyof React.JSX.IntrinsicElements[Tag] = keyof React.JSX.IntrinsicElements[Tag],
   >(
     tag: Tag,
-    options: FilteringStyledOptions<React.JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<React.JSX.IntrinsicElements[Tag], ForwardedProps> &
+      MuiStyledOptions,
   ): CreateStyledComponent<
     MUIStyledCommonProps,
     Pick<React.JSX.IntrinsicElements[Tag], ForwardedProps>,
@@ -372,8 +374,9 @@ export type CreateMUIStyled<
   T extends object = {},
 > = ThemedBaseStyledInterface<MUIStyledCommonProps, MuiStyledOptions, AnyIfEmpty<T>>;
 
-export type PropsOf<C extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>> =
-  React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>;
+export type PropsOf<
+  C extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+> = React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>;
 
 export interface MUIStyledComponent<
   ComponentProps extends {},

--- a/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.d.ts
+++ b/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.d.ts
@@ -8,4 +8,4 @@ export interface GlobalStylesProps<Theme = {}> {
 
 export default function GlobalStyles<Theme = {}>(
   props: GlobalStylesProps<Theme>,
-): React.ReactElement;
+): React.ReactElement<any>;

--- a/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.spec.tsx
+++ b/packages/mui-styled-engine/src/GlobalStyles/GlobalStyles.spec.tsx
@@ -25,7 +25,7 @@ export interface GlobalStylesProps {
   styles: EmGlobalStylesProps<Theme>['styles'];
 }
 
-function GlobalStyles(props: GlobalStylesProps): React.ReactElement {
+function GlobalStyles(props: GlobalStylesProps): React.ReactElement<any> {
   return <EmGlobalStyles {...props} defaultTheme={defaultTheme} />;
 }
 

--- a/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.d.ts
+++ b/packages/mui-styled-engine/src/StyledEngineProvider/StyledEngineProvider.d.ts
@@ -5,4 +5,4 @@ export interface StyledEngineProviderProps {
   injectFirst?: boolean;
 }
 
-export default function StyledEngineProvider(props: StyledEngineProviderProps): JSX.Element;
+export default function StyledEngineProvider(props: StyledEngineProviderProps): React.JSX.Element;

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -201,10 +201,12 @@ export interface CreateMUIStyled<
 
   <
     Tag extends keyof React.JSX.IntrinsicElements,
-    ForwardedProps extends keyof React.JSX.IntrinsicElements[Tag] = keyof React.JSX.IntrinsicElements[Tag],
+    ForwardedProps extends
+      keyof React.JSX.IntrinsicElements[Tag] = keyof React.JSX.IntrinsicElements[Tag],
   >(
     tag: Tag,
-    options: FilteringStyledOptions<React.JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<React.JSX.IntrinsicElements[Tag], ForwardedProps> &
+      MuiStyledOptions,
   ): CreateStyledComponent<
     MUIStyledCommonProps,
     Pick<React.JSX.IntrinsicElements[Tag], ForwardedProps>,

--- a/packages/mui-styled-engine/src/index.d.ts
+++ b/packages/mui-styled-engine/src/index.d.ts
@@ -200,20 +200,20 @@ export interface CreateMUIStyled<
   ): CreateStyledComponent<PropsOf<C> & MUIStyledCommonProps, {}, {}, Theme>;
 
   <
-    Tag extends keyof JSX.IntrinsicElements,
-    ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag],
+    Tag extends keyof React.JSX.IntrinsicElements,
+    ForwardedProps extends keyof React.JSX.IntrinsicElements[Tag] = keyof React.JSX.IntrinsicElements[Tag],
   >(
     tag: Tag,
-    options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
+    options: FilteringStyledOptions<React.JSX.IntrinsicElements[Tag], ForwardedProps> & MuiStyledOptions,
   ): CreateStyledComponent<
     MUIStyledCommonProps,
-    Pick<JSX.IntrinsicElements[Tag], ForwardedProps>,
+    Pick<React.JSX.IntrinsicElements[Tag], ForwardedProps>,
     {},
     Theme
   >;
 
-  <Tag extends keyof JSX.IntrinsicElements>(
+  <Tag extends keyof React.JSX.IntrinsicElements>(
     tag: Tag,
     options?: StyledOptions<MUIStyledCommonProps> & MuiStyledOptions,
-  ): CreateStyledComponent<MUIStyledCommonProps, JSX.IntrinsicElements[Tag], {}, Theme>;
+  ): CreateStyledComponent<MUIStyledCommonProps, React.JSX.IntrinsicElements[Tag], {}, Theme>;
 }

--- a/packages/mui-styles/src/ServerStyleSheets/ServerStyleSheets.d.ts
+++ b/packages/mui-styles/src/ServerStyleSheets/ServerStyleSheets.d.ts
@@ -5,7 +5,7 @@ declare class ServerStyleSheets {
   constructor(options?: object);
   collect(children: React.ReactNode, options?: object): React.ReactElement<StylesProviderProps>;
   toString(): string;
-  getStyleElement(props?: object): React.ReactElement;
+  getStyleElement(props?: object): React.ReactElement<any>;
 }
 
 export default ServerStyleSheets;

--- a/packages/mui-styles/src/styled/styled.d.ts
+++ b/packages/mui-styles/src/styled/styled.d.ts
@@ -23,7 +23,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
   options?: WithStylesOptions<Theme>,
 ) => StyledComponent<
   DistributiveOmit<
-    JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
+    React.JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'
   > &
     StyledComponentProps<'root'> &

--- a/packages/mui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/mui-styles/src/withTheme/withTheme.d.ts
@@ -25,7 +25,7 @@ export default function withTheme<
   component: C,
 ): React.JSXElementConstructor<
   DistributiveOmit<
-    JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>,
+    React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>,
     keyof WithTheme<Theme>
   > &
     Partial<WithTheme<Theme>> &

--- a/packages/mui-styles/test/styles.spec.tsx
+++ b/packages/mui-styles/test/styles.spec.tsx
@@ -215,7 +215,7 @@ withStyles((theme) =>
     });
 
   interface ListItemContentProps extends WithStyles<typeof styles> {
-    children?: React.ReactElement;
+    children?: React.ReactElement<any>;
     inset?: boolean;
     row?: boolean;
   }

--- a/packages/mui-system/src/Stack/createStack.tsx
+++ b/packages/mui-system/src/Stack/createStack.tsx
@@ -50,7 +50,7 @@ function useThemePropsDefault<T extends {}>(props: T) {
  * > joinChildren([1,2,3], 0)
  * [1,0,2,0,3]
  */
-function joinChildren(children: React.ReactNode, separator: React.ReactElement) {
+function joinChildren(children: React.ReactNode, separator: React.ReactElement<any>) {
   const childrenArray = React.Children.toArray(children).filter(Boolean);
 
   return childrenArray.reduce<React.ReactNode[]>((output, child, index) => {
@@ -209,7 +209,7 @@ export default function createStack(
         className={clsx(classes.root, className)}
         {...other}
       >
-        {divider ? joinChildren(children, divider as React.ReactElement) : children}
+        {divider ? joinChildren(children, divider as React.ReactElement<any>) : children}
       </StackRoot>
     );
   }) as OverridableComponent<StackTypeMap>;

--- a/packages/mui-system/src/Unstable_Grid/createGrid.tsx
+++ b/packages/mui-system/src/Unstable_Grid/createGrid.tsx
@@ -166,7 +166,7 @@ export default function createGrid(
         {React.Children.map(children, (child) => {
           if (React.isValidElement(child) && isMuiElement(child, ['Grid'])) {
             return React.cloneElement(child, {
-              unstable_level: child.props.unstable_level ?? level + 1,
+              unstable_level: (child.props as any).unstable_level ?? level + 1,
             } as GridProps);
           }
           return child;

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -90,7 +90,7 @@ export interface CreateCssVarsProviderResult<
         disableStyleSheetGeneration?: boolean;
       }
     >,
-  ) => React.ReactElement;
+  ) => React.ReactElement<any>;
   useColorScheme: () => ColorSchemeContextValue<ColorScheme>;
   getInitColorSchemeScript: typeof getInitColorSchemeScript;
 }

--- a/packages/mui-system/test/describeConformance.ts
+++ b/packages/mui-system/test/describeConformance.ts
@@ -5,7 +5,7 @@ import {
 import { ThemeProvider, createTheme } from '@mui/system';
 
 export default function describeConformance(
-  minimalElement: React.ReactElement,
+  minimalElement: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   function getOptionsWithDefaults() {

--- a/packages/mui-types/OverridableComponentAugmentation.ts
+++ b/packages/mui-types/OverridableComponentAugmentation.ts
@@ -15,8 +15,8 @@ declare module '@mui/types' {
          */
         component: C;
       } & OverridePropsVer2<M, C>,
-    ): JSX.Element;
-    (props: DefaultComponentPropsVer2<M>): JSX.Element;
+    ): React.JSX.Element;
+    (props: DefaultComponentPropsVer2<M>): React.JSX.Element;
     propTypes?: any;
   }
 

--- a/packages/mui-types/index.d.ts
+++ b/packages/mui-types/index.d.ts
@@ -27,7 +27,10 @@ export type PropInjector<InjectedProps, AdditionalProps = {}> = <
 >(
   component: C,
 ) => React.JSXElementConstructor<
-  DistributiveOmit<React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
+  DistributiveOmit<
+    React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>,
+    keyof InjectedProps
+  > &
     AdditionalProps
 >;
 

--- a/packages/mui-types/index.d.ts
+++ b/packages/mui-types/index.d.ts
@@ -27,7 +27,7 @@ export type PropInjector<InjectedProps, AdditionalProps = {}> = <
 >(
   component: C,
 ) => React.JSXElementConstructor<
-  DistributiveOmit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
+  DistributiveOmit<React.JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
     AdditionalProps
 >;
 
@@ -101,8 +101,8 @@ export interface OverridableComponent<M extends OverridableTypeMap> {
        */
       component: C;
     } & OverrideProps<M, C>,
-  ): JSX.Element | null;
-  (props: DefaultComponentProps<M>): JSX.Element | null;
+  ): React.JSX.Element | null;
+  (props: DefaultComponentProps<M>): React.JSX.Element | null;
   propTypes?: any;
 }
 

--- a/packages/mui-utils/src/getValidReactChildren/getValidReactChildren.ts
+++ b/packages/mui-utils/src/getValidReactChildren/getValidReactChildren.ts
@@ -9,5 +9,5 @@ import * as React from 'react';
 export default function getValidReactChildren(children: React.ReactNode) {
   return React.Children.toArray(children).filter((child) =>
     React.isValidElement(child),
-  ) as React.ReactElement[];
+  ) as React.ReactElement<any>[];
 }

--- a/packages/test-utils/src/createMount.tsx
+++ b/packages/test-utils/src/createMount.tsx
@@ -11,7 +11,7 @@ interface ModeProps {
    * using `wrapper.setProps({ children })` would work differently if this component
    * would be the root.
    */
-  __element: React.ReactElement;
+  __element: React.ReactElement<any>;
   __strict: boolean;
 }
 
@@ -93,7 +93,7 @@ export default function createMount(options: CreateMountOptions = {}) {
   });
 
   const mountWithContext = function mountWithContext(
-    node: React.ReactElement,
+    node: React.ReactElement<any>,
     localOptions: Omit<CreateMountOptions, 'mount'> = {},
   ) {
     const { strict = globalStrict, ...localEnzymeOptions } = localOptions;

--- a/packages/test-utils/src/createRenderer.tsx
+++ b/packages/test-utils/src/createRenderer.tsx
@@ -281,7 +281,7 @@ export interface MuiRenderToStringResult {
 }
 
 function render(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   configuration: ClientRenderConfiguration,
 ): MuiRenderResult {
   const { container, hydrate, wrapper } = configuration;
@@ -316,7 +316,7 @@ function render(
 }
 
 function renderToString(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   configuration: ServerRenderConfiguration,
 ): { container: HTMLElement; hydrate(): MuiRenderResult } {
   const { container, wrapper: Wrapper } = configuration;
@@ -438,8 +438,11 @@ function createClock(defaultMode: 'fake' | 'real', config: ClockConfig): Clock {
 
 interface Renderer {
   clock: Clock;
-  render(element: React.ReactElement, options?: RenderOptions): MuiRenderResult;
-  renderToString(element: React.ReactElement, options?: RenderOptions): MuiRenderToStringResult;
+  render(element: React.ReactElement<any>, options?: RenderOptions): MuiRenderResult;
+  renderToString(
+    element: React.ReactElement<any>,
+    options?: RenderOptions,
+  ): MuiRenderToStringResult;
 }
 
 export interface CreateRendererOptions extends Pick<RenderOptions, 'strict' | 'strictEffects'> {
@@ -577,7 +580,7 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
 
   return {
     clock,
-    render(element: React.ReactElement, options: RenderOptions = {}) {
+    render(element: React.ReactElement<any>, options: RenderOptions = {}) {
       if (!prepared) {
         throw new Error(
           'Unable to finish setup before `render()` was called. ' +
@@ -592,7 +595,7 @@ export function createRenderer(globalOptions: CreateRendererOptions = {}): Rende
         wrapper: createWrapper(options),
       });
     },
-    renderToString(element: React.ReactElement, options: RenderOptions = {}) {
+    renderToString(element: React.ReactElement<any>, options: RenderOptions = {}) {
       if (!prepared) {
         throw new Error(
           'Unable to finish setup before `render()` was called. ' +

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -45,8 +45,8 @@ export interface ConformanceOptions {
   refInstanceof: any;
   after?: () => void;
   inheritComponent?: React.ElementType;
-  render: (node: React.ReactElement) => MuiRenderResult;
-  mount?: (node: React.ReactElement) => ReactWrapper;
+  render: (node: React.ReactElement<any>) => MuiRenderResult;
+  mount?: (node: React.ReactElement<any>) => ReactWrapper;
   only?: Array<keyof typeof fullSuite>;
   skip?: Array<keyof typeof fullSuite | 'classesRoot'>;
   testComponentsRootPropWith?: string;
@@ -58,8 +58,8 @@ export interface ConformanceOptions {
   testVariantProps?: object;
   testLegacyComponentsProp?: boolean;
   wrapMount?: (
-    mount: (node: React.ReactElement) => ReactWrapper,
-  ) => (node: React.ReactElement) => ReactWrapper;
+    mount: (node: React.ReactElement<any>) => ReactWrapper,
+  ) => (node: React.ReactElement<any>) => ReactWrapper;
   slots?: Record<string, SlotTestingOptions>;
   ThemeProvider?: React.ElementType;
   createTheme?: (arg: any) => any;
@@ -79,7 +79,7 @@ function assertDOMNode(node: unknown) {
  * The element should have a component wrapped in withStyles as the root
  */
 function testRef(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   mount: ConformanceOptions['mount'],
   onRef: (instance: unknown, wrapper: import('enzyme').ReactWrapper) => void = assertDOMNode,
 ) {
@@ -129,7 +129,10 @@ function throwMissingPropError(field: string): never {
  * MUI components have a `className` prop. The `className` is applied to
  * the root component.
  */
-export function testClassName(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+export function testClassName(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   it('applies the className to the root component', () => {
     const { mount } = getOptions();
     if (!mount) {
@@ -149,7 +152,7 @@ export function testClassName(element: React.ReactElement, getOptions: () => Con
  * Component from @inheritComponent
  */
 export function testComponentProp(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   describe('prop: component', () => {
@@ -169,7 +172,10 @@ export function testComponentProp(
 /**
  * MUI components can spread additional props to a documented component.
  */
-export function testPropsSpread(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+export function testPropsSpread(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   it(`spreads props to the root component`, () => {
     // type def in ConformanceOptions
     const { inheritComponent, mount } = getOptions();
@@ -199,7 +205,10 @@ export function testPropsSpread(element: React.ReactElement, getOptions: () => C
  * This is determined by a given constructor i.e. a React.Component or HTMLElement for
  * components that forward their ref and attach it to a host component.
  */
-export function describeRef(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+export function describeRef(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   describe('ref', () => {
     it(`attaches the ref`, () => {
       // type def in ConformanceOptions
@@ -220,7 +229,10 @@ export function describeRef(element: React.ReactElement, getOptions: () => Confo
 /**
  * Tests that the root component has the root class
  */
-export function testRootClass(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+export function testRootClass(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   it('applies the root class to the root component if it has this class', () => {
     const { classes, render, skip } = getOptions();
     if (classes.root == null) {
@@ -259,7 +271,7 @@ export function testRootClass(element: React.ReactElement, getOptions: () => Con
  * Tests that the component can be rendered with react-test-renderer.
  * This is important for snapshot testing with Jest (even if we don't encourage it).
  */
-export function testReactTestRenderer(element: React.ReactElement) {
+export function testReactTestRenderer(element: React.ReactElement<any>) {
   it('should render without errors in ReactTestRenderer', () => {
     ReactTestRenderer.act(() => {
       ReactTestRenderer.create(element, {
@@ -286,7 +298,7 @@ function forEachSlot(
   });
 }
 
-function testSlotsProp(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testSlotsProp(element: React.ReactElement<any>, getOptions: () => ConformanceOptions) {
   const { render, slots, testLegacyComponentsProp } = getOptions();
 
   const CustomComponent = React.forwardRef<
@@ -457,7 +469,7 @@ function testSlotsProp(element: React.ReactElement, getOptions: () => Conformanc
   });
 }
 
-function testSlotPropsProp(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testSlotPropsProp(element: React.ReactElement<any>, getOptions: () => ConformanceOptions) {
   const { render, slots, testLegacyComponentsProp } = getOptions();
 
   if (!render) {
@@ -540,7 +552,10 @@ function testSlotPropsProp(element: React.ReactElement, getOptions: () => Confor
   });
 }
 
-function testSlotPropsCallback(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testSlotPropsCallback(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   const { render, slots } = getOptions();
 
   if (!render) {
@@ -568,7 +583,10 @@ function testSlotPropsCallback(element: React.ReactElement, getOptions: () => Co
  * MUI components have a `components` prop that allows rendering a different
  * Components from @inheritComponent
  */
-function testComponentsProp(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testComponentsProp(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   describe('prop components:', () => {
     it('can render another root component with the `components` prop', () => {
       const { mount, testComponentsRootPropWith: component = 'em' } = getOptions();
@@ -587,7 +605,10 @@ function testComponentsProp(element: React.ReactElement, getOptions: () => Confo
  * MUI theme has a components section that allows specifying default props.
  * Components from @inheritComponent
  */
-function testThemeDefaultProps(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testThemeDefaultProps(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   describe('theme default components:', () => {
     it("respect theme's defaultProps", () => {
       const testProp = 'data-id';
@@ -631,7 +652,7 @@ function testThemeDefaultProps(element: React.ReactElement, getOptions: () => Co
  * Components from @inheritComponent
  */
 function testThemeStyleOverrides(
-  element: React.ReactElement,
+  element: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   describe('theme style overrides:', () => {
@@ -877,7 +898,7 @@ function testThemeStyleOverrides(
  * MUI theme has a components section that allows specifying custom variants.
  * Components from @inheritComponent
  */
-function testThemeVariants(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testThemeVariants(element: React.ReactElement<any>, getOptions: () => ConformanceOptions) {
   describe('theme variants:', () => {
     it("respect theme's variants", function test() {
       if (/jsdom/.test(window.navigator.userAgent)) {
@@ -982,7 +1003,10 @@ function testThemeVariants(element: React.ReactElement, getOptions: () => Confor
  * MUI theme supports custom palettes.
  * The components that iterate over the palette via `variants` should be able to render with or without applying the custom palette styles.
  */
-function testThemeCustomPalette(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+function testThemeCustomPalette(
+  element: React.ReactElement<any>,
+  getOptions: () => ConformanceOptions,
+) {
   describe('theme extended palette:', () => {
     it('should render without errors', function test() {
       const { render, ThemeProvider, createTheme } = getOptions();
@@ -1026,7 +1050,7 @@ const fullSuite = {
  * components.
  */
 function describeConformance(
-  minimalElement: React.ReactElement,
+  minimalElement: React.ReactElement<any>,
   getOptions: () => ConformanceOptions,
 ) {
   let originalMatchmedia: typeof window.matchMedia;

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -26,7 +26,7 @@ export interface SlotTestingOptions {
   /**
    * A custom HTML tag to use for the `slots` prop.
    */
-  testWithElement?: keyof JSX.IntrinsicElements | null;
+  testWithElement?: keyof React.JSX.IntrinsicElements | null;
   /**
    * To ensure that the slot has this class name when `slotProps` is provided.
    */


### PR DESCRIPTION
Based on https://github.com/mui/material-ui/issues/42032
First step towards https://github.com/mui/material-ui/issues/42032

### Summary

This PR includes the type changes we can implement **without upgrading to the new `@/types` packages** (which is a [WIP](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022)). It's achieved by:

- Running `npx types-react-codemod@latest preset-19` but skipping the `useRef-required-initial` codemod (See missing section below)
- Running `npx types-react-codemod@latest react-element-default-any-props` to maintain `ReactElement`'s previous default.

This results in the following changes:

- Remove [global `JSX` usage](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#:~:text=No%20replacement-,JSX%20Namespace,-A%20long%2Dtime) in favor of `React.JSX`
- Specify `ReactElement<any>` to [retain the previous default](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#:~:text=%3D%3E%20state%3B-,ReactElement,-The%20props%20of)

### Missing

The following are missing, to be implemented after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022 is merged:

- I didn't apply [the `useRef-required-initial` codemod](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#:~:text=of%20defaultProps.-,Ref%20changes,-A%20long%2Dtime) yet. This is because it will be much easier with [the new `useRef(undefined)` overload that's coming](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#:~:text=To%20ease%20migration%20due%20to%20the%20required%20argument%20for%20useRef%2C%20a%20convenience%20overload%20for%20useRef(undefined)%20was%20added%20that%20automatically%20returns%20RefObject%3CT%20%7C%20undefined%3E.).
- Even though `npx types-react-codemod@latest react-element-default-any-props` is provided, it [is discouraged](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#:~:text=Element%20introspection%20only%20exists%20as%20an%20escape%20hatch%20and%20you%20should%20make%20it%20explicit%20that%20your%20props%20access%20is%20unsound%20via%20an%20explicit%20any.). We should eventually fix them to work with the `unknown` default.
- `@emotion/react@11.11.4` references deprecated global JSX namespace. They mention [they'll work on it once React 19 is released](https://github.com/emotion-js/emotion/issues/3186#issuecomment-2119956203). We could look into contributing to it.



