### PR TITLE
[mui-system] Remove IE11 code

### DIFF
--- a/packages/mui-system/src/Container/createContainer.tsx
+++ b/packages/mui-system/src/Container/createContainer.tsx
@@ -79,7 +79,6 @@ export default function createContainer<Theme extends RequiredThemeStructure = D
         marginLeft: 'auto',
         boxSizing: 'border-box',
         marginRight: 'auto',
-        display: 'block', // Fix IE11 layout when used with main.
         ...(!ownerState.disableGutters && {
           paddingLeft: theme.spacing(2),
           paddingRight: theme.spacing(2),


### PR DESCRIPTION
MUI System portion of https://github.com/mui/material-ui/issues/14420

Remove the remaining IE11-related code from the MUI System package. There was only one.