### PR TITLE
[joy-ui][Modal] DialogActions tab order resolved

### DIFF
--- a/docs/data/joy/components/divider/DividerInModalDialog.js
+++ b/docs/data/joy/components/divider/DividerInModalDialog.js
@@ -31,7 +31,7 @@ export default function DividerInModalDialog() {
         <Divider inset="context" />
         <DialogActions
           buttonFlex="none"
-          sx={{ pt: 1.5, justifyContent: 'flex-start' }}
+          sx={{ pt: 1.5, justifyContent: 'flex-end' }}
         >
           <Button size="sm">Got it!</Button>
         </DialogActions>

--- a/docs/data/joy/components/divider/DividerInModalDialog.tsx
+++ b/docs/data/joy/components/divider/DividerInModalDialog.tsx
@@ -31,7 +31,7 @@ export default function DividerInModalDialog() {
         <Divider inset="context" />
         <DialogActions
           buttonFlex="none"
-          sx={{ pt: 1.5, justifyContent: 'flex-start' }}
+          sx={{ pt: 1.5, justifyContent: 'flex-end' }}
         >
           <Button size="sm">Got it!</Button>
         </DialogActions>

--- a/packages/mui-joy/src/DialogActions/DialogActions.tsx
+++ b/packages/mui-joy/src/DialogActions/DialogActions.tsx
@@ -24,17 +24,13 @@ const DialogActionsRoot = styled(StyledCardActionsRoot, {
   overridesResolver: (props, styles) => styles.root,
 })<{ ownerState: DialogActionsProps }>(({ ownerState }) => {
   return {
-    ...(ownerState.orientation?.startsWith('horizontal') && {
-      alignItems: 'center', // it is common to have children aligned center in horizontal orientation, but not vertically.
-    }),
-    flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
     ...(ownerState.orientation === 'horizontal-reverse' && {
       flexDirection: 'row',
-      justifyContent: 'end',
+      justifyContent: 'flex-end',
     }),
     ...(ownerState.orientation === 'horizontal' && {
       flexDirection: 'row-reverse',
-      justifyContent: 'start',
+      justifyContent: 'flex-end',
     }),
     ...(ownerState.orientation === 'vertical' && {
       flexDirection: 'column-reverse',

--- a/packages/mui-joy/src/DialogActions/DialogActions.tsx
+++ b/packages/mui-joy/src/DialogActions/DialogActions.tsx
@@ -22,7 +22,25 @@ const DialogActionsRoot = styled(StyledCardActionsRoot, {
   name: 'JoyDialogActions',
   slot: 'Root',
   overridesResolver: (props, styles) => styles.root,
-})<{ ownerState: DialogActionsProps }>({});
+})<{ ownerState: DialogActionsProps }>(({ ownerState }) => {
+  return {
+    ...(ownerState.orientation?.startsWith('horizontal') && {
+      alignItems: 'center', // it is common to have children aligned center in horizontal orientation, but not vertically.
+    }),
+    flexDirection: ownerState.orientation === 'horizontal' ? 'row' : 'column',
+    ...(ownerState.orientation === 'horizontal-reverse' && {
+      flexDirection: 'row',
+      justifyContent: 'end',
+    }),
+    ...(ownerState.orientation === 'horizontal' && {
+      flexDirection: 'row-reverse',
+      justifyContent: 'start',
+    }),
+    ...(ownerState.orientation === 'vertical' && {
+      flexDirection: 'column-reverse',
+    }),
+  };
+});
 /**
  *
  * Demos:
@@ -67,7 +85,9 @@ const DialogActions = React.forwardRef(function DialogActions(inProps, ref) {
     ownerState,
   });
 
-  return <SlotRoot {...rootProps}>{children}</SlotRoot>;
+  const reorderedChildren = React.Children.toArray(children).reverse();
+
+  return <SlotRoot {...rootProps}>{reorderedChildren}</SlotRoot>;
 }) as OverridableComponent<DialogActionsTypeMap>;
 
 DialogActions.propTypes /* remove-proptypes */ = {


### PR DESCRIPTION
children of component reversed for current tab order. component styling added to maintain current visual appearance despite new child order.

resolves #42185

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
