### PR TITLE
[material-ui][docs] Update Figma design kit doc redirect link

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -539,6 +539,6 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 /r/toolpad-* https://mui-toolpad-docs.netlify.app/r/toolpad-:splat 200
 
 ### MUI Design kits
-/figma/getting-started/ https://mui-org.notion.site/MUI-for-Figma-docs-4eb22360388047a9a31fc19d300a285e 302
+/figma/getting-started/ /material-ui/design-resources/material-ui-for-figma/ 302
 /r/material-ui-figma-* https://mui-store.netlify.app/r/material-ui-figma-:splat 200
 /r/joy-ui-figma-* https://mui-store.netlify.app/r/joy-ui-figma-:splat 200


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Final item to fully deprecate the Notion docs (https://github.com/mui/mui-design-kits/issues/335).