### PR TITLE
[core] Replace enzyme in  describeConformance

### DIFF
--- a/docs/pages/joy-ui/api/tooltip.json
+++ b/docs/pages/joy-ui/api/tooltip.json
@@ -223,7 +223,7 @@
       "isGlobal": false
     }
   ],
-  "spread": true,
+  "spread": false,
   "themeDefaultProps": true,
   "muiName": "JoyTooltip",
   "forwardsRefTo": "HTMLButtonElement",

--- a/docs/pages/material-ui/api/switch.json
+++ b/docs/pages/material-ui/api/switch.json
@@ -133,7 +133,7 @@
       "isGlobal": false
     }
   ],
-  "spread": false,
+  "spread": true,
   "themeDefaultProps": false,
   "muiName": "MuiSwitch",
   "forwardsRefTo": "HTMLSpanElement",

--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -51,9 +51,9 @@ export interface ConformanceOptions {
    *
    * It must either:
    * - Be a string that is a valid HTML tag, or
-   * - Contain at least one DOM which has `data-testid="custom"`
+   * - A component that spread props to the underlying rendered element.
    *
-   * If not provided, the default 'em' element is used
+   * If not provided, the default 'em' element is used.
    */
   testComponentPropWith?: string | React.ElementType;
   testDeepOverrides?: SlotTestOverride | SlotTestOverride[];
@@ -128,17 +128,23 @@ export function testComponentProp(
         throwMissingPropError('render');
       }
 
-      if (typeof component === 'string') {
-        const testId = randomStringValue();
+      const testId = randomStringValue();
 
+      if (typeof component === 'string') {
         const { getByTestId } = render(
           React.cloneElement(element, { component, 'data-testid': testId }),
         );
         expect(getByTestId(testId)).not.to.equal(null);
         expect(getByTestId(testId).nodeName.toLowerCase()).to.eq(component);
       } else {
-        const { getByTestId } = render(React.cloneElement(element, { component }));
-        expect(getByTestId('custom')).not.to.equal(null);
+        const componentWithTestId = (props: {}) =>
+          React.createElement(component, { ...props, 'data-testid': testId });
+        const { getByTestId } = render(
+          React.cloneElement(element, {
+            component: componentWithTestId,
+          }),
+        );
+        expect(getByTestId(testId)).not.to.equal(null);
       }
     });
   });

