### PR TITLE
[joy-ui][docs] Fix template responsiveness

### DIFF
--- a/docs/data/joy/getting-started/templates/messages/components/ChatsPane.tsx
+++ b/docs/data/joy/getting-started/templates/messages/components/ChatsPane.tsx
@@ -24,7 +24,7 @@ export default function ChatsPane(props: ChatsPaneProps) {
       sx={{
         borderRight: '1px solid',
         borderColor: 'divider',
-        height: 'calc(100dvh - var(--Header-height))',
+        height: { sm: 'calc(100dvh - var(--Header-height))', md: '100dvh' },
         overflowY: 'auto',
       }}
     >

--- a/docs/data/joy/getting-started/templates/messages/components/Header.tsx
+++ b/docs/data/joy/getting-started/templates/messages/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
   return (
     <Sheet
       sx={{
-        display: { xs: 'flex', sm: 'none' },
+        display: { sm: 'flex', md: 'none' },
         alignItems: 'center',
         justifyContent: 'space-between',
         position: 'fixed',

--- a/docs/data/joy/getting-started/templates/messages/components/MessagesPane.tsx
+++ b/docs/data/joy/getting-started/templates/messages/components/MessagesPane.tsx
@@ -24,7 +24,7 @@ export default function MessagesPane(props: MessagesPaneProps) {
   return (
     <Sheet
       sx={{
-        height: { xs: 'calc(100dvh - var(--Header-height))', lg: '100dvh' },
+        height: { xs: 'calc(100dvh - var(--Header-height))', md: '100dvh' },
         display: 'flex',
         flexDirection: 'column',
         backgroundColor: 'background.level1',

--- a/docs/data/joy/getting-started/templates/messages/components/MyMessages.tsx
+++ b/docs/data/joy/getting-started/templates/messages/components/MyMessages.tsx
@@ -14,7 +14,7 @@ export default function MyProfile() {
         flex: 1,
         width: '100%',
         mx: 'auto',
-        pt: { xs: 'var(--Header-height)', sm: 0 },
+        pt: { xs: 'var(--Header-height)', md: 0 },
         display: 'grid',
         gridTemplateColumns: {
           xs: '1fr',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

In the message template. Between screen widths 1200 and 600, there is a (black bar) below the MessagesPane and ChatsPane components, caused by the lack of configuration of the height break points, related to the header component. I corrected it, adding the correct height break points in the necessary components for better responsiveness.
![Captura de tela de 2024-05-27 19-47-35](https://github.com/mui/material-ui/assets/28969800/c6405efd-cd17-45e6-be20-0682561035e1)
