### PR TITLE
[material-ui][useMediaQuery] Remove unused useMediaQueryTheme

### DIFF
--- a/packages/mui-material/src/useMediaQuery/useMediaQueryTheme.d.ts
+++ b/packages/mui-material/src/useMediaQuery/useMediaQueryTheme.d.ts
@@ -1,3 +1,0 @@
-import useMediaQuery from '@mui/system/useMediaQuery';
-
-export default useMediaQuery;

--- a/packages/mui-material/src/useMediaQuery/useMediaQueryTheme.js
+++ b/packages/mui-material/src/useMediaQuery/useMediaQueryTheme.js
@@ -1,7 +1,0 @@
-'use client';
-import useMediaQuery from '@mui/system/useMediaQuery';
-
-// TODO v5: to deprecate in v4.x and remove in v5
-export default function useMediaQueryTheme(...args) {
-  return useMediaQuery(...args);
-}


### PR DESCRIPTION
Removes `useMediaQueryTheme` since it's not exported and is unused in the codebase. It was meant to be removed in v5.