### PR TITLE
[docs] Link to pnpm installation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ git checkout master
 git pull upstream master
 ```
 
-4. Install the dependencies with pnpm (yarn or npm aren't supported):
+4. Install the dependencies with [pnpm](https://pnpm.io/installation) (yarn or npm aren't supported):
 
 ```bash
 pnpm install


### PR DESCRIPTION
Adds a link to the pnpm [installation guide](https://pnpm.io/installation) in CONTRIBUTING.md

Sparked from https://github.com/mui/material-ui/issues/42388