### PR TITLE
[docs-infra] Fix Toolpad Core API links

### DIFF
--- a/packages/markdown/prepareMarkdown.js
+++ b/packages/markdown/prepareMarkdown.js
@@ -39,6 +39,9 @@ function resolveComponentApiUrl(productId, componentPkg, component) {
   if (componentPkg === 'mui-base' || BaseUIReexportedComponents.indexOf(component) >= 0) {
     return `/base-ui/react-${kebabCase(component)}/components-api/#${kebabCase(component)}`;
   }
+  if (productId === 'toolpad-core') {
+    return `/toolpad/core/api/${kebabCase(component)}/`;
+  }
   return `/${productId}/api/${kebabCase(component)}/`;
 }
 


### PR DESCRIPTION
I just added automatic generation of API docs pages for the Toolpad Core components in https://github.com/mui/mui-toolpad/pull/3536.
I adapted the scripts that most of the MUI libraries are using for that, but the API links are broken. 
I guess we need to add this change to the `markdown` package to fix it?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).