### PR TITLE
[docs-infra] Make menu styles consistent

### DIFF
--- a/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
+++ b/docs/src/modules/components/ApiPage/sections/ToggleDisplayOption.tsx
@@ -135,10 +135,10 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
           data-ga-event-action={sectionType}
           data-ga-event-label="table"
         >
-          <CheckIcon
-            sx={{ fontSize: '0.85rem', mr: 1, opacity: displayOption === 'table' ? 1 : 0 }}
-          />
           Table
+          <CheckIcon
+            sx={{ fontSize: '0.85rem', ml: 'auto', opacity: displayOption === 'table' ? 1 : 0 }}
+          />
         </MenuItem>
         <MenuItem
           value="expanded"
@@ -148,10 +148,10 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
           data-ga-event-action={sectionType}
           data-ga-event-label="expanded"
         >
-          <CheckIcon
-            sx={{ fontSize: '0.85rem', mr: 1, opacity: displayOption === 'expanded' ? 1 : 0 }}
-          />
           Expanded list
+          <CheckIcon
+            sx={{ fontSize: '0.85rem', ml: 'auto', opacity: displayOption === 'expanded' ? 1 : 0 }}
+          />
         </MenuItem>
         <MenuItem
           value="collapsed"
@@ -161,10 +161,10 @@ export default function ToggleDisplayOption(props: ToggleDisplayOptionProps) {
           data-ga-event-action={sectionType}
           data-ga-event-label="collapsed"
         >
-          <CheckIcon
-            sx={{ fontSize: '0.85rem', mr: 1, opacity: displayOption === 'collapsed' ? 1 : 0 }}
-          />
           Collapsed list
+          <CheckIcon
+            sx={{ fontSize: '0.85rem', ml: 'auto', opacity: displayOption === 'collapsed' ? 1 : 0 }}
+          />
         </MenuItem>
       </Menu>
     </React.Fragment>

--- a/docs/src/modules/components/AppNavDrawer.js
+++ b/docs/src/modules/components/AppNavDrawer.js
@@ -356,7 +356,7 @@ export default function AppNavDrawer(props) {
             {versions.map((item) => {
               if (item.text === 'View all versions') {
                 return [
-                  <Divider key="divider" sx={{ mx: -1 }} />,
+                  <Divider key="divider" />,
                   <MenuItem key="all-versions" component="a" href={item.href} onClick={onClose}>
                     {/* eslint-disable-next-line material-ui/no-hardcoded-labels -- version string is untranslatable */}
                     {`View all versions`}

--- a/packages/mui-docs/src/branding/brandingTheme.ts
+++ b/packages/mui-docs/src/branding/brandingTheme.ts
@@ -509,7 +509,7 @@ export function getThemedComponents(): ThemeOptions {
                 color: (theme.vars || theme).palette.text.primary,
                 backgroundColor: alpha(theme.palette.primaryDark[50], 0.1),
                 borderColor: (theme.vars || theme).palette.primaryDark[100],
-                boxShadow: `${alpha(theme.palette.grey[200], 0.5)} 0 1px 0 inset, ${alpha(theme.palette.grey[100], 0.4)} 0 -1px 0 inset, ${alpha(theme.palette.grey[200], 0.5)} 0 1px 2px 0`,
+                boxShadow: `#FFF 0 1px 0 inset, ${alpha(theme.palette.grey[200], 0.4)} 0 -1px 0 inset, ${alpha(theme.palette.grey[200], 0.5)} 0 1px 2px 0`,
                 '&:hover': {
                   backgroundColor: (theme.vars || theme).palette.grey[50],
                 },
@@ -801,6 +801,14 @@ export function getThemedComponents(): ThemeOptions {
               border: '1px solid',
               backgroundColor: (theme.vars || theme).palette.background.paper,
               borderColor: (theme.vars || theme).palette.grey[200],
+              '& .MuiMenu-list': {
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '2px',
+                '& .MuiDivider-root': {
+                  margin: '4px -8px 4px -8px',
+                },
+              },
               '& .MuiMenuItem-root': {
                 padding: '6px 12px',
                 borderRadius: '6px',
@@ -849,10 +857,7 @@ export function getThemedComponents(): ThemeOptions {
       MuiDivider: {
         styleOverrides: {
           root: ({ theme }) => ({
-            borderColor: (theme.vars || theme).palette.grey[100],
-            ...theme.applyDarkStyles({
-              borderColor: alpha(theme.palette.primaryDark[500], 0.3),
-            }),
+            borderColor: (theme.vars || theme).palette.divider,
           }),
         },
       },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Run-down of the changes:
- If there's a check icon to illustrate which item is currently active, put the icons on the far right (the API page layout menu was inconsistent with the version menu in this regard)
- Tweak spacing between menu items so they don't collide (try hovering the menu item right below a selected one)
- Fix secondary button styles so that light (lightest inset box-shadow) comes from the top
- Make the Divider component color consistent in the branding theme