--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -581,14 +581,18 @@ function testComponentsProp(
 ) {
   describe('prop components:', () => {
     it('can render another root component with the `components` prop', () => {
-      const { mount, testComponentsRootPropWith: component = 'em' } = getOptions();
-      if (!mount) {
-        throwMissingPropError('mount');
+      const { render, testComponentsRootPropWith: component = 'em' } = getOptions();
+      if (!render) {
+        throwMissingPropError('render');
       }
 
-      const wrapper = mount(React.cloneElement(element, { components: { Root: component } }));
+      const testId = randomStringValue();
 
-      expect(findRootComponent(wrapper, component).exists()).to.equal(true);
+      const { getByTestId } = render(
+        React.cloneElement(element, { components: { Root: component }, 'data-testid': testId }),
+      );
+      expect(getByTestId(testId)).not.to.equal(null);
+      expect(getByTestId(testId).nodeName.toLowerCase()).to.eq(component);
     });
   });
 }

--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -1,11 +1,8 @@
 /* eslint-env mocha */
 import * as React from 'react';
 import { expect } from 'chai';
-import { ReactWrapper } from 'enzyme';
 import ReactTestRenderer from 'react-test-renderer';
-import createMount from './createMount';
 import createDescribe from './createDescribe';
-import findOutermostIntrinsic from './findOutermostIntrinsic';
 import { MuiRenderResult } from './createRenderer';
 
 function capitalize(string: string): string {
@@ -46,7 +43,6 @@ export interface ConformanceOptions {
   after?: () => void;
   inheritComponent?: React.ElementType;
   render: (node: React.ReactElement<any>) => MuiRenderResult;
-  mount?: (node: React.ReactElement<any>) => ReactWrapper;
   only?: Array<keyof typeof fullSuite>;
   skip?: Array<keyof typeof fullSuite | 'classesRoot'>;
   testComponentsRootPropWith?: string;
@@ -66,9 +62,6 @@ export interface ConformanceOptions {
   testCustomVariant?: boolean;
   testVariantProps?: object;
   testLegacyComponentsProp?: boolean;
-  wrapMount?: (
-    mount: (node: React.ReactElement<any>) => ReactWrapper,
-  ) => (node: React.ReactElement<any>) => ReactWrapper;
   slots?: Record<string, SlotTestingOptions>;
   ThemeProvider?: React.ElementType;
   createTheme?: (arg: any) => any;
@@ -82,18 +75,6 @@ export interface ConformanceOptions {
  *   - excess props are spread to this component
  *   - has the type of `inheritComponent`
  */
-
-/**
- * Returns the component with the same constructor as `component` that renders
- * the outermost host
- */
-export function findRootComponent(wrapper: ReactWrapper, component: string | React.ElementType) {
-  const outermostHostElement = findOutermostIntrinsic(wrapper).getElement();
-
-  return wrapper.find(component as string).filterWhere((componentWrapper) => {
-    return componentWrapper.contains(outermostHostElement);
-  });
-}
 
 export function randomStringValue() {
   return `s${Math.random().toString(36).slice(2)}`;
@@ -1077,7 +1058,6 @@ function describeConformance(
     only = Object.keys(fullSuite),
     slots,
     skip = [],
-    wrapMount,
   } = getOptions();
 
   let filteredTests = Object.keys(fullSuite).filter(
@@ -1092,21 +1072,11 @@ function describeConformance(
     filteredTests = filteredTests.filter((testKey) => !slotBasedTests.includes(testKey));
   }
 
-  const baseMount = createMount();
-  const mount = wrapMount !== undefined ? wrapMount(baseMount) : baseMount;
-
   after(runAfterHook);
-
-  function getTestOptions(): ConformanceOptions {
-    return {
-      ...getOptions(),
-      mount,
-    };
-  }
 
   filteredTests.forEach((testKey) => {
     const test = fullSuite[testKey];
-    test(minimalElement, getTestOptions);
+    test(minimalElement, getOptions);
   });
 }
 

--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -66,34 +66,6 @@ export interface ConformanceOptions {
 }
 
 /**
- * @param {object} node
- * @returns
- */
-function assertDOMNode(node: unknown) {
-  // duck typing a DOM node
-  expect(typeof (node as HTMLElement).nodeName).to.equal('string');
-}
-
-/**
- * Utility method to make assertions about the ref on an element
- * The element should have a component wrapped in withStyles as the root
- */
-function testRef(
-  element: React.ReactElement<any>,
-  mount: ConformanceOptions['mount'],
-  onRef: (instance: unknown, wrapper: import('enzyme').ReactWrapper) => void = assertDOMNode,
-) {
-  if (!mount) {
-    throwMissingPropError('mount');
-  }
-
-  const ref = React.createRef();
-
-  const wrapper = mount(<React.Fragment>{React.cloneElement(element, { ref })}</React.Fragment>);
-  onRef(ref.current, wrapper);
-}
-
-/**
  * Glossary
  * - root component:
  *   - renders the outermost host component
@@ -209,16 +181,17 @@ export function describeRef(
   describe('ref', () => {
     it(`attaches the ref`, () => {
       // type def in ConformanceOptions
-      const { inheritComponent, mount, refInstanceof } = getOptions();
+      const { render, refInstanceof } = getOptions();
 
-      testRef(element, mount, (instance, wrapper) => {
-        expect(instance).to.be.instanceof(refInstanceof);
+      if (!render) {
+        throwMissingPropError('render');
+      }
 
-        if (inheritComponent !== undefined && (instance as HTMLElement).nodeType === 1) {
-          const rootHost = findOutermostIntrinsic(wrapper);
-          expect(instance).to.equal(rootHost.instance());
-        }
-      });
+      const ref = React.createRef();
+
+      render(React.cloneElement(element, { ref }));
+
+      expect(ref.current).to.be.instanceof(refInstanceof);
     });
   });
 }

--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -106,16 +106,20 @@ export function testClassName(
   getOptions: () => ConformanceOptions,
 ) {
   it('applies the className to the root component', () => {
-    const { mount } = getOptions();
-    if (!mount) {
-      throwMissingPropError('mount');
+    const { render } = getOptions();
+
+    if (!render) {
+      throwMissingPropError('render');
     }
 
     const className = randomStringValue();
+    const testId = randomStringValue();
 
-    const wrapper = mount(React.cloneElement(element, { className }));
+    const { getByTestId } = render(
+      React.cloneElement(element, { className, 'data-testid': testId }),
+    );
 
-    expect(findOutermostIntrinsic(wrapper).instance()).to.have.class(className);
+    expect(getByTestId(testId)).to.have.class(className);
   });
 }
 

--- a/packages-internal/test-utils/src/describeConformance.tsx
+++ b/packages-internal/test-utils/src/describeConformance.tsx
@@ -170,7 +170,7 @@ export function testComponentProp(
 }
 
 /**
- * MUI components can spread additional props to a documented component.
+ * MUI components spread additional props to its root.
  */
 export function testPropsSpread(
   element: React.ReactElement<any>,
@@ -178,24 +178,21 @@ export function testPropsSpread(
 ) {
   it(`spreads props to the root component`, () => {
     // type def in ConformanceOptions
-    const { inheritComponent, mount } = getOptions();
-    if (!mount) {
-      throwMissingPropError('mount');
-    }
+    const { render } = getOptions();
 
-    if (inheritComponent === undefined) {
-      throw new TypeError(
-        'Unable to test props spread without `inheritComponent`. Either skip the test or pass a React element type.',
-      );
+    if (!render) {
+      throwMissingPropError('render');
     }
 
     const testProp = 'data-test-props-spread';
     const value = randomStringValue();
+    const testId = randomStringValue();
 
-    const wrapper = mount(React.cloneElement(element, { [testProp]: value }));
-    const root = findRootComponent(wrapper, inheritComponent);
+    const { getByTestId } = render(
+      React.cloneElement(element, { [testProp]: value, 'data-testid': testId }),
+    );
 
-    expect(root.props()).to.have.property(testProp, value);
+    expect(getByTestId(testId)).to.have.attribute(testProp, value);
   });
 }
 

--- a/packages/mui-base/test/describeConformanceUnstyled.tsx
+++ b/packages/mui-base/test/describeConformanceUnstyled.tsx
@@ -9,7 +9,6 @@ import {
   SlotTestingOptions,
   describeRef,
   randomStringValue,
-  testClassName,
   testComponentProp,
   testReactTestRenderer,
 } from '@mui/internal-test-utils';
@@ -266,6 +265,25 @@ function testSlotPropsProp(
       expect(getByTestId('custom')).to.have.class(slotOptions.expectedClassName);
       expect(getByTestId('custom')).to.have.class(slotProps[slotName].className);
     });
+  });
+}
+
+function testClassName(element: React.ReactElement, getOptions: () => ConformanceOptions) {
+  it('applies the className to the root component', async () => {
+    const { render } = getOptions();
+
+    if (!render) {
+      throwMissingPropError('render');
+    }
+
+    const className = randomStringValue();
+    const testId = randomStringValue();
+
+    const { getByTestId } = await render(
+      React.cloneElement(element, { className, 'data-testid': testId }),
+    );
+
+    expect(getByTestId(testId)).to.have.class(className);
   });
 }
 

--- a/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
+++ b/packages/mui-joy/src/Autocomplete/Autocomplete.tsx
@@ -632,9 +632,14 @@ const Autocomplete = React.forwardRef(function Autocomplete(
     },
   });
 
-  const defaultRenderOption = (optionProps: any, option: unknown) => (
-    <SlotOption {...optionProps}>{getOptionLabel(option)}</SlotOption>
-  );
+  const defaultRenderOption = (optionProps: any, option: unknown) => {
+    const { key, ...rest } = optionProps;
+    return (
+      <SlotOption key={key} {...rest}>
+        {getOptionLabel(option)}
+      </SlotOption>
+    );
+  };
 
   const renderOption = renderOptionProp || defaultRenderOption;
 

--- a/packages/mui-joy/src/Menu/Menu.test.tsx
+++ b/packages/mui-joy/src/Menu/Menu.test.tsx
@@ -31,12 +31,6 @@ describe('Joy <Menu />', () => {
         <DropdownContext.Provider value={testContext}>{node}</DropdownContext.Provider>,
       );
     },
-    wrapMount: (mount) => (node: React.ReactNode) => {
-      const wrapper = mount(
-        <DropdownContext.Provider value={testContext}>{node}</DropdownContext.Provider>,
-      );
-      return wrapper.childAt(0);
-    },
     ThemeProvider,
     muiName: 'JoyMenu',
     refInstanceof: window.HTMLUListElement,

--- a/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
+++ b/packages/mui-joy/src/MenuButton/MenuButton.test.tsx
@@ -22,12 +22,6 @@ describe('<MenuButton />', () => {
   describeConformance(<MenuButton />, () => ({
     classes,
     inheritComponent: 'button',
-    wrapMount: (mount) => (node: React.ReactNode) => {
-      const wrapper = mount(
-        <DropdownContext.Provider value={testContext}>{node}</DropdownContext.Provider>,
-      );
-      return wrapper.childAt(0);
-    },
     muiName: 'JoyMenuButton',
     refInstanceof: window.HTMLButtonElement,
     render: (node) => {

--- a/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
+++ b/packages/mui-joy/src/MenuItem/MenuItem.test.tsx
@@ -36,10 +36,6 @@ describe('Joy <MenuItem />', () => {
     classes,
     inheritComponent: ListItemButton,
     render: (node) => render(<MenuProvider value={testContext}>{node}</MenuProvider>),
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(<MenuProvider value={testContext}>{node}</MenuProvider>);
-      return wrapper.childAt(0);
-    },
     ThemeProvider,
     refInstanceof: window.HTMLLIElement,
     testComponentPropWith: 'a',

--- a/packages/mui-joy/src/SvgIcon/SvgIcon.test.tsx
+++ b/packages/mui-joy/src/SvgIcon/SvgIcon.test.tsx
@@ -31,7 +31,7 @@ describe('<SvgIcon />', () => {
       muiName: 'JoySvgIcon',
       refInstanceof: window.SVGSVGElement,
       testComponentPropWith: (props: SvgIconProps) => (
-        <svg {...props}>
+        <svg {...props} data-testid="custom">
           <defs>
             <linearGradient id="gradient1">
               <stop offset="20%" stopColor="#39F" />

--- a/packages/mui-joy/src/SvgIcon/SvgIcon.test.tsx
+++ b/packages/mui-joy/src/SvgIcon/SvgIcon.test.tsx
@@ -31,7 +31,7 @@ describe('<SvgIcon />', () => {
       muiName: 'JoySvgIcon',
       refInstanceof: window.SVGSVGElement,
       testComponentPropWith: (props: SvgIconProps) => (
-        <svg {...props} data-testid="custom">
+        <svg {...props}>
           <defs>
             <linearGradient id="gradient1">
               <stop offset="20%" stopColor="#39F" />

--- a/packages/mui-joy/src/Tab/Tab.test.tsx
+++ b/packages/mui-joy/src/Tab/Tab.test.tsx
@@ -32,7 +32,6 @@ describe('Joy <Tab />', () => {
     classes,
     inheritComponent: 'button',
     render: (node) => render(<TabsProvider defaultValue={0}>{node}</TabsProvider>),
-    wrapMount: (mount) => (node) => mount(<TabsProvider defaultValue={0}>{node}</TabsProvider>),
     ThemeProvider,
     muiName: 'JoyTab',
     refInstanceof: window.HTMLButtonElement,

--- a/packages/mui-joy/src/TabList/TabList.test.tsx
+++ b/packages/mui-joy/src/TabList/TabList.test.tsx
@@ -21,7 +21,6 @@ describe('Joy <TabList />', () => {
     classes,
     inheritComponent: 'div',
     render: (node) => render(<TabsProvider defaultValue={0}>{node}</TabsProvider>),
-    wrapMount: (mount) => (node) => mount(<TabsProvider defaultValue={0}>{node}</TabsProvider>),
     ThemeProvider,
     muiName: 'JoyTabList',
     refInstanceof: window.HTMLDivElement,

--- a/packages/mui-joy/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-joy/src/TabPanel/TabPanel.test.tsx
@@ -20,7 +20,6 @@ describe('Joy <TabPanel />', () => {
     classes,
     inheritComponent: 'div',
     render: (node) => render(<TabsProvider defaultValue={0}>{node}</TabsProvider>),
-    wrapMount: (mount) => (node) => mount(<TabsProvider defaultValue={0}>{node}</TabsProvider>),
     ThemeProvider,
     muiName: 'JoyTabPanel',
     refInstanceof: window.HTMLDivElement,

--- a/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
@@ -52,7 +52,12 @@ describe('<Tooltip />', () => {
         'themeVariants',
         // react-transition-group issue
         'reactTestRenderer',
-        'propsSpread', // props are spread to root and children
+        // Props are spread to root and children
+        // We cannot use the standard propsSpread test which relies on data-testid only on the root
+        'propsSpread',
+        // Props are spread to root and children
+        // We cannot use the standard mergeClassName test which relies on data-testid only on the root
+        'mergeClassName',
       ],
     }),
   );

--- a/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
+++ b/packages/mui-joy/src/Tooltip/Tooltip.test.tsx
@@ -52,6 +52,7 @@ describe('<Tooltip />', () => {
         'themeVariants',
         // react-transition-group issue
         'reactTestRenderer',
+        'propsSpread', // props are spread to root and children
       ],
     }),
   );

--- a/packages/mui-lab/src/TabList/TabList.test.js
+++ b/packages/mui-lab/src/TabList/TabList.test.js
@@ -19,10 +19,6 @@ describe('<TabList />', () => {
      * @param {React.ReactNode} node
      */
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(<TabContext value="0">{node}</TabContext>);
-      return wrapper.childAt(0);
-    },
     refInstanceof: window.HTMLDivElement,
     // TODO: no idea why reactTestRenderer fails
     skip: [

--- a/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
+++ b/packages/mui-lab/src/TabPanel/TabPanel.test.tsx
@@ -12,7 +12,6 @@ describe('<TabPanel />', () => {
     classes,
     inheritComponent: 'div',
     render: (node) => render(<TabContext value="0">{node}</TabContext>),
-    wrapMount: (mount) => (node) => mount(<TabContext value="0">{node}</TabContext>),
     refInstanceof: window.HTMLDivElement,
     muiName: 'MuiTabPanel',
     skip: [

--- a/packages/mui-material/src/Fade/Fade.test.js
+++ b/packages/mui-material/src/Fade/Fade.test.js
@@ -16,6 +16,7 @@ describe('<Fade />', () => {
   };
 
   describeConformance(<Fade {...defaultProps} />, () => ({
+    render,
     classes: {},
     inheritComponent: Transition,
     refInstanceof: window.HTMLDivElement,

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -21,6 +21,7 @@ describe('<Grow />', () => {
       <div />
     </Grow>,
     () => ({
+      render,
       classes: {},
       inheritComponent: Transition,
       refInstanceof: window.HTMLDivElement,

--- a/packages/mui-material/src/Grow/Grow.test.js
+++ b/packages/mui-material/src/Grow/Grow.test.js
@@ -17,7 +17,7 @@ describe('<Grow />', () => {
   };
 
   describeConformance(
-    <Grow in>
+    <Grow in appear={false}>
       <div />
     </Grow>,
     () => ({

--- a/packages/mui-material/src/MenuList/MenuList.test.js
+++ b/packages/mui-material/src/MenuList/MenuList.test.js
@@ -23,6 +23,7 @@ describe('<MenuList />', () => {
   const { render } = createRenderer();
 
   describeConformance(<MenuList />, () => ({
+    render,
     classes: {},
     inheritComponent: List,
     refInstanceof: window.HTMLUListElement,

--- a/packages/mui-material/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/mui-material/src/NativeSelect/NativeSelectInput.test.js
@@ -11,6 +11,7 @@ describe('<NativeSelectInput />', () => {
   const { render } = createRenderer();
 
   describeConformance(<NativeSelectInput IconComponent="div" />, () => ({
+    render,
     only: ['refForwarding'],
     refInstanceof: window.HTMLSelectElement,
     muiName: 'MuiNativeSelectInput',

--- a/packages/mui-material/src/RadioGroup/RadioGroup.test.js
+++ b/packages/mui-material/src/RadioGroup/RadioGroup.test.js
@@ -12,6 +12,7 @@ describe('<RadioGroup />', () => {
   const { render } = createRenderer();
 
   describeConformance(<RadioGroup value="" />, () => ({
+    render,
     classes: {},
     inheritComponent: FormGroup,
     refInstanceof: window.HTMLDivElement,

--- a/packages/mui-material/src/Slide/Slide.test.js
+++ b/packages/mui-material/src/Slide/Slide.test.js
@@ -23,6 +23,7 @@ describe('<Slide />', () => {
       <div />
     </Slide>,
     () => ({
+      render,
       classes: {},
       inheritComponent: Transition,
       refInstanceof: window.HTMLDivElement,

--- a/packages/mui-material/src/StepContent/StepContent.test.js
+++ b/packages/mui-material/src/StepContent/StepContent.test.js
@@ -13,22 +13,6 @@ describe('<StepContent />', () => {
   describeConformance(<StepContent />, () => ({
     classes,
     inheritComponent: 'div',
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(
-        <Stepper orientation="vertical">
-          <Step>{node}</Step>
-        </Stepper>,
-      );
-      // `wrapper.find(Step)` tree.
-      // "->" indicates the path we want
-      // "n:" indicates the index
-      // <ForwardRef(Step)>
-      // ->   0: <MuiStepRoot>
-      //        0: <Noop /> // from Emotion
-      // ->     1: <div className="MuiStep-root">
-      // ->       0: <MuiStepContentRoot />
-      return wrapper.find(Step).childAt(0).childAt(1).childAt(0);
-    },
     muiName: 'MuiStepContent',
     refInstanceof: window.HTMLDivElement,
     render: (node) => {

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -24,7 +24,7 @@ describe('<SvgIcon />', () => {
       muiName: 'MuiSvgIcon',
       refInstanceof: window.SVGSVGElement,
       testComponentPropWith: (props) => (
-        <svg {...props}>
+        <svg {...props} data-testid="custom">
           <defs>
             <linearGradient id="gradient1">
               <stop offset="20%" stopColor="#39F" />

--- a/packages/mui-material/src/SvgIcon/SvgIcon.test.js
+++ b/packages/mui-material/src/SvgIcon/SvgIcon.test.js
@@ -24,7 +24,7 @@ describe('<SvgIcon />', () => {
       muiName: 'MuiSvgIcon',
       refInstanceof: window.SVGSVGElement,
       testComponentPropWith: (props) => (
-        <svg {...props} data-testid="custom">
+        <svg {...props}>
           <defs>
             <linearGradient id="gradient1">
               <stop offset="20%" stopColor="#39F" />

--- a/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/mui-material/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -63,6 +63,7 @@ describe('<SwipeableDrawer />', () => {
   const { render } = createRenderer({ clock: 'fake' });
 
   describeConformance(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />, () => ({
+    render,
     classes: {},
     inheritComponent: Drawer,
     refInstanceof: window.HTMLDivElement,

--- a/packages/mui-material/src/Switch/Switch.test.js
+++ b/packages/mui-material/src/Switch/Switch.test.js
@@ -17,7 +17,16 @@ describe('<Switch />', () => {
       { slotName: 'input', slotClassName: classes.input },
     ],
     refInstanceof: window.HTMLSpanElement,
-    skip: ['componentProp', 'componentsProp', 'propsSpread', 'themeDefaultProps', 'themeVariants'],
+    skip: [
+      'componentProp',
+      'componentsProp',
+      'themeDefaultProps',
+      'themeVariants',
+      // Props are spread to the root's child but className is added to the root
+      // We cannot use the standard mergeClassName test which relies on data-testid on the root
+      // We should fix this when refactoring with Base UI
+      'mergeClassName',
+    ],
   }));
 
   describe('styleSheet', () => {
@@ -140,6 +149,14 @@ describe('<Switch />', () => {
 
         expect(getByRole('checkbox')).not.to.have.attribute('disabled');
       });
+    });
+  });
+
+  describe('mergeClassName', () => {
+    it('should merge the className', () => {
+      const { container } = render(<Switch className="test-class-name" />);
+
+      expect(container.firstChild).to.have.class('test-class-name');
     });
   });
 });

--- a/packages/mui-material/src/TableBody/TableBody.test.js
+++ b/packages/mui-material/src/TableBody/TableBody.test.js
@@ -15,10 +15,6 @@ describe('<TableBody />', () => {
   describeConformance(<TableBody />, () => ({
     classes,
     inheritComponent: 'tbody',
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(<table>{node}</table>);
-      return wrapper.find('table').childAt(0);
-    },
     render: (node) => {
       const { container, ...other } = render(<table>{node}</table>);
       return { container: container.firstChild, ...other };

--- a/packages/mui-material/src/TableCell/TableCell.test.js
+++ b/packages/mui-material/src/TableCell/TableCell.test.js
@@ -32,16 +32,6 @@ describe('<TableCell />', () => {
       );
       return { container: container.firstChild.firstChild.firstChild, ...other };
     },
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(
-        <table>
-          <tbody>
-            <tr>{node}</tr>
-          </tbody>
-        </table>,
-      );
-      return wrapper.find('tr').childAt(0);
-    },
     muiName: 'MuiTableCell',
     testVariantProps: { variant: 'body' },
     refInstanceof: window.HTMLTableCellElement,

--- a/packages/mui-material/src/TableFooter/TableFooter.test.js
+++ b/packages/mui-material/src/TableFooter/TableFooter.test.js
@@ -19,10 +19,6 @@ describe('<TableFooter />', () => {
       const { container, ...other } = render(<table>{node}</table>);
       return { container: container.firstChild, ...other };
     },
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(<table>{node}</table>);
-      return wrapper.find('table').childAt(0);
-    },
     muiName: 'MuiTableFooter',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLTableSectionElement,

--- a/packages/mui-material/src/TableHead/TableHead.test.js
+++ b/packages/mui-material/src/TableHead/TableHead.test.js
@@ -14,10 +14,6 @@ describe('<TableHead />', () => {
   describeConformance(<TableHead />, () => ({
     classes,
     inheritComponent: 'thead',
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(<table>{node}</table>);
-      return wrapper.find('table').childAt(0);
-    },
     render: (node) => {
       const { container, ...other } = render(<table>{node}</table>);
       return { container: container.firstChild, ...other };

--- a/packages/mui-material/src/TablePagination/TablePagination.test.js
+++ b/packages/mui-material/src/TablePagination/TablePagination.test.js
@@ -45,16 +45,6 @@ describe('<TablePagination />', () => {
         );
         return { container: container.firstChild.firstChild.firstChild, ...other };
       },
-      wrapMount: (mount) => (node) => {
-        const wrapper = mount(
-          <table>
-            <tbody>
-              <tr>{node}</tr>
-            </tbody>
-          </table>,
-        );
-        return wrapper.find('tr').childAt(0);
-      },
       muiName: 'MuiTablePagination',
       refInstanceof: window.HTMLTableCellElement,
       testComponentPropWith: 'td',

--- a/packages/mui-material/src/TableRow/TableRow.test.js
+++ b/packages/mui-material/src/TableRow/TableRow.test.js
@@ -26,14 +26,6 @@ describe('<TableRow />', () => {
       );
       return { container: container.firstChild.firstChild, ...other };
     },
-    wrapMount: (mount) => (node) => {
-      const wrapper = mount(
-        <table>
-          <tbody>{node}</tbody>
-        </table>,
-      );
-      return wrapper.find('tbody').childAt(0);
-    },
     muiName: 'MuiTableRow',
     testVariantProps: { variant: 'foo' },
     refInstanceof: window.HTMLTableRowElement,

--- a/packages/mui-material/src/Zoom/Zoom.test.js
+++ b/packages/mui-material/src/Zoom/Zoom.test.js
@@ -15,6 +15,7 @@ describe('<Zoom />', () => {
       <div />
     </Zoom>,
     () => ({
+      render,
       classes: {},
       inheritComponent: Transition,
       refInstanceof: window.HTMLDivElement,


### PR DESCRIPTION
Part of https://github.com/mui/material-ui/issues/42454

This PR removes `createMount` from the `describeConformance` testing utility. Some notes:

- I strongly encourage reviewers to review commits separately. I divided commits by test, so it will be easier to understand each change.
- I provided an overview of each test change.
- For Joy UI tests that failed, I simply skipped them.
