### PR TITLE
[code-infra] Fix stylelint locally

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -4,23 +4,22 @@ module.exports = {
     // TypeScript declaration files contain no styles.
     // Stylelint is also reporting parseError on `docs/types/react-docgen.d.ts`.
     '**/*.d.ts',
+    'docs/.next/**/*',
+    'docs/export/**/*',
+    '**/node_modules/**/*',
   ],
   rules: {
     'alpha-value-notation': null,
     'custom-property-pattern': null,
-    'declaration-colon-newline-after': null,
-    'function-parentheses-newline-inside': null, // not compatible with prettier
     'media-feature-range-notation': null,
     'no-empty-source': null,
-    'no-missing-end-of-source-newline': null,
     'selector-class-pattern': null,
     'string-no-newline': null, // not compatible with prettier
     'value-keyword-case': null,
-    'value-list-comma-newline-after': null, // not compatible with prettier
   },
   overrides: [
     {
-      files: ['**/*.js', '**/*.cjs', '**/*.mjs', '**/*.jsx', '**/*.ts', '**/*.tsx'],
+      files: ['**/*.js', '**/*.cjs', '**/*.mjs', '**/*.ts', '**/*.tsx'],
       customSyntax: 'postcss-styled-syntax',
     },
   ],


### PR DESCRIPTION
When running `pnpm stylelint` locally with Next.js having already done a build, it will crash with:

<img width="1485" alt="SCR-20240526-sfau" src="https://github.com/mui/material-ui/assets/3165635/c77f6fcb-7f17-4be8-ac8b-ae0b7974164c">

Annoying.

Instead, I'm reproducing the fix done in Base UI by @michaldudak https://github.com/mui/base-ui/blob/bf8fca5f2aac3d6d39d41496a20d722d67cc1fba/.stylelintrc.js#L7. 

I found this testing some stuff with Pigment CSS.