### PR TITLE
[material-ui][responsiveFontSizes] Handled undefined variants

### DIFF
--- a/packages/mui-material/src/styles/responsiveFontSizes.js
+++ b/packages/mui-material/src/styles/responsiveFontSizes.js
@@ -34,6 +34,11 @@ export default function responsiveFontSizes(themeInput, options = {}) {
 
   variants.forEach((variant) => {
     const style = typography[variant];
+
+    if (!style) {
+      return;
+    }
+
     const remFontSize = parseFloat(convert(style.fontSize, 'rem'));
 
     if (remFontSize <= 1) {

--- a/packages/mui-material/src/styles/responsiveFontSizes.test.js
+++ b/packages/mui-material/src/styles/responsiveFontSizes.test.js
@@ -59,6 +59,19 @@ describe('responsiveFontSizes', () => {
     });
   });
 
+  it('should handle variants that have been reset to undefined', () => {
+    const theme = createTheme({
+      typography: {
+        h1: undefined,
+      },
+    });
+    const { typography } = responsiveFontSizes(theme, {
+      disableAlign: true,
+    });
+
+    expect(typography.h1).to.deep.equal(undefined);
+  });
+
   describe('when requesting a responsive typography with non unitless line height and alignment', () => {
     it('should throw an error, as this is not supported', () => {
       const theme = createTheme({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

We [ask](https://mui.com/material-ui/customization/typography/#adding-amp-disabling-variants) users to disable typography variants by setting them to undefined but this was not handled in the runtime code of `responsiveFontSizes`.
This change fixes that.

Fixes #42252 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
